### PR TITLE
fix: Split panel appearance based on splitPanel prop

### DIFF
--- a/src/app-layout/__tests__/split-panel.test.tsx
+++ b/src/app-layout/__tests__/split-panel.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 /* eslint simple-import-sort/imports: 0 */
-import React from 'react';
+import React, { useState } from 'react';
 import { screen } from '@testing-library/react';
 import AppLayout from '../../../lib/components/app-layout';
 import { AppLayoutProps } from '../../../lib/components/app-layout/interfaces';
@@ -225,6 +225,31 @@ describeEachAppLayout({ sizes: ['desktop'] }, ({ theme }) => {
     );
     wrapper.findSplitPanel()!.findSlider()!.keydown(KeyCode.pageUp);
     expect(onSplitPanelResize).toHaveBeenCalled();
+  });
+
+  test('should dynamically show and hide split panel based on "splitPanel" prop', () => {
+    const CustomAppLayout = () => {
+      const [splitPanelEnabled, setSplitPanelEnabled] = useState(true);
+      return (
+        <AppLayout
+          splitPanel={splitPanelEnabled && defaultSplitPanel}
+          content={
+            <>
+              <button data-testid="toggle-split-panel" onClick={() => setSplitPanelEnabled(!splitPanelEnabled)}>
+                toggle
+              </button>
+            </>
+          }
+        />
+      );
+    };
+    const { wrapper } = renderComponent(<CustomAppLayout />);
+
+    expect(wrapper.findSplitPanelOpenButton()!.getElement()).toBeInTheDocument();
+
+    wrapper.find('[data-testid="toggle-split-panel"]')!.click();
+
+    expect(wrapper.findSplitPanelOpenButton()).toBeFalsy();
   });
 });
 

--- a/src/app-layout/__tests__/split-panel.test.tsx
+++ b/src/app-layout/__tests__/split-panel.test.tsx
@@ -248,6 +248,10 @@ describeEachAppLayout({ sizes: ['desktop'] }, ({ theme }) => {
     wrapper.find('[data-testid="toggle-split-panel"]')!.click();
 
     expect(wrapper.findSplitPanelOpenButton()).toBeFalsy();
+
+    wrapper.find('[data-testid="toggle-split-panel"]')!.click();
+
+    expect(wrapper.findSplitPanelOpenButton()!.getElement()).toBeInTheDocument();
   });
 });
 

--- a/src/app-layout/__tests__/split-panel.test.tsx
+++ b/src/app-layout/__tests__/split-panel.test.tsx
@@ -234,11 +234,9 @@ describeEachAppLayout({ sizes: ['desktop'] }, ({ theme }) => {
         <AppLayout
           splitPanel={splitPanelEnabled && defaultSplitPanel}
           content={
-            <>
-              <button data-testid="toggle-split-panel" onClick={() => setSplitPanelEnabled(!splitPanelEnabled)}>
-                toggle
-              </button>
-            </>
+            <button data-testid="toggle-split-panel" onClick={() => setSplitPanelEnabled(!splitPanelEnabled)}>
+              toggle
+            </button>
           }
         />
       );

--- a/src/split-panel/implementation.tsx
+++ b/src/split-panel/implementation.tsx
@@ -58,6 +58,10 @@ export const SplitPanelImplementation = React.forwardRef<HTMLElement, SplitPanel
     const openButtonAriaLabel = i18nStrings.openButtonAriaLabel;
     useEffect(() => {
       setSplitPanelToggle({ displayed: closeBehavior === 'collapse', ariaLabel: openButtonAriaLabel });
+
+      return () => {
+        setSplitPanelToggle({ displayed: false, ariaLabel: undefined });
+      };
     }, [setSplitPanelToggle, openButtonAriaLabel, closeBehavior]);
 
     const splitPanelRefObject = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
### Description

Deactivated split panel should not appear. It works as expected in classic and VR, but visual-refresh-toolbar.

![image](https://github.com/user-attachments/assets/8e5aeae8-7b37-413a-b058-2aaf9bd98ecf)

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
