### PR TITLE
fix: Pass empty string to onLoadItems after clicking Clear button

### DIFF
--- a/pages/property-filter/async-loading.integ.page.tsx
+++ b/pages/property-filter/async-loading.integ.page.tsx
@@ -79,7 +79,6 @@ export default function () {
   return (
     <>
       <h1>Integration tests fixture for async loading suggestions</h1>
-      <button id="focus-target">focus target</button>
       <ScreenshotArea disableAnimations={true}>
         <PropertyFilter
           {...labels}

--- a/pages/property-filter/async-loading.integ.page.tsx
+++ b/pages/property-filter/async-loading.integ.page.tsx
@@ -79,6 +79,7 @@ export default function () {
   return (
     <>
       <h1>Integration tests fixture for async loading suggestions</h1>
+      <button id="focus-target">focus target</button>
       <ScreenshotArea disableAnimations={true}>
         <PropertyFilter
           {...labels}

--- a/src/autosuggest/__tests__/load-more-controller.test.ts
+++ b/src/autosuggest/__tests__/load-more-controller.test.ts
@@ -60,7 +60,7 @@ describe('Autosuggest load-more-controller', () => {
     expect(onLoadItems).toBeCalledTimes(1);
   });
 
-  test('overrides filtering text when called on input focus', () => {
+  test('returns current filtering text when called on input focus', () => {
     let filteringText = '';
     const onLoadItems = (detail: OptionsLoadItemsDetail) => {
       filteringText = detail.filteringText;
@@ -70,7 +70,7 @@ describe('Autosuggest load-more-controller', () => {
     });
     act(() => result.current.fireLoadMoreOnInputChange('input'));
     act(() => result.current.fireLoadMoreOnInputFocus());
-    expect(filteringText).toBe('');
+    expect(filteringText).toBe('input');
   });
 
   test('does not override filtering text when called on recovery or scroll', () => {

--- a/src/autosuggest/load-more-controller.ts
+++ b/src/autosuggest/load-more-controller.ts
@@ -36,7 +36,12 @@ export const useAutosuggestLoadMore = ({
     samePage: boolean;
     filteringText?: string;
   }) => {
-    if (filteringText === undefined || lastFilteringText.current !== filteringText) {
+    if (
+      filteringText === undefined ||
+      lastFilteringText.current !== filteringText ||
+      // special handling for clear input click
+      (filteringText === '' && lastFilteringText.current === '')
+    ) {
       if (filteringText !== undefined) {
         lastFilteringText.current = filteringText;
       }

--- a/src/autosuggest/load-more-controller.ts
+++ b/src/autosuggest/load-more-controller.ts
@@ -36,12 +36,7 @@ export const useAutosuggestLoadMore = ({
     samePage: boolean;
     filteringText?: string;
   }) => {
-    if (
-      filteringText === undefined ||
-      lastFilteringText.current !== filteringText ||
-      // special handling for clear input click
-      (filteringText === '' && lastFilteringText.current === '')
-    ) {
+    if (filteringText === undefined || lastFilteringText.current !== filteringText) {
       if (filteringText !== undefined) {
         lastFilteringText.current = filteringText;
       }
@@ -55,7 +50,8 @@ export const useAutosuggestLoadMore = ({
 
   const fireLoadMoreOnRecoveryClick = () => fireLoadMore({ firstPage: false, samePage: true });
 
-  const fireLoadMoreOnInputFocus = () => fireLoadMore({ firstPage: true, samePage: false, filteringText: '' });
+  const fireLoadMoreOnInputFocus = () =>
+    fireLoadMore({ firstPage: true, samePage: false, filteringText: lastFilteringText.current ?? '' });
 
   const fireLoadMoreOnInputChange = (filteringText: string) =>
     fireLoadMore({ firstPage: true, samePage: false, filteringText });

--- a/src/property-filter/__integ__/async-loading.test.ts
+++ b/src/property-filter/__integ__/async-loading.test.ts
@@ -58,6 +58,9 @@ class AsyncPropertyFilterPage extends BasePageObject {
     await this.openValueEdit();
     await this.keys(value);
   };
+  clearFilteringInput = async () => {
+    await this.click(wrapper.findClearButton().toSelector());
+  };
 }
 
 function setupTest(
@@ -205,4 +208,25 @@ test.each<TestCase>(testCases)('%p', (_, asyncProperties, token, scenario) =>
       await page.expectLoadItemsEvents(result);
     }
   })()
+);
+
+test(
+  'calls onLoadItems with an empty string if Clear button is clicked',
+  setupTest(true, 'property', async page => {
+    await page.typeInFilteringInput('1');
+    await page.expectLoadItemsEvents([
+      { firstPage: true, samePage: false, filteringText: '' },
+      { filteringText: '1', firstPage: true, samePage: false },
+    ]);
+
+    await page.click('#focus-target');
+    await page.clearFilteringInput();
+    await page.waitForJsTimers(500);
+    await page.expectLoadItemsEvents([
+      { firstPage: true, samePage: false, filteringText: '' },
+      { filteringText: '1', firstPage: true, samePage: false },
+      { filteringText: '1', firstPage: true, samePage: false },
+      { filteringText: '', firstPage: true, samePage: false },
+    ]);
+  })
 );

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -284,7 +284,7 @@ describe('property filter parts', () => {
       expect(loadItemCalls).toHaveLength(1);
     });
 
-    test('calls onLoadItems when clear button is clicked and asyncProperties=true', () => {
+    test('calls onLoadItems on clear when filter by property and asyncProperties=true', () => {
       const loadItemCalls: PropertyFilterProps.LoadItemsDetail[] = [];
       const { propertyFilterWrapper: wrapper, container } = renderComponent({
         onLoadItems: ({ detail }) => loadItemCalls.push(detail),
@@ -319,6 +319,43 @@ describe('property filter parts', () => {
         expect.objectContaining({ filteringText: '123', filteringProperty: stateProperty, filteringOperator: '=' }),
         expect.objectContaining({ filteringText: '123', filteringProperty: stateProperty, filteringOperator: '=' }),
         expect.objectContaining({ filteringText: '' }),
+        expect.objectContaining({ filteringText: '' }),
+      ]);
+    });
+
+    test('calls onLoadItems on clear when filter by text and asyncProperties=true', () => {
+      const loadItemCalls: PropertyFilterProps.LoadItemsDetail[] = [];
+      const { propertyFilterWrapper: wrapper, container } = renderComponent({
+        onLoadItems: ({ detail }) => loadItemCalls.push(detail),
+        filteringStatusType: 'pending',
+        asyncProperties: true,
+      });
+
+      wrapper.focus();
+      expect(loadItemCalls).toEqual([
+        expect.objectContaining({ filteringText: '' }),
+        expect.objectContaining({ filteringText: '' }),
+      ]);
+
+      wrapper.setInputValue('stat');
+      expect(loadItemCalls).toHaveLength(2);
+
+      jest.advanceTimersByTime(1000);
+      expect(loadItemCalls).toEqual([
+        expect.objectContaining({ filteringText: '' }),
+        expect.objectContaining({ filteringText: '' }),
+        expect.objectContaining({ filteringText: 'stat' }),
+      ]);
+
+      createWrapper(container).find('#focus-target')!.focus();
+
+      wrapper.findClearButton()!.click();
+
+      expect(loadItemCalls).toEqual([
+        expect.objectContaining({ filteringText: '' }),
+        expect.objectContaining({ filteringText: '' }),
+        expect.objectContaining({ filteringText: 'stat' }),
+        expect.objectContaining({ filteringText: 'stat' }),
         expect.objectContaining({ filteringText: '' }),
       ]);
     });

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -89,7 +89,12 @@ const filteringOptions: readonly FilteringOption[] = [
 const defaultProps = createDefaultProps(filteringProperties, filteringOptions);
 
 const renderComponent = (props?: Partial<PropertyFilterProps>) => {
-  const { container } = render(<PropertyFilter {...defaultProps} {...props} />);
+  const { container } = render(
+    <div>
+      <button id="focus-target" />
+      <PropertyFilter {...defaultProps} {...props} />
+    </div>
+  );
   return { container, propertyFilterWrapper: createWrapper(container).findPropertyFilter()! };
 };
 
@@ -281,7 +286,7 @@ describe('property filter parts', () => {
 
     test('calls onLoadItems when clear button is clicked and asyncProperties=true', () => {
       const loadItemCalls: PropertyFilterProps.LoadItemsDetail[] = [];
-      const { propertyFilterWrapper: wrapper } = renderComponent({
+      const { propertyFilterWrapper: wrapper, container } = renderComponent({
         onLoadItems: ({ detail }) => loadItemCalls.push(detail),
         filteringStatusType: 'pending',
         asyncProperties: true,
@@ -303,12 +308,17 @@ describe('property filter parts', () => {
         expect.objectContaining({ filteringText: '123', filteringProperty: stateProperty, filteringOperator: '=' }),
       ]);
 
+      createWrapper(container).find('#focus-target')!.focus();
+
       wrapper.findClearButton()!.click();
       jest.advanceTimersByTime(1000);
+
       expect(loadItemCalls).toEqual([
         expect.objectContaining({ filteringText: '' }),
         expect.objectContaining({ filteringText: '' }),
         expect.objectContaining({ filteringText: '123', filteringProperty: stateProperty, filteringOperator: '=' }),
+        expect.objectContaining({ filteringText: '123', filteringProperty: stateProperty, filteringOperator: '=' }),
+        expect.objectContaining({ filteringText: '' }),
         expect.objectContaining({ filteringText: '' }),
       ]);
     });

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -296,54 +296,6 @@ describe('property filter parts', () => {
       expect(loadItemCalls).toHaveLength(1);
     });
 
-    test('calls onLoadItems on clear when filter by property and asyncProperties=true', () => {
-      const loadItemCalls: PropertyFilterProps.LoadItemsDetail[] = [];
-      const {
-        propertyFilterWrapper: wrapper,
-        container,
-        rerender,
-      } = renderComponent({
-        onLoadItems: ({ detail }) => loadItemCalls.push(detail),
-        filteringStatusType: 'pending',
-        asyncProperties: true,
-      });
-
-      wrapper.focus();
-      expect(loadItemCalls).toEqual([
-        expect.objectContaining({ filteringText: '' }),
-        expect.objectContaining({ filteringText: '' }),
-      ]);
-
-      wrapper.setInputValue('state = 123');
-      expect(loadItemCalls).toHaveLength(2);
-
-      jest.advanceTimersByTime(1000);
-      expect(loadItemCalls).toEqual([
-        expect.objectContaining({ filteringText: '' }),
-        expect.objectContaining({ filteringText: '' }),
-        expect.objectContaining({ filteringText: '123', filteringProperty: stateProperty, filteringOperator: '=' }),
-      ]);
-
-      rerender({
-        onLoadItems: ({ detail }) => loadItemCalls.push(detail),
-        filteringStatusType: 'finished',
-        asyncProperties: true,
-      });
-
-      createWrapper(container).find('#focus-target')!.focus();
-
-      wrapper.findClearButton()!.click();
-      jest.advanceTimersByTime(1000);
-
-      expect(loadItemCalls).toEqual([
-        expect.objectContaining({ filteringText: '' }),
-        expect.objectContaining({ filteringText: '' }),
-        expect.objectContaining({ filteringText: '123', filteringProperty: stateProperty, filteringOperator: '=' }),
-        expect.objectContaining({ filteringText: '123', filteringProperty: stateProperty, filteringOperator: '=' }),
-        expect.objectContaining({ filteringText: '' }),
-      ]);
-    });
-
     test('calls onLoadItems on clear when filter by text and asyncProperties=true', () => {
       const loadItemCalls: PropertyFilterProps.LoadItemsDetail[] = [];
       const {
@@ -362,14 +314,14 @@ describe('property filter parts', () => {
         expect.objectContaining({ filteringText: '' }),
       ]);
 
-      wrapper.setInputValue('stat');
+      wrapper.setInputValue('free-text');
       expect(loadItemCalls).toHaveLength(2);
 
       jest.advanceTimersByTime(1000);
       expect(loadItemCalls).toEqual([
         expect.objectContaining({ filteringText: '' }),
         expect.objectContaining({ filteringText: '' }),
-        expect.objectContaining({ filteringText: 'stat' }),
+        expect.objectContaining({ filteringText: 'free-text' }),
       ]);
 
       rerender({
@@ -387,8 +339,8 @@ describe('property filter parts', () => {
       expect(loadItemCalls).toEqual([
         expect.objectContaining({ filteringText: '' }),
         expect.objectContaining({ filteringText: '' }),
-        expect.objectContaining({ filteringText: 'stat' }),
-        expect.objectContaining({ filteringText: 'stat' }),
+        expect.objectContaining({ filteringText: 'free-text' }),
+        expect.objectContaining({ filteringText: 'free-text' }),
         expect.objectContaining({ filteringText: '' }),
       ]);
     });


### PR DESCRIPTION
### Description

Currently, in the Property Filter there is a specific corner case: with `asyncProperties === true` when moving focus away from the input and then clicking on Clear button, `onLoadItems` is invoked with only previous `filteringText` value. That means, callback for `onLoadItems` won't load items for a new, empty string. The issue happens when filter by free text, not when specific property was detected

This is not expected and different from similar behaviour in autosuggest.

With this fix, there will be multiple subsequent `onLoadItems` calls:
1. with the previous `filteringText` value on input focus, which happens before Clear button callback is invoked;
2. with empty `filteringText`

Related links, issue #, if available: AWSUI-59621

### How has this been tested?

* update unit test to move focus away before clicking on Clear
* (not related to this specific issue) clearing input by selecting the text and deleting with keyboard

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
