### PR TITLE
chore: Make toolbar z-index the same that it was in vr and classic

### DIFF
--- a/src/app-layout/constants.scss
+++ b/src/app-layout/constants.scss
@@ -29,6 +29,8 @@ $dashboard-content-widths: (
 $drawer-z-index: 830;
 // should be above mobile toolbar
 $drawer-z-index-mobile: 1001;
+// used in both mobile toolbar and vr-toolbar
+$toolbar-z-index: 1000;
 
 // Shared toolbar drawer component values
 $toolbar-vertical-panel-icon-offset: 10px;

--- a/src/app-layout/mobile-toolbar/styles.scss
+++ b/src/app-layout/mobile-toolbar/styles.scss
@@ -16,7 +16,7 @@
   display: flex;
   align-items: center;
   flex-shrink: 0;
-  z-index: 1000;
+  z-index: constants.$toolbar-z-index;
   inline-size: 100%;
   box-sizing: border-box;
   background-color: awsui.$color-background-layout-mobile-panel;

--- a/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
@@ -6,6 +6,7 @@
 @use '../../../internal/styles' as styles;
 @use '../../../internal/styles/tokens' as awsui;
 @use '../../../internal/generated/custom-css-properties/index.scss' as custom-props;
+@use '../../constants.scss' as constants;
 
 .universal-toolbar {
   background-color: awsui.$color-background-layout-panel-content;
@@ -15,7 +16,7 @@
   //right padding set in child trigger-container below for focus indicator to show correctly
   padding-inline-end: 0;
   position: sticky;
-  z-index: 840;
+  z-index: constants.$toolbar-z-index;
   @include styles.with-motion {
     transition: ease awsui.$motion-duration-refresh-only-slow;
     transition-property: inset-block-start, opacity;

--- a/src/app-layout/visual-refresh/mobile-toolbar.scss
+++ b/src/app-layout/visual-refresh/mobile-toolbar.scss
@@ -6,6 +6,7 @@
 @use '../../internal/styles/' as styles;
 @use '../../internal/styles/tokens' as awsui;
 @use '../../internal/generated/custom-css-properties/index.scss' as custom-props;
+@use '../constants.scss' as constants;
 
 section.mobile-toolbar {
   align-items: center;
@@ -22,7 +23,7 @@ section.mobile-toolbar {
   padding-inline: awsui.$space-m;
   position: sticky;
   inset-block-start: var(#{custom-props.$offsetTop});
-  z-index: 1000;
+  z-index: constants.$toolbar-z-index;
   &:not(.remove-high-contrast-header) {
     background-color: awsui.$color-background-layout-main;
     box-shadow: awsui.$shadow-panel-toggle;


### PR DESCRIPTION
### Description

Reset the toolbar z-index to the same that was used in vr and classic to make it backward compatible.
This is to prevent breaking anyone who relied on the old z-indexes. For example, it broke a page in Systems Manager which implemented a custom scroll area which set `z-index: 999`.

![Screenshot 2024-10-08 at 18 08 48](https://github.com/user-attachments/assets/9ba03152-cef4-4091-9dec-e4801c4f617e)

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
