### PR TITLE
fix: New app-layout and old widgets

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
@@ -101,12 +101,10 @@
   @include desktop-only {
     grid-area: tools;
 
-    @-moz-document url-prefix() {
-      // workaround when new app layout and old widgets
-      &:not(:has([data-testid])) {
-        inline-size: var(#{custom-props.$toolsWidth});
-        border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-layout;
-      }
+    // workaround when new app layout and old widgets
+    &:not(:has([data-testid])) {
+      inline-size: var(#{custom-props.$toolsWidth});
+      border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-layout;
     }
   }
 }

--- a/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
@@ -103,7 +103,7 @@
 
     // workaround when new app layout and old widgets
     /* stylelint-disable plugin/no-unsupported-browser-features */
-    &:not(:has([data-testid])) {
+    &:not(:has(> [data-testid])) {
       inline-size: var(#{custom-props.$toolsWidth});
       border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-layout;
     }

--- a/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
@@ -100,6 +100,14 @@
 .tools {
   @include desktop-only {
     grid-area: tools;
+
+    @-moz-document url-prefix() {
+      // workaround when new app layout and old widgets
+      &:not(:has([data-testid])) {
+        inline-size: var(#{custom-props.$toolsWidth});
+        border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-layout;
+      }
+    }
   }
 }
 

--- a/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
@@ -102,6 +102,7 @@
     grid-area: tools;
 
     // workaround when new app layout and old widgets
+    /* stylelint-disable plugin/no-unsupported-browser-features */
     &:not(:has([data-testid])) {
       inline-size: var(#{custom-props.$toolsWidth});
       border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-layout;


### PR DESCRIPTION
### Description

When using the new app layout with the old widgets, the tools panel doesn't adjust to the correct size. This PR fixes that issue.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
