### PR TITLE
fix: Fixes collection prefs filtering when column labels are not strings and filtering is disabled

### DIFF
--- a/src/collection-preferences/content-display/__tests__/content-display.test.tsx
+++ b/src/collection-preferences/content-display/__tests__/content-display.test.tsx
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import React from 'react';
 import { fireEvent } from '@testing-library/react';
 
 import { CollectionPreferencesProps } from '../../../../lib/components';
@@ -255,6 +256,8 @@ describe('Content Display preference', () => {
         contentDisplayPreference: {
           ...contentDisplayPreference,
           enableColumnFiltering: false,
+          // Adding an option with a non-string label to ensure the filter does not break rendering
+          options: [...contentDisplayPreference.options, { id: 'id-extra', label: (<span>Extra</span>) as any }],
         },
       });
       const filterInput = wrapper.findTextFilter();

--- a/src/collection-preferences/content-display/index.tsx
+++ b/src/collection-preferences/content-display/index.tsx
@@ -17,7 +17,7 @@ import ContentDisplayOption from './content-display-option';
 import DraggableOption from './draggable-option';
 import useDragAndDropReorder from './use-drag-and-drop-reorder';
 import useLiveAnnouncements from './use-live-announcements';
-import { getSortedOptions, OptionWithVisibility } from './utils';
+import { getFilteredOptions, getSortedOptions, OptionWithVisibility } from './utils';
 
 import styles from '../styles.css.js';
 
@@ -60,10 +60,7 @@ export default function ContentDisplayPreference({
   const descriptionId = `${idPrefix}-description`;
 
   const sortedAndFilteredOptions = useMemo(
-    () =>
-      getSortedOptions({ options, contentDisplay: value }).filter(option =>
-        option.label.toLowerCase().trim().includes(columnFilteringText.toLowerCase().trim())
-      ),
+    () => getFilteredOptions(getSortedOptions({ options, contentDisplay: value }), columnFilteringText),
     [columnFilteringText, options, value]
   );
 

--- a/src/collection-preferences/content-display/utils.ts
+++ b/src/collection-preferences/content-display/utils.ts
@@ -24,3 +24,16 @@ export function getSortedOptions({
     }))
     .filter(Boolean);
 }
+
+export function getFilteredOptions(
+  options: ReadonlyArray<CollectionPreferencesProps.ContentDisplayOption>,
+  filterText: string
+) {
+  filterText = filterText.trim().toLowerCase();
+
+  if (!filterText) {
+    return options;
+  }
+
+  return options.filter(option => option.label.toLowerCase().trim().includes(filterText));
+}


### PR DESCRIPTION
### Description

Option labels in collection prefs must be strings but it is technically possible to use React nodes.

The PR fixes component rendering for this case but only when the filtering feature is not activated.

Rel: AWSUI-59826

### How has this been tested?

* Updated unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
