### PR TITLE
chore: adding page with reproducible problem

### DIFF
--- a/pages/app-layout/controlled-navigation.page.tsx
+++ b/pages/app-layout/controlled-navigation.page.tsx
@@ -1,0 +1,134 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext, useEffect, useState } from 'react';
+
+import AppLayout, { AppLayoutProps } from '~components/app-layout';
+import Button from '~components/button';
+import Checkbox from '~components/checkbox';
+import Header from '~components/header';
+import SpaceBetween from '~components/space-between';
+import Toggle from '~components/toggle';
+
+import AppContext, { AppContextType } from '../app/app-context';
+import ScreenshotArea from '../utils/screenshot-area';
+import { Containers, Navigation } from './utils/content-blocks';
+import labels from './utils/labels';
+
+type ControlledNavigationDemoContext = React.Context<
+  AppContextType<{
+    navigationOpen: AppLayoutProps['navigationOpen'];
+    navigationHide: AppLayoutProps['navigationHide'];
+    navOpenOverrideValue?: boolean | null;
+    applyNavOpenOverride: boolean;
+  }>
+>;
+
+export default function () {
+  const {
+    urlParams: {
+      navigationOpen = true,
+      navigationHide = false,
+      navOpenOverrideValue = null,
+      applyNavOpenOverride = false,
+    },
+    setUrlParams,
+  } = useContext(AppContext as ControlledNavigationDemoContext);
+  const [resetNeeded, setResetNeeded] = useState(false);
+  const [navigationEmpty, setNavigationEmpty] = useState(false);
+  const [resolvedNavOpen, setResolvedNavOpen] = useState(navigationOpen);
+
+  const Content = (
+    <>
+      <div style={{ marginBottom: '1rem' }}>
+        <Header variant="h1" description="Basic demo with split panel">
+          AppLayout where NavigationHide is {navigationHide.toString()}
+        </Header>
+      </div>
+
+      <SpaceBetween size="l">
+        <SpaceBetween size="s" direction="horizontal">
+          <Toggle
+            id="control-navigation-open"
+            checked={navigationOpen}
+            onChange={e => setUrlParams({ navigationOpen: e.detail.checked })}
+          >
+            Navigation Open
+          </Toggle>
+          <Toggle
+            id="control-navigation-hide"
+            checked={navigationHide}
+            onChange={e => setUrlParams({ navigationHide: e.detail.checked })}
+          >
+            Navigation Hide
+          </Toggle>
+          <Toggle
+            id="control-navigation-empty"
+            checked={navigationEmpty}
+            onChange={e => setNavigationEmpty(e.detail.checked)}
+          >
+            Navigation Empty
+          </Toggle>
+        </SpaceBetween>
+        <SpaceBetween size="s" direction="horizontal">
+          <Checkbox
+            onChange={e => setUrlParams({ applyNavOpenOverride: e.detail.checked })}
+            checked={applyNavOpenOverride}
+          >
+            Apply override
+          </Checkbox>
+          <Toggle
+            id="override-nav-open"
+            checked={!!navOpenOverrideValue}
+            disabled={!applyNavOpenOverride}
+            onChange={e => setUrlParams({ navOpenOverrideValue: e.detail.checked })}
+          >
+            override Navigation Open
+          </Toggle>
+          <Button
+            id="reset-button"
+            onClick={() => setResetNeeded(true)}
+            disabled={resetNeeded}
+            loading={resetNeeded}
+            data-testid="reset-app-layout"
+          >
+            Reset - Force rerender
+          </Button>
+        </SpaceBetween>
+        <Containers />
+      </SpaceBetween>
+    </>
+  );
+
+  useEffect(() => {
+    if (resetNeeded) {
+      setUrlParams({ applyNavOpenOverride: false, navOpenOverrideValue: null });
+      setTimeout(() => {
+        setResetNeeded(false);
+      }, 200);
+    }
+  }, [resetNeeded, setUrlParams]);
+
+  useEffect(() => {
+    if (applyNavOpenOverride && navOpenOverrideValue !== null) {
+      setResolvedNavOpen(navOpenOverrideValue);
+    }
+  }, [applyNavOpenOverride, navOpenOverrideValue]);
+
+  return (
+    <ScreenshotArea gutters={false}>
+      {resetNeeded ? (
+        <></>
+      ) : (
+        <AppLayout
+          data-testid="main-layout"
+          ariaLabels={labels}
+          navigationHide={navigationHide}
+          navigation={navigationEmpty ? <></> : <Navigation />}
+          navigationOpen={resolvedNavOpen}
+          onNavigationChange={e => setUrlParams({ navigationOpen: e.detail.open })}
+          content={Content}
+        />
+      )}
+    </ScreenshotArea>
+  );
+}


### PR DESCRIPTION
### Description

Problem can be seen on path `/light/app-layout/controlled-navigation/?appLayoutToolbar=true&navigationHide=false&applyNavOpenOverride=true&navOpenOverrideValue=false`

on deployment. Go to https://d21d5uik3ws71m.cloudfront.net/components/b77b2547c6b1210f0de973956d6efb31ae58c212/dev-pages/index.html#/light/app-layout/controlled-navigation/?appLayoutToolbar=true&navigationHide=false&applyNavOpenOverride=true&navOpenOverrideValue=false

and refresh the page.

This is needed so a regression test can be completed

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
