### PR TITLE
chore: Enable rest of multi-layout integ tests for toolbar

### DIFF
--- a/src/app-layout/__integ__/multi-app-layout.test.ts
+++ b/src/app-layout/__integ__/multi-app-layout.test.ts
@@ -4,7 +4,7 @@ import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objec
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper from '../../../lib/components/test-utils/selectors';
-import { getUrlParams, testIf, Theme } from './utils';
+import { getUrlParams, Theme } from './utils';
 
 describe.each(['classic', 'refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
   describe.each([[true], [false]])('iframe=%s', iframe => {
@@ -45,13 +45,20 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as Theme[])('%s', theme 
         })
       );
 
-      // TODO: Fix for toolbar
-      testIf(theme !== 'refresh-toolbar')(
+      test(
         'tools panel the secondary layout works',
         setupTest(async (page, switchToIframe) => {
           await switchToIframe(async () => {
             await expect(page.isDisplayed(secondaryLayout.findToolsClose().toSelector())).resolves.toBe(false);
-            await page.click(secondaryLayout.findToolsToggle().toSelector());
+          });
+          if (theme === 'refresh-toolbar') {
+            await page.click(mainLayout.findToolsToggle().toSelector());
+          } else {
+            await switchToIframe(async () => {
+              await page.click(secondaryLayout.findToolsToggle().toSelector());
+            });
+          }
+          await switchToIframe(async () => {
             await expect(page.isDisplayed(secondaryLayout.findToolsClose().toSelector())).resolves.toBe(true);
           });
         })


### PR DESCRIPTION
### Description

Enables the remaining integ test in app layout toolbar for nested app layouts.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
