### PR TITLE
chore: Add missing metrics for new disabled reason properties

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -6670,7 +6670,6 @@ is provided by its parent form field component.
       "type": "Array<DateRangePickerProps.TimeUnit>",
     },
     {
-      "defaultValue": "() => ''",
       "description": "Provides a reason why a particular date in the calendar is not enabled (only when \`isDateEnabled\` returns \`false\`).
 If provided, the date becomes focusable.",
       "inlineType": {

--- a/src/button-dropdown/index.tsx
+++ b/src/button-dropdown/index.tsx
@@ -10,7 +10,7 @@ import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { GeneratedAnalyticsMetadataButtonDropdownComponent } from './analytics-metadata/interfaces';
 import { ButtonDropdownProps } from './interfaces';
 import InternalButtonDropdown from './internal';
-import { hasCheckboxItems } from './utils/utils';
+import { hasCheckboxItems, hasDisabledReasonItems } from './utils/utils';
 
 import analyticsSelectors from './analytics-metadata/styles.css.js';
 
@@ -41,6 +41,8 @@ const ButtonDropdown = React.forwardRef(
       metadata: {
         mainAction: !!mainAction,
         checkboxItems: hasCheckboxItems(items),
+        hasDisabledReason: Boolean(disabledReason),
+        hasDisabledReasons: hasDisabledReasonItems(items),
       },
     });
     const baseProps = getBaseProps(props);

--- a/src/button-dropdown/utils/utils.ts
+++ b/src/button-dropdown/utils/utils.ts
@@ -47,3 +47,13 @@ export function hasCheckboxItems(items: ButtonDropdownProps.Items) {
   });
   return hasCheckboxItems;
 }
+
+export function hasDisabledReasonItems(items: ButtonDropdownProps.Items) {
+  let hasDisabledReasons = false;
+  traverseItems(items, item => {
+    if (item.disabledReason) {
+      hasDisabledReasons = true;
+    }
+  });
+  return hasDisabledReasons;
+}

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -44,6 +44,7 @@ const Button = React.forwardRef(
   ) => {
     const baseComponentProps = useBaseComponent('Button', {
       props: { formAction, fullWidth, iconAlign, iconName, rel, target, variant, wrapText },
+      metadata: { hasDisabledReason: Boolean(disabledReason) },
     });
     const baseProps = getBaseProps(props);
     return (

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -16,7 +16,12 @@ export default function Calendar({
   granularity = 'day',
   ...props
 }: CalendarProps) {
-  const baseComponentProps = useBaseComponent('Calendar');
+  const baseComponentProps = useBaseComponent('Calendar', {
+    props: { granularity },
+    metadata: {
+      hasDisabledReasons: Boolean(props.dateDisabledReason),
+    },
+  });
   return (
     <InternalCalendar
       {...props}

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -66,6 +66,7 @@ const DatePicker = React.forwardRef(
   ) => {
     const { __internalRootRef } = useBaseComponent('DatePicker', {
       props: { autoFocus, expandToViewport, granularity, readOnly },
+      metadata: { hasDisabledReasons: Boolean(dateDisabledReason) },
     });
     checkControlled('DatePicker', 'value', value, 'onChange', onChange);
 

--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -28,7 +28,6 @@ export interface DateRangePickerDropdownProps
       Required<DateRangePickerProps>,
       | 'locale'
       | 'isDateEnabled'
-      | 'dateDisabledReason'
       | 'isValidRange'
       | 'value'
       | 'relativeOptions'
@@ -46,6 +45,7 @@ export interface DateRangePickerDropdownProps
       | 'ariaDescribedby'
       | 'i18nStrings'
       | 'customRelativeRangeUnits'
+      | 'dateDisabledReason'
     > {
   onClear: () => void;
   onApply: (value: null | DateRangePickerProps.Value) => DateRangePickerProps.ValidationResult;
@@ -58,7 +58,7 @@ export function DateRangePickerDropdown({
   locale = '',
   startOfWeek,
   isDateEnabled,
-  dateDisabledReason,
+  dateDisabledReason = () => '',
   isValidRange,
   value,
   onClear: clearValue,

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -112,7 +112,7 @@ const DateRangePicker = React.forwardRef(
       locale = '',
       startOfWeek,
       isDateEnabled = () => true,
-      dateDisabledReason = () => '',
+      dateDisabledReason,
       value,
       placeholder,
       readOnly = false,
@@ -149,6 +149,7 @@ const DateRangePicker = React.forwardRef(
         timeInputFormat,
         hideTimeOffset,
       },
+      metadata: { hasDisabledReasons: Boolean(dateDisabledReason) },
     });
     checkControlled('DateRangePicker', 'value', value, 'onChange', onChange);
 

--- a/src/multiselect/index.tsx
+++ b/src/multiselect/index.tsx
@@ -38,6 +38,9 @@ const Multiselect = React.forwardRef(
         virtualScroll: restProps.virtualScroll,
         readOnly: restProps.readOnly,
       },
+      metadata: {
+        hasDisabledReasons: options.some(option => Boolean(option.disabledReason)),
+      },
     });
 
     // Private API for inline tokens

--- a/src/segmented-control/index.tsx
+++ b/src/segmented-control/index.tsx
@@ -10,7 +10,12 @@ import InternalSegmentedControl from './internal';
 export { SegmentedControlProps };
 
 export default function SegmentedControl(props: SegmentedControlProps) {
-  const baseComponentProps = useBaseComponent('SegmentedControl');
+  const baseComponentProps = useBaseComponent('SegmentedControl', {
+    props: {},
+    metadata: {
+      hasDisabledReasons: (props.options ?? []).some(option => Boolean(option.disabledReason)),
+    },
+  });
   return <InternalSegmentedControl {...props} {...baseComponentProps} />;
 }
 

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -37,6 +37,7 @@ const Select = React.forwardRef(
       },
       metadata: {
         hasInlineLabel: Boolean(restProps.inlineLabelText),
+        hasDisabledReasons: options.some(option => Boolean(option.disabledReason)),
       },
     });
     const externalProps = getExternalProps(restProps);

--- a/src/toggle-button/index.tsx
+++ b/src/toggle-button/index.tsx
@@ -37,6 +37,9 @@ const ToggleButton = React.forwardRef(
   ) => {
     const baseComponentProps = useBaseComponent('ToggleButton', {
       props: { iconName, pressedIconName, pressed, variant, wrapText },
+      metadata: {
+        hasDisabledReason: Boolean(disabledReason),
+      },
     });
     const baseProps = getBaseProps(props);
 


### PR DESCRIPTION
### Description

Adds missing metrics to new additions of disabled reason properties in some components.

Note on the naming: I've used `hasDisabledReason` for components that can only have a singular disabled reason (e.g., button), and `hasDisabledReasons` (plural) for components that can have multiple (e.g., date picker). This aligns with the previous addition of `hasDisabledReasons` for tabs: https://github.com/cloudscape-design/components/pull/2692/files.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
