### PR TITLE
chore: Cleanup and enable remaining toolbar app layout focus delegation tests 

### DIFF
--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -120,14 +120,17 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
         )
       );
 
-      //todo tools functionality needs to be added to toolbar
-      testIf(theme !== 'refresh-toolbar')(
-        'focuses tools panel closed button when it is opened using keyboard and caused split panel to change position',
+      test(
+        'focuses tools panel closed button when it is opened and caused split panel to change position',
         setupTest(
           async page => {
-            await page.setWindowSize({ width: 1000, height: 800 });
+            await page.setWindowSize({ width: 878, height: 800 });
             await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
-            await page.keys(['Tab', 'Tab', 'Tab', 'Tab', 'Enter']);
+            if (theme !== 'refresh-toolbar') {
+              await page.keys(['Tab', 'Tab', 'Tab', 'Tab', 'Enter']);
+            } else {
+              await page.click(wrapper.findToolsToggle().toSelector());
+            }
             await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
           },
           { pageName: 'with-split-panel', theme, mobile, splitPanelPosition: 'side' }

--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -121,16 +121,26 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
       );
 
       test(
-        'focuses tools panel closed button when it is opened and caused split panel to change position',
+        'focuses tools panel closed button when it is opened via keyboard and caused split panel to change position',
         setupTest(
           async page => {
-            await page.setWindowSize({ width: 878, height: 800 });
+            // Mobile nav is closed on page load
+            mobile && (await page.click(wrapper.findNavigationToggle().toSelector()));
+            await page.setWindowSize({ width: 1100, height: 800 });
             await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
+            await expect(page.isExisting(wrapper.findSplitPanel().findOpenPanelSide().toSelector())).resolves.toBe(
+              true
+            );
             if (theme !== 'refresh-toolbar') {
               await page.keys(['Tab', 'Tab', 'Tab', 'Tab', 'Enter']);
             } else {
-              await page.click(wrapper.findToolsToggle().toSelector());
+              // Click the current page in breadcrumb to reset focus to toolbar
+              await page.click(wrapper.findBreadcrumbs().findBreadcrumbGroup().findBreadcrumbLink(2).toSelector());
+              await page.keys(['Tab', 'Tab', 'Enter']);
             }
+            await expect(page.isExisting(wrapper.findSplitPanel().findOpenPanelBottom().toSelector())).resolves.toBe(
+              true
+            );
             await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
           },
           { pageName: 'with-split-panel', theme, mobile, splitPanelPosition: 'side' }

--- a/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
@@ -142,7 +142,6 @@ export function DrawerTriggers({
               selected={splitPanelToggleProps.active}
               ref={splitPanelFocusRef}
               hasTooltip={true}
-              testId={`awsui-app-layout-trigger-slide-panel`}
               isMobile={isMobile}
               isForSplitPanel={true}
               disabled={disabled}

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -300,7 +300,6 @@ function DesktopTriggers() {
             selected={hasSplitPanel && isSplitPanelOpen}
             ref={splitPanelRefs.toggle}
             highContrastHeader={headerVariant === 'high-contrast'}
-            testId="awsui-app-layout-trigger-slide-panel"
           />
         )}
       </div>


### PR DESCRIPTION
### Description

- Removed duplicated tests
- Removed unnecessary test id
- Edited and enabled remaining toolbar test. The tab order is different in vr-toolbar on split panel blur because the tab order follows DOM reading order, and toolbar comes before the main content in the toolbar version, thus focus should not go back to tools trigger.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
