### PR TITLE
fix: Fix area-chart zero height when statusType is loading then finished with  true

### DIFF
--- a/pages/area-chart/loading.page.tsx
+++ b/pages/area-chart/loading.page.tsx
@@ -1,0 +1,115 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext, useEffect, useState } from 'react';
+
+import { AreaChart, Box, Button, Checkbox, SpaceBetween } from '~components';
+
+import AppContext, { AppContextType } from '../app/app-context';
+import ScreenshotArea from '../utils/screenshot-area';
+import { createLinearTimeLatencyProps } from './series';
+
+type DemoContext = React.Context<
+  AppContextType<{ fitHeight: boolean; hideFilter: boolean; hideLegend: boolean; minHeight: number }>
+>;
+
+const chartData = createLinearTimeLatencyProps();
+
+export default function () {
+  const [status, setStatus] = useState<'finished' | 'error' | 'loading' | undefined>('loading');
+
+  useEffect(() => {
+    setTimeout(() => {
+      setStatus('finished');
+    }, 1000);
+  }, []);
+
+  const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
+  const minHeight = parseInt(urlParams.minHeight?.toString() || '0');
+  const heights = [800];
+  const fitHeight = urlParams.fitHeight ?? true;
+  return (
+    <Box padding="m">
+      <h1>Area chart loading states</h1>
+
+      <Box>
+        <Checkbox checked={fitHeight} onChange={e => setUrlParams({ fitHeight: e.detail.checked })}>
+          fit height
+        </Checkbox>
+        <Checkbox checked={urlParams.hideFilter} onChange={e => setUrlParams({ hideFilter: e.detail.checked })}>
+          hide filter
+        </Checkbox>
+        <Checkbox checked={urlParams.hideLegend} onChange={e => setUrlParams({ hideLegend: e.detail.checked })}>
+          hide legend
+        </Checkbox>
+        <SpaceBetween size="xs" direction="horizontal" alignItems="center">
+          <input
+            id="min-height-input"
+            type="number"
+            value={minHeight}
+            onChange={e => setUrlParams({ minHeight: parseInt(e.target.value) })}
+          />
+          <label htmlFor="min-height-input">min height</label>
+        </SpaceBetween>
+      </Box>
+
+      <ScreenshotArea>
+        <SpaceBetween size="l">
+          {heights.map(height => (
+            <Box key={height}>
+              <Box>{height}px</Box>
+              <div
+                style={{ boxSizing: 'border-box', width: '100%', padding: '8px', border: '2px solid black', height }}
+              >
+                <AreaChart
+                  id="chart"
+                  statusType={status}
+                  fitHeight={true}
+                  height={200}
+                  hideFilter={urlParams.hideFilter}
+                  hideLegend={urlParams.hideLegend}
+                  ariaLabel="Linear latency chart"
+                  ariaDescription="Use up/down arrow keys to navigate between series, and left/right arrow keys to navigate within a series."
+                  loadingText="Loading chart data..."
+                  errorText="Error loading chart data."
+                  recoveryText="Retry"
+                  onRecoveryClick={() => {}}
+                  empty={
+                    <Box textAlign="center" color="inherit">
+                      <b>No data</b>
+                      <Box variant="p" color="inherit">
+                        There is no data to display
+                      </Box>
+                    </Box>
+                  }
+                  noMatch={
+                    <Box textAlign="center" color="inherit">
+                      <b>No matching data</b>
+                      <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+                        There is no data to display
+                      </Box>
+                      <Button onClick={() => alert('Not implemented in the example')}>Clear filter</Button>
+                    </Box>
+                  }
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed data',
+                    filterPlaceholder: 'Filter data',
+                    filterSelectedAriaLabel: '(selected)',
+                    detailTotalLabel: 'Total',
+                    detailPopoverDismissAriaLabel: 'Dismiss',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'area chart',
+                    xAxisAriaRoleDescription: 'x axis',
+                    yAxisAriaRoleDescription: 'y axis',
+                    xTickFormatter: value => `${value}\nxxx`,
+                  }}
+                  xDomain={[0, 119]}
+                  {...chartData}
+                />
+              </div>
+            </Box>
+          ))}
+        </SpaceBetween>
+      </ScreenshotArea>
+    </Box>
+  );
+}

--- a/src/area-chart/__integ__/area-chart.test.ts
+++ b/src/area-chart/__integ__/area-chart.test.ts
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
+import { AreaChartWrapper } from '../../../lib/components/test-utils/selectors';
 import AreaChartPageObject from './page-objects/area-chart-page';
+
+const computedDomainChartWrapper = new AreaChartWrapper('#chart');
 
 function setupTest(url: string, name: string, testFn: (page: AreaChartPageObject) => Promise<void>) {
   return useBrowser(async browser => {
@@ -488,7 +491,22 @@ describe('Controlled', () => {
     })
   );
 });
+describe('Loading state', () => {
+  test(
+    'height of the chart is displayed correctly after changing loading state to finished',
+    setupTest('#/light/area-chart/loading', 'chart', async page => {
+      await page.setWindowSize({ width: 500, height: 800 });
+      // the loading is about 1000ms in the loading page and then the
+      // statusType becomes 'finished'. This just waits for it.
+      await page.waitForJsTimers(2000);
 
+      // we only need to validate one of the series here, looping over all
+      // of the series will cause a failure since we might have one series with height 0 (threshold one)
+      const seriesBox = await page.getBoundingBox(computedDomainChartWrapper.findSeries().get(1).toSelector());
+      expect(seriesBox.height).toBeGreaterThan(200);
+    })
+  );
+});
 describe('Labels', () => {
   test(
     'log labels have no intersections',

--- a/src/area-chart/__integ__/area-chart.test.ts
+++ b/src/area-chart/__integ__/area-chart.test.ts
@@ -501,7 +501,7 @@ describe('Loading state', () => {
       await page.waitForJsTimers(2000);
 
       // we only need to validate one of the series here, looping over all
-      // of the series will cause a failure since we might have one series with height 0 (threshold one)
+      // of the series will cause a failure since we might have one series with height 0 (threshold one).
       const seriesBox = await page.getBoundingBox(computedDomainChartWrapper.findSeries().get(1).toSelector());
       expect(seriesBox.height).toBeGreaterThan(200);
     })

--- a/src/area-chart/__tests__/area-chart-use-chart-model.test.tsx
+++ b/src/area-chart/__tests__/area-chart-use-chart-model.test.tsx
@@ -147,6 +147,7 @@ describe('useChartModel', () => {
         externalSeries: series,
         visibleSeries: series,
         popoverRef: { current: null },
+        statusType: 'finished',
       });
       wrapper.focus();
 
@@ -182,6 +183,7 @@ describe('useChartModel', () => {
           externalSeries: series,
           visibleSeries: series,
           popoverRef: { current: null },
+          statusType: 'finished',
         });
         wrapper.focus();
 
@@ -215,6 +217,7 @@ describe('useChartModel', () => {
           externalSeries: series,
           visibleSeries: series,
           popoverRef: { current: null },
+          statusType: 'finished',
         });
         wrapper.focus();
         expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('0');
@@ -238,6 +241,7 @@ describe('useChartModel', () => {
           externalSeries: series,
           visibleSeries: series,
           popoverRef: { current: null },
+          statusType: 'finished',
         });
         wrapper.focus();
 
@@ -273,6 +277,7 @@ describe('useChartModel', () => {
           externalSeries: series,
           visibleSeries: series,
           popoverRef: { current: null },
+          statusType: 'finished',
         });
         wrapper.focus();
 
@@ -299,6 +304,7 @@ describe('useChartModel', () => {
           externalSeries: series,
           visibleSeries: series,
           popoverRef: { current: null },
+          statusType: 'finished',
         });
 
         const mouseMoveEvent = {
@@ -335,6 +341,7 @@ describe('useChartModel', () => {
           externalSeries: series,
           visibleSeries: series,
           popoverRef: { current: null },
+          statusType: 'finished',
         });
 
         const mouseMoveEvent = {
@@ -379,6 +386,7 @@ describe('useChartModel', () => {
           externalSeries: series,
           visibleSeries: series,
           popoverRef: { current: null },
+          statusType: 'finished',
         });
 
         const mouseMoveEvent = {
@@ -415,6 +423,7 @@ describe('useChartModel', () => {
           externalSeries: series,
           visibleSeries: series,
           popoverRef: { current: null },
+          statusType: 'finished',
         });
 
         const mouseMoveEvent = {

--- a/src/area-chart/internal.tsx
+++ b/src/area-chart/internal.tsx
@@ -112,6 +112,7 @@ export default function InternalAreaChart<T extends AreaChartProps.DataTypes>({
     height,
     width,
     popoverRef,
+    statusType,
   });
 
   const { isEmpty, isNoMatch, showChart } = getChartStatus({

--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -40,6 +40,7 @@ export interface UseChartModelProps<T extends AreaChartProps.DataTypes> {
   height: number;
   width: number;
   popoverRef: RefObject<HTMLElement>;
+  statusType: 'loading' | 'finished' | 'error';
 }
 
 // Represents the core the chart logic, including the model of all allowed user interactions.
@@ -58,6 +59,7 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
   height: explicitHeight,
   width,
   popoverRef,
+  statusType,
 }: UseChartModelProps<T>): ChartModel<T> {
   // Chart elements refs used in handlers.
   const plotRef = useRef<ChartPlotRef>(null);
@@ -66,8 +68,8 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
 
   const plotMeasureRef = useRef<SVGLineElement>(null);
   const hasVisibleSeries = series.length > 0;
-  const height = useHeightMeasure(() => plotMeasureRef.current, !fitHeight, [hasVisibleSeries]) ?? explicitHeight;
-
+  const height =
+    useHeightMeasure(() => plotMeasureRef.current, !fitHeight, [hasVisibleSeries, statusType]) ?? explicitHeight;
   const stableSetVisibleSeries = useStableCallback(setVisibleSeries);
 
   const model = useMemo(() => {


### PR DESCRIPTION

### Description
When an area-chart is rendered with `fitHeight` true and has an initial `statusType` of loading then transitions to `finished` the height of the chart becomes zero.

We calculate the chart height given its ref to `useHeightMeasure` and some deps, this is solved by also passing to it the `statusType` as a dependency.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
