### PR TITLE
chore: Remove internal imports

### DIFF
--- a/src/app-layout/__tests__/trigger-button.test.tsx
+++ b/src/app-layout/__tests__/trigger-button.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils.js';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import * as AllContext from '../../../lib/components/app-layout/visual-refresh/context.js';
 import VisualRefreshTriggerButton, {

--- a/src/area-chart/__tests__/area-chart-initial-state.test.tsx
+++ b/src/area-chart/__tests__/area-chart-initial-state.test.tsx
@@ -5,7 +5,7 @@ import { render } from '@testing-library/react';
 import { cloneDeep } from 'lodash';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import '../../__a11y__/to-validate-a11y';
 import AreaChart, { AreaChartProps } from '../../../lib/components/area-chart';

--- a/src/collection-preferences/content-display/content-display-option.tsx
+++ b/src/collection-preferences/content-display/content-display-option.tsx
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { ForwardedRef, forwardRef } from 'react';
-import { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities';
 
-import DragHandle from '../../internal/components/drag-handle';
+import DragHandle, { DragHandleProps } from '../../internal/components/drag-handle';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import InternalToggle from '../../toggle/internal';
 import { OptionWithVisibility } from './utils';
@@ -15,7 +14,7 @@ export const getClassName = (suffix?: string) => styles[[componentPrefix, suffix
 
 export interface ContentDisplayOptionProps {
   dragHandleAriaLabel?: string;
-  listeners?: SyntheticListenerMap;
+  listeners?: DragHandleProps['listeners'];
   onToggle?: (option: OptionWithVisibility) => void;
   option: OptionWithVisibility;
   disabled?: boolean;

--- a/src/date-input/__tests__/date-input.test.tsx
+++ b/src/date-input/__tests__/date-input.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import DateInput, { DateInputProps } from '../../../lib/components/date-input';
 import createWrapper from '../../../lib/components/test-utils/dom';

--- a/src/expandable-section/__tests__/interactions.test.tsx
+++ b/src/expandable-section/__tests__/interactions.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import Button from '../../../lib/components/button';
 import ExpandableSection, { ExpandableSectionProps } from '../../../lib/components/expandable-section';

--- a/src/internal/components/chart-legend/__tests__/chart-legend.test.tsx
+++ b/src/internal/components/chart-legend/__tests__/chart-legend.test.tsx
@@ -3,8 +3,8 @@
 import React, { useState } from 'react';
 import { act, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
 import { ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import ChartLegend from '../../../../../lib/components/internal/components/chart-legend';
 import createWrapper from '../../../../../lib/components/test-utils/dom';

--- a/src/internal/components/chart-plot/__tests__/chart-plot.test.tsx
+++ b/src/internal/components/chart-plot/__tests__/chart-plot.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { act, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import ChartPlot, { ChartPlotRef } from '../../../../../lib/components/internal/components/chart-plot';
 import { ElementWrapper } from '../../../../../lib/components/test-utils/dom';

--- a/src/internal/components/drag-handle/index.tsx
+++ b/src/internal/components/drag-handle/index.tsx
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { ButtonHTMLAttributes } from 'react';
-import { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities';
 import clsx from 'clsx';
 
 import InternalIcon from '../../../icon/internal';
@@ -13,7 +12,9 @@ import styles from './styles.css.js';
 export interface DragHandleProps {
   attributes: ButtonHTMLAttributes<HTMLDivElement>;
   hideFocus?: boolean;
-  listeners?: SyntheticListenerMap;
+  // @dnd-kit uses this type
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  listeners: Record<string, Function> | undefined;
   disabled?: boolean;
 }
 

--- a/src/internal/components/masked-input/__tests__/masked-input.test.tsx
+++ b/src/internal/components/masked-input/__tests__/masked-input.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import MaskedInput, { MaskedInputProps } from '../../../../../lib/components/internal/components/masked-input';
 import createWrapper, { InputWrapper } from '../../../../../lib/components/test-utils/dom';

--- a/src/link/__tests__/index.test.tsx
+++ b/src/link/__tests__/index.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { act, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils.js';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import FormField from '../../../lib/components/form-field';
 import Header from '../../../lib/components/header';

--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { waitFor } from '@testing-library/react';
 
 import { getIsRtl } from '@cloudscape-design/component-toolkit/internal';
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import MixedLineBarChart, { MixedLineBarChartProps } from '../../../lib/components/mixed-line-bar-chart';
 import positions from '../../../lib/components/popover/utils/positions';

--- a/src/mixed-line-bar-chart/__tests__/use-navigation.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/use-navigation.test.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import { act, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import { ChartScale, NumericChartScale } from '../../../lib/components/internal/components/cartesian-chart/scales';
 import { useNavigation, UseNavigationProps } from '../../../lib/components/mixed-line-bar-chart/hooks/use-navigation';

--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import TestI18nProvider from '../../../lib/components/i18n/testing';
 import PieChart, { PieChartProps } from '../../../lib/components/pie-chart';

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { act, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import '../../__a11y__/to-validate-a11y';
 import TestI18nProvider from '../../../lib/components/i18n/testing';

--- a/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
+++ b/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { act, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils.js';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import Input from '../../../lib/components/input';
 import PropertyFilter from '../../../lib/components/property-filter';

--- a/src/property-filter/__tests__/property-filter.filtering-input.test.tsx
+++ b/src/property-filter/__tests__/property-filter.filtering-input.test.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { act, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import PropertyFilter from '../../../lib/components/property-filter';
 import {

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { act, render } from '@testing-library/react';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import '../../__a11y__/to-validate-a11y';
 import PropertyFilter from '../../../lib/components/property-filter';

--- a/src/split-panel/__tests__/split-panel.test.tsx
+++ b/src/split-panel/__tests__/split-panel.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import TestI18nProvider from '../../../lib/components/i18n/testing';
 import {

--- a/src/table/__tests__/interaction-metrics.test.tsx
+++ b/src/table/__tests__/interaction-metrics.test.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { render as rtlRender } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import CollectionPreferences from '../../../lib/components/collection-preferences';
 import { PerformanceMetrics } from '../../../lib/components/internal/analytics';

--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -6,7 +6,7 @@ import times from 'lodash/times';
 
 import { ContainerQueryEntry } from '@cloudscape-design/component-toolkit';
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import Table, { TableProps } from '../../../lib/components/table';
 import createWrapper, { TableWrapper } from '../../../lib/components/test-utils/dom';

--- a/src/table/__tests__/selection.test.tsx
+++ b/src/table/__tests__/selection.test.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import Table, { TableProps } from '../../../lib/components/table';
 import createWrapper, { TableWrapper } from '../../../lib/components/test-utils/dom';

--- a/src/table/__tests__/sorting.test.tsx
+++ b/src/table/__tests__/sorting.test.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import Table from '../../../lib/components/table';
 import { TableProps } from '../../../lib/components/table/interfaces';

--- a/src/tabs/__tests__/tabs.test.tsx
+++ b/src/tabs/__tests__/tabs.test.tsx
@@ -1,10 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-/* eslint-disable @typescript-eslint/no-var-requires */
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import TestI18nProvider from '../../../lib/components/i18n/testing';
 import Tabs, { TabsProps } from '../../../lib/components/tabs';

--- a/src/time-input/__tests__/time-input.test.tsx
+++ b/src/time-input/__tests__/time-input.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import createWrapper from '../../../lib/components/test-utils/dom';
 import TimeInput, { TimeInputProps } from '../../../lib/components/time-input';


### PR DESCRIPTION
### Description

Remove usage of internal imports

* `@cloudscape-design/test-utils-core/dist/utils` -> `@cloudscape-design/test-utils-core/utils`
*  `@dnd-kit/core/dist/hooks/utilities` -> replace with our own type, because that one is not public


Related links, issue #, if available: n/a

### How has this been tested?

Typescript complies fine afterwards

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
