### PR TITLE
chore: Adds external link to a dev test page with an iframe

### DIFF
--- a/pages/app-layout/multi-layout-iframe.page.tsx
+++ b/pages/app-layout/multi-layout-iframe.page.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import { Link } from '~components';
 import AppLayout from '~components/app-layout';
 import Header from '~components/header';
 import ScreenreaderOnly from '~components/internal/components/screenreader-only';
@@ -25,6 +26,11 @@ function InnerApp() {
           <Header variant="h1" description="This page contains nested app layout instances with an iframe">
             Multiple app layouts with iframe
           </Header>
+
+          <Link external={true} href="#">
+            External link
+          </Link>
+
           <Containers />
         </SpaceBetween>
       }

--- a/pages/app-layout/multi-layout-simple.page.tsx
+++ b/pages/app-layout/multi-layout-simple.page.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import { Link } from '~components';
 import AppLayout from '~components/app-layout';
 import Header from '~components/header';
 import SpaceBetween from '~components/space-between';
@@ -31,6 +32,11 @@ export default function () {
                 <Header variant="h1" description="This page contains nested app layout instances">
                   Multiple app layouts
                 </Header>
+
+                <Link external={true} href="#">
+                  External link
+                </Link>
+
                 <Containers />
               </SpaceBetween>
             }


### PR DESCRIPTION
### Description

The external link icon position is off until this fix is added: https://github.com/cloudscape-design/components/pull/2783

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
