### PR TITLE
fix: Constain main content when content paddings are disabled in toolbar

### DIFF
--- a/pages/app-layout/disable-paddings-with-split-panel.page.tsx
+++ b/pages/app-layout/disable-paddings-with-split-panel.page.tsx
@@ -1,16 +1,29 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useContext } from 'react';
 
-import AppLayout from '~components/app-layout';
+import AppLayout, { AppLayoutProps } from '~components/app-layout';
 import Box from '~components/box';
 import SplitPanel from '~components/split-panel';
 
+import AppContext, { AppContextType } from '../app/app-context';
 import { Breadcrumbs, Navigation, Tools } from './utils/content-blocks';
 import labels from './utils/labels';
 import * as toolsContent from './utils/tools-content';
 
+type SplitPanelDemoContext = React.Context<
+  AppContextType<{
+    splitPanelPosition: AppLayoutProps.SplitPanelPreferences['position'];
+    splitPanelOpen: boolean;
+  }>
+>;
+
 export default function () {
+  const {
+    urlParams: { splitPanelPosition, splitPanelOpen = false },
+    setUrlParams,
+  } = useContext(AppContext as SplitPanelDemoContext);
+
   return (
     <AppLayout
       disableContentPaddings={true}
@@ -18,6 +31,13 @@ export default function () {
       breadcrumbs={<Breadcrumbs />}
       navigation={<Navigation />}
       tools={<Tools>{toolsContent.long}</Tools>}
+      splitPanelPreferences={{ position: splitPanelPosition }}
+      onSplitPanelPreferencesChange={event => {
+        const { position } = event.detail;
+        setUrlParams({ splitPanelPosition: position === 'side' ? position : undefined });
+      }}
+      splitPanelOpen={splitPanelOpen}
+      onSplitPanelToggle={event => setUrlParams({ splitPanelOpen: event.detail.open })}
       splitPanel={
         <SplitPanel
           header="Split panel header"
@@ -37,7 +57,13 @@ export default function () {
           <Box>Content</Box>
         </SplitPanel>
       }
-      content={<Box variant="h1">Content</Box>}
+      content={
+        <Box padding="m">
+          <div style={{ border: '1px solid magenta' }}>
+            <Box variant="h1">Content</Box>
+          </div>
+        </Box>
+      }
     />
   );
 }

--- a/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
@@ -22,7 +22,7 @@
 @mixin grid-column-full-content-width {
   grid-column: 1 / -1;
   @include desktop-only {
-    grid-column: 2 / span 4;
+    grid-column: 2 / 5;
   }
 }
 
@@ -139,7 +139,10 @@
   z-index: 840;
   align-self: end;
   grid-area: main;
-  @include grid-column-full-content-width;
+  grid-column: 1 / -1;
+  @include desktop-only {
+    grid-column: 2 / span 4;
+  }
 }
 
 .panel-hidden {


### PR DESCRIPTION
### Description

Currently, when `disableContentPaddings=true`, the content of the toolbar goes behind the Split panel.
<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
