### PR TITLE
feat: Allow to override analytics action in Internal button

### DIFF
--- a/src/button/__tests__/analytics-metadata.test.tsx
+++ b/src/button/__tests__/analytics-metadata.test.tsx
@@ -76,15 +76,27 @@ describe('Button renders correct analytics metadata', () => {
     expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual(getMetadata('button text aria', 'inline-icon'));
   });
 });
-
-test('Internal Button does not render "component" metadata', () => {
-  const renderResult = render(<InternalButton>inline button text</InternalButton>);
-  const wrapper = createWrapper(renderResult.container).findButton()!;
-  validateComponentNameAndLabels(wrapper.getElement(), labels);
-  expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual({
-    action: 'click',
-    detail: {
-      label: 'inline button text',
-    },
+describe('Internal Button', () => {
+  test('does not render "component" metadata', () => {
+    const renderResult = render(<InternalButton>inline button text</InternalButton>);
+    const wrapper = createWrapper(renderResult.container).findButton()!;
+    validateComponentNameAndLabels(wrapper.getElement(), labels);
+    expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual({
+      action: 'click',
+      detail: {
+        label: 'inline button text',
+      },
+    });
+  });
+  test('allows to override the analytics action', () => {
+    const renderResult = render(<InternalButton analyticsAction="open">inline button text</InternalButton>);
+    const wrapper = createWrapper(renderResult.container).findButton()!;
+    validateComponentNameAndLabels(wrapper.getElement(), labels);
+    expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual({
+      action: 'open',
+      detail: {
+        label: 'inline button text',
+      },
+    });
   });
 });

--- a/src/button/analytics-metadata/interfaces.ts
+++ b/src/button/analytics-metadata/interfaces.ts
@@ -4,7 +4,7 @@
 import { LabelIdentifier } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 interface GeneratedAnalyticsMetadataButtonClick {
-  action: 'click';
+  action: string;
   detail: {
     label: string | LabelIdentifier;
   };

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -39,6 +39,7 @@ import testUtilStyles from './test-classes/styles.css.js';
 export type InternalButtonProps = Omit<ButtonProps, 'variant'> & {
   variant?: ButtonProps['variant'] | 'flashbar-icon' | 'breadcrumb-group' | 'menu-trigger' | 'modal-dismiss';
   badge?: boolean;
+  analyticsAction?: string;
   __nativeAttributes?:
     | (React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>)
     | Record<`data-${string}`, string>;
@@ -84,6 +85,7 @@ export const InternalButton = React.forwardRef(
       __injectAnalyticsComponentMetadata = false,
       __title,
       __emitPerformanceMarks = true,
+      analyticsAction = 'click',
       ...props
     }: InternalButtonProps,
     ref: React.Ref<ButtonProps.Ref>
@@ -170,7 +172,7 @@ export const InternalButton = React.forwardRef(
     const analyticsMetadata: GeneratedAnalyticsMetadataButtonFragment = disabled
       ? {}
       : {
-          action: 'click',
+          action: analyticsAction,
           detail: { label: { root: 'self' } },
         };
     if (__injectAnalyticsComponentMetadata) {


### PR DESCRIPTION
### Description

Needed for Collection Preferences instrumentation: in [this file](https://github.com/cloudscape-design/components/blob/main/src/collection-preferences/index.tsx#L146) we have buttons whose action needs to be more specific than clicking.

The property will remove the need to add artificial spans, as we did in [property filter](https://github.com/cloudscape-design/components/blob/main/src/property-filter/token-editor.tsx#L210), which caused visual changes. A follow-up PR will adopt the new Button property in Property filter component.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
