### PR TITLE
fix: Removes group highlight state from Select

### DIFF
--- a/pages/select/screenshot.page.tsx
+++ b/pages/select/screenshot.page.tsx
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 import React, { useState } from 'react';
 
+import { SpaceBetween } from '~components';
 import Select, { SelectProps } from '~components/select';
 
 import ScreenshotArea from '../utils/screenshot-area';
@@ -25,11 +27,16 @@ const options: SelectProps.Options = [
     options: [{ value: 'forth', label: 'Nested option' }],
   },
 ];
+const options2: SelectProps.Options = [
+  {
+    label: 'Option group',
+    options: [{ value: 'forth', label: 'Nested option' }],
+  },
+];
 
 export default function () {
   const [selected, setSelected] = useState<SelectProps['selectedOption']>(null);
   const [virtualScroll, setVirtualScroll] = useState<boolean>(false);
-
   return (
     <>
       <h1>Select for screenshot</h1>
@@ -44,27 +51,41 @@ export default function () {
           paddingBlockEnd: 300,
         }}
       >
-        <Select
-          placeholder="Select an option"
-          selectedOption={selected}
-          options={options}
-          filteringType="manual"
-          finishedText="End of all results"
-          onChange={event => setSelected(event.detail.selectedOption)}
-          virtualScroll={virtualScroll}
-          ariaLabel="select demo"
-          data-testid="select-demo"
-        />
-        <Select
-          placeholder="Select an option"
-          selectedOption={selected}
-          options={options}
-          finishedText="End of all results"
-          onChange={event => setSelected(event.detail.selectedOption)}
-          virtualScroll={virtualScroll}
-          ariaLabel="select demo no filtering"
-          data-testid="select-demo-no-filtering"
-        />
+        <SpaceBetween size="s">
+          <Select
+            placeholder="Demo with manual filtering"
+            selectedOption={selected}
+            options={options}
+            filteringType="manual"
+            finishedText="End of all results"
+            onChange={event => setSelected(event.detail.selectedOption)}
+            virtualScroll={virtualScroll}
+            ariaLabel="select demo"
+            data-testid="select-demo"
+          />
+
+          <Select
+            placeholder="Demo with no filtering"
+            selectedOption={selected}
+            options={options}
+            finishedText="End of all results"
+            onChange={event => setSelected(event.detail.selectedOption)}
+            virtualScroll={virtualScroll}
+            ariaLabel="select demo no filtering"
+            data-testid="select-demo-no-filtering"
+          />
+
+          <Select
+            placeholder="Demo with a single option inside group"
+            selectedOption={selected}
+            options={options2}
+            // finishedText="End of all results"
+            onChange={event => setSelected(event.detail.selectedOption)}
+            // virtualScroll={virtualScroll}
+            ariaLabel="select demo single option inside group"
+            data-testid="select-demo-single-option-inside-group"
+          />
+        </SpaceBetween>
       </ScreenshotArea>
     </>
   );

--- a/pages/select/screenshot.page.tsx
+++ b/pages/select/screenshot.page.tsx
@@ -79,9 +79,9 @@ export default function () {
             placeholder="Demo with a single option inside group"
             selectedOption={selected}
             options={options2}
-            // finishedText="End of all results"
+            finishedText="End of all results"
             onChange={event => setSelected(event.detail.selectedOption)}
-            // virtualScroll={virtualScroll}
+            virtualScroll={virtualScroll}
             ariaLabel="select demo single option inside group"
             data-testid="select-demo-single-option-inside-group"
           />

--- a/src/select/__tests__/use-select.test.ts
+++ b/src/select/__tests__/use-select.test.ts
@@ -22,6 +22,7 @@ const createTestEvent = (keyCode: KeyCode) =>
     },
   });
 
+const optionChild31 = { value: 'child31', label: 'Child 3-1' };
 const options = [
   {
     label: 'Group 1',
@@ -53,7 +54,11 @@ const options = [
       },
     ],
   },
-];
+  {
+    label: 'Group 3',
+    options: [optionChild31],
+  },
+] as const;
 
 const { flatOptions } = flattenOptions(options);
 const updateSelectedOption = jest.fn();
@@ -137,6 +142,36 @@ describe('useSelect', () => {
     });
   });
 
+  test('option group is not selected when its only option is selected', () => {
+    const hook = renderHook(useSelect, { initialProps: { ...initialProps, selectedOptions: [optionChild31] } });
+    const { getOptionProps, getMenuProps } = hook.result.current;
+    const { id: menuId } = getMenuProps();
+
+    const groupProps = getOptionProps(flatOptions[7], 7);
+    expect(groupProps).toEqual({
+      'data-mouse-target': -1,
+      highlighted: false,
+      key: 7,
+      option: { type: 'parent', option: { label: 'Group 3', options: [{ value: 'child31', label: 'Child 3-1' }] } },
+      selected: false,
+      isNextSelected: true,
+      indeterminate: false,
+      id: getOptionId(menuId!, 7),
+    });
+
+    const optionProps = getOptionProps(flatOptions[8], 8);
+    expect(optionProps).toEqual({
+      'data-mouse-target': 8,
+      highlighted: false,
+      key: 8,
+      option: { type: 'child', option: { value: 'child31', label: 'Child 3-1' } },
+      selected: true,
+      isNextSelected: false,
+      indeterminate: false,
+      id: getOptionId(menuId!, 8),
+    });
+  });
+
   test('should open and close the dropdown', () => {
     const hook = renderHook(useSelect, {
       initialProps,
@@ -177,11 +212,7 @@ describe('useSelect', () => {
 
     act(() => hook.result.current.getFilterProps().onKeyDown!(createTestEvent(KeyCode.down)));
     act(() => hook.result.current.getFilterProps().onKeyDown!(createTestEvent(KeyCode.up)));
-    expect(hook.result.current.highlightedOption).toEqual({
-      disabled: true,
-      option: { disabled: true, label: 'Child 2' },
-      type: 'child',
-    });
+    expect(hook.result.current.highlightedOption).toEqual({ type: 'child', option: optionChild31 });
   });
 
   test('should navigate to the first parent option by triggering keyboard:up on second child option (interactive groups)', () => {

--- a/src/select/utils/use-select.ts
+++ b/src/select/utils/use-select.ts
@@ -238,7 +238,7 @@ export function useSelect({
     const hasSelected = totalSelected > 0;
     const allSelected = totalSelected === option.options.length;
     return {
-      selected: hasSelected && allSelected,
+      selected: hasSelected && allSelected && useInteractiveGroups,
       indeterminate: hasSelected && !allSelected,
     };
   };
@@ -252,7 +252,6 @@ export function useSelect({
       !!nextOption && isGroup(nextOption)
         ? getGroupState(nextOption).selected
         : __selectedOptions.indexOf(options[index + 1]) > -1;
-
     const optionProps: any = {
       key: index,
       option,


### PR DESCRIPTION
### Description

The Select component groups are not supposed to be selectable. However, as the useSelect util is reused between Select and Multiselect, there was logic that made groups selected if all children are selected that affected Select components having a single options inside a group.

Before:


https://github.com/user-attachments/assets/d3b8c9a8-f3fa-46b4-92e9-e05b5ba06ec5



After:


https://github.com/user-attachments/assets/e51fa5bf-6700-43d8-b831-690e8ed2cef3

Rel: AWSUI-59650

### How has this been tested?

* New unit test
* Screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
