### PR TITLE
chore: Supporting webdriverio v9 migration 2

### DIFF
--- a/build-tools/tasks/a11y.js
+++ b/build-tools/tasks/a11y.js
@@ -27,6 +27,7 @@ module.exports = task('test:a11y', async () => {
   }
   await execa('jest', commands, {
     stdio: 'inherit',
+    env: { ...process.env, NODE_OPTIONS: '--experimental-vm-modules' },
   });
 
   devServer.cancel();

--- a/src/button-dropdown/__integ__/performance-marks.test.ts
+++ b/src/button-dropdown/__integ__/performance-marks.test.ts
@@ -18,7 +18,10 @@ function setupTest(
       const marks = await browser.execute(() => performance.getEntriesByType('mark') as PerformanceMark[]);
       return marks.filter(m => m.detail?.source === 'awsui');
     };
-    const getElementByPerformanceMark = (id: string) => browser.$(`[data-analytics-performance-mark="${id}"]`);
+    const getElementByPerformanceMark = async (id: string) => {
+      const element = await browser.$(`[data-analytics-performance-mark="${id}"]`);
+      return element;
+    };
 
     await testFn({ page, getMarks, getElementByPerformanceMark });
   });

--- a/src/button/__integ__/performance-marks.test.ts
+++ b/src/button/__integ__/performance-marks.test.ts
@@ -18,7 +18,10 @@ function setupTest(
       const marks = await browser.execute(() => performance.getEntriesByType('mark') as PerformanceMark[]);
       return marks.filter(m => m.detail?.source === 'awsui');
     };
-    const getElementByPerformanceMark = (id: string) => browser.$(`[data-analytics-performance-mark="${id}"]`);
+    const getElementByPerformanceMark = async (id: string) => {
+      const element = await browser.$(`[data-analytics-performance-mark="${id}"]`);
+      return element;
+    };
 
     await testFn({ page, getMarks, getElementByPerformanceMark });
   });


### PR DESCRIPTION
### Description

A follow-up for https://github.com/cloudscape-design/components/pull/2735, fixing more failures from the dry run of https://github.com/cloudscape-design/browser-test-tools/pull/109

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
