### PR TITLE
fix: Fixes property filter count text when token groups are used

### DIFF
--- a/src/property-filter/__tests__/property-filter.filtering-input.test.tsx
+++ b/src/property-filter/__tests__/property-filter.filtering-input.test.tsx
@@ -409,6 +409,15 @@ describe('count text', () => {
     });
     expect(wrapper.findResultsCount()!.getElement()).toHaveTextContent('5 matches');
   });
+
+  test('is visible when there is at least 1 token group', () => {
+    const { propertyFilterWrapper: wrapper } = renderComponent({
+      enableTokenGroups: true,
+      countText: '5 matches',
+      query: { operation: 'or', tokens: [], tokenGroups: [{ propertyKey: 'string', value: 'first', operator: ':' }] },
+    });
+    expect(wrapper.findResultsCount()!.getElement()).toHaveTextContent('5 matches');
+  });
 });
 
 describe('constraint text', () => {

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -113,7 +113,6 @@ const PropertyFilterInternal = React.forwardRef(
     const i18nStrings = usePropertyFilterI18n(rest.i18nStrings);
 
     useImperativeHandle(ref, () => ({ focus: () => inputRef.current?.focus() }), []);
-    const showResults = !!query.tokens?.length && !disabled && !!countText;
     const [filteringText, setFilteringText] = useState<string>('');
 
     const { internalProperties, internalOptions, internalQuery, internalFreeText } = (() => {
@@ -306,6 +305,9 @@ const PropertyFilterInternal = React.forwardRef(
     const textboxAriaDescribedBy = filteringConstraintText
       ? joinStrings(rest.ariaDescribedby, constraintTextId)
       : rest.ariaDescribedby;
+
+    const showResults = !!internalQuery.tokens?.length && !disabled && !!countText;
+
     return (
       <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={mergedRef}>
         <div className={clsx(styles['search-field'], analyticsSelectors['search-field'])}>


### PR DESCRIPTION
### Description

Rel: AWSUI-59725

### How has this been tested?

* New unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
