### PR TITLE
chore: Property filter custom form header improvement

### DIFF
--- a/pages/property-filter/custom-forms.scss
+++ b/pages/property-filter/custom-forms.scss
@@ -10,8 +10,14 @@
   grid-template-columns: auto;
   gap: awsui.$space-scaled-s;
 }
+
 @media (min-width: 688px) {
   .date-time-form {
     grid-template-columns: repeat(2, minmax(100px, max-content));
   }
+}
+
+.multiselect-form {
+  min-width: 200px;
+  max-width: 250px;
 }

--- a/pages/property-filter/custom-forms.tsx
+++ b/pages/property-filter/custom-forms.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from 'react';
 import { DatePicker, FormField, RadioGroup, TimeInput, TimeInputProps } from '~components';
 import Calendar, { CalendarProps } from '~components/calendar';
 import DateInput from '~components/date-input';
+import EmbeddedMultiselect from '~components/multiselect/embedded';
 import InternalMultiselect from '~components/multiselect/internal';
 import { ExtendedOperatorFormProps } from '~components/property-filter/interfaces';
 
@@ -220,11 +221,12 @@ function formatTimezoneOffset(isoDate: string, offsetInMinutes?: number) {
 
 const allOwners = [...new Set(allItems.map(({ owner }) => owner))];
 
-export function OwnerMultiSelectForm({ value, onChange }: ExtendedOperatorFormProps<string[]>) {
+export function OwnerMultiSelectForm({ value, onChange, filter }: ExtendedOperatorFormProps<string[]>) {
   value = value && Array.isArray(value) ? value : [];
-  return (
-    <FormField stretch={true}>
-      <InternalMultiselect
+
+  if (typeof filter !== 'undefined') {
+    return (
+      <EmbeddedMultiselect
         options={allOwners.map(owner => ({ value: owner, label: owner }))}
         selectedOptions={value.map(owner => ({ value: owner, label: owner })) ?? []}
         onChange={event =>
@@ -234,14 +236,37 @@ export function OwnerMultiSelectForm({ value, onChange }: ExtendedOperatorFormPr
               .filter((value): value is string => typeof value !== 'undefined')
           )
         }
+        filteringText={filter}
         statusType="finished"
-        filteringType="none"
-        expandToViewport={true}
-        keepOpen={true}
-        hideTokens={false}
-        inlineTokens={true}
+        filteringType="auto"
+        empty="No options available"
+        noMatch="No options matched"
       />
-    </FormField>
+    );
+  }
+
+  return (
+    <div className={styles['multiselect-form']}>
+      <FormField stretch={true}>
+        <InternalMultiselect
+          options={allOwners.map(owner => ({ value: owner, label: owner }))}
+          selectedOptions={value.map(owner => ({ value: owner, label: owner })) ?? []}
+          onChange={event =>
+            onChange(
+              event.detail.selectedOptions
+                .map(({ value }) => value)
+                .filter((value): value is string => typeof value !== 'undefined')
+            )
+          }
+          statusType="finished"
+          filteringType="none"
+          expandToViewport={true}
+          keepOpen={true}
+          hideTokens={false}
+          inlineTokens={true}
+        />
+      </FormField>
+    </div>
   );
 }
 

--- a/src/multiselect/embedded.tsx
+++ b/src/multiselect/embedded.tsx
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import DropdownFooter from '../internal/components/dropdown-footer/index.js';
-import ScreenreaderOnly from '../internal/components/screenreader-only/index.js';
+import { useFormFieldContext } from '../contexts/form-field';
+import DropdownFooter from '../internal/components/dropdown-footer';
+import ScreenreaderOnly from '../internal/components/screenreader-only';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { SomeRequired } from '../internal/types';
 import PlainList from '../select/parts/plain-list';
@@ -30,14 +31,15 @@ export type EmbeddedMultiselectProps = SomeRequired<
     | 'finishedText'
     | 'errorText'
     | 'recoveryText'
+    | 'empty'
+    | 'noMatch'
   >,
-  'options' | 'selectedOptions' | 'filteringType' | 'statusType' | 'controlId'
+  'options' | 'selectedOptions' | 'filteringType' | 'statusType'
 > & { filteringText?: string };
 
 const EmbeddedMultiselect = React.forwardRef(
   (
     {
-      controlId,
       options,
       filteringType,
       ariaLabel,
@@ -49,8 +51,11 @@ const EmbeddedMultiselect = React.forwardRef(
     }: EmbeddedMultiselectProps,
     externalRef: React.Ref<MultiselectProps.Ref>
   ) => {
+    const formFieldContext = useFormFieldContext(restProps);
     const ariaLabelId = useUniqueId('multiselect-ariaLabel-');
     const footerId = useUniqueId('multiselect-footer-');
+    const selfControlId = useUniqueId('multiselect-trigger-');
+    const controlId = formFieldContext.controlId ?? selfControlId;
 
     const multiselectProps = useMultiselect({
       options,

--- a/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
+++ b/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
@@ -6,6 +6,7 @@ import { act, render } from '@testing-library/react';
 
 import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils.js';
 
+import Input from '../../../lib/components/input';
 import PropertyFilter from '../../../lib/components/property-filter';
 import { FilteringProperty, PropertyFilterProps, Ref } from '../../../lib/components/property-filter/interfaces.js';
 import createWrapper, { PropertyFilterWrapper } from '../../../lib/components/test-utils/dom';
@@ -54,11 +55,25 @@ describe('extended operators', () => {
           </button>
         ),
       },
+      {
+        operator: '=',
+        form: ({ value, onChange }) => (
+          <Input name="" value={value} onChange={({ detail }) => onChange(detail.value)} />
+        ),
+      },
     ],
     propertyLabel: 'index',
     groupValuesLabel: 'index value',
   };
   const extendedOperatorProps = { filteringProperties: [indexProperty] };
+
+  test('property label is used to annotate custom form field', () => {
+    const { propertyFilterWrapper: wrapper } = renderComponent(extendedOperatorProps);
+    wrapper.setInputValue('index =');
+    expect(
+      wrapper.findDropdown()!.findOpenDropdown()!.findInput()!.findNativeInput()!.getElement()
+    ).toHaveAccessibleName('index value');
+  });
 
   test('property filter renders operator form instead of options list', () => {
     const { propertyFilterWrapper: wrapper } = renderComponent(extendedOperatorProps);

--- a/src/property-filter/property-editor.tsx
+++ b/src/property-filter/property-editor.tsx
@@ -4,7 +4,8 @@
 import React from 'react';
 
 import InternalButton from '../button/internal';
-import InternalFormField from '../form-field/internal';
+import { FormFieldContext } from '../internal/context/form-field-context';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { I18nStringsInternal } from './i18n-utils';
 import { ComparisonOperator, ExtendedOperatorForm, InternalFilteringProperty, InternalToken } from './interfaces';
 
@@ -25,12 +26,16 @@ export function PropertyEditorContent<TokenValue = any>({
   onChange: (value: null | TokenValue) => void;
   operatorForm: ExtendedOperatorForm<TokenValue>;
 }) {
+  const labelId = useUniqueId();
   return (
     <div className={styles['property-editor']}>
+      <div className={styles['property-editor-header']} id={labelId}>
+        {property.groupValuesLabel}
+      </div>
       <div className={styles['property-editor-form']}>
-        <InternalFormField label={property.groupValuesLabel}>
+        <FormFieldContext.Provider value={{ ariaLabelledby: labelId }}>
           {operatorForm({ value, onChange, operator, filter })}
-        </InternalFormField>
+        </FormFieldContext.Provider>
       </div>
     </div>
   );

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -40,22 +40,21 @@ $operator-field-width: 120px;
 }
 
 .property-editor {
-  margin-block: awsui.$space-xxs;
-  margin-inline: awsui.$space-xxs;
-  padding-block: awsui.$space-m;
-  padding-inline: awsui.$space-m;
   overflow-y: auto;
 
-  &-field-property {
-    /* used in test-utils */
+  &-header {
+    @include styles.default-text-style;
+    font-weight: bold;
+
+    padding-block-start: awsui.$space-s;
+    padding-block-end: awsui.$space-xxs;
+    padding-inline: awsui.$space-s;
   }
 
-  &-field-operator {
-    margin-block-start: awsui.$space-scaled-l;
-  }
-
-  &-field-value {
-    margin-block-start: awsui.$space-scaled-l;
+  &-form {
+    padding-block-start: awsui.$space-xxs;
+    padding-block-end: awsui.$space-s;
+    padding-inline: awsui.$space-s;
   }
 
   &-cancel {


### PR DESCRIPTION
### Description

Replacing internal form field header with a custom header. That is needed to unblock https://github.com/cloudscape-design/components/pull/2739, where the header and the form body to use different paddings.

Similar to: https://github.com/cloudscape-design/components/pull/2818

### How has this been tested?

* New unit test to secure custom form label assignment

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
