### PR TITLE
chore: Property filter custom form footer

### DIFF
--- a/src/property-filter/__tests__/property-filter-autosuggest.test.tsx
+++ b/src/property-filter/__tests__/property-filter-autosuggest.test.tsx
@@ -172,12 +172,15 @@ describe('Property filter autosuggest', () => {
         enteredTextLabel={() => ''}
         value=""
         onChange={() => {}}
-        customForm={
-          <div>
-            <button id="first-focusable">first focusable</button>
-            <button id="second-focusable">second focusable</button>
-          </div>
-        }
+        customForm={{
+          content: (
+            <div>
+              <button id="first-focusable">first focusable</button>
+              <button id="second-focusable">second focusable</button>
+            </div>
+          ),
+          footer: null,
+        }}
       />
     );
     wrapper.focus();

--- a/src/property-filter/__tests__/property-filter-autosuggest.test.tsx
+++ b/src/property-filter/__tests__/property-filter-autosuggest.test.tsx
@@ -204,7 +204,12 @@ describe('Property filter autosuggest', () => {
 
   test('has focus trap when custom form', () => {
     const { wrapper } = renderAutosuggest(
-      <PropertyFilterAutosuggest options={[]} value="" onChange={() => {}} customForm={<div />} />
+      <PropertyFilterAutosuggest
+        options={[]}
+        value=""
+        onChange={() => {}}
+        customForm={{ content: <div />, footer: <div /> }}
+      />
     );
 
     expect(wrapper.findByClassName(tabTrapStyles.root)!.getElement()).toHaveAttribute('tabIndex', '-1');

--- a/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
+++ b/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
@@ -122,6 +122,19 @@ describe('extended operators', () => {
     expect(wrapper.findNativeInput().getElement()).toHaveFocus();
   });
 
+  test('extended operator form value is reset when operator changes', () => {
+    const { propertyFilterWrapper: wrapper, pageWrapper } = renderComponent({ ...extendedOperatorProps });
+
+    // Increment value
+    wrapper.setInputValue('index >');
+    act(() => pageWrapper.find('[data-testid="change+"]')!.click());
+    expect(wrapper.find('[data-testid="change+"]')!.getElement()).toHaveTextContent('1');
+
+    // Change operator
+    wrapper.setInputValue('index <');
+    expect(wrapper.find('[data-testid="change-"]')!.getElement()).toHaveTextContent('0');
+  });
+
   test('extended operator form takes chosen operator and entered filter text', () => {
     const { propertyFilterWrapper: wrapper, pageWrapper } = renderComponent(extendedOperatorProps);
 

--- a/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
+++ b/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import { act, render } from '@testing-library/react';
 
+import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils.js';
+
 import PropertyFilter from '../../../lib/components/property-filter';
 import { FilteringProperty, PropertyFilterProps, Ref } from '../../../lib/components/property-filter/interfaces.js';
 import createWrapper, { PropertyFilterWrapper } from '../../../lib/components/test-utils/dom';
@@ -133,6 +135,23 @@ describe('extended operators', () => {
     // Change operator
     wrapper.setInputValue('index <');
     expect(wrapper.find('[data-testid="change-"]')!.getElement()).toHaveTextContent('0');
+  });
+
+  test('extended operator form value is reset when dropdown closes', () => {
+    const { propertyFilterWrapper: wrapper, pageWrapper } = renderComponent({ ...extendedOperatorProps });
+
+    // Increment value
+    wrapper.setInputValue('index >');
+    act(() => pageWrapper.find('[data-testid="change+"]')!.click());
+    expect(wrapper.find('[data-testid="change+"]')!.getElement()).toHaveTextContent('1');
+
+    // Close dropdown
+    wrapper.findNativeInput().keydown(KeyCode.escape);
+    expect(wrapper.findDropdown()?.findOpenDropdown()).toBeFalsy();
+
+    // Reopen dropdown
+    wrapper.setInputValue('index >');
+    expect(wrapper.find('[data-testid="change+"]')!.getElement()).toHaveTextContent('0');
   });
 
   test('extended operator form takes chosen operator and entered filter text', () => {

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -370,6 +370,7 @@ const PropertyFilterInternal = React.forwardRef(
                   }
                 : undefined
             }
+            onCloseDropdown={() => setCustomFormValueRecord({})}
             hideEnteredTextOption={internalFreeText.disabled && parsedText.step !== 'property'}
             clearAriaLabel={i18nStrings.clearAriaLabel}
             searchResultsId={showResults ? searchResultsId : undefined}

--- a/src/property-filter/property-editor.tsx
+++ b/src/property-filter/property-editor.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useState } from 'react';
+import React from 'react';
 
 import InternalButton from '../button/internal';
 import InternalFormField from '../form-field/internal';
@@ -10,27 +10,21 @@ import { ComparisonOperator, ExtendedOperatorForm, InternalFilteringProperty, In
 
 import styles from './styles.css.js';
 
-interface PropertyEditorProps<TokenValue> {
-  property: InternalFilteringProperty;
-  operator: ComparisonOperator;
-  filter: string;
-  operatorForm: ExtendedOperatorForm<TokenValue>;
-  onCancel: () => void;
-  onSubmit: (value: InternalToken) => void;
-  i18nStrings: I18nStringsInternal;
-}
-
-export function PropertyEditor<TokenValue = any>({
+export function PropertyEditorContent<TokenValue = any>({
   property,
   operator,
   filter,
+  value,
+  onChange,
   operatorForm,
-  onCancel,
-  onSubmit,
-  i18nStrings,
-}: PropertyEditorProps<TokenValue>) {
-  const [value, onChange] = useState<null | TokenValue>(null);
-  const submitToken = () => onSubmit({ property, operator, value });
+}: {
+  property: InternalFilteringProperty;
+  operator: ComparisonOperator;
+  filter: string;
+  value: null | TokenValue;
+  onChange: (value: null | TokenValue) => void;
+  operatorForm: ExtendedOperatorForm<TokenValue>;
+}) {
   return (
     <div className={styles['property-editor']}>
       <div className={styles['property-editor-form']}>
@@ -38,15 +32,34 @@ export function PropertyEditor<TokenValue = any>({
           {operatorForm({ value, onChange, operator, filter })}
         </InternalFormField>
       </div>
+    </div>
+  );
+}
 
-      <div className={styles['property-editor-actions']}>
-        <InternalButton variant="link" className={styles['property-editor-cancel']} onClick={onCancel}>
-          {i18nStrings.cancelActionText}
-        </InternalButton>
-        <InternalButton className={styles['property-editor-submit']} onClick={submitToken}>
-          {i18nStrings.applyActionText}
-        </InternalButton>
-      </div>
+export function PropertyEditorFooter<TokenValue = any>({
+  property,
+  operator,
+  value,
+  onCancel,
+  onSubmit,
+  i18nStrings,
+}: {
+  property: InternalFilteringProperty;
+  operator: ComparisonOperator;
+  value: null | TokenValue;
+  onCancel: () => void;
+  onSubmit: (value: InternalToken) => void;
+  i18nStrings: I18nStringsInternal;
+}) {
+  const submitToken = () => onSubmit({ property, operator, value });
+  return (
+    <div className={styles['property-editor-actions']}>
+      <InternalButton variant="link" className={styles['property-editor-cancel']} onClick={onCancel}>
+        {i18nStrings.cancelActionText}
+      </InternalButton>
+      <InternalButton className={styles['property-editor-submit']} onClick={submitToken}>
+        {i18nStrings.applyActionText}
+      </InternalButton>
     </div>
   );
 }

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -44,6 +44,7 @@ export interface PropertyFilterAutosuggestProps
   onOptionClick?: CancelableEventHandler<AutosuggestProps.Option>;
   hideEnteredTextOption?: boolean;
   searchResultsId?: string;
+  onCloseDropdown?: () => void;
 }
 
 const PropertyFilterAutosuggest = React.forwardRef(
@@ -68,6 +69,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
       onOptionClick,
       hideEnteredTextOption,
       searchResultsId,
+      onCloseDropdown,
       ...rest
     } = props;
     const highlightText = filterText === undefined ? value : filterText;
@@ -141,6 +143,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
 
     const handleCloseDropdown = () => {
       autosuggestItemsHandlers.resetHighlightWithKeyboard();
+      onCloseDropdown?.();
     };
 
     const handleRecoveryClick = () => {

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -36,7 +36,10 @@ const DROPDOWN_WIDTH_CUSTOM_FORM = 200;
 export interface PropertyFilterAutosuggestProps
   extends Omit<AutosuggestProps, 'filteringResultsText'>,
     InternalBaseComponentProps {
-  customForm?: React.ReactNode;
+  customForm?: {
+    content: React.ReactNode;
+    footer: React.ReactNode;
+  };
   filterText?: string;
   onOptionClick?: CancelableEventHandler<AutosuggestProps.Option>;
   hideEnteredTextOption?: boolean;
@@ -164,7 +167,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
     if (customForm) {
       content = (
         <div ref={customFormRef} className={styles['custom-content-wrapper']}>
-          {customForm}
+          {customForm.content}
         </div>
       );
     } else if (autosuggestItemsState.items.length > 0) {
@@ -210,12 +213,14 @@ const PropertyFilterAutosuggest = React.forwardRef(
         dropdownContentKey={customForm ? 'custom' : 'options'}
         dropdownContent={content}
         dropdownFooter={
-          dropdownStatus.isSticky && dropdownStatus.content ? (
+          dropdownStatus.isSticky && dropdownStatus.content && !customForm ? (
             <DropdownFooter
               content={dropdownStatus.content}
               hasItems={autosuggestItemsState.items.length >= 1}
               id={footerId}
             />
+          ) : customForm ? (
+            customForm.footer
           ) : null
         }
         dropdownWidth={customForm ? DROPDOWN_WIDTH_CUSTOM_FORM : DROPDOWN_WIDTH_OPTIONS_LIST}

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -46,10 +46,6 @@ $operator-field-width: 120px;
   padding-inline: awsui.$space-m;
   overflow-y: auto;
 
-  &-form {
-    margin-block-end: awsui.$space-scaled-l;
-  }
-
   &-field-property {
     /* used in test-utils */
   }
@@ -73,8 +69,10 @@ $operator-field-width: 120px;
   &-actions {
     display: flex;
     justify-content: flex-end;
-    padding-block-start: awsui.$space-s;
-    border-block-start: 1px solid #{awsui.$color-border-dropdown-item-default};
+
+    border-block-start: awsui.$border-divider-list-width solid awsui.$color-border-dropdown-item-default;
+    padding-inline: awsui.$space-l;
+    padding-block: awsui.$space-s;
   }
 }
 
@@ -161,6 +159,7 @@ $operator-field-width: 120px;
         align-items: flex-end;
         justify-content: flex-end;
       }
+
       &.token-editor-narrow:nth-child(4) {
         display: flex;
         justify-content: flex-end;


### PR DESCRIPTION
### Description

This PR changes the way custom forms are rendered in the property filter. Now, the form footer is rendered to the dropdown footer which makes it sticky in case the custom form is large.

### How has this been tested?

* New unit test
* Screenshot tests
* Dry-run

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
