### PR TITLE
feat: Adds property filter custom form actions test utils selectors

### DIFF
--- a/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -452,6 +452,8 @@ exports[`test-utils selectors 1`] = `
     "awsui_filtering-token-inner_1heb1",
     "awsui_filtering-token-select_1heb1",
     "awsui_filtering-token_1heb1",
+    "awsui_property-editor-cancel_1heb1",
+    "awsui_property-editor-submit_1heb1",
     "awsui_remove-all_1wzqe",
     "awsui_root_1wzqe",
     "awsui_token-editor-cancel_1heb1",

--- a/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
+++ b/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
@@ -12,8 +12,6 @@ import { FilteringProperty, PropertyFilterProps, Ref } from '../../../lib/compon
 import createWrapper, { PropertyFilterWrapper } from '../../../lib/components/test-utils/dom';
 import { createDefaultProps } from './common';
 
-import styles from '../../../lib/components/property-filter/styles.selectors.js';
-
 const defaultProps = createDefaultProps([], []);
 
 const renderComponent = (props?: Partial<PropertyFilterProps & { ref: React.Ref<Ref> }>) => {
@@ -116,7 +114,7 @@ describe('extended operators', () => {
     act(() => pageWrapper.find('[data-testid="change+"]')!.click());
 
     // Click cancel
-    act(() => pageWrapper.findButton(`.${styles['property-editor-cancel']}`)!.click());
+    act(() => wrapper.findPropertyCancelButton()!.click());
     expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
     expect(onChange).not.toBeCalled();
     expect(wrapper.findNativeInput().getElement()).toHaveFocus();
@@ -126,7 +124,7 @@ describe('extended operators', () => {
     act(() => pageWrapper.find('[data-testid="change-"]')!.click());
 
     // Click submit
-    act(() => pageWrapper.findButton(`.${styles['property-editor-submit']}`)!.click());
+    act(() => wrapper.findPropertySubmitButton()!.click());
     expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
     expect(onChange).toBeCalledWith(
       expect.objectContaining({

--- a/src/property-filter/property-editor.tsx
+++ b/src/property-filter/property-editor.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
+import clsx from 'clsx';
 
 import InternalButton from '../button/internal';
 import { FormFieldContext } from '../internal/context/form-field-context';
@@ -10,6 +11,7 @@ import { I18nStringsInternal } from './i18n-utils';
 import { ComparisonOperator, ExtendedOperatorForm, InternalFilteringProperty, InternalToken } from './interfaces';
 
 import styles from './styles.css.js';
+import testUtilStyles from './test-classes/styles.css.js';
 
 export function PropertyEditorContent<TokenValue = any>({
   property,
@@ -59,10 +61,14 @@ export function PropertyEditorFooter<TokenValue = any>({
   const submitToken = () => onSubmit({ property, operator, value });
   return (
     <div className={styles['property-editor-actions']}>
-      <InternalButton variant="link" className={styles['property-editor-cancel']} onClick={onCancel}>
+      <InternalButton
+        variant="link"
+        className={clsx(styles['property-editor-cancel'], testUtilStyles['property-editor-cancel'])}
+        onClick={onCancel}
+      >
         {i18nStrings.cancelActionText}
       </InternalButton>
-      <InternalButton className={styles['property-editor-submit']} onClick={submitToken}>
+      <InternalButton className={testUtilStyles['property-editor-submit']} onClick={submitToken}>
         {i18nStrings.applyActionText}
       </InternalButton>
     </div>

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -61,10 +61,6 @@ $operator-field-width: 120px;
     margin-inline-end: awsui.$space-xs;
   }
 
-  &-submit {
-    /* used in test-utils */
-  }
-
   &-actions {
     display: flex;
     justify-content: flex-end;

--- a/src/property-filter/test-classes/styles.scss
+++ b/src/property-filter/test-classes/styles.scss
@@ -66,3 +66,11 @@
 .token-editor-submit {
   /* used in test-utils */
 }
+
+.property-editor-cancel {
+  /* used in test-utils */
+}
+
+.property-editor-submit {
+  /* used in test-utils */
+}

--- a/src/test-utils/dom/property-filter/index.ts
+++ b/src/test-utils/dom/property-filter/index.ts
@@ -61,6 +61,26 @@ export default class PropertyFilterWrapper extends AutosuggestWrapper {
   findConstraint(): ElementWrapper | null {
     return this.findByClassName(styles.constraint);
   }
+
+  /**
+   * Returns custom property form cancel button.
+   *
+   * @param options
+   * * expandToViewport (boolean) - Use this when the component under test is rendered with an `expandToViewport` flag.
+   */
+  findPropertyCancelButton(options = { expandToViewport: false }): null | ButtonWrapper {
+    return this.findDropdown(options).findComponent(`.${testUtilStyles['property-editor-cancel']}`, ButtonWrapper);
+  }
+
+  /**
+   * Returns custom property form submit button.
+   *
+   * @param options
+   * * expandToViewport (boolean) - Use this when the component under test is rendered with an `expandToViewport` flag.
+   */
+  findPropertySubmitButton(options = { expandToViewport: false }): null | ButtonWrapper {
+    return this.findDropdown(options).findComponent(`.${testUtilStyles['property-editor-submit']}`, ButtonWrapper);
+  }
 }
 
 export class FilteringTokenWrapper extends ComponentWrapper {


### PR DESCRIPTION
### Description

Adding test util methods to find the Cancel and Submit buttons in the property filter custom form. The same methods are to be reused for multi-choice forms implemented here: https://github.com/cloudscape-design/components/pull/2739.

The new methods can be used as follows:
```
createWrapper().findPropertyFilter().findPropertyCancelButton().click()
createWrapper().findPropertyFilter().findPropertySubmitButton({ expandToViewport: true }).click()
```

That is similar to existing:
```
createWrapper().findPropertyFilter().findErrorRecoveryButton({ expandToViewport: true }).click()
```

<img width="668" alt="Screenshot 2024-10-10 at 14 06 54" src="https://github.com/user-attachments/assets/b30aa28e-9d66-403d-922e-c868c366c5c8">

### How has this been tested?

* Updated existing unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
