### PR TITLE
chore: enabling toolbar in integ tests for runtime drawers controllability in AppLayout

### DIFF
--- a/src/app-layout/__integ__/runtime-drawers-controllability.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers-controllability.test.ts
@@ -7,8 +7,6 @@ import createWrapper from '../../../lib/components/test-utils/selectors';
 
 const wrapper = createWrapper().findAppLayout();
 
-const testIf = (condition: boolean) => (condition ? test : test.skip);
-
 describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme => {
   for (const pageName of ['runtime-drawers', 'runtime-drawers-imperative']) {
     describe(`page=${pageName}`, () => {
@@ -47,7 +45,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
         })
       );
 
-      testIf(!(theme === 'refresh-toolbar' && pageName === 'runtime-drawers-imperative'))(
+      test(
         'should allow switching to a drawer after clicking an info link',
         setupTest(async page => {
           await page.click('[data-testid="info-link-header"]');
@@ -61,7 +59,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
         })
       );
 
-      testIf(!(theme === 'refresh-toolbar' && pageName === 'runtime-drawers-imperative'))(
+      test(
         'should open and close tools via controlled mode',
         setupTest(async page => {
           const toolsContentSelector = wrapper.findTools().getElement();
@@ -76,7 +74,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
         })
       );
 
-      testIf(!(theme === 'refresh-toolbar' && pageName === 'runtime-drawers-imperative'))(
+      test(
         'should switch help panel content and close the panel afterwards',
         setupTest(async page => {
           await page.click('[data-testid="info-link-header"]');
@@ -93,7 +91,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
         })
       );
 
-      testIf(!(theme === 'refresh-toolbar' && pageName === 'runtime-drawers-imperative'))(
+      test(
         'should move focus to previous focused element after closing tools',
         setupTest(async page => {
           await page.click('[data-testid="info-link-header"]');


### PR DESCRIPTION
### Description

The latest PR https://github.com/cloudscape-design/components/pull/2828 that preserved tools inner now allows tests to pass for the toolbar variant of AppLayout against the `runtime-drawers-imperative` path, thus the tests no longer need to be be skipped

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
