### PR TITLE
fix: Hide disabled reason tooltips when the option is scrolled away

### DIFF
--- a/pages/multiselect/disabled-reason.page.tsx
+++ b/pages/multiselect/disabled-reason.page.tsx
@@ -7,6 +7,14 @@ import Multiselect, { MultiselectProps } from '~components/multiselect';
 
 import ScreenshotArea from '../utils/screenshot-area';
 
+const extraOptions = [...Array(30).keys()].map(n => {
+  const numberToDisplay = (n + 5).toString();
+  return {
+    value: numberToDisplay,
+    label: `Option ${n + 5}`,
+  };
+});
+
 const options: MultiselectProps.Options = [
   { value: 'first', label: 'Simple' },
   { value: 'second', label: 'With small icon', iconName: 'folder' },
@@ -24,6 +32,8 @@ const options: MultiselectProps.Options = [
     disabled: true,
     disabledReason: 'disabled reason',
   },
+  ...extraOptions,
+  { label: 'Last option', disabled: true, disabledReason: 'disabled reason' },
 ];
 
 export default function MultiselectPage() {

--- a/pages/select/disabled-reason.page.tsx
+++ b/pages/select/disabled-reason.page.tsx
@@ -1,24 +1,23 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import * as React from 'react';
+import React from 'react';
 
 import Box from '~components/box';
 import Select from '~components/select';
 
 import ScreenshotArea from '../utils/screenshot-area';
 
-const options = [
-  {
-    value: '1',
-    label: 'Option 1',
-    disabled: true,
-    disabledReason: 'disabled reason',
-  },
-  {
-    value: '2',
-    label: 'Option 2',
-  },
-];
+const options = [...Array(50).keys()].map(n => {
+  const numberToDisplay = (n + 1).toString();
+  const baseOption = {
+    value: numberToDisplay,
+    label: `Option ${numberToDisplay}`,
+  };
+  if (n === 0 || n === 24 || n === 49) {
+    return { ...baseOption, disabled: true, disabledReason: 'disabled reason' };
+  }
+  return baseOption;
+});
 
 export default function SelectPage() {
   return (

--- a/src/internal/components/tooltip/index.tsx
+++ b/src/internal/components/tooltip/index.tsx
@@ -20,6 +20,7 @@ export interface TooltipProps {
   className?: string;
   contentAttributes?: React.HTMLAttributes<HTMLDivElement>;
   size?: PopoverProps['size'];
+  hideOnOverscroll?: boolean;
 }
 
 export default function Tooltip({
@@ -30,6 +31,7 @@ export default function Tooltip({
   contentAttributes = {},
   position = 'top',
   size = 'small',
+  hideOnOverscroll,
 }: TooltipProps) {
   if (!trackKey && (typeof value === 'string' || typeof value === 'number')) {
     trackKey = value;
@@ -48,6 +50,7 @@ export default function Tooltip({
               position={position}
               zIndex={7000}
               arrow={position => <PopoverArrow position={position} />}
+              hideOnOverscroll={hideOnOverscroll}
             >
               <PopoverBody dismissButton={false} dismissAriaLabel={undefined} onDismiss={undefined} header={undefined}>
                 {value}

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useLayoutEffect, useRef } from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 import { nodeContains } from '@cloudscape-design/component-toolkit/dom';
@@ -39,6 +39,8 @@ export interface PopoverContainerProps {
   // Do not use this if the popover is open on hover, in order to avoid unexpected movement.
   allowScrollToFit?: boolean;
   allowVerticalOverflow?: boolean;
+  // Whether the popover should be hidden when the trigger is scrolled away.
+  hideOnOverscroll?: boolean;
 }
 
 export default function PopoverContainer({
@@ -55,11 +57,14 @@ export default function PopoverContainer({
   keepPosition,
   allowScrollToFit,
   allowVerticalOverflow,
+  hideOnOverscroll = false,
 }: PopoverContainerProps) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const arrowRef = useRef<HTMLDivElement | null>(null);
+
+  const [hideDueToOverScroll, setHideDueToOverscroll] = useState(false);
 
   const isRefresh = useVisualRefresh();
 
@@ -75,6 +80,7 @@ export default function PopoverContainer({
     preferredPosition: position,
     renderWithPortal,
     keepPosition,
+    setHideDueToOverscroll: hideOnOverscroll ? setHideDueToOverscroll : undefined,
   });
 
   // Recalculate position when properties change.
@@ -114,7 +120,6 @@ export default function PopoverContainer({
 
     const updatePositionOnResize = () => requestAnimationFrame(() => updatePositionHandler());
     const refreshPosition = () => requestAnimationFrame(() => positionHandlerRef.current());
-
     window.addEventListener('click', onClick);
     window.addEventListener('resize', updatePositionOnResize);
     window.addEventListener('scroll', refreshPosition, true);
@@ -124,9 +129,9 @@ export default function PopoverContainer({
       window.removeEventListener('resize', updatePositionOnResize);
       window.removeEventListener('scroll', refreshPosition, true);
     };
-  }, [keepPosition, positionHandlerRef, trackRef, updatePositionHandler]);
+  }, [hideOnOverscroll, keepPosition, positionHandlerRef, trackRef, updatePositionHandler]);
 
-  return (
+  return hideDueToOverScroll ? null : (
     <div
       ref={popoverRef}
       style={{ ...popoverStyle, zIndex }}

--- a/src/popover/interfaces.ts
+++ b/src/popover/interfaces.ts
@@ -106,6 +106,11 @@ export interface Dimensions {
 
 export type BoundingBox = Dimensions & Offset;
 
+export type Rect = BoundingBox & {
+  insetBlockEnd: number;
+  insetInlineEnd: number;
+};
+
 export namespace PopoverProps {
   export type Position = 'top' | 'right' | 'bottom' | 'left';
   export type Size = 'small' | 'medium' | 'large';

--- a/src/popover/utils/positions.ts
+++ b/src/popover/utils/positions.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { BoundingBox, Dimensions, InternalPosition, PopoverProps } from '../interfaces';
+import { BoundingBox, Dimensions, InternalPosition, PopoverProps, Rect } from '../interfaces';
 
 // A structure describing how the popover should be positioned
 interface CalculatedPosition {
@@ -335,4 +335,11 @@ export function getDimensions(element: HTMLElement) {
 
 function isTopOrBottom(internalPosition: InternalPosition) {
   return ['top', 'bottom'].includes(internalPosition.split('-')[0]);
+}
+
+export function isCenterOutside(child: Rect, parent: Rect) {
+  const childCenter = child.insetBlockStart + child.blockSize / 2;
+  const overflowsBlockStart = childCenter < parent.insetBlockStart;
+  const overflowsBlockEnd = childCenter > parent.insetBlockEnd;
+  return overflowsBlockStart || overflowsBlockEnd;
 }

--- a/src/select/__integ__/disabled-reason.test.ts
+++ b/src/select/__integ__/disabled-reason.test.ts
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+import createWrapper from '../../../lib/components/test-utils/selectors';
+import SelectPageObject from './page-objects/select-page';
+
+function setupTest(testFn: (page: SelectPageObject) => Promise<void>) {
+  return useBrowser(async browser => {
+    await browser.url('/#/light/select/disabled-reason');
+    const select = createWrapper().findSelect();
+    const page = new SelectPageObject(browser, select);
+    await testFn(page);
+  });
+}
+
+describe('Disabled reasons', () => {
+  test(
+    'shows disabled reason on hover',
+    setupTest(async page => {
+      await page.pause(100);
+      const select = createWrapper().findSelect();
+      await page.clickSelect();
+      await page.assertDropdownOpen(true);
+      const firstDisabledOption = select.findDropdown().findOption(1);
+      await page.hoverElement(firstDisabledOption.toSelector());
+      const disabledTooltip = firstDisabledOption.findDisabledReason();
+      await page.waitForJsTimers();
+      expect(await page.isDisplayed(disabledTooltip.toSelector())).toBe(true);
+    })
+  );
+
+  test(
+    'hides disabled reason when the disabled option is scrolled out of view',
+    setupTest(async page => {
+      await page.pause(100);
+      const select = createWrapper().findSelect();
+      await page.clickSelect();
+      await page.assertDropdownOpen(true);
+      const dropdown = select.findDropdown();
+      const firstDisabledOption = select.findDropdown().findOption(1);
+      await page.hoverElement(firstDisabledOption.toSelector());
+      const disabledTooltipSelector = firstDisabledOption.findDisabledReason().toSelector();
+      expect(await page.isDisplayed(disabledTooltipSelector)).toBe(true);
+      await page.elementScrollTo(dropdown.findOptionsContainer().toSelector(), { top: 500 });
+      await page.waitForJsTimers();
+      expect(await page.isDisplayed(disabledTooltipSelector)).toBe(false);
+      await page.elementScrollTo(dropdown.findOptionsContainer().toSelector(), { top: 0 });
+      await page.waitForJsTimers();
+      expect(await page.isDisplayed(disabledTooltipSelector)).toBe(true);
+    })
+  );
+});

--- a/src/select/__tests__/common.ts
+++ b/src/select/__tests__/common.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { SelectProps } from '../../../lib/components/select';
+
+export const VALUE_WITH_SPECIAL_CHARS = 'Option 4, test"2';
+
+export const defaultOptions: SelectProps.Options = [
+  { label: 'First', value: '1' },
+  { label: 'Second', value: '2' },
+  {
+    label: 'Group',
+    options: [
+      {
+        label: 'Third',
+        value: '3',
+        lang: 'de',
+      },
+      {
+        label: 'Forth',
+        value: VALUE_WITH_SPECIAL_CHARS,
+      },
+    ],
+  },
+];
+
+export const defaultProps = {
+  options: defaultOptions,
+  selectedOption: null,
+  onChange: () => {},
+};

--- a/src/select/__tests__/disabled.test.tsx
+++ b/src/select/__tests__/disabled.test.tsx
@@ -1,0 +1,162 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { render, waitFor } from '@testing-library/react';
+
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
+
+import Select, { SelectProps } from '../../../lib/components/select';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import { defaultOptions, defaultProps } from './common';
+
+// Mocks for the disabled reason tooltip popover
+jest.mock('../../../lib/components/popover/utils/positions', () => {
+  const originalModule = jest.requireActual('../../../lib/components/popover/utils/positions');
+  return {
+    ...originalModule,
+    getOffsetDimensions: () => ({ offsetWidth: 136, offsetHeight: 44 }), // Approximate mock dimensions for the disabled reason popover dimensions
+    isCenterOutside: () => true,
+  };
+});
+jest.mock('../../../lib/components/internal/utils/scrollable-containers', () => {
+  const originalModule = jest.requireActual('../../../lib/components/internal/utils/scrollable-containers');
+  return {
+    __esModule: true,
+    ...originalModule,
+    getFirstScrollableParent: () => createWrapper().findSelect()!.findDropdown()!.getElement(),
+  };
+});
+
+function renderSelect(props?: Partial<SelectProps>) {
+  const { container } = render(<Select {...defaultProps} {...props} />);
+  const wrapper = createWrapper(container).findSelect()!;
+  return { container, wrapper };
+}
+
+describe.each([false, true])('expandToViewport=%s', expandToViewport => {
+  describe('Disabled state', () => {
+    test('enabled by default', () => {
+      const { wrapper } = renderSelect();
+      expect(wrapper.isDisabled()).toEqual(false);
+      wrapper.openDropdown();
+      expect(wrapper.findDropdown({ expandToViewport })!.findOpenDropdown()).toBeTruthy();
+    });
+
+    test('can be disabled', () => {
+      const { wrapper } = renderSelect({ disabled: true });
+      expect(wrapper.isDisabled()).toEqual(true);
+      wrapper.openDropdown();
+      expect(wrapper.findDropdown({ expandToViewport })?.findOpenDropdown()).toBeFalsy();
+    });
+
+    describe('Disabled item with reason', () => {
+      test('has no tooltip open by default', () => {
+        const { wrapper } = renderSelect({
+          options: [{ label: 'First', value: '1', disabled: true, disabledReason: 'disabled reason' }],
+        });
+        wrapper.openDropdown();
+
+        expect(wrapper.findDropdown({ expandToViewport }).findOption(1)!.findDisabledReason()).toBe(null);
+      });
+
+      test('has no tooltip without disabledReason', () => {
+        const { wrapper } = renderSelect({
+          options: [{ label: 'First', value: '1', disabled: true }],
+        });
+        wrapper.openDropdown();
+        wrapper.findTrigger()!.keydown(KeyCode.down);
+
+        expect(wrapper.findDropdown({ expandToViewport }).findOption(1)!.findDisabledReason()).toBe(null);
+      });
+
+      test('open tooltip when the item is highlighted', () => {
+        const { wrapper } = renderSelect({
+          options: [{ label: 'First', value: '1', disabled: true, disabledReason: 'disabled reason' }],
+        });
+        wrapper.openDropdown();
+        wrapper.findTrigger().keydown(KeyCode.down);
+
+        expect(
+          wrapper.findDropdown({ expandToViewport }).findOption(1)!.findDisabledReason()!.getElement()
+        ).toHaveTextContent('disabled reason');
+      });
+
+      test('has no disabledReason a11y attributes by default', () => {
+        const { wrapper } = renderSelect({
+          options: defaultOptions,
+        });
+        wrapper.openDropdown();
+
+        expect(
+          wrapper.findDropdown({ expandToViewport })!.find('[data-test-index="1"]')!.getElement()
+        ).not.toHaveAttribute('aria-describedby');
+        expect(wrapper.findDropdown({ expandToViewport })!.find('[data-test-index="1"]')!.find('span[hidden]')).toBe(
+          null
+        );
+      });
+
+      test('has disabledReason a11y attributes', () => {
+        const { wrapper } = renderSelect({
+          options: [{ label: 'First', value: '1', disabled: true, disabledReason: 'disabled reason' }],
+        });
+        wrapper.openDropdown();
+
+        expect(wrapper.findDropdown({ expandToViewport })!.find('[data-test-index="1"]')!.getElement()).toHaveAttribute(
+          'aria-describedby'
+        );
+        expect(
+          wrapper.findDropdown({ expandToViewport })!.find('[data-test-index="1"]')!.find('span[hidden]')!.getElement()
+        ).toHaveTextContent('disabled reason');
+      });
+
+      test('can not select disabled with reason option', () => {
+        const onChange = jest.fn();
+        const { wrapper } = renderSelect({
+          options: [{ label: 'First', value: '1', disabled: true, disabledReason: 'disabled reason' }],
+          onChange,
+        });
+        wrapper.openDropdown();
+        wrapper.selectOptionByValue('1', { expandToViewport });
+        expect(onChange).not.toHaveBeenCalled();
+      });
+
+      test('click on disabled with reason option does not close dropdown', () => {
+        const { wrapper } = renderSelect({
+          options: [{ label: 'First', value: '1', disabled: true, disabledReason: 'disabled reason' }],
+        });
+        wrapper.openDropdown();
+        wrapper.selectOptionByValue('1', { expandToViewport });
+        expect(wrapper.findDropdown({ expandToViewport })?.findOpenDropdown()).toBeTruthy();
+      });
+
+      test('hides disabled reason when the option is scrolled away', async () => {
+        const options = [...Array(50).keys()].map(n => {
+          const numberToDisplay = (n + 1).toString();
+          const baseOption = {
+            value: numberToDisplay,
+            label: `Option ${numberToDisplay}`,
+          };
+          if (n === 0) {
+            return { ...baseOption, disabled: true, disabledReason: 'disabled reason' };
+          }
+          return baseOption;
+        });
+
+        const { wrapper } = renderSelect({
+          options,
+        });
+        wrapper.openDropdown();
+
+        wrapper.findTrigger().keydown(KeyCode.down);
+        const dropdown = wrapper.findDropdown({ expandToViewport });
+        expect(dropdown.findOption(1)!.findDisabledReason()!.getElement()).toHaveTextContent('disabled reason');
+        window.dispatchEvent(new Event('scroll'));
+        await waitFor(() => {
+          expect(
+            wrapper.findDropdown({ expandToViewport }).findOption(1)!.findDisabledReason()!.getElement()
+          ).toBeEmptyDOMElement();
+        });
+      });
+    });
+  });
+});

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -9,6 +9,7 @@ import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 import '../../__a11y__/to-validate-a11y';
 import Select, { SelectProps } from '../../../lib/components/select';
 import createWrapper from '../../../lib/components/test-utils/dom';
+import { defaultOptions, defaultProps, VALUE_WITH_SPECIAL_CHARS } from './common';
 
 import selectPartsStyles from '../../../lib/components/select/parts/styles.css.js';
 import statusIconStyles from '../../../lib/components/status-indicator/styles.selectors.js';
@@ -27,34 +28,7 @@ beforeEach(() => {
   (warnOnce as any).mockClear();
 });
 
-const VALUE_WITH_SPECIAL_CHARS = 'Option 4, test"2';
-const defaultOptions: SelectProps.Options = [
-  { label: 'First', value: '1' },
-  { label: 'Second', value: '2' },
-  {
-    label: 'Group',
-    options: [
-      {
-        label: 'Third',
-        value: '3',
-        lang: 'de',
-      },
-      {
-        label: 'Forth',
-        value: VALUE_WITH_SPECIAL_CHARS,
-      },
-    ],
-  },
-];
-
 describe.each([false, true])('expandToViewport=%s', expandToViewport => {
-  const defaultProps = {
-    options: defaultOptions,
-    selectedOption: null,
-    onChange: () => {},
-    expandToViewport,
-  };
-
   function renderSelect(props?: Partial<SelectProps>) {
     const { container, rerender } = render(<Select {...defaultProps} {...props} />);
     const wrapper = createWrapper(container).findSelect()!;
@@ -436,103 +410,6 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
         statusType: 'error',
       });
       expect(wrapper.findStatusIndicator({ expandToViewport: true })!.getElement()).toHaveTextContent('Error');
-    });
-  });
-
-  describe('Disabled state', () => {
-    test('enabled by default', () => {
-      const { wrapper } = renderSelect();
-      expect(wrapper.isDisabled()).toEqual(false);
-      wrapper.openDropdown();
-      expect(wrapper.findDropdown({ expandToViewport })!.findOpenDropdown()).toBeTruthy();
-    });
-
-    test('can be disabled', () => {
-      const { wrapper } = renderSelect({ disabled: true });
-      expect(wrapper.isDisabled()).toEqual(true);
-      wrapper.openDropdown();
-      expect(wrapper.findDropdown({ expandToViewport })?.findOpenDropdown()).toBeFalsy();
-    });
-
-    describe('Disabled item with reason', () => {
-      test('has no tooltip open by default', () => {
-        const { wrapper } = renderSelect({
-          options: [{ label: 'First', value: '1', disabled: true, disabledReason: 'disabled reason' }],
-        });
-        wrapper.openDropdown();
-
-        expect(wrapper.findDropdown({ expandToViewport }).findOption(1)!.findDisabledReason()).toBe(null);
-      });
-
-      test('has no tooltip without disabledReason', () => {
-        const { wrapper } = renderSelect({
-          options: [{ label: 'First', value: '1', disabled: true }],
-        });
-        wrapper.openDropdown();
-        wrapper.findTrigger()!.keydown(KeyCode.down);
-
-        expect(wrapper.findDropdown({ expandToViewport }).findOption(1)!.findDisabledReason()).toBe(null);
-      });
-
-      test('open tooltip when the item is highlighted', () => {
-        const { wrapper } = renderSelect({
-          options: [{ label: 'First', value: '1', disabled: true, disabledReason: 'disabled reason' }],
-        });
-        wrapper.openDropdown();
-        wrapper.findTrigger().keydown(KeyCode.down);
-
-        expect(
-          wrapper.findDropdown({ expandToViewport }).findOption(1)!.findDisabledReason()!.getElement()
-        ).toHaveTextContent('disabled reason');
-      });
-
-      test('has no disabledReason a11y attributes by default', () => {
-        const { wrapper } = renderSelect({
-          options: defaultOptions,
-        });
-        wrapper.openDropdown();
-
-        expect(
-          wrapper.findDropdown({ expandToViewport })!.find('[data-test-index="1"]')!.getElement()
-        ).not.toHaveAttribute('aria-describedby');
-        expect(wrapper.findDropdown({ expandToViewport })!.find('[data-test-index="1"]')!.find('span[hidden]')).toBe(
-          null
-        );
-      });
-
-      test('has disabledReason a11y attributes', () => {
-        const { wrapper } = renderSelect({
-          options: [{ label: 'First', value: '1', disabled: true, disabledReason: 'disabled reason' }],
-        });
-        wrapper.openDropdown();
-
-        expect(wrapper.findDropdown({ expandToViewport })!.find('[data-test-index="1"]')!.getElement()).toHaveAttribute(
-          'aria-describedby'
-        );
-        expect(
-          wrapper.findDropdown({ expandToViewport })!.find('[data-test-index="1"]')!.find('span[hidden]')!.getElement()
-        ).toHaveTextContent('disabled reason');
-      });
-
-      test('can not select disabled with reason option', () => {
-        const onChange = jest.fn();
-        const { wrapper } = renderSelect({
-          options: [{ label: 'First', value: '1', disabled: true, disabledReason: 'disabled reason' }],
-          onChange,
-        });
-        wrapper.openDropdown();
-        wrapper.selectOptionByValue('1', { expandToViewport });
-        expect(onChange).not.toHaveBeenCalled();
-      });
-
-      test('click on disabled with reason option does not close dropdown', () => {
-        const { wrapper } = renderSelect({
-          options: [{ label: 'First', value: '1', disabled: true, disabledReason: 'disabled reason' }],
-        });
-        wrapper.openDropdown();
-        wrapper.selectOptionByValue('1', { expandToViewport });
-        expect(wrapper.findDropdown({ expandToViewport })?.findOpenDropdown()).toBeTruthy();
-      });
     });
   });
 

--- a/src/select/parts/item.tsx
+++ b/src/select/parts/item.tsx
@@ -108,6 +108,7 @@ const Item = (
                 trackRef={internalRef}
                 value={disabledReason!}
                 position="right"
+                hideOnOverscroll={true}
               />
             )}
           </>

--- a/src/select/parts/multiselect-item.tsx
+++ b/src/select/parts/multiselect-item.tsx
@@ -96,6 +96,7 @@ const MultiSelectItem = (
               trackRef={internalRef}
               value={disabledReason!}
               position="right"
+              hideOnOverscroll={true}
             />
           )}
         </>


### PR DESCRIPTION
### Description


Before:

https://github.com/user-attachments/assets/335704df-4366-4f08-a12b-dbd5c2906b69

After:

https://github.com/user-attachments/assets/80600dc7-3970-46b1-a28a-7815e77fc0cf

Issue: AWSUI-55390

### How has this been tested?

- Manually
- Added integration tests
- Added one unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
