### PR TITLE
feat: enabling tooltip on drawer triggers in AppLayout 

### DIFF
--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-drawer-trigger-tooltip.test.tsx
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-drawer-trigger-tooltip.test.tsx
@@ -6,10 +6,7 @@ import { setupTest } from '../utils';
 
 const wrapper = createWrapper().findAppLayout();
 
-describe('refresh-toolbar', () => {
-  //using a theme variable below that will be set when iterating over ['refresh-toolbar', 'refresh']
-  const theme = 'refresh-toolbar';
-
+describe.each(['refresh', 'refresh-toolbar'] as const)('%s', theme => {
   describe.each(['desktop', 'mobile'] as const)('%s', size => {
     const firstDrawerId = 'security'; //matches drawerIds[0]
     const secondDrawerId = 'pro-help'; //matches drawerIds[1]

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-no-tooltips.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-no-tooltips.test.ts
@@ -5,7 +5,7 @@ import { setupTest } from '../utils';
 
 const wrapper = createWrapper().findAppLayout();
 
-describe.each(['refresh', 'classic'] as const)('%s', theme => {
+describe('No tooltips in classic', () => {
   describe.each(['desktop', 'mobile'] as const)('%s', size => {
     //matches drawerItems[0].id from 'lib/dev-pages/pages/app-layout/utils/drawers';
     const firstDrawerId = 'security';
@@ -14,7 +14,7 @@ describe.each(['refresh', 'classic'] as const)('%s', theme => {
 
     test(
       'No drawer trigger tooltip showing for mouse interactions',
-      setupTest({ size, theme }, async page => {
+      setupTest({ size, theme: 'classic' }, async page => {
         await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.hoverElement(firstDrawerTriggerSelector);
         await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
@@ -23,7 +23,7 @@ describe.each(['refresh', 'classic'] as const)('%s', theme => {
 
     test(
       'No drawer trigger tooltip showing for pointer interactions',
-      setupTest({ size, theme }, async page => {
+      setupTest({ size, theme: 'classic' }, async page => {
         await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         await page.buttonDownOnElement(firstDrawerTriggerSelector);
         await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
@@ -32,7 +32,7 @@ describe.each(['refresh', 'classic'] as const)('%s', theme => {
 
     test(
       'No drawer trigger tooltip showing for keyboard (tab) interactions',
-      setupTest({ size, theme }, async page => {
+      setupTest({ size, theme: 'classic' }, async page => {
         await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
         //set focus by clicking open and close
         await page.click(firstDrawerTriggerSelector);
@@ -49,7 +49,7 @@ describe.each(['refresh', 'classic'] as const)('%s', theme => {
     describe.each(['bottom', 'side'] as const)('splitPanelPosition=%s', splitPanelPosition => {
       test(
         'No split panel trigger tooltip showing for mouse interactions',
-        setupTest({ size, theme, splitPanelPosition }, async page => {
+        setupTest({ size, theme: 'classic', splitPanelPosition }, async page => {
           await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
           await page.hoverElement(wrapper.findSplitPanelOpenButton().toSelector());
           await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
@@ -58,7 +58,7 @@ describe.each(['refresh', 'classic'] as const)('%s', theme => {
 
       test(
         'No split panel trigger tooltip showing for pointer interactions',
-        setupTest({ size, theme, splitPanelPosition }, async page => {
+        setupTest({ size, theme: 'classic', splitPanelPosition }, async page => {
           await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
           await page.buttonDownOnElement(wrapper.findSplitPanelOpenButton().toSelector());
           await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
@@ -67,7 +67,7 @@ describe.each(['refresh', 'classic'] as const)('%s', theme => {
 
       test(
         'No split panel trigger tooltip showing for keyboard (tab) interactions',
-        setupTest({ size, theme, splitPanelPosition }, async page => {
+        setupTest({ size, theme: 'classic', splitPanelPosition }, async page => {
           await expect(page.isExisting(triggerTooltipSelector)).resolves.toBe(false);
           //set focus by clicking open and close
           await page.click(wrapper.findSplitPanelOpenButton().toSelector());

--- a/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
+++ b/src/app-layout/__integ__/toolbar-tooltips/app-layout-toolbar-split-panel-trigger-tooltip.test.ts
@@ -5,9 +5,7 @@ import { AppLayoutDrawersPage, setupTest } from '../utils';
 
 const wrapper = createWrapper().findAppLayout();
 
-describe('refresh-toolbar', () => {
-  const theme = 'refresh-toolbar';
-
+describe.each(['refresh', 'refresh-toolbar'] as const)('%s', theme => {
   describe.each(['desktop', 'mobile'] as const)('%s', size => {
     //matches drawerItems[0].id from '../../../../lib/dev-pages/pages/app-layout/utils/drawers';
     const firstDrawerId = 'security';

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -197,7 +197,7 @@ describeEachAppLayout(({ size, theme }) => {
     expect(drawerTrigger!.getElement()).not.toHaveClass(selectedClass);
   });
 
-  testIf(theme === 'refresh-toolbar')('tooltip renders correctly on focus, blur, and escape key press events', () => {
+  testIf(theme !== 'classic')('tooltip renders correctly on focus, blur, and escape key press events', () => {
     const mockDrawers = [testDrawer];
     const result = render(<AppLayout drawers={mockDrawers} />);
     const wrapper = createWrapper(result.container).findAppLayout();
@@ -228,41 +228,38 @@ describeEachAppLayout(({ size, theme }) => {
     expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
   });
 
-  testIf(theme === 'refresh-toolbar')(
-    'tooltip renders correctly on pointer events and is removed on escape key press',
-    () => {
-      const mockDrawers = [testDrawer];
-      const result = render(<AppLayout drawers={mockDrawers} />);
-      const wrapper = createWrapper(result.container).findAppLayout();
-      expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
-      expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
+  testIf(theme !== 'classic')('tooltip renders correctly on pointer events and is removed on escape key press', () => {
+    const mockDrawers = [testDrawer];
+    const result = render(<AppLayout drawers={mockDrawers} />);
+    const wrapper = createWrapper(result.container).findAppLayout();
+    expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
+    expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
 
-      const items = wrapper!.findDrawersTriggers();
-      expect(items?.length).toEqual(mockDrawers.length);
+    const items = wrapper!.findDrawersTriggers();
+    expect(items?.length).toEqual(mockDrawers.length);
 
-      fireEvent.pointerEnter(items![0].getElement());
-      expect(wrapper!.findDrawerTriggerTooltip()).toBeTruthy();
-      expect(result.getByText(testDrawer.ariaLabels.drawerName)).toBeTruthy();
+    fireEvent.pointerEnter(items![0].getElement());
+    expect(wrapper!.findDrawerTriggerTooltip()).toBeTruthy();
+    expect(result.getByText(testDrawer.ariaLabels.drawerName)).toBeTruthy();
 
-      fireEvent.pointerLeave(items![0].getElement());
-      expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
-      expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
+    fireEvent.pointerLeave(items![0].getElement());
+    expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
+    expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
 
-      fireEvent.pointerEnter(items![0].getElement());
-      expect(wrapper!.findDrawerTriggerTooltip()).toBeTruthy();
-      expect(result.getByText(testDrawer.ariaLabels.drawerName)).toBeTruthy();
+    fireEvent.pointerEnter(items![0].getElement());
+    expect(wrapper!.findDrawerTriggerTooltip()).toBeTruthy();
+    expect(result.getByText(testDrawer.ariaLabels.drawerName)).toBeTruthy();
 
-      fireEvent.keyDown(items![0].getElement(), {
-        ...mockEventBubble,
-        key: 'Escape',
-        code: KeyCode.escape,
-      });
-      expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
-      expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
-    }
-  );
+    fireEvent.keyDown(items![0].getElement(), {
+      ...mockEventBubble,
+      key: 'Escape',
+      code: KeyCode.escape,
+    });
+    expect(wrapper!.findDrawerTriggerTooltip()).toBeNull();
+    expect(() => result.getByTestId(testDrawer.ariaLabels.drawerName)).toThrow();
+  });
 
-  testIf(theme === 'refresh-toolbar')('tooltip does not render on trigger focus via close button', () => {
+  testIf(theme !== 'classic')('tooltip does not render on trigger focus via close button', () => {
     const mockDrawers = [testDrawer];
     const result = render(<AppLayout drawers={mockDrawers} />);
     const wrapper = createWrapper(result.container).findAppLayout();

--- a/src/app-layout/__tests__/trigger-button.test.tsx
+++ b/src/app-layout/__tests__/trigger-button.test.tsx
@@ -16,7 +16,6 @@ import { ButtonProps } from '../../../lib/components/button';
 import { IconProps } from '../../../lib/components/icon/interfaces.js';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
-import testUtilStyles from '../../../lib/components/app-layout/test-classes/styles.css.js';
 import visualRefreshStyles from '../../../lib/components/app-layout/visual-refresh/styles.css.js';
 import toolbarTriggerButtonStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/trigger-button/styles.css.js';
 
@@ -54,13 +53,14 @@ const mockEventBubble = {
   relatedTarget: null,
 };
 
-const mockRelatedTarget = new EventTarget();
-const mockEventBubbleWithRelatedTarget = {
+const mockEventBubbleWithShiftFocus = {
   ...mockEventBubble,
-  relatedTarget: mockRelatedTarget,
+  relatedTarget: {
+    dataset: {
+      shiftFocus: 'last-opened-toolbar-trigger-button',
+    },
+  },
 };
-
-const triggerButtoonTooltipClass = testUtilStyles['trigger-tooltip'];
 
 const testIf = (condition: boolean) => (condition ? test : test.skip);
 
@@ -266,7 +266,7 @@ describe('Visual refresh trigger-button (not in appLayoutWidget toolbar)', () =>
     expect(getByTestId(mockTestId)).toBeTruthy();
     expect(button).toBeTruthy();
     expect(document.activeElement).not.toBe(button!.getElement());
-    (ref.current as any)?.focus(mockEventBubbleWithRelatedTarget);
+    (ref.current as any)?.focus(mockEventBubbleWithShiftFocus);
     expect(document.activeElement).toBe(button!.getElement());
   });
 });
@@ -356,14 +356,17 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           expect(getByTestId(mockTestId)).toBeTruthy();
           const button = wrapper!.find('button');
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
+          expect(
+            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+          ).toBe(false);
+          expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           expect(button).toBeTruthy();
           expect(document.activeElement).not.toBe(button!.getElement());
-          (ref.current as any)?.focus(mockEventBubbleWithRelatedTarget);
+          (ref.current as any)?.focus(mockEventBubbleWithShiftFocus);
           expect(document.activeElement).toBe(button!.getElement());
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
+          expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
         });
 
         test('pointer events work properly', () => {
@@ -372,17 +375,32 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             isMobile,
           });
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
+          expect(
+            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+          ).toBe(false);
+          expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           fireEvent.pointerEnter(wrapper!.getElement());
           if (hasTooltip) {
             expect(getByText(mockTooltipText)).toBeTruthy();
+            expect(
+              wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+            ).toBe(true);
             //trigger event again to assert the tooltip remains
             fireEvent.pointerDown(wrapper!.getElement());
+            expect(
+              wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+            ).toBe(true);
           } else {
             expect(() => getByText(mockTooltipText)).toThrow();
+            expect(
+              wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+            ).toBe(false);
           }
           fireEvent.pointerLeave(wrapper!.getElement(), mockEventBubble);
+          expect(
+            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+          ).toBe(false);
           expect(() => getByText(mockTooltipText)).toThrow();
         });
 
@@ -392,7 +410,10 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             isMobile,
           });
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
+          expect(
+            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+          ).toBe(false);
+          expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           fireEvent.focus(wrapper!.getElement());
 
@@ -401,9 +422,15 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           } else {
             expect(() => getByText(mockTooltipText)).toThrow();
           }
+          expect(
+            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+          ).toBe(hasTooltip);
 
           fireEvent.blur(wrapper!.getElement());
-          expect(wrapper.findByClassName(triggerButtoonTooltipClass)).toBeNull();
+          expect(wrapper.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+          expect(
+            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+          ).toBe(false);
           expect(() => getByText(mockTooltipText)).toThrow();
         });
 
@@ -413,10 +440,16 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             isMobile,
           });
           expect(getByTestId(mockTestId)).toBeTruthy();
-          expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
+          expect(
+            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+          ).toBe(false);
+          expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
           expect(() => getByText(mockTooltipText)).toThrow();
           fireEvent.focus(wrapper!.getElement());
           expect(getByText(mockTooltipText)).toBeTruthy();
+          expect(
+            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+          ).toBe(true);
 
           fireEvent.keyDown(wrapper!.getElement(), {
             ...mockEventBubble,
@@ -424,7 +457,10 @@ describe('Visual Refresh Toolbar trigger-button', () => {
             code: KeyCode.escape,
           });
 
-          expect(wrapper.findByClassName(triggerButtoonTooltipClass)).toBeNull();
+          expect(wrapper.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
+          expect(
+            wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+          ).toBe(false);
           expect(() => getByText(mockTooltipText)).toThrow();
         });
 
@@ -436,13 +472,22 @@ describe('Visual Refresh Toolbar trigger-button', () => {
               tooltipText: '',
             });
             expect(getByTestId(mockTestId)).toBeTruthy();
-            expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
+            expect(
+              wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+            ).toBe(false);
+            expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
 
             fireEvent.pointerEnter(wrapper!.getElement());
-            expect(wrapper.findByClassName(triggerButtoonTooltipClass)).toBeNull();
+            expect(
+              wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+            ).toBe(false);
+            expect(wrapper.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
 
             fireEvent.focus(wrapper!.getElement());
-            expect(wrapper.findByClassName(triggerButtoonTooltipClass)).toBeNull();
+            expect(
+              wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+            ).toBe(false);
+            expect(wrapper.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
           }
         );
       });
@@ -452,60 +497,15 @@ describe('Visual Refresh Toolbar trigger-button', () => {
           hasOpenDrawer: true,
         });
         expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
-
+        expect(
+          wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+        ).toBe(false);
+        expect(wrapper!.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
         fireEvent.focus(wrapper!.getElement());
-        expect(wrapper.findByClassName(triggerButtoonTooltipClass)).toBeNull();
-      });
-
-      //the realatedTarget here would be truthy when key or click navigation
-      //relatedTarget exists on events that are not associated with closeing the split panel from within
-      test('Focus and blur events work properly for split panel and related target exists', () => {
-        const { wrapper, getByText, getByTestId } = renderVisualRefreshToolbarTriggerButton({
-          hasTooltip: true,
-          isMobile,
-          isForSplitPanel: true,
-        });
-        expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
-        expect(() => getByText(mockTooltipText)).toThrow();
-
-        fireEvent.focus(wrapper!.getElement(), mockEventBubbleWithRelatedTarget);
-        expect(getByText(mockTooltipText)).toBeTruthy();
-
-        fireEvent.blur(wrapper!.getElement());
-        expect(wrapper.findByClassName(triggerButtoonTooltipClass)).toBeNull();
-        expect(() => getByText(mockTooltipText)).toThrow();
-      });
-
-      //the relatedTarget here will be null just like when a split panel closed via mouse or key interaction
-      //with the close button on the split panel
-      test('Focus and blur events work properly for split panel and relatedTarget is null', () => {
-        const { wrapper, getByText, getByTestId } = renderVisualRefreshToolbarTriggerButton({
-          hasTooltip: true,
-          isMobile,
-          isForSplitPanel: true,
-        });
-        expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
-        expect(() => getByText(mockTooltipText)).toThrow();
-        fireEvent.focus(wrapper!.getElement());
-
-        expect(() => getByText(mockTooltipText)).toThrow();
-      });
-
-      test('Focus events work properly for isForPreviousDrawer', () => {
-        const { wrapper, getByText, getByTestId } = renderVisualRefreshToolbarTriggerButton({
-          hasTooltip: true,
-          isMobile,
-          isForPreviousActiveDrawer: true,
-        });
-        expect(getByTestId(mockTestId)).toBeTruthy();
-        expect(wrapper!.findByClassName(triggerButtoonTooltipClass)).toBeNull();
-        expect(() => getByText(mockTooltipText)).toThrow();
-
-        fireEvent.focus(wrapper!.getElement());
-        expect(() => getByText(mockTooltipText)).toThrow();
+        expect(
+          wrapper!.getElement().classList.contains(toolbarTriggerButtonStyles['trigger-wrapper-tooltip-visible'])
+        ).toBe(false);
+        expect(wrapper.findByClassName(toolbarTriggerButtonStyles['trigger-tooltip'])).toBeNull();
       });
     });
   });

--- a/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
@@ -63,6 +63,45 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
   const size = getLimitedValue(minDrawerSize, activeDrawerSize, maxDrawerSize);
   const lastOpenedDrawerId = drawersOpenQueue?.length ? drawersOpenQueue[0] : activeDrawerId;
 
+  const handleDrawerClose = () => {
+    onActiveDrawerChange(null);
+    drawersFocusControl.setFocus();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    const container = e.currentTarget as any;
+    const focusableElements = getFocusableElements(container);
+    const lastIndex = focusableElements.length - 1;
+
+    if (e.key === 'Tab') {
+      if (e.shiftKey) {
+        // Shift + Tab pressed
+        if (document.activeElement === focusableElements[0]) {
+          // Focus the last focusable element
+          // focusableElements[lastIndex].focus();
+
+          drawersFocusControl.loseFocus();
+          // e.preventDefault();
+        }
+      } else {
+        // Tab pressed
+        if (document.activeElement === focusableElements[lastIndex]) {
+          // Focus the desired element (e.g., the first focusable element)
+          // focusableElements[0].focus();
+          drawersFocusControl.loseFocus();
+          // e.preventDefault();
+        }
+      }
+    }
+  };
+
+  const getFocusableElements = (container: HTMLDivElement): HTMLElement[] => {
+    const focusableElements = Array.from(
+      container.querySelectorAll('a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])')
+    );
+    return focusableElements as HTMLElement[];
+  };
+
   return (
     <Transition nodeRef={drawerRef} in={!!activeDrawer} appear={true} timeout={0}>
       {state => (
@@ -84,6 +123,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
               drawersFocusControl.loseFocus();
             }
           }}
+          onKeyDown={e => handleKeyDown(e)}
           style={{
             blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)`,
             insetBlockStart: drawersTopOffset,
@@ -117,7 +157,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
                 })}
                 formAction="none"
                 iconName={isMobile ? 'close' : 'angle-right'}
-                onClick={() => onActiveDrawerChange(null)}
+                onClick={handleDrawerClose}
                 ref={drawersFocusControl.refs.close}
                 variant="icon"
               />

--- a/src/app-layout/visual-refresh/mobile-toolbar.tsx
+++ b/src/app-layout/visual-refresh/mobile-toolbar.tsx
@@ -42,13 +42,12 @@ export default function MobileToolbar() {
     <section
       className={clsx(
         styles['mobile-toolbar'],
-        [testutilStyles['mobile-bar']],
+        testutilStyles['mobile-bar'],
         {
           [styles['has-breadcrumbs']]: breadcrumbs,
           [styles.unfocusable]: hasDrawerViewportOverlay,
           [highContrastHeaderClassName]: headerVariant === 'high-contrast',
         },
-        testutilStyles['mobile-bar'],
         headerVariant !== 'high-contrast' && styles['remove-high-contrast-header']
       )}
     >

--- a/src/app-layout/visual-refresh/trigger-button.tsx
+++ b/src/app-layout/visual-refresh/trigger-button.tsx
@@ -1,12 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { Ref } from 'react';
+import React, { Ref, useCallback, useEffect, useState } from 'react';
 import clsx from 'clsx';
 
 import { ButtonProps } from '../../button/interfaces';
 import { InternalButton } from '../../button/internal';
 import { IconProps } from '../../icon/interfaces';
 import Icon from '../../icon/internal';
+import Tooltip from '../../internal/components/tooltip';
+import { registerTooltip } from '../../internal/components/tooltip/registry';
 import { useAppLayoutInternals } from './context';
 
 import styles from './styles.css.js';
@@ -30,6 +32,22 @@ export interface TriggerButtonProps {
   onClick: () => void;
   badge?: boolean;
   highContrastHeader?: boolean;
+  /**
+   * If the button is expected to have a tooltip. When false it will not set the event listeners
+   *
+   * defaults to false
+   */
+  hasTooltip?: boolean;
+  /**
+   * This text allows for a customized tooltip.
+   *
+   * When falsy, the tooltip will parse the tooltip form the aria-lable
+   */
+  tooltipText?: string;
+  /**
+   * set to true if the trigger button was used to open the last active drawer
+   */
+  isForPreviousActiveDrawer?: boolean;
 }
 
 function TriggerButton(
@@ -46,64 +64,229 @@ function TriggerButton(
     badge,
     selected = false,
     highContrastHeader,
+    hasTooltip = false,
+    tooltipText = '',
+    isForPreviousActiveDrawer = false,
   }: TriggerButtonProps,
   ref: React.Ref<ButtonProps.Ref>
 ) {
-  const { isMobile } = useAppLayoutInternals();
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+  const tooltipValue = tooltipText ? tooltipText : ariaLabel ? ariaLabel : '';
+  const [showTooltip, setShowTooltip] = useState<boolean>(false);
+  const [suppressTooltip, setSupressTooltip] = useState<boolean>(false);
+  const { hasOpenDrawer, isMobile } = useAppLayoutInternals();
+
+  const tooltipVisible =
+    containerRef &&
+    containerRef?.current &&
+    tooltipValue &&
+    !(isMobile && hasOpenDrawer) &&
+    showTooltip &&
+    !suppressTooltip;
+
+  /**
+   * Takes the drawer being closed and the data-shift-focus value from a close button on that drawer that persists
+   * on the event relatedTarget to determine not to show the tooltip
+   * @param event
+   */
+  const handleFocus = useCallback(
+    (event: FocusEvent) => {
+      const eventWithRelatedTarget = event as any;
+
+      const shouldSupressTooltip = () => {
+        const isFromDrawerCloseButton =
+          eventWithRelatedTarget?.relatedTarget?.dataset?.shiftFocus === 'last-opened-toolbar-trigger-button';
+        const isFromAnotherTrigger =
+          eventWithRelatedTarget?.relatedTarget?.dataset?.shiftFocus === 'awsui-layout-drawer-trigger';
+
+        if (selected && isForPreviousActiveDrawer && !isFromDrawerCloseButton) {
+          const resizeButtonWrapper = document.querySelector('div[data-shift-focus="drawer-resize-button-handle"]');
+          if (
+            resizeButtonWrapper &&
+            eventWithRelatedTarget?.relatedTarget &&
+            resizeButtonWrapper.contains(eventWithRelatedTarget.relatedTarget)
+          ) {
+            //focus will be on the close or resize upon opening drawer via trigger
+            //and will still remain on sumsequent close
+            return false;
+          }
+        } else if (!selected && isForPreviousActiveDrawer) {
+          if (isFromDrawerCloseButton) {
+            //for tab being returned to toggle button from clicking the close button
+            return false;
+          }
+        }
+        if (
+          isFromAnotherTrigger || //for keyed navigation
+          !isForPreviousActiveDrawer
+        ) {
+          return true; //for keyed navigation inside the toolbar
+        } else {
+          if (
+            selected //neccessary because tab navigation from drawer close to 1st trigger button
+          ) {
+            //determine if from a badge button
+            return false;
+          }
+          if (isFromDrawerCloseButton) {
+            //exception made for click from close drawer button
+            return false;
+          }
+          //for keyed navigation inside and outside the toolbar
+          return true;
+        }
+      };
+      setSupressTooltip(!shouldSupressTooltip());
+      setShowTooltip(true);
+    },
+    [
+      // To assert reference equality check
+      isForPreviousActiveDrawer,
+      selected,
+    ]
+  );
+
+  const handleTriggerClick = (event: MouseEvent) => {
+    event.stopPropagation();
+    setShowTooltip(false);
+    setSupressTooltip(true);
+    onClick();
+  };
+
+  const handleBlur = (keepSupressed = false) => {
+    setSupressTooltip(keepSupressed);
+    setShowTooltip(false);
+  };
+
+  const handlePointerEnter = () => {
+    setSupressTooltip(false);
+    setShowTooltip(true);
+  };
+
+  useEffect(() => {
+    if (hasTooltip && tooltipValue) {
+      const close = () => {
+        setShowTooltip(false);
+        setSupressTooltip(false);
+      };
+
+      const shouldCloseTooltip = (event: PointerEvent) => {
+        if (event.target && containerRef && (containerRef.current as any)?.contains(event.target as HTMLElement)) {
+          return false;
+        }
+        return true;
+      };
+
+      const handlePointerDownEvent = (event: PointerEvent) => {
+        if (shouldCloseTooltip(event)) {
+          close();
+        }
+      };
+
+      const handleKeyDownEvent = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          close();
+        }
+      };
+
+      const wrapperDiv = containerRef.current;
+      if (wrapperDiv) {
+        wrapperDiv.addEventListener('pointerdown', handlePointerDownEvent);
+        wrapperDiv.addEventListener('keydown', handleKeyDownEvent);
+
+        return () => {
+          wrapperDiv.removeEventListener('pointerdown', handlePointerDownEvent);
+          wrapperDiv.removeEventListener('keydown', handleKeyDownEvent);
+        };
+      }
+    }
+  }, [containerRef, hasTooltip, tooltipValue]);
+
+  useEffect(() => {
+    if (tooltipVisible) {
+      return registerTooltip(() => {
+        setShowTooltip(false);
+        setSupressTooltip(false);
+      });
+    }
+  }, [tooltipVisible]);
 
   return (
-    <div className={clsx(styles['trigger-wrapper'], !highContrastHeader && styles['remove-high-contrast-header'])}>
-      {isMobile ? (
-        <InternalButton
-          ariaExpanded={ariaExpanded}
-          ariaLabel={ariaLabel}
-          ariaControls={ariaControls}
-          className={className}
-          disabled={disabled}
-          ref={ref}
-          formAction="none"
-          iconName={iconName}
-          iconSvg={iconSvg}
-          badge={badge}
-          onClick={onClick}
-          variant="icon"
-          __nativeAttributes={{
-            'aria-haspopup': true,
-            ...(testId && {
-              'data-testid': testId,
-            }),
-          }}
-        />
-      ) : (
-        <>
-          <button
-            aria-expanded={ariaExpanded}
-            aria-controls={ariaControls}
-            aria-haspopup={true}
-            aria-label={ariaLabel}
-            aria-disabled={disabled}
+    <div
+      ref={containerRef}
+      {...(hasTooltip && {
+        onPointerEnter: () => handlePointerEnter(),
+        onPointerLeave: () => handleBlur(false),
+        onFocus: e => handleFocus(e as any),
+        onBlur: () => handleBlur(true),
+      })}
+      className={clsx(styles['trigger-wrapper'], {
+        [styles['remove-high-contrast-header']]: !highContrastHeader,
+        [styles['trigger-wrapper-tooltip-visible']]: tooltipVisible,
+      })}
+    >
+      <div className={clsx(styles['trigger-wrapper'], !highContrastHeader && styles['remove-high-contrast-header'])}>
+        {isMobile ? (
+          <InternalButton
+            ariaExpanded={ariaExpanded}
+            ariaLabel={ariaLabel}
+            ariaControls={ariaControls}
+            className={className}
             disabled={disabled}
-            className={clsx(
-              styles.trigger,
-              styles['trigger-button-styles'],
-              {
-                [styles.selected]: selected,
-                [styles.badge]: badge,
-              },
-              className
-            )}
+            ref={ref}
+            formAction="none"
+            iconName={iconName}
+            iconSvg={iconSvg}
+            badge={badge}
             onClick={onClick}
-            ref={ref as Ref<HTMLButtonElement>}
-            type="button"
-            data-testid={testId}
-          >
-            <span className={clsx(badge && clsx(styles['trigger-badge-wrapper'], styles['trigger-button-styles']))}>
-              {(iconName || iconSvg) && <Icon name={iconName} svg={iconSvg} />}
-            </span>
-          </button>
-          {badge && <div className={styles.dot} />}
-        </>
-      )}
+            variant="icon"
+            __nativeAttributes={{
+              'aria-haspopup': true,
+              ...(testId && {
+                'data-testid': testId,
+                'data-shift-focus': 'awsui-layout-drawer-trigger',
+              }),
+            }}
+          />
+        ) : (
+          <>
+            <button
+              aria-expanded={ariaExpanded}
+              aria-controls={ariaControls}
+              aria-haspopup={true}
+              aria-label={ariaLabel}
+              aria-disabled={disabled}
+              disabled={disabled}
+              className={clsx(
+                styles.trigger,
+                styles['trigger-button-styles'],
+                {
+                  [styles.selected]: selected,
+                  [styles.badge]: badge,
+                },
+                className
+              )}
+              onClick={e => handleTriggerClick(e as any)}
+              ref={ref as Ref<HTMLButtonElement>}
+              type="button"
+              data-testid={testId}
+            >
+              <span className={clsx(badge && clsx(styles['trigger-badge-wrapper'], styles['trigger-button-styles']))}>
+                {(iconName || iconSvg) && <Icon name={iconName} svg={iconSvg} />}
+              </span>
+            </button>
+            {badge && <div className={styles.dot} />}
+          </>
+        )}
+        {tooltipVisible && (
+          <Tooltip
+            trackRef={containerRef}
+            value={tooltipValue}
+            className={styles['trigger-tooltip']}
+            {...(!isMobile && { position: 'left' })}
+          />
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
this is a draft PR that enables the tooltip in visual refresh. It includes the changes to the applicable components as long as integ tests and unit tests. 

Note: the feature is not 100%. Check out the doc Quip ref: [WuXzAKOQVQAR] on the steps necessary to make it fully functional. 

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
