### PR TITLE
fix: Partially controllable tools

### DIFF
--- a/src/app-layout/__tests__/tools.test.tsx
+++ b/src/app-layout/__tests__/tools.test.tsx
@@ -6,7 +6,7 @@ import { act, waitFor } from '@testing-library/react';
 import { describeEachAppLayout, renderComponent, isDrawerClosed } from './utils';
 import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
 
-describeEachAppLayout({ themes: ['classic', 'refresh', 'refresh-toolbar'] }, () => {
+describeEachAppLayout({ themes: ['classic', 'refresh', 'refresh-toolbar'] }, ({ theme }) => {
   test('opens tools drawer', () => {
     let ref: AppLayoutProps.Ref | null = null;
     const { wrapper } = renderComponent(<AppLayout ref={newRef => (ref = newRef)} />);
@@ -55,5 +55,25 @@ describeEachAppLayout({ themes: ['classic', 'refresh', 'refresh-toolbar'] }, () 
     await waitFor(() => {
       expect(wrapper.find('#custom-button')!.getElement()).toEqual(document.activeElement);
     });
+  });
+
+  test('should not open partially controllable tools', () => {
+    const { wrapper } = renderComponent(
+      <AppLayout tools={<button id="custom-button">Click me</button>} toolsOpen={false} />
+    );
+
+    wrapper.findToolsToggle()!.click();
+
+    if (theme === 'refresh-toolbar') {
+      expect(wrapper.findTools()).toBeFalsy();
+    }
+
+    if (theme === 'refresh') {
+      expect(wrapper.findTools().getElement()).toHaveAttribute('aria-hidden', 'true');
+    }
+
+    if (theme === 'classic') {
+      expect(wrapper.findTools().getElement().style).not.toContain('width');
+    }
   });
 });

--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -198,7 +198,9 @@ export function useDrawers(
   }
 
   function onActiveDrawerChange(newDrawerId: string | null) {
-    setActiveDrawerId(newDrawerId);
+    if (newDrawerId !== TOOLS_DRAWER_ID) {
+      setActiveDrawerId(newDrawerId);
+    }
     if (newDrawerId) {
       onAddNewActiveDrawer?.(newDrawerId);
     }

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -330,6 +330,8 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       onNavigationToggle,
       onActiveDrawerChange: onActiveDrawerChangeHandler,
       onActiveDrawerResize,
+      toolsOpen,
+      onToolsToggle,
     };
 
     const splitPanelInternals: SplitPanelProviderProps = {

--- a/src/app-layout/visual-refresh-toolbar/interfaces.ts
+++ b/src/app-layout/visual-refresh-toolbar/interfaces.ts
@@ -52,4 +52,6 @@ export interface AppLayoutInternals {
   onActiveDrawerChange: (newDrawerId: string | null) => void;
   onActiveDrawerResize: (detail: { id: string; size: number }) => void;
   onActiveGlobalDrawersChange: (newDrawerId: string) => void;
+  toolsOpen: boolean;
+  onToolsToggle: (value: boolean) => void;
 }

--- a/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
@@ -38,6 +38,9 @@ interface DrawerTriggersProps {
   globalDrawers: ReadonlyArray<AppLayoutProps.Drawer>;
   onActiveGlobalDrawersChange?: (newDrawerId: string) => void;
 
+  toolsOpen: boolean;
+  onToolsToggle: (value: boolean) => void;
+
   splitPanelOpen?: boolean;
   splitPanelPosition?: AppLayoutProps.SplitPanelPreferences['position'];
   splitPanelToggleProps: SplitPanelToggleProps | undefined;
@@ -62,6 +65,7 @@ export function DrawerTriggers({
   globalDrawers,
   globalDrawersFocusControl,
   onActiveGlobalDrawersChange,
+  toolsOpen,
 }: DrawerTriggersProps) {
   const isMobile = useMobile();
   const hasMultipleTriggers = drawers.length > 1;
@@ -149,11 +153,12 @@ export function DrawerTriggers({
         )}
         {visibleItems.slice(0, globalDrawersStartIndex).map(item => {
           const isForPreviousActiveDrawer = previousActiveLocalDrawerId?.current === item.id;
+          const isActive = item.id === TOOLS_DRAWER_ID ? toolsOpen : item.id === activeDrawerId;
           return (
             <TriggerButton
               ariaLabel={item.ariaLabels?.triggerButton}
-              ariaExpanded={item.id === activeDrawerId}
-              ariaControls={activeDrawerId === item.id ? item.id : undefined}
+              ariaExpanded={isActive}
+              ariaControls={isActive ? item.id : undefined}
               className={clsx(
                 styles['drawers-trigger'],
                 !toolsOnlyMode && testutilStyles['drawers-trigger'],

--- a/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
@@ -169,7 +169,7 @@ export function DrawerTriggers({
               key={item.id}
               onClick={() => onActiveDrawerChange?.(activeDrawerId !== item.id ? item.id : null)}
               ref={item.id === previousActiveLocalDrawerId.current ? drawersFocusRef : undefined}
-              selected={item.id === activeDrawerId}
+              selected={isActive}
               badge={item.badge}
               testId={`awsui-app-layout-trigger-${item.id}`}
               hasTooltip={true}

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -95,6 +95,8 @@ export function AppLayoutToolbarImplementation({
     setToolbarState,
     setToolbarHeight,
     globalDrawersFocusControl,
+    toolsOpen,
+    onToolsToggle,
   } = appLayoutInternals;
   const {
     ariaLabels,
@@ -219,6 +221,8 @@ export function AppLayoutToolbarImplementation({
               globalDrawers={globalDrawers?.filter(item => !!item.trigger) ?? []}
               activeGlobalDrawersIds={activeGlobalDrawersIds ?? []}
               onActiveGlobalDrawersChange={onActiveGlobalDrawersChange}
+              toolsOpen={toolsOpen}
+              onToolsToggle={onToolsToggle}
             />
           </div>
         )}


### PR DESCRIPTION
### Description

Aligned controllable tools behavior for the app layout toolbar theme with the refresh-layout theme. If tools are partially controllable (where either `toolsOpen` or `onToolsChange` is provided, but not both), the tools will not be activated when clicking on the corresponding trigger button

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
