### PR TITLE
fix: Fix forwardRef warning in split panel

### DIFF
--- a/src/internal/widgets/__tests__/widgets.test.tsx
+++ b/src/internal/widgets/__tests__/widgets.test.tsx
@@ -4,28 +4,12 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import { useVisualRefresh } from '../../../../lib/components/internal/hooks/use-visual-mode';
-import { createWidgetizedComponent, createWidgetizedForwardRef } from '../../../../lib/components/internal/widgets';
+import { createWidgetizedComponent } from '../../../../lib/components/internal/widgets';
 import { describeWithAppLayoutFeatureFlagEnabled } from './utils';
 
 const LoaderSkeleton = () => <div data-testid="loader">Loading...</div>;
 const RealComponent = () => <div data-testid="content">Real content</div>;
 const WidgetizedComponent = createWidgetizedComponent(RealComponent)(LoaderSkeleton);
-
-const LoaderWithRef = React.forwardRef<HTMLDivElement>((props, ref) => (
-  <div ref={ref} data-testid="loader">
-    Loading...
-  </div>
-));
-const RealComponentWithRef = React.forwardRef<HTMLDivElement>((props, ref) => (
-  <div ref={ref} data-testid="content">
-    Real content
-  </div>
-));
-const WidgetizedComponentWithRef = createWidgetizedForwardRef<
-  { children?: React.ReactNode },
-  HTMLDivElement,
-  typeof RealComponentWithRef
->(RealComponentWithRef)(LoaderWithRef);
 
 function findLoader(container: HTMLElement) {
   return container.querySelector('[data-testid="loader"]');
@@ -74,26 +58,6 @@ describe('Refresh design', () => {
       const { container } = render(<WidgetizedComponent />);
       expect(findContent(container)).toBeFalsy();
       expect(findLoader(container)).toBeTruthy();
-    });
-  });
-});
-
-describe('Ref handling', () => {
-  test('should forward ref to content', () => {
-    const ref = React.createRef<HTMLDivElement>();
-    const { container } = render(<WidgetizedComponentWithRef ref={ref} />);
-    expect(findContent(container)).toBeTruthy();
-    expect(findLoader(container)).toBeFalsy();
-    expect(ref.current).toHaveTextContent('Real content');
-  });
-
-  describeWithAppLayoutFeatureFlagEnabled(() => {
-    test('should forward ref to loader', () => {
-      const ref = React.createRef<HTMLDivElement>();
-      const { container } = render(<WidgetizedComponentWithRef ref={ref} />);
-      expect(findContent(container)).toBeFalsy();
-      expect(findLoader(container)).toBeTruthy();
-      expect(ref.current).toHaveTextContent('Loading...');
     });
   });
 });

--- a/src/internal/widgets/index.tsx
+++ b/src/internal/widgets/index.tsx
@@ -21,20 +21,3 @@ export function createWidgetizedComponent<Component extends FunctionComponent<an
     }) as Component;
   };
 }
-
-export function createWidgetizedForwardRef<
-  Props,
-  RefType,
-  Component extends React.ForwardRefExoticComponent<Props & React.RefAttributes<RefType>>,
->(Implementation: Component) {
-  return (Loader?: Component): Component => {
-    return React.forwardRef<RefType, Props>((props, ref) => {
-      const isRefresh = useVisualRefresh();
-      if (isRefresh && getGlobalFlag('appLayoutWidget') && Loader) {
-        return <Loader ref={ref} {...(props as any)} />;
-      }
-
-      return <Implementation ref={ref} {...(props as any)} />;
-    }) as Component;
-  };
-}

--- a/src/split-panel/__tests__/widgetized-panel.test.tsx
+++ b/src/split-panel/__tests__/widgetized-panel.test.tsx
@@ -5,15 +5,17 @@ import { render } from '@testing-library/react';
 
 import { SplitPanelContextProvider } from '../../../lib/components/internal/context/split-panel-context';
 import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-visual-mode';
-import { createWidgetizedSplitPanel } from '../../../lib/components/split-panel/implementation';
-import { SplitPanelProps } from '../../../lib/components/split-panel/interfaces';
+import {
+  createWidgetizedSplitPanel,
+  SplitPanelImplementationProps,
+} from '../../../lib/components/split-panel/implementation';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { describeWithAppLayoutFeatureFlagEnabled } from '../../internal/widgets/__tests__/utils';
 import { defaultSplitPanelContextProps } from './helpers';
 
-const LoaderSkeleton = React.forwardRef<HTMLElement, SplitPanelProps>(() => {
+const LoaderSkeleton = () => {
   return <div data-testid="loader">Loading...</div>;
-});
+};
 
 function findLoader(container: HTMLElement) {
   return container.querySelector('[data-testid="loader"]');
@@ -32,8 +34,10 @@ function renderComponent(jsx: React.ReactElement) {
 
 const WidgetizedPanel = createWidgetizedSplitPanel(LoaderSkeleton);
 
-const defaultProps: SplitPanelProps = {
+const defaultProps: SplitPanelImplementationProps = {
   header: '',
+  hidePreferencesButton: false,
+  closeBehavior: 'collapse',
   children: <></>,
 };
 

--- a/src/split-panel/implementation.tsx
+++ b/src/split-panel/implementation.tsx
@@ -11,11 +11,13 @@ import { InternalButton } from '../button/internal';
 import { getBaseProps } from '../internal/base-component';
 import PanelResizeHandle from '../internal/components/panel-resize-handle';
 import { useSplitPanelContext } from '../internal/context/split-panel-context';
+import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import globalVars from '../internal/styles/global-vars';
-import { createWidgetizedForwardRef } from '../internal/widgets';
+import { SomeRequired } from '../internal/types';
+import { createWidgetizedComponent } from '../internal/widgets';
 import { SplitPanelContentBottom } from './bottom';
 import { SplitPanelProps } from './interfaces';
 import PreferencesModal from './preferences-modal';
@@ -24,133 +26,134 @@ import { SplitPanelContentSide } from './side';
 import styles from './styles.css.js';
 import testUtilStyles from './test-classes/styles.css.js';
 
-export { SplitPanelProps };
+export type SplitPanelImplementationProps = SomeRequired<SplitPanelProps, 'hidePreferencesButton' | 'closeBehavior'> &
+  InternalBaseComponentProps;
 
-export const SplitPanelImplementation = React.forwardRef<HTMLElement, SplitPanelProps>(
-  (
-    { header, children, hidePreferencesButton = false, closeBehavior = 'collapse', i18nStrings = {}, ...restProps },
-    __internalRootRef
-  ) => {
-    const isRefresh = useVisualRefresh();
-    const isToolbar = useAppLayoutToolbarEnabled();
+export function SplitPanelImplementation({
+  __internalRootRef,
+  header,
+  children,
+  hidePreferencesButton,
+  closeBehavior,
+  i18nStrings = {},
+  ...restProps
+}: SplitPanelImplementationProps) {
+  const isRefresh = useVisualRefresh();
+  const isToolbar = useAppLayoutToolbarEnabled();
 
-    const {
-      position,
-      topOffset,
-      bottomOffset,
-      rightOffset,
-      contentWidthStyles,
-      isOpen,
-      isForcedPosition,
-      onPreferencesChange,
-      onResize,
-      onToggle,
-      size,
-      relativeSize,
-      setSplitPanelToggle,
-      refs,
-    } = useSplitPanelContext();
-    const baseProps = getBaseProps(restProps);
-    const [isPreferencesOpen, setPreferencesOpen] = useState<boolean>(false);
+  const {
+    position,
+    topOffset,
+    bottomOffset,
+    rightOffset,
+    contentWidthStyles,
+    isOpen,
+    isForcedPosition,
+    onPreferencesChange,
+    onResize,
+    onToggle,
+    size,
+    relativeSize,
+    setSplitPanelToggle,
+    refs,
+  } = useSplitPanelContext();
+  const baseProps = getBaseProps(restProps);
+  const [isPreferencesOpen, setPreferencesOpen] = useState<boolean>(false);
 
-    const appLayoutMaxWidth = isRefresh && position === 'bottom' ? contentWidthStyles : undefined;
+  const appLayoutMaxWidth = isRefresh && position === 'bottom' ? contentWidthStyles : undefined;
 
-    const openButtonAriaLabel = i18nStrings.openButtonAriaLabel;
-    useEffect(() => {
-      setSplitPanelToggle({ displayed: closeBehavior === 'collapse', ariaLabel: openButtonAriaLabel });
+  const openButtonAriaLabel = i18nStrings.openButtonAriaLabel;
+  useEffect(() => {
+    setSplitPanelToggle({ displayed: closeBehavior === 'collapse', ariaLabel: openButtonAriaLabel });
 
-      return () => {
-        setSplitPanelToggle({ displayed: false, ariaLabel: undefined });
-      };
-    }, [setSplitPanelToggle, openButtonAriaLabel, closeBehavior]);
-
-    const splitPanelRefObject = useRef<HTMLDivElement>(null);
-
-    const sizeControlProps: SizeControlProps = {
-      position,
-      panelRef: splitPanelRefObject,
-      handleRef: refs.slider,
-      onResize,
-      hasTransitions: true,
+    return () => {
+      setSplitPanelToggle({ displayed: false, ariaLabel: undefined });
     };
-    const onSliderPointerDown = usePointerEvents(sizeControlProps);
-    const onKeyDown = useKeyboardEvents(sizeControlProps);
+  }, [setSplitPanelToggle, openButtonAriaLabel, closeBehavior]);
 
-    const contentStyle = {
-      [globalVars.stickyVerticalTopOffset]: topOffset,
-      [globalVars.stickyVerticalBottomOffset]: bottomOffset,
-    };
+  const splitPanelRefObject = useRef<HTMLDivElement>(null);
 
-    const panelHeaderId = useUniqueId('split-panel-header');
+  const sizeControlProps: SizeControlProps = {
+    position,
+    panelRef: splitPanelRefObject,
+    handleRef: refs.slider,
+    onResize,
+    hasTransitions: true,
+  };
+  const onSliderPointerDown = usePointerEvents(sizeControlProps);
+  const onKeyDown = useKeyboardEvents(sizeControlProps);
 
-    const wrappedHeader = (
-      <div className={clsx(styles.header, isToolbar && styles['with-toolbar'])} style={appLayoutMaxWidth}>
-        <h2 className={clsx(styles['header-text'], testUtilStyles['header-text'])} id={panelHeaderId}>
-          {header}
-        </h2>
-        <div className={styles['header-actions']}>
-          {!hidePreferencesButton && isOpen && (
-            <>
-              <InternalButton
-                className={testUtilStyles['preferences-button']}
-                iconName="settings"
-                variant="icon"
-                onClick={() => setPreferencesOpen(true)}
-                formAction="none"
-                ariaLabel={i18nStrings.preferencesTitle}
-                ref={refs.preferences}
-              />
-              <span className={styles.divider} />
-            </>
-          )}
+  const contentStyle = {
+    [globalVars.stickyVerticalTopOffset]: topOffset,
+    [globalVars.stickyVerticalBottomOffset]: bottomOffset,
+  };
 
-          {isOpen ? (
+  const panelHeaderId = useUniqueId('split-panel-header');
+
+  const wrappedHeader = (
+    <div className={clsx(styles.header, isToolbar && styles['with-toolbar'])} style={appLayoutMaxWidth}>
+      <h2 className={clsx(styles['header-text'], testUtilStyles['header-text'])} id={panelHeaderId}>
+        {header}
+      </h2>
+      <div className={styles['header-actions']}>
+        {!hidePreferencesButton && isOpen && (
+          <>
             <InternalButton
-              className={testUtilStyles['close-button']}
-              iconName={
-                isRefresh && closeBehavior === 'collapse'
-                  ? position === 'side'
-                    ? 'angle-right'
-                    : 'angle-down'
-                  : 'close'
-              }
+              className={testUtilStyles['preferences-button']}
+              iconName="settings"
               variant="icon"
-              onClick={onToggle}
+              onClick={() => setPreferencesOpen(true)}
               formAction="none"
-              ariaLabel={i18nStrings.closeButtonAriaLabel}
-              ariaExpanded={isOpen}
+              ariaLabel={i18nStrings.preferencesTitle}
+              ref={refs.preferences}
             />
-          ) : isToolbar || position === 'side' ? null : (
-            <InternalButton
-              className={testUtilStyles['open-button']}
-              iconName="angle-up"
-              variant="icon"
-              formAction="none"
-              ariaLabel={i18nStrings.openButtonAriaLabel}
-              ref={refs.toggle}
-              ariaExpanded={isOpen}
-            />
-          )}
-        </div>
+            <span className={styles.divider} />
+          </>
+        )}
+
+        {isOpen ? (
+          <InternalButton
+            className={testUtilStyles['close-button']}
+            iconName={
+              isRefresh && closeBehavior === 'collapse' ? (position === 'side' ? 'angle-right' : 'angle-down') : 'close'
+            }
+            variant="icon"
+            onClick={onToggle}
+            formAction="none"
+            ariaLabel={i18nStrings.closeButtonAriaLabel}
+            ariaExpanded={isOpen}
+          />
+        ) : isToolbar || position === 'side' ? null : (
+          <InternalButton
+            className={testUtilStyles['open-button']}
+            iconName="angle-up"
+            variant="icon"
+            formAction="none"
+            ariaLabel={i18nStrings.openButtonAriaLabel}
+            ref={refs.toggle}
+            ariaExpanded={isOpen}
+          />
+        )}
       </div>
-    );
+    </div>
+  );
 
-    const resizeHandle = (
-      <PanelResizeHandle
-        ref={refs.slider}
-        className={testUtilStyles.slider}
-        ariaLabel={i18nStrings.resizeHandleAriaLabel}
-        // Allows us to use the logical left/right keys to move the slider left/right,
-        // but match aria keyboard behavior of using left/right to decrease/increase
-        // the slider value.
-        ariaValuenow={position === 'bottom' ? relativeSize : 100 - relativeSize}
-        position={position}
-        onKeyDown={onKeyDown}
-        onPointerDown={onSliderPointerDown}
-      />
-    );
+  const resizeHandle = (
+    <PanelResizeHandle
+      ref={refs.slider}
+      className={testUtilStyles.slider}
+      ariaLabel={i18nStrings.resizeHandleAriaLabel}
+      // Allows us to use the logical left/right keys to move the slider left/right,
+      // but match aria keyboard behavior of using left/right to decrease/increase
+      // the slider value.
+      ariaValuenow={position === 'bottom' ? relativeSize : 100 - relativeSize}
+      position={position}
+      onKeyDown={onKeyDown}
+      onPointerDown={onSliderPointerDown}
+    />
+  );
 
-    /*
+  /*
     This effect forces the browser to recalculate the layout
     whenever the split panel might have moved.
 
@@ -158,106 +161,101 @@ export const SplitPanelImplementation = React.forwardRef<HTMLElement, SplitPanel
     not automatically calculate the new position of the split panel
     _content_ when the split panel moves.
   */
-    useLayoutEffect(() => {
-      const root = splitPanelRefObject.current;
+  useLayoutEffect(() => {
+    const root = splitPanelRefObject.current;
 
-      if (root) {
-        const property = 'transform';
-        const temporaryValue = 'translateZ(0)';
+    if (root) {
+      const property = 'transform';
+      const temporaryValue = 'translateZ(0)';
 
-        const valueBefore = root.style[property];
-        root.style[property] = temporaryValue;
+      const valueBefore = root.style[property];
+      root.style[property] = temporaryValue;
 
-        // This line forces the browser to recalculate the layout
-        void root.offsetHeight;
+      // This line forces the browser to recalculate the layout
+      void root.offsetHeight;
 
-        root.style[property] = valueBefore;
-      }
-    }, [rightOffset, __internalRootRef]);
-
-    const mergedRef = useMergeRefs(splitPanelRefObject, __internalRootRef);
-
-    if (closeBehavior === 'hide' && !isOpen) {
-      return <></>;
+      root.style[property] = valueBefore;
     }
+  }, [rightOffset, __internalRootRef]);
 
-    /**
-     * The AppLayout factor moved the circular buttons out of the
-     * SplitPanel and into the Tools component. This conditional
-     * is still needed for the early return to prevent execution
-     * of the following code.
-     */
-    if (isRefresh && !isToolbar && !isOpen && position === 'side') {
-      return <></>;
-    }
+  const mergedRef = useMergeRefs(splitPanelRefObject, __internalRootRef);
 
-    return (
-      <>
-        {position === 'side' && (
-          <SplitPanelContentSide
-            style={contentStyle}
-            resizeHandle={resizeHandle}
-            baseProps={baseProps}
-            isOpen={isOpen}
-            splitPanelRef={mergedRef}
-            cappedSize={size}
-            onToggle={onToggle}
-            openButtonAriaLabel={openButtonAriaLabel}
-            toggleRef={refs.toggle}
-            header={wrappedHeader}
-            panelHeaderId={panelHeaderId}
-          >
-            {children}
-          </SplitPanelContentSide>
-        )}
-
-        {position === 'bottom' && (
-          <SplitPanelContentBottom
-            style={contentStyle}
-            resizeHandle={resizeHandle}
-            baseProps={baseProps}
-            isOpen={isOpen}
-            splitPanelRef={mergedRef}
-            cappedSize={size}
-            onToggle={onToggle}
-            header={wrappedHeader}
-            panelHeaderId={panelHeaderId}
-            appLayoutMaxWidth={appLayoutMaxWidth}
-          >
-            {children}
-          </SplitPanelContentBottom>
-        )}
-        {isPreferencesOpen && (
-          <PreferencesModal
-            visible={true}
-            preferences={{ position }}
-            disabledSidePosition={position === 'bottom' && isForcedPosition}
-            isRefresh={isRefresh}
-            i18nStrings={{
-              header: i18nStrings.preferencesTitle,
-              confirm: i18nStrings.preferencesConfirm,
-              cancel: i18nStrings.preferencesCancel,
-              positionLabel: i18nStrings.preferencesPositionLabel,
-              positionDescription: i18nStrings.preferencesPositionDescription,
-              positionBottom: i18nStrings.preferencesPositionBottom,
-              positionSide: i18nStrings.preferencesPositionSide,
-            }}
-            onConfirm={preferences => {
-              onPreferencesChange({ ...preferences });
-              setPreferencesOpen(false);
-            }}
-            onDismiss={() => {
-              setPreferencesOpen(false);
-            }}
-          />
-        )}
-      </>
-    );
+  if (closeBehavior === 'hide' && !isOpen) {
+    return <></>;
   }
-);
 
-export const createWidgetizedSplitPanel = createWidgetizedForwardRef<
-  SplitPanelProps,
-  HTMLElement,
-  typeof SplitPanelImplementation
->(SplitPanelImplementation);
+  /**
+   * The AppLayout factor moved the circular buttons out of the
+   * SplitPanel and into the Tools component. This conditional
+   * is still needed for the early return to prevent execution
+   * of the following code.
+   */
+  if (isRefresh && !isToolbar && !isOpen && position === 'side') {
+    return <></>;
+  }
+
+  return (
+    <>
+      {position === 'side' && (
+        <SplitPanelContentSide
+          style={contentStyle}
+          resizeHandle={resizeHandle}
+          baseProps={baseProps}
+          isOpen={isOpen}
+          splitPanelRef={mergedRef}
+          cappedSize={size}
+          onToggle={onToggle}
+          openButtonAriaLabel={openButtonAriaLabel}
+          toggleRef={refs.toggle}
+          header={wrappedHeader}
+          panelHeaderId={panelHeaderId}
+        >
+          {children}
+        </SplitPanelContentSide>
+      )}
+
+      {position === 'bottom' && (
+        <SplitPanelContentBottom
+          style={contentStyle}
+          resizeHandle={resizeHandle}
+          baseProps={baseProps}
+          isOpen={isOpen}
+          splitPanelRef={mergedRef}
+          cappedSize={size}
+          onToggle={onToggle}
+          header={wrappedHeader}
+          panelHeaderId={panelHeaderId}
+          appLayoutMaxWidth={appLayoutMaxWidth}
+        >
+          {children}
+        </SplitPanelContentBottom>
+      )}
+      {isPreferencesOpen && (
+        <PreferencesModal
+          visible={true}
+          preferences={{ position }}
+          disabledSidePosition={position === 'bottom' && isForcedPosition}
+          isRefresh={isRefresh}
+          i18nStrings={{
+            header: i18nStrings.preferencesTitle,
+            confirm: i18nStrings.preferencesConfirm,
+            cancel: i18nStrings.preferencesCancel,
+            positionLabel: i18nStrings.preferencesPositionLabel,
+            positionDescription: i18nStrings.preferencesPositionDescription,
+            positionBottom: i18nStrings.preferencesPositionBottom,
+            positionSide: i18nStrings.preferencesPositionSide,
+          }}
+          onConfirm={preferences => {
+            onPreferencesChange({ ...preferences });
+            setPreferencesOpen(false);
+          }}
+          onDismiss={() => {
+            setPreferencesOpen(false);
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+export const createWidgetizedSplitPanel = createWidgetizedComponent(SplitPanelImplementation);

--- a/src/split-panel/index.tsx
+++ b/src/split-panel/index.tsx
@@ -23,7 +23,7 @@ export default function SplitPanel({
   return (
     <SplitPanelInternal
       {...restProps}
-      ref={__internalRootRef}
+      __internalRootRef={__internalRootRef}
       hidePreferencesButton={hidePreferencesButton}
       closeBehavior={closeBehavior}
       i18nStrings={{


### PR DESCRIPTION
### Description

Replace forwardRef with a plain component to fix this React warning:

```
Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()
```

Related links, issue #, if available: n/a

### How has this been tested?

Locally, because it is only a warning

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
