### PR TITLE
fix: Resizable column focus ring positioning

### DIFF
--- a/src/table/resizer/styles.scss
+++ b/src/table/resizer/styles.scss
@@ -68,8 +68,10 @@ th:not(:last-child) > .divider {
   }
   &.has-focus {
     @include focus-visible.when-visible-unfocused {
-      position: absolute;
       @include styles.focus-highlight(calc(#{awsui.$space-table-header-focus-outline-gutter} - 2px));
+      & {
+        position: absolute;
+      }
     }
   }
 }


### PR DESCRIPTION
### Description

Before this change, the resizer button was relatively positioned when focused. This caused the resizable button change it's position when focused (see screen recording below). The relative position was coming from the `focus-highlight` mixin. This regression was introduced when fixing sass deprecation warnings (#2638).

 Wrapping the absolute position in `& {}` creates a separate rule which takes precedence because of the rule declaration order.


Screen recording of the issue (left tab before, right tab after):

https://github.com/user-attachments/assets/04c1b2ac-0083-4283-a2e4-b689a4403dff


Related links, issue #, if available: AWSUI-59724

### How has this been tested?

- Manually tested in supported browsers on Mac.
- Added additional screenshot test (WIP in my pipeline).
- Can be tested by opening a the [table resizable column demo page](https://d21d5uik3ws71m.cloudfront.net/components/8d581545d37b05b732e22928fe010536046be949/dev-pages/index.html#/light/table/resizable-columns) of this PR.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
