### PR TITLE
revert: preserves tools inner in local drawer in AppLayout toolbar variant

### DIFF
--- a/src/app-layout/__integ__/awsui-applayout.test.ts
+++ b/src/app-layout/__integ__/awsui-applayout.test.ts
@@ -111,7 +111,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as Theme[])('%s', theme 
   );
 
   test(
-    'preserves navigation inner state when drawer closes and opens',
+    'preserves inner state when drawer closes and opens',
     setupTest({ pageName: 'stateful' }, async page => {
       await page.click('#navigation-button');
       await expect(page.getText('#navigation-text')).resolves.toBe('Clicked: 1');

--- a/src/app-layout/__integ__/utils.ts
+++ b/src/app-layout/__integ__/utils.ts
@@ -8,8 +8,6 @@ import { viewports } from './constants';
 
 export const testIf = (condition: boolean) => (condition ? test : test.skip);
 
-export const testOnlyIf = (condition: boolean) => (condition ? test.only : test.skip);
-
 export type Theme = 'classic' | 'refresh' | 'refresh-toolbar';
 
 export interface SetupTestOptions {

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -392,39 +392,43 @@ describeEachAppLayout(({ theme, size }) => {
       expect(onToolsChange).toHaveBeenCalledWith({ open: true });
     });
 
-    test('preserves tools inner state while switching drawers', async () => {
-      function Counter() {
-        const [count, setCount] = useState(0);
-        return (
-          <>
-            <button data-testid="count-increment" onClick={() => setCount(count + 1)}>
-              Inc
-            </button>
-            <div>Count: {count}</div>
-          </>
-        );
+    // Not implemented on the toolbar version yet
+    (theme !== 'refresh-toolbar' ? test : test.skip)(
+      'preserves tools inner state while switching drawers',
+      async () => {
+        function Counter() {
+          const [count, setCount] = useState(0);
+          return (
+            <>
+              <button data-testid="count-increment" onClick={() => setCount(count + 1)}>
+                Inc
+              </button>
+              <div>Count: {count}</div>
+            </>
+          );
+        }
+
+        awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
+        const { wrapper } = await renderComponent(<AppLayout tools={<Counter />} />);
+        wrapper.findToolsToggle().click();
+        expect(wrapper.findTools().getElement()).toHaveTextContent('Count: 0');
+        wrapper.find('[data-testid="count-increment"]')!.click();
+
+        expect(wrapper.findTools().getElement()).toHaveTextContent('Count: 1');
+
+        wrapper.findToolsClose().click();
+        expect(wrapper.findTools()).toBeFalsy();
+
+        wrapper.findToolsToggle().click();
+        expect(wrapper.findTools().getElement()).toHaveTextContent('Count: 1');
+
+        wrapper.findDrawerTriggerById(drawerDefaults.id)!.click();
+        expect(wrapper.findTools()).toBeFalsy();
+
+        wrapper.findDrawerTriggerById(TOOLS_DRAWER_ID)!.click();
+        expect(wrapper.findTools().getElement()).toHaveTextContent('Count: 1');
       }
-
-      awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
-      const { wrapper } = await renderComponent(<AppLayout tools={<Counter />} />);
-      wrapper.findToolsToggle().click();
-      expect(wrapper.findTools().getElement()).toHaveTextContent('Count: 0');
-      wrapper.find('[data-testid="count-increment"]')!.click();
-
-      expect(wrapper.findTools().getElement()).toHaveTextContent('Count: 1');
-
-      wrapper.findToolsClose().click();
-      expect(wrapper.findTools()).toBeFalsy();
-
-      wrapper.findToolsToggle().click();
-      expect(wrapper.findTools().getElement()).toHaveTextContent('Count: 1');
-
-      wrapper.findDrawerTriggerById(drawerDefaults.id)!.click();
-      expect(wrapper.findTools()).toBeFalsy();
-
-      wrapper.findDrawerTriggerById(TOOLS_DRAWER_ID)!.click();
-      expect(wrapper.findTools().getElement()).toHaveTextContent('Count: 1');
-    });
+    );
   });
 
   test('updates active drawer if multiple are registered', async () => {

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -394,7 +394,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
           navigation={resolvedNavigation && <AppLayoutNavigation appLayoutInternals={appLayoutInternals} />}
           navigationOpen={navigationOpen}
           navigationWidth={navigationWidth}
-          tools={<AppLayoutDrawer appLayoutInternals={appLayoutInternals} />}
+          tools={activeDrawer && <AppLayoutDrawer appLayoutInternals={appLayoutInternals} />}
           globalTools={
             <ActiveDrawersContext.Provider value={activeGlobalDrawersIds}>
               <AppLayoutGlobalDrawers appLayoutInternals={appLayoutInternals} />


### PR DESCRIPTION
Reverts cloudscape-design/components#2816

There is a regression: https://d21d5uik3ws71m.cloudfront.net/components/2dc1dbac64920a30fa81c761749f6ca825d93410/dev-pages/index.html#/light/app-layout/with-split-panel?appLayoutToolbar=true

This page renders an empty space on the right now 

<img width="552" alt="image" src="https://github.com/user-attachments/assets/3cc07a31-a18c-4a3c-b318-8c7a64982d00">
