### PR TITLE
chore: Add `initialCheck` capability to alert/flash content API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "@types/react-resizable": "^1.7.4",
         "@types/react-router": "^5.1.18",
         "@types/react-router-dom": "^5.3.2",
+        "@types/react-test-renderer": "^18.3.0",
         "@types/react-transition-group": "^4.4.4",
         "@types/webpack-env": "^1.16.3",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
@@ -3568,6 +3569,15 @@
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router": "*"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.3.0.tgz",
+      "integrity": "sha512-HW4MuEYxfDbOHQsVlY/XtOvNHftCVEPhJF2pQXXwcUiUF+Oyb0usgp48HSgpK5rt8m9KZb22yqOeZm+rrVG8gw==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
   "devDependencies": {
     "@babel/core": "^7.23.7",
     "@babel/plugin-syntax-typescript": "^7.23.3",
-    "@cloudscape-design/build-tools": "^3.0.0",
     "@cloudscape-design/browser-test-tools": "^3.0.0",
+    "@cloudscape-design/build-tools": "^3.0.0",
     "@cloudscape-design/documenter": "^1.0.0",
     "@cloudscape-design/eslint-plugin": "file:build-tools/eslint",
     "@cloudscape-design/global-styles": "^1.0.0",
@@ -77,6 +77,7 @@
     "@types/react-resizable": "^1.7.4",
     "@types/react-router": "^5.1.18",
     "@types/react-router-dom": "^5.3.2",
+    "@types/react-test-renderer": "^18.3.0",
     "@types/react-transition-group": "^4.4.4",
     "@types/webpack-env": "^1.16.3",
     "@typescript-eslint/eslint-plugin": "^5.45.0",

--- a/pages/alert/runtime-content.page.tsx
+++ b/pages/alert/runtime-content.page.tsx
@@ -104,7 +104,11 @@ export default function () {
           <Checkbox onChange={e => setUrlParams({ loading: e.detail.checked })} checked={loading}>
             Content loading
           </Checkbox>
-          <Checkbox onChange={e => setUrlParams({ hidden: e.detail.checked })} checked={hidden}>
+          <Checkbox
+            onChange={e => setUrlParams({ hidden: e.detail.checked })}
+            checked={hidden}
+            data-testid="unmount-all"
+          >
             Unmount all
           </Checkbox>
           <Checkbox onChange={e => setUnrelatedState(e.detail.checked)} checked={unrelatedState}>
@@ -147,6 +151,7 @@ export default function () {
                 header="Header"
                 action={<Button>Action</Button>}
                 ref={alertRef}
+                data-testid="error-alert"
               >
                 {!contentSwapped ? content2 : content1}
               </Alert>

--- a/pages/alert/runtime-content.page.tsx
+++ b/pages/alert/runtime-content.page.tsx
@@ -63,7 +63,15 @@ awsuiPlugins.alertContent.registerContentReplacer({
     };
   },
   initialCheck(context) {
-    return context.type === 'error' && !!context.contentText?.match('Access denied');
+    return (
+      context.type === 'error' &&
+      !!(
+        context.content &&
+        typeof context.content === 'object' &&
+        'props' in context.content &&
+        context.content.props.children?.match('Access denied')
+      )
+    );
   },
 });
 

--- a/pages/alert/runtime-content.page.tsx
+++ b/pages/alert/runtime-content.page.tsx
@@ -60,6 +60,13 @@ awsuiPlugins.alertContent.registerContentReplacer({
       },
     };
   },
+  initialCheck(context) {
+    const found = context.type === 'error' && context.contentText?.match('Access denied');
+    return {
+      header: found ? 'remove' : 'original',
+      content: found ? 'replaced' : 'original',
+    };
+  },
 });
 
 const alertTypeOptions = ['error', 'warning', 'info', 'success'].map(type => ({ value: type }));
@@ -106,7 +113,7 @@ export default function () {
         <ScreenshotArea gutters={false}>
           {hidden ? null : (
             <SpaceBetween size="m">
-              <Alert
+              {/* <Alert
                 type={type}
                 statusIconAriaLabel={type}
                 dismissAriaLabel="Dismiss"
@@ -114,7 +121,7 @@ export default function () {
                 action={<Button>Action</Button>}
               >
                 {!contentSwapped ? content1 : content2}
-              </Alert>
+              </Alert> */}
 
               <Alert
                 type={type}

--- a/pages/flashbar/runtime-content.page.tsx
+++ b/pages/flashbar/runtime-content.page.tsx
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useContext, useState } from 'react';
+import React, { ReactNode, useContext, useState } from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
+import flattenChildren from 'react-keyed-flatten-children';
 
 import {
   Box,
@@ -23,6 +24,12 @@ import ScreenshotArea from '../utils/screenshot-area';
 type PageContext = React.Context<
   AppContextType<{ loading: boolean; hidden: boolean; stackItems: boolean; type: FlashbarProps.Type }>
 >;
+
+const nodeAsString = (node: ReactNode) =>
+  flattenChildren(node)
+    .map(node => (typeof node === 'object' ? node.props.children : node))
+    .filter(node => typeof node === 'string')
+    .join('');
 
 awsuiPlugins.flashContent.registerContentReplacer({
   id: 'awsui/flashbar-test-action',
@@ -62,9 +69,31 @@ awsuiPlugins.flashContent.registerContentReplacer({
       },
     };
   },
+  initialCheck(context) {
+    return context.type === 'error' && !!nodeAsString(context.content).match('Access denied');
+  },
 });
 
 const messageTypeOptions = ['error', 'warning', 'info', 'success'].map(type => ({ value: type }));
+
+const content = (
+  <>
+    <p>There was an error: Access denied because of XYZ</p>
+    <p>There was an error: Access denied because of XYZ</p>
+    <p>There was an error: Access denied because of XYZ</p>
+    <p>There was an error: Access denied because of XYZ</p>
+    <p>There was an error: Access denied because of XYZ</p>
+    <p>There was an error: Access denied because of XYZ</p>
+    <p>There was an error: Access denied because of XYZ</p>
+    <p>There was an error: Access denied because of XYZ</p>
+    <p>There was an error: Access denied because of XYZ</p>
+    <p>There was an error: Access denied because of XYZ</p>
+    <p>There was an error: Access denied because of XYZ</p>
+    <p>There was an error: Access denied because of XYZ</p>
+    <p>There was an error: Access denied because of XYZ</p>
+    <p>There was an error: Access denied because of XYZ</p>
+  </>
+);
 
 export default function () {
   const {
@@ -117,7 +146,7 @@ export default function () {
                   type,
                   statusIconAriaLabel: type,
                   header: 'Header',
-                  content: loading ? 'Loading...' : 'There was an error: Access denied because of XYZ',
+                  content: loading ? 'Loading...' : content,
                   action: <Button>Action</Button>,
                 },
               ]}

--- a/src/alert/__integ__/runtime-content.test.ts
+++ b/src/alert/__integ__/runtime-content.test.ts
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+import createWrapper from '../../../lib/components/test-utils/selectors';
+
+class RuntimeContentPage extends BasePageObject {
+  async rerenderAlerts() {
+    await this.click(createWrapper().findCheckbox('[data-testid="unmount-all"]').findNativeInput().toSelector());
+    await this.keys(['Space']);
+  }
+}
+
+function setupTest(testFn: (page: RuntimeContentPage) => Promise<void>) {
+  return useBrowser(async browser => {
+    const page = new RuntimeContentPage(browser);
+    await browser.url('#/light/alert/runtime-content/?autofocus=true');
+    await page.waitForVisible('.screenshot-area');
+    await testFn(page);
+  });
+}
+
+test(
+  'should focus the alert',
+  setupTest(async page => {
+    await page.rerenderAlerts();
+
+    await expect(page.getFocusedElementText()).resolves.toEqual(expect.stringContaining('---REPLACEMENT---'));
+    // (make sure entire page isn't focused)
+    await expect(page.getFocusedElementText()).resolves.toEqual(expect.not.stringContaining('Header'));
+  })
+);

--- a/src/alert/__tests__/runtime-content-initial.test.tsx
+++ b/src/alert/__tests__/runtime-content-initial.test.tsx
@@ -16,6 +16,8 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
+// In a separate file as mixing react-test-renderer and @testing-library/react in a single file can cause some issues.
+// We use react-test-renderer here as it works at a slightly lower level, so doesn't "hide" the first render cycle from tests.
 describe('initialCheck method', () => {
   let initialCheck: jest.Mock<boolean>;
   beforeEach(() => {

--- a/src/alert/__tests__/runtime-content-initial.test.tsx
+++ b/src/alert/__tests__/runtime-content-initial.test.tsx
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import testRenderer, { ReactTestRendererJSON } from 'react-test-renderer';
+
+import Alert from '../../../lib/components/alert';
+import awsuiPlugins from '../../../lib/components/internal/plugins';
+import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
+import { AlertFlashContentConfig } from '../../../lib/components/internal/plugins/controllers/alert-flash-content';
+
+import stylesCss from '../../../lib/components/alert/styles.css.js';
+
+afterEach(() => {
+  awsuiPluginsInternal.alertContent.clearRegisteredReplacer();
+  jest.resetAllMocks();
+  jest.restoreAllMocks();
+});
+
+describe('initialCheck method', () => {
+  let initialCheck: jest.Mock<boolean>;
+  beforeEach(() => {
+    initialCheck = jest.fn(() => true);
+    const plugin: AlertFlashContentConfig = {
+      id: 'plugin-1',
+      runReplacer: () => {
+        return { update: () => {}, unmount: () => {} };
+      },
+      initialCheck,
+    };
+    awsuiPlugins.alertContent.registerContentReplacer(plugin);
+  });
+
+  test('calls `initialCheck` method, and hides alert if true', () => {
+    const basicRender = testRenderer.create(<Alert type="error">Content</Alert>);
+    expect(initialCheck).toHaveBeenCalledTimes(1);
+    expect((basicRender.toJSON() as ReactTestRendererJSON).props.className.split(' ')).toEqual(
+      expect.arrayContaining([stylesCss['initial-hidden']])
+    );
+  });
+
+  test('re-shows alert on next render', () => {
+    const basicRender = testRenderer.create(<Alert type="error">Content</Alert>);
+    basicRender.update(<Alert type="error">Content</Alert>);
+    expect(initialCheck).toHaveBeenCalledTimes(1);
+    expect((basicRender.toJSON() as ReactTestRendererJSON).props.className.split(' ')).toEqual(
+      expect.not.arrayContaining([stylesCss['initial-hidden']])
+    );
+  });
+
+  test('does not hide alert if `initialCheck` returns false', () => {
+    initialCheck.mockReturnValue(false);
+    const basicRender = testRenderer.create(<Alert type="error">Content</Alert>);
+    expect((basicRender.toJSON() as ReactTestRendererJSON).props.className.split(' ')).toEqual(
+      expect.not.arrayContaining([stylesCss['initial-hidden']])
+    );
+  });
+});

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -71,6 +71,7 @@ const InternalAlert = React.forwardRef(
 
     const { discoveredActions, headerRef: headerRefAction, contentRef: contentRefAction } = useDiscoveredAction(type);
     const {
+      initialHidden,
       headerReplacementType,
       contentReplacementType,
       headerRef: headerRefContent,
@@ -100,7 +101,11 @@ const InternalAlert = React.forwardRef(
         {...baseProps}
         {...analyticsAttributes}
         aria-hidden={!visible}
-        className={clsx(styles.root, { [styles.hidden]: !visible }, baseProps.className)}
+        className={clsx(
+          styles.root,
+          { [styles.hidden]: !visible, [styles['initial-hidden']]: initialHidden },
+          baseProps.className
+        )}
         ref={mergedRef}
       >
         <LinkDefaultVariantContext.Provider value={{ defaultVariant: 'primary' }}>

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -39,7 +39,7 @@ const typeToIcon: Record<AlertProps.Type, IconProps['name']> = {
 type InternalAlertProps = SomeRequired<AlertProps, 'type'> & InternalBaseComponentProps<HTMLDivElement>;
 
 const useDiscoveredAction = createUseDiscoveredAction(awsuiPluginsInternal.alert.onActionRegistered);
-const useDiscoveredContent = createUseDiscoveredContent('alert', awsuiPluginsInternal.alertContent.onContentRegistered);
+const useDiscoveredContent = createUseDiscoveredContent('alert', awsuiPluginsInternal.alertContent);
 
 const InternalAlert = React.forwardRef(
   (

--- a/src/alert/styles.scss
+++ b/src/alert/styles.scss
@@ -56,11 +56,8 @@
 }
 // visibly hidden, but focusable
 .initial-hidden {
-  // TODO: decide if it should take up space:
-  opacity: 0;
-  // or be entirely hidden:
-  // overflow: hidden;
-  // height: 0;
+  overflow: hidden;
+  block-size: 0;
 }
 
 .header,

--- a/src/alert/styles.scss
+++ b/src/alert/styles.scss
@@ -54,6 +54,14 @@
 .hidden {
   display: none;
 }
+// visibly hidden, but focusable
+.initial-hidden {
+  // TODO: decide if it should take up space:
+  opacity: 0;
+  // or be entirely hidden:
+  // overflow: hidden;
+  // height: 0;
+}
 
 .header,
 .header-replacement {

--- a/src/flashbar/__tests__/runtime-content-initial.test.tsx
+++ b/src/flashbar/__tests__/runtime-content-initial.test.tsx
@@ -16,6 +16,8 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
+// In a separate file as mixing react-test-renderer and @testing-library/react in a single file can cause some issues.
+// We use react-test-renderer here as it works at a slightly lower level, so doesn't "hide" the first render cycle from tests.
 describe('initialCheck method', () => {
   let initialCheck: jest.Mock<boolean>;
   const getFirstFlash = (basicRender: ReactTestRenderer) =>

--- a/src/flashbar/__tests__/runtime-content-initial.test.tsx
+++ b/src/flashbar/__tests__/runtime-content-initial.test.tsx
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import testRenderer, { ReactTestRenderer, ReactTestRendererJSON } from 'react-test-renderer';
+
+import Flashbar from '../../../lib/components/flashbar';
+import awsuiPlugins from '../../../lib/components/internal/plugins';
+import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
+import { AlertFlashContentConfig } from '../../../lib/components/internal/plugins/controllers/alert-flash-content';
+
+import stylesCss from '../../../lib/components/flashbar/styles.css.js';
+
+afterEach(() => {
+  awsuiPluginsInternal.flashContent.clearRegisteredReplacer();
+  jest.resetAllMocks();
+  jest.restoreAllMocks();
+});
+
+describe('initialCheck method', () => {
+  let initialCheck: jest.Mock<boolean>;
+  const getFirstFlash = (basicRender: ReactTestRenderer) =>
+    (
+      ((basicRender.toJSON() as ReactTestRendererJSON).children![0] as ReactTestRendererJSON)
+        .children![0] as ReactTestRendererJSON
+    ).children![0] as ReactTestRendererJSON;
+  beforeEach(() => {
+    initialCheck = jest.fn(() => true);
+    const plugin: AlertFlashContentConfig = {
+      id: 'plugin-1',
+      runReplacer: () => {
+        return { update: () => {}, unmount: () => {} };
+      },
+      initialCheck,
+    };
+    awsuiPlugins.flashContent.registerContentReplacer(plugin);
+  });
+
+  test('calls `initialCheck` method, and hides flash if true', () => {
+    const basicRender = testRenderer.create(<Flashbar items={[{}]} />);
+    expect(initialCheck).toHaveBeenCalledTimes(1);
+    expect(getFirstFlash(basicRender).props.className.split(' ')).toEqual(
+      expect.arrayContaining([stylesCss['initial-hidden']])
+    );
+  });
+
+  test('re-shows alert on next render', () => {
+    const basicRender = testRenderer.create(<Flashbar items={[{}]} />);
+    basicRender.update(<Flashbar items={[{}]} />);
+    expect(initialCheck).toHaveBeenCalledTimes(1);
+    expect(getFirstFlash(basicRender).props.className.split(' ')).toEqual(
+      expect.not.arrayContaining([stylesCss['initial-hidden']])
+    );
+  });
+
+  test('does not hide flash if `initialCheck` returns false', () => {
+    initialCheck.mockReturnValue(false);
+    const basicRender = testRenderer.create(<Flashbar items={[{}]} />);
+    expect(initialCheck).toHaveBeenCalledTimes(1);
+    expect(getFirstFlash(basicRender).props.className.split(' ')).toEqual(
+      expect.not.arrayContaining([stylesCss['initial-hidden']])
+    );
+  });
+});

--- a/src/flashbar/flash.tsx
+++ b/src/flashbar/flash.tsx
@@ -124,6 +124,7 @@ export const Flash = React.forwardRef(
     const contentRefObject = useRef<HTMLDivElement>(null);
     const { discoveredActions, headerRef: headerRefAction, contentRef: contentRefAction } = useDiscoveredAction(type);
     const {
+      initialHidden,
       headerReplacementType,
       contentReplacementType,
       headerRef: headerRefContent,
@@ -174,7 +175,8 @@ export const Flash = React.forwardRef(
             [styles.exiting]: transitionState === 'exiting',
             [styles.exited]: transitionState === 'exited',
           },
-          getVisualContextClassname(type === 'warning' && !loading ? 'flashbar-warning' : 'flashbar')
+          getVisualContextClassname(type === 'warning' && !loading ? 'flashbar-warning' : 'flashbar'),
+          initialHidden && styles['initial-hidden']
         )}
         {...analyticsAttributes}
       >

--- a/src/flashbar/flash.tsx
+++ b/src/flashbar/flash.tsx
@@ -38,7 +38,7 @@ const ICON_TYPES = {
 } as const;
 
 const useDiscoveredAction = createUseDiscoveredAction(awsuiPluginsInternal.flashbar.onActionRegistered);
-const useDiscoveredContent = createUseDiscoveredContent('flash', awsuiPluginsInternal.flashContent.onContentRegistered);
+const useDiscoveredContent = createUseDiscoveredContent('flash', awsuiPluginsInternal.flashContent);
 
 function dismissButton(
   dismissLabel: FlashbarProps.MessageDefinition['dismissLabel'],

--- a/src/flashbar/styles.scss
+++ b/src/flashbar/styles.scss
@@ -52,6 +52,11 @@
   }
 }
 
+.initial-hidden {
+  overflow: hidden;
+  block-size: 0;
+}
+
 .flash-list {
   list-style: none;
   padding-block: 0;

--- a/src/internal/plugins/controllers/alert-flash-content.ts
+++ b/src/internal/plugins/controllers/alert-flash-content.ts
@@ -45,15 +45,10 @@ export interface AlertFlashContentResult {
   unmount: (containers: { replacementHeaderContainer: HTMLElement; replacementContentContainer: HTMLElement }) => void;
 }
 
-export interface AlertFlashContentInitialResult {
-  header: ReplacementType;
-  content: ReplacementType;
-}
-
 export interface AlertFlashContentConfig {
   id: string;
   runReplacer: (context: AlertFlashContentContext, replacementApi: ReplacementApi) => AlertFlashContentResult;
-  initialCheck?: (context: AlertFlashContentInitialContext) => AlertFlashContentInitialResult;
+  initialCheck?: (context: AlertFlashContentInitialContext) => boolean;
 }
 
 export type AlertFlashContentRegistrationListener = (provider: AlertFlashContentConfig) => () => void;
@@ -65,7 +60,7 @@ export interface AlertFlashContentApiPublic {
 export interface AlertFlashContentApiInternal {
   clearRegisteredReplacer(): void;
   onContentRegistered(listener: AlertFlashContentRegistrationListener): () => void;
-  initialSyncRender(context: AlertFlashContentInitialContextRaw): AlertFlashContentInitialResult;
+  initialCheck(context: AlertFlashContentInitialContextRaw): boolean;
 }
 
 const nodeAsString = (node: ReactNode) =>
@@ -107,7 +102,7 @@ export class AlertFlashContentController {
     this.#provider = undefined;
   };
 
-  initialSyncRender = (context: AlertFlashContentInitialContextRaw): AlertFlashContentInitialResult => {
+  initialCheck = (context: AlertFlashContentInitialContextRaw): boolean => {
     if (this.#provider?.initialCheck) {
       const processedContext: AlertFlashContentInitialContext = {
         type: context.type,
@@ -116,10 +111,7 @@ export class AlertFlashContentController {
       };
       return this.#provider.initialCheck(processedContext);
     }
-    return {
-      header: 'original',
-      content: 'original',
-    };
+    return false;
   };
 
   onContentRegistered = (listener: AlertFlashContentRegistrationListener) => {
@@ -145,7 +137,7 @@ export class AlertFlashContentController {
   installInternal(internalApi: Partial<AlertFlashContentApiInternal> = {}): AlertFlashContentApiInternal {
     internalApi.clearRegisteredReplacer ??= this.clearRegisteredReplacer;
     internalApi.onContentRegistered ??= this.onContentRegistered;
-    internalApi.initialSyncRender ??= this.initialSyncRender;
+    internalApi.initialCheck ??= this.initialCheck;
     return internalApi as AlertFlashContentApiInternal;
   }
 }

--- a/src/internal/plugins/controllers/alert-flash-content.ts
+++ b/src/internal/plugins/controllers/alert-flash-content.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ReactNode } from 'react';
-import flattenChildren from 'react-keyed-flatten-children';
 
 import debounce from '../../debounce';
 
@@ -17,16 +16,10 @@ export interface AlertFlashContentContext {
   contentRef: RefShim<HTMLElement>;
 }
 
-interface AlertFlashContentInitialContextRaw {
+interface AlertFlashContentInitialContext {
   type: string;
   header?: ReactNode;
   content?: ReactNode;
-}
-
-export interface AlertFlashContentInitialContext {
-  type: string;
-  headerText?: string;
-  contentText?: string;
 }
 
 export type ReplacementType = 'original' | 'remove' | 'replaced';
@@ -60,14 +53,8 @@ export interface AlertFlashContentApiPublic {
 export interface AlertFlashContentApiInternal {
   clearRegisteredReplacer(): void;
   onContentRegistered(listener: AlertFlashContentRegistrationListener): () => void;
-  initialCheck(context: AlertFlashContentInitialContextRaw): boolean;
+  initialCheck(context: AlertFlashContentInitialContext): boolean;
 }
-
-const nodeAsString = (node: ReactNode) =>
-  flattenChildren(node)
-    .map(node => (typeof node === 'object' ? node.props.children : node))
-    .filter(node => typeof node === 'string')
-    .join('');
 
 export class AlertFlashContentController {
   #listeners: Array<AlertFlashContentRegistrationListener> = [];
@@ -102,14 +89,9 @@ export class AlertFlashContentController {
     this.#provider = undefined;
   };
 
-  initialCheck = (context: AlertFlashContentInitialContextRaw): boolean => {
+  initialCheck = (context: AlertFlashContentInitialContext): boolean => {
     if (this.#provider?.initialCheck) {
-      const processedContext: AlertFlashContentInitialContext = {
-        type: context.type,
-        headerText: nodeAsString(context.header),
-        contentText: nodeAsString(context.content),
-      };
-      return this.#provider.initialCheck(processedContext);
+      return this.#provider.initialCheck(context);
     }
     return false;
   };

--- a/src/internal/plugins/helpers/use-discovered-content.tsx
+++ b/src/internal/plugins/helpers/use-discovered-content.tsx
@@ -22,19 +22,21 @@ export function createUseDiscoveredContent(componentName: string, controller: Al
     const contentRef = useRef<HTMLDivElement>(null);
     const replacementHeaderRef = useRef<HTMLDivElement>(null);
     const replacementContentRef = useRef<HTMLDivElement>(null);
-    const [initialState] = useState(() =>
-      controller.initialSyncRender({
+    const [initialHidden, setInitialHidden] = useState(() =>
+      controller.initialCheck({
         type,
         header,
         content: children,
       })
     );
-    const [headerReplacementType, setFoundHeaderReplacement] = useState<ReplacementType>(initialState.header);
-    const [contentReplacementType, setFoundContentReplacement] = useState<ReplacementType>(initialState.content);
+    const [headerReplacementType, setFoundHeaderReplacement] = useState<ReplacementType>('original');
+    const [contentReplacementType, setFoundContentReplacement] = useState<ReplacementType>('original');
     const mountedProvider = useRef<AlertFlashContentResult | undefined>();
 
     useEffect(() => {
       const context = { type, headerRef, contentRef };
+
+      setInitialHidden(false);
 
       return controller.onContentRegistered(provider => {
         let mounted = true;
@@ -99,6 +101,7 @@ export function createUseDiscoveredContent(componentName: string, controller: Al
     }, [type, header, children]);
 
     return {
+      initialHidden,
       headerReplacementType,
       contentReplacementType,
       headerRef: headerRef as React.Ref<HTMLDivElement>,

--- a/src/internal/plugins/helpers/use-discovered-content.tsx
+++ b/src/internal/plugins/helpers/use-discovered-content.tsx
@@ -3,15 +3,12 @@
 import { ReactNode, useEffect, useRef, useState } from 'react';
 
 import {
-  AlertFlashContentController,
+  AlertFlashContentApiInternal,
   AlertFlashContentResult,
   ReplacementType,
 } from '../controllers/alert-flash-content';
 
-export function createUseDiscoveredContent(
-  componentName: string,
-  onContentRegistered: AlertFlashContentController['onContentRegistered']
-) {
+export function createUseDiscoveredContent(componentName: string, controller: AlertFlashContentApiInternal) {
   return function useDiscoveredContent({
     type,
     header,
@@ -25,14 +22,21 @@ export function createUseDiscoveredContent(
     const contentRef = useRef<HTMLDivElement>(null);
     const replacementHeaderRef = useRef<HTMLDivElement>(null);
     const replacementContentRef = useRef<HTMLDivElement>(null);
-    const [headerReplacementType, setFoundHeaderReplacement] = useState<ReplacementType>('original');
-    const [contentReplacementType, setFoundContentReplacement] = useState<ReplacementType>('original');
+    const [initialState] = useState(() =>
+      controller.initialSyncRender({
+        type,
+        header,
+        content: children,
+      })
+    );
+    const [headerReplacementType, setFoundHeaderReplacement] = useState<ReplacementType>(initialState.header);
+    const [contentReplacementType, setFoundContentReplacement] = useState<ReplacementType>(initialState.content);
     const mountedProvider = useRef<AlertFlashContentResult | undefined>();
 
     useEffect(() => {
       const context = { type, headerRef, contentRef };
 
-      return onContentRegistered(provider => {
+      return controller.onContentRegistered(provider => {
         let mounted = true;
 
         function checkMounted(methodName: string) {


### PR DESCRIPTION
### Description

Add capability to conditionally hide the initial render of alerts and flashes. This reduces the layout shift
that occurs when the alert/flash content is then replaced via runtime API.

Related links, issue #, if available: n/a

### How has this been tested?

New unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
