### PR TITLE
chore: Integ test manual shards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
   integTest:
     name: Components integ tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
@@ -37,7 +40,7 @@ jobs:
           node-version: 18
       - run: npm install
       - run: npm run build
-      - run: npm run test:integ
+      - run: npm run test:integ -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
   a11yTest:
     name: Components a11y tests

--- a/build-tools/tasks/integ.js
+++ b/build-tools/tasks/integ.js
@@ -4,8 +4,17 @@ const execa = require('execa');
 const glob = require('glob');
 const waitOn = require('wait-on');
 const { task } = require('../utils/gulp-utils.js');
+const { parseArgs } = require('node:util');
 
 module.exports = task('test:integ', async () => {
+  const options = {
+    shard: {
+      // Must be in format {shard}/{totalShards} e.g. 1/3, 2/3, ... if there are 3 chunks.
+      type: 'string',
+    },
+  };
+  const shard = parseArgs({ options, strict: false }).values.shard;
+
   const devServer = execa('webpack', ['serve', '--config', 'pages/webpack.config.integ.js'], {
     env: {
       NODE_ENV: 'development',
@@ -13,7 +22,18 @@ module.exports = task('test:integ', async () => {
   });
   await waitOn({ resources: ['http://localhost:8080'] });
 
-  const files = glob.sync('src/**/__integ__/**/*.test.ts');
+  const paths = createShards('src/**/__integ__/**/*.test.ts', [
+    ['src/app-layout/__integ__/*.test.ts'],
+    ['src/app-layout/visual-refresh-toolbar/__integ__/*.test.ts'],
+    ['src/*chart/**/__integ__/**/*.test.ts', 'src/table/**/__integ__/**/*.test.ts'],
+  ]);
+  const files = shard ? paths[shard] : paths.all;
+  if (!files) {
+    throw new Error(`No path defined for shard "${shard}".`);
+  }
+  if (shard) {
+    console.log(`Shard ${shard} includes:\n`, files);
+  }
   await execa('jest', ['-c', 'jest.integ.config.js', ...files], {
     stdio: 'inherit',
     env: { ...process.env, NODE_OPTIONS: '--experimental-vm-modules' },
@@ -21,3 +41,13 @@ module.exports = task('test:integ', async () => {
 
   devServer.cancel();
 });
+
+function createShards(pathAll, shardChunks) {
+  const shardsCount = shardChunks.length + 1;
+  const mapping = { all: glob.sync(pathAll) };
+  for (let shard = 1; shard <= shardChunks.length; shard++) {
+    mapping[`${shard}/${shardsCount}`] = [...shardChunks[shard - 1].flatMap(path => glob.sync(path))];
+  }
+  mapping[`${shardsCount}/${shardsCount}`] = glob.sync(pathAll, { ignore: shardChunks.flatMap(path => path) });
+  return mapping;
+}

--- a/src/app-layout/visual-refresh-toolbar/__integ__/app-layout-toolbar-tooltips.test.ts
+++ b/src/app-layout/visual-refresh-toolbar/__integ__/app-layout-toolbar-tooltips.test.ts
@@ -3,12 +3,12 @@
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
-import createWrapper from '../../../lib/components/test-utils/selectors';
-import { drawerIds as drawerIdObj } from '../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
-import { viewports } from './constants';
+import createWrapper from '../../../../lib/components/test-utils/selectors';
+import { drawerIds as drawerIdObj } from '../../../../lib/dev-pages/pages/app-layout/utils/drawer-ids';
+import { viewports } from '../../__integ__/constants';
 
-import toolbarStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/styles.selectors.js';
-import tooltipStyles from '../../../lib/components/internal/components/tooltip/styles.selectors.js';
+import toolbarStyles from '../../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/styles.selectors.js';
+import tooltipStyles from '../../../../lib/components/internal/components/tooltip/styles.selectors.js';
 
 const wrapper = createWrapper().findAppLayout();
 


### PR DESCRIPTION
### Description

Split integ tests in shards using custom chunks.

Attempted to use Jest's sharding mechanism but it always produces a single too large chunk because of the time-consuming app layout tests, see: https://github.com/cloudscape-design/components/pull/2760.

Requires follow-up: https://github.com/cloudscape-design/actions/pull/42

### How has this been tested?

* Tested chunk paths locally by running `npm run test:integ -- -- shard=1/4` etc.
* Tested in Release action

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
