### PR TITLE
chore: Fix doctype setup for iframe dev pages

### DIFF
--- a/pages/utils/iframe-wrapper.tsx
+++ b/pages/utils/iframe-wrapper.tsx
@@ -40,13 +40,14 @@ export function IframeWrapper({ id, AppComponent }: { id: string; AppComponent: 
     iframeEl.className = styles['full-screen'];
     iframeEl.id = id;
     iframeEl.title = id;
-    iframeEl.srcdoc = '<!DOCTYPE html>';
     container.appendChild(iframeEl);
 
     const iframeDocument = iframeEl.contentDocument!;
     // Prevent iframe document instance from reload
     // https://bugzilla.mozilla.org/show_bug.cgi?id=543435
     iframeDocument.open();
+    // set html5 doctype
+    iframeDocument.writeln('<!DOCTYPE html>');
     iframeDocument.close();
 
     const innerAppRoot = iframeDocument.createElement('div');


### PR DESCRIPTION
### Description

Without this fix, the doctype inside the iframe is not set. Our components only work with html5 doctype.

Related links, issue #, if available: n/a

### How has this been tested?

Locally, by checking `document.doctype` value

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
