### PR TITLE
fix: Flashbar box shadow disappearing behind parent background

### DIFF
--- a/src/flashbar/styles.scss
+++ b/src/flashbar/styles.scss
@@ -59,6 +59,14 @@
   margin-block: 0;
   margin-inline: 0;
 
+  /*
+     Adds a new stacking context for the flashbar
+     This prevents the flashbar shadow to disappear behind its container's
+     background due to z-index: -1
+   */
+  position: relative;
+  z-index: 1;
+
   &:not(.collapsed) {
     > li:not(:last-child) {
       margin-block-end: awsui.$space-xxxs;


### PR DESCRIPTION
### Description

Adds a stacking context around the flash-list to prevent the box shadow disappearing behind the parent element's background.

This has been blocking #2655 

Related links, issue #, if available: AWSUI-59453

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

- Automated visual tests.
- For manual testing, run the project locally, go to the flashbar page and set a background color to any parent `<div />` element. Verify that the flashbar shadow is not disappearing.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
