### PR TITLE
fix: Ensure date picker relative unit select has valid default value

### DIFF
--- a/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
@@ -262,6 +262,17 @@ describe('Date range picker', () => {
       expect(getCustomRelativeRangeUnits(wrapper)).toEqual(['hours', 'minutes']);
     });
 
+    test('ensures default unit is a valid one specified from list', () => {
+      const { wrapper } = renderDateRangePicker({
+        ...defaultProps,
+        rangeSelectorMode: 'relative-only',
+        relativeOptions: [],
+        customRelativeRangeUnits: ['hour', 'day'],
+      });
+      wrapper.findTrigger().click();
+      expect(wrapper.findDropdown()!.findCustomRelativeRangeUnit()!.getElement()).toHaveTextContent('hours');
+    });
+
     test('warns about (and ignores) invalid custom units', () => {
       const { wrapper } = renderDateRangePicker({
         ...defaultProps,

--- a/src/date-range-picker/relative-range/index.tsx
+++ b/src/date-range-picker/relative-range/index.tsx
@@ -88,14 +88,6 @@ export default function RelativeRangePicker({
     return NaN;
   });
 
-  const initialCustomTimeUnit = dateOnly ? 'day' : 'minute';
-  const [customUnitOfTime, setCustomUnitOfTime] = useState<DateRangePickerProps.TimeUnit>(
-    initialRange?.unit ?? initialCustomTimeUnit
-  );
-
-  const showRadioControl = clientOptions.length > 0;
-  const showCustomControls = clientOptions.length === 0 || selectedRadio === CUSTOM_OPTION_SELECT_KEY;
-
   let finalUnits = dateOnly ? dayUnits : units;
   if (customUnits) {
     finalUnits = customUnits.filter(unit => {
@@ -109,6 +101,17 @@ export default function RelativeRangePicker({
       return false;
     });
   }
+
+  let initialCustomTimeUnit: DateRangePickerProps.TimeUnit = dateOnly ? 'day' : 'minute';
+  if (!finalUnits.includes(initialCustomTimeUnit)) {
+    initialCustomTimeUnit = finalUnits[0];
+  }
+  const [customUnitOfTime, setCustomUnitOfTime] = useState<DateRangePickerProps.TimeUnit>(
+    initialRange?.unit ?? initialCustomTimeUnit
+  );
+
+  const showRadioControl = clientOptions.length > 0;
+  const showCustomControls = clientOptions.length === 0 || selectedRadio === CUSTOM_OPTION_SELECT_KEY;
 
   return (
     <div>


### PR DESCRIPTION
### Description

Ensure date picker relative unit select has valid default value (previously it always used "days" or "minutes", even if that was not a valid unit)

Related links, issue #, if available: n/a

### How has this been tested?

New unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
