### PR TITLE
fix: restoring focus to button on dom that opened panel once panel closed on mobile

### DIFF
--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -279,13 +279,15 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
           )
         );
 
-        testIf(!mobile)(
+        test(
           'moves focus back to last opened button when panel is closed',
           setupTest(
             async page => {
-              await page.click(
-                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button"]').toSelector()
-              );
+              if (!mobile) {
+                await page.click(
+                  wrapper.findContentRegion().findButton('[data-testid="open-drawer-button"]').toSelector()
+                );
+              }
               await page.click(
                 wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
               );

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -162,7 +162,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       displayed: false,
     });
 
-    const drawersFocusControl = useFocusControl(!!activeDrawer?.id, !isMobile, activeDrawer?.id);
+    const drawersFocusControl = useFocusControl(!!activeDrawer?.id, true, activeDrawer?.id);
     const navigationFocusControl = useFocusControl(navigationOpen);
     const splitPanelFocusControl = useSplitPanelFocusControl([splitPanelPreferences, splitPanelOpen]);
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

Currently, in the toolbar variant of AppLayout, when a drawer is opened by a custom button (vs it's trigger) the focus is not restored when that drawer is closed on mobile. This returns that focus. It also asserts this functionality is working on an integ test that was skipped before.

To view bug, go to https://d81a4az09pn2q.cloudfront.net/polaris/index.html#/light/app-layout/with-drawers/?visualRefresh=true&appLayoutWidget=true&splitPanelPosition=side on mobile width, open drawer via button in the content, close drawer and note the focus is not back on the button in content.

Compare with https://d21d5uik3ws71m.cloudfront.net/components/48328fe77949ce9cabbf48dfb532bfcff3d17531/dev-pages/index.html#/light/app-layout/with-drawers/?visualRefresh=true&appLayoutWidget=true&splitPanelPosition=side


<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a
This is a p1 but for the AppLayout toolbr variant

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
