### PR TITLE
chore: Fix accidental margin on non-fit-height charts

### DIFF
--- a/src/internal/components/cartesian-chart/styles.scss
+++ b/src/internal/components/cartesian-chart/styles.scss
@@ -124,12 +124,11 @@
 .chart-container-outer {
   display: flex;
 
-  &:not(.axis-label + &, &.has-filters) {
-    margin-block-start: calc(0.5 * #{awsui.$font-chart-detail-size});
-  }
-
   &.fit-height {
     flex: 1;
+    &:not(.axis-label + &, &.has-filters) {
+      margin-block-start: calc(0.5 * #{awsui.$font-chart-detail-size});
+    }
   }
 }
 


### PR DESCRIPTION
### Description

Small fix for a styling regression introduced in #2853

Related links, issue #, if available: n/a

### How has this been tested?

Tested locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
