### PR TITLE
fix: Property filter editor async props

### DIFF
--- a/pages/common/options-loader.ts
+++ b/pages/common/options-loader.ts
@@ -64,8 +64,9 @@ export function useOptionsLoader<Item>({ pageSize = 25, timeout = 1000, randomEr
         if (randomErrors && Math.random() < 0.3) {
           reject();
         } else {
-          const nextItems = sourceItems.slice(pageNumber * pageSize, (pageNumber + 1) * pageSize);
-          resolve({ items: nextItems, hasNextPage: items.length + nextItems.length < sourceItems.length });
+          const newItems = sourceItems.slice(pageNumber * pageSize, (pageNumber + 1) * pageSize);
+          const nextItems = [...items, ...newItems];
+          resolve({ items: nextItems, hasNextPage: nextItems.length < sourceItems.length });
         }
       }, timeout)
     );
@@ -100,7 +101,7 @@ export function useOptionsLoader<Item>({ pageSize = 25, timeout = 1000, randomEr
     request.promise
       .then(response => {
         if (!request.cancelled) {
-          setItems(prev => [...prev, ...(response.items as Item[])]);
+          setItems(response.items as Item[]);
           setStatus(response.hasNextPage ? 'pending' : 'finished');
         }
       })

--- a/pages/dropdown/expandable.page.tsx
+++ b/pages/dropdown/expandable.page.tsx
@@ -171,10 +171,6 @@ const components = {
           },
         ]}
         filteringOptions={propertyFilterOptions}
-        filteringLoadingText={'loading text'}
-        filteringErrorText={'error text'}
-        filteringRecoveryText={'recovery text'}
-        filteringFinishedText={'finished text'}
         {...propertyFilterLabels}
         i18nStrings={propertyFilterI18n}
         expandToViewport={expandToViewport}

--- a/pages/multiselect/multiselect.async.example.page.tsx
+++ b/pages/multiselect/multiselect.async.example.page.tsx
@@ -106,7 +106,7 @@ function EmbeddedMultiselectIntegration(props: EmbeddedMultiselectProps) {
         filteringPlaceholder="Find security group"
       />
 
-      <div style={{ maxBlockSize: 400, display: 'flex' }}>
+      <div style={{ maxBlockSize: 400, display: 'flex', flexDirection: 'column' }}>
         <EmbeddedMultiselect {...props} filteringText={filteringText} />
       </div>
     </SpaceBetween>

--- a/pages/property-filter/async-loading.integ.page.tsx
+++ b/pages/property-filter/async-loading.integ.page.tsx
@@ -88,10 +88,6 @@ export default function () {
           filteringProperties={filteringProperties}
           filteringOptions={optionsLoader.items}
           filteringStatusType={status}
-          filteringLoadingText={'loading text'}
-          filteringErrorText={'error text'}
-          filteringRecoveryText={'recovery text'}
-          filteringFinishedText={'finished text'}
           onLoadItems={handleLoadItems}
           asyncProperties={urlParams.asyncProperties}
           virtualScroll={true}

--- a/pages/property-filter/common-props.tsx
+++ b/pages/property-filter/common-props.tsx
@@ -162,10 +162,10 @@ export const columnDefinitions = [
 export const labels = {
   filteringAriaLabel: 'your choice',
   filteringPlaceholder: 'Search',
-  filteringLoadingText: 'loading text',
-  filteringErrorText: 'error text',
-  filteringRecoveryText: 'recovery text',
-  filteringFinishedText: 'finished text',
+  filteringLoadingText: 'Loading suggestions',
+  filteringErrorText: 'Error fetching results.',
+  filteringRecoveryText: 'Retry',
+  filteringFinishedText: 'End of results',
 };
 
 export const i18nStrings: PropertyFilterProps.I18nStrings = {

--- a/pages/property-filter/common-props.tsx
+++ b/pages/property-filter/common-props.tsx
@@ -17,7 +17,8 @@ import {
 } from './custom-forms';
 import { states, TableItem } from './table.data';
 
-const getStateLabel = (value: TableItem['state']) => (value !== undefined && states[value]) || 'Unknown';
+const getStateLabel = (value: TableItem['state'], fallback = 'Invalid value') =>
+  (value !== undefined && states[value]) || fallback;
 
 export const columnDefinitions = [
   {
@@ -73,7 +74,7 @@ export const columnDefinitions = [
     id: 'owner',
     sortingField: 'owner',
     header: 'Owner',
-    type: 'text',
+    type: 'enum',
     propertyLabel: 'Owner',
     cell: (item: TableItem) => item.owner,
   },
@@ -161,6 +162,10 @@ export const columnDefinitions = [
 export const labels = {
   filteringAriaLabel: 'your choice',
   filteringPlaceholder: 'Search',
+  filteringLoadingText: 'loading text',
+  filteringErrorText: 'error text',
+  filteringRecoveryText: 'recovery text',
+  filteringFinishedText: 'finished text',
 };
 
 export const i18nStrings: PropertyFilterProps.I18nStrings = {

--- a/pages/property-filter/split-panel-app-layout-integration.page.tsx
+++ b/pages/property-filter/split-panel-app-layout-integration.page.tsx
@@ -123,9 +123,6 @@ export default function () {
         asyncProperties: false,
         filteringStatusType: optionsLoader.status,
         onLoadItems: handleLoadItems,
-        filteringLoadingText: 'Loading options',
-        filteringErrorText: 'Error fetching results.',
-        filteringRecoveryText: 'Retry',
         filteringFinishedText: filteringText ? `End of "${filteringText}" results` : 'End of all results',
       }
     : {};

--- a/src/multiselect/styles.scss
+++ b/src/multiselect/styles.scss
@@ -12,10 +12,7 @@
 
 .embedded {
   @include styles.styles-reset;
-
-  display: flex;
-  flex-direction: column;
-  inline-size: 100%;
+  display: contents;
 }
 
 .tokens {

--- a/src/property-filter/__integ__/async-loading.test.ts
+++ b/src/property-filter/__integ__/async-loading.test.ts
@@ -152,7 +152,7 @@ const testCases: TestCase[] = [
       { command: 'open-token-editor', result: [] },
       {
         command: 'open-value-edit',
-        result: [{ firstPage: true, samePage: false, filteringText: '', filteringProperty }],
+        result: [{ firstPage: true, samePage: false, filteringProperty, filteringOperator: ':', filteringText: '1' }],
       },
     ],
   ],

--- a/src/property-filter/__tests__/property-filter.filtering-input.test.tsx
+++ b/src/property-filter/__tests__/property-filter.filtering-input.test.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { act, render } from '@testing-library/react';
 
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 import PropertyFilter from '../../../lib/components/property-filter';
 import {

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -294,6 +294,31 @@ describe('property filter parts', () => {
           .map(optionWrapper => optionWrapper.getElement().textContent)
       ).toEqual(['Stopped', 'Stopping', 'Running']);
     });
+
+    test('calls onLoadItem when opening editor value autosuggest', () => {
+      const onLoadItems = jest.fn();
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        onLoadItems,
+        filteringOptions: [],
+        filteringStatusType: 'pending',
+        query: { operation: 'and', tokens: [{ propertyKey: 'state', operator: ':', value: 'Sto' }] },
+      });
+
+      const [contentWrapper] = openTokenEditor(wrapper);
+      const valueSelectWrapper = findValueSelector(contentWrapper);
+      valueSelectWrapper.focus();
+      expect(onLoadItems).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: {
+            filteringProperty: expect.objectContaining({ key: 'state' }),
+            filteringOperator: ':',
+            filteringText: 'Sto',
+            firstPage: true,
+            samePage: false,
+          },
+        })
+      );
+    });
   });
 
   describe('labelled values', () => {

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -12,7 +12,6 @@ import {
   FilteringOption,
   FilteringProperty,
   PropertyFilterProps,
-  Ref,
 } from '../../../lib/components/property-filter/interfaces';
 import createWrapper, { ElementWrapper, PropertyFilterWrapper } from '../../../lib/components/test-utils/dom';
 import { createDefaultProps } from './common';
@@ -88,7 +87,7 @@ const filteringOptions: readonly FilteringOption[] = [
 
 const defaultProps = createDefaultProps(filteringProperties, filteringOptions);
 
-const renderComponent = (props?: Partial<PropertyFilterProps & { ref: React.Ref<Ref> }>) => {
+const renderComponent = (props?: Partial<PropertyFilterProps>) => {
   const { container } = render(<PropertyFilter {...defaultProps} {...props} />);
   return { container, propertyFilterWrapper: createWrapper(container).findPropertyFilter()! };
 };

--- a/src/property-filter/token-editor-inputs.tsx
+++ b/src/property-filter/token-editor-inputs.tsx
@@ -145,7 +145,7 @@ export function ValueInput({
         .map(({ label, value }) => ({ label, value }))
     : [];
 
-  const valueAutosuggestHandlers = useLoadItems(onLoadItems, '', property?.externalProperty);
+  const valueAutosuggestHandlers = useLoadItems(onLoadItems, '', property?.externalProperty, value, operator);
   const asyncValueAutosuggestProps = property?.propertyKey
     ? { ...valueAutosuggestHandlers, ...asyncProps }
     : { empty: asyncProps.empty };


### PR DESCRIPTION
### Description

This fixes an issue when load items detail from token editor does not include info of selected operator and filtering text, which makes it inconsistent with the same event issued on token creation.

### How has this been tested?

* New unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
