### PR TITLE
fix: Shaking split panel

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useImperativeHandle, useState } from 'react';
+import React, { useEffect, useImperativeHandle, useMemo, useState } from 'react';
 
 import ScreenreaderOnly from '../../internal/components/screenreader-only';
 import { SplitPanelSideToggleProps } from '../../internal/context/split-panel-context';
@@ -202,10 +202,15 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       fireNonCancelableEvent(onSplitPanelPreferencesChange, detail);
     };
 
+    const splitPanelDefaultSize = useMemo(
+      () => getSplitPanelDefaultSize(splitPanelPreferences?.position ?? 'bottom'),
+      [splitPanelPreferences?.position]
+    );
+
     const [splitPanelSize = 0, setSplitPanelSize] = useControllable(
       controlledSplitPanelSize,
       onSplitPanelResize,
-      getSplitPanelDefaultSize(splitPanelPreferences?.position ?? 'bottom'),
+      splitPanelDefaultSize,
       { componentName: 'AppLayout', controlledProp: 'splitPanelSize', changeHandler: 'onSplitPanelResize' }
     );
 

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -204,7 +204,8 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
 
     const splitPanelDefaultSize = useMemo(
       () => getSplitPanelDefaultSize(splitPanelPreferences?.position ?? 'bottom'),
-      [splitPanelPreferences?.position]
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [splitPanelPreferences?.position, isMobile]
     );
 
     const [splitPanelSize = 0, setSplitPanelSize] = useControllable(

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useImperativeHandle, useMemo, useState } from 'react';
+import React, { useEffect, useImperativeHandle, useState } from 'react';
 
 import ScreenreaderOnly from '../../internal/components/screenreader-only';
 import { SplitPanelSideToggleProps } from '../../internal/context/split-panel-context';
@@ -202,16 +202,10 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       fireNonCancelableEvent(onSplitPanelPreferencesChange, detail);
     };
 
-    const splitPanelDefaultSize = useMemo(
-      () => getSplitPanelDefaultSize(splitPanelPreferences?.position ?? 'bottom'),
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [splitPanelPreferences?.position, isMobile]
-    );
-
     const [splitPanelSize = 0, setSplitPanelSize] = useControllable(
       controlledSplitPanelSize,
       onSplitPanelResize,
-      splitPanelDefaultSize,
+      getSplitPanelDefaultSize(splitPanelPreferences?.position ?? 'bottom'),
       { componentName: 'AppLayout', controlledProp: 'splitPanelSize', changeHandler: 'onSplitPanelResize' }
     );
 

--- a/src/app-layout/visual-refresh-toolbar/split-panel/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/split-panel/styles.scss
@@ -10,4 +10,5 @@
 .split-panel-side {
   position: sticky;
   z-index: 830;
+  overflow-x: hidden;
 }


### PR DESCRIPTION
### Description

This issue occurs when the 'Show scroll bars' option is set to 'Always' in the macOS Appearance System preferences. 

The problem arises when the side split panel is opened at desktop screen size, causing the scroll bar to appear briefly and then hide because of the animation. This problem is fixed via setting `overflow: hidden` to side-panel's parent element.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
