### PR TITLE
fix: Apply property filter max width only to filtering input

### DIFF
--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -316,70 +316,72 @@ const PropertyFilterInternal = React.forwardRef(
       <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={mergedRef}>
         <div className={clsx(styles['search-field'], analyticsSelectors['search-field'])}>
           {customControl && <div className={styles['custom-control']}>{customControl}</div>}
-          <PropertyFilterAutosuggest
-            ref={inputRef}
-            virtualScroll={virtualScroll}
-            enteredTextLabel={i18nStrings.enteredTextLabel}
-            ariaLabel={filteringAriaLabel ?? i18nStrings.filteringAriaLabel}
-            placeholder={filteringPlaceholder ?? i18nStrings.filteringPlaceholder}
-            ariaLabelledby={rest.ariaLabelledby}
-            ariaDescribedby={textboxAriaDescribedBy}
-            controlId={rest.controlId}
-            value={filteringText}
-            disabled={disabled}
-            {...autosuggestOptions}
-            onChange={event => setFilteringText(event.detail.value)}
-            empty={filteringEmpty}
-            {...asyncAutosuggestProps}
-            expandToViewport={expandToViewport}
-            onOptionClick={handleSelected}
-            customForm={
-              operatorForm
-                ? {
-                    content: (
-                      <PropertyEditorContent
-                        key={customValueKey}
-                        property={propertyStep.property}
-                        operator={propertyStep.operator}
-                        filter={propertyStep.value}
-                        operatorForm={operatorForm}
-                        value={customFormValue}
-                        onChange={setCustomFormValue}
-                      />
-                    ),
-                    footer: (
-                      <PropertyEditorFooter
-                        key={customValueKey}
-                        property={propertyStep.property}
-                        operator={propertyStep.operator}
-                        value={customFormValue}
-                        i18nStrings={i18nStrings}
-                        onCancel={() => {
-                          setFilteringText('');
-                          inputRef.current?.close();
-                          inputRef.current?.focus({ preventDropdown: true });
-                        }}
-                        onSubmit={token => {
-                          addToken(token);
-                          setFilteringText('');
-                          inputRef.current?.focus({ preventDropdown: true });
-                          inputRef.current?.close();
-                        }}
-                      />
-                    ),
-                  }
-                : undefined
-            }
-            onCloseDropdown={() => setCustomFormValueRecord({})}
-            hideEnteredTextOption={internalFreeText.disabled && parsedText.step !== 'property'}
-            clearAriaLabel={i18nStrings.clearAriaLabel}
-            searchResultsId={showResults ? searchResultsId : undefined}
-          />
-          {showResults ? (
-            <div className={styles.results}>
-              <SearchResults id={searchResultsId}>{countText}</SearchResults>
-            </div>
-          ) : null}
+          <div className={styles['input-wrapper']}>
+            <PropertyFilterAutosuggest
+              ref={inputRef}
+              virtualScroll={virtualScroll}
+              enteredTextLabel={i18nStrings.enteredTextLabel}
+              ariaLabel={filteringAriaLabel ?? i18nStrings.filteringAriaLabel}
+              placeholder={filteringPlaceholder ?? i18nStrings.filteringPlaceholder}
+              ariaLabelledby={rest.ariaLabelledby}
+              ariaDescribedby={textboxAriaDescribedBy}
+              controlId={rest.controlId}
+              value={filteringText}
+              disabled={disabled}
+              {...autosuggestOptions}
+              onChange={event => setFilteringText(event.detail.value)}
+              empty={filteringEmpty}
+              {...asyncAutosuggestProps}
+              expandToViewport={expandToViewport}
+              onOptionClick={handleSelected}
+              customForm={
+                operatorForm
+                  ? {
+                      content: (
+                        <PropertyEditorContent
+                          key={customValueKey}
+                          property={propertyStep.property}
+                          operator={propertyStep.operator}
+                          filter={propertyStep.value}
+                          operatorForm={operatorForm}
+                          value={customFormValue}
+                          onChange={setCustomFormValue}
+                        />
+                      ),
+                      footer: (
+                        <PropertyEditorFooter
+                          key={customValueKey}
+                          property={propertyStep.property}
+                          operator={propertyStep.operator}
+                          value={customFormValue}
+                          i18nStrings={i18nStrings}
+                          onCancel={() => {
+                            setFilteringText('');
+                            inputRef.current?.close();
+                            inputRef.current?.focus({ preventDropdown: true });
+                          }}
+                          onSubmit={token => {
+                            addToken(token);
+                            setFilteringText('');
+                            inputRef.current?.focus({ preventDropdown: true });
+                            inputRef.current?.close();
+                          }}
+                        />
+                      ),
+                    }
+                  : undefined
+              }
+              onCloseDropdown={() => setCustomFormValueRecord({})}
+              hideEnteredTextOption={internalFreeText.disabled && parsedText.step !== 'property'}
+              clearAriaLabel={i18nStrings.clearAriaLabel}
+              searchResultsId={showResults ? searchResultsId : undefined}
+            />
+            {showResults ? (
+              <div className={styles.results}>
+                <SearchResults id={searchResultsId}>{countText}</SearchResults>
+              </div>
+            ) : null}
+          </div>
         </div>
         {filteringConstraintText && (
           <div id={constraintTextId} className={styles.constraint}>

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -15,12 +15,14 @@ $operator-field-width: 120px;
 .search-field {
   display: flex;
   align-items: flex-end;
-  // The xs breakpoint, minus the table tools container padding
-  max-inline-size: calc(#{styles.$breakpoint-x-small} - 2 * #{awsui.$space-l});
 }
 
 .input-wrapper {
   flex-grow: 1;
+  display: flex;
+  align-items: flex-end;
+  // The xs breakpoint, minus the table tools container padding
+  max-inline-size: calc(#{styles.$breakpoint-x-small} - 2 * #{awsui.$space-l});
 }
 
 .add-token {


### PR DESCRIPTION
### Description

Apply the max width only to the filtering input (and count text), not to additional custom controls,
so that custom controls don't result in an overly small filtering input.

Related links, issue #, if available: AWSUI-59729

### How has this been tested?

Checked for expected diffs in screenshot tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
