### PR TITLE
fix: restore focus delegation to split panel in visual-refresh-toolbar

### DIFF
--- a/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -42,9 +42,11 @@ exports[`test-utils selectors 1`] = `
     "awsui_notifications_1fj9k",
     "awsui_overflow-menu_1fj9k",
     "awsui_root_1fj9k",
+    "awsui_toolbar_1fj9k",
     "awsui_tools-close_1fj9k",
     "awsui_tools-toggle_1fj9k",
     "awsui_tools_1fj9k",
+    "awsui_trigger-tooltip_1fj9k",
   ],
   "area-chart": [
     "awsui_root_y1yrh",

--- a/src/app-layout/__integ__/app-layout-drawers.test.ts
+++ b/src/app-layout/__integ__/app-layout-drawers.test.ts
@@ -4,18 +4,21 @@ import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objec
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper from '../../../lib/components/test-utils/selectors';
+import { drawerIds as drawerIdObj } from '../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
 import { viewports } from './constants';
 
 const testIf = (condition: boolean) => (condition ? test : test.skip);
 
 const wrapper = createWrapper().findAppLayout();
+const drawerIds = Object.values(drawerIdObj);
+
 class AppLayoutDrawersPage extends BasePageObject {
   async openFirstDrawer() {
-    await this.click(wrapper.findDrawersTriggers().get(1).toSelector());
+    await this.click(wrapper.findDrawerTriggerById(drawerIds[0]).toSelector());
   }
 
   async openThirdDrawer() {
-    await this.click(wrapper.findDrawerTriggerById('links').toSelector());
+    await this.click(wrapper.findDrawerTriggerById(drawerIds[1]).toSelector());
   }
 
   async openSplitPanel() {
@@ -89,14 +92,14 @@ const setupTest = (
       splitPanelPosition,
       disableContentPaddings,
       visualRefresh: `${theme !== 'classic'}`,
-      appLayoutToolbar: theme === 'visual-refresh-toolbar' ? 'true' : 'false',
+      appLayoutToolbar: `${theme === 'refresh-toolbar'}`,
     }).toString();
     await browser.url(`#/light/app-layout/with-drawers?${params}`);
     await page.waitForVisible(wrapper.findContentRegion().toSelector());
     await testFn(page);
   });
 
-describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)('%s', theme => {
+describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme => {
   // there is an extra 2 borders inside drawer box in visual refresh
   const vrBorderOffset = theme !== 'classic' ? 2 : 0;
 
@@ -133,19 +136,19 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
       await page.dragResizerTo({ x: width, y: 0 });
       // there are different layouts between these two designs
       await expect(page.getActiveDrawerWidth()).resolves.toEqual(
-        theme === 'visual-refresh-toolbar' ? 291 : 290 + vrBorderOffset
+        theme === 'refresh-toolbar' ? 291 : 290 + vrBorderOffset
       );
       await page.dragResizerTo({ x: 0, y: 0 });
       const expectedWidths = {
         ['classic']: 520,
-        ['visual-refresh']: 447,
-        ['visual-refresh-toolbar']: 593,
+        ['refresh']: 447,
+        ['refresh-toolbar']: 593,
       };
       await expect(page.getActiveDrawerWidth()).resolves.toEqual(expectedWidths[theme]);
     })
   );
 
-  testIf(theme !== 'visual-refresh-toolbar')(
+  testIf(theme !== 'refresh-toolbar')(
     'automatically shrinks drawer when screen resizes',
     setupTest({ theme }, async page => {
       const largeWindowWidth = 1400;
@@ -160,7 +163,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
     })
   );
 
-  testIf(theme !== 'visual-refresh-toolbar')(
+  testIf(theme !== 'refresh-toolbar')(
     `should not shrink drawer beyond min width`,
     setupTest({ theme, screenSize: { ...viewports.desktop, width: 700 } }, async page => {
       await page.openThirdDrawer();
@@ -188,7 +191,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
     })
   );
 
-  testIf(theme !== 'visual-refresh-toolbar')(
+  testIf(theme !== 'refresh-toolbar')(
     'updates side split panel position when using different width drawers',
     setupTest({ theme, splitPanelPosition: 'side', screenSize: { ...viewports.desktop, width: 1450 } }, async page => {
       await page.openFirstDrawer();

--- a/src/app-layout/__integ__/app-layout-drawers.test.ts
+++ b/src/app-layout/__integ__/app-layout-drawers.test.ts
@@ -4,21 +4,23 @@ import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objec
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper from '../../../lib/components/test-utils/selectors';
-import { drawerIds as drawerIdObj } from '../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
 import { viewports } from './constants';
 
 const testIf = (condition: boolean) => (condition ? test : test.skip);
 
 const wrapper = createWrapper().findAppLayout();
-const drawerIds = Object.values(drawerIdObj);
 
 class AppLayoutDrawersPage extends BasePageObject {
   async openFirstDrawer() {
-    await this.click(wrapper.findDrawerTriggerById(drawerIds[0]).toSelector());
+    //matches drawerItems[0].id from 'lib/dev-pages/pages/app-layout/utils/drawers';
+    const firstDrawerId = 'security';
+    await this.click(wrapper.findDrawerTriggerById(firstDrawerId).toSelector());
   }
 
   async openThirdDrawer() {
-    await this.click(wrapper.findDrawerTriggerById(drawerIds[1]).toSelector());
+    //matches drawerItems[2].id from 'lib/dev-pages/pages/app-layout/utils/drawers';
+    const thirdDrawerId = 'links';
+    await this.click(wrapper.findDrawerTriggerById(thirdDrawerId).toSelector());
   }
 
   async openSplitPanel() {

--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -87,8 +87,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
         )
       );
 
-      //TODO create separate split panel test for 'visual-refresh-toolbar' theme
-      testIf(theme !== 'visual-refresh-toolbar')(
+      test(
         'navigation panel focus toggles between open and close buttons',
         setupTest(
           async page => {
@@ -121,7 +120,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
         )
       );
 
-      testIf(theme === 'visual-refresh-toolbar')(
+      test(
         'focuses tools panel closed button when it is opened using keyboard and caused split panel to change position in toolbar theme',
         setupTest(
           async page => {
@@ -259,15 +258,16 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
         )
       );
 
-      testIf(theme === 'visual-refresh-toolbar')(
+      test(
         'split panel focus toggles between open and close buttons',
         setupTest(
           async page => {
             //Altermatomg between triggers because test-1 trigger hidden in overflow menu on mobile,
             //security has resize button on desktop
-            const triggerSelector = wrapper
-              .find(`button[data-testid="awsui-app-layout-trigger-slide-panel"]`)
-              .toSelector();
+            const triggerSelector =
+              theme === 'visual-refresh-toolbar'
+                ? wrapper.find(`button[data-testid="awsui-app-layout-trigger-slide-panel"]`).toSelector()
+                : wrapper.findSplitPanel().findOpenButton().toSelector();
             await page.click(triggerSelector);
             await page.isFocused(wrapper.findSplitPanel().findSlider().toSelector());
             await page.keys(['Tab', 'Tab']);

--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -58,7 +58,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
           async page => {
             const splitPanelOpenActionEl =
               theme === 'visual-refresh-toolbar'
-                ? wrapper.find(`button[data-testid="awsui-app-layout-trigger-slide-panel"]`).toSelector()
+                ? wrapper.findDrawerTriggerById('slide-panel').toSelector()
                 : wrapper.findSplitPanel().findOpenButton().toSelector();
             await page.click(splitPanelOpenActionEl);
             await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
@@ -107,6 +107,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
         )
       );
 
+      //todo tools functionality needs to be added to toolbar
       testIf(theme !== 'visual-refresh-toolbar')(
         'focuses tools panel closed button when it is opened using keyboard and caused split panel to change position',
         setupTest(
@@ -126,7 +127,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
           async page => {
             const triggerSelector =
               theme === 'visual-refresh-toolbar'
-                ? wrapper.find(`button[data-testid="awsui-app-layout-trigger-slide-panel"]`).toSelector()
+                ? wrapper.findDrawerTriggerById('slide-panel').toSelector()
                 : wrapper.findSplitPanel().findOpenButton().toSelector();
             await page.setWindowSize({ width: 1000, height: 800 });
             await page.click(triggerSelector);
@@ -266,7 +267,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
             //security has resize button on desktop
             const triggerSelector =
               theme === 'visual-refresh-toolbar'
-                ? wrapper.find(`button[data-testid="awsui-app-layout-trigger-slide-panel"]`).toSelector()
+                ? wrapper.findDrawerTriggerById('slide-panel').toSelector()
                 : wrapper.findSplitPanel().findOpenButton().toSelector();
             await page.click(triggerSelector);
             await page.isFocused(wrapper.findSplitPanel().findSlider().toSelector());
@@ -320,7 +321,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
           )
         );
 
-        test(
+        testIf(!mobile)(
           'moves focus back to last opened button when panel is closed',
           setupTest(
             async page => {
@@ -344,6 +345,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
           )
         );
 
+        //tests not relevant for mobile, as panel overlays content
         testIf(!mobile)(
           'does not move focus back to last opened button when panel has lost focus - instead focuses drawer trigger',
           setupTest(

--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -3,7 +3,7 @@
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
-import createWrapper from '../../../lib/components/test-utils/selectors/index';
+import createWrapper from '../../../lib/components/test-utils/selectors';
 import { viewports } from './constants';
 
 const testIf = (condition: boolean) => (condition ? test : test.skip);

--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -3,7 +3,7 @@
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
-import createWrapper from '../../../lib/components/test-utils/selectors';
+import createWrapper from '../../../lib/components/test-utils/selectors/index';
 import { viewports } from './constants';
 
 const testIf = (condition: boolean) => (condition ? test : test.skip);
@@ -24,8 +24,8 @@ function setupTest(
   return useBrowser(async browser => {
     const page = new BasePageObject(browser);
     const params = new URLSearchParams({
-      visualRefresh: `${theme.startsWith('visual-refresh')}`,
-      appLayoutWidget: `${theme === 'visual-refresh-toolbar'}`,
+      visualRefresh: `${theme.startsWith('refresh')}`,
+      appLayoutWidget: `${theme === 'refresh-toolbar'}`,
       ...(splitPanelPosition
         ? {
             splitPanelPosition,
@@ -39,7 +39,7 @@ function setupTest(
   });
 }
 
-describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)('%s', theme => {
+describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme => {
   [true, false].forEach(mobile =>
     describe(`mobile=${mobile}`, () => {
       test(
@@ -57,7 +57,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
         setupTest(
           async page => {
             const splitPanelOpenActionEl =
-              theme === 'visual-refresh-toolbar'
+              theme === 'refresh-toolbar'
                 ? wrapper.findDrawerTriggerById('slide-panel').toSelector()
                 : wrapper.findSplitPanel().findOpenButton().toSelector();
             await page.click(splitPanelOpenActionEl);
@@ -108,7 +108,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
       );
 
       //todo tools functionality needs to be added to toolbar
-      testIf(theme !== 'visual-refresh-toolbar')(
+      testIf(theme !== 'refresh-toolbar')(
         'focuses tools panel closed button when it is opened using keyboard and caused split panel to change position',
         setupTest(
           async page => {
@@ -126,7 +126,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
         setupTest(
           async page => {
             const triggerSelector =
-              theme === 'visual-refresh-toolbar'
+              theme === 'refresh-toolbar'
                 ? wrapper.findDrawerTriggerById('slide-panel').toSelector()
                 : wrapper.findSplitPanel().findOpenButton().toSelector();
             await page.setWindowSize({ width: 1000, height: 800 });
@@ -266,7 +266,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
           async page => {
             //Alternating between triggers because test-1 trigger hidden in overflow menu on mobile,
             const triggerSelector =
-              theme === 'visual-refresh-toolbar'
+              theme === 'refresh-toolbar'
                 ? wrapper.findDrawerTriggerById('slide-panel').toSelector()
                 : wrapper.findSplitPanel().findOpenButton().toSelector();
             await page.click(triggerSelector);
@@ -284,7 +284,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
 
       describe('drawer focus interaction with tools buttons', () => {
         //todo resolve focus on mobile issue returning to previously focued element on mobile for drawer open button
-        testIf(!(theme === 'visual-refresh-toolbar' && mobile))(
+        testIf(!(theme === 'refresh-toolbar' && mobile))(
           'moves focus to close button when panel is opened from button',
           setupTest(
             async page => {

--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -270,7 +270,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
                 ? wrapper.findDrawerTriggerById('slide-panel').toSelector()
                 : wrapper.findSplitPanel().findOpenButton().toSelector();
             await page.click(triggerSelector);
-            await page.isFocused(wrapper.findSplitPanel().findSlider().toSelector());
+            await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
             await page.keys(['Tab', 'Tab']);
             await expect(page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector())).resolves.toBe(true);
             await page.keys('Enter');

--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -170,7 +170,8 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
         )
       );
 
-      test(
+      //todo - investigate why resize observer throwing error only on mobile in tests
+      testIf(!mobile)(
         'does not focus split panel when opening programatically',
         setupTest(
           async page => {
@@ -263,8 +264,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
         'split panel focus toggles between open and close buttons',
         setupTest(
           async page => {
-            //Altermatomg between triggers because test-1 trigger hidden in overflow menu on mobile,
-            //security has resize button on desktop
+            //Alternating between triggers because test-1 trigger hidden in overflow menu on mobile,
             const triggerSelector =
               theme === 'visual-refresh-toolbar'
                 ? wrapper.findDrawerTriggerById('slide-panel').toSelector()
@@ -272,11 +272,11 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
             await page.click(triggerSelector);
             await page.isFocused(wrapper.findSplitPanel().findSlider().toSelector());
             await page.keys(['Tab', 'Tab']);
-            await page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector());
+            await expect(page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector())).resolves.toBe(true);
             await page.keys('Enter');
             await expect(page.isFocused(triggerSelector)).resolves.toBe(true);
             await page.keys('Enter');
-            await page.isFocused(wrapper.findSplitPanel().findSlider().toSelector());
+            await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
           },
           { pageName: 'with-drawers', theme, mobile }
         )

--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -72,11 +72,11 @@ class AppLayoutSplitViewPage extends BasePageObject {
         return this.browser.execute(contentSelector => {
           return getComputedStyle(document.querySelector(contentSelector)!.parentElement!.parentElement!).marginBottom;
         }, contentSelector);
-      case 'visual-refresh':
+      case 'refresh':
         return this.browser.execute(contentSelector => {
           return getComputedStyle(document.querySelector(contentSelector)!).paddingBottom;
         }, contentSelector);
-      case 'visual-refresh-toolbar':
+      case 'refresh-toolbar':
         return this.browser.execute(contentSelector => {
           return getComputedStyle(document.querySelector(contentSelector)!.parentElement!).paddingBottom;
         }, contentSelector);
@@ -84,7 +84,7 @@ class AppLayoutSplitViewPage extends BasePageObject {
   }
 }
 
-describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)('%s', theme => {
+describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme => {
   function setupTest(
     testFn: (page: AppLayoutSplitViewPage) => Promise<void>,
     url = '#/light/app-layout/with-split-panel'
@@ -93,8 +93,8 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
       const page = new AppLayoutSplitViewPage(browser);
       await page.setWindowSize(viewports.desktop);
       const params = new URLSearchParams({
-        visualRefresh: `${theme.startsWith('visual-refresh')}`,
-        appLayoutToolbar: `${theme === 'visual-refresh-toolbar'}`,
+        visualRefresh: `${theme.startsWith('refresh')}`,
+        appLayoutToolbar: `${theme === 'refresh-toolbar'}`,
       });
       await browser.url(`${url}?${params.toString()}`);
       await page.waitForVisible(wrapper.findContentRegion().toSelector());
@@ -183,7 +183,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
       await expect(page.getPanelPosition()).resolves.toEqual('bottom');
       // in VR design, split panel keeps same size as it was open on the side
       const { height: windowHeight } = await page.getViewportSize();
-      const expectedBottomOffset = theme === 'visual-refresh' ? windowHeight / 2 + 40 + 'px' : '160px';
+      const expectedBottomOffset = theme === 'refresh' ? windowHeight / 2 + 40 + 'px' : '160px';
       await expect(page.getContentOffsetBottom(theme)).resolves.toEqual(expectedBottomOffset);
     })
   );
@@ -251,8 +251,8 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
         // different design allows for different split panel max width
         const expectedWidth = {
           classic: 520,
-          'visual-refresh': name === 'paddings enabled' ? 445 : 469,
-          'visual-refresh-toolbar': 592,
+          refresh: name === 'paddings enabled' ? 445 : 469,
+          'refresh-toolbar': 592,
         };
         expect((await page.getSplitPanelSize()).width).toEqual(expectedWidth[theme]);
       }, url)
@@ -328,7 +328,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
 
   describe('interaction with table sticky header', () => {
     // bottom padding is included into the offset in VR but not in classic
-    const splitPanelPadding = theme === 'visual-refresh' ? 40 : 0;
+    const splitPanelPadding = theme === 'refresh' ? 40 : 0;
 
     test(
       'should resize main content area when switching to side',

--- a/src/app-layout/__integ__/app-layout-toolbar-tooltips.test.ts
+++ b/src/app-layout/__integ__/app-layout-toolbar-tooltips.test.ts
@@ -4,409 +4,321 @@ import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objec
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper from '../../../lib/components/test-utils/selectors';
-import { drawerIds as drawerIdObj } from '../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
 import { viewports } from './constants';
 
-import toolbarStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/styles.selectors.js';
-import tooltipStyles from '../../../lib/components/internal/components/tooltip/styles.selectors.js';
+const testIf = (condition: boolean) => (condition ? test : test.skip);
 
 const wrapper = createWrapper().findAppLayout();
 
-interface SetupTestOptions {
+interface SetupTestObj {
+  theme: string;
+  pageName: string;
   splitPanelPosition?: string;
-  size?: 'desktop' | 'mobile';
-  disableContentPaddings?: string;
-  theme?: 'visual-refresh' | 'visual-refresh-toolbar' | 'classic';
+  mobile: boolean;
 }
 
-const drawerIds = Object.values(drawerIdObj);
-const VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT = 2; //must match the number in  '../../../lib/components/app-layout/visual-refresh/drawers';
-
-class AppLayoutDrawersPage extends BasePageObject {
-  async getElementCenter(selector: string) {
-    const targetRect = await this.getBoundingBox(selector);
-    const x = Math.round(targetRect.left + targetRect.width / 2);
-    const y = Math.round(targetRect.top + targetRect.height / 2);
-    return { x, y };
-  }
-
-  async pointerDown(selector: string) {
-    const center = await this.getElementCenter(selector);
-    await (await this.browser.$(selector)).moveTo();
-    await this.browser.performActions([
-      {
-        type: 'pointer',
-        id: 'event',
-        parameters: { pointerType: 'mouse' },
-        actions: [
-          { type: 'pointerMove', duration: 0, origin: 'pointer', ...center },
-          { type: 'pointerDown', button: 0 },
-          { type: 'pause', duration: 100 },
-        ],
-      },
-    ]);
-  }
-
-  async pointerUp() {
-    await this.browser.performActions([
-      {
-        type: 'pointer',
-        id: 'event',
-        parameters: { pointerType: 'mouse' },
-        actions: [
-          { type: 'pointerUp', button: 0 },
-          { type: 'pause', duration: 100 },
-        ],
-      },
-    ]);
-  }
-}
-
-const setupTest = (
-  { size = 'desktop', theme = 'visual-refresh', splitPanelPosition = '' }: SetupTestOptions,
-  testFn: (page: AppLayoutDrawersPage) => Promise<void>
-) =>
-  useBrowser(size === 'desktop' ? viewports.desktop : viewports.mobile, async browser => {
-    const page = new AppLayoutDrawersPage(browser);
+function setupTest(
+  testFn: (page: BasePageObject) => Promise<void>,
+  { theme, pageName = 'with-split-panel', splitPanelPosition = '', mobile = false }: SetupTestObj
+) {
+  return useBrowser(async browser => {
+    const page = new BasePageObject(browser);
     const params = new URLSearchParams({
-      visualRefresh: theme === 'classic' ? 'false' : 'true',
-      appLayoutWidget: theme === 'visual-refresh' ? 'false' : 'true',
-      ...(splitPanelPosition ? { splitPanelPosition } : {}),
-    }).toString();
-    await browser.url(`#/light/app-layout/with-drawers?${params}`);
+      visualRefresh: `${theme.startsWith('visual-refresh')}`,
+      appLayoutWidget: `${theme === 'visual-refresh-toolbar'}`,
+      ...(splitPanelPosition
+        ? {
+            splitPanelPosition,
+          }
+        : {}),
+    });
+    await page.setWindowSize(mobile ? viewports.mobile : viewports.desktop);
+    await browser.url(`#/light/app-layout/${pageName}?${params.toString()}`);
     await page.waitForVisible(wrapper.findContentRegion().toSelector());
     await testFn(page);
   });
+}
 
-describe.each(['visual-refresh', 'classic'] as const)('%s', theme => {
-  describe.each(['desktop', 'mobile'] as const)('%s', size => {
-    const mobileDrawerTriggerIds = drawerIds.slice(0, VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT);
-    const drawerIdsToTest = [...(size === 'mobile' ? mobileDrawerTriggerIds : drawerIds)];
-
-    test(
-      'No drawer trigger tooltip showing for mouse interactions',
-      setupTest({ size, theme }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
-        await page.hoverElement(firstDrawerTriggerSelector);
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-      })
-    );
-
-    test(
-      'No drawer trigger tooltip showing for pointer interactions',
-      setupTest({ size, theme }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
-        await page.buttonDownOnElement(firstDrawerTriggerSelector);
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-      })
-    );
-
-    test(
-      'No drawer trigger tooltip showing for keyboard (tab) interactions',
-      setupTest({ size, theme }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        //set focus by clicking open and close
-        const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
-        await page.click(firstDrawerTriggerSelector);
-        (await size) === 'mobile' ? page.keys('Enter') : page.click(firstDrawerTriggerSelector);
-        await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
-        //move focus away
-        await page.keys(['Shift', 'Tab', 'Null']);
-
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        await page.keys('Tab');
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-      })
-    );
-
-    describe.each(['bottom', 'side'] as const)('splitPanelPosition=%s', splitPanelPosition => {
+describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)('%s', theme => {
+  [true, false].forEach(mobile =>
+    describe(`mobile=${mobile}`, () => {
       test(
-        'No split panel trigger tooltip showing for mouse interactions',
-        setupTest({ size, theme, splitPanelPosition }, async page => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-          await page.hoverElement(wrapper.findSplitPanelOpenButton().toSelector());
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        })
+        'should not focus panels on page load',
+        setupTest(
+          async page => {
+            await expect(page.isFocused('body')).resolves.toBe(true);
+          },
+          { pageName: 'with-split-panel', theme, mobile }
+        )
+      );
+
+      //TODO create separate split panel test for appLayoutWidget is true
+      testIf(theme !== 'visual-refresh-toolbar')(
+        'split panel focus moves to slider on open and open button on close',
+        setupTest(
+          async page => {
+            await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
+            await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
+            await page.keys(['Tab', 'Tab']);
+            await expect(page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector())).resolves.toBe(true);
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findSplitPanel().findOpenButton().toSelector())).resolves.toBe(true);
+          },
+          { pageName: 'with-split-panel', theme, mobile }
+        )
       );
 
       test(
-        'No split panel trigger tooltip showing for pointer interactions',
-        setupTest({ size, theme, splitPanelPosition }, async page => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-          await page.buttonDownOnElement(wrapper.findSplitPanelOpenButton().toSelector());
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        })
+        'tools panel focus toggles between open and close buttons',
+        setupTest(
+          async page => {
+            await page.click(wrapper.findToolsToggle().toSelector());
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
+          },
+          { pageName: 'with-split-panel', theme, mobile }
+        )
+      );
+
+      //TODO create separate split panel test for 'visual-refresh-toolbar' theme
+      testIf(theme !== 'visual-refresh-toolbar')(
+        'navigation panel focus toggles between open and close buttons',
+        setupTest(
+          async page => {
+            // panel is closed by default on mobile
+            if (mobile) {
+              await page.click(wrapper.findNavigationToggle().toSelector());
+            }
+            await page.click(wrapper.findNavigationClose().toSelector());
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findNavigationClose().toSelector())).resolves.toBe(true);
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findNavigationToggle().toSelector())).resolves.toBe(true);
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findNavigationClose().toSelector())).resolves.toBe(true);
+          },
+          { pageName: 'with-split-panel', theme, mobile }
+        )
+      );
+
+      //todo create test specifically for mobile and visual-refresh-toolbar
+      testIf(theme !== 'visual-refresh-toolbar')(
+        'focuses tools panel closed button when it is opened using keyboard and caused split panel to change position',
+        setupTest(
+          async page => {
+            await page.setWindowSize({ width: 1000, height: 800 });
+            await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
+            await page.keys(['Tab', 'Tab', 'Tab', 'Tab', 'Enter']);
+            await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
+          },
+          { pageName: 'with-split-panel', theme, mobile, splitPanelPosition: 'side' }
+        )
       );
 
       test(
-        'No split panel trigger tooltip showing for keyboard (tab) interactions',
-        setupTest({ size, theme, splitPanelPosition }, async page => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-          //set focus by clicking open and close
-          await page.click(wrapper.findSplitPanelOpenButton().toSelector());
-          await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
-          //move focus away
-          await page.keys(['Shift', 'Tab', 'Null']);
-
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-          await page.keys('Tab');
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        })
+        'focuses split panel preferences button when its position changes from bottom to side',
+        setupTest(
+          async page => {
+            await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
+            await page.click(wrapper.findSplitPanel().findPreferencesButton().toSelector());
+            await page.keys(['Tab', 'Right', 'Tab', 'Tab', 'Enter']);
+            await expect(page.isFocused(wrapper.findSplitPanel().findPreferencesButton().toSelector())).resolves.toBe(
+              true
+            );
+          },
+          { pageName: 'with-split-panel', theme, mobile, splitPanelPosition: 'bottom' }
+        )
       );
-    });
-  });
-});
 
-describe('visual-refresh-toolbar', () => {
-  const theme = 'visual-refresh-toolbar';
-  const mobileDrawerTriggerIds = drawerIds.slice(
-    0,
-    VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT + (theme === 'visual-refresh-toolbar' ? 1 : 0)
+      test(
+        'focuses split panel preferences button when its position changes from side to bottom',
+        setupTest(
+          async page => {
+            await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
+            await expect(page.isExisting(wrapper.findSplitPanel().toSelector())).resolves.toBeTruthy();
+            await page.keys('Escape'); //escape tooltip from still hovering over open trigger button
+            await page.click(wrapper.findSplitPanel().findPreferencesButton().toSelector());
+            await page.keys(['Tab', 'Left', 'Tab', 'Tab', 'Enter']);
+            await expect(page.isFocused(wrapper.findSplitPanel().findPreferencesButton().toSelector())).resolves.toBe(
+              true
+            );
+          },
+          { pageName: 'with-split-panel', theme, mobile, splitPanelPosition: 'side' }
+        )
+      );
+
+      test(
+        'does not focus split panel when opening programatically',
+        setupTest(
+          async page => {
+            const selection = wrapper.findContentRegion().findTable().findRowSelectionArea(1).toSelector();
+            await page.click(selection);
+            await expect(page.isFocused(selection + ' input')).resolves.toBe(true);
+          },
+          {
+            pageName: 'with-table-and-split-panel',
+            theme,
+            mobile,
+          }
+        )
+      );
+
+      describe('focus interaction with info links', () => {
+        test(
+          'moves focus to close button when panel is opened from info link',
+          setupTest(
+            async page => {
+              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
+              await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
+            },
+            { pageName: 'with-fixed-header-footer', theme, mobile }
+          )
+        );
+
+        testIf(!mobile)(
+          'moves focus to close button when panel content is changed using second info link',
+          setupTest(
+            async page => {
+              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
+              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector());
+              await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
+            },
+            { pageName: 'with-fixed-header-footer', theme, mobile }
+          )
+        );
+
+        testIf(!mobile)(
+          'moves focus back to last opened info link when panel is closed',
+          setupTest(
+            async page => {
+              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
+              const infoLink = wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector();
+              await page.click(infoLink);
+              await page.click(wrapper.findToolsClose().toSelector());
+              await expect(page.isFocused(infoLink)).resolves.toBe(true);
+            },
+            { pageName: 'with-fixed-header-footer', theme, mobile }
+          )
+        );
+
+        testIf(!mobile)(
+          'does not move focus back to last opened info link when panel has lost focus - instead focuses tools toggle',
+          setupTest(
+            async page => {
+              const infoLink = wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector();
+              await page.click(infoLink);
+              await page.click(wrapper.findContentRegion().findContainer().toSelector());
+              await page.click(wrapper.findToolsClose().toSelector());
+              await expect(page.isFocused(infoLink)).resolves.toBe(false);
+              await expect(page.isFocused(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
+            },
+            { pageName: 'with-fixed-header-footer', theme, mobile }
+          )
+        );
+      });
+
+      test(
+        'drawers focus toggles between open and close buttons',
+        setupTest(
+          async page => {
+            //Altermatomg between triggers because test-1 trigger hidden in overflow menu on mobile,
+            //security has resize button on desktop
+            const triggerSelector = wrapper.findDrawerTriggerById(mobile ? 'security' : 'test-1').toSelector();
+            await page.click(triggerSelector);
+            await page.keys('Enter');
+            await expect(page.isFocused(triggerSelector)).resolves.toBe(true);
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findActiveDrawerCloseButton().toSelector())).resolves.toBe(true);
+            await page.keys('Enter');
+            await expect(page.isFocused(triggerSelector)).resolves.toBe(true);
+          },
+          { pageName: 'with-drawers', theme, mobile }
+        )
+      );
+
+      describe('drawer focus interaction with tools buttons', () => {
+        //todo resolve focus issue returning to previously focued element on mobile for drawer open button
+        testIf(theme !== 'visual-refresh-toolbar')(
+          'moves focus to close button when panel is opened from button',
+          setupTest(
+            async page => {
+              await page.click(
+                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
+              );
+              await expect(page.isFocused(wrapper.findActiveDrawerCloseButton().toSelector())).resolves.toBe(true);
+              await page.keys('Enter');
+              await expect(
+                page.isFocused(
+                  wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
+                )
+              ).resolves.toBe(true);
+            },
+            { pageName: 'with-drawers', theme, mobile }
+          )
+        );
+
+        //tests not relevant for mobile, as panel overlays content
+        testIf(!mobile)(
+          'moves focus to close button when panel content is changed using second button',
+          setupTest(
+            async page => {
+              await page.click(
+                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button"]').toSelector()
+              );
+              await page.click(
+                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
+              );
+              await page.keys('Tab');
+              await expect(page.isFocused(wrapper.findActiveDrawerCloseButton().toSelector())).resolves.toBe(true);
+            },
+            { pageName: 'with-drawers', theme, mobile }
+          )
+        );
+
+        testIf(!mobile)(
+          'moves focus back to last opened button when panel is closed',
+          setupTest(
+            async page => {
+              await page.click(
+                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button"]').toSelector()
+              );
+              await page.click(
+                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
+              );
+
+              await page.click(wrapper.findActiveDrawerCloseButton().toSelector());
+              await expect(
+                page.isFocused(
+                  wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
+                )
+              ).resolves.toBe(true);
+            },
+            { pageName: 'with-drawers', theme, mobile }
+          )
+        );
+
+        testIf(!mobile && theme !== 'visual-refresh-toolbar')(
+          'does not move focus back to last opened button when panel has lost focus - instead focuses drawer trigger',
+          setupTest(
+            async page => {
+              const infoLink = wrapper
+                .findContentRegion()
+                .findButton('[data-testid="open-drawer-button-2"]')
+                .toSelector();
+              await page.click(infoLink);
+              await page.click(wrapper.findContentRegion().findContainer().toSelector());
+              await page.click(wrapper.findActiveDrawerCloseButton().toSelector());
+              await expect(page.isFocused(infoLink)).resolves.toBe(false);
+              await expect(page.isFocused(wrapper.findDrawerTriggerById('pro-help').toSelector())).resolves.toBe(true);
+            },
+            { pageName: 'with-drawers', theme, mobile }
+          )
+        );
+      });
+    })
   );
-  const appliedThemeStyles = toolbarStyles; //use visualRefreshStyles when theme === 'visual-refresh'
-
-  describe.each(['desktop', 'mobile'] as const)('%s', size => {
-    const drawersTriggerContainerClassKey = `drawers-${size === 'desktop' ? 'desktop' : 'mobile'}-triggers-container`;
-    const drawerIdsToTest = size === 'mobile' ? mobileDrawerTriggerIds : drawerIds; //toolbarDrawerIds;
-    const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
-    const secondDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[1]}"]`;
-    const splitPanelTriggerSelector = `button[data-testid="awsui-app-layout-trigger-slide-panel"]`;
-
-    test(
-      'Shows tooltip correctly on drawer trigger for mouse interactions drawer triggers',
-      setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
-        await page.hoverElement(firstDrawerTriggerSelector);
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-        await page.hoverElement(wrapper.findNavigationToggle().toSelector());
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-      })
-    );
-
-    test(
-      'Shows tooltip correctly on drawer trigger for mouse interactions during drawer actions',
-      setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
-        await page.click(firstDrawerTriggerSelector);
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        await page.click(`button[aria-label="Security close button"`);
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        await page.hoverElement(firstDrawerTriggerSelector);
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-      })
-    );
-
-    test(
-      'Removes tooltip from drawer trigger on escape key press after showing from mouse hover',
-      setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
-        await page.hoverElement(firstDrawerTriggerSelector);
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-        await page.keys(['Escape']);
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-      })
-    );
-
-    test(
-      'Shows tooltip correctly on drawer trigger for pointer interactions',
-      setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
-        await page.pointerDown(firstDrawerTriggerSelector);
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-        await page.pointerUp();
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-      })
-    );
-
-    test(
-      'Removes tooltip from drawer trigger on escape key press after showing from pointer down',
-      setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
-        await page.buttonDownOnElement(`button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`);
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-        await page.keys('Escape');
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-      })
-    );
-
-    test(
-      'Shows tooltip correctly on drawer trigger for keyboard (tab) interactions',
-      setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
-        await page.click(firstDrawerTriggerSelector);
-        //close drawer via keys
-        await page.keys(size === 'desktop' ? ['Tab', 'Enter'] : ['Enter']); //first focus element is resize in desktop
-        await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        //navigate away from drawer triggers
-        if (theme === 'visual-refresh-toolbar') {
-          await page.keys(['Shift', 'Tab', 'Null']); // to split panel drawer
-        }
-        await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        //navigate back to drawer trigger
-        await page.keys(theme === 'visual-refresh-toolbar' ? ['Tab', 'Tab'] : ['Tab']);
-        await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-        await page.keys(['Shift', 'Tab', 'Null']);
-        if (theme === 'visual-refresh-toolbar') {
-          await page.keys(['Shift', 'Tab', 'Null']); // one more time to least breadcrumb - be aware if breadcrumb has tooltip
-        }
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-      })
-    );
-
-    test(
-      'Removes tooltip from drawer trigger on escape key press after showing from keyboard event',
-      setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
-        await page.click(firstDrawerTriggerSelector);
-        //close drawer via keys
-        await page.keys(size === 'desktop' ? ['Tab', 'Enter'] : ['Enter']); //focus element is resize in desktop
-
-        await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        //navigate away from drawer triggers
-        if (theme === 'visual-refresh-toolbar') {
-          await page.keys(['Shift', 'Tab', 'Null']); // to split panel drawer
-        }
-        await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        //navigate back to drawer trigger
-        await page.keys(theme === 'visual-refresh-toolbar' ? ['Tab', 'Tab'] : ['Tab']);
-        await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-        await page.keys('Escape');
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-      })
-    );
-
-    test(
-      'Shows tooltip correctly on drawer trigger for keyboard (tab) interactions after drawer actions',
-      setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
-        await page.click(firstDrawerTriggerSelector);
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        //close drawer via keys
-        await page.keys(size === 'desktop' ? ['Tab', 'Enter'] : ['Enter']); //first focus element is resize in desktop
-        await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        await page.keys(['Tab']);
-        await expect(page.isFocused(secondDrawerTriggerSelector)).resolves.toBeTruthy();
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-        await page.keys(['Shift', 'Tab', 'Null']);
-        await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-      })
-    );
-
-    describe.each(['bottom', 'side'] as const)('splitPanelPosition=%s', splitPanelPosition => {
-      test(
-        'Shows tooltip correctly on split panel trigger for mouse interactions',
-        setupTest({ theme, size, splitPanelPosition }, async page => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-          await expect(
-            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
-          ).resolves.toBeTruthy();
-          await page.hoverElement(splitPanelTriggerSelector);
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-          await page.hoverElement(wrapper.findNavigationToggle().toSelector());
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        })
-      );
-
-      test(
-        'Shows tooltip correctly on split panel trigger for mouse interactions during split-panel actions',
-        setupTest({ theme, size, splitPanelPosition }, async page => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-          await expect(
-            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
-          ).resolves.toBeTruthy();
-          await page.click(splitPanelTriggerSelector);
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-          await page.click(splitPanelTriggerSelector); //this could change witf focus fixes
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-          await page.hoverElement(firstDrawerTriggerSelector);
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-          await page.hoverElement(splitPanelTriggerSelector);
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-        })
-      );
-
-      test(
-        'Removes tooltip from split panel trigger on escape key press after showing from mouse hover',
-        setupTest({ theme, size, splitPanelPosition }, async page => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-          await expect(
-            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
-          ).resolves.toBeTruthy();
-          await page.hoverElement(splitPanelTriggerSelector);
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-          await page.keys(['Escape']);
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        })
-      );
-
-      test(
-        'Shows tooltip correctly for split panel trigger for keyboard (tab) interactions',
-        setupTest({ theme, size, splitPanelPosition }, async page => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-          await expect(
-            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
-          ).resolves.toBeTruthy();
-          await page.click(splitPanelTriggerSelector);
-
-          await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
-          //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
-          await page.keys(['Tab', 'Tab']);
-          await page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector());
-          await page.keys('Enter');
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-          //navigate away from slide panel
-          await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
-          //navigate back to drawer trigger
-          await page.keys(['Tab']);
-          await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-          await page.keys(['Shift', 'Tab', 'Null']);
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        })
-      );
-
-      test(
-        'Removes tooltip from split panel trigger on escape key press after showing from keyboard event',
-        setupTest({ theme, size, splitPanelPosition }, async page => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-          await expect(
-            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
-          ).resolves.toBeTruthy();
-          await page.click(splitPanelTriggerSelector);
-          await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
-          //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-          await page.click(splitPanelTriggerSelector);
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-          //navigate away from slide panel
-          await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-          //navigate back to drawer trigger
-          await page.keys(['Tab']);
-          await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-          await page.keys('Escape');
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        })
-      );
-    });
-  });
 });

--- a/src/app-layout/__integ__/app-layout-toolbar-tooltips.test.ts
+++ b/src/app-layout/__integ__/app-layout-toolbar-tooltips.test.ts
@@ -12,8 +12,6 @@ import tooltipStyles from '../../../lib/components/internal/components/tooltip/s
 
 const wrapper = createWrapper().findAppLayout();
 
-const testIf = (condition: boolean) => (condition ? test : test.skip);
-
 interface SetupTestOptions {
   splitPanelPosition?: string;
   size?: 'desktop' | 'mobile';
@@ -65,7 +63,7 @@ class AppLayoutDrawersPage extends BasePageObject {
 }
 
 const setupTest = (
-  { size = 'desktop', theme = 'visual-refresh' }: SetupTestOptions,
+  { size = 'desktop', theme = 'visual-refresh', splitPanelPosition = '' }: SetupTestOptions,
   testFn: (page: AppLayoutDrawersPage) => Promise<void>
 ) =>
   useBrowser(size === 'desktop' ? viewports.desktop : viewports.mobile, async browser => {
@@ -73,6 +71,7 @@ const setupTest = (
     const params = new URLSearchParams({
       visualRefresh: theme === 'classic' ? 'false' : 'true',
       appLayoutWidget: theme === 'visual-refresh' ? 'false' : 'true',
+      ...(splitPanelPosition ? { splitPanelPosition } : {}),
     }).toString();
     await browser.url(`#/light/app-layout/with-drawers?${params}`);
     await page.waitForVisible(wrapper.findContentRegion().toSelector());
@@ -85,7 +84,7 @@ describe.each(['visual-refresh', 'classic'] as const)('%s', theme => {
     const drawerIdsToTest = [...(size === 'mobile' ? mobileDrawerTriggerIds : drawerIds)];
 
     test(
-      'No tooltip showing for mouse interactions',
+      'No drawer trigger tooltip showing for mouse interactions',
       setupTest({ size, theme }, async page => {
         await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
         const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
@@ -95,7 +94,7 @@ describe.each(['visual-refresh', 'classic'] as const)('%s', theme => {
     );
 
     test(
-      'No tooltip showing for pointer interactions',
+      'No drawer trigger tooltip showing for pointer interactions',
       setupTest({ size, theme }, async page => {
         await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
         const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
@@ -105,7 +104,7 @@ describe.each(['visual-refresh', 'classic'] as const)('%s', theme => {
     );
 
     test(
-      'No tooltip showing for keyboard (tab) interactions',
+      'No drawer trigger tooltip showing for keyboard (tab) interactions',
       setupTest({ size, theme }, async page => {
         await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
         //set focus by clicking open and close
@@ -121,6 +120,42 @@ describe.each(['visual-refresh', 'classic'] as const)('%s', theme => {
         await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
       })
     );
+
+    describe.each(['bottom', 'side'] as const)('splitPanelPosition=%s', splitPanelPosition => {
+      test(
+        'No split panel trigger tooltip showing for mouse interactions',
+        setupTest({ size, theme, splitPanelPosition }, async page => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await page.hoverElement(wrapper.findSplitPanelOpenButton().toSelector());
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        })
+      );
+
+      test(
+        'No split panel trigger tooltip showing for pointer interactions',
+        setupTest({ size, theme, splitPanelPosition }, async page => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await page.buttonDownOnElement(wrapper.findSplitPanelOpenButton().toSelector());
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        })
+      );
+
+      test(
+        'No split panel trigger tooltip showing for keyboard (tab) interactions',
+        setupTest({ size, theme, splitPanelPosition }, async page => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          //set focus by clicking open and close
+          await page.click(wrapper.findSplitPanelOpenButton().toSelector());
+          await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
+          //move focus away
+          await page.keys(['Shift', 'Tab', 'Null']);
+
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await page.keys('Tab');
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        })
+      );
+    });
   });
 });
 
@@ -275,91 +310,103 @@ describe('visual-refresh-toolbar', () => {
       })
     );
 
-    test(
-      'Shows tooltip correctly on split panel trigger for mouse interactions',
-      setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
-        await page.hoverElement(splitPanelTriggerSelector);
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-        await page.hoverElement(wrapper.findNavigationToggle().toSelector());
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-      })
-    );
+    describe.each(['bottom', 'side'] as const)('splitPanelPosition=%s', splitPanelPosition => {
+      test(
+        'Shows tooltip correctly on split panel trigger for mouse interactions',
+        setupTest({ theme, size, splitPanelPosition }, async page => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(
+            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
+          ).resolves.toBeTruthy();
+          await page.hoverElement(splitPanelTriggerSelector);
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await page.hoverElement(wrapper.findNavigationToggle().toSelector());
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        })
+      );
 
-    test(
-      'Shows tooltip correctly on split panel trigger for mouse interactions during split-panel actions',
-      setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
-        await page.click(splitPanelTriggerSelector);
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        await page.click(splitPanelTriggerSelector); //this could change witf focus fixes
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        await page.hoverElement(firstDrawerTriggerSelector);
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-        await page.hoverElement(splitPanelTriggerSelector);
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-      })
-    );
+      test(
+        'Shows tooltip correctly on split panel trigger for mouse interactions during split-panel actions',
+        setupTest({ theme, size, splitPanelPosition }, async page => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(
+            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
+          ).resolves.toBeTruthy();
+          await page.click(splitPanelTriggerSelector);
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await page.click(splitPanelTriggerSelector); //this could change witf focus fixes
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await page.hoverElement(firstDrawerTriggerSelector);
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await page.hoverElement(splitPanelTriggerSelector);
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+        })
+      );
 
-    test(
-      'Removes tooltip from split panel trigger on escape key press after showing from mouse hover',
-      setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
-        await page.hoverElement(splitPanelTriggerSelector);
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-        await page.keys(['Escape']);
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-      })
-    );
+      test(
+        'Removes tooltip from split panel trigger on escape key press after showing from mouse hover',
+        setupTest({ theme, size, splitPanelPosition }, async page => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(
+            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
+          ).resolves.toBeTruthy();
+          await page.hoverElement(splitPanelTriggerSelector);
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await page.keys(['Escape']);
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        })
+      );
 
-    testIf(theme === 'visual-refresh-toolbar')(
-      'Shows tooltip correctly for split panel trigger for keyboard (tab) interactions',
-      setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
-        await page.click(splitPanelTriggerSelector);
+      test(
+        'Shows tooltip correctly for split panel trigger for keyboard (tab) interactions',
+        setupTest({ theme, size, splitPanelPosition }, async page => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(
+            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
+          ).resolves.toBeTruthy();
+          await page.click(splitPanelTriggerSelector);
 
-        await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
-        //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
-        await page.keys(['Tab', 'Tab']);
-        await page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector());
-        await page.keys('Enter');
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        //navigate away from slide panel
-        await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
-        //navigate back to drawer trigger
-        await page.keys(['Tab']);
-        await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-        await page.keys(['Shift', 'Tab', 'Null']);
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-      })
-    );
+          await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
+          //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
+          await page.keys(['Tab', 'Tab']);
+          await page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector());
+          await page.keys('Enter');
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          //navigate away from slide panel
+          await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
+          //navigate back to drawer trigger
+          await page.keys(['Tab']);
+          await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await page.keys(['Shift', 'Tab', 'Null']);
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        })
+      );
 
-    testIf(theme === 'visual-refresh-toolbar')(
-      'Removes tooltip from split panel trigger on escape key press after showing from keyboard event',
-      setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
-        await page.click(splitPanelTriggerSelector);
-        await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
-        //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        await page.click(splitPanelTriggerSelector);
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        //navigate away from slide panel
-        await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        //navigate back to drawer trigger
-        await page.keys(['Tab']);
-        await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
-        await page.keys('Escape');
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-      })
-    );
+      test(
+        'Removes tooltip from split panel trigger on escape key press after showing from keyboard event',
+        setupTest({ theme, size, splitPanelPosition }, async page => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(
+            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
+          ).resolves.toBeTruthy();
+          await page.click(splitPanelTriggerSelector);
+          await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
+          //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await page.click(splitPanelTriggerSelector);
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          //navigate away from slide panel
+          await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          //navigate back to drawer trigger
+          await page.keys(['Tab']);
+          await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await page.keys('Escape');
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        })
+      );
+    });
   });
 });

--- a/src/app-layout/__integ__/app-layout-toolbar-tooltips.test.ts
+++ b/src/app-layout/__integ__/app-layout-toolbar-tooltips.test.ts
@@ -334,7 +334,7 @@ describe('visual-refresh-toolbar', () => {
           ).resolves.toBeTruthy();
           await page.click(splitPanelTriggerSelector);
           await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-          await page.click(splitPanelTriggerSelector); //this could change with focus fixes
+          await page.click(splitPanelTriggerSelector); //this could change witf focus fixes
           await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
           await page.hoverElement(firstDrawerTriggerSelector);
           await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
@@ -369,7 +369,7 @@ describe('visual-refresh-toolbar', () => {
           await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
           //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
           await page.keys(['Tab', 'Tab']);
-          await expect(page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector())).resolves.toBeTruthy();
+          await page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector());
           await page.keys('Enter');
           await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
           //navigate away from slide panel

--- a/src/app-layout/__integ__/app-layout-toolbar-tooltips.test.ts
+++ b/src/app-layout/__integ__/app-layout-toolbar-tooltips.test.ts
@@ -237,6 +237,7 @@ describe('visual-refresh-toolbar', () => {
         await page.click(firstDrawerTriggerSelector);
         //close drawer via keys
         await page.keys(size === 'desktop' ? ['Tab', 'Enter'] : ['Enter']); //focus element is resize in desktop
+
         await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
         await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
         //navigate away from drawer triggers
@@ -274,7 +275,7 @@ describe('visual-refresh-toolbar', () => {
       })
     );
 
-    testIf(theme === 'visual-refresh-toolbar')(
+    test(
       'Shows tooltip correctly on split panel trigger for mouse interactions',
       setupTest({ theme, size }, async page => {
         await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
@@ -286,7 +287,6 @@ describe('visual-refresh-toolbar', () => {
       })
     );
 
-    //vr-toolbar-only
     test(
       'Shows tooltip correctly on split panel trigger for mouse interactions during split-panel actions',
       setupTest({ theme, size }, async page => {
@@ -303,7 +303,6 @@ describe('visual-refresh-toolbar', () => {
       })
     );
 
-    //vr-toolbar-only
     test(
       'Removes tooltip from split panel trigger on escape key press after showing from mouse hover',
       setupTest({ theme, size }, async page => {
@@ -316,20 +315,21 @@ describe('visual-refresh-toolbar', () => {
       })
     );
 
-    //vr-toolbar-only
-    test(
+    testIf(theme === 'visual-refresh-toolbar')(
       'Shows tooltip correctly for split panel trigger for keyboard (tab) interactions',
       setupTest({ theme, size }, async page => {
         await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
         await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
         await page.click(splitPanelTriggerSelector);
-        await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-        await page.click(splitPanelTriggerSelector);
+
+        await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
+        //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
+        await page.keys(['Tab', 'Tab']);
+        await page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector());
+        await page.keys('Enter');
         await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
         //navigate away from slide panel
         await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
         //navigate back to drawer trigger
         await page.keys(['Tab']);
         await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
@@ -339,14 +339,14 @@ describe('visual-refresh-toolbar', () => {
       })
     );
 
-    //vr-toolbar-only
-    test(
+    testIf(theme === 'visual-refresh-toolbar')(
       'Removes tooltip from split panel trigger on escape key press after showing from keyboard event',
       setupTest({ theme, size }, async page => {
         await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
         await expect(page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)).resolves.toBeTruthy();
         await page.click(splitPanelTriggerSelector);
-        await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
+        await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
+        //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
         await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
         await page.click(splitPanelTriggerSelector);
         await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);

--- a/src/app-layout/__integ__/app-layout-toolbar-tooltips.test.ts
+++ b/src/app-layout/__integ__/app-layout-toolbar-tooltips.test.ts
@@ -334,7 +334,7 @@ describe('visual-refresh-toolbar', () => {
           ).resolves.toBeTruthy();
           await page.click(splitPanelTriggerSelector);
           await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
-          await page.click(splitPanelTriggerSelector); //this could change witf focus fixes
+          await page.click(splitPanelTriggerSelector); //this could change with focus fixes
           await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
           await page.hoverElement(firstDrawerTriggerSelector);
           await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
@@ -369,7 +369,7 @@ describe('visual-refresh-toolbar', () => {
           await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
           //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
           await page.keys(['Tab', 'Tab']);
-          await page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector());
+          await expect(page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector())).resolves.toBeTruthy();
           await page.keys('Enter');
           await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
           //navigate away from slide panel

--- a/src/app-layout/__integ__/constants.ts
+++ b/src/app-layout/__integ__/constants.ts
@@ -4,3 +4,6 @@ export const viewports = {
   desktop: { width: 1200, height: 800 },
   mobile: { width: 400, height: 800 },
 };
+
+//must match the number in  '../../../lib/components/app-layout/visual-refresh/drawers';
+export const VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT = 2;

--- a/src/app-layout/__integ__/constants.ts
+++ b/src/app-layout/__integ__/constants.ts
@@ -4,6 +4,3 @@ export const viewports = {
   desktop: { width: 1200, height: 800 },
   mobile: { width: 400, height: 800 },
 };
-
-//must match the number in  '../../../lib/components/app-layout/visual-refresh/drawers';
-export const VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT = 2;

--- a/src/app-layout/__integ__/constants.ts
+++ b/src/app-layout/__integ__/constants.ts
@@ -4,3 +4,6 @@ export const viewports = {
   desktop: { width: 1200, height: 800 },
   mobile: { width: 400, height: 800 },
 };
+
+//must match the number in  '../../../lib/components/app-layout/visual-refresh/drawers';
+export const visibleMobileToolbarTriggersLimit = 2;

--- a/src/app-layout/__integ__/constants.ts
+++ b/src/app-layout/__integ__/constants.ts
@@ -6,4 +6,4 @@ export const viewports = {
 };
 
 //must match the number in  '../../../lib/components/app-layout/visual-refresh/drawers';
-export const visibleMobileToolbarTriggersLimit = 2;
+export const VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT = 2;

--- a/src/app-layout/__integ__/global-breadcrumbs.test.ts
+++ b/src/app-layout/__integ__/global-breadcrumbs.test.ts
@@ -32,8 +32,8 @@ function setupTest({ url }: { url: string }, testFn: (page: GlobalBreadcrumbsPag
   });
 }
 
-describe.each(['classic', 'visual-refresh'])('%s', theme => {
-  const visualRefresh = theme === 'visual-refresh' ? 'true' : 'false';
+describe.each(['classic', 'refresh'])('%s', theme => {
+  const visualRefresh = theme === 'refresh' ? 'true' : 'false';
   test(
     'does not work in this design',
     setupTest(
@@ -68,7 +68,7 @@ describe('classic', () => {
   );
 });
 
-describe('visual-refresh-toolbar', () => {
+describe('refresh-toolbar', () => {
   test(
     'deduplicates breadcrumbs',
     setupTest({ url: `#/light/app-layout/global-breadcrumbs/?visualRefresh=true&appLayoutWidget=true` }, async page => {

--- a/src/app-layout/__integ__/runtime-drawers-controllability.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers-controllability.test.ts
@@ -9,7 +9,7 @@ const wrapper = createWrapper().findAppLayout();
 
 const testIf = (condition: boolean) => (condition ? test : test.skip);
 
-describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)('%s', theme => {
+describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme => {
   for (const pageName of ['runtime-drawers', 'runtime-drawers-imperative']) {
     describe(`page=${pageName}`, () => {
       function setupTest(testFn: (page: BasePageObject) => Promise<void>) {
@@ -20,8 +20,8 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
             `#/light/app-layout/${pageName}?${new URLSearchParams({
               hasDrawers: 'false',
               hasTools: 'true',
-              visualRefresh: `${theme.startsWith('visual-refresh')}`,
-              appLayoutToolbar: theme === 'visual-refresh-toolbar' ? 'true' : 'false',
+              visualRefresh: `${theme !== 'classic'}`,
+              appLayoutToolbar: `${theme === 'refresh-toolbar'}`,
             }).toString()}`
           );
           await page.waitForVisible(wrapper.findDrawerTriggerById('security').toSelector(), true);
@@ -47,7 +47,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
         })
       );
 
-      testIf(!(theme === 'visual-refresh-toolbar' && pageName === 'runtime-drawers-imperative'))(
+      testIf(!(theme === 'refresh-toolbar' && pageName === 'runtime-drawers-imperative'))(
         'should allow switching to a drawer after clicking an info link',
         setupTest(async page => {
           await page.click('[data-testid="info-link-header"]');
@@ -61,7 +61,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
         })
       );
 
-      testIf(!(theme === 'visual-refresh-toolbar' && pageName === 'runtime-drawers-imperative'))(
+      testIf(!(theme === 'refresh-toolbar' && pageName === 'runtime-drawers-imperative'))(
         'should open and close tools via controlled mode',
         setupTest(async page => {
           const toolsContentSelector = wrapper.findTools().getElement();
@@ -76,7 +76,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
         })
       );
 
-      testIf(!(theme === 'visual-refresh-toolbar' && pageName === 'runtime-drawers-imperative'))(
+      testIf(!(theme === 'refresh-toolbar' && pageName === 'runtime-drawers-imperative'))(
         'should switch help panel content and close the panel afterwards',
         setupTest(async page => {
           await page.click('[data-testid="info-link-header"]');
@@ -93,7 +93,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
         })
       );
 
-      testIf(!(theme === 'visual-refresh-toolbar' && pageName === 'runtime-drawers-imperative'))(
+      testIf(!(theme === 'refresh-toolbar' && pageName === 'runtime-drawers-imperative'))(
         'should move focus to previous focused element after closing tools',
         setupTest(async page => {
           await page.click('[data-testid="info-link-header"]');

--- a/src/app-layout/__integ__/runtime-drawers.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers.test.ts
@@ -11,7 +11,7 @@ const findDrawerById = (wrapper: AppLayoutWrapper, id: string) => {
   return wrapper.find(`[data-testid="awsui-app-layout-drawer-${id}"]`);
 };
 
-describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)('%s', theme => {
+describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme => {
   function setupTest(testFn: (page: BasePageObject) => Promise<void>) {
     return useBrowser(async browser => {
       const page = new BasePageObject(browser);
@@ -21,8 +21,8 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
           hasDrawers: 'false',
           hasTools: 'true',
           splitPanelPosition: 'side',
-          visualRefresh: `${theme.startsWith('visual-refresh')}`,
-          appLayoutToolbar: theme === 'visual-refresh-toolbar' ? 'true' : 'false',
+          visualRefresh: `${theme !== 'classic'}`,
+          appLayoutToolbar: `${theme === 'refresh-toolbar'}`,
         }).toString()}`
       );
       await page.waitForVisible(wrapper.findDrawerTriggerById('security').toSelector(), true);

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-drawer-trigger-tooltip.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-drawer-trigger-tooltip.test.ts
@@ -1,324 +1,165 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
-import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
-
-import createWrapper from '../../../../lib/components/test-utils/selectors';
-import { viewports } from '../constants';
-
-const testIf = (condition: boolean) => (condition ? test : test.skip);
+import createWrapper from '../../../../lib/components/test-utils/selectors/index';
+import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
+import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../constants';
+import { setupTest } from '../utils';
 
 const wrapper = createWrapper().findAppLayout();
+const drawerIds = Object.values(drawerIdObj);
 
-interface SetupTestObj {
-  theme: string;
-  pageName: string;
-  splitPanelPosition?: string;
-  mobile: boolean;
-}
-
-function setupTest(
-  testFn: (page: BasePageObject) => Promise<void>,
-  { theme, pageName = 'with-split-panel', splitPanelPosition = '', mobile = false }: SetupTestObj
-) {
-  return useBrowser(async browser => {
-    const page = new BasePageObject(browser);
-    const params = new URLSearchParams({
-      visualRefresh: `${theme.startsWith('visual-refresh')}`,
-      appLayoutWidget: `${theme === 'visual-refresh-toolbar'}`,
-      ...(splitPanelPosition
-        ? {
-            splitPanelPosition,
-          }
-        : {}),
-    });
-    await page.setWindowSize(mobile ? viewports.mobile : viewports.desktop);
-    await browser.url(`#/light/app-layout/${pageName}?${params.toString()}`);
-    await page.waitForVisible(wrapper.findContentRegion().toSelector());
-    await testFn(page);
-  });
-}
-
-describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)('%s', theme => {
-  [true, false].forEach(mobile =>
-    describe(`mobile=${mobile}`, () => {
-      test(
-        'should not focus panels on page load',
-        setupTest(
-          async page => {
-            await expect(page.isFocused('body')).resolves.toBe(true);
-          },
-          { pageName: 'with-split-panel', theme, mobile }
-        )
-      );
-
-      //TODO create separate split panel test for appLayoutWidget is true
-      testIf(theme !== 'visual-refresh-toolbar')(
-        'split panel focus moves to slider on open and open button on close',
-        setupTest(
-          async page => {
-            await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
-            await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
-            await page.keys(['Tab', 'Tab']);
-            await expect(page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector())).resolves.toBe(true);
-            await page.keys('Enter');
-            await expect(page.isFocused(wrapper.findSplitPanel().findOpenButton().toSelector())).resolves.toBe(true);
-          },
-          { pageName: 'with-split-panel', theme, mobile }
-        )
-      );
-
-      test(
-        'tools panel focus toggles between open and close buttons',
-        setupTest(
-          async page => {
-            await page.click(wrapper.findToolsToggle().toSelector());
-            await page.keys('Enter');
-            await expect(page.isFocused(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
-            await page.keys('Enter');
-            await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
-            await page.keys('Enter');
-            await expect(page.isFocused(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
-          },
-          { pageName: 'with-split-panel', theme, mobile }
-        )
-      );
-
-      //TODO create separate split panel test for 'visual-refresh-toolbar' theme
-      testIf(theme !== 'visual-refresh-toolbar')(
-        'navigation panel focus toggles between open and close buttons',
-        setupTest(
-          async page => {
-            // panel is closed by default on mobile
-            if (mobile) {
-              await page.click(wrapper.findNavigationToggle().toSelector());
-            }
-            await page.click(wrapper.findNavigationClose().toSelector());
-            await page.keys('Enter');
-            await expect(page.isFocused(wrapper.findNavigationClose().toSelector())).resolves.toBe(true);
-            await page.keys('Enter');
-            await expect(page.isFocused(wrapper.findNavigationToggle().toSelector())).resolves.toBe(true);
-            await page.keys('Enter');
-            await expect(page.isFocused(wrapper.findNavigationClose().toSelector())).resolves.toBe(true);
-          },
-          { pageName: 'with-split-panel', theme, mobile }
-        )
-      );
-
-      //todo create test specifically for mobile and visual-refresh-toolbar
-      testIf(theme !== 'visual-refresh-toolbar')(
-        'focuses tools panel closed button when it is opened using keyboard and caused split panel to change position',
-        setupTest(
-          async page => {
-            await page.setWindowSize({ width: 1000, height: 800 });
-            await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
-            await page.keys(['Tab', 'Tab', 'Tab', 'Tab', 'Enter']);
-            await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
-          },
-          { pageName: 'with-split-panel', theme, mobile, splitPanelPosition: 'side' }
-        )
-      );
-
-      test(
-        'focuses split panel preferences button when its position changes from bottom to side',
-        setupTest(
-          async page => {
-            await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
-            await page.click(wrapper.findSplitPanel().findPreferencesButton().toSelector());
-            await page.keys(['Tab', 'Right', 'Tab', 'Tab', 'Enter']);
-            await expect(page.isFocused(wrapper.findSplitPanel().findPreferencesButton().toSelector())).resolves.toBe(
-              true
-            );
-          },
-          { pageName: 'with-split-panel', theme, mobile, splitPanelPosition: 'bottom' }
-        )
-      );
-
-      test(
-        'focuses split panel preferences button when its position changes from side to bottom',
-        setupTest(
-          async page => {
-            await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
-            await expect(page.isExisting(wrapper.findSplitPanel().toSelector())).resolves.toBeTruthy();
-            await page.keys('Escape'); //escape tooltip from still hovering over open trigger button
-            await page.click(wrapper.findSplitPanel().findPreferencesButton().toSelector());
-            await page.keys(['Tab', 'Left', 'Tab', 'Tab', 'Enter']);
-            await expect(page.isFocused(wrapper.findSplitPanel().findPreferencesButton().toSelector())).resolves.toBe(
-              true
-            );
-          },
-          { pageName: 'with-split-panel', theme, mobile, splitPanelPosition: 'side' }
-        )
-      );
-
-      test(
-        'does not focus split panel when opening programatically',
-        setupTest(
-          async page => {
-            const selection = wrapper.findContentRegion().findTable().findRowSelectionArea(1).toSelector();
-            await page.click(selection);
-            await expect(page.isFocused(selection + ' input')).resolves.toBe(true);
-          },
-          {
-            pageName: 'with-table-and-split-panel',
-            theme,
-            mobile,
-          }
-        )
-      );
-
-      describe('focus interaction with info links', () => {
-        test(
-          'moves focus to close button when panel is opened from info link',
-          setupTest(
-            async page => {
-              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
-              await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
-            },
-            { pageName: 'with-fixed-header-footer', theme, mobile }
-          )
-        );
-
-        testIf(!mobile)(
-          'moves focus to close button when panel content is changed using second info link',
-          setupTest(
-            async page => {
-              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
-              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector());
-              await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
-            },
-            { pageName: 'with-fixed-header-footer', theme, mobile }
-          )
-        );
-
-        testIf(!mobile)(
-          'moves focus back to last opened info link when panel is closed',
-          setupTest(
-            async page => {
-              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
-              const infoLink = wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector();
-              await page.click(infoLink);
-              await page.click(wrapper.findToolsClose().toSelector());
-              await expect(page.isFocused(infoLink)).resolves.toBe(true);
-            },
-            { pageName: 'with-fixed-header-footer', theme, mobile }
-          )
-        );
-
-        testIf(!mobile)(
-          'does not move focus back to last opened info link when panel has lost focus - instead focuses tools toggle',
-          setupTest(
-            async page => {
-              const infoLink = wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector();
-              await page.click(infoLink);
-              await page.click(wrapper.findContentRegion().findContainer().toSelector());
-              await page.click(wrapper.findToolsClose().toSelector());
-              await expect(page.isFocused(infoLink)).resolves.toBe(false);
-              await expect(page.isFocused(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
-            },
-            { pageName: 'with-fixed-header-footer', theme, mobile }
-          )
-        );
-      });
-
-      test(
-        'drawers focus toggles between open and close buttons',
-        setupTest(
-          async page => {
-            //Altermatomg between triggers because test-1 trigger hidden in overflow menu on mobile,
-            //security has resize button on desktop
-            const triggerSelector = wrapper.findDrawerTriggerById(mobile ? 'security' : 'test-1').toSelector();
-            await page.click(triggerSelector);
-            await page.keys('Enter');
-            await expect(page.isFocused(triggerSelector)).resolves.toBe(true);
-            await page.keys('Enter');
-            await expect(page.isFocused(wrapper.findActiveDrawerCloseButton().toSelector())).resolves.toBe(true);
-            await page.keys('Enter');
-            await expect(page.isFocused(triggerSelector)).resolves.toBe(true);
-          },
-          { pageName: 'with-drawers', theme, mobile }
-        )
-      );
-
-      describe('drawer focus interaction with tools buttons', () => {
-        //todo resolve focus issue returning to previously focued element on mobile for drawer open button
-        testIf(theme !== 'visual-refresh-toolbar')(
-          'moves focus to close button when panel is opened from button',
-          setupTest(
-            async page => {
-              await page.click(
-                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-              );
-              await expect(page.isFocused(wrapper.findActiveDrawerCloseButton().toSelector())).resolves.toBe(true);
-              await page.keys('Enter');
-              await expect(
-                page.isFocused(
-                  wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-                )
-              ).resolves.toBe(true);
-            },
-            { pageName: 'with-drawers', theme, mobile }
-          )
-        );
-
-        //tests not relevant for mobile, as panel overlays content
-        testIf(!mobile)(
-          'moves focus to close button when panel content is changed using second button',
-          setupTest(
-            async page => {
-              await page.click(
-                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button"]').toSelector()
-              );
-              await page.click(
-                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-              );
-              await page.keys('Tab');
-              await expect(page.isFocused(wrapper.findActiveDrawerCloseButton().toSelector())).resolves.toBe(true);
-            },
-            { pageName: 'with-drawers', theme, mobile }
-          )
-        );
-
-        testIf(!mobile)(
-          'moves focus back to last opened button when panel is closed',
-          setupTest(
-            async page => {
-              await page.click(
-                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button"]').toSelector()
-              );
-              await page.click(
-                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-              );
-
-              await page.click(wrapper.findActiveDrawerCloseButton().toSelector());
-              await expect(
-                page.isFocused(
-                  wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-                )
-              ).resolves.toBe(true);
-            },
-            { pageName: 'with-drawers', theme, mobile }
-          )
-        );
-
-        testIf(!mobile && theme !== 'visual-refresh-toolbar')(
-          'does not move focus back to last opened button when panel has lost focus - instead focuses drawer trigger',
-          setupTest(
-            async page => {
-              const infoLink = wrapper
-                .findContentRegion()
-                .findButton('[data-testid="open-drawer-button-2"]')
-                .toSelector();
-              await page.click(infoLink);
-              await page.click(wrapper.findContentRegion().findContainer().toSelector());
-              await page.click(wrapper.findActiveDrawerCloseButton().toSelector());
-              await expect(page.isFocused(infoLink)).resolves.toBe(false);
-              await expect(page.isFocused(wrapper.findDrawerTriggerById('pro-help').toSelector())).resolves.toBe(true);
-            },
-            { pageName: 'with-drawers', theme, mobile }
-          )
-        );
-      });
-    })
+describe('refresh-toolbar', () => {
+  //using a theme variable below that will be set when iterating over ['refresh-toolbar', 'refresh']
+  const theme = 'refresh-toolbar';
+  const mobileDrawerTriggerIds = drawerIds.slice(
+    0,
+    VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT + (theme === 'refresh-toolbar' ? 1 : 0)
   );
+
+  describe.each(['desktop', 'mobile'] as const)('%s', size => {
+    const drawerIdsToTest = size === 'mobile' ? mobileDrawerTriggerIds : drawerIds; //toolbarDrawerIds;
+    const firstDrawerTriggerSelector = wrapper.findDrawerTriggerById(drawerIdsToTest[0]).toSelector();
+    const expectedFirstDrawerTriggerTooltipText = 'Security'; //must match drawerItems[0].ariaLabels.drawer from /lib/dev-pages/pages/app-layout/utils/drawers
+    const secondDrawerTriggerSelector = wrapper.findDrawerTriggerById(drawerIdsToTest[1]).toSelector();
+    const expectedSecondDrawerTriggerTooltipText = 'Pro help'; //must match drawerItems[0].ariaLabels.drawer from /lib/dev-pages/pages/app-layout/utils/drawers
+    const triggerTooltipSelector = wrapper.findDrawerTriggerTooltip().toSelector();
+
+    test(
+      'Shows tooltip correctly on drawer trigger for mouse interactions drawer triggers',
+      setupTest({ theme, size }, async page => {
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await page.hoverElement(firstDrawerTriggerSelector);
+        await expect(page.getText(triggerTooltipSelector)).resolves.toBe(expectedFirstDrawerTriggerTooltipText);
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(1);
+        await page.hoverElement(wrapper.findNavigationToggle().toSelector());
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
+      })
+    );
+
+    test(
+      'Shows tooltip correctly on drawer trigger for mouse interactions during drawer actions',
+      setupTest({ theme, size }, async page => {
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await page.click(firstDrawerTriggerSelector);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
+        await page.click(wrapper.findActiveDrawerCloseButton().toSelector());
+        // await page.click(`button[aria-label="Security close button"`);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
+        await page.hoverElement(firstDrawerTriggerSelector);
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(1);
+        await expect(page.getText(triggerTooltipSelector)).resolves.toBe(expectedFirstDrawerTriggerTooltipText);
+      })
+    );
+
+    test(
+      'Removes tooltip from drawer trigger on escape key press after showing from mouse hover',
+      setupTest({ theme, size }, async page => {
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await page.hoverElement(firstDrawerTriggerSelector);
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(1);
+        await expect(page.getText(triggerTooltipSelector)).resolves.toBe(expectedFirstDrawerTriggerTooltipText);
+        await page.keys(['Escape']);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
+      })
+    );
+
+    test(
+      'Shows tooltip correctly on drawer trigger for pointer interactions',
+      setupTest({ theme, size }, async page => {
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await page.pointerDown(firstDrawerTriggerSelector);
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(1);
+        await expect(page.getText(triggerTooltipSelector)).resolves.toBe(expectedFirstDrawerTriggerTooltipText);
+        await page.pointerUp();
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
+      })
+    );
+
+    test(
+      'Removes tooltip from drawer trigger on escape key press after showing from pointer down',
+      setupTest({ theme, size }, async page => {
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await page.buttonDownOnElement(firstDrawerTriggerSelector);
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(1);
+        await expect(page.getText(triggerTooltipSelector)).resolves.toBe(expectedFirstDrawerTriggerTooltipText);
+        await page.keys('Escape');
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
+      })
+    );
+
+    test(
+      'Shows tooltip correctly on drawer trigger for keyboard (tab) interactions',
+      setupTest({ theme, size }, async page => {
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await page.click(firstDrawerTriggerSelector);
+        //close drawer via keys
+        await page.keys(size === 'desktop' ? ['Tab', 'Enter'] : ['Enter']); //first focus element is resize in desktop
+        await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
+        //navigate away from drawer triggers
+        if (theme === 'refresh-toolbar') {
+          await page.keys(['Shift', 'Tab', 'Null']); // to split panel drawer
+        }
+        await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
+        //navigate back to drawer trigger
+        await page.keys(theme === 'refresh-toolbar' ? ['Tab', 'Tab'] : ['Tab']);
+        await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(1);
+        await expect(page.getText(triggerTooltipSelector)).resolves.toBe(expectedFirstDrawerTriggerTooltipText);
+        await page.keys(['Shift', 'Tab', 'Null']);
+        if (theme === 'refresh-toolbar') {
+          await page.keys(['Shift', 'Tab', 'Null']); // one more time to least breadcrumb - be aware if breadcrumb has tooltip
+        }
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
+      })
+    );
+
+    test(
+      'Removes tooltip from drawer trigger on escape key press after showing from keyboard event',
+      setupTest({ theme, size }, async page => {
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await page.click(firstDrawerTriggerSelector);
+        //close drawer via keys
+        await page.keys(size === 'desktop' ? ['Tab', 'Enter'] : ['Enter']); //focus element is resize in desktop
+
+        await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
+        //navigate away from drawer triggers
+        if (theme === 'refresh-toolbar') {
+          await page.keys(['Shift', 'Tab', 'Null']); // to split panel drawer
+        }
+        await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
+        //navigate back to drawer trigger
+        await page.keys(theme === 'refresh-toolbar' ? ['Tab', 'Tab'] : ['Tab']);
+        await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(1);
+        await expect(page.getText(triggerTooltipSelector)).resolves.toBe(expectedFirstDrawerTriggerTooltipText);
+        await page.keys('Escape');
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
+      })
+    );
+
+    test(
+      'Shows tooltip correctly on drawer trigger for keyboard (tab) interactions after drawer actions',
+      setupTest({ theme, size }, async page => {
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await page.click(firstDrawerTriggerSelector);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
+        //close drawer via keys
+        await page.keys(size === 'desktop' ? ['Tab', 'Enter'] : ['Enter']); //first focus element is resize in desktop
+        await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
+        await page.keys(['Tab']);
+        await expect(page.isFocused(secondDrawerTriggerSelector)).resolves.toBeTruthy();
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(1);
+        await expect(page.getText(triggerTooltipSelector)).resolves.toBe(expectedSecondDrawerTriggerTooltipText);
+        await page.keys(['Shift', 'Tab', 'Null']);
+        await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
+        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(1);
+        await expect(page.getText(triggerTooltipSelector)).resolves.toBe(expectedFirstDrawerTriggerTooltipText);
+      })
+    );
+  });
 });

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-drawer-trigger-tooltip.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-drawer-trigger-tooltip.test.ts
@@ -3,8 +3,8 @@
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
-import createWrapper from '../../../lib/components/test-utils/selectors';
-import { viewports } from './constants';
+import createWrapper from '../../../../lib/components/test-utils/selectors';
+import { viewports } from '../constants';
 
 const testIf = (condition: boolean) => (condition ? test : test.skip);
 

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-drawer-trigger-tooltip.test.tsx
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-drawer-trigger-tooltip.test.tsx
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../../../../lib/components/app-layout/visual-refresh/drawers';
 import createWrapper from '../../../../lib/components/test-utils/selectors';
 import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
-import { drawerItems } from '../../../../lib/dev-pages/pages/app-layout/utils/drawers.js';
+import { drawerItems } from '../../../../lib/dev-pages/pages/app-layout/utils/drawers';
+import { visibleMobileToolbarTriggersLimit } from '../constants';
 import { setupTest } from '../utils';
 
 const wrapper = createWrapper().findAppLayout();
@@ -14,7 +14,7 @@ describe('refresh-toolbar', () => {
   const theme = 'refresh-toolbar';
   const mobileDrawerTriggerIds = drawerIds.slice(
     0,
-    VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT + 1 //use conditional for 0 when theme is refresh
+    visibleMobileToolbarTriggersLimit + 1 //use conditional for 0 when theme is refresh
   );
 
   describe.each(['desktop', 'mobile'] as const)('%s', size => {

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-drawer-trigger-tooltip.test.tsx
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-drawer-trigger-tooltip.test.tsx
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../../../../lib/components/app-layout/visual-refresh/drawers';
 import createWrapper from '../../../../lib/components/test-utils/selectors/index';
 import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
-import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../constants';
+import { drawerItems } from '../../../../lib/dev-pages/pages/app-layout/utils/drawers.js';
 import { setupTest } from '../utils';
 
 const wrapper = createWrapper().findAppLayout();
@@ -13,21 +14,21 @@ describe('refresh-toolbar', () => {
   const theme = 'refresh-toolbar';
   const mobileDrawerTriggerIds = drawerIds.slice(
     0,
-    VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT + (theme === 'refresh-toolbar' ? 1 : 0)
+    VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT + 1 //use conditional for 0 when theme is refresh
   );
 
   describe.each(['desktop', 'mobile'] as const)('%s', size => {
     const drawerIdsToTest = size === 'mobile' ? mobileDrawerTriggerIds : drawerIds; //toolbarDrawerIds;
     const firstDrawerTriggerSelector = wrapper.findDrawerTriggerById(drawerIdsToTest[0]).toSelector();
-    const expectedFirstDrawerTriggerTooltipText = 'Security'; //must match drawerItems[0].ariaLabels.drawer from /lib/dev-pages/pages/app-layout/utils/drawers
+    const expectedFirstDrawerTriggerTooltipText = drawerItems[0].ariaLabels.drawer;
     const secondDrawerTriggerSelector = wrapper.findDrawerTriggerById(drawerIdsToTest[1]).toSelector();
-    const expectedSecondDrawerTriggerTooltipText = 'Pro help'; //must match drawerItems[0].ariaLabels.drawer from /lib/dev-pages/pages/app-layout/utils/drawers
+    const expectedSecondDrawerTriggerTooltipText = drawerItems[0].ariaLabels.drawer;
     const triggerTooltipSelector = wrapper.findDrawerTriggerTooltip().toSelector();
 
     test(
       'Shows tooltip correctly on drawer trigger for mouse interactions drawer triggers',
       setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.hoverElement(firstDrawerTriggerSelector);
         await expect(page.getText(triggerTooltipSelector)).resolves.toBe(expectedFirstDrawerTriggerTooltipText);
         await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(1);
@@ -39,11 +40,10 @@ describe('refresh-toolbar', () => {
     test(
       'Shows tooltip correctly on drawer trigger for mouse interactions during drawer actions',
       setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.click(firstDrawerTriggerSelector);
         await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.click(wrapper.findActiveDrawerCloseButton().toSelector());
-        // await page.click(`button[aria-label="Security close button"`);
         await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.hoverElement(firstDrawerTriggerSelector);
         await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(1);
@@ -54,7 +54,7 @@ describe('refresh-toolbar', () => {
     test(
       'Removes tooltip from drawer trigger on escape key press after showing from mouse hover',
       setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.hoverElement(firstDrawerTriggerSelector);
         await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(1);
         await expect(page.getText(triggerTooltipSelector)).resolves.toBe(expectedFirstDrawerTriggerTooltipText);
@@ -66,7 +66,7 @@ describe('refresh-toolbar', () => {
     test(
       'Shows tooltip correctly on drawer trigger for pointer interactions',
       setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.pointerDown(firstDrawerTriggerSelector);
         await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(1);
         await expect(page.getText(triggerTooltipSelector)).resolves.toBe(expectedFirstDrawerTriggerTooltipText);
@@ -78,7 +78,7 @@ describe('refresh-toolbar', () => {
     test(
       'Removes tooltip from drawer trigger on escape key press after showing from pointer down',
       setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.buttonDownOnElement(firstDrawerTriggerSelector);
         await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(1);
         await expect(page.getText(triggerTooltipSelector)).resolves.toBe(expectedFirstDrawerTriggerTooltipText);
@@ -90,7 +90,7 @@ describe('refresh-toolbar', () => {
     test(
       'Shows tooltip correctly on drawer trigger for keyboard (tab) interactions',
       setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.click(firstDrawerTriggerSelector);
         //close drawer via keys
         await page.keys(size === 'desktop' ? ['Tab', 'Enter'] : ['Enter']); //first focus element is resize in desktop
@@ -118,7 +118,7 @@ describe('refresh-toolbar', () => {
     test(
       'Removes tooltip from drawer trigger on escape key press after showing from keyboard event',
       setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.click(firstDrawerTriggerSelector);
         //close drawer via keys
         await page.keys(size === 'desktop' ? ['Tab', 'Enter'] : ['Enter']); //focus element is resize in desktop
@@ -144,7 +144,7 @@ describe('refresh-toolbar', () => {
     test(
       'Shows tooltip correctly on drawer trigger for keyboard (tab) interactions after drawer actions',
       setupTest({ theme, size }, async page => {
-        await expect(page.getElementsCount(triggerTooltipSelector)).resolves.toBe(0);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.click(firstDrawerTriggerSelector);
         await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         //close drawer via keys

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-drawer-trigger-tooltip.test.tsx
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-drawer-trigger-tooltip.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../../../../lib/components/app-layout/visual-refresh/drawers';
-import createWrapper from '../../../../lib/components/test-utils/selectors/index';
+import createWrapper from '../../../../lib/components/test-utils/selectors';
 import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
 import { drawerItems } from '../../../../lib/dev-pages/pages/app-layout/utils/drawers.js';
 import { setupTest } from '../utils';

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-drawer-trigger-tooltip.test.tsx
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-drawer-trigger-tooltip.test.tsx
@@ -1,28 +1,24 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import createWrapper from '../../../../lib/components/test-utils/selectors';
-import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
 import { drawerItems } from '../../../../lib/dev-pages/pages/app-layout/utils/drawers';
-import { visibleMobileToolbarTriggersLimit } from '../constants';
 import { setupTest } from '../utils';
 
 const wrapper = createWrapper().findAppLayout();
-const drawerIds = Object.values(drawerIdObj);
 
 describe('refresh-toolbar', () => {
   //using a theme variable below that will be set when iterating over ['refresh-toolbar', 'refresh']
   const theme = 'refresh-toolbar';
-  const mobileDrawerTriggerIds = drawerIds.slice(
-    0,
-    visibleMobileToolbarTriggersLimit + 1 //use conditional for 0 when theme is refresh
-  );
 
   describe.each(['desktop', 'mobile'] as const)('%s', size => {
-    const drawerIdsToTest = size === 'mobile' ? mobileDrawerTriggerIds : drawerIds; //toolbarDrawerIds;
-    const firstDrawerTriggerSelector = wrapper.findDrawerTriggerById(drawerIdsToTest[0]).toSelector();
-    const expectedFirstDrawerTriggerTooltipText = drawerItems[0].ariaLabels.drawer;
-    const secondDrawerTriggerSelector = wrapper.findDrawerTriggerById(drawerIdsToTest[1]).toSelector();
-    const expectedSecondDrawerTriggerTooltipText = drawerItems[0].ariaLabels.drawer;
+    const firstDrawerId = 'security'; //matches drawerIds[0]
+    const secondDrawerId = 'pro-help'; //matches drawerIds[1]
+    const firstDrawerTriggerSelector = wrapper.findDrawerTriggerById(firstDrawerId).toSelector();
+    const expectedFirstDrawerTriggerTooltipText = drawerItems.find(drawer => drawer.id === firstDrawerId)?.ariaLabels
+      ?.drawer;
+    const secondDrawerTriggerSelector = wrapper.findDrawerTriggerById(secondDrawerId).toSelector();
+    const expectedSecondDrawerTriggerTooltipText = drawerItems.find(drawer => drawer.id === secondDrawerId)?.ariaLabels
+      ?.drawer;
     const triggerTooltipSelector = wrapper.findDrawerTriggerTooltip().toSelector();
 
     test(

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-no-tooltips.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-no-tooltips.test.ts
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import createWrapper from '../../../../lib/components/test-utils/selectors/index';
+import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
+import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../constants';
+import { setupTest } from '../utils';
+
+import tooltipStyles from '../../../../lib/components/internal/components/tooltip/styles.selectors.js';
+
+const wrapper = createWrapper().findAppLayout();
+const drawerIds = Object.values(drawerIdObj);
+
+describe.each(['refresh', 'classic'] as const)('%s', theme => {
+  describe.each(['desktop', 'mobile'] as const)('%s', size => {
+    const mobileDrawerTriggerIds = drawerIds.slice(0, VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT);
+    const drawerIdsToTest = [...(size === 'mobile' ? mobileDrawerTriggerIds : drawerIds)];
+
+    test(
+      'No drawer trigger tooltip showing for mouse interactions',
+      setupTest({ size, theme }, async page => {
+        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+        const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
+        await page.hoverElement(firstDrawerTriggerSelector);
+        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+      })
+    );
+
+    test(
+      'No drawer trigger tooltip showing for pointer interactions',
+      setupTest({ size, theme }, async page => {
+        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+        const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
+        await page.buttonDownOnElement(firstDrawerTriggerSelector);
+        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+      })
+    );
+
+    test(
+      'No drawer trigger tooltip showing for keyboard (tab) interactions',
+      setupTest({ size, theme }, async page => {
+        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+        //set focus by clicking open and close
+        const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
+        await page.click(firstDrawerTriggerSelector);
+        (await size) === 'mobile' ? page.keys('Enter') : page.click(firstDrawerTriggerSelector);
+        await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
+        //move focus away
+        await page.keys(['Shift', 'Tab', 'Null']);
+
+        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        await page.keys('Tab');
+        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+      })
+    );
+
+    describe.each(['bottom', 'side'] as const)('splitPanelPosition=%s', splitPanelPosition => {
+      test(
+        'No split panel trigger tooltip showing for mouse interactions',
+        setupTest({ size, theme, splitPanelPosition }, async page => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await page.hoverElement(wrapper.findSplitPanelOpenButton().toSelector());
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        })
+      );
+
+      test(
+        'No split panel trigger tooltip showing for pointer interactions',
+        setupTest({ size, theme, splitPanelPosition }, async page => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await page.buttonDownOnElement(wrapper.findSplitPanelOpenButton().toSelector());
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        })
+      );
+
+      test(
+        'No split panel trigger tooltip showing for keyboard (tab) interactions',
+        setupTest({ size, theme, splitPanelPosition }, async page => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          //set focus by clicking open and close
+          await page.click(wrapper.findSplitPanelOpenButton().toSelector());
+          await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
+          //move focus away
+          await page.keys(['Shift', 'Tab', 'Null']);
+
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await page.keys('Tab');
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        })
+      );
+    });
+  });
+});

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-no-tooltips.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-no-tooltips.test.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../../../../lib/components/app-layout/visual-refresh/drawers';
 import createWrapper from '../../../../lib/components/test-utils/selectors';
 import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
+import { visibleMobileToolbarTriggersLimit } from '../constants';
 import { setupTest } from '../utils';
 
 const wrapper = createWrapper().findAppLayout();
@@ -10,7 +10,7 @@ const drawerIds = Object.values(drawerIdObj);
 
 describe.each(['refresh', 'classic'] as const)('%s', theme => {
   describe.each(['desktop', 'mobile'] as const)('%s', size => {
-    const mobileDrawerTriggerIds = drawerIds.slice(0, VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT);
+    const mobileDrawerTriggerIds = drawerIds.slice(0, visibleMobileToolbarTriggersLimit);
     const drawerIdsToTest = [...(size === 'mobile' ? mobileDrawerTriggerIds : drawerIds)];
     const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
     const triggerTooltipSelector = wrapper.findDrawerTriggerTooltip().toSelector();

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-no-tooltips.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-no-tooltips.test.ts
@@ -1,18 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import createWrapper from '../../../../lib/components/test-utils/selectors';
-import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
-import { visibleMobileToolbarTriggersLimit } from '../constants';
 import { setupTest } from '../utils';
 
 const wrapper = createWrapper().findAppLayout();
-const drawerIds = Object.values(drawerIdObj);
 
 describe.each(['refresh', 'classic'] as const)('%s', theme => {
   describe.each(['desktop', 'mobile'] as const)('%s', size => {
-    const mobileDrawerTriggerIds = drawerIds.slice(0, visibleMobileToolbarTriggersLimit);
-    const drawerIdsToTest = [...(size === 'mobile' ? mobileDrawerTriggerIds : drawerIds)];
-    const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
+    //matches drawerItems[0].id from 'lib/dev-pages/pages/app-layout/utils/drawers';
+    const firstDrawerId = 'security';
+    const firstDrawerTriggerSelector = wrapper.findDrawerTriggerById(firstDrawerId).toSelector();
     const triggerTooltipSelector = wrapper.findDrawerTriggerTooltip().toSelector();
 
     test(

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-no-tooltips.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-no-tooltips.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../../../../lib/components/app-layout/visual-refresh/drawers';
-import createWrapper from '../../../../lib/components/test-utils/selectors/index';
+import createWrapper from '../../../../lib/components/test-utils/selectors';
 import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
 import { setupTest } from '../utils';
 

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-no-tooltips.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-no-tooltips.test.ts
@@ -1,11 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../../../../lib/components/app-layout/visual-refresh/drawers';
 import createWrapper from '../../../../lib/components/test-utils/selectors/index';
 import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
-import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../constants';
 import { setupTest } from '../utils';
-
-import tooltipStyles from '../../../../lib/components/internal/components/tooltip/styles.selectors.js';
 
 const wrapper = createWrapper().findAppLayout();
 const drawerIds = Object.values(drawerIdObj);
@@ -14,42 +12,40 @@ describe.each(['refresh', 'classic'] as const)('%s', theme => {
   describe.each(['desktop', 'mobile'] as const)('%s', size => {
     const mobileDrawerTriggerIds = drawerIds.slice(0, VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT);
     const drawerIdsToTest = [...(size === 'mobile' ? mobileDrawerTriggerIds : drawerIds)];
+    const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
+    const triggerTooltipSelector = wrapper.findDrawerTriggerTooltip().toSelector();
 
     test(
       'No drawer trigger tooltip showing for mouse interactions',
       setupTest({ size, theme }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.hoverElement(firstDrawerTriggerSelector);
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
       })
     );
 
     test(
       'No drawer trigger tooltip showing for pointer interactions',
       setupTest({ size, theme }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-        const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.buttonDownOnElement(firstDrawerTriggerSelector);
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
       })
     );
 
     test(
       'No drawer trigger tooltip showing for keyboard (tab) interactions',
       setupTest({ size, theme }, async page => {
-        await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         //set focus by clicking open and close
-        const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
         await page.click(firstDrawerTriggerSelector);
         (await size) === 'mobile' ? page.keys('Enter') : page.click(firstDrawerTriggerSelector);
         await expect(page.isFocused(firstDrawerTriggerSelector)).resolves.toBeTruthy();
         //move focus away
         await page.keys(['Shift', 'Tab', 'Null']);
-
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.keys('Tab');
-        await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
       })
     );
 
@@ -57,34 +53,34 @@ describe.each(['refresh', 'classic'] as const)('%s', theme => {
       test(
         'No split panel trigger tooltip showing for mouse interactions',
         setupTest({ size, theme, splitPanelPosition }, async page => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
           await page.hoverElement(wrapper.findSplitPanelOpenButton().toSelector());
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         })
       );
 
       test(
         'No split panel trigger tooltip showing for pointer interactions',
         setupTest({ size, theme, splitPanelPosition }, async page => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
           await page.buttonDownOnElement(wrapper.findSplitPanelOpenButton().toSelector());
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         })
       );
 
       test(
         'No split panel trigger tooltip showing for keyboard (tab) interactions',
         setupTest({ size, theme, splitPanelPosition }, async page => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
           //set focus by clicking open and close
           await page.click(wrapper.findSplitPanelOpenButton().toSelector());
           await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
           //move focus away
           await page.keys(['Shift', 'Tab', 'Null']);
 
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
           await page.keys('Tab');
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         })
       );
     });

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
@@ -25,6 +25,7 @@ describe('refresh-toolbar', () => {
     const firstDrawerTriggerSelector = wrapper.findDrawerTriggerById(drawerIdsToTest[0]).toSelector();
     const splitPanelTriggerSelector = wrapper.findSplitPanelOpenButton().toSelector();
     const tooltipSelector = wrapper.findDrawerTriggerTooltip().toSelector();
+    const expectedTooltipText = 'Open panel';
 
     describe.each(['bottom', 'side'] as const)('splitPanelPosition=%s', splitPanelPosition => {
       test(
@@ -32,6 +33,7 @@ describe('refresh-toolbar', () => {
         setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
           await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(0);
           await page.hoverElement(splitPanelTriggerSelector);
+          await expect(page.getText(tooltipSelector)).resolves.toBe(expectedTooltipText);
           await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(1);
           await page.hoverElement(wrapper.findNavigationToggle().toSelector());
           await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
@@ -64,6 +66,7 @@ describe('refresh-toolbar', () => {
             page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
           ).resolves.toBeTruthy();
           await page.hoverElement(splitPanelTriggerSelector);
+          await expect(page.getText(tooltipSelector)).resolves.toBe(expectedTooltipText);
           await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(1);
           await page.keys(['Escape']);
           await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
@@ -90,6 +93,7 @@ describe('refresh-toolbar', () => {
           //navigate back to drawer trigger
           await page.keys(['Tab']);
           await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
+          await await expect(page.getText(tooltipSelector)).resolves.toBe(expectedTooltipText);
           await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(1);
           await page.keys(['Shift', 'Tab', 'Null']);
           await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
@@ -115,6 +119,7 @@ describe('refresh-toolbar', () => {
           //navigate back to drawer trigger
           await page.keys(['Tab']);
           await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
+          await expect(page.getText(tooltipSelector)).resolves.toBe(expectedTooltipText);
           await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(1);
           await page.keys('Escape');
           await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../../../../lib/components/app-layout/visual-refresh/drawers';
 import createWrapper from '../../../../lib/components/test-utils/selectors';
 import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
+import { visibleMobileToolbarTriggersLimit } from '../constants';
 import { AppLayoutDrawersPage, setupTest } from '../utils';
 
 const wrapper = createWrapper().findAppLayout();
@@ -13,7 +13,7 @@ describe('refresh-toolbar', () => {
   const theme = 'refresh-toolbar';
   const mobileDrawerTriggerIds = drawerIds.slice(
     0,
-    VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT + 1 //use conditional for 0 when theme is refresh
+    visibleMobileToolbarTriggersLimit + 1 //use conditional for 0 when theme is refresh
   );
   describe.each(['desktop', 'mobile'] as const)('%s', size => {
     const drawerIdsToTest = size === 'mobile' ? mobileDrawerTriggerIds : drawerIds; //toolbarDrawerIds;

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
@@ -1,23 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import createWrapper from '../../../../lib/components/test-utils/selectors';
-import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
-import { visibleMobileToolbarTriggersLimit } from '../constants';
 import { AppLayoutDrawersPage, setupTest } from '../utils';
 
 const wrapper = createWrapper().findAppLayout();
 
-const drawerIds = Object.values(drawerIdObj);
-
 describe('refresh-toolbar', () => {
   const theme = 'refresh-toolbar';
-  const mobileDrawerTriggerIds = drawerIds.slice(
-    0,
-    visibleMobileToolbarTriggersLimit + 1 //use conditional for 0 when theme is refresh
-  );
+
   describe.each(['desktop', 'mobile'] as const)('%s', size => {
-    const drawerIdsToTest = size === 'mobile' ? mobileDrawerTriggerIds : drawerIds; //toolbarDrawerIds;
-    const firstDrawerTriggerSelector = wrapper.findDrawerTriggerById(drawerIdsToTest[0]).toSelector();
+    //matches drawerItems[0].id from '../../../../lib/dev-pages/pages/app-layout/utils/drawers';
+    const firstDrawerId = 'security';
+    const firstDrawerTriggerSelector = wrapper.findDrawerTriggerById(firstDrawerId).toSelector();
     const splitPanelTriggerSelector = wrapper.findSplitPanelOpenButton().toSelector();
     const tooltipSelector = wrapper.findDrawerTriggerTooltip().toSelector();
     const expectedTooltipText = 'Open panel';

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
@@ -1,0 +1,127 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import createWrapper from '../../../../lib/components/test-utils/selectors/index';
+import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
+import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../constants';
+import { AppLayoutDrawersPage, setupTest } from '../utils';
+
+import toolbarStyles from '../../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/styles.selectors.js';
+import tooltipStyles from '../../../../lib/components/internal/components/tooltip/styles.selectors.js';
+
+const wrapper = createWrapper().findAppLayout();
+const drawerIds = Object.values(drawerIdObj);
+
+describe('refresh-toolbar', () => {
+  const theme = 'refresh-toolbar';
+  const mobileDrawerTriggerIds = drawerIds.slice(
+    0,
+    VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT + (theme === 'refresh-toolbar' ? 1 : 0)
+  );
+  const appliedThemeStyles = toolbarStyles; //use visualRefreshStyles when theme === 'refresh'
+
+  describe.each(['desktop', 'mobile'] as const)('%s', size => {
+    const drawersTriggerContainerClassKey = `drawers-${size === 'desktop' ? 'desktop' : 'mobile'}-triggers-container`;
+    const drawerIdsToTest = size === 'mobile' ? mobileDrawerTriggerIds : drawerIds; //toolbarDrawerIds;
+    const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
+    const splitPanelTriggerSelector = `button[data-testid="awsui-app-layout-trigger-slide-panel"]`;
+
+    describe.each(['bottom', 'side'] as const)('splitPanelPosition=%s', splitPanelPosition => {
+      test(
+        'Shows tooltip correctly on split panel trigger for mouse interactions',
+        setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(
+            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
+          ).resolves.toBeTruthy();
+          await page.hoverElement(splitPanelTriggerSelector);
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await page.hoverElement(wrapper.findNavigationToggle().toSelector());
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        })
+      );
+
+      test(
+        'Shows tooltip correctly on split panel trigger for mouse interactions during split-panel actions',
+        setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(
+            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
+          ).resolves.toBeTruthy();
+          await page.click(splitPanelTriggerSelector);
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await page.click(splitPanelTriggerSelector); //this could change witf focus fixes
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await page.hoverElement(firstDrawerTriggerSelector);
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await page.hoverElement(splitPanelTriggerSelector);
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+        })
+      );
+
+      test(
+        'Removes tooltip from split panel trigger on escape key press after showing from mouse hover',
+        setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(
+            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
+          ).resolves.toBeTruthy();
+          await page.hoverElement(splitPanelTriggerSelector);
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await page.keys(['Escape']);
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        })
+      );
+
+      test(
+        'Shows tooltip correctly for split panel trigger for keyboard (tab) interactions',
+        setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(
+            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
+          ).resolves.toBeTruthy();
+          await page.click(splitPanelTriggerSelector);
+
+          await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
+          //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
+          await page.keys(['Tab', 'Tab']);
+          await page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector());
+          await page.keys('Enter');
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          //navigate away from slide panel
+          await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
+          //navigate back to drawer trigger
+          await page.keys(['Tab']);
+          await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await page.keys(['Shift', 'Tab', 'Null']);
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        })
+      );
+
+      test(
+        'Removes tooltip from split panel trigger on escape key press after showing from keyboard event',
+        setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(
+            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
+          ).resolves.toBeTruthy();
+          await page.click(splitPanelTriggerSelector);
+          await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
+          //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await page.click(splitPanelTriggerSelector);
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          //navigate away from slide panel
+          await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          //navigate back to drawer trigger
+          await page.keys(['Tab']);
+          await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
+          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await page.keys('Escape');
+          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+        })
+      );
+    });
+  });
+});

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
@@ -1,11 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../../../../lib/components/app-layout/visual-refresh/drawers';
 import createWrapper from '../../../../lib/components/test-utils/selectors/index';
 import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
-import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../constants';
 import { AppLayoutDrawersPage, setupTest } from '../utils';
-
-import toolbarStyles from '../../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/styles.selectors.js';
 
 const wrapper = createWrapper().findAppLayout();
 
@@ -15,12 +13,9 @@ describe('refresh-toolbar', () => {
   const theme = 'refresh-toolbar';
   const mobileDrawerTriggerIds = drawerIds.slice(
     0,
-    VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT + (theme === 'refresh-toolbar' ? 1 : 0)
+    VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT + 1 //use conditional for 0 when theme is refresh
   );
-  const appliedThemeStyles = toolbarStyles; //use visualRefreshStyles when theme === 'refresh'
-
   describe.each(['desktop', 'mobile'] as const)('%s', size => {
-    const drawersTriggerContainerClassKey = `drawers-${size === 'desktop' ? 'desktop' : 'mobile'}-triggers-container`;
     const drawerIdsToTest = size === 'mobile' ? mobileDrawerTriggerIds : drawerIds; //toolbarDrawerIds;
     const firstDrawerTriggerSelector = wrapper.findDrawerTriggerById(drawerIdsToTest[0]).toSelector();
     const splitPanelTriggerSelector = wrapper.findSplitPanelOpenButton().toSelector();
@@ -31,7 +26,7 @@ describe('refresh-toolbar', () => {
       test(
         'Shows tooltip correctly on split panel trigger for mouse interactions',
         setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
-          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(0);
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
           await page.hoverElement(splitPanelTriggerSelector);
           await expect(page.getText(tooltipSelector)).resolves.toBe(expectedTooltipText);
           await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(1);
@@ -43,10 +38,7 @@ describe('refresh-toolbar', () => {
       test(
         'Shows tooltip correctly on split panel trigger for mouse interactions during split-panel actions',
         setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
-          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(0);
-          await expect(
-            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
-          ).resolves.toBeTruthy();
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
           await page.click(splitPanelTriggerSelector);
           await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
           await page.click(splitPanelTriggerSelector); //this could change witf focus fixes
@@ -61,10 +53,7 @@ describe('refresh-toolbar', () => {
       test(
         'Removes tooltip from split panel trigger on escape key press after showing from mouse hover',
         setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
-          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(0);
-          await expect(
-            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
-          ).resolves.toBeTruthy();
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
           await page.hoverElement(splitPanelTriggerSelector);
           await expect(page.getText(tooltipSelector)).resolves.toBe(expectedTooltipText);
           await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(1);
@@ -76,14 +65,10 @@ describe('refresh-toolbar', () => {
       test(
         'Shows tooltip correctly for split panel trigger for keyboard (tab) interactions',
         setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
-          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(0);
-          await expect(
-            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
-          ).resolves.toBeTruthy();
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
           await page.click(splitPanelTriggerSelector);
 
           await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
-          //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
           await page.keys(['Tab', 'Tab']);
           await page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector());
           await page.keys('Enter');
@@ -103,13 +88,9 @@ describe('refresh-toolbar', () => {
       test(
         'Removes tooltip from split panel trigger on escape key press after showing from keyboard event',
         setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
-          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(0);
-          await expect(
-            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
-          ).resolves.toBeTruthy();
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
           await page.click(splitPanelTriggerSelector);
           await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
-          //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
           await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
           await page.click(splitPanelTriggerSelector);
           await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../../../../lib/components/app-layout/visual-refresh/drawers';
-import createWrapper from '../../../../lib/components/test-utils/selectors/index';
+import createWrapper from '../../../../lib/components/test-utils/selectors';
 import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
 import { AppLayoutDrawersPage, setupTest } from '../utils';
 

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
@@ -6,9 +6,9 @@ import { VISIBLE_MOBILE_TOOLBAR_TRIGGERS_LIMIT } from '../constants';
 import { AppLayoutDrawersPage, setupTest } from '../utils';
 
 import toolbarStyles from '../../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/styles.selectors.js';
-import tooltipStyles from '../../../../lib/components/internal/components/tooltip/styles.selectors.js';
 
 const wrapper = createWrapper().findAppLayout();
+
 const drawerIds = Object.values(drawerIdObj);
 
 describe('refresh-toolbar', () => {
@@ -22,60 +22,58 @@ describe('refresh-toolbar', () => {
   describe.each(['desktop', 'mobile'] as const)('%s', size => {
     const drawersTriggerContainerClassKey = `drawers-${size === 'desktop' ? 'desktop' : 'mobile'}-triggers-container`;
     const drawerIdsToTest = size === 'mobile' ? mobileDrawerTriggerIds : drawerIds; //toolbarDrawerIds;
-    const firstDrawerTriggerSelector = `button[data-testid="awsui-app-layout-trigger-${drawerIdsToTest[0]}"]`;
-    const splitPanelTriggerSelector = `button[data-testid="awsui-app-layout-trigger-slide-panel"]`;
+    const firstDrawerTriggerSelector = wrapper.findDrawerTriggerById(drawerIdsToTest[0]).toSelector();
+    const splitPanelTriggerSelector = wrapper.findSplitPanelOpenButton().toSelector();
+    const tooltipSelector = wrapper.findDrawerTriggerTooltip().toSelector();
 
     describe.each(['bottom', 'side'] as const)('splitPanelPosition=%s', splitPanelPosition => {
       test(
         'Shows tooltip correctly on split panel trigger for mouse interactions',
         setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
-          await expect(
-            page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
-          ).resolves.toBeTruthy();
+          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(0);
           await page.hoverElement(splitPanelTriggerSelector);
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(1);
           await page.hoverElement(wrapper.findNavigationToggle().toSelector());
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
         })
       );
 
       test(
         'Shows tooltip correctly on split panel trigger for mouse interactions during split-panel actions',
         setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(0);
           await expect(
             page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
           ).resolves.toBeTruthy();
           await page.click(splitPanelTriggerSelector);
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
           await page.click(splitPanelTriggerSelector); //this could change witf focus fixes
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
           await page.hoverElement(firstDrawerTriggerSelector);
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(1);
           await page.hoverElement(splitPanelTriggerSelector);
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(1);
         })
       );
 
       test(
         'Removes tooltip from split panel trigger on escape key press after showing from mouse hover',
         setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(0);
           await expect(
             page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
           ).resolves.toBeTruthy();
           await page.hoverElement(splitPanelTriggerSelector);
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(1);
           await page.keys(['Escape']);
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
         })
       );
 
       test(
         'Shows tooltip correctly for split panel trigger for keyboard (tab) interactions',
         setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(0);
           await expect(
             page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
           ).resolves.toBeTruthy();
@@ -86,40 +84,40 @@ describe('refresh-toolbar', () => {
           await page.keys(['Tab', 'Tab']);
           await page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector());
           await page.keys('Enter');
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
           //navigate away from slide panel
           await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
           //navigate back to drawer trigger
           await page.keys(['Tab']);
           await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(1);
           await page.keys(['Shift', 'Tab', 'Null']);
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
         })
       );
 
       test(
         'Removes tooltip from split panel trigger on escape key press after showing from keyboard event',
         setupTest({ theme, size, splitPanelPosition }, async (page: AppLayoutDrawersPage) => {
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(0);
+          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(0);
           await expect(
             page.isExisting(`.${appliedThemeStyles[drawersTriggerContainerClassKey]}`)
           ).resolves.toBeTruthy();
           await page.click(splitPanelTriggerSelector);
           await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBeTruthy();
           //todo - assert the tooltip is not visible. Curently it closes on click then reopened as the UI shifts and causign an unexpected new hover event
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
           await page.click(splitPanelTriggerSelector);
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
           //navigate away from slide panel
           await page.keys(['Shift', 'Tab', 'Null']); // to last breadcrumb - be aware if breadcrumb has tooltip
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
           //navigate back to drawer trigger
           await page.keys(['Tab']);
           await expect(page.isFocused(splitPanelTriggerSelector)).resolves.toBeTruthy();
-          await expect(page.getElementsCount(`.${tooltipStyles.root}`)).resolves.toBe(1);
+          await expect(page.getElementsCount(tooltipSelector)).resolves.toBe(1);
           await page.keys('Escape');
-          await expect(page.isExisting(`.${tooltipStyles.root}`)).resolves.toBe(false);
+          await expect(page.isExisting(tooltipSelector)).resolves.toBe(false);
         })
       );
     });

--- a/src/app-layout/__integ__/utils.ts
+++ b/src/app-layout/__integ__/utils.ts
@@ -1,15 +1,84 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+import createWrapper from '../../../lib/components/test-utils/selectors';
+import { viewports } from './constants';
 
 export const testIf = (condition: boolean) => (condition ? test : test.skip);
 
 export type Theme = 'classic' | 'refresh' | 'refresh-toolbar';
 
+export interface SetupTestOptions {
+  splitPanelPosition?: string;
+  size?: 'desktop' | 'mobile';
+  disableContentPaddings?: string;
+  theme?: 'refresh' | 'refresh-toolbar' | 'classic';
+}
+
 export function getUrlParams(theme: Theme, other?: Record<string, string>) {
   const params = new URLSearchParams({
-    visualRefresh: `${theme.startsWith('refresh')}`,
+    visualRefresh: `${theme !== 'classic'}`,
     appLayoutToolbar: `${theme === 'refresh-toolbar'}`,
     ...other,
   });
   return params.toString();
 }
+
+export class AppLayoutDrawersPage extends BasePageObject {
+  async getElementCenter(selector: string) {
+    const targetRect = await this.getBoundingBox(selector);
+    const x = Math.round(targetRect.left + targetRect.width / 2);
+    const y = Math.round(targetRect.top + targetRect.height / 2);
+    return { x, y };
+  }
+
+  async pointerDown(selector: string) {
+    const center = await this.getElementCenter(selector);
+    await (await this.browser.$(selector)).moveTo();
+    await this.browser.performActions([
+      {
+        type: 'pointer',
+        id: 'event',
+        parameters: { pointerType: 'mouse' },
+        actions: [
+          { type: 'pointerMove', duration: 0, origin: 'pointer', ...center },
+          { type: 'pointerDown', button: 0 },
+          { type: 'pause', duration: 100 },
+        ],
+      },
+    ]);
+  }
+
+  async pointerUp() {
+    await this.browser.performActions([
+      {
+        type: 'pointer',
+        id: 'event',
+        parameters: { pointerType: 'mouse' },
+        actions: [
+          { type: 'pointerUp', button: 0 },
+          { type: 'pause', duration: 100 },
+        ],
+      },
+    ]);
+  }
+}
+
+export const setupTest = (
+  { size = 'desktop', theme = 'refresh', splitPanelPosition = '' }: SetupTestOptions,
+  testFn: (page: AppLayoutDrawersPage) => Promise<void>
+) =>
+  useBrowser(size === 'desktop' ? viewports.desktop : viewports.mobile, async browser => {
+    const wrapper = createWrapper().findAppLayout();
+    const page = new AppLayoutDrawersPage(browser);
+    const params = new URLSearchParams({
+      visualRefresh: `${theme !== 'classic'}`,
+      appLayoutWidget: `${theme === 'refresh-toolbar'}`,
+      ...(splitPanelPosition ? { splitPanelPosition } : {}),
+    }).toString();
+    await browser.url(`#/light/app-layout/with-drawers?${params}`);
+    await page.waitForVisible(wrapper.findContentRegion().toSelector());
+    await testFn(page);
+  });

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -16,9 +16,7 @@ import {
 } from './utils';
 
 import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
-import tooltipStyles from '../../../lib/components/internal/components/tooltip/styles.selectors.js';
 import visualRefreshStyles from '../../../lib/components/app-layout/visual-refresh/styles.selectors.js';
-import toolbarStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/styles.css.js';
 import toolbarTriggerButtonStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/trigger-button/styles.css.js';
 
 jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
@@ -43,8 +41,9 @@ describeEachAppLayout(({ size, theme }) => {
     const { wrapper, rerender } = renderComponent(<AppLayout toolsHide={true} drawers={[testDrawer]} />);
     expect(wrapper.findDrawersTriggers()).toHaveLength(1);
     rerender(<AppLayout />);
+
     expect(wrapper.findDrawersTriggers()).toHaveLength(0);
-    expect(wrapper.findByClassName(tooltipStyles.root)).toBeNull();
+    expect(wrapper.findDrawerTriggerTooltip()).toBeNull();
   });
 
   test('should not apply drawers treatment to the tools if the drawers array is empty', () => {
@@ -189,6 +188,7 @@ describeEachAppLayout(({ size, theme }) => {
     const drawerTrigger = wrapper.findDrawerTriggerById('security')!;
     const selectedClass = theme === 'refresh' ? visualRefreshStyles.selected : toolbarTriggerButtonStyles.selected;
     expect(drawerTrigger!.getElement()).not.toHaveClass(selectedClass);
+    expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
 
     drawerTrigger.click();
     expect(drawerTrigger!.getElement()).toHaveClass(selectedClass);
@@ -200,32 +200,23 @@ describeEachAppLayout(({ size, theme }) => {
   testIf(theme === 'refresh-toolbar')('tooltip renders correctly on focus, blur, and escape key press events', () => {
     const mockDrawers = [testDrawer];
     const result = render(<AppLayout drawers={mockDrawers} />);
-    const wrapper = createWrapper(result.container);
-    const appliedThemeStyles = toolbarStyles;
-    const appliedTriggerStyles = toolbarTriggerButtonStyles;
-    const containerClass = `drawers-${size === 'mobile' ? 'mobile' : 'desktop'}-triggers-container`;
+    const wrapper = createWrapper(result.container).findAppLayout();
+    expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
     expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
-    const triggerButtonContainer = wrapper.findByClassName(appliedThemeStyles[containerClass]);
 
-    expect(triggerButtonContainer).not.toBeNull();
-
-    const items = triggerButtonContainer?.findAllByClassName(appliedTriggerStyles['trigger-wrapper']);
-    expect(items?.length).toEqual(mockDrawers.length);
+    const items = wrapper!.findDrawersTriggers();
+    expect(items.length).toEqual(mockDrawers.length);
 
     fireEvent.focus(items![0].getElement());
-
-    const tooltipWrapper = result.getByTestId(testDrawer.ariaLabels.drawerName);
-    expect(tooltipWrapper.classList.contains(tooltipStyles.root)).toBeTruthy();
-    expect(tooltipWrapper.classList.contains(appliedTriggerStyles['trigger-tooltip'])).toBeTruthy();
+    expect(wrapper!.findDrawerTriggerTooltip()).toBeTruthy();
     expect(result.getByText(testDrawer.ariaLabels.drawerName)).toBeTruthy();
 
     fireEvent.blur(items![0].getElement());
+    expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
     expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
 
     fireEvent.focus(items![0].getElement());
-
-    expect(tooltipWrapper.classList.contains(tooltipStyles.root)).toBeTruthy();
-    expect(tooltipWrapper.classList.contains(appliedTriggerStyles['trigger-tooltip'])).toBeTruthy();
+    expect(wrapper!.findDrawerTriggerTooltip()).toBeTruthy();
     expect(result.getByText(testDrawer.ariaLabels.drawerName)).toBeTruthy();
 
     fireEvent.keyDown(items![0].getElement(), {
@@ -233,6 +224,7 @@ describeEachAppLayout(({ size, theme }) => {
       key: 'Escape',
       code: KeyCode.escape,
     });
+    expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
     expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
   });
 
@@ -241,32 +233,23 @@ describeEachAppLayout(({ size, theme }) => {
     () => {
       const mockDrawers = [testDrawer];
       const result = render(<AppLayout drawers={mockDrawers} />);
-      const wrapper = createWrapper(result.container);
-      const appliedThemeStyles = toolbarStyles;
-      const appliedTriggerStyles = toolbarTriggerButtonStyles;
-      const containerClass = `drawers-${size === 'mobile' ? 'mobile' : 'desktop'}-triggers-container`;
-
+      const wrapper = createWrapper(result.container).findAppLayout();
+      expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
       expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
 
-      const triggerButtonContainer = wrapper.findByClassName(appliedThemeStyles[containerClass]);
-      expect(triggerButtonContainer).not.toBeNull();
-      const items = triggerButtonContainer?.findAllByClassName(appliedTriggerStyles['trigger-wrapper']);
+      const items = wrapper!.findDrawersTriggers();
       expect(items?.length).toEqual(mockDrawers.length);
 
       fireEvent.pointerEnter(items![0].getElement());
-
-      const tooltipWrapper = result.getByTestId(testDrawer.ariaLabels.drawerName);
-      expect(tooltipWrapper.classList.contains(tooltipStyles.root)).toBeTruthy();
-      expect(tooltipWrapper.classList.contains(appliedTriggerStyles['trigger-tooltip'])).toBeTruthy();
+      expect(wrapper!.findDrawerTriggerTooltip()).toBeTruthy();
       expect(result.getByText(testDrawer.ariaLabels.drawerName)).toBeTruthy();
 
       fireEvent.pointerLeave(items![0].getElement());
+      expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
       expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
 
       fireEvent.pointerEnter(items![0].getElement());
-
-      expect(tooltipWrapper.classList.contains(tooltipStyles.root)).toBeTruthy();
-      expect(tooltipWrapper.classList.contains(appliedTriggerStyles['trigger-tooltip'])).toBeTruthy();
+      expect(wrapper!.findDrawerTriggerTooltip()).toBeTruthy();
       expect(result.getByText(testDrawer.ariaLabels.drawerName)).toBeTruthy();
 
       fireEvent.keyDown(items![0].getElement(), {
@@ -274,6 +257,7 @@ describeEachAppLayout(({ size, theme }) => {
         key: 'Escape',
         code: KeyCode.escape,
       });
+      expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
       expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
     }
   );
@@ -281,25 +265,13 @@ describeEachAppLayout(({ size, theme }) => {
   testIf(theme === 'refresh-toolbar')('tooltip does not render on trigger focus via close button', () => {
     const mockDrawers = [testDrawer];
     const result = render(<AppLayout drawers={mockDrawers} />);
-    const wrapper = createWrapper(result.container);
-    const appliedThemeStyles = toolbarStyles;
-    const containerClass = `drawers-${size === 'mobile' ? 'mobile' : 'desktop'}-triggers-container`;
+    const wrapper = createWrapper(result.container).findAppLayout();
+    expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
     expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
-
-    const triggerButtonContainer = wrapper.findByClassName(appliedThemeStyles[containerClass]);
-    expect(triggerButtonContainer).not.toBeNull();
-    const drawerTrigger = triggerButtonContainer!.find(
-      `button[data-testid="awsui-app-layout-trigger-${testDrawer.id}"]`
-    );
-    drawerTrigger?.click();
-
-    expect(result.getByText('Security')).toBeTruthy();
-    expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
-
-    const closeButton = wrapper.findDrawer()?.find(`button[title="${testDrawer.ariaLabels.drawerName}-close-button"]`);
-    expect(closeButton).not.toBeNull();
-    closeButton?.click();
-
+    wrapper?.findDrawerTriggerById(testDrawer.id)!.click();
+    expect(wrapper?.findActiveDrawer()).toBeTruthy();
+    wrapper?.findActiveDrawerCloseButton()!.click();
+    expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
     expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
   });
 });

--- a/src/app-layout/__tests__/split-panel.test.tsx
+++ b/src/app-layout/__tests__/split-panel.test.tsx
@@ -121,11 +121,7 @@ describeEachAppLayout({ sizes: ['desktop'] }, ({ theme }) => {
           onSplitPanelPreferencesChange={noop}
         />
       );
-      const slidePanelTrigger =
-        theme === 'refresh-toolbar'
-          ? wrapper.find(`button[data-testid="awsui-app-layout-trigger-slide-panel"]`)
-          : wrapper.findSplitPanelOpenButton();
-      slidePanelTrigger!.click();
+      wrapper.findSplitPanelOpenButton()!.click();
       expect(wrapper.findSplitPanel()!.findSlider()!.getElement()).toHaveFocus();
     });
 
@@ -137,11 +133,7 @@ describeEachAppLayout({ sizes: ['desktop'] }, ({ theme }) => {
           onSplitPanelPreferencesChange={noop}
         />
       );
-      const slidePanelTrigger =
-        theme === 'refresh-toolbar'
-          ? wrapper.find(`button[data-testid="awsui-app-layout-trigger-slide-panel"]`)
-          : wrapper.findSplitPanelOpenButton();
-      slidePanelTrigger!.click();
+      wrapper.findSplitPanelOpenButton()!.click();
       wrapper.findSplitPanel()!.findCloseButton()!.click();
       expect(wrapper.findSplitPanelOpenButton()!.getElement()).toHaveFocus();
     });

--- a/src/app-layout/__tests__/split-panel.test.tsx
+++ b/src/app-layout/__tests__/split-panel.test.tsx
@@ -113,8 +113,7 @@ describeEachAppLayout({ sizes: ['desktop'] }, ({ theme }) => {
       expect(wrapper.findSplitPanelOpenButton()).not.toBeNull();
     });
 
-    // Not implemented on the toolbar version yet
-    (theme !== 'refresh-toolbar' ? test : test.skip)('Moves focus to slider when opened', () => {
+    test('Moves focus to slider when opened', () => {
       const { wrapper } = renderComponent(
         <AppLayout
           splitPanel={defaultSplitPanel}
@@ -122,12 +121,15 @@ describeEachAppLayout({ sizes: ['desktop'] }, ({ theme }) => {
           onSplitPanelPreferencesChange={noop}
         />
       );
-      wrapper.findSplitPanelOpenButton()!.click();
+      const slidePanelTrigger =
+        theme === 'refresh-toolbar'
+          ? wrapper.find(`button[data-testid="awsui-app-layout-trigger-slide-panel"]`)
+          : wrapper.findSplitPanelOpenButton();
+      slidePanelTrigger!.click();
       expect(wrapper.findSplitPanel()!.findSlider()!.getElement()).toHaveFocus();
     });
 
-    // Not implemented on the toolbar version yet
-    (theme !== 'refresh-toolbar' ? test : test.skip)('Moves focus to open button when closed', () => {
+    test('Moves focus to open button when closed', () => {
       const { wrapper } = renderComponent(
         <AppLayout
           splitPanel={defaultSplitPanel}
@@ -135,7 +137,11 @@ describeEachAppLayout({ sizes: ['desktop'] }, ({ theme }) => {
           onSplitPanelPreferencesChange={noop}
         />
       );
-      wrapper.findSplitPanelOpenButton()!.click();
+      const slidePanelTrigger =
+        theme === 'refresh-toolbar'
+          ? wrapper.find(`button[data-testid="awsui-app-layout-trigger-slide-panel"]`)
+          : wrapper.findSplitPanelOpenButton();
+      slidePanelTrigger!.click();
       wrapper.findSplitPanel()!.findCloseButton()!.click();
       expect(wrapper.findSplitPanelOpenButton()!.getElement()).toHaveFocus();
     });

--- a/src/app-layout/__tests__/toolbar.test.tsx
+++ b/src/app-layout/__tests__/toolbar.test.tsx
@@ -7,13 +7,13 @@ import { describeEachAppLayout, manyDrawers, renderComponent } from './utils';
 
 import AppLayout from '../../../lib/components/app-layout';
 import SplitPanel from '../../../lib/components/split-panel';
-import { AppLayoutWrapper } from '../../../lib/components/test-utils/dom';
+// import createWrapper, { AppLayoutWrapper } from '../../../lib/components/test-utils/dom';
 
-import testUtilStyles from '../../../lib/components/app-layout/test-classes/styles.css.js';
+// import testUtilStyles from '../../../lib/components/app-layout/test-classes/styles.css.js';
 
-function findToolbar(wrapper: AppLayoutWrapper) {
-  return wrapper.findByClassName(testUtilStyles.toolbar)?.getElement();
-}
+// function findToolbar(wrapper: AppLayoutWrapper) {
+//   return wrapper.findByClassName(testUtilStyles.toolbar)?.getElement();
+// }
 
 // no-op function to suppress controllability warnings
 function noop() {}
@@ -22,21 +22,21 @@ describe('toolbar mode only features', () => {
   describeEachAppLayout({ themes: ['refresh-toolbar'] }, ({ size }) => {
     test('does not render the toolbar when all panels are hidden', () => {
       const { wrapper } = renderComponent(<AppLayout navigationHide={true} toolsHide={true} />);
-      expect(findToolbar(wrapper)).toBeFalsy();
+      expect(wrapper.findToolbar()).toBeFalsy();
     });
 
     test('renders toggle buttons when drawers are closed', () => {
       const { wrapper } = renderComponent(
         <AppLayout navigationOpen={false} toolsOpen={false} onNavigationChange={noop} onToolsChange={noop} />
       );
-      expect(findToolbar(wrapper)).toBeTruthy();
-      expect(findToolbar(wrapper)).toContainElement(wrapper.findNavigationToggle().getElement());
-      expect(findToolbar(wrapper)).toContainElement(wrapper.findToolsToggle().getElement());
+      expect(wrapper.findToolbar()).toBeTruthy();
+      expect(wrapper.findToolbar()).toContainElement(wrapper.findNavigationToggle().getElement());
+      expect(wrapper.findToolbar()).toContainElement(wrapper.findToolsToggle().getElement());
     });
 
     test('renders navigation toggle button for open state', () => {
       const { wrapper } = renderComponent(<AppLayout navigationOpen={true} onNavigationChange={noop} />);
-      expect(findToolbar(wrapper)).toBeTruthy();
+      expect(wrapper.findToolbar()).toBeTruthy();
       expect(wrapper.findNavigationToggle()).toBeTruthy();
     });
 
@@ -44,8 +44,8 @@ describe('toolbar mode only features', () => {
       const { wrapper } = renderComponent(
         <AppLayout splitPanel={<SplitPanel header="Testing">Dummy for testing</SplitPanel>} />
       );
-      expect(findToolbar(wrapper)).toBeTruthy();
-      expect(findToolbar(wrapper)).toContainElement(wrapper.findSplitPanelOpenButton()!.getElement());
+      expect(wrapper.findToolbar()).toBeTruthy();
+      expect(wrapper.findToolbar()).toContainElement(wrapper.findSplitPanelOpenButton()!.getElement());
     });
 
     test('renders toolbar with split panel trigger in active state', () => {
@@ -56,8 +56,8 @@ describe('toolbar mode only features', () => {
           onSplitPanelToggle={noop}
         />
       );
-      expect(findToolbar(wrapper)).toBeTruthy();
-      expect(findToolbar(wrapper)).toContainElement(wrapper.findSplitPanelOpenButton()!.getElement());
+      expect(wrapper.findToolbar()).toBeTruthy();
+      expect(wrapper.findToolbar()).toContainElement(wrapper.findSplitPanelOpenButton()!.getElement());
       expect(wrapper.findSplitPanelOpenButton()!.getElement()).toHaveAttribute('aria-expanded', 'true');
     });
 
@@ -65,8 +65,8 @@ describe('toolbar mode only features', () => {
     (size === 'mobile' ? describe : describe.skip)('multiple drawers', () => {
       test('renders multiple toggle buttons', () => {
         const { wrapper } = renderComponent(<AppLayout drawers={manyDrawers} />);
-        expect(findToolbar(wrapper)).toBeTruthy();
-        expect(findToolbar(wrapper)).toContainElement(wrapper.findDrawerTriggerById(manyDrawers[0].id)!.getElement());
+        expect(wrapper.findToolbar()).toBeTruthy();
+        expect(wrapper.findToolbar()).toContainElement(wrapper.findDrawerTriggerById(manyDrawers[0].id)!.getElement());
         expect(wrapper.findDrawerTriggerById(manyDrawers[0].id)!.getElement()).toHaveAttribute(
           'aria-expanded',
           'false'
@@ -77,8 +77,8 @@ describe('toolbar mode only features', () => {
         const { wrapper } = renderComponent(
           <AppLayout activeDrawerId={manyDrawers[0].id} drawers={manyDrawers} onDrawerChange={noop} />
         );
-        expect(findToolbar(wrapper)).toBeTruthy();
-        expect(findToolbar(wrapper)).toContainElement(wrapper.findDrawerTriggerById(manyDrawers[0].id)!.getElement());
+        expect(wrapper.findToolbar()).toBeTruthy();
+        expect(wrapper.findToolbar()).toContainElement(wrapper.findDrawerTriggerById(manyDrawers[0].id)!.getElement());
         expect(wrapper.findDrawerTriggerById(manyDrawers[0].id)!.getElement()).toHaveAttribute('aria-expanded', 'true');
       });
     });

--- a/src/app-layout/__tests__/toolbar.test.tsx
+++ b/src/app-layout/__tests__/toolbar.test.tsx
@@ -29,9 +29,10 @@ describe('toolbar mode only features', () => {
       const { wrapper } = renderComponent(
         <AppLayout navigationOpen={false} toolsOpen={false} onNavigationChange={noop} onToolsChange={noop} />
       );
+      expect(wrapper.findActiveDrawer()).toBeNull();
       expect(wrapper.findToolbar()).toBeTruthy();
-      expect(wrapper.findToolbar()).toContainElement(wrapper.findNavigationToggle().getElement());
-      expect(wrapper.findToolbar()).toContainElement(wrapper.findToolsToggle().getElement());
+      expect(wrapper.findToolbar()!.getElement()).toContainElement(wrapper.findNavigationToggle()!.getElement());
+      expect(wrapper.findToolbar()!.getElement()).toContainElement(wrapper.findToolsToggle()!.getElement());
     });
 
     test('renders navigation toggle button for open state', () => {
@@ -45,7 +46,7 @@ describe('toolbar mode only features', () => {
         <AppLayout splitPanel={<SplitPanel header="Testing">Dummy for testing</SplitPanel>} />
       );
       expect(wrapper.findToolbar()).toBeTruthy();
-      expect(wrapper.findToolbar()).toContainElement(wrapper.findSplitPanelOpenButton()!.getElement());
+      expect(wrapper.findToolbar()!.getElement()).toContainElement(wrapper.findSplitPanelOpenButton()!.getElement());
     });
 
     test('renders toolbar with split panel trigger in active state', () => {
@@ -57,7 +58,7 @@ describe('toolbar mode only features', () => {
         />
       );
       expect(wrapper.findToolbar()).toBeTruthy();
-      expect(wrapper.findToolbar()).toContainElement(wrapper.findSplitPanelOpenButton()!.getElement());
+      expect(wrapper.findToolbar()!.getElement()).toContainElement(wrapper.findSplitPanelOpenButton()!.getElement());
       expect(wrapper.findSplitPanelOpenButton()!.getElement()).toHaveAttribute('aria-expanded', 'true');
     });
 
@@ -66,7 +67,9 @@ describe('toolbar mode only features', () => {
       test('renders multiple toggle buttons', () => {
         const { wrapper } = renderComponent(<AppLayout drawers={manyDrawers} />);
         expect(wrapper.findToolbar()).toBeTruthy();
-        expect(wrapper.findToolbar()).toContainElement(wrapper.findDrawerTriggerById(manyDrawers[0].id)!.getElement());
+        expect(wrapper.findToolbar()!.getElement()).toContainElement(
+          wrapper.findDrawerTriggerById(manyDrawers[0].id)!.getElement()
+        );
         expect(wrapper.findDrawerTriggerById(manyDrawers[0].id)!.getElement()).toHaveAttribute(
           'aria-expanded',
           'false'
@@ -78,7 +81,9 @@ describe('toolbar mode only features', () => {
           <AppLayout activeDrawerId={manyDrawers[0].id} drawers={manyDrawers} onDrawerChange={noop} />
         );
         expect(wrapper.findToolbar()).toBeTruthy();
-        expect(wrapper.findToolbar()).toContainElement(wrapper.findDrawerTriggerById(manyDrawers[0].id)!.getElement());
+        expect(wrapper.findToolbar()!.getElement()).toContainElement(
+          wrapper.findDrawerTriggerById(manyDrawers[0].id)!.getElement()
+        );
         expect(wrapper.findDrawerTriggerById(manyDrawers[0].id)!.getElement()).toHaveAttribute('aria-expanded', 'true');
       });
     });

--- a/src/app-layout/__tests__/toolbar.test.tsx
+++ b/src/app-layout/__tests__/toolbar.test.tsx
@@ -7,13 +7,6 @@ import { describeEachAppLayout, manyDrawers, renderComponent } from './utils';
 
 import AppLayout from '../../../lib/components/app-layout';
 import SplitPanel from '../../../lib/components/split-panel';
-// import createWrapper, { AppLayoutWrapper } from '../../../lib/components/test-utils/dom';
-
-// import testUtilStyles from '../../../lib/components/app-layout/test-classes/styles.css.js';
-
-// function findToolbar(wrapper: AppLayoutWrapper) {
-//   return wrapper.findByClassName(testUtilStyles.toolbar)?.getElement();
-// }
 
 // no-op function to suppress controllability warnings
 function noop() {}

--- a/src/app-layout/__tests__/trigger-button.test.tsx
+++ b/src/app-layout/__tests__/trigger-button.test.tsx
@@ -16,6 +16,7 @@ import { ButtonProps } from '../../../lib/components/button';
 import { IconProps } from '../../../lib/components/icon/interfaces.js';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
+import testUtilStyles from '../../../lib/components/app-layout/test-classes/styles.css.js';
 import visualRefreshStyles from '../../../lib/components/app-layout/visual-refresh/styles.css.js';
 import toolbarTriggerButtonStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/trigger-button/styles.css.js';
 
@@ -353,17 +354,17 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           expect(getByTestId(mockTestId)).toBeTruthy();
           const button = wrapper!.find('button');
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(
-            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-          ).toBe(false);
-          expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+            false
+          );
+          expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           expect(button).toBeTruthy();
           expect(document.activeElement).not.toBe(button!.getElement());
           (ref.current as any)?.focus(mockEventBubbleWithRelatedTarget);
           expect(document.activeElement).toBe(button!.getElement());
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+          expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
         });
 
         test('pointer events work properly', () => {
@@ -372,32 +373,32 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             isMobile,
           });
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(
-            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-          ).toBe(false);
-          expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+            false
+          );
+          expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           fireEvent.pointerEnter(wrapper!.getElement());
           if (hasTooltip) {
             expect(getByText(mockTooltipText)).toBeTruthy();
-            expect(
-              wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-            ).toBe(true);
+            expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+              true
+            );
             //trigger event again to assert the tooltip remains
             fireEvent.pointerDown(wrapper!.getElement());
-            expect(
-              wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-            ).toBe(true);
+            expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+              true
+            );
           } else {
             expect(() => getByText(mockTooltipText)).toThrow();
-            expect(
-              wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-            ).toBe(false);
+            expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+              false
+            );
           }
           fireEvent.pointerLeave(wrapper!.getElement(), mockEventBubble);
-          expect(
-            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-          ).toBe(false);
+          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+            false
+          );
           expect(() => getByText(mockTooltipText)).toThrow();
         });
 
@@ -407,10 +408,10 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             isMobile,
           });
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(
-            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-          ).toBe(false);
-          expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+            false
+          );
+          expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           fireEvent.focus(wrapper!.getElement());
 
@@ -419,15 +420,15 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           } else {
             expect(() => getByText(mockTooltipText)).toThrow();
           }
-          expect(
-            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-          ).toBe(hasTooltip);
+          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+            hasTooltip
+          );
 
           fireEvent.blur(wrapper!.getElement());
-          expect(wrapper.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
-          expect(
-            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-          ).toBe(false);
+          expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+            false
+          );
           expect(() => getByText(mockTooltipText)).toThrow();
         });
 
@@ -437,16 +438,16 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             isMobile,
           });
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(
-            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-          ).toBe(false);
-          expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+            false
+          );
+          expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           fireEvent.focus(wrapper!.getElement());
           expect(getByText(mockTooltipText)).toBeTruthy();
-          expect(
-            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-          ).toBe(true);
+          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+            true
+          );
 
           fireEvent.keyDown(wrapper!.getElement(), {
             ...mockEventBubble,
@@ -454,10 +455,10 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             code: KeyCode.escape,
           });
 
-          expect(wrapper.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
-          expect(
-            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-          ).toBe(false);
+          expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+            false
+          );
           expect(() => getByText(mockTooltipText)).toThrow();
         });
 
@@ -469,22 +470,22 @@ describe('Visual Refresh Toolbar trigger-button', () => {
               tooltipText: '',
             });
             expect(getByTestId(mockTestId)).toBeTruthy();
-            expect(
-              wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-            ).toBe(false);
-            expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+            expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+              false
+            );
+            expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
 
             fireEvent.pointerEnter(wrapper!.getElement());
-            expect(
-              wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-            ).toBe(false);
-            expect(wrapper.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+            expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+              false
+            );
+            expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
 
             fireEvent.focus(wrapper!.getElement());
-            expect(
-              wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-            ).toBe(false);
-            expect(wrapper.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+            expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
+              false
+            );
+            expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
           }
         );
       });
@@ -494,15 +495,11 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           hasOpenDrawer: true,
         });
         expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(
-          wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-        ).toBe(false);
-        expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(false);
+        expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
         fireEvent.focus(wrapper!.getElement());
-        expect(
-          wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-        ).toBe(false);
-        expect(wrapper.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(false);
+        expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
       });
 
       //the realatedTarget here would be truthy when key or click navigation
@@ -514,21 +511,15 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           isForSplitPanel: true,
         });
         expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(
-          wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-        ).toBe(false);
-        expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(false);
+        expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
         expect(() => getByText(mockTooltipText)).toThrow();
         fireEvent.focus(wrapper!.getElement(), mockEventBubbleWithRelatedTarget);
         expect(getByText(mockTooltipText)).toBeTruthy();
-        expect(
-          wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-        ).toBe(true);
+        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(true);
         fireEvent.blur(wrapper!.getElement());
-        expect(wrapper.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
-        expect(
-          wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-        ).toBe(false);
+        expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(false);
         expect(() => getByText(mockTooltipText)).toThrow();
       });
 
@@ -541,17 +532,13 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           isForSplitPanel: true,
         });
         expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(
-          wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-        ).toBe(false);
-        expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(false);
+        expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
         expect(() => getByText(mockTooltipText)).toThrow();
         fireEvent.focus(wrapper!.getElement());
 
         expect(() => getByText(mockTooltipText)).toThrow();
-        expect(
-          wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-        ).toBeFalsy();
+        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBeFalsy();
       });
 
       test('Focus events work properly for isForPreviousDrawer', () => {
@@ -561,10 +548,8 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           isForPreviousActiveDrawer: true,
         });
         expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(
-          wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-        ).toBe(false);
-        expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(false);
+        expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
         expect(() => getByText(mockTooltipText)).toThrow();
         fireEvent.focus(wrapper!.getElement());
 

--- a/src/app-layout/__tests__/trigger-button.test.tsx
+++ b/src/app-layout/__tests__/trigger-button.test.tsx
@@ -507,7 +507,8 @@ describe('Visual Refresh Toolbar trigger-button', () => {
         expect(wrapper.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
       });
 
-      test('Focus and blur events work properly for split panel and not from another trigger', () => {
+      //the realatedTarget here would be truthy when key or click navigation
+      test('Focus and blur events work properly for split panel and related target exists', () => {
         const { wrapper, getByText, getByTestId } = renderVisualRefreshToolbarTriggerButton({
           hasTooltip: true,
           isMobile,
@@ -519,7 +520,7 @@ describe('Visual Refresh Toolbar trigger-button', () => {
         ).toBe(false);
         expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
         expect(() => getByText(mockTooltipText)).toThrow();
-        fireEvent.focus(wrapper!.getElement());
+        fireEvent.focus(wrapper!.getElement(), mockEventBubbleWithRelatedTarget);
 
         expect(getByText(mockTooltipText)).toBeTruthy();
         expect(
@@ -531,6 +532,27 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
         ).toBe(false);
         expect(() => getByText(mockTooltipText)).toThrow();
+      });
+
+      //the relatedTarget here will be null just like when a split panel close button is clicked/keyed
+      test('Focus and blur events work properly for split panel and relatedTarget is null', () => {
+        const { wrapper, getByText, getByTestId } = renderVisualRefreshToolbarTriggerButton({
+          hasTooltip: true,
+          isMobile,
+          isForSplitPanel: true,
+        });
+        expect(getByTestId(mockTestId)).toBeTruthy();
+        expect(
+          wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+        ).toBe(false);
+        expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+        expect(() => getByText(mockTooltipText)).toThrow();
+        fireEvent.focus(wrapper!.getElement(), { relatedTarget: null });
+
+        expect(() => getByText(mockTooltipText)).toThrow();
+        expect(
+          wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+        ).toBeFalsy();
       });
 
       test('Focus events work properly for split panel and not from a close button', () => {

--- a/src/app-layout/__tests__/trigger-button.test.tsx
+++ b/src/app-layout/__tests__/trigger-button.test.tsx
@@ -60,6 +60,8 @@ const mockEventBubbleWithRelatedTarget = {
   relatedTarget: mockRelatedTarget,
 };
 
+const triggerButtoonTooltipClass = testUtilStyles['trigger-tooltip'];
+
 const testIf = (condition: boolean) => (condition ? test : test.skip);
 
 const renderVisualRefreshTriggerButton = (
@@ -354,14 +356,14 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           expect(getByTestId(mockTestId)).toBeTruthy();
           const button = wrapper!.find('button');
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+          expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           expect(button).toBeTruthy();
           expect(document.activeElement).not.toBe(button!.getElement());
           (ref.current as any)?.focus(mockEventBubbleWithRelatedTarget);
           expect(document.activeElement).toBe(button!.getElement());
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+          expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
         });
 
         test('pointer events work properly', () => {
@@ -370,7 +372,7 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             isMobile,
           });
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+          expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           fireEvent.pointerEnter(wrapper!.getElement());
           if (hasTooltip) {
@@ -390,7 +392,7 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             isMobile,
           });
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+          expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           fireEvent.focus(wrapper!.getElement());
 
@@ -401,7 +403,7 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           }
 
           fireEvent.blur(wrapper!.getElement());
-          expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+          expect(wrapper.findByClassName(triggerButtoonTooltipClass)).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
         });
 
@@ -411,7 +413,7 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             isMobile,
           });
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+          expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           fireEvent.focus(wrapper!.getElement());
           expect(getByText(mockTooltipText)).toBeTruthy();
@@ -422,7 +424,7 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             code: KeyCode.escape,
           });
 
-          expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+          expect(wrapper.findByClassName(triggerButtoonTooltipClass)).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
         });
 
@@ -434,13 +436,13 @@ describe('Visual Refresh Toolbar trigger-button', () => {
               tooltipText: '',
             });
             expect(getByTestId(mockTestId)).toBeTruthy();
-            expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+            expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
 
             fireEvent.pointerEnter(wrapper!.getElement());
-            expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+            expect(wrapper.findByClassName(triggerButtoonTooltipClass)).toBeNull();
 
             fireEvent.focus(wrapper!.getElement());
-            expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+            expect(wrapper.findByClassName(triggerButtoonTooltipClass)).toBeNull();
           }
         );
       });
@@ -450,10 +452,10 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           hasOpenDrawer: true,
         });
         expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+        expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
 
         fireEvent.focus(wrapper!.getElement());
-        expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+        expect(wrapper.findByClassName(triggerButtoonTooltipClass)).toBeNull();
       });
 
       //the realatedTarget here would be truthy when key or click navigation
@@ -465,14 +467,14 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           isForSplitPanel: true,
         });
         expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+        expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
         expect(() => getByText(mockTooltipText)).toThrow();
 
         fireEvent.focus(wrapper!.getElement(), mockEventBubbleWithRelatedTarget);
         expect(getByText(mockTooltipText)).toBeTruthy();
 
         fireEvent.blur(wrapper!.getElement());
-        expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+        expect(wrapper.findByClassName(triggerButtoonTooltipClass)).toBeNull();
         expect(() => getByText(mockTooltipText)).toThrow();
       });
 
@@ -485,7 +487,7 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           isForSplitPanel: true,
         });
         expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+        expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
         expect(() => getByText(mockTooltipText)).toThrow();
         fireEvent.focus(wrapper!.getElement());
 
@@ -499,7 +501,7 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           isForPreviousActiveDrawer: true,
         });
         expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+        expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
         expect(() => getByText(mockTooltipText)).toThrow();
 
         fireEvent.focus(wrapper!.getElement());

--- a/src/app-layout/__tests__/trigger-button.test.tsx
+++ b/src/app-layout/__tests__/trigger-button.test.tsx
@@ -59,8 +59,6 @@ const mockEventBubbleWithRelatedTarget = {
   relatedTarget: mockRelatedTarget,
 };
 
-const mockQuerySelector = jest.spyOn(document, 'querySelector');
-
 const testIf = (condition: boolean) => (condition ? test : test.skip);
 
 const renderVisualRefreshTriggerButton = (
@@ -508,6 +506,7 @@ describe('Visual Refresh Toolbar trigger-button', () => {
       });
 
       //the realatedTarget here would be truthy when key or click navigation
+      //relatedTarget exists on events that are not associated with closeing the split panel from within
       test('Focus and blur events work properly for split panel and related target exists', () => {
         const { wrapper, getByText, getByTestId } = renderVisualRefreshToolbarTriggerButton({
           hasTooltip: true,
@@ -521,7 +520,6 @@ describe('Visual Refresh Toolbar trigger-button', () => {
         expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
         expect(() => getByText(mockTooltipText)).toThrow();
         fireEvent.focus(wrapper!.getElement(), mockEventBubbleWithRelatedTarget);
-
         expect(getByText(mockTooltipText)).toBeTruthy();
         expect(
           wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
@@ -534,7 +532,8 @@ describe('Visual Refresh Toolbar trigger-button', () => {
         expect(() => getByText(mockTooltipText)).toThrow();
       });
 
-      //the relatedTarget here will be null just like when a split panel close button is clicked/keyed
+      //the relatedTarget here will be null just like when a split panel closed via mouse or key interaction
+      //with the close button on the split panel
       test('Focus and blur events work properly for split panel and relatedTarget is null', () => {
         const { wrapper, getByText, getByTestId } = renderVisualRefreshToolbarTriggerButton({
           hasTooltip: true,
@@ -547,33 +546,12 @@ describe('Visual Refresh Toolbar trigger-button', () => {
         ).toBe(false);
         expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
         expect(() => getByText(mockTooltipText)).toThrow();
-        fireEvent.focus(wrapper!.getElement(), { relatedTarget: null });
+        fireEvent.focus(wrapper!.getElement());
 
         expect(() => getByText(mockTooltipText)).toThrow();
         expect(
           wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
         ).toBeFalsy();
-      });
-
-      test('Focus events work properly for split panel and not from a close button', () => {
-        const mockBreadcrumbWrapper = {
-          contains: jest.fn().mockReturnValue(true),
-        };
-        mockQuerySelector.mockReturnValue(mockBreadcrumbWrapper as any);
-        const { wrapper, getByText, getByTestId } = renderVisualRefreshToolbarTriggerButton({
-          hasTooltip: true,
-          isMobile,
-          isForSplitPanel: true,
-        });
-        expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(
-          wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
-        ).toBe(false);
-        expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
-        expect(() => getByText(mockTooltipText)).toThrow();
-        fireEvent.focus(wrapper!.getElement(), { relatedTarget: mockRelatedTarget });
-
-        expect(getByText(mockTooltipText)).toBeTruthy();
       });
 
       test('Focus events work properly for isForPreviousDrawer', () => {

--- a/src/app-layout/__tests__/trigger-button.test.tsx
+++ b/src/app-layout/__tests__/trigger-button.test.tsx
@@ -354,9 +354,6 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           expect(getByTestId(mockTestId)).toBeTruthy();
           const button = wrapper!.find('button');
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-            false
-          );
           expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           expect(button).toBeTruthy();
@@ -373,32 +370,17 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             isMobile,
           });
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-            false
-          );
           expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           fireEvent.pointerEnter(wrapper!.getElement());
           if (hasTooltip) {
             expect(getByText(mockTooltipText)).toBeTruthy();
-            expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-              true
-            );
             //trigger event again to assert the tooltip remains
             fireEvent.pointerDown(wrapper!.getElement());
-            expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-              true
-            );
           } else {
             expect(() => getByText(mockTooltipText)).toThrow();
-            expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-              false
-            );
           }
           fireEvent.pointerLeave(wrapper!.getElement(), mockEventBubble);
-          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-            false
-          );
           expect(() => getByText(mockTooltipText)).toThrow();
         });
 
@@ -408,9 +390,6 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             isMobile,
           });
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-            false
-          );
           expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           fireEvent.focus(wrapper!.getElement());
@@ -420,15 +399,9 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           } else {
             expect(() => getByText(mockTooltipText)).toThrow();
           }
-          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-            hasTooltip
-          );
 
           fireEvent.blur(wrapper!.getElement());
           expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
-          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-            false
-          );
           expect(() => getByText(mockTooltipText)).toThrow();
         });
 
@@ -438,16 +411,10 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             isMobile,
           });
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-            false
-          );
           expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           fireEvent.focus(wrapper!.getElement());
           expect(getByText(mockTooltipText)).toBeTruthy();
-          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-            true
-          );
 
           fireEvent.keyDown(wrapper!.getElement(), {
             ...mockEventBubble,
@@ -456,9 +423,6 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           });
 
           expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
-          expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-            false
-          );
           expect(() => getByText(mockTooltipText)).toThrow();
         });
 
@@ -470,21 +434,12 @@ describe('Visual Refresh Toolbar trigger-button', () => {
               tooltipText: '',
             });
             expect(getByTestId(mockTestId)).toBeTruthy();
-            expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-              false
-            );
             expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
 
             fireEvent.pointerEnter(wrapper!.getElement());
-            expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-              false
-            );
             expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
 
             fireEvent.focus(wrapper!.getElement());
-            expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(
-              false
-            );
             expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
           }
         );
@@ -495,10 +450,9 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           hasOpenDrawer: true,
         });
         expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(false);
         expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
+
         fireEvent.focus(wrapper!.getElement());
-        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(false);
         expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
       });
 
@@ -511,15 +465,14 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           isForSplitPanel: true,
         });
         expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(false);
         expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
         expect(() => getByText(mockTooltipText)).toThrow();
+
         fireEvent.focus(wrapper!.getElement(), mockEventBubbleWithRelatedTarget);
         expect(getByText(mockTooltipText)).toBeTruthy();
-        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(true);
+
         fireEvent.blur(wrapper!.getElement());
         expect(wrapper.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
-        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(false);
         expect(() => getByText(mockTooltipText)).toThrow();
       });
 
@@ -532,13 +485,11 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           isForSplitPanel: true,
         });
         expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(false);
         expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
         expect(() => getByText(mockTooltipText)).toThrow();
         fireEvent.focus(wrapper!.getElement());
 
         expect(() => getByText(mockTooltipText)).toThrow();
-        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBeFalsy();
       });
 
       test('Focus events work properly for isForPreviousDrawer', () => {
@@ -548,11 +499,10 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           isForPreviousActiveDrawer: true,
         });
         expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(wrapper!.getElement().classList.contains(testUtilStyles['trigger-wrapper-tooltip-visible'])).toBe(false);
         expect(wrapper!.findByClassName(testUtilStyles['trigger-tooltip'])).toBeNull();
         expect(() => getByText(mockTooltipText)).toThrow();
-        fireEvent.focus(wrapper!.getElement());
 
+        fireEvent.focus(wrapper!.getElement());
         expect(() => getByText(mockTooltipText)).toThrow();
       });
     });

--- a/src/app-layout/test-classes/styles.scss
+++ b/src/app-layout/test-classes/styles.scss
@@ -64,3 +64,19 @@
 .toolbar {
   /* used in tests */
 }
+
+// .drawers-mobile-triggers-container {
+//   /* used in tests */
+// }
+
+// .drawers-desktop-triggers-container {
+//   /* used in tests */
+// }
+
+.trigger-wrapper-tooltip-visible {
+  /* used in tests */
+}
+
+.trigger-tooltip {
+  /* used in tests */
+}

--- a/src/app-layout/test-classes/styles.scss
+++ b/src/app-layout/test-classes/styles.scss
@@ -65,14 +65,6 @@
   /* used in tests */
 }
 
-// .drawers-mobile-triggers-container {
-//   /* used in tests */
-// }
-
-// .drawers-desktop-triggers-container {
-//   /* used in tests */
-// }
-
 .trigger-wrapper-tooltip-visible {
   /* used in tests */
 }

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -182,6 +182,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
 
     const onSplitPanelToggleHandler = () => {
       setSplitPanelOpen(!splitPanelOpen);
+      splitPanelFocusControl.setLastInteraction({ type: splitPanelOpen ? 'close' : 'open' });
       fireNonCancelableEvent(onSplitPanelToggle, { open: !splitPanelOpen });
     };
 

--- a/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
@@ -140,7 +140,6 @@ export function DrawerTriggers({
               hasTooltip={true}
               testId={`awsui-app-layout-trigger-slide-panel`}
               isMobile={isMobile}
-              isForPreviousActiveDrawer={splitPanelToggleProps.active}
               isForSplitPanel={true}
               disabled={disabled}
             />

--- a/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
@@ -132,7 +132,11 @@ export function DrawerTriggers({
               ariaLabel={splitPanelToggleProps.ariaLabel}
               ariaControls={splitPanelToggleProps.controlId}
               ariaExpanded={splitPanelToggleProps.active}
-              className={clsx(styles['drawers-trigger'], splitPanelTestUtilStyles['open-button'])}
+              className={clsx(
+                styles['drawers-trigger'],
+                testutilStyles['drawers-trigger'],
+                splitPanelTestUtilStyles['open-button']
+              )}
               iconName={splitPanelToggleProps.position === 'side' ? 'view-vertical' : 'view-horizontal'}
               onClick={() => onSplitPanelToggle?.()}
               selected={splitPanelToggleProps.active}

--- a/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/index.tsx
@@ -205,9 +205,7 @@ function TriggerButton(
         onFocus: e => handleOnFocus(e as any),
         onBlur: () => handleBlur(true),
       })}
-      className={clsx(styles['trigger-wrapper'], !highContrastHeader ? styles['remove-high-contrast-header'] : '', {
-        [testutilStyles['trigger-wrapper-tooltip-visible']]: tooltipVisible,
-      })}
+      className={clsx(styles['trigger-wrapper'], !highContrastHeader ? styles['remove-high-contrast-header'] : '')}
     >
       <button
         aria-expanded={ariaExpanded}

--- a/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/index.tsx
@@ -28,6 +28,7 @@ export interface TriggerButtonProps {
    */
   selected?: boolean;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
+
   badge?: boolean;
   highContrastHeader?: boolean;
   /**
@@ -118,9 +119,10 @@ function TriggerButton(
       const relatedTarget = eventWithRelatedTarget?.relatedTarget;
       const isFromAnotherTrigger = relatedTarget?.dataset?.shiftFocus === 'awsui-layout-drawer-trigger';
       if (
-        isForSplitPanel || //for key navigation to button from breadcrumb
-        isFromAnotherTrigger || //for key navigation from another trigger button
-        !isForPreviousActiveDrawer //for when the drawer was not opened recently
+        (isForSplitPanel && !!relatedTarget) || //for when a split panel is closed via button
+        (!isForSplitPanel &&
+          (isFromAnotherTrigger || //for key navigation from another trigger button
+            !isForPreviousActiveDrawer)) //for when the drawer was not opened recently
       ) {
         shouldShowTooltip = true;
       }

--- a/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/index.tsx
@@ -9,6 +9,7 @@ import Icon from '../../../../icon/internal';
 import Tooltip from '../../../../internal/components/tooltip';
 import { registerTooltip } from '../../../../internal/components/tooltip/registry';
 
+import testutilStyles from '../../../test-classes/styles.css.js';
 import styles from './styles.css.js';
 
 export interface TriggerButtonProps {
@@ -205,7 +206,7 @@ function TriggerButton(
         onBlur: () => handleBlur(true),
       })}
       className={clsx(styles['trigger-wrapper'], !highContrastHeader ? styles['remove-high-contrast-header'] : '', {
-        [styles['trigger-wrapper-tooltip-visible']]: tooltipVisible,
+        [testutilStyles['trigger-wrapper-tooltip-visible']]: tooltipVisible,
       })}
     >
       <button
@@ -235,7 +236,9 @@ function TriggerButton(
         </span>
       </button>
       {badge && <div className={styles.dot} />}
-      {tooltipVisible && <Tooltip trackRef={containerRef} value={tooltipValue} className={styles['trigger-tooltip']} />}
+      {tooltipVisible && (
+        <Tooltip trackRef={containerRef} value={tooltipValue} className={testutilStyles['trigger-tooltip']} />
+      )}
     </div>
   );
 }

--- a/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/index.tsx
@@ -119,10 +119,10 @@ function TriggerButton(
       const relatedTarget = eventWithRelatedTarget?.relatedTarget;
       const isFromAnotherTrigger = relatedTarget?.dataset?.shiftFocus === 'awsui-layout-drawer-trigger';
       if (
-        (isForSplitPanel && !!relatedTarget) || //for when a split panel is closed via button
+        (isForSplitPanel && !!relatedTarget) || // relatedTarget is null when split panel is closed
         (!isForSplitPanel &&
-          (isFromAnotherTrigger || //for key navigation from another trigger button
-            !isForPreviousActiveDrawer)) //for when the drawer was not opened recently
+          (isFromAnotherTrigger || // for key navigation from another trigger button
+            !isForPreviousActiveDrawer)) // for when the drawer was not opened recently
       ) {
         shouldShowTooltip = true;
       }

--- a/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/styles.scss
@@ -99,9 +99,9 @@
   border-end-end-radius: 50%;
 }
 
-.trigger-wrapper-tooltip-visible {
-  /* used in test-utils*/
-}
+// .trigger-wrapper-tooltip-visible {
+//   /* used in test-utils*/
+// }
 
 .dot {
   position: absolute;
@@ -116,6 +116,6 @@
   inset-inline-end: -1px;
 }
 
-.trigger-tooltip {
-  /* used in test-utils */
-}
+// .trigger-tooltip {
+//   /* used in test-utils */
+// }

--- a/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/styles.scss
@@ -99,10 +99,6 @@
   border-end-end-radius: 50%;
 }
 
-// .trigger-wrapper-tooltip-visible {
-//   /* used in test-utils*/
-// }
-
 .dot {
   position: absolute;
   inline-size: 8px;
@@ -115,7 +111,3 @@
   inset-block-start: 1px;
   inset-inline-end: -1px;
 }
-
-// .trigger-tooltip {
-//   /* used in test-utils */
-// }

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -300,6 +300,7 @@ function DesktopTriggers() {
             selected={hasSplitPanel && isSplitPanelOpen}
             ref={splitPanelRefs.toggle}
             highContrastHeader={headerVariant === 'high-contrast'}
+            testId="awsui-app-layout-trigger-slide-panel"
           />
         )}
       </div>

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -255,8 +255,8 @@ function DesktopTriggers() {
                 testutilStyles['drawers-trigger'],
                 item.id === TOOLS_DRAWER_ID && testutilStyles['tools-toggle']
               )}
-              iconName={item.trigger!.iconName}
-              iconSvg={item.trigger!.iconSvg}
+              iconName={item?.trigger?.iconName}
+              iconSvg={item?.trigger?.iconSvg}
               key={item.id}
               onClick={() => handleDrawersClick(item.id)}
               ref={isForPreviousActiveDrawer ? drawersRefs.toggle : undefined}
@@ -365,8 +365,8 @@ export function MobileTriggers() {
               )}
               disabled={hasDrawerViewportOverlay}
               ref={isForPreviousActiveDrawer ? drawersRefs.toggle : undefined}
-              iconName={item.trigger!.iconName}
-              iconSvg={item.trigger!.iconSvg}
+              iconName={item?.trigger?.iconName}
+              iconSvg={item?.trigger?.iconSvg}
               badge={item.badge}
               key={item.id}
               onClick={() => handleDrawersClick(item.id)}

--- a/src/split-panel/implementation.tsx
+++ b/src/split-panel/implementation.tsx
@@ -123,7 +123,7 @@ export const SplitPanelImplementation = React.forwardRef<HTMLElement, SplitPanel
               variant="icon"
               formAction="none"
               ariaLabel={i18nStrings.openButtonAriaLabel}
-              ref={refs.toggle}
+              ref={!isToolbar ? refs.toggle : undefined}
               ariaExpanded={isOpen}
             />
           )}

--- a/src/split-panel/implementation.tsx
+++ b/src/split-panel/implementation.tsx
@@ -116,14 +116,14 @@ export const SplitPanelImplementation = React.forwardRef<HTMLElement, SplitPanel
               ariaLabel={i18nStrings.closeButtonAriaLabel}
               ariaExpanded={isOpen}
             />
-          ) : position === 'side' ? null : (
+          ) : isToolbar || position === 'side' ? null : (
             <InternalButton
               className={testUtilStyles['open-button']}
               iconName="angle-up"
               variant="icon"
               formAction="none"
               ariaLabel={i18nStrings.openButtonAriaLabel}
-              ref={!isToolbar ? refs.toggle : undefined}
+              ref={refs.toggle}
               ariaExpanded={isOpen}
             />
           )}

--- a/src/split-panel/side.tsx
+++ b/src/split-panel/side.tsx
@@ -70,8 +70,8 @@ export function SplitPanelContentSide({
         role="region"
       >
         {isOpen ? (
-          <div className={styles['slider-wrapper-side']}>{resizeHandle}</div>
-        ) : (
+          <div className={clsx(styles['slider-wrapper-side'], isToolbar && styles['with-toolbar'])}>{resizeHandle}</div>
+        ) : !isToolbar ? (
           <InternalButton
             className={clsx(testUtilStyles['open-button'], styles['open-button-side'])}
             iconName="angle-left"
@@ -81,7 +81,7 @@ export function SplitPanelContentSide({
             ariaExpanded={isOpen}
             ref={isRefresh ? null : toggleRef}
           />
-        )}
+        ) : null}
         <div
           className={clsx(styles['content-side'], isToolbar && styles['with-toolbar'])}
           aria-hidden={!isOpen}

--- a/src/split-panel/side.tsx
+++ b/src/split-panel/side.tsx
@@ -71,7 +71,7 @@ export function SplitPanelContentSide({
       >
         {isOpen ? (
           <div className={clsx(styles['slider-wrapper-side'], isToolbar && styles['with-toolbar'])}>{resizeHandle}</div>
-        ) : !isToolbar ? (
+        ) : (
           <InternalButton
             className={clsx(testUtilStyles['open-button'], styles['open-button-side'])}
             iconName="angle-left"
@@ -79,9 +79,10 @@ export function SplitPanelContentSide({
             formAction="none"
             ariaLabel={openButtonAriaLabel}
             ariaExpanded={isOpen}
-            ref={isRefresh ? null : toggleRef}
+            //toggleRef should only be assigned when there is no other trigger-buttons
+            ref={isRefresh || isToolbar ? null : toggleRef}
           />
-        ) : null}
+        )}
         <div
           className={clsx(styles['content-side'], isToolbar && styles['with-toolbar'])}
           aria-hidden={!isOpen}

--- a/src/split-panel/styles.scss
+++ b/src/split-panel/styles.scss
@@ -118,6 +118,9 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
   display: flex;
   align-items: center;
   z-index: 1;
+  &.with-toolbar {
+    position: unset;
+  }
 }
 
 .open-button-side {

--- a/src/test-utils/dom/app-layout/index.ts
+++ b/src/test-utils/dom/app-layout/index.ts
@@ -1,30 +1,29 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { ComponentWrapper, createWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 
 import ButtonDropdownWrapper from '../button-dropdown';
 import SplitPanelWrapper from '../split-panel';
 
 import testutilStyles from '../../../app-layout/test-classes/styles.selectors.js';
-import appLayoutToolbarStyles from '../../../app-layout/visual-refresh-toolbar/toolbar/stlyes.selectors.js';
 import splitPanelTestUtilStyles from '../../../split-panel/test-classes/styles.selectors.js';
 
 export default class AppLayoutWrapper extends ComponentWrapper {
   static rootSelector = testutilStyles.root;
 
-  findNavigation(): ElementWrapper {
+  findNavigation(): ElementWrapper | null {
     return this.findByClassName(testutilStyles.navigation)!;
   }
 
-  findNavigationToggle(): ElementWrapper<HTMLButtonElement> {
+  findNavigationToggle(): ElementWrapper<HTMLButtonElement> | null {
     return this.findByClassName<HTMLButtonElement>(testutilStyles['navigation-toggle'])!;
   }
 
-  findNavigationClose(): ElementWrapper<HTMLButtonElement> {
+  findNavigationClose(): ElementWrapper<HTMLButtonElement> | null {
     return this.findByClassName<HTMLButtonElement>(testutilStyles['navigation-close'])!;
   }
 
-  findContentRegion(): ElementWrapper {
+  findContentRegion(): ElementWrapper | null {
     return this.findByClassName(testutilStyles.content)!;
   }
 
@@ -36,15 +35,15 @@ export default class AppLayoutWrapper extends ComponentWrapper {
     return this.findByClassName(testutilStyles.breadcrumbs);
   }
 
-  findTools(): ElementWrapper {
+  findTools(): ElementWrapper | null {
     return this.findByClassName(testutilStyles.tools)!;
   }
 
-  findToolsClose(): ElementWrapper<HTMLButtonElement> {
+  findToolsClose(): ElementWrapper<HTMLButtonElement> | null {
     return this.findByClassName<HTMLButtonElement>(testutilStyles['tools-close'])!;
   }
 
-  findToolsToggle(): ElementWrapper<HTMLButtonElement> {
+  findToolsToggle(): ElementWrapper<HTMLButtonElement> | null {
     return this.findByClassName<HTMLButtonElement>(testutilStyles['tools-toggle'])!;
   }
 
@@ -80,11 +79,11 @@ export default class AppLayoutWrapper extends ComponentWrapper {
     return this.findByClassName(testutilStyles['drawers-slider']);
   }
 
-  findToolbarTriggerButtonContainer(isMobile: boolean): ElementWrapper | null {
-    const drawersTriggerContainerClassKey = `drawers-${isMobile ? 'mobile' : 'desktop'}-triggers-container`;
-    return this.findByClassName(appLayoutToolbarStyles[drawersTriggerContainerClassKey]);
-    //if not working try createWrapper().find(`.${}`);
-  }
+  // findToolbarTriggerButtonContainer(isMobile: boolean): ElementWrapper | null {
+  //   const drawersTriggerContainerClassKey = `drawers-${isMobile ? 'mobile' : 'desktop'}-triggers-container`;
+  //   return this.findByClassName(appLayoutToolbarStyles[drawersTriggerContainerClassKey]);
+  //   //if not working try createWrapper().find(`.${}`);
+  // }
 
   findToolbar(): ElementWrapper | null {
     return this.findByClassName(testutilStyles.toolbar);
@@ -95,6 +94,7 @@ export default class AppLayoutWrapper extends ComponentWrapper {
   }
 
   findDrawerTriggerTooltip(): ElementWrapper | null {
-    return this.findByClassName(testutilStyles['trigger-tooltip']);
+    // return this.findByClassName(testutilStyles['trigger-tooltip']);
+    return createWrapper().findByClassName(testutilStyles['trigger-tooltip']);
   }
 }

--- a/src/test-utils/dom/app-layout/index.ts
+++ b/src/test-utils/dom/app-layout/index.ts
@@ -6,6 +6,7 @@ import ButtonDropdownWrapper from '../button-dropdown';
 import SplitPanelWrapper from '../split-panel';
 
 import testutilStyles from '../../../app-layout/test-classes/styles.selectors.js';
+import appLayoutToolbarStyles from '../../../app-layout/visual-refresh-toolbar/toolbar/stlyes.selectors.js';
 import splitPanelTestUtilStyles from '../../../split-panel/test-classes/styles.selectors.js';
 
 export default class AppLayoutWrapper extends ComponentWrapper {
@@ -77,5 +78,23 @@ export default class AppLayoutWrapper extends ComponentWrapper {
 
   findActiveDrawerResizeHandle(): ElementWrapper | null {
     return this.findByClassName(testutilStyles['drawers-slider']);
+  }
+
+  findToolbarTriggerButtonContainer(isMobile: boolean): ElementWrapper | null {
+    const drawersTriggerContainerClassKey = `drawers-${isMobile ? 'mobile' : 'desktop'}-triggers-container`;
+    return this.findByClassName(appLayoutToolbarStyles[drawersTriggerContainerClassKey]);
+    //if not working try createWrapper().find(`.${}`);
+  }
+
+  findToolbar(): ElementWrapper | null {
+    return this.findByClassName(testutilStyles.toolbar);
+  }
+
+  findDrawerTriggerWrapperWithTooltip(): ElementWrapper | null {
+    return this.findByClassName(testutilStyles['trigger-wrapper-tooltip-visible']);
+  }
+
+  findDrawerTriggerTooltip(): ElementWrapper | null {
+    return this.findByClassName(testutilStyles['trigger-tooltip']);
   }
 }

--- a/src/test-utils/dom/app-layout/index.ts
+++ b/src/test-utils/dom/app-layout/index.ts
@@ -11,19 +11,19 @@ import splitPanelTestUtilStyles from '../../../split-panel/test-classes/styles.s
 export default class AppLayoutWrapper extends ComponentWrapper {
   static rootSelector = testutilStyles.root;
 
-  findNavigation(): ElementWrapper | null {
+  findNavigation(): ElementWrapper {
     return this.findByClassName(testutilStyles.navigation)!;
   }
 
-  findNavigationToggle(): ElementWrapper<HTMLButtonElement> | null {
+  findNavigationToggle(): ElementWrapper<HTMLButtonElement> {
     return this.findByClassName<HTMLButtonElement>(testutilStyles['navigation-toggle'])!;
   }
 
-  findNavigationClose(): ElementWrapper<HTMLButtonElement> | null {
+  findNavigationClose(): ElementWrapper<HTMLButtonElement> {
     return this.findByClassName<HTMLButtonElement>(testutilStyles['navigation-close'])!;
   }
 
-  findContentRegion(): ElementWrapper | null {
+  findContentRegion(): ElementWrapper {
     return this.findByClassName(testutilStyles.content)!;
   }
 
@@ -35,15 +35,15 @@ export default class AppLayoutWrapper extends ComponentWrapper {
     return this.findByClassName(testutilStyles.breadcrumbs);
   }
 
-  findTools(): ElementWrapper | null {
+  findTools(): ElementWrapper {
     return this.findByClassName(testutilStyles.tools)!;
   }
 
-  findToolsClose(): ElementWrapper<HTMLButtonElement> | null {
+  findToolsClose(): ElementWrapper<HTMLButtonElement> {
     return this.findByClassName<HTMLButtonElement>(testutilStyles['tools-close'])!;
   }
 
-  findToolsToggle(): ElementWrapper<HTMLButtonElement> | null {
+  findToolsToggle(): ElementWrapper<HTMLButtonElement> {
     return this.findByClassName<HTMLButtonElement>(testutilStyles['tools-toggle'])!;
   }
 
@@ -79,22 +79,11 @@ export default class AppLayoutWrapper extends ComponentWrapper {
     return this.findByClassName(testutilStyles['drawers-slider']);
   }
 
-  // findToolbarTriggerButtonContainer(isMobile: boolean): ElementWrapper | null {
-  //   const drawersTriggerContainerClassKey = `drawers-${isMobile ? 'mobile' : 'desktop'}-triggers-container`;
-  //   return this.findByClassName(appLayoutToolbarStyles[drawersTriggerContainerClassKey]);
-  //   //if not working try createWrapper().find(`.${}`);
-  // }
-
   findToolbar(): ElementWrapper | null {
     return this.findByClassName(testutilStyles.toolbar);
   }
 
-  findDrawerTriggerWrapperWithTooltip(): ElementWrapper | null {
-    return this.findByClassName(testutilStyles['trigger-wrapper-tooltip-visible']);
-  }
-
   findDrawerTriggerTooltip(): ElementWrapper | null {
-    // return this.findByClassName(testutilStyles['trigger-tooltip']);
     return createWrapper().findByClassName(testutilStyles['trigger-tooltip']);
   }
 }


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
- works for both spit panel positions
- set focus to split panel resize button when split panel opened via toolbar trigger button
- set focus back to split panel trigger button on the toolbar once it is closed from the close button on the split panel
-  returns split panel interactions in integ tests

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?
- update to app layout integ tests where:
   - removed redundant classes
   - moved test added testutil functions and updated the tests to use those util functions
   - separated tooltip tests into multiple files with a util

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->
got to deployment with the following path & params - /light/app-layout/with-split-panel?appLayoutWidget=true
- open split panel via the first button in the toolbar
- close split panel via its close button
- note the focus
Confirm /light/app-layout/with-split-panel also works in classic and visual refresh

- compare to current https://d21d5uik3ws71m.cloudfront.net/components/3f188c630a8446f5776683b9dffc0f2b6ce157ef/dev-pages/index.html#/light/app-layout/with-split-panel?appLayoutWidget=true

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
