### PR TITLE
chore: Add metrics for new `readOnly` prop additions

### DIFF
--- a/src/checkbox/index.tsx
+++ b/src/checkbox/index.tsx
@@ -10,7 +10,9 @@ import InternalCheckbox from './internal';
 export { CheckboxProps };
 
 const Checkbox = React.forwardRef(({ ...props }: CheckboxProps, ref: React.Ref<CheckboxProps.Ref>) => {
-  const baseComponentProps = useBaseComponent('Checkbox');
+  const baseComponentProps = useBaseComponent('Checkbox', {
+    props: { readOnly: props.readOnly },
+  });
   return <InternalCheckbox {...props} {...baseComponentProps} ref={ref} __injectAnalyticsComponentMetadata={true} />;
 });
 

--- a/src/multiselect/index.tsx
+++ b/src/multiselect/index.tsx
@@ -36,6 +36,7 @@ const Multiselect = React.forwardRef(
         keepOpen,
         tokenLimit: restProps.tokenLimit,
         virtualScroll: restProps.virtualScroll,
+        readOnly: restProps.readOnly,
       },
     });
 

--- a/src/radio-group/index.tsx
+++ b/src/radio-group/index.tsx
@@ -13,7 +13,7 @@ import InternalRadioGroup from './internal';
 export { RadioGroupProps };
 
 const RadioGroup = React.forwardRef((props: RadioGroupProps, ref: React.Ref<RadioGroupProps.Ref>) => {
-  const baseComponentProps = useBaseComponent('RadioGroup');
+  const baseComponentProps = useBaseComponent('RadioGroup', { props: { readOnly: props.readOnly } });
   return (
     <InternalRadioGroup
       ref={ref}

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -33,6 +33,7 @@ const Select = React.forwardRef(
         filteringType,
         triggerVariant,
         virtualScroll: restProps.virtualScroll,
+        readOnly: restProps.readOnly,
       },
     });
     const externalProps = getExternalProps(restProps);

--- a/src/slider/index.tsx
+++ b/src/slider/index.tsx
@@ -10,7 +10,9 @@ import InternalSlider from './internal';
 export { SliderProps };
 
 export default function Slider({ tickMarks, hideFillLine, ...props }: SliderProps) {
-  const baseComponentProps = useBaseComponent('Slider', { props: { tickMarks, hideFillLine } });
+  const baseComponentProps = useBaseComponent('Slider', {
+    props: { tickMarks, hideFillLine, readOnly: props.readOnly },
+  });
   return <InternalSlider tickMarks={tickMarks} hideFillLine={hideFillLine} {...props} {...baseComponentProps} />;
 }
 applyDisplayName(Slider, 'Slider');

--- a/src/tiles/index.tsx
+++ b/src/tiles/index.tsx
@@ -14,7 +14,7 @@ export { TilesProps };
 
 const Tiles = React.forwardRef((props: TilesProps, ref: React.Ref<TilesProps.Ref>) => {
   const baseComponentProps = useBaseComponent('Tiles', {
-    props: { columns: props.columns },
+    props: { columns: props.columns, readOnly: props.readOnly },
   });
   const componentAnalyticsMetadata: GeneratedAnalyticsMetadataTilesComponent = {
     name: 'awsui.Tiles',

--- a/src/toggle/index.tsx
+++ b/src/toggle/index.tsx
@@ -10,7 +10,7 @@ import InternalToggle from './internal';
 export { ToggleProps };
 
 const Toggle = React.forwardRef<ToggleProps.Ref, ToggleProps>((props, ref) => {
-  const baseComponentProps = useBaseComponent('Toggle');
+  const baseComponentProps = useBaseComponent('Toggle', { props: { readOnly: props.readOnly } });
   return <InternalToggle {...props} {...baseComponentProps} ref={ref} __injectAnalyticsComponentMetadata={true} />;
 });
 

--- a/src/token-group/index.tsx
+++ b/src/token-group/index.tsx
@@ -14,7 +14,7 @@ export { TokenGroupProps };
 
 export default function TokenGroup({ items = [], alignment = 'horizontal', ...props }: TokenGroupProps) {
   const baseComponentProps = useBaseComponent('TokenGroup', {
-    props: { alignment, disableOuterPadding: props.disableOuterPadding, limit: props.limit },
+    props: { alignment, disableOuterPadding: props.disableOuterPadding, limit: props.limit, readOnly: props.readOnly },
   });
 
   const componentAnalyticsMetadata: GeneratedAnalyticsMetadataTokenGroupComponent = {


### PR DESCRIPTION
### Description

We have recently added `readOnly` to more components. This change adds the metrics for this.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
