### PR TITLE
fix: Prevent breadcrumbs from flickering when rendered inside app layout toolbar breadcrumbs slot

### DIFF
--- a/src/app-layout/__tests__/global-breadcrumbs.test.tsx
+++ b/src/app-layout/__tests__/global-breadcrumbs.test.tsx
@@ -29,6 +29,10 @@ function findAllBreadcrumbsInstances() {
   return wrapper.findAllByClassName(BreadcrumbGroupWrapper.rootSelector);
 }
 
+function findDiscoveredBreadcrumbs() {
+  return wrapper.findAppLayout()!.find('[data-awsui-discovered-breadcrumbs="true"]');
+}
+
 function findAppLayoutBreadcrumbItems() {
   return wrapper.findAppLayout()!.findBreadcrumbs()!.findBreadcrumbGroup()!.findBreadcrumbLinks();
 }
@@ -45,7 +49,7 @@ function delay() {
 async function renderAsync(jsx: React.ReactElement) {
   render(jsx);
   await waitFor(() => {
-    expect(wrapper.findAppLayout()!.find('[data-awsui-discovered-breadcrumbs="true"]')).toBeTruthy();
+    expect(findDiscoveredBreadcrumbs()).toBeTruthy();
     expect(findAllBreadcrumbsInstances()).toHaveLength(1);
   });
 }
@@ -69,14 +73,17 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
     expect(wrapper.findBreadcrumbGroup()!.findBreadcrumbLinks()).toHaveLength(2);
   });
 
-  test('renders breadcrumbs inside app layout breadcrumbs slot', async () => {
-    await renderAsync(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+  test('renders normal breadcrumbs when placed inside the breadcrumbs slot', async () => {
+    render(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+    await delay();
+    expect(findDiscoveredBreadcrumbs()).toBeFalsy();
     expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
   });
 
   test('no relocation happens on the initial render', () => {
     render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
     expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(findDiscoveredBreadcrumbs()).toBeFalsy();
     expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
     expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
   });
@@ -108,15 +115,17 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
     );
   });
 
-  test('when breadcrumbs are rendered in multiple slots, the last one takes precedence', async () => {
-    await renderAsync(
+  test('when breadcrumbs are rendered in multiple slots, the one in the breadcrumbs slot takes precedence', async () => {
+    render(
       <AppLayout
         breadcrumbs={<BreadcrumbGroup items={[{ text: 'First', href: '/first' }]} />}
         content={<BreadcrumbGroup items={[{ text: 'Second', href: '/second' }]} />}
       />
     );
-    expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
-    expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
+    await delay();
+    expect(findAllBreadcrumbsInstances()).toHaveLength(2);
+    expect(findDiscoveredBreadcrumbs()).toBeFalsy();
+    expect(findRootBreadcrumb().getElement()).toHaveTextContent('First');
   });
 
   test('when multiple breadcrumbs instances are present the latest is applied', async () => {

--- a/src/app-layout/visual-refresh-toolbar/contexts.ts
+++ b/src/app-layout/visual-refresh-toolbar/contexts.ts
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { awsuiPluginsInternal } from '../../internal/plugins/api';
+
+interface BreadcrumbsSlotContextType {
+  isInToolbar: boolean;
+}
+
+export const BreadcrumbsSlotContext =
+  awsuiPluginsInternal.sharedReactContexts.createContext<BreadcrumbsSlotContextType>(React, 'BreadcrumbsSlotContext');

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -282,7 +282,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
     });
 
     const hasToolbar = !embeddedViewMode && !!toolbarProps;
-    const discoveredBreadcrumbs = useGetGlobalBreadcrumbs(hasToolbar);
+    const discoveredBreadcrumbs = useGetGlobalBreadcrumbs(hasToolbar && !breadcrumbs);
 
     const verticalOffsets = computeVerticalLayout({
       topOffset: placement.insetBlockStart,

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -9,6 +9,7 @@ import { BreadcrumbGroupImplementation } from '../../../breadcrumb-group/impleme
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { AppLayoutProps } from '../../interfaces';
 import { Focusable, FocusControlMultipleStates } from '../../utils/use-focus-control';
+import { BreadcrumbsSlotContext } from '../contexts';
 import { AppLayoutInternals } from '../interfaces';
 import { ToolbarSlot } from '../skeleton/slot-wrappers';
 import { DrawerTriggers, SplitPanelToggleProps } from './drawer-triggers';
@@ -193,14 +194,16 @@ export function AppLayoutToolbarImplementation({
         )}
         {(breadcrumbs || discoveredBreadcrumbs) && (
           <div className={clsx(styles['universal-toolbar-breadcrumbs'], testutilStyles.breadcrumbs)}>
-            {breadcrumbs}
-            {discoveredBreadcrumbs && (
-              <BreadcrumbGroupImplementation
-                {...discoveredBreadcrumbs}
-                data-awsui-discovered-breadcrumbs={true}
-                __injectAnalyticsComponentMetadata={true}
-              />
-            )}
+            <BreadcrumbsSlotContext.Provider value={{ isInToolbar: true }}>
+              {breadcrumbs ||
+                (discoveredBreadcrumbs && (
+                  <BreadcrumbGroupImplementation
+                    {...discoveredBreadcrumbs}
+                    data-awsui-discovered-breadcrumbs={true}
+                    __injectAnalyticsComponentMetadata={true}
+                  />
+                ))}
+            </BreadcrumbsSlotContext.Provider>
           </div>
         )}
         {((drawers && drawers.length > 0) || (hasSplitPanel && splitPanelToggleProps?.displayed)) && (

--- a/src/internal/plugins/api.ts
+++ b/src/internal/plugins/api.ts
@@ -10,6 +10,7 @@ import {
 import { AppLayoutWidgetApiInternal, AppLayoutWidgetController } from './controllers/app-layout-widget';
 import { BreadcrumbsApiInternal, BreadcrumbsController } from './controllers/breadcrumbs';
 import { DrawersApiInternal, DrawersApiPublic, DrawersController } from './controllers/drawers';
+import { SharedReactContexts, SharedReactContextsApiInternal } from './controllers/shared-react-contexts';
 
 const storageKey = Symbol.for('awsui-plugin-api');
 
@@ -29,6 +30,7 @@ interface AwsuiApi {
     flashbar: ActionsApiInternal;
     flashContent: AlertFlashContentApiInternal;
     breadcrumbs: BreadcrumbsApiInternal<BreadcrumbGroupProps>;
+    sharedReactContexts: SharedReactContextsApiInternal;
   };
 }
 
@@ -99,6 +101,11 @@ function installApi(api: DeepPartial<AwsuiApi>): AwsuiApi {
 
   const breadcrumbs = new BreadcrumbsController<BreadcrumbGroupProps>();
   api.awsuiPluginsInternal.breadcrumbs = breadcrumbs.installInternal(api.awsuiPluginsInternal.breadcrumbs);
+
+  const sharedReactContexts = new SharedReactContexts();
+  api.awsuiPluginsInternal.sharedReactContexts = sharedReactContexts.installInternal(
+    api.awsuiPluginsInternal.sharedReactContexts
+  );
 
   return api as AwsuiApi;
 }

--- a/src/internal/plugins/controllers/__tests__/shared-react-contexts.test.ts
+++ b/src/internal/plugins/controllers/__tests__/shared-react-contexts.test.ts
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { SharedReactContexts } from '../../../../../lib/components/internal/plugins/controllers/shared-react-contexts';
+
+test('returns the same context for the same React and the name', () => {
+  const contexts = new SharedReactContexts();
+  const first = contexts.createContext(React, 'testing');
+  const second = contexts.createContext(React, 'testing');
+  expect(first).toBeTruthy();
+  expect(second).toBeTruthy();
+  expect(first).toBe(second);
+});
+
+test('returns different contexts for different names', () => {
+  const contexts = new SharedReactContexts();
+  const first = contexts.createContext(React, 'testing1');
+  const second = contexts.createContext(React, 'testing2');
+  expect(first).toBeTruthy();
+  expect(second).toBeTruthy();
+  expect(first).not.toBe(second);
+});
+
+test('returns different contexts for different react instances', () => {
+  const firstReact = { createContext: jest.fn().mockReturnValue({}) };
+  const secondReact = { createContext: jest.fn().mockReturnValue({}) };
+  const contexts = new SharedReactContexts();
+  const first = contexts.createContext(firstReact as unknown as typeof React, 'testing');
+  const second = contexts.createContext(secondReact as unknown as typeof React, 'testing');
+  expect(first).toBeTruthy();
+  expect(second).toBeTruthy();
+  expect(firstReact.createContext).toHaveBeenCalledTimes(1);
+  expect(secondReact.createContext).toHaveBeenCalledTimes(1);
+  expect(first).not.toBe(second);
+});

--- a/src/internal/plugins/controllers/shared-react-contexts.ts
+++ b/src/internal/plugins/controllers/shared-react-contexts.ts
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+export interface SharedReactContextsApiInternal {
+  createContext: <T>(ReactInstance: typeof React, contextName: string) => React.Context<T | undefined>;
+}
+
+export class SharedReactContexts {
+  #registeredContexts = new WeakMap<typeof React, Map<string, React.Context<any>>>();
+
+  createContext = <T>(ReactInstance: typeof React, contextName: string) => {
+    let contexts = this.#registeredContexts.get(ReactInstance);
+    if (!contexts) {
+      contexts = new Map();
+      this.#registeredContexts.set(ReactInstance, contexts);
+    }
+
+    let cachedContext = contexts.get(contextName);
+
+    if (!cachedContext) {
+      cachedContext = ReactInstance.createContext<T>(undefined as T);
+      contexts.set(contextName, cachedContext);
+    }
+
+    return cachedContext;
+  };
+
+  installInternal(internalApi: Partial<SharedReactContextsApiInternal> = {}): SharedReactContextsApiInternal {
+    internalApi.createContext ??= this.createContext;
+    return internalApi as SharedReactContextsApiInternal;
+  }
+}

--- a/src/internal/plugins/helpers/use-global-breadcrumbs.ts
+++ b/src/internal/plugins/helpers/use-global-breadcrumbs.ts
@@ -1,17 +1,22 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { useAppLayoutToolbarEnabled } from '../../../app-layout/utils/feature-flags';
+import { BreadcrumbsSlotContext } from '../../../app-layout/visual-refresh-toolbar/contexts';
 import { BreadcrumbGroupProps } from '../../../breadcrumb-group/interfaces';
 import { awsuiPluginsInternal } from '../api';
 import { BreadcrumbsGlobalRegistration } from '../controllers/breadcrumbs';
 
 function useSetGlobalBreadcrumbsImplementation(props: BreadcrumbGroupProps<any>) {
+  const { isInToolbar } = useContext(BreadcrumbsSlotContext) ?? {};
   const registrationRef = useRef<BreadcrumbsGlobalRegistration<BreadcrumbGroupProps> | null>();
   const [registered, setRegistered] = useState(false);
 
   useEffect(() => {
+    if (isInToolbar) {
+      return;
+    }
     const registration = awsuiPluginsInternal.breadcrumbs.registerBreadcrumbs(props, () => setRegistered(true));
     registrationRef.current = registration;
 
@@ -20,7 +25,7 @@ function useSetGlobalBreadcrumbsImplementation(props: BreadcrumbGroupProps<any>)
     };
     // subsequent prop changes are handled by another effect
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isInToolbar]);
 
   useLayoutEffect(() => {
     registrationRef.current?.update(props);


### PR DESCRIPTION
### Description

When breadcrumbs are already rendered in the expected slot, there is no need for the runtime API interactions. This allows for a fast track without additional re-renders

Related links, issue #, if available: n/a

### How has this been tested?

1. Updated relevant unit tests
2. Tested the actual flickering locally on the dev page

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
