### PR TITLE
chore: adding assertion tools are hidden in own test

### DIFF
--- a/src/app-layout/__integ__/app-layout-tools.test.ts
+++ b/src/app-layout/__integ__/app-layout-tools.test.ts
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+import createWrapper from '../../../lib/components/test-utils/selectors';
+import { viewports } from './constants';
+
+const wrapper = createWrapper().findAppLayout();
+class AppLayoutToolsViewPage extends BasePageObject {
+  async openTools() {
+    await this.click(wrapper.findToolsToggle().toSelector());
+  }
+
+  async closeTools() {
+    await this.click(wrapper.findToolsClose().toSelector());
+  }
+}
+
+describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme => {
+  function setupTest(testFn: (page: AppLayoutToolsViewPage) => Promise<void>, path: string) {
+    return useBrowser(async browser => {
+      const page = new AppLayoutToolsViewPage(browser);
+      const url = `#/light/app-layout/${path}`;
+      await page.setWindowSize(viewports.desktop);
+      const params = new URLSearchParams({
+        visualRefresh: `${theme.startsWith('refresh')}`,
+        appLayoutToolbar: `${theme === 'refresh-toolbar'}`,
+      });
+      await browser.url(`${url}?${params.toString()}`);
+      await page.waitForVisible(wrapper.findContentRegion().toSelector());
+      await testFn(page);
+    });
+  }
+
+  test(
+    'tools is displayed properly with split panel',
+    setupTest(async page => {
+      await expect(page.isDisplayed(wrapper.findTools().toSelector())).resolves.toBe(theme === 'classic');
+      await expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBe(false);
+      await page.openTools();
+      await expect(page.isDisplayed(wrapper.findTools().toSelector())).resolves.toBe(true);
+      await page.closeTools();
+      await expect(page.isDisplayed(wrapper.findTools().toSelector())).resolves.toBe(theme === 'classic');
+      await expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBe(false);
+    }, 'with-split-panel')
+  );
+});


### PR DESCRIPTION
### Description

This test asserts the tools are hidden when expected in all variants of AppLayout

this added test will pick up on unexpected changes before they get to regression as they did here https://github.com/cloudscape-design/components/pull/2826

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
