### PR TITLE
feat: Allow table column to be marked as dynamic

### DIFF
--- a/pages/table/dynamic-content.page.tsx
+++ b/pages/table/dynamic-content.page.tsx
@@ -1,0 +1,117 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useState } from 'react';
+
+import { useCollection } from '@cloudscape-design/collection-hooks';
+
+import Button from '~components/button';
+import CollectionPreferences, { CollectionPreferencesProps } from '~components/collection-preferences';
+import Header from '~components/header';
+import Pagination from '~components/pagination';
+import Table from '~components/table';
+import TextFilter from '~components/text-filter';
+
+import { contentDisplayPreferenceI18nStrings } from '../common/i18n-strings';
+import ScreenshotArea from '../utils/screenshot-area';
+import { generateItems, Instance } from './generate-data';
+import {
+  columnsConfig,
+  contentDisplayPreference,
+  defaultPreferences,
+  EmptyState,
+  getMatchesCountText,
+  pageSizeOptions,
+  paginationLabels,
+} from './shared-configs';
+
+const allItems = generateItems();
+
+const DynamicContent = ({ text }: { text?: string }) => {
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    setTimeout(() => setLoaded(true), 2000);
+  }, []);
+  return <div>{loaded ? text : <span>Empty</span>}</div>;
+};
+
+const dynamicColumnsConfig = columnsConfig.map<(typeof columnsConfig)[0]>(c =>
+  c.id === 'dnsName'
+    ? {
+        ...c,
+        hasDynamicContent: true,
+        cell: i => <DynamicContent text={i.dnsName} />,
+      }
+    : c
+);
+
+export default function App() {
+  const [preferences, setPreferences] = useState<CollectionPreferencesProps.Preferences>(defaultPreferences);
+  const { items, actions, filteredItemsCount, collectionProps, filterProps, paginationProps } = useCollection(
+    allItems,
+    {
+      filtering: {
+        empty: (
+          <EmptyState
+            title="No resources"
+            subtitle="No resources to display."
+            action={<Button>Create resource</Button>}
+          />
+        ),
+        noMatch: (
+          <EmptyState
+            title="No matches"
+            subtitle="We can’t find a match."
+            action={<Button onClick={() => actions.setFiltering('')}>Clear filter</Button>}
+          />
+        ),
+      },
+      pagination: { pageSize: preferences.pageSize },
+      sorting: {},
+    }
+  );
+  return (
+    <ScreenshotArea>
+      <Table<Instance>
+        {...collectionProps}
+        header={
+          <Header headingTagOverride="h1" counter={`(${allItems.length})`}>
+            Instances
+          </Header>
+        }
+        columnDefinitions={dynamicColumnsConfig}
+        items={items}
+        pagination={<Pagination {...paginationProps} ariaLabels={paginationLabels} />}
+        filter={
+          <TextFilter
+            {...filterProps!}
+            countText={getMatchesCountText(filteredItemsCount!)}
+            filteringAriaLabel="Filter instances"
+          />
+        }
+        columnDisplay={preferences.contentDisplay}
+        preferences={
+          <CollectionPreferences
+            title="Preferences"
+            confirmLabel="Confirm"
+            cancelLabel="Cancel"
+            onConfirm={({ detail }) => setPreferences(detail)}
+            preferences={preferences}
+            pageSizePreference={{
+              title: 'Select page size',
+              options: pageSizeOptions,
+            }}
+            contentDisplayPreference={{
+              ...contentDisplayPreference,
+              ...contentDisplayPreferenceI18nStrings,
+            }}
+            wrapLinesPreference={{
+              label: 'Wrap lines',
+              description: 'Wrap lines description',
+            }}
+          />
+        }
+        stickyHeader={true}
+      />
+    </ScreenshotArea>
+  );
+}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -15122,6 +15122,8 @@ add a meaningful description to the whole selection.
     * \`cellContext.currentValue\` - State to keep track of a value in input fields while editing.
     * \`cellContext.setValue\` - Function to update \`currentValue\`. This should be called when the value in input field changes.
 * \`isRowHeader\` (boolean) - Specifies that cells in this column should be used as row headers.
+* \`hasDynamicContent\` (boolean) - Specifies that cells in this column may have dynamic content. The contents will then be observed to update calculated column widths.
+   This may have a negative performance impact, so should be used only if necessary. It has no effect if \`resizableColumns\` is set to \`true\`.
 * \`verticalAlign\` ('middle' | 'top') - Determines the alignment of the content in the table cell.",
       "name": "columnDefinitions",
       "optional": false,

--- a/src/table/__integ__/dynamic-content.test.ts
+++ b/src/table/__integ__/dynamic-content.test.ts
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+import createWrapper from '../../../lib/components/test-utils/selectors/index.js';
+
+const tableWrapper = createWrapper().findTable();
+
+class TablePage extends BasePageObject {
+  async getColumnWidth(columnIndex: number) {
+    const columnSelector = tableWrapper.findColumnHeaders().get(columnIndex).toSelector();
+    const element = await this.browser.$(columnSelector);
+    const size = await element.getSize();
+    return size.width;
+  }
+}
+
+test(
+  'something',
+  useBrowser(async browser => {
+    await browser.url('#/light/table/dynamic-content');
+    const page = new TablePage(browser);
+
+    await page.waitForVisible(tableWrapper.findColumnHeaders().toSelector());
+
+    await expect(page.getColumnWidth(3)).resolves.toBeLessThan(350);
+
+    await page.waitForJsTimers(2000);
+
+    await expect(page.getColumnWidth(3)).resolves.toBeGreaterThan(400);
+  })
+);

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -3,11 +3,13 @@
 import React, { useRef } from 'react';
 import clsx from 'clsx';
 
+import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 import { useInternalI18n } from '../../i18n/context';
 import InternalIcon from '../../icon/internal';
 import { useSingleTabStopNavigation } from '../../internal/context/single-tab-stop-navigation-context';
+import { useMergeRefs } from '../../internal/hooks/use-merge-refs';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { KeyCode } from '../../internal/keycode';
 import { GeneratedAnalyticsMetadataTableSort } from '../analytics-metadata/interfaces';
@@ -44,6 +46,7 @@ export interface TableHeaderCellProps<ItemType> {
   tableRole: TableRole;
   resizerRoleDescription?: string;
   isExpandable?: boolean;
+  hasDynamicContent?: boolean;
 }
 
 export function TableHeaderCell<ItemType>({
@@ -69,6 +72,7 @@ export function TableHeaderCell<ItemType>({
   tableRole,
   resizerRoleDescription,
   isExpandable,
+  hasDynamicContent,
 }: TableHeaderCellProps<ItemType>) {
   const i18n = useInternalI18n('table');
   const sortable = !!column.sortingComparator || !!column.sortingField;
@@ -96,11 +100,26 @@ export function TableHeaderCell<ItemType>({
   const clickableHeaderRef = useRef<HTMLDivElement>(null);
   const { tabIndex: clickableHeaderTabIndex } = useSingleTabStopNavigation(clickableHeaderRef, { tabIndex });
 
+  const cellRefObject = useRef<HTMLElement>(null);
+  const cellRefCombined = useMergeRefs(cellRef, cellRefObject);
+
+  // Keep sticky and non-sticky headers in sync for dynamic cell
+  // content changes. This is only needed when:
+  // - Column has dynamic content
+  // - This is the non-sticky version of a sticky header (hidden === true)
+  // - Columns are not resizable
+  useResizeObserver(hasDynamicContent ? cellRefObject : () => null, entry => {
+    if (!hasDynamicContent || !hidden || resizableColumns) {
+      return;
+    }
+    updateColumn(columnId, entry.borderBoxWidth);
+  });
+
   return (
     <TableThElement
       className={className}
       style={style}
-      cellRef={cellRef}
+      cellRef={cellRefCombined}
       sortingStatus={sortingStatus}
       sortingDisabled={sortingDisabled}
       focusedComponent={focusedComponent}

--- a/src/table/header-cell/th-element.tsx
+++ b/src/table/header-cell/th-element.tsx
@@ -24,7 +24,7 @@ interface TableThElementProps {
   colIndex: number;
   columnId: PropertyKey;
   stickyState: StickyColumnsModel;
-  cellRef?: React.RefCallback<HTMLElement>;
+  cellRef?: React.RefCallback<HTMLElement> | null;
   tableRole: TableRole;
   children: React.ReactNode;
 }

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -112,6 +112,8 @@ export interface TableProps<T = any> extends BaseComponentProps {
    *     * `cellContext.currentValue` - State to keep track of a value in input fields while editing.
    *     * `cellContext.setValue` - Function to update `currentValue`. This should be called when the value in input field changes.
    * * `isRowHeader` (boolean) - Specifies that cells in this column should be used as row headers.
+   * * `hasDynamicContent` (boolean) - Specifies that cells in this column may have dynamic content. The contents will then be observed to update calculated column widths.
+   *    This may have a negative performance impact, so should be used only if necessary. It has no effect if `resizableColumns` is set to `true`.
    * * `verticalAlign` ('middle' | 'top') - Determines the alignment of the content in the table cell.
    */
   columnDefinitions: ReadonlyArray<TableProps.ColumnDefinition<T>>;
@@ -440,6 +442,7 @@ export namespace TableProps {
     editConfig?: EditConfig<ItemType>;
     isRowHeader?: boolean;
     verticalAlign?: VerticalAlign;
+    hasDynamicContent?: boolean;
     cell(item: ItemType): React.ReactNode;
   } & SortingColumn<ItemType>;
 

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -176,6 +176,7 @@ const Thead = React.forwardRef(
                 // Expandable option is only applicable to the first data column of the table.
                 // When present, the header content receives extra padding to match the first offset in the data cells.
                 isExpandable={colIndex === 0 && isExpandable}
+                hasDynamicContent={column.hasDynamicContent}
               />
             );
           })}


### PR DESCRIPTION
### Description

Allow table columns to be marked as containing dynamic content. When this flag is set,
a resize observer is attached to auto-update the column widths based on new content.

(Resize observer is needed because the dynamic update might happen nested down the React tree,
in which case no React state change occurs in the table component itself).

Related links, issue #, if available: AWSUI-52826

### How has this been tested?

- New tests
- Ran performance tests locally to ensure no negative impact for non-dynamic cases

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
