### PR TITLE
fix: Fixes release workflow with shards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
       - run: npm run build
       - run: npm run test:unit
 
-  integTest:
-    name: Components integ tests
+  integTestShards:
+    name: Components integ tests shard
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -42,8 +42,16 @@ jobs:
       - run: npm run build
       - run: npm run test:integ -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
-  a11yTest:
-    name: Components a11y tests
+  integTest:
+    name: Components integ tests
+    runs-on: ubuntu-latest
+    needs:
+      - integTestShards
+    steps:
+      - run: echo "Completed all integration tests"
+
+  a11yTestShards:
+    name: Components a11y tests shard
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -57,6 +65,14 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run test:a11y -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+
+  a11yTest:
+    name: Components a11y tests
+    runs-on: ubuntu-latest
+    needs:
+      - a11yTestShards
+    steps:
+      - run: echo "Completed all a11y tests"
 
   release:
     uses: cloudscape-design/actions/.github/workflows/release.yml@main


### PR DESCRIPTION
### Description

Using the same setup as in https://github.com/cloudscape-design/actions/blob/main/.github/workflows/dry-run.yml

The setup requires all integ/a11y shards to complete before release is allowed.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
