### PR TITLE
fix: Ensure single fileupload dropzone only accepts single files

### DIFF
--- a/src/file-upload/__tests__/file-upload.test.tsx
+++ b/src/file-upload/__tests__/file-upload.test.tsx
@@ -185,7 +185,10 @@ describe('FileUpload input', () => {
     Object.defineProperty(input, 'files', { value: [file1, file2] });
     fireEvent(input, new CustomEvent('change', { bubbles: true }));
 
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { value: [file1, file1] } }));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { value: [file1, file2] } }));
+    // additional equality check, because `expect.objectContaining` above thinks file1 === file2
+    expect((onChange as jest.Mock).mock.lastCall[0].detail.value[0]).toBe(file1);
+    expect((onChange as jest.Mock).mock.lastCall[0].detail.value[1]).toBe(file2);
   });
 
   test('file input fires onChange with only the first file if not multiple', () => {
@@ -195,6 +198,7 @@ describe('FileUpload input', () => {
     fireEvent(input, new CustomEvent('change', { bubbles: true }));
 
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { value: [file1] } }));
+    expect((onChange as jest.Mock).mock.lastCall[0].detail.value[0]).toBe(file1);
   });
 });
 

--- a/src/file-upload/__tests__/file-upload.test.tsx
+++ b/src/file-upload/__tests__/file-upload.test.tsx
@@ -181,9 +181,20 @@ describe('FileUpload input', () => {
 
   test('file input fires onChange with files in details', () => {
     const wrapper = render({ multiple: true });
-    fireEvent(wrapper.findNativeInput().getElement(), new CustomEvent('change', { bubbles: true }));
+    const input = wrapper.findNativeInput().getElement();
+    Object.defineProperty(input, 'files', { value: [file1, file2] });
+    fireEvent(input, new CustomEvent('change', { bubbles: true }));
 
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { value: [] } }));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { value: [file1, file1] } }));
+  });
+
+  test('file input fires onChange with only the first file if not multiple', () => {
+    const wrapper = render({});
+    const input = wrapper.findNativeInput().getElement();
+    Object.defineProperty(input, 'files', { value: [file1, file2] });
+    fireEvent(input, new CustomEvent('change', { bubbles: true }));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { value: [file1] } }));
   });
 });
 

--- a/src/file-upload/internal.tsx
+++ b/src/file-upload/internal.tsx
@@ -85,7 +85,7 @@ function InternalFileUpload(
   }
 
   const handleFilesChange = (newFiles: File[]) => {
-    const newValue = multiple ? [...value, ...newFiles] : newFiles[0] ? newFiles : [...value];
+    const newValue = multiple ? [...value, ...newFiles] : newFiles[0] ? newFiles.slice(0, 1) : [...value];
     fireNonCancelableEvent(onChange, { value: newValue });
   };
 


### PR DESCRIPTION
### Description

Ensure that, if `multiple` is not set, only one file can be dragged into the dropzone.

Related links, issue #, if available: AWSUI-21885

### How has this been tested?

New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
