### PR TITLE
revert: "feat: Prompt input secondary actions and content slots (#2720)"

### DIFF
--- a/pages/prompt-input/permutations.page.tsx
+++ b/pages/prompt-input/permutations.page.tsx
@@ -16,8 +16,8 @@ const permutations = createPermutations<PromptInputProps>([
     actionButtonIconName: [undefined, 'send'],
     value: [
       '',
-      'Short value 1',
-      'Long value 1, enough to extend beyond the input width.  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+      'Short value',
+      'Long value, enough to extend beyond the input width.  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
     ],
   },
   {
@@ -30,13 +30,13 @@ const permutations = createPermutations<PromptInputProps>([
   {
     disabled: [false, true],
     actionButtonIconName: [undefined, 'send'],
-    value: ['', 'Short value 2'],
+    value: ['', 'Short value'],
   },
   {
     value: [
       '',
-      'Short value 3',
-      'Long value 3, enough to extend beyond the input width.  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+      'Short value',
+      'Long value, enough to extend beyond the input width.  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
     ],
     actionButtonIconSvg: [
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" focusable="false" key="0">
@@ -52,26 +52,11 @@ const permutations = createPermutations<PromptInputProps>([
   {
     value: [
       '',
-      'Short value 4',
-      'Long value 4, enough to extend beyond the input width.  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+      'Short value',
+      'Long value, enough to extend beyond the input width.  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
     ],
     actionButtonIconUrl: [img],
     actionButtonIconAlt: ['Letter A'],
-  },
-  {
-    value: ['Short value 5'],
-    actionButtonIconName: [undefined, 'send'],
-    secondaryActions: [undefined, 'secondary actions 1'],
-    secondaryContent: [undefined, 'secondary content 1'],
-    invalid: [false, true],
-  },
-  {
-    value: ['Short value 6'],
-    actionButtonIconName: ['send'],
-    secondaryActions: ['secondary actions 2'],
-    secondaryContent: ['secondary content 2'],
-    disableSecondaryActionsPaddings: [false, true],
-    disableSecondaryContentPaddings: [false, true],
   },
 ]);
 
@@ -82,9 +67,9 @@ export default function PromptInputPermutations() {
       <ScreenshotArea>
         <PermutationsView
           permutations={permutations}
-          render={(permutation, index) => (
+          render={permutation => (
             <PromptInput
-              ariaLabel={`Prompt input test ${index}`}
+              ariaLabel="Prompt input field"
               actionButtonAriaLabel="Action button aria label"
               onChange={() => {
                 /*empty handler to suppress react controlled property warning*/

--- a/pages/prompt-input/simple.page.tsx
+++ b/pages/prompt-input/simple.page.tsx
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useState } from 'react';
 
-import { Box, TokenGroup } from '~components';
-import ButtonGroup from '~components/button-group';
 import Checkbox from '~components/checkbox';
 import ColumnLayout from '~components/column-layout';
 import FormField from '~components/form-field';
@@ -12,7 +10,7 @@ import SpaceBetween from '~components/space-between';
 
 import AppContext, { AppContextType } from '../app/app-context';
 
-const MAX_CHARS = 2000;
+const MAX_CHARS = 200;
 
 type DemoContext = React.Context<
   AppContextType<{
@@ -21,8 +19,6 @@ type DemoContext = React.Context<
     isInvalid: boolean;
     hasWarning: boolean;
     hasText: boolean;
-    hasSecondaryContent: boolean;
-    hasSecondaryActions: boolean;
   }>
 >;
 
@@ -33,13 +29,7 @@ export default function PromptInputPage() {
   const [textareaValue, setTextareaValue] = useState('');
   const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
 
-  const { isDisabled, isReadOnly, isInvalid, hasWarning, hasText, hasSecondaryActions, hasSecondaryContent } =
-    urlParams;
-  const [items, setItems] = React.useState([
-    { label: 'Item 1', dismissLabel: 'Remove item 1', disabled: isDisabled },
-    { label: 'Item 2', dismissLabel: 'Remove item 2', disabled: isDisabled },
-    { label: 'Item 3', dismissLabel: 'Remove item 3', disabled: isDisabled },
-  ]);
+  const { isDisabled, isReadOnly, isInvalid, hasWarning, hasText } = urlParams;
 
   useEffect(() => {
     if (hasText) {
@@ -53,23 +43,6 @@ export default function PromptInputPage() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [textareaValue]);
-
-  useEffect(() => {
-    if (items.length === 0) {
-      ref.current?.focus();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [items]);
-
-  useEffect(() => {
-    const newItems = items.map(item => ({
-      label: item.label,
-      dismissLabel: item.dismissLabel,
-      disabled: isDisabled,
-    }));
-    setItems([...newItems]);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDisabled]);
 
   const ref = React.createRef<HTMLTextAreaElement>();
 
@@ -90,40 +63,17 @@ export default function PromptInputPage() {
           <Checkbox checked={hasWarning} onChange={() => setUrlParams({ hasWarning: !hasWarning })}>
             Warning
           </Checkbox>
-          <Checkbox
-            checked={hasSecondaryContent}
-            onChange={() =>
-              setUrlParams({
-                hasSecondaryContent: !hasSecondaryContent,
-              })
-            }
-          >
-            Secondary content
-          </Checkbox>
-          <Checkbox
-            checked={hasSecondaryActions}
-            onChange={() =>
-              setUrlParams({
-                hasSecondaryActions: !hasSecondaryActions,
-              })
-            }
-          >
-            Secondary actions
-          </Checkbox>
         </FormField>
         <button id="placeholder-text-button" onClick={() => setUrlParams({ hasText: true })}>
           Fill with placeholder text
         </button>
 
-        <button id="focus-button" onClick={() => ref.current?.focus()}>
-          Focus component
-        </button>
+        <button onClick={() => ref.current?.focus()}>Focus component</button>
         <button onClick={() => ref.current?.select()}>Select all text</button>
 
         <ColumnLayout columns={2}>
           <FormField
-            errorText={(textareaValue.length > MAX_CHARS || isInvalid) && 'The query has too many characters.'}
-            warningText={hasWarning && 'This input has a warning'}
+            errorText={textareaValue.length > MAX_CHARS && 'The query has too many characters.'}
             constraintText={
               <>
                 This service is subject to some policy. Character count: {textareaValue.length}/{MAX_CHARS}
@@ -133,7 +83,6 @@ export default function PromptInputPage() {
             i18nStrings={{ errorIconAriaLabel: 'Error' }}
           >
             <PromptInput
-              ariaLabel="Chat input"
               actionButtonIconName="send"
               actionButtonAriaLabel="Submit prompt"
               value={textareaValue}
@@ -146,51 +95,6 @@ export default function PromptInputPage() {
               invalid={isInvalid || textareaValue.length > MAX_CHARS}
               warning={hasWarning}
               ref={ref}
-              disableSecondaryActionsPaddings={true}
-              secondaryActions={
-                hasSecondaryActions ? (
-                  <Box padding={{ left: 'xxs', top: 'xs' }}>
-                    <ButtonGroup
-                      ariaLabel="Chat actions"
-                      items={[
-                        {
-                          type: 'icon-button',
-                          id: 'copy',
-                          iconName: 'upload',
-                          text: 'Upload files',
-                          disabled: isDisabled || isReadOnly,
-                        },
-                        {
-                          type: 'icon-button',
-                          id: 'expand',
-                          iconName: 'expand',
-                          text: 'Go full page',
-                          disabled: isDisabled || isReadOnly,
-                        },
-                        {
-                          type: 'icon-button',
-                          id: 'remove',
-                          iconName: 'remove',
-                          text: 'Remove',
-                          disabled: isDisabled || isReadOnly,
-                        },
-                      ]}
-                      variant="icon"
-                    />
-                  </Box>
-                ) : undefined
-              }
-              secondaryContent={
-                hasSecondaryContent ? (
-                  <TokenGroup
-                    onDismiss={({ detail: { itemIndex } }) => {
-                      setItems([...items.slice(0, itemIndex), ...items.slice(itemIndex + 1)]);
-                    }}
-                    items={items}
-                    readOnly={isReadOnly}
-                  />
-                ) : undefined
-              }
             />
           </FormField>
           <div />

--- a/pages/utils/permutations-view.tsx
+++ b/pages/utils/permutations-view.tsx
@@ -6,7 +6,7 @@ import SpaceBetween from '~components/space-between';
 
 interface PermutationsViewProps<T> {
   permutations: ReadonlyArray<T>;
-  render: (props: T, index?: number) => React.ReactElement;
+  render: (props: T) => React.ReactElement;
 }
 
 function formatValue(key: string, value: any) {
@@ -24,11 +24,11 @@ function formatValue(key: string, value: any) {
 export default function PermutationsView<T>({ permutations, render }: PermutationsViewProps<T>) {
   return (
     <SpaceBetween size="m">
-      {permutations.map((permutation, index) => {
+      {permutations.map(permutation => {
         const id = JSON.stringify(permutation, formatValue);
         return (
           <div key={id} data-permutation={id}>
-            {render(permutation, index)}
+            {render(permutation)}
           </div>
         );
       })}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11949,18 +11949,6 @@ of the user's browser.",
       "type": "boolean",
     },
     {
-      "description": "Determines whether the secondary actions area of the input has padding. If true, removes the default padding from the secondary actions area.",
-      "name": "disableSecondaryActionsPaddings",
-      "optional": true,
-      "type": "boolean",
-    },
-    {
-      "description": "Determines whether the secondary content area of the input has padding. If true, removes the default padding from the secondary content area.",
-      "name": "disableSecondaryContentPaddings",
-      "optional": true,
-      "type": "boolean",
-    },
-    {
       "description": "Specifies if the control is disabled, which prevents the
 user from modifying the value and prevents the value from
 being included in a form submission. A disabled control can't
@@ -12078,16 +12066,6 @@ In most cases, they aren't needed, as the \`svg\` element inherits styles from t
 ",
       "isDefault": false,
       "name": "actionButtonIconSvg",
-    },
-    {
-      "description": "Use this slot to add secondary actions to the prompt input.",
-      "isDefault": false,
-      "name": "secondaryActions",
-    },
-    {
-      "description": "Use this slot to add secondary content, such as file attachments, to the prompt input.",
-      "isDefault": false,
-      "name": "secondaryContent",
     },
   ],
   "releaseStatus": "stable",

--- a/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -433,8 +433,6 @@ exports[`test-utils selectors 1`] = `
   "prompt-input": [
     "awsui_action-button_nr3gs",
     "awsui_root_nr3gs",
-    "awsui_secondary-actions_nr3gs",
-    "awsui_secondary-content_nr3gs",
     "awsui_textarea_nr3gs",
   ],
   "property-filter": [

--- a/src/internal/styles/forms/mixins.scss
+++ b/src/internal/styles/forms/mixins.scss
@@ -255,10 +255,3 @@
   block-size: $height;
   inline-size: $width;
 }
-
-@mixin control-border-radius-full {
-  border-start-start-radius: constants.$control-border-radius;
-  border-start-end-radius: constants.$control-border-radius;
-  border-end-start-radius: constants.$control-border-radius;
-  border-end-end-radius: constants.$control-border-radius;
-}

--- a/src/prompt-input/__integ__/prompt-input.test.ts
+++ b/src/prompt-input/__integ__/prompt-input.test.ts
@@ -17,7 +17,7 @@ class PromptInputPage extends BasePageObject {
 const setupTest = (testFn: (page: PromptInputPage) => Promise<void>) => {
   return useBrowser(async browser => {
     const page = new PromptInputPage(browser);
-    await browser.url(`#/light/prompt-input/simple/?isReadOnly=true`);
+    await browser.url(`#/light/prompt-input/simple`);
     await page.waitForVisible(promptInputWrapper.toSelector());
     await testFn(page);
   });
@@ -28,16 +28,7 @@ describe('Prompt input', () => {
     setupTest(async page => {
       await expect(page.getPromptInputHeight()).resolves.toEqual(32);
       await page.click('#placeholder-text-button');
-      await expect(page.getPromptInputHeight()).resolves.toEqual(96);
-    })
-  );
-
-  test(
-    'Action button should be focusable in read-only state',
-    setupTest(async page => {
-      await page.click('#focus-button');
-      await page.keys('Tab');
-      await expect(page.isFocused(promptInputWrapper.find('button').toSelector())).resolves.toBe(true);
+      await expect(page.getPromptInputHeight()).resolves.toEqual(92);
     })
   );
 });

--- a/src/prompt-input/__tests__/prompt-input.test.tsx
+++ b/src/prompt-input/__tests__/prompt-input.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { act, render, within } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 import '../../__a11y__/to-validate-a11y';
 import { KeyCode } from '../../../lib/components/internal/keycode';
@@ -66,10 +66,7 @@ describe('disableBrowserAutocorrect', () => {
   });
 
   test('does not modify autocorrect features when falsy', () => {
-    const { wrapper } = renderPromptInput({
-      value: '',
-      disableBrowserAutocorrect: false,
-    });
+    const { wrapper } = renderPromptInput({ value: '', disableBrowserAutocorrect: false });
     const textarea = wrapper.findNativeTextarea().getElement();
 
     expect(textarea).not.toHaveAttribute('autocorrect');
@@ -77,10 +74,7 @@ describe('disableBrowserAutocorrect', () => {
   });
 
   test('can disable autocorrect features when set', () => {
-    const { wrapper } = renderPromptInput({
-      value: '',
-      disableBrowserAutocorrect: true,
-    });
+    const { wrapper } = renderPromptInput({ value: '', disableBrowserAutocorrect: true });
     const textarea = wrapper.findNativeTextarea().getElement();
 
     expect(textarea).toHaveAttribute('autocorrect', 'off');
@@ -110,45 +104,18 @@ describe('action button', () => {
   });
 
   test('present when added', () => {
-    const { wrapper } = renderPromptInput({
-      value: '',
-      actionButtonIconName: 'send',
-    });
+    const { wrapper } = renderPromptInput({ value: '', actionButtonIconName: 'send' });
     expect(wrapper.findActionButton().getElement()).toBeInTheDocument();
   });
 
-  test('should render action button inside secondary actions container when secondary actions are present', () => {
-    const { wrapper } = renderPromptInput({
-      value: '',
-      minRows: 4,
-      secondaryActions: 'secondary actions',
-      actionButtonIconName: 'send',
-    });
-
-    const secondaryActionsContainer = wrapper.findSecondaryActions()!.getElement();
-    const actionButton = within(secondaryActionsContainer).getByRole('button');
-
-    expect(actionButton).toBeInTheDocument();
-  });
-
   test('disabled when in disabled state', () => {
-    const { wrapper } = renderPromptInput({
-      value: '',
-      actionButtonIconName: 'send',
-      disabled: true,
-    });
+    const { wrapper } = renderPromptInput({ value: '', actionButtonIconName: 'send', disabled: true });
     expect(wrapper.findActionButton().getElement()).toHaveAttribute('disabled');
   });
 
-  test('adds aria disabled but not disabled attribute when in read-only state', () => {
-    const { wrapper } = renderPromptInput({
-      value: '',
-      actionButtonIconName: 'send',
-      readOnly: true,
-    });
-
-    expect(wrapper.findActionButton().getElement()).toHaveAttribute('aria-disabled', 'true');
-    expect(wrapper.findActionButton().getElement()).not.toHaveAttribute('disabled');
+  test('disabled when in read-only state', () => {
+    const { wrapper } = renderPromptInput({ value: '', actionButtonIconName: 'send', readOnly: true });
+    expect(wrapper.findActionButton().getElement()).toHaveAttribute('disabled');
   });
 });
 
@@ -206,10 +173,7 @@ describe('prompt input in form', () => {
   });
 
   test('cancelling key event prevents submission', () => {
-    const [wrapper, submitSpy] = renderPromptInputInForm({
-      value: '',
-      onKeyDown: event => event.preventDefault(),
-    });
+    const [wrapper, submitSpy] = renderPromptInputInForm({ value: '', onKeyDown: event => event.preventDefault() });
     wrapper.findNativeTextarea().keydown(KeyCode.enter);
     expect(submitSpy).not.toHaveBeenCalled();
   });
@@ -276,30 +240,6 @@ describe('min and max rows', () => {
   });
 });
 
-describe('secondary actions', () => {
-  test('should render correct text in secondary actions slot', () => {
-    const { wrapper } = renderPromptInput({
-      value: '',
-      minRows: 4,
-      secondaryActions: 'secondary actions',
-    });
-
-    expect(wrapper.findSecondaryActions()?.getElement()).toHaveTextContent('secondary actions');
-  });
-});
-
-describe('secondary content', () => {
-  test('should render correct text in secondary content slot', () => {
-    const { wrapper } = renderPromptInput({
-      value: '',
-      minRows: 4,
-      secondaryContent: 'secondary content',
-    });
-
-    expect(wrapper.findSecondaryContent()?.getElement()).toHaveTextContent('secondary content');
-  });
-});
-
 describe('a11y', () => {
   test('Valides a11y', async () => {
     const { container } = render(<PromptInput ariaLabel="Prompt input" value="" />);
@@ -313,18 +253,8 @@ describe('a11y', () => {
       expect(wrapper.findNativeTextarea().getElement()).not.toHaveAttribute('aria-label');
     });
     test('can be set to custom value', () => {
-      const { wrapper } = renderPromptInput({
-        value: '',
-        ariaLabel: 'my-custom-label',
-      });
+      const { wrapper } = renderPromptInput({ value: '', ariaLabel: 'my-custom-label' });
       expect(wrapper.findNativeTextarea().getElement()).toHaveAttribute('aria-label', 'my-custom-label');
-    });
-    test('is added to the region wrapper', () => {
-      const { wrapper } = renderPromptInput({
-        value: '',
-        ariaLabel: 'my-custom-label',
-      });
-      expect(within(wrapper.getElement()).getByRole('region')).toHaveAttribute('aria-label', 'my-custom-label');
     });
   });
 
@@ -334,18 +264,11 @@ describe('a11y', () => {
       expect(wrapper.findNativeTextarea().getElement()).not.toHaveAttribute('aria-describedby');
     });
     test('can be set to custom value', () => {
-      const { wrapper } = renderPromptInput({
-        value: '',
-        ariaDescribedby: 'my-custom-id',
-      });
+      const { wrapper } = renderPromptInput({ value: '', ariaDescribedby: 'my-custom-id' });
       expect(wrapper.findNativeTextarea().getElement()).toHaveAttribute('aria-describedby', 'my-custom-id');
     });
     test('can be customized without controlId', () => {
-      const { wrapper } = renderPromptInput({
-        value: '',
-        controlId: undefined,
-        ariaDescribedby: 'my-custom-id',
-      });
+      const { wrapper } = renderPromptInput({ value: '', controlId: undefined, ariaDescribedby: 'my-custom-id' });
 
       expect(wrapper.findNativeTextarea().getElement()).toHaveAttribute('aria-describedby', 'my-custom-id');
     });
@@ -357,10 +280,7 @@ describe('a11y', () => {
       expect(wrapper.findNativeTextarea().getElement()).not.toHaveAttribute('aria-labelledby');
     });
     test('can be set to custom value', () => {
-      const { wrapper } = renderPromptInput({
-        value: '',
-        ariaLabelledby: 'my-custom-id',
-      });
+      const { wrapper } = renderPromptInput({ value: '', ariaLabelledby: 'my-custom-id' });
       expect(wrapper.findNativeTextarea().getElement()).toHaveAttribute('aria-labelledby', 'my-custom-id');
     });
   });

--- a/src/prompt-input/interfaces.ts
+++ b/src/prompt-input/interfaces.ts
@@ -83,26 +83,6 @@ export interface PromptInputProps
    * Specifies the maximum number of lines of text the textarea will expand to.
    */
   maxRows?: number;
-
-  /**
-   * Use this slot to add secondary actions to the prompt input.
-   */
-  secondaryActions?: React.ReactNode;
-
-  /**
-   * Use this slot to add secondary content, such as file attachments, to the prompt input.
-   */
-  secondaryContent?: React.ReactNode;
-
-  /**
-   * Determines whether the secondary actions area of the input has padding. If true, removes the default padding from the secondary actions area.
-   */
-  disableSecondaryActionsPaddings?: boolean;
-
-  /**
-   * Determines whether the secondary content area of the input has padding. If true, removes the default padding from the secondary content area.
-   */
-  disableSecondaryContentPaddings?: boolean;
 }
 
 export namespace PromptInputProps {

--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -47,10 +47,6 @@ const InternalPromptInput = React.forwardRef(
       placeholder,
       readOnly,
       spellcheck,
-      secondaryActions,
-      secondaryContent,
-      disableSecondaryActionsPaddings,
-      disableSecondaryContentPaddings,
       __internalRootRef = null,
       ...rest
     }: InternalPromptInputProps,
@@ -101,13 +97,11 @@ const InternalPromptInput = React.forwardRef(
       adjustTextareaHeight();
     };
 
-    const hasActionButton = actionButtonIconName || actionButtonIconSvg || actionButtonIconUrl;
-
     const adjustTextareaHeight = useCallback(() => {
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto';
         const maxRowsHeight = `calc(${maxRows <= 0 ? 3 : maxRows} * (${LINE_HEIGHT} + ${PADDING} / 2) + ${PADDING})`;
-        const scrollHeight = `calc(${textareaRef.current.scrollHeight}px)`;
+        const scrollHeight = `calc(${textareaRef.current.scrollHeight}px + ${PADDING})`;
         textareaRef.current.style.height = `min(${scrollHeight}, ${maxRowsHeight})`;
       }
     }, [maxRows, LINE_HEIGHT, PADDING]);
@@ -137,8 +131,10 @@ const InternalPromptInput = React.forwardRef(
       placeholder,
       autoFocus,
       className: clsx(styles.textarea, testutilStyles.textarea, {
-        [styles.invalid]: invalid,
-        [styles.warning]: warning,
+        [styles['textarea-readonly']]: readOnly,
+        [styles['textarea-invalid']]: invalid,
+        [styles['textarea-warning']]: warning && !invalid,
+        [styles['textarea-with-button']]: actionButtonIconName,
       }),
       autoComplete: convertAutoComplete(autoComplete),
       spellCheck: spellcheck,
@@ -154,66 +150,33 @@ const InternalPromptInput = React.forwardRef(
       onFocus: onFocus && (() => fireNonCancelableEvent(onFocus)),
     };
 
+    const hasActionButton = actionButtonIconName || actionButtonIconSvg || actionButtonIconUrl;
+
     if (disableBrowserAutocorrect) {
       attributes.autoCorrect = 'off';
       attributes.autoCapitalize = 'off';
     }
 
-    const action = (
-      <div className={styles.button}>
-        <InternalButton
-          className={clsx(styles['action-button'], testutilStyles['action-button'])}
-          ariaLabel={actionButtonAriaLabel}
-          disabled={disabled || readOnly || disableActionButton}
-          __focusable={readOnly}
-          iconName={actionButtonIconName}
-          iconUrl={actionButtonIconUrl}
-          iconSvg={actionButtonIconSvg}
-          iconAlt={actionButtonIconAlt}
-          onClick={() => fireNonCancelableEvent(onAction, { value })}
-          variant="icon"
-        />
-      </div>
-    );
-
     return (
       <div
         {...baseProps}
-        aria-label={ariaLabel}
-        className={clsx(styles.root, testutilStyles.root, baseProps.className, {
-          [styles['textarea-readonly']]: readOnly,
-          [styles['textarea-invalid']]: invalid,
-          [styles['textarea-warning']]: warning && !invalid,
-          [styles.disabled]: disabled,
-        })}
+        className={clsx(styles.root, testutilStyles.root, baseProps.className)}
         ref={__internalRootRef}
-        role="region"
       >
-        {secondaryContent && (
-          <div
-            className={clsx(styles['secondary-content'], testutilStyles['secondary-content'], {
-              [styles['with-paddings']]: !disableSecondaryContentPaddings,
-              [styles.invalid]: invalid,
-              [styles.warning]: warning,
-            })}
-          >
-            {secondaryContent}
-          </div>
-        )}
-        <div className={styles['textarea-wrapper']}>
-          <textarea ref={textareaRef} id={controlId} {...attributes} />
-          {hasActionButton && !secondaryActions && action}
-        </div>
-        {secondaryActions && (
-          <div
-            className={clsx(styles['secondary-actions'], testutilStyles['secondary-actions'], {
-              [styles['with-paddings']]: !disableSecondaryActionsPaddings,
-              [styles.invalid]: invalid,
-              [styles.warning]: warning,
-            })}
-          >
-            {secondaryActions}
-            {hasActionButton && action}
+        <textarea ref={textareaRef} id={controlId} {...attributes} />
+        {hasActionButton && (
+          <div className={styles.button}>
+            <InternalButton
+              className={clsx(styles['action-button'], testutilStyles['action-button'])}
+              ariaLabel={actionButtonAriaLabel}
+              disabled={disabled || readOnly || disableActionButton}
+              iconName={actionButtonIconName}
+              iconUrl={actionButtonIconUrl}
+              iconSvg={actionButtonIconSvg}
+              iconAlt={actionButtonIconAlt}
+              onClick={() => fireNonCancelableEvent(onAction, { value })}
+              variant="icon"
+            />
           </div>
         )}
       </div>

--- a/src/prompt-input/styles.scss
+++ b/src/prompt-input/styles.scss
@@ -6,81 +6,40 @@
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '../internal/styles/foundation/' as foundation;
-@use '../internal/styles/forms/constants' as constants;
 @use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 $send-icon-right-spacing: awsui.$space-static-xxs;
-$invalid-border-offset: constants.$invalid-control-left-padding;
 
 .root {
-  @include styles.styles-reset;
-  @include styles.control-border-radius-full();
-  cursor: text;
+  position: relative;
 
-  background-color: awsui.$color-background-input-default;
+  > .button {
+    position: absolute;
+    inset-inline-end: $send-icon-right-spacing;
+    inset-block-end: 0;
 
-  border-block: styles.$control-border-width solid awsui.$color-border-input-default;
-  border-inline: styles.$control-border-width solid awsui.$color-border-input-default;
-
-  &.textarea-readonly {
-    @include styles.form-readonly-element;
-  }
-
-  &.disabled {
-    @include styles.form-disabled-element;
-    cursor: default;
-  }
-
-  &.textarea-invalid {
-    @include styles.form-invalid-control();
-    & {
-      padding-inline-start: 0;
-    }
-
-    &:focus-within,
-    &:focus {
-      @include styles.form-invalid-control();
-      & {
-        padding-inline-start: 0;
-        box-shadow: foundation.$box-shadow-focused-light-invalid;
+    > .action-button {
+      // offset the focus ring by 1px per side so it doesn't blend into the textarea border
+      @include focus-visible.when-visible {
+        @include styles.focus-highlight(
+          (
+            'vertical': calc((-1 * #{awsui.$space-xxxs}) - 1px),
+            'horizontal': calc((#{awsui.$space-xxxs}) - 1px),
+          )
+        );
       }
     }
-  }
-
-  &.textarea-warning {
-    @include styles.form-warning-control();
-    & {
-      padding-inline-start: 0;
-    }
-
-    &:focus-within,
-    &:focus {
-      @include styles.form-warning-control();
-      & {
-        padding-inline-start: 0;
-        box-shadow: foundation.$box-shadow-focused-light-invalid;
-      }
-    }
-  }
-
-  &:focus-within,
-  &:focus {
-    @include styles.form-focus-element;
   }
 }
 
 .textarea {
   @include styles.styles-reset;
-  @include styles.control-border-radius-full();
-  @include styles.font-body-m;
   // Restore browsers' default resize values
   resize: none;
   // Restore default text cursor
   cursor: text;
   // Allow multi-line placeholders
   white-space: pre-wrap;
-  background-color: inherit;
 
   padding-block: styles.$control-padding-vertical;
   padding-inline: styles.$control-padding-horizontal;
@@ -90,8 +49,19 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
   inline-size: 100%;
   display: block;
   box-sizing: border-box;
+  background-color: awsui.$color-background-input-default;
+  border-start-start-radius: styles.$control-border-radius;
+  border-start-end-radius: styles.$control-border-radius;
+  border-end-start-radius: styles.$control-border-radius;
+  border-end-end-radius: styles.$control-border-radius;
+  border-block: styles.$control-border-width solid awsui.$color-border-input-default;
+  border-inline: styles.$control-border-width solid awsui.$color-border-input-default;
 
-  border: 0;
+  @include styles.font-body-m;
+
+  &.textarea-readonly {
+    @include styles.form-readonly-element;
+  }
 
   &::placeholder {
     @include styles.form-placeholder;
@@ -103,7 +73,7 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
   }
 
   &:focus {
-    outline: none;
+    @include styles.form-focus-element;
   }
 
   &:invalid {
@@ -111,14 +81,8 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
     box-shadow: none;
   }
 
-  &.invalid,
-  &.warning {
-    padding-inline-start: $invalid-border-offset;
-  }
-
   &:disabled {
     @include styles.form-disabled-element;
-    border: 0;
     cursor: default;
 
     &::placeholder {
@@ -131,71 +95,14 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
     }
   }
 
-  &-wrapper {
-    display: flex;
-  }
-}
-
-.button {
-  align-self: flex-end;
-  padding-inline: calc(styles.$control-padding-horizontal / 2);
-  padding-block-end: awsui.$space-scaled-xxxs;
-
-  > .action-button {
-    padding: 0;
-
-    // offset the focus ring by 1px per side so it doesn't blend into the textarea border
-    @include focus-visible.when-visible {
-      @include styles.focus-highlight(
-        (
-          'vertical': calc((-1 * #{awsui.$space-xxxs}) - 1px),
-          'horizontal': calc((#{awsui.$space-xxxs}) - 1px),
-        )
-      );
-    }
-  }
-}
-
-.secondary-content {
-  @include styles.styles-reset;
-  @include styles.control-border-radius-full();
-
-  &.with-paddings {
-    padding-block-start: styles.$control-padding-vertical;
-    padding-block-end: awsui.$space-scaled-s;
-    padding-inline-start: styles.$control-padding-horizontal;
-    padding-inline-end: calc(styles.$control-padding-horizontal / 2);
-
-    &.invalid,
-    &.warning {
-      padding-inline-start: $invalid-border-offset;
-    }
-  }
-}
-
-.secondary-actions {
-  @include styles.styles-reset;
-  @include styles.control-border-radius-full();
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-
-  &.with-paddings {
-    padding-inline-start: styles.$control-padding-horizontal;
-    padding-block-start: awsui.$space-scaled-s;
-    padding-block-end: styles.$control-padding-vertical;
-
-    &.invalid,
-    &.warning {
-      padding-inline-start: $invalid-border-offset;
-    }
-
-    > .button {
-      padding-block-end: 0;
-    }
+  &.textarea-invalid {
+    @include styles.form-invalid-control();
   }
 
-  > .button {
-    padding-block-end: awsui.$space-scaled-xxs;
+  &.textarea-warning {
+    @include styles.form-warning-control();
+  }
+  &.textarea-with-button {
+    padding-inline-end: calc(styles.$control-padding-horizontal + $send-icon-right-spacing + awsui.$size-icon-normal);
   }
 }

--- a/src/prompt-input/test-classes/styles.scss
+++ b/src/prompt-input/test-classes/styles.scss
@@ -13,11 +13,3 @@
 .action-button {
   /* used in test-utils */
 }
-
-.secondary-actions {
-  /* used in test-utils */
-}
-
-.secondary-content {
-  /* used in test-utils */
-}

--- a/src/test-utils/dom/prompt-input/index.ts
+++ b/src/test-utils/dom/prompt-input/index.ts
@@ -18,14 +18,6 @@ export default class PromptInputWrapper extends ComponentWrapper {
     return this.findByClassName<HTMLButtonElement>(testutilStyles['action-button'])!;
   }
 
-  findSecondaryActions(): ElementWrapper<HTMLDivElement> {
-    return this.findByClassName<HTMLDivElement>(testutilStyles['secondary-actions'])!;
-  }
-
-  findSecondaryContent(): ElementWrapper<HTMLDivElement> {
-    return this.findByClassName<HTMLDivElement>(testutilStyles['secondary-content'])!;
-  }
-
   /**
    * Gets the value of the component.
    *


### PR DESCRIPTION
This reverts commit 680ece35b6a6b57f22a4f54835bdfcb0f47e01f5.

Reverts https://github.com/cloudscape-design/components/commit/680ece35b6a6b57f22a4f54835bdfcb0f47e01f5 as it is rendering two `aria-labels` and this result in tests that looks for labels to return multiple elements and fail.


related build: 7045624283

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
