### PR TITLE
chore: Instrument modal for funnels

### DIFF
--- a/pages/funnel-analytics/modal.page.tsx
+++ b/pages/funnel-analytics/modal.page.tsx
@@ -1,0 +1,105 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { FormEvent, useState } from 'react';
+
+import { Alert, Box, Button, ColumnLayout, Container, FormField, Input, Link, Modal, SpaceBetween } from '~components';
+import { setFunnelMetrics } from '~components/internal/analytics';
+
+import { MockedFunnelMetrics } from './mock-funnel';
+setFunnelMetrics(MockedFunnelMetrics);
+
+const deleteConsentText = 'confirm';
+export default function ModalFunnelPage() {
+  const [visible, setVisible] = useState(false);
+
+  const [deleteInputText, setDeleteInputText] = useState('');
+  const [additionalInputText, setAdditionalInputText] = useState('');
+  const inputMatchesConsentText = deleteInputText.toLowerCase() === deleteConsentText;
+
+  const onDiscard = () => {
+    setVisible(false);
+  };
+
+  const onConfirm = () => {
+    setVisible(false);
+  };
+
+  const handleDeleteSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (inputMatchesConsentText) {
+      onConfirm();
+    }
+  };
+
+  return (
+    <>
+      <h1>Modal Funnel</h1>
+      <Button onClick={() => setVisible(true)}>Open Modal</Button>
+      {visible && (
+        <Modal
+          analyticsMetadata={{
+            flowType: 'delete',
+            instanceIdentifier: 'delete-flow',
+            resourceType: 'instance',
+          }}
+          onDismiss={() => setVisible(false)}
+          visible={true}
+          footer={
+            <Box float="right">
+              <SpaceBetween direction="horizontal" size="xs">
+                <Button variant="link" onClick={onDiscard}>
+                  Cancel
+                </Button>
+                <Button variant="primary" onClick={onConfirm} disabled={!inputMatchesConsentText} data-testid="submit">
+                  Delete
+                </Button>
+              </SpaceBetween>
+            </Box>
+          }
+          header="Modal title"
+        >
+          <SpaceBetween size="m">
+            <Box variant="span">
+              Permanently delete instance{' '}
+              <Box variant="span" fontWeight="bold">
+                1234567890
+              </Box>
+              ? You can’t undo this action.
+            </Box>
+
+            <Alert type="warning" statusIconAriaLabel="Warning">
+              Proceeding with this action will delete the instance with all its content and can affect related
+              resources.{' '}
+              <Link external={true} href="#" ariaLabel="Learn more about resource management, opens in new tab">
+                Learn more
+              </Link>
+            </Alert>
+
+            <Box>To avoid accidental deletions, we ask you to provide additional written consent.</Box>
+            <Container>
+              <FormField label="Nested input">
+                <Input
+                  placeholder="Additional nested input"
+                  onChange={event => setAdditionalInputText(event.detail.value)}
+                  value={additionalInputText}
+                />
+              </FormField>
+            </Container>
+            <form onSubmit={handleDeleteSubmit}>
+              <FormField label={`To confirm this deletion, type "${deleteConsentText}".`}>
+                <ColumnLayout columns={2}>
+                  <Input
+                    placeholder={deleteConsentText}
+                    onChange={event => setDeleteInputText(event.detail.value)}
+                    value={deleteInputText}
+                    ariaRequired={true}
+                  />
+                </ColumnLayout>
+              </FormField>
+            </form>
+          </SpaceBetween>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10093,6 +10093,37 @@ The event detail contains the \`reason\`, which can be any of the following:
   "name": "Modal",
   "properties": [
     {
+      "analyticsTag": "",
+      "description": "Specifies additional analytics-related metadata.
+* \`instanceIdentifier\` - A unique string that identifies this component instance in your application.
+* \`flowType\` - Identifies the type of flow represented by the component.
+* \`resourceType\` - Identifies the type of resource represented by the flow. **Note:** This API is currently experimental.",
+      "inlineType": {
+        "name": "ModalProps.AnalyticsMetadata",
+        "properties": [
+          {
+            "name": "flowType",
+            "optional": true,
+            "type": "FlowType",
+          },
+          {
+            "name": "instanceIdentifier",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "resourceType",
+            "optional": true,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "analyticsMetadata",
+      "optional": true,
+      "type": "ModalProps.AnalyticsMetadata",
+    },
+    {
       "deprecatedTag": "Custom CSS is not supported. For testing and other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
       "description": "Adds the specified classes to the root element of the component.",
       "name": "className",

--- a/src/alert/__tests__/alert-analytics.test.tsx
+++ b/src/alert/__tests__/alert-analytics.test.tsx
@@ -11,26 +11,15 @@ import {
   AnalyticsFunnelSubStep,
 } from '../../../lib/components/internal/analytics/components/analytics-funnel';
 import { useFunnel } from '../../../lib/components/internal/analytics/hooks/use-funnel';
-import { mockFunnelMetrics } from '../../internal/analytics/__tests__/mocks';
+import { mockFunnelMetrics, mockGetBoundingClientRect } from '../../internal/analytics/__tests__/mocks';
+
+mockGetBoundingClientRect();
 
 describe('Alert Analytics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     mockFunnelMetrics();
-
-    // These numbers were chosen at random
-    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
-      width: 300,
-      height: 200,
-      x: 30,
-      y: 50,
-      left: 30,
-      top: 50,
-      bottom: 100,
-      right: 400,
-      toJSON: () => '',
-    });
   });
 
   test('sends funnelSubStepError metric when the alert is placed inside a substep', () => {

--- a/src/form-field/__tests__/form-field-analytics.test.tsx
+++ b/src/form-field/__tests__/form-field-analytics.test.tsx
@@ -13,26 +13,15 @@ import {
 } from '../../../lib/components/internal/analytics/components/analytics-funnel';
 import { useFunnel } from '../../../lib/components/internal/analytics/hooks/use-funnel';
 import { DATA_ATTR_FIELD_ERROR, DATA_ATTR_FIELD_LABEL } from '../../../lib/components/internal/analytics/selectors';
-import { mockFunnelMetrics } from '../../internal/analytics/__tests__/mocks';
+import { mockFunnelMetrics, mockGetBoundingClientRect } from '../../internal/analytics/__tests__/mocks';
+
+mockGetBoundingClientRect();
 
 describe('FormField Analytics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     mockFunnelMetrics();
-
-    // These numbers were chosen at random
-    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
-      width: 300,
-      height: 200,
-      x: 30,
-      y: 50,
-      left: 30,
-      top: 50,
-      bottom: 100,
-      right: 400,
-      toJSON: () => '',
-    });
   });
 
   test('sends funnelSubStepError metric when errorText is present', () => {

--- a/src/form/__tests__/analytics.test.tsx
+++ b/src/form/__tests__/analytics.test.tsx
@@ -13,7 +13,6 @@ import Modal from '../../../lib/components/modal';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { mockFunnelMetrics, mockInnerText } from '../../internal/analytics/__tests__/mocks';
 
-import headerStyles from '../../../lib/components/header/styles.selectors.js';
 import modalStyles from '../../../lib/components/modal/styles.selectors.js';
 
 mockInnerText();
@@ -46,11 +45,12 @@ describe('Form Analytics', () => {
         funnelType: 'single-page',
         totalFunnelSteps: 1,
         optionalStepNumbers: [],
-        funnelNameSelector: `.${headerStyles['heading-text']}`,
+        funnelName: 'My funnel',
+        stepConfiguration: [{ isOptional: false, name: 'My funnel', number: 1 }],
+        funnelNameSelector: expect.any(String),
         funnelVersion: expect.any(String),
         componentVersion: expect.any(String),
         componentTheme: expect.any(String),
-        stepConfiguration: [{ isOptional: false, name: 'My funnel', number: 1 }],
       })
     );
 
@@ -276,7 +276,7 @@ describe('Form Analytics', () => {
     render(<Form errorText="Error" />);
     act(() => void jest.runAllTimers());
 
-    expect(FunnelMetrics.funnelError).toBeCalledTimes(1);
+    expect(FunnelMetrics.funnelError).toHaveBeenCalledTimes(1);
     expect(FunnelMetrics.funnelError).toHaveBeenCalledWith(
       expect.objectContaining({
         funnelInteractionId: expect.any(String),
@@ -377,5 +377,29 @@ describe('Form Analytics', () => {
     const { container } = render(<Form></Form>);
     const form = createWrapper(container).findForm()!.getElement();
     expect(form).toHaveAttribute('data-analytics-funnel-step', '1');
+  });
+
+  test('modals to not create a new funnel', () => {
+    render(
+      <Form header="Form Funnel">
+        <Modal header="Modal Funnel" visible={true} />
+      </Form>
+    );
+
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelStart).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledTimes(1);
+
+    expect(FunnelMetrics.funnelStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        funnelType: 'single-page',
+      })
+    );
+
+    expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stepName: 'Form Funnel',
+      })
+    );
   });
 });

--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -13,7 +13,7 @@ import { FormProps } from './interfaces';
 import InternalForm from './internal';
 
 import headerStyles from '../header/styles.css.js';
-import formStyles from './styles.css.js';
+import analyticsSelectors from './analytics-metadata/styles.css.js';
 
 export { FormProps };
 
@@ -80,7 +80,8 @@ export default function Form({ variant = 'full-page', ...props }: FormProps) {
     analyticsMetadata
   );
   const inheritedFunnelNameSelector = useFunnelNameSelector();
-  const funnelNameSelector = inheritedFunnelNameSelector || `.${headerStyles['heading-text']}`;
+  const funnelNameSelector =
+    inheritedFunnelNameSelector || `.${analyticsSelectors.header} .${headerStyles['heading-text']}`;
 
   return (
     <AnalyticsFunnel
@@ -91,7 +92,7 @@ export default function Form({ variant = 'full-page', ...props }: FormProps) {
       funnelType="single-page"
       optionalStepNumbers={[]}
       totalFunnelSteps={1}
-      funnelNameSelectors={[funnelNameSelector, `.${formStyles.header}`]}
+      funnelNameSelectors={[funnelNameSelector, `.${analyticsSelectors.header}`]}
     >
       <AnalyticsFunnelStep
         stepIdentifier={analyticsMetadata?.instanceIdentifier}

--- a/src/internal/analytics/__integ__/static-multi-page-create.test.ts
+++ b/src/internal/analytics/__integ__/static-multi-page-create.test.ts
@@ -52,6 +52,7 @@ describe('Multi-page create', () => {
         funnelNameSelector: expect.any(String),
         funnelVersion: expect.any(String),
         funnelIdentifier: FUNNEL_IDENTIFIER,
+        funnelName: 'Create Resource',
         flowType: 'create',
         funnelType: 'multi-page',
         resourceType: 'Components',

--- a/src/internal/analytics/__integ__/static-single-page-flow.test.ts
+++ b/src/internal/analytics/__integ__/static-single-page-flow.test.ts
@@ -52,6 +52,7 @@ describe('Single-page create', () => {
         funnelNameSelector: expect.any(String),
         funnelVersion: expect.any(String),
         funnelIdentifier: FUNNEL_IDENTIFIER,
+        funnelName: 'Form Header',
         flowType: 'create',
         funnelType: 'single-page',
         resourceType: 'Components',

--- a/src/internal/analytics/__tests__/mocks.ts
+++ b/src/internal/analytics/__tests__/mocks.ts
@@ -48,3 +48,25 @@ export function mockInnerText() {
     afterEach(() => delete (HTMLElement.prototype as Partial<HTMLElement>).innerText);
   }
 }
+
+export function mockGetBoundingClientRect() {
+  beforeEach(() => {
+    Element.prototype.getBoundingClientRect = jest.fn(() => {
+      return {
+        width: 100,
+        height: 100,
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        x: 0,
+        y: 0,
+        toJSON: jest.fn(),
+      };
+    });
+  });
+
+  afterEach(() => {
+    delete (Element.prototype as Partial<Element>).getBoundingClientRect;
+  });
+}

--- a/src/internal/analytics/hooks/use-funnel.ts
+++ b/src/internal/analytics/hooks/use-funnel.ts
@@ -7,6 +7,7 @@ import { nodeBelongs } from '../../utils/node-belongs';
 import { FunnelMetrics } from '../';
 import {
   FunnelContext,
+  FunnelContextValue,
   FunnelNameSelectorContext,
   FunnelStepContext,
   FunnelSubStepContext,
@@ -185,9 +186,14 @@ export const useFunnelStep = () => {
  *
  * The 'data-analytics-funnel-interaction-id' property of funnelProps is used to track the unique identifier of the current interaction with the funnel.
  */
-export const useFunnel = () => {
+export type FunnelProps = Record<string, string | number | boolean | undefined>;
+type UseFunnel = () => FunnelContextValue & {
+  funnelProps: FunnelProps;
+};
+
+export const useFunnel: UseFunnel = () => {
   const context = useContext(FunnelContext);
-  const funnelProps: Record<string, string | number | boolean | undefined> = context.funnelInteractionId
+  const funnelProps: FunnelProps = context.funnelInteractionId
     ? {
         [DATA_ATTR_FUNNEL_INTERACTION_ID]: context.funnelInteractionId,
       }

--- a/src/internal/analytics/interfaces.ts
+++ b/src/internal/analytics/interfaces.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export type FunnelType = 'single-page' | 'multi-page';
-export type FlowType = 'create' | 'edit' | 'home' | 'dashboard' | 'view-resource';
+export type FunnelType = 'single-page' | 'multi-page' | 'modal';
+export type FlowType = 'create' | 'edit' | 'delete' | 'home' | 'dashboard' | 'view-resource';
 export interface AnalyticsMetadata {
   instanceIdentifier?: string;
   flowType?: FlowType;
@@ -24,6 +24,7 @@ export interface FunnelErrorProps extends BaseFunnelProps {
 export interface FunnelStartProps extends Omit<BaseFunnelProps, 'funnelInteractionId'> {
   flowType?: FlowType;
   resourceType?: string;
+  funnelName: string;
   funnelNameSelector: string;
   totalFunnelSteps: number;
   optionalStepNumbers: number[];

--- a/src/modal/__tests__/analytics.test.tsx
+++ b/src/modal/__tests__/analytics.test.tsx
@@ -1,0 +1,244 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { act, render } from '@testing-library/react';
+
+import Alert from '../../../lib/components/alert';
+import Button from '../../../lib/components/button';
+import FormField from '../../../lib/components/form-field';
+import { FunnelMetrics } from '../../../lib/components/internal/analytics';
+import Modal, { ModalProps } from '../../../lib/components/modal';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import { mockFunnelMetrics, mockGetBoundingClientRect, mockInnerText } from '../../internal/analytics/__tests__/mocks';
+
+mockInnerText();
+mockGetBoundingClientRect();
+
+function renderModal(props: Partial<ModalProps> = {}) {
+  const modalRoot = document.createElement('div');
+  document.body.appendChild(modalRoot);
+  const { container } = render(<Modal visible={false} {...props} modalRoot={modalRoot} />, {
+    container: modalRoot,
+  });
+
+  return createWrapper(container).findModal()!;
+}
+
+describe('Modal Analytics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockFunnelMetrics();
+  });
+
+  test('does not send any funnel start events when the modal is mounted but not visible', () => {
+    render(<Modal visible={false} />);
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelStart).toHaveBeenCalledTimes(0);
+    expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledTimes(0);
+    expect(FunnelMetrics.funnelSubStepStart).toHaveBeenCalledTimes(0);
+  });
+
+  test('sends funnelStart and funnelStepStart metrics when Modal is visible', () => {
+    render(<Modal header="Modal title" visible={true} />);
+    act(() => void jest.runAllTimers());
+
+    expect(FunnelMetrics.funnelStart).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        funnelType: 'modal',
+        totalFunnelSteps: 1,
+        optionalStepNumbers: [],
+        funnelName: 'Modal title',
+        stepConfiguration: [
+          {
+            isOptional: false,
+            name: 'Modal title',
+            number: 1,
+          },
+        ],
+        funnelNameSelector: expect.any(String),
+        funnelVersion: expect.any(String),
+        componentVersion: expect.any(String),
+        componentTheme: expect.any(String),
+      })
+    );
+
+    expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stepNumber: 1,
+        stepName: 'Modal title',
+        subStepConfiguration: [
+          {
+            name: '',
+            number: 1,
+          },
+        ],
+        totalSubSteps: 1,
+        funnelInteractionId: expect.any(String),
+        stepNameSelector: expect.any(String),
+        subStepAllSelector: expect.any(String),
+      })
+    );
+  });
+
+  test('sends funnelCancelled when modal is dismissed', () => {
+    const { rerender } = render(<Modal header="Modal title" visible={true} />);
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelStart).toHaveBeenCalledTimes(1);
+
+    rerender(<Modal header="Modal title" visible={false} />);
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelCancelled).toHaveBeenCalledTimes(1);
+  });
+
+  test('sends funnelCancelled when modal is unmounted', () => {
+    const { rerender } = render(<Modal header="Modal title" visible={true} />);
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelStart).toHaveBeenCalledTimes(1);
+
+    rerender(<></>);
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelCancelled).toHaveBeenCalledTimes(1);
+  });
+
+  test('sends funnelComplete when primary button in footer is clicked', () => {
+    const modalRoot = document.createElement('div');
+    document.body.appendChild(modalRoot);
+    const { container } = render(
+      <Modal
+        header="Modal title"
+        footer={
+          <Button data-testid="submit" variant="primary">
+            Submit
+          </Button>
+        }
+        visible={true}
+        modalRoot={modalRoot}
+      />,
+      {
+        container: modalRoot,
+      }
+    );
+
+    const wrapper = createWrapper(container);
+    wrapper.findModal()!.findFooter()!.findButton('[data-testid="submit"]')?.click();
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelComplete).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        funnelInteractionId: expect.any(String),
+      })
+    );
+  });
+
+  test('sends funnelSuccessful when primary button in footer is clicked and modal is dismissed', () => {
+    const modalRoot = document.createElement('div');
+    document.body.appendChild(modalRoot);
+    const { container, rerender } = render(
+      <Modal
+        header="Modal title"
+        footer={
+          <Button data-testid="submit" variant="primary">
+            Submit
+          </Button>
+        }
+        visible={true}
+        modalRoot={modalRoot}
+      />,
+      {
+        container: modalRoot,
+      }
+    );
+    act(() => void jest.runAllTimers());
+
+    const wrapper = createWrapper(container);
+    wrapper.findModal()!.findFooter()!.findButton('[data-testid="submit"]')?.click();
+    rerender(
+      <Modal
+        header="Modal title"
+        footer={
+          <Button data-testid="submit" variant="primary">
+            Submit
+          </Button>
+        }
+        visible={false}
+        modalRoot={modalRoot}
+      />
+    );
+
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelSuccessful).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelSuccessful).toHaveBeenCalledWith(
+      expect.objectContaining({
+        funnelInteractionId: expect.any(String),
+      })
+    );
+  });
+
+  test('sends funnelSubstepError when a FormField with errorText is present', () => {
+    render(
+      <Modal header="Modal title" visible={true}>
+        <FormField label="Field Label" errorText="Error" />
+      </Modal>
+    );
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelSubStepError).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelSubStepError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        funnelInteractionId: expect.any(String),
+        fieldErrorSelector: expect.any(String),
+        fieldLabelSelector: expect.any(String),
+        subStepSelector: expect.any(String),
+        stepNameSelector: expect.any(String),
+        subStepAllSelector: expect.any(String),
+        subStepNameSelector: expect.any(String),
+      })
+    );
+  });
+
+  test('sends funnelSubStepError when an Alert with type error is present', () => {
+    render(
+      <Modal header="Modal title" visible={true}>
+        <Alert type="error">Error</Alert>
+      </Modal>
+    );
+
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelSubStepError).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelSubStepError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        funnelInteractionId: expect.any(String),
+        subStepSelector: expect.any(String),
+        stepNameSelector: expect.any(String),
+        subStepAllSelector: expect.any(String),
+        subStepNameSelector: expect.any(String),
+      })
+    );
+  });
+
+  test('adds data-analytics-funnel-interaction-id to root node of modal', () => {
+    const wrapper = renderModal({ visible: true });
+    act(() => void jest.runAllTimers());
+
+    expect(wrapper.getElement()).toHaveAttribute('data-analytics-funnel-interaction-id');
+    expect(wrapper.getElement().getAttribute('data-analytics-funnel-interaction-id')).toEqual('mocked-funnel-id');
+  });
+
+  test('adds data-analytics-funnel-step to root node of modal', () => {
+    const wrapper = renderModal({ visible: true });
+    act(() => void jest.runAllTimers());
+
+    expect(wrapper.getElement()).toHaveAttribute('data-analytics-funnel-step');
+    expect(wrapper.getElement().getAttribute('data-analytics-funnel-step')).toEqual('1');
+  });
+
+  test('adds data-analytics-funnel-substep to content node of modal', () => {
+    const wrapper = renderModal({ visible: true });
+    act(() => void jest.runAllTimers());
+
+    expect(wrapper.findContent().getElement()).toHaveAttribute('data-analytics-funnel-substep');
+    expect(wrapper.findContent().getElement().getAttribute('data-analytics-funnel-substep')).not.toBeFalsy();
+  });
+});

--- a/src/modal/index.tsx
+++ b/src/modal/index.tsx
@@ -2,17 +2,88 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import {
+  AnalyticsFunnel,
+  AnalyticsFunnelStep,
+  AnalyticsFunnelSubStep,
+} from '../internal/analytics/components/analytics-funnel';
+import { useFunnel } from '../internal/analytics/hooks/use-funnel';
+import { BasePropsWithAnalyticsMetadata, getAnalyticsMetadataProps } from '../internal/base-component';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { ModalProps } from './interfaces';
-import InternalModal from './internal';
+import InternalModal, { InternalModalAsFunnel } from './internal';
+
+import styles from './styles.css.js';
 
 export { ModalProps };
 
+function ModalWithAnalyticsFunnel({
+  analyticsMetadata,
+  baseComponentProps,
+  size = 'medium',
+  ...props
+}: ModalProps & { analyticsMetadata: any; baseComponentProps: ReturnType<typeof useBaseComponent> }) {
+  return (
+    <AnalyticsFunnel
+      mounted={props.visible}
+      funnelIdentifier={analyticsMetadata?.instanceIdentifier}
+      funnelFlowType={analyticsMetadata?.flowType}
+      funnelErrorContext={analyticsMetadata?.errorContext}
+      funnelResourceType={analyticsMetadata?.resourceType}
+      funnelType="modal"
+      optionalStepNumbers={[]}
+      totalFunnelSteps={1}
+      funnelNameSelectors={[`.${styles['header--text']}`]}
+    >
+      <AnalyticsFunnelStep
+        mounted={props.visible}
+        stepIdentifier={analyticsMetadata?.instanceIdentifier}
+        stepErrorContext={analyticsMetadata?.errorContext}
+        stepNumber={1}
+      >
+        <AnalyticsFunnelSubStep
+          subStepIdentifier={analyticsMetadata?.instanceIdentifier}
+          subStepErrorContext={analyticsMetadata?.errorContext}
+        >
+          <InternalModalAsFunnel
+            size={size}
+            {...props}
+            {...baseComponentProps}
+            __injectAnalyticsComponentMetadata={true}
+          />
+        </AnalyticsFunnelSubStep>
+      </AnalyticsFunnelStep>
+    </AnalyticsFunnel>
+  );
+}
+
 export default function Modal({ size = 'medium', ...props }: ModalProps) {
-  const baseComponentProps = useBaseComponent('Modal', {
-    props: { size, disableContentPaddings: props.disableContentPaddings },
-  });
+  const { isInFunnel } = useFunnel();
+  const analyticsMetadata = getAnalyticsMetadataProps(props as BasePropsWithAnalyticsMetadata);
+  const baseComponentProps = useBaseComponent(
+    'Modal',
+    {
+      props: { size, disableContentPaddings: props.disableContentPaddings },
+      metadata: {
+        hasResourceType: Boolean(analyticsMetadata?.resourceType),
+        hasInstanceIdentifier: Boolean(analyticsMetadata?.instanceIdentifier),
+      },
+    },
+    analyticsMetadata
+  );
+
+  if (!isInFunnel) {
+    return (
+      <ModalWithAnalyticsFunnel
+        analyticsMetadata={analyticsMetadata}
+        baseComponentProps={baseComponentProps}
+        size={size}
+        {...props}
+      />
+    );
+  }
+
   return <InternalModal size={size} {...props} {...baseComponentProps} __injectAnalyticsComponentMetadata={true} />;
 }
 

--- a/src/modal/interfaces.ts
+++ b/src/modal/interfaces.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import { FlowType } from '../internal/analytics/interfaces';
 import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
 
@@ -66,6 +67,15 @@ export interface ModalProps extends BaseComponentProps, BaseModalProps {
    * render to an element under `document.body`.
    */
   modalRoot?: HTMLElement;
+
+  /**
+   * Specifies additional analytics-related metadata.
+   * * `instanceIdentifier` - A unique string that identifies this component instance in your application.
+   * * `flowType` - Identifies the type of flow represented by the component.
+   * * `resourceType` - Identifies the type of resource represented by the flow. **Note:** This API is currently experimental.
+   * @analytics
+   */
+  analyticsMetadata?: ModalProps.AnalyticsMetadata;
 }
 
 export namespace ModalProps {
@@ -73,5 +83,11 @@ export namespace ModalProps {
 
   export interface DismissDetail {
     reason: string;
+  }
+
+  export interface AnalyticsMetadata {
+    instanceIdentifier?: string;
+    flowType?: FlowType;
+    resourceType?: string;
   }
 }

--- a/src/wizard/__tests__/analytics.test.tsx
+++ b/src/wizard/__tests__/analytics.test.tsx
@@ -58,6 +58,7 @@ describe('Wizard Analytics', () => {
         funnelType: 'multi-page',
         totalFunnelSteps: 3, // Length of DEFAULT_STEPS.length,
         optionalStepNumbers: [2], // DEFAULT_STEPS[1] is optional
+        funnelName: '', // Funnel Name is derived from breadcrumbs
         funnelNameSelector: expect.any(String),
         funnelVersion: expect.any(String),
         componentVersion: expect.any(String),


### PR DESCRIPTION
### Description

This change adds funnel support for the Modal component. This allows the potential collection of user interactions through deletion flows within Modals.

Quip: tiy2A6a3X2qu

#### Change summary
- Adds funnel instrumentation to Modals
- Add analyticsMetadata with `delete` type to Modal

### How has this been tested?

- Unit tests added for Modals

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
