### PR TITLE
fix: Disable toolbar sticky notifications on mobile

### DIFF
--- a/src/app-layout/__integ__/awsui-applayout-sticky.test.ts
+++ b/src/app-layout/__integ__/awsui-applayout-sticky.test.ts
@@ -5,7 +5,7 @@ import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper from '../../../lib/components/test-utils/selectors';
 import { viewports } from './constants';
-import { getUrlParams, testIf, Theme } from './utils';
+import { getUrlParams, Theme } from './utils';
 
 const wrapper = createWrapper().findAppLayout();
 const stickyToggleSelector = createWrapper().findFlashbar().findItems().get(1).findActionButton().toSelector();
@@ -49,8 +49,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as Theme[])('%s', theme 
     })
   );
 
-  // TODO: Implement in toolbar
-  testIf(theme !== 'refresh-toolbar')(
+  test(
     'Notifications are never sticky in narrow viewports',
     setupTest({ viewport: viewports.mobile }, async page => {
       await expect(page.isNotificationVisible()).resolves.toBe(true);

--- a/src/app-layout/visual-refresh-toolbar/notifications/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/notifications/styles.scss
@@ -2,7 +2,11 @@
  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  SPDX-License-Identifier: Apache-2.0
 */
-.sticky-notifications {
-  position: sticky;
-  z-index: 850;
+@use '../../../internal/styles/' as styles;
+
+@include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
+  &.sticky-notifications {
+    position: sticky;
+    z-index: 850;
+  }
 }


### PR DESCRIPTION
### Description

Enable remaining tests in `__integ__/awsui-applayout-sticky.test.ts` by disabling sticky notifications on narrow viewports.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
