### PR TITLE
chore: Fixes flakiness in dropdown width test

### DIFF
--- a/pages/common/flush-response.ts
+++ b/pages/common/flush-response.ts
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export interface WindowWithFlushResponse extends Window {
+  __pendingCallbacks: Array<() => void>;
+  __flushServerResponse: () => void;
+}
+declare const window: WindowWithFlushResponse;
+
+window.__pendingCallbacks = [];
+window.__flushServerResponse = () => {
+  for (const cb of window.__pendingCallbacks) {
+    cb();
+  }
+  window.__pendingCallbacks = [];
+};

--- a/pages/common/flush-response.ts
+++ b/pages/common/flush-response.ts
@@ -7,10 +7,12 @@ export interface WindowWithFlushResponse extends Window {
 }
 declare const window: WindowWithFlushResponse;
 
-window.__pendingCallbacks = [];
-window.__flushServerResponse = () => {
-  for (const cb of window.__pendingCallbacks) {
-    cb();
-  }
+export function enhanceWindow() {
   window.__pendingCallbacks = [];
-};
+  window.__flushServerResponse = () => {
+    for (const cb of window.__pendingCallbacks) {
+      cb();
+    }
+    window.__pendingCallbacks = [];
+  };
+}

--- a/pages/dropdown/width.page.tsx
+++ b/pages/dropdown/width.page.tsx
@@ -9,9 +9,10 @@ import Select, { SelectProps } from '~components/select';
 import SpaceBetween from '~components/space-between';
 
 import AppContext, { AppContextType } from '../app/app-context';
-import { WindowWithFlushResponse } from '../common/flush-response';
+import { enhanceWindow, WindowWithFlushResponse } from '../common/flush-response';
 
 declare const window: WindowWithFlushResponse;
+enhanceWindow();
 
 type DemoContext = React.Context<
   AppContextType<{

--- a/pages/dropdown/width.page.tsx
+++ b/pages/dropdown/width.page.tsx
@@ -9,6 +9,9 @@ import Select, { SelectProps } from '~components/select';
 import SpaceBetween from '~components/space-between';
 
 import AppContext, { AppContextType } from '../app/app-context';
+import { WindowWithFlushResponse } from '../common/flush-response';
+
+declare const window: WindowWithFlushResponse;
 
 type DemoContext = React.Context<
   AppContextType<{
@@ -18,6 +21,7 @@ type DemoContext = React.Context<
     virtualScroll: boolean;
     expandToViewport: boolean;
     containerWidth: string;
+    manualServerMock: boolean;
   }>
 >;
 
@@ -207,12 +211,17 @@ function CustomSelect({ expandToViewport, loading, onOpen, onClose, virtualScrol
 
 export default function () {
   const { urlParams } = useContext(AppContext as DemoContext);
-  const { asyncLoading, component, triggerWidth, virtualScroll, expandToViewport, containerWidth } = urlParams;
+  const { asyncLoading, component, triggerWidth, virtualScroll, expandToViewport, containerWidth, manualServerMock } =
+    urlParams;
   const [loading, setLoading] = useState(asyncLoading);
   const onOpen = () => {
     if (asyncLoading) {
       setLoading(true);
-      setTimeout(() => setLoading(false), 500);
+      if (manualServerMock) {
+        window.__pendingCallbacks.push(() => setLoading(false));
+      } else {
+        setTimeout(() => setLoading(false), 500);
+      }
     }
   };
   const onClose = () => setLoading(asyncLoading);

--- a/src/__integ__/page-objects/async-response-page.ts
+++ b/src/__integ__/page-objects/async-response-page.ts
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+
+interface ExtendedWindow extends Window {
+  __flushServerResponse: () => void;
+}
+declare const window: ExtendedWindow;
+
+export class AsyncResponsePage extends BasePageObject {
+  flushResponse() {
+    return this.browser.execute(() => window.__flushServerResponse());
+  }
+}

--- a/src/internal/components/dropdown/__integ__/width.test.ts
+++ b/src/internal/components/dropdown/__integ__/width.test.ts
@@ -1,13 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper from '../../../../../lib/components/test-utils/selectors';
+import { AsyncResponsePage } from '../../../../__integ__/page-objects/async-response-page';
 
 type ComponentId = 'autosuggest' | 'multiselect' | 'select';
 
-export class DropdownPageObject extends BasePageObject {
+export class DropdownPageObject extends AsyncResponsePage {
   getWrapperAndTrigger(componentId: ComponentId) {
     const wrapper = createWrapper();
     let componentWrapper;
@@ -55,7 +55,7 @@ function setupTest(
 ) {
   return useBrowser({ width: pageWidth, height: 1000 }, async browser => {
     await browser.url(
-      `#/light/dropdown/width?component=${componentId}&expandToViewport=${expandToViewport}&triggerWidth=${triggerWidth}px&asyncLoading=${asyncLoading}`
+      `#/light/dropdown/width?component=${componentId}&expandToViewport=${expandToViewport}&triggerWidth=${triggerWidth}px&asyncLoading=${asyncLoading}&manualServerMock=${asyncLoading}`
     );
     const page = new DropdownPageObject(browser);
     await page.waitForVisible(page.getWrapperAndTrigger(componentId).wrapper.toSelector());
@@ -148,9 +148,8 @@ describe('Dropdown width', () => {
         });
         expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
         await expect(page.getText(dropdownSelector)).resolves.toContain('Loading');
-        await page.waitUntil(async () => (await page.getText(dropdownSelector)).includes('A very'), {
-          timeout: 1000,
-        });
+        await page.flushResponse();
+        await expect(page.getText(dropdownSelector)).resolves.toContain('A very');
         const newBox = await page.getBoundingBox(dropdownSelector);
         expect(newBox.left + newBox.width).toBeLessThanOrEqual(pageWidth);
       }


### PR DESCRIPTION
### Description

Removing dependency on test page timeout in dropdown width integ tests.

Similar fix: https://github.com/cloudscape-design/components/pull/2882

### How has this been tested?

* Validated by running the test over 100 times in GitHub actions

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
