### PR TITLE
fix: Toolbar with multi-layout nested iframe bugs

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
@@ -40,8 +40,9 @@
     }
   }
 
-  &.last-opened {
-    @include mobile-only {
+  @include mobile-only {
+    inline-size: 100%;
+    &.last-opened {
       z-index: constants.$drawer-z-index-mobile;
     }
   }

--- a/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import clsx from 'clsx';
 
 import customCssProps from '../../../internal/generated/custom-css-properties';
+import { useMobile } from '../../../internal/hooks/use-mobile';
 import { highContrastHeaderClassName } from '../../../internal/utils/content-header-utils';
 import { AppLayoutPropsWithDefaults } from '../../interfaces';
 
@@ -63,6 +64,7 @@ export function SkeletonLayout({
   disableContentPaddings,
   globalToolsOpen,
 }: SkeletonLayoutProps) {
+  const isMobile = useMobile();
   const isMaxWidth = maxContentWidth === Number.MAX_VALUE || maxContentWidth === Number.MAX_SAFE_INTEGER;
   const anyPanelOpen = navigationOpen || toolsOpen;
   return (
@@ -91,7 +93,7 @@ export function SkeletonLayout({
           {navigation}
         </div>
       )}
-      <main className={clsx(styles['main-landmark'], anyPanelOpen && styles['unfocusable-mobile'])}>
+      <main className={clsx(styles['main-landmark'], isMobile && anyPanelOpen && styles['unfocusable-mobile'])}>
         {notifications && (
           <div
             className={clsx(


### PR DESCRIPTION
### Description

This commit fixes two issues caused by nested app layouts with iframes. Because the outer app layout imposes boundaries on the inner app layout that the inner app layout is not aware of, the mobile breakpoint gets unintentionally activated on the inner layout too soon, causing a few side effects which can be seen in the video below:

https://github.com/user-attachments/assets/cb2eb1d8-ac28-4d5e-b8f8-516e9b6ca92f

Mitigations for these bugs: 
1. Drawer width should be 100% when mobile breakpoint is activated.
2. The inner layout's content should still be focusable when a panel on the outer app layout is open, and the inner layout is smaller than the mobile breakpoint.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
