### PR TITLE
fix: Empty notifications height

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -326,6 +326,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       setToolbarState,
       verticalOffsets,
       drawersOpenQueue,
+      notificationsHeight,
       setToolbarHeight,
       setNotificationsHeight,
       onSplitPanelToggle: onSplitPanelToggleHandler,

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useImperativeHandle, useState } from 'react';
 import ScreenreaderOnly from '../../internal/components/screenreader-only';
 import { SplitPanelSideToggleProps } from '../../internal/context/split-panel-context';
 import { fireNonCancelableEvent } from '../../internal/events';
+import * as tokens from '../../internal/generated/styles/tokens';
 import { useControllable } from '../../internal/hooks/use-controllable';
 import { useMobile } from '../../internal/hooks/use-mobile';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
@@ -378,7 +379,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
         {!hasToolbar && breadcrumbs ? <ScreenreaderOnly>{breadcrumbs}</ScreenreaderOnly> : null}
         <SkeletonLayout
           style={{
-            [globalVars.stickyVerticalTopOffset]: `${verticalOffsets.header}px`,
+            [globalVars.stickyVerticalTopOffset]: `${verticalOffsets.header}px + ${resolvedStickyNotifications && notificationsHeight > 0 ? tokens.spaceXs : '0px'}`,
             [globalVars.stickyVerticalBottomOffset]: `${placement.insetBlockEnd}px`,
             paddingBlockEnd: splitPanelOpen && splitPanelPosition === 'bottom' ? splitPanelReportedSize : '',
           }}

--- a/src/app-layout/visual-refresh-toolbar/interfaces.ts
+++ b/src/app-layout/visual-refresh-toolbar/interfaces.ts
@@ -54,4 +54,5 @@ export interface AppLayoutInternals {
   onActiveGlobalDrawersChange: (newDrawerId: string) => void;
   toolsOpen: boolean;
   onToolsToggle: (value: boolean) => void;
+  notificationsHeight: number;
 }

--- a/src/app-layout/visual-refresh-toolbar/notifications/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/notifications/index.tsx
@@ -21,8 +21,10 @@ export function AppLayoutNotificationsImplementation({
   appLayoutInternals,
   children,
 }: AppLayoutNotificationsImplementationProps) {
-  const { ariaLabels, stickyNotifications, setNotificationsHeight, verticalOffsets } = appLayoutInternals;
+  const { ariaLabels, stickyNotifications, setNotificationsHeight, verticalOffsets, notificationsHeight } =
+    appLayoutInternals;
   const ref = useRef<HTMLElement>(null);
+  const hasNotificationsContent = notificationsHeight > 0;
   useResizeObserver(ref, entry => setNotificationsHeight(entry.borderBoxHeight));
   useEffect(() => {
     return () => {
@@ -34,7 +36,10 @@ export function AppLayoutNotificationsImplementation({
   return (
     <NotificationsSlot
       ref={ref}
-      className={clsx(stickyNotifications && styles['sticky-notifications'])}
+      className={clsx(
+        stickyNotifications && styles['sticky-notifications'],
+        hasNotificationsContent && styles['has-notifications-content']
+      )}
       style={{
         insetBlockStart: stickyNotifications ? verticalOffsets.notifications : undefined,
       }}

--- a/src/app-layout/visual-refresh-toolbar/notifications/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/notifications/index.tsx
@@ -23,7 +23,7 @@ export function AppLayoutNotificationsImplementation({
 }: AppLayoutNotificationsImplementationProps) {
   const { ariaLabels, stickyNotifications, setNotificationsHeight, verticalOffsets, notificationsHeight } =
     appLayoutInternals;
-  const ref = useRef<HTMLElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
   const hasNotificationsContent = notificationsHeight > 0;
   useResizeObserver(ref, entry => setNotificationsHeight(entry.borderBoxHeight));
   useEffect(() => {
@@ -35,7 +35,6 @@ export function AppLayoutNotificationsImplementation({
   }, []);
   return (
     <NotificationsSlot
-      ref={ref}
       className={clsx(
         stickyNotifications && styles['sticky-notifications'],
         hasNotificationsContent && styles['has-notifications-content']
@@ -44,7 +43,7 @@ export function AppLayoutNotificationsImplementation({
         insetBlockStart: stickyNotifications ? verticalOffsets.notifications : undefined,
       }}
     >
-      <div className={testutilStyles.notifications} role="region" aria-label={ariaLabels?.notifications}>
+      <div ref={ref} className={testutilStyles.notifications} role="region" aria-label={ariaLabels?.notifications}>
         {children}
       </div>
     </NotificationsSlot>

--- a/src/app-layout/visual-refresh-toolbar/notifications/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/notifications/styles.scss
@@ -2,7 +2,13 @@
  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  SPDX-License-Identifier: Apache-2.0
 */
+@use '../../../internal/styles/tokens' as awsui;
+
 .sticky-notifications {
   position: sticky;
   z-index: 850;
+}
+
+.has-notifications-content {
+  padding-block-start: awsui.$space-scaled-xs;
 }

--- a/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
@@ -156,9 +156,6 @@
 
 .notifications-container {
   grid-area: notifications;
-  &:not(:empty) {
-    padding-block-start: awsui.$space-scaled-xs;
-  }
 }
 
 .main-landmark {


### PR DESCRIPTION
### Description

This issue arises when the notifications in the refresh-toolbar theme are empty. The current implementation relies on the :not(:empty) CSS property, which doesn't work because the notifications DOM node is always present, even when there are no notifications. In this PR, I updated the calculation to match how it's handled in the refresh theme

<img width="1108" alt="image" src="https://github.com/user-attachments/assets/8586da55-5a83-41d9-914c-011ae52f560d">

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
