### PR TITLE
fix: Adds flex-wrap to the property filter header

### DIFF
--- a/pages/app/styles.scss
+++ b/pages/app/styles.scss
@@ -30,3 +30,11 @@ body {
     }
   }
 }
+
+/*
+ This sets a background color to the page's container
+ to reveal the effects of negative z-index.
+*/
+:global(#app) {
+  background-color: tokens.$color-background-container-content;
+}

--- a/src/flashbar/collapsible.scss
+++ b/src/flashbar/collapsible.scss
@@ -90,8 +90,8 @@ the grid layout will be:
     );
   }
 
-  > .item:not(:last-child) > .flash::before,
-  > .item.flash::before {
+  > .item:not(:last-child) > .flash,
+  > .item.flash {
     box-shadow: awsui.$shadow-flash-collapsed;
   }
 }

--- a/src/flashbar/styles.scss
+++ b/src/flashbar/styles.scss
@@ -38,18 +38,7 @@
   color: awsui.$color-text-notification-default;
   overflow-wrap: break-word;
   word-wrap: break-word;
-
-  &::before {
-    @include styles.base-pseudo-element;
-    border-start-start-radius: awsui.$border-radius-flashbar;
-    border-start-end-radius: awsui.$border-radius-flashbar;
-    border-end-start-radius: awsui.$border-radius-flashbar;
-    border-end-end-radius: awsui.$border-radius-flashbar;
-    box-shadow: awsui.$shadow-flash-sticky;
-  }
-  &-refresh::before {
-    z-index: -1;
-  }
+  box-shadow: awsui.$shadow-flash-sticky;
 }
 
 .flash-list {


### PR DESCRIPTION
### Description

Fixes the property filter component overflowing its container in small screens.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-59283

### How has this been tested?

<!-- How did you test to verify your changes? -->

Visual tests dev pipeline.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
