### PR TITLE
chore: Expose private API to disable breadcrumbs globalization

### DIFF
--- a/src/app-layout/__tests__/global-breadcrumbs.test.tsx
+++ b/src/app-layout/__tests__/global-breadcrumbs.test.tsx
@@ -248,6 +248,19 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
       expect(findRootBreadcrumb().getElement()).toHaveTextContent('Static');
     });
   });
+
+  test('allows opt-out from this behavior', async () => {
+    render(
+      <AppLayout
+        breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />}
+        content={<BreadcrumbGroup items={[{ text: 'Local', href: '' }]} {...{ __disableGlobalization: true }} />}
+      />
+    );
+    await waitFor(() =>
+      expect(wrapper.findAppLayout()!.find('[data-awsui-discovered-breadcrumbs="true"]')).toBeTruthy()
+    );
+    expect(findAllBreadcrumbsInstances()).toHaveLength(2);
+  });
 });
 
 describe('without feature flag', () => {

--- a/src/internal/plugins/helpers/use-global-breadcrumbs.ts
+++ b/src/internal/plugins/helpers/use-global-breadcrumbs.ts
@@ -7,11 +7,17 @@ import { BreadcrumbGroupProps } from '../../../breadcrumb-group/interfaces';
 import { awsuiPluginsInternal } from '../api';
 import { BreadcrumbsGlobalRegistration } from '../controllers/breadcrumbs';
 
-function useSetGlobalBreadcrumbsImplementation(props: BreadcrumbGroupProps<any>) {
+function useSetGlobalBreadcrumbsImplementation({
+  __disableGlobalization,
+  ...props
+}: BreadcrumbGroupProps<any> & { __disableGlobalization?: boolean }) {
   const registrationRef = useRef<BreadcrumbsGlobalRegistration<BreadcrumbGroupProps> | null>();
   const [registered, setRegistered] = useState(false);
 
   useEffect(() => {
+    if (__disableGlobalization) {
+      return;
+    }
     const registration = awsuiPluginsInternal.breadcrumbs.registerBreadcrumbs(props, () => setRegistered(true));
     registrationRef.current = registration;
 
@@ -20,7 +26,7 @@ function useSetGlobalBreadcrumbsImplementation(props: BreadcrumbGroupProps<any>)
     };
     // subsequent prop changes are handled by another effect
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [__disableGlobalization]);
 
   useLayoutEffect(() => {
     registrationRef.current?.update(props);


### PR DESCRIPTION
### Description

App Layout toolbar automatically absorbs all BreadcrumbGroup instances from the page to place them into the toolbar slot.

This feature allows to opt out with this code

```
<BreadcrumbGroup items={[{ text: 'Local', href: '' }]} {...{ __disableGlobalization: true }} />
```


Related links, issue #, if available: n/a

### How has this been tested?

Added unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
