### PR TITLE
fix: resolving motion issue with split panel in side position when open and closed

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
@@ -97,7 +97,13 @@ export function SkeletonLayout({
         )}
       </main>
       {sideSplitPanel && (
-        <div className={clsx(styles['split-panel-side'], !splitPanelOpen && styles['panel-hidden'])}>
+        <div
+          className={clsx(
+            styles['split-panel-side'],
+            sharedStyles['with-motion'],
+            !splitPanelOpen && styles['panel-hidden']
+          )}
+        >
           {sideSplitPanel}
         </div>
       )}


### PR DESCRIPTION
### Description

This fixes the obsure bug where when you click the side panel button in toolbar variant of AppLayout, and close it you will see a motion issue.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->
Go to https://d21d5uik3ws71m.cloudfront.net/components/52be0150127dc1f92321863db704b1cd8c0b69e4/dev-pages/index.html#/light/app-layout/with-drawers/?splitPanelPosition=side&appLayoutWidget=true and confrim no weird shift 
- also confirm not changes with classic and visualRefresh

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
