### PR TITLE
chore: Fixes flakiness in expandable rows integ test

### DIFF
--- a/pages/table/expandable-rows-test.page.tsx
+++ b/pages/table/expandable-rows-test.page.tsx
@@ -31,13 +31,14 @@ import messages from '~components/i18n/messages/all.en';
 import SpaceBetween from '~components/space-between';
 
 import AppContext, { AppContextType } from '../app/app-context';
-import { WindowWithFlushResponse } from '../common/flush-response';
+import { enhanceWindow, WindowWithFlushResponse } from '../common/flush-response';
 import { ariaLabels, getHeaderCounterText, Instance } from './expandable-rows/common';
 import { createColumns, createPreferences, filteringProperties } from './expandable-rows/expandable-rows-configs';
 import { allInstances } from './expandable-rows/expandable-rows-data';
 import { EmptyState, getMatchesCountText, renderAriaLive } from './shared-configs';
 
 declare const window: WindowWithFlushResponse;
+enhanceWindow();
 
 type LoadingState = Map<string, { pages: number; status: TableProps.LoadingStatus }>;
 

--- a/src/table/__integ__/expandable-rows.test.ts
+++ b/src/table/__integ__/expandable-rows.test.ts
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { range } from 'lodash';
 
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
@@ -46,7 +45,8 @@ describe('Expandable rows', () => {
     })
   );
 
-  test.each(range(0, 100))('uses items loader on the first expandable item, i=%s', () =>
+  test(
+    'uses items loader on the first expandable item, i=%s',
     setupTest({ useProgressiveLoading: true, useServerMock: true }, async page => {
       const targetCluster = 'cluster-33387b6c';
       const targetClusterLoadMore = tableWrapper.findItemsLoaderByItemId(targetCluster).findButton();
@@ -85,6 +85,6 @@ describe('Expandable rows', () => {
       await page.flushResponse();
       await page.waitForAssertion(() => expect(page.isFocused(page3Toggle.toSelector())).resolves.toBe(true));
       await page.waitForAssertion(() => expect(getRowsCount()).resolves.toBe(15 + 1));
-    })()
+    })
   );
 });

--- a/src/table/__integ__/expandable-rows.test.ts
+++ b/src/table/__integ__/expandable-rows.test.ts
@@ -46,7 +46,7 @@ describe('Expandable rows', () => {
   );
 
   test(
-    'uses items loader on the first expandable item, i=%s',
+    'uses items loader on the first expandable item',
     setupTest({ useProgressiveLoading: true, useServerMock: true }, async page => {
       const targetCluster = 'cluster-33387b6c';
       const targetClusterLoadMore = tableWrapper.findItemsLoaderByItemId(targetCluster).findButton();


### PR DESCRIPTION
### Description

Removing dependency on test page timeout in expandable rows integ tests.

Similar fix: https://github.com/cloudscape-design/components/pull/2883

### How has this been tested?

* Validated by running the test over 100 times in GitHub actions

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
