### PR TITLE
fix: Remove min-width from date range picker trigger

### DIFF
--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -277,34 +277,32 @@ const DateRangePicker = React.forwardRef(
     });
 
     const trigger = (
-      <div className={styles['trigger-wrapper']}>
-        <ButtonTrigger
-          ref={triggerRef}
-          id={controlId}
-          invalid={invalid}
-          warning={warning}
-          ariaLabelledby={joinStrings(ariaLabelledby, triggerContentId)}
-          ariaLabel={i18nStrings?.ariaLabel}
-          ariaDescribedby={ariaDescribedby}
-          className={clsx(styles.label, {
-            [styles['label-enabled']]: !readOnly && !disabled,
-          })}
-          hideCaret={true}
-          onClick={() => {
-            setIsDropDownOpen(true);
-          }}
-          disabled={disabled}
-          readOnly={readOnly}
-          ariaHasPopup="dialog"
-        >
-          <span className={styles['trigger-flexbox']}>
-            <span className={styles['icon-wrapper']}>
-              <InternalIcon name="calendar" variant={disabled || readOnly ? 'disabled' : 'normal'} />
-            </span>
-            <span id={triggerContentId}>{formattedDate}</span>
+      <ButtonTrigger
+        ref={triggerRef}
+        id={controlId}
+        invalid={invalid}
+        warning={warning}
+        ariaLabelledby={joinStrings(ariaLabelledby, triggerContentId)}
+        ariaLabel={i18nStrings?.ariaLabel}
+        ariaDescribedby={ariaDescribedby}
+        className={clsx(styles.label, {
+          [styles['label-enabled']]: !readOnly && !disabled,
+        })}
+        hideCaret={true}
+        onClick={() => {
+          setIsDropDownOpen(true);
+        }}
+        disabled={disabled}
+        readOnly={readOnly}
+        ariaHasPopup="dialog"
+      >
+        <span className={styles['trigger-flexbox']}>
+          <span className={styles['icon-wrapper']}>
+            <InternalIcon name="calendar" variant={disabled || readOnly ? 'disabled' : 'normal'} />
           </span>
-        </ButtonTrigger>
-      </div>
+          <span id={triggerContentId}>{formattedDate}</span>
+        </span>
+      </ButtonTrigger>
     );
 
     const mergedRef = useMergeRefs(rootRef, __internalRootRef);

--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -26,10 +26,6 @@ $calendar-header-color: awsui.$color-text-body-default;
   display: contents;
 }
 
-.trigger-wrapper {
-  min-inline-size: calc(#{$calendar-grid-width} + 2 * #{awsui.$space-l});
-}
-
 .trigger-flexbox {
   display: flex;
 }


### PR DESCRIPTION
### Description

Spot the issue.

<img width="307" alt="Screenshot 2024-09-26 at 14 17 14" src="https://github.com/user-attachments/assets/49de90ca-844a-46d4-b3a9-7da4085757f2">

In small screens, the date range picker blows past the screen width. The dropdown does as well (the trigger is designed to match the min-width of the dropdown), but let's just focus on the trigger for now. The design options for the dropdown itself are a little ambiguous for now.

Related links, issue #, if available: AWSUI-59654

### How has this been tested?

Screenshot tests. Actually, this doesn't fail anything, though it should. We could add a constrained width test on the simple or "small viewport" pages on the internal package rather than making a new dev page. Internal CR will follow after this merges.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
