### PR TITLE
fix: Let sticky header react only to user-generated resize events

### DIFF
--- a/src/container/__tests__/sticky-header.test.tsx
+++ b/src/container/__tests__/sticky-header.test.tsx
@@ -96,3 +96,22 @@ test('should set isStuck to false when headerRef is null', () => {
 
   expect(result.current.isStuck).toBe(false);
 });
+
+test('should not react to synthetic window resize events', () => {
+  const rootRef = {
+    current: document.createElement('div'),
+  };
+  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+
+  const headerRef = {
+    current: document.createElement('div'),
+  };
+  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
+
+  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
+  act(() => {
+    window.dispatchEvent(new Event('resize'));
+  });
+
+  expect(result.current.isStuck).toBe(false);
+});

--- a/src/container/use-sticky-header.ts
+++ b/src/container/use-sticky-header.ts
@@ -87,19 +87,26 @@ export const useStickyHeader = (
 
   // "stuck" state, when the header has moved from its original posititon has a
   // box-shadow, applied here by a "header-stuck" className
-  const checkIfStuck = useCallback(() => {
-    if (rootRef.current && headerRef.current) {
-      const rootTopBorderWidth = parseFloat(getComputedStyle(rootRef.current).borderTopWidth) || 0;
-      const rootTop = rootRef.current.getBoundingClientRect().top + rootTopBorderWidth;
-      const headerTop = headerRef.current.getBoundingClientRect().top;
-
-      if (rootTop < headerTop) {
-        setIsStuck(true);
-      } else {
-        setIsStuck(false);
+  const checkIfStuck = useCallback(
+    ({ isTrusted, target, type }) => {
+      if (type === 'resize' && target === window && !isTrusted) {
+        // The window size didn't actually change, it was a synthetic event
+        return;
       }
-    }
-  }, [rootRef, headerRef]);
+      if (rootRef.current && headerRef.current) {
+        const rootTopBorderWidth = parseFloat(getComputedStyle(rootRef.current).borderTopWidth) || 0;
+        const rootTop = rootRef.current.getBoundingClientRect().top + rootTopBorderWidth;
+        const headerTop = headerRef.current.getBoundingClientRect().top;
+
+        if (rootTop < headerTop) {
+          setIsStuck(true);
+        } else {
+          setIsStuck(false);
+        }
+      }
+    },
+    [rootRef, headerRef]
+  );
   useEffect(() => {
     if (isSticky) {
       window.addEventListener('scroll', checkIfStuck, true);


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-59633

### How has this been tested?

- Added a unit test
- Just in case, manually verified that the sticky header behavior keeps working when reloading a page in scrolled state. The browser generates a trusted scroll event in this case

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
