### PR TITLE
fix: Let notifications background cover entire page width

### DIFF
--- a/pages/app-layout/disable-paddings-with-table.page.tsx
+++ b/pages/app-layout/disable-paddings-with-table.page.tsx
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import AppLayout from '~components/app-layout';
+import Box from '~components/box';
+import Header from '~components/header';
+import Table from '~components/table';
+
+import { generateItems, Instance } from '../table/generate-data';
+import { columnsConfig } from '../table/shared-configs';
+import ScreenshotArea from '../utils/screenshot-area';
+import labels from './utils/labels';
+
+import styles from './styles.scss';
+
+const items = generateItems(20);
+
+export default function () {
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        ariaLabels={labels}
+        disableContentPaddings={true}
+        notifications={
+          <div className={styles.highlightBorder}>
+            <Box variant="h2">Notifications</Box>
+          </div>
+        }
+        stickyNotifications={true}
+        content={
+          <Table<Instance>
+            header={<Header variant="awsui-h1-sticky">Full-page table</Header>}
+            stickyHeader={true}
+            variant="full-page"
+            columnDefinitions={columnsConfig}
+            items={items}
+          />
+        }
+        navigation={<Box variant="h2">Navigation</Box>}
+        tools={<Box variant="h2">Tools</Box>}
+      />
+    </ScreenshotArea>
+  );
+}


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
