### PR TITLE
feat: Allow property filter input to span full width

### DIFF
--- a/pages/property-filter/permutations.page.tsx
+++ b/pages/property-filter/permutations.page.tsx
@@ -63,6 +63,7 @@ const permutations = createPermutations<Partial<PropertyFilterProps>>([
     ],
     hideOperations: [true, false],
     disabled: [true, false],
+    fullWidth: [true, false],
   },
   {
     query: [

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12387,6 +12387,12 @@ Use the \`onLoadItems\` event to perform a recovery action (for example, retryin
       "type": "PropertyFilterProps.FreeTextFiltering",
     },
     {
+      "description": "Allows the filtering input to occupy the full available width.",
+      "name": "fullWidth",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
       "defaultValue": "false",
       "description": "If hideOperations it set, the indicator of the operation (that is, \`and\` or \`or\`) and the selection of operations
 (applied to the property and value token) are hidden from the user. Only use when you have a custom

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -219,6 +219,10 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    * Use to assign unique labels when there are multiple token groups with the same `tokenLimitShowMore` label on one page.
    */
   tokenLimitShowMoreAriaLabel?: string;
+  /**
+   * Allows the filtering input to occupy the full available width.
+   */
+  fullWidth?: boolean;
 }
 
 export namespace PropertyFilterProps {

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -85,6 +85,7 @@ const PropertyFilterInternal = React.forwardRef(
       tokenLimitShowFewerAriaLabel,
       tokenLimitShowMoreAriaLabel,
       enableTokenGroups,
+      fullWidth,
       __internalRootRef,
       ...rest
     }: PropertyFilterInternalProps,
@@ -314,7 +315,13 @@ const PropertyFilterInternal = React.forwardRef(
 
     return (
       <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={mergedRef}>
-        <div className={clsx(styles['search-field'], analyticsSelectors['search-field'])}>
+        <div
+          className={clsx(
+            styles['search-field'],
+            analyticsSelectors['search-field'],
+            !fullWidth && styles['limited-width']
+          )}
+        >
           {customControl && <div className={styles['custom-control']}>{customControl}</div>}
           <PropertyFilterAutosuggest
             ref={inputRef}

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -15,8 +15,10 @@ $operator-field-width: 120px;
 .search-field {
   display: flex;
   align-items: flex-end;
-  // The xs breakpoint, minus the table tools container padding
-  max-inline-size: calc(#{styles.$breakpoint-x-small} - 2 * #{awsui.$space-l});
+  &.limited-width {
+    // The xs breakpoint, minus the table tools container padding
+    max-inline-size: calc(#{styles.$breakpoint-x-small} - 2 * #{awsui.$space-l});
+  }
 }
 
 .input-wrapper {


### PR DESCRIPTION
### Description

Allow property filter text input to optionally span the full available width

Related links, issue #, if available: AWSUI-59729

### How has this been tested?

Local testing & new permutations

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
