### PR TITLE
fix: Removes unneeded tab stop from property filter

### DIFF
--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -254,7 +254,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
           />
         ) : null
       }
-      loopFocus={statusType === 'error' && !!recoveryText && !!onLoadItems}
+      loopFocus={dropdownStatus.hasRecoveryButton}
       onCloseDropdown={handleCloseDropdown}
       onDelayedInput={handleDelayedInput}
       onPressArrowDown={handlePressArrowDown}

--- a/src/internal/components/dropdown-status/index.tsx
+++ b/src/internal/components/dropdown-status/index.tsx
@@ -55,6 +55,7 @@ type UseDropdownStatus = ({
 export interface DropdownStatusResult {
   isSticky: boolean;
   content: React.ReactNode | null;
+  hasRecoveryButton: boolean;
 }
 
 export const useDropdownStatus: UseDropdownStatus = ({
@@ -72,13 +73,14 @@ export const useDropdownStatus: UseDropdownStatus = ({
   onRecoveryClick,
   hasRecoveryCallback = false,
   errorIconAriaLabel,
-}) => {
+}): DropdownStatusResult => {
   const previousStatusType = usePrevious(statusType);
-  const statusResult: DropdownStatusResult = { isSticky: true, content: null };
+  const statusResult: DropdownStatusResult = { isSticky: true, content: null, hasRecoveryButton: false };
 
   if (statusType === 'loading') {
     statusResult.content = <InternalStatusIndicator type={'loading'}>{loadingText}</InternalStatusIndicator>;
   } else if (statusType === 'error') {
+    statusResult.hasRecoveryButton = !!recoveryText && hasRecoveryCallback;
     statusResult.content = (
       <span>
         <InternalStatusIndicator
@@ -89,7 +91,7 @@ export const useDropdownStatus: UseDropdownStatus = ({
         >
           {errorText}
         </InternalStatusIndicator>{' '}
-        {!!recoveryText && hasRecoveryCallback && (
+        {statusResult.hasRecoveryButton && (
           <InternalLink
             onFollow={() => fireNonCancelableEvent(onRecoveryClick)}
             variant="recovery"

--- a/src/internal/components/tab-trap/index.tsx
+++ b/src/internal/components/tab-trap/index.tsx
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import styles from './styles.css.js';
+
 export interface TabTrapProps {
   focusNextCallback: (event: React.FocusEvent) => void;
   disabled?: boolean;
@@ -13,5 +15,5 @@ export interface TabTrapProps {
  * which can forward the focus to another element.
  */
 export default function TabTrap({ focusNextCallback, disabled = false }: TabTrapProps) {
-  return <div tabIndex={disabled ? -1 : 0} onFocus={focusNextCallback} />;
+  return <div className={styles.root} tabIndex={disabled ? -1 : 0} onFocus={focusNextCallback} />;
 }

--- a/src/internal/components/tab-trap/styles.scss
+++ b/src/internal/components/tab-trap/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.root {
+  /* used in tests */
+}

--- a/src/property-filter/__tests__/property-filter-autosuggest.test.tsx
+++ b/src/property-filter/__tests__/property-filter-autosuggest.test.tsx
@@ -189,7 +189,7 @@ describe('Property filter autosuggest', () => {
     expect(wrapper.find('#first-focusable')!.getElement()).toHaveFocus();
   });
 
-  test('has no focus trap when no custom form or recovery button', () => {
+  test('has no focus trap when no custom form and no recovery button', () => {
     const { wrapper } = renderAutosuggest(<PropertyFilterAutosuggest options={options} value="" onChange={() => {}} />);
 
     expect(wrapper.findByClassName(tabTrapStyles.root)!.getElement()).toHaveAttribute('tabIndex', '-1');

--- a/src/property-filter/__tests__/property-filter-autosuggest.test.tsx
+++ b/src/property-filter/__tests__/property-filter-autosuggest.test.tsx
@@ -10,6 +10,8 @@ import PropertyFilterAutosuggest from '../../../lib/components/property-filter/p
 import createWrapper from '../../../lib/components/test-utils/dom';
 import AutosuggestWrapper from '../../../lib/components/test-utils/dom/autosuggest';
 
+import tabTrapStyles from '../../../lib/components/internal/components/tab-trap/styles.selectors.js';
+
 const options: AutosuggestProps.Options = [
   { value: '123', label: '123' },
   { value: 'abc', label: 'abc' },
@@ -18,7 +20,7 @@ const options: AutosuggestProps.Options = [
 function renderAutosuggest(jsx: React.ReactElement) {
   const { container, rerender } = render(jsx);
   const wrapper = createWrapper(container).findAutosuggest()!;
-  return { wrapper, rerender };
+  return { container, wrapper, rerender };
 }
 
 describe('Property filter autosuggest', () => {
@@ -185,5 +187,46 @@ describe('Property filter autosuggest', () => {
 
     wrapper.findNativeInput().keydown(KeyCode.down);
     expect(wrapper.find('#first-focusable')!.getElement()).toHaveFocus();
+  });
+
+  test('has no focus trap when no custom form or recovery button', () => {
+    const { wrapper } = renderAutosuggest(<PropertyFilterAutosuggest options={options} value="" onChange={() => {}} />);
+
+    expect(wrapper.findByClassName(tabTrapStyles.root)!.getElement()).toHaveAttribute('tabIndex', '-1');
+
+    wrapper.focus();
+
+    expect(wrapper.findByClassName(tabTrapStyles.root)!.getElement()).toHaveAttribute('tabIndex', '-1');
+  });
+
+  test('has focus trap when custom form', () => {
+    const { wrapper } = renderAutosuggest(
+      <PropertyFilterAutosuggest options={[]} value="" onChange={() => {}} customForm={<div />} />
+    );
+
+    expect(wrapper.findByClassName(tabTrapStyles.root)!.getElement()).toHaveAttribute('tabIndex', '-1');
+
+    wrapper.focus();
+
+    expect(wrapper.findByClassName(tabTrapStyles.root)!.getElement()).toHaveAttribute('tabIndex', '0');
+  });
+
+  test('has focus trap when recovery button', () => {
+    const { wrapper } = renderAutosuggest(
+      <PropertyFilterAutosuggest
+        options={options}
+        value=""
+        onChange={() => {}}
+        statusType="error"
+        recoveryText="retry"
+        onLoadItems={() => {}}
+      />
+    );
+
+    expect(wrapper.findByClassName(tabTrapStyles.root)!.getElement()).toHaveAttribute('tabIndex', '-1');
+
+    wrapper.focus();
+
+    expect(wrapper.findByClassName(tabTrapStyles.root)!.getElement()).toHaveAttribute('tabIndex', '0');
   });
 });

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -225,7 +225,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
         onPressArrowDown={handlePressArrowDown}
         onPressArrowUp={handlePressArrowUp}
         onPressEnter={handlePressEnter}
-        loopFocus={!!customForm || (statusType === 'error' && !!rest.recoveryText && !!onLoadItems)}
+        loopFocus={!!customForm || dropdownStatus.hasRecoveryButton}
       />
     );
   }

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -225,6 +225,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
         onPressArrowDown={handlePressArrowDown}
         onPressArrowUp={handlePressArrowUp}
         onPressEnter={handlePressEnter}
+        loopFocus={!!customForm || (statusType === 'error' && !!rest.recoveryText && !!onLoadItems)}
       />
     );
   }


### PR DESCRIPTION
### Description

The tab stop inside property filter and autosuggest dropdown is used to loop focus when there are interactive elements in the dropdown such as the recovery button or custom form. When there are no interactive element the tab stop must be disabled as otherwise it does not forward the focus requiring an extra Tab press to exit the dropdown.

### How has this been tested?

* New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
