### PR TITLE
chore: returning the deprecated disableBodyScroll to AppLayoutToolbar

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
@@ -43,6 +43,7 @@ function AppLayoutGlobalDrawerImplementation({
     activeGlobalDrawersSizes,
     verticalOffsets,
     drawersOpenQueue,
+    disableBodyScroll,
   } = appLayoutInternals;
   const drawerRef = useRef<HTMLDivElement>(null);
   const activeDrawerId = activeGlobalDrawer?.id ?? '';
@@ -99,7 +100,7 @@ function AppLayoutGlobalDrawerImplementation({
             }}
             style={{
               blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)`,
-              insetBlockStart: drawersTopOffset,
+              ...(!disableBodyScroll ? { insetBlockStart: drawersTopOffset } : {}),
               ...(!isMobile && {
                 [customCssProps.drawerSize]: `${['entering', 'entered'].includes(state) ? size : 0}px`,
               }),

--- a/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
@@ -35,6 +35,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
     placement,
     verticalOffsets,
     drawersOpenQueue,
+    disableBodyScroll,
     onActiveDrawerChange,
     onActiveDrawerResize,
   } = appLayoutInternals;
@@ -86,7 +87,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
           }}
           style={{
             blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)`,
-            insetBlockStart: drawersTopOffset,
+            ...(!disableBodyScroll ? { insetBlockStart: drawersTopOffset } : {}),
             ...(!isMobile &&
               !isLegacyDrawer && {
                 [customCssProps.drawerSize]: `${['entering', 'entered'].includes(state) ? size : 0}px`,

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -60,6 +60,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       onSplitPanelResize,
       onSplitPanelPreferencesChange,
       disableContentPaddings,
+      disableBodyScroll,
       minContentWidth,
       maxContentWidth,
       placement,
@@ -332,6 +333,11 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       onNavigationToggle,
       onActiveDrawerChange: onActiveDrawerChangeHandler,
       onActiveDrawerResize,
+      disableBodyScroll,
+      //
+      // offsetBottom,
+      // stickyNotifications,
+      // notificationsHeight,
     };
 
     const splitPanelInternals: SplitPanelProviderProps = {
@@ -428,6 +434,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
           contentType={contentType}
           maxContentWidth={maxContentWidth}
           disableContentPaddings={disableContentPaddings}
+          disableBodyScroll={disableBodyScroll}
         />
       </>
     );

--- a/src/app-layout/visual-refresh-toolbar/interfaces.ts
+++ b/src/app-layout/visual-refresh-toolbar/interfaces.ts
@@ -40,6 +40,11 @@ export interface AppLayoutInternals {
   activeGlobalDrawersSizes: Record<string, number>;
   stickyNotifications: AppLayoutPropsWithDefaults['stickyNotifications'];
   breadcrumbs: React.ReactNode;
+  /**
+   * Needed for backward compatibility
+   * @deprecated
+   */
+  disableBodyScroll?: AppLayoutPropsWithDefaults['disableBodyScroll'];
   discoveredBreadcrumbs: BreadcrumbGroupProps | null;
   toolbarState: 'show' | 'hide';
   setToolbarState: (state: 'show' | 'hide') => void;

--- a/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
@@ -28,6 +28,7 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
     navigationFocusControl,
     placement,
     verticalOffsets,
+    disableBodyScroll,
   } = appLayoutInternals;
 
   const drawersTopOffset = getDrawerTopOffset(verticalOffsets, isMobile, placement);
@@ -59,7 +60,7 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
       onClick={onNavigationClick}
       style={{
         blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)`,
-        insetBlockStart: drawersTopOffset,
+        ...(!disableBodyScroll ? { insetBlockStart: drawersTopOffset } : {}),
       }}
     >
       <div className={clsx(styles['animated-content'])}>

--- a/src/app-layout/visual-refresh-toolbar/notifications/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/notifications/index.tsx
@@ -22,7 +22,8 @@ export function AppLayoutNotificationsImplementation({
   appLayoutInternals,
   children,
 }: AppLayoutNotificationsImplementationProps) {
-  const { ariaLabels, stickyNotifications, setNotificationsHeight, verticalOffsets } = appLayoutInternals;
+  const { ariaLabels, stickyNotifications, setNotificationsHeight, verticalOffsets, disableBodyScroll } =
+    appLayoutInternals;
   const ref = useRef<HTMLElement>(null);
   useResizeObserver(ref, entry => setNotificationsHeight(entry.borderBoxHeight));
   useEffect(() => {
@@ -41,7 +42,7 @@ export function AppLayoutNotificationsImplementation({
         appLayoutInternals.headerVariant !== 'high-contrast' && styles['sticky-notifications-with-background']
       )}
       style={{
-        insetBlockStart: stickyNotifications ? verticalOffsets.notifications : undefined,
+        insetBlockStart: !disableBodyScroll && stickyNotifications ? verticalOffsets.notifications : undefined,
       }}
     >
       <div className={testutilStyles.notifications} role="region" aria-label={ariaLabels?.notifications}>

--- a/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
@@ -24,6 +24,7 @@ interface SkeletonLayoutProps
     | 'contentType'
     | 'maxContentWidth'
     | 'disableContentPaddings'
+    | 'disableBodyScroll'
     | 'navigation'
     | 'navigationOpen'
     | 'navigationWidth'
@@ -63,18 +64,22 @@ export function SkeletonLayout({
   maxContentWidth,
   disableContentPaddings,
   globalToolsOpen,
+  disableBodyScroll,
 }: SkeletonLayoutProps) {
   const isMobile = useMobile();
   const isMaxWidth = maxContentWidth === Number.MAX_VALUE || maxContentWidth === Number.MAX_SAFE_INTEGER;
   const anyPanelOpen = navigationOpen || toolsOpen;
+
   return (
     <div
       className={clsx(styles.root, testutilStyles.root, {
         [styles['has-adaptive-widths-default']]: !contentTypeCustomWidths.includes(contentType),
         [styles['has-adaptive-widths-dashboard']]: contentType === 'dashboard',
+        [styles['disable-body-scroll']]: disableBodyScroll,
       })}
       style={{
-        minBlockSize: `calc(100vh - ${placement.insetBlockStart + placement.insetBlockEnd}px)`,
+        [disableBodyScroll ? 'blockSize' : 'minBlockSize']:
+          `calc(100vh - (${placement.insetBlockStart + placement.insetBlockEnd}px))`,
         [customCssProps.maxContentWidth]: isMaxWidth ? '100%' : maxContentWidth ? `${maxContentWidth}px` : '',
         [customCssProps.navigationWidth]: `${navigationWidth}px`,
         [customCssProps.toolsWidth]: `${toolsWidth}px`,
@@ -93,11 +98,18 @@ export function SkeletonLayout({
           {navigation}
         </div>
       )}
-      <main className={clsx(styles['main-landmark'], isMobile && anyPanelOpen && styles['unfocusable-mobile'])}>
+      <main
+        className={clsx(styles['main-landmark'], styles.layout, {
+          [styles['unfocusable-mobile']]: isMobile && anyPanelOpen,
+          [styles['disable-body-scroll']]: disableBodyScroll,
+          [testutilStyles['disable-body-scroll-root']]: disableBodyScroll,
+        })}
+      >
         {notifications && (
           <div
             className={clsx(
               styles['notifications-background'],
+
               headerVariant === 'high-contrast' && highContrastHeaderClassName
             )}
           ></div>

--- a/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
@@ -76,6 +76,11 @@
       }
     }
   }
+
+  &.disable-body-scroll {
+    overflow: hidden;
+    -moz-hidden-unscrollable: hidden;
+  }
 }
 
 .navigation,
@@ -171,11 +176,19 @@
   background: awsui.$color-background-layout-main;
   grid-area: notifications;
   @include grid-column-full-content-width;
+
+  &.disable-body-scroll {
+    block-size: 0;
+  }
 }
 
 .main-landmark {
   // does not participate in the layout, rendered for accessibility grouping
   display: contents;
+
+  &.disable-body-scroll {
+    overflow: auto;
+  }
 }
 
 .main {

--- a/src/app-layout/visual-refresh-toolbar/split-panel/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/split-panel/index.tsx
@@ -19,7 +19,7 @@ export function AppLayoutSplitPanelDrawerSideImplementation({
   appLayoutInternals,
   splitPanelInternals,
 }: AppLayoutSplitPanelDrawerSideImplementationProps) {
-  const { splitPanelControlId, placement, verticalOffsets } = appLayoutInternals;
+  const { splitPanelControlId, placement, verticalOffsets, disableBodyScroll } = appLayoutInternals;
   const drawerTopOffset = verticalOffsets.drawers ?? placement.insetBlockStart;
   return (
     <SplitPanelProvider {...splitPanelInternals}>
@@ -28,7 +28,7 @@ export function AppLayoutSplitPanelDrawerSideImplementation({
         className={styles['split-panel-side']}
         style={{
           blockSize: `calc(100vh - ${drawerTopOffset}px - ${placement.insetBlockEnd}px)`,
-          insetBlockStart: drawerTopOffset,
+          ...(!disableBodyScroll ? { insetBlockStart: drawerTopOffset } : {}),
         }}
       >
         {children}

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -45,6 +45,8 @@ export interface ToolbarProps {
   globalDrawers?: ReadonlyArray<AppLayoutProps.Drawer> | undefined;
   activeGlobalDrawersIds?: ReadonlyArray<string>;
   onActiveGlobalDrawersChange?: ((drawerId: string) => void) | undefined;
+
+  disableBodyScroll?: AppLayoutProps['disableBodyScroll'];
 }
 
 interface AppLayoutToolbarImplementationProps {
@@ -77,6 +79,7 @@ function convertLegacyProps(toolbarProps: ToolbarProps, legacyProps: AppLayoutIn
       position: legacyProps.splitPanelPosition,
     },
     onSplitPanelToggle: toolbarProps.onSplitPanelToggle ?? legacyProps.onSplitPanelToggle,
+    disableBodyScroll: legacyProps.disableBodyScroll,
   };
 }
 
@@ -95,6 +98,7 @@ export function AppLayoutToolbarImplementation({
     setToolbarState,
     setToolbarHeight,
     globalDrawersFocusControl,
+    disableBodyScroll,
   } = appLayoutInternals;
   const {
     ariaLabels,
@@ -173,7 +177,7 @@ export function AppLayoutToolbarImplementation({
         [styles['toolbar-hidden']]: toolbarHidden,
       })}
       style={{
-        insetBlockStart: toolbarHidden ? '-60px' : verticalOffsets.toolbar,
+        insetBlockStart: disableBodyScroll || toolbarHidden ? '-60px' : verticalOffsets.toolbar,
       }}
     >
       <div className={styles['toolbar-container']}>


### PR DESCRIPTION
### This is not complete. Needs to be resolved

This is just an exploration to see how to resolve this issue However it creates more. So we need to determine if it is worth it and the potential risks it exposes to re-establish the deprecated prop `disableBodyScroll` .

What needs to be done
- If needed, we need a way to have the the main content scrollable. Simple scss or adding the style inline is not allowing this
- We then need to add more styling so with the prop is not passed it does not mess anything up
- confirm no negative impacts on other pages, in visual refresh, with and without toolbar and classic
- does it take into account where there is no Footer

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
