### PR TITLE
feat: Add disableBrowserAutocorrect prop to TextFilter

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -16182,6 +16182,16 @@ The count text is only displayed when \`filteringText\` isn't empty.
       "type": "string",
     },
     {
+      "description": "Specifies whether to disable browser autocorrect and related features.
+If you set this to \`true\`, it disables any native browser capabilities
+that automatically correct user input, such as \`autocorrect\` and
+\`autocapitalize\`. If you don't set it, the behavior follows the default behavior
+of the user's browser.",
+      "name": "disableBrowserAutocorrect",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
       "description": "Specifies if the filtering input is disabled.
 For example, you can use it if you are fetching new items upon filtering change
 in order to prevent the user from changing the filtering text.",

--- a/src/text-filter/__tests__/text-filter.test.tsx
+++ b/src/text-filter/__tests__/text-filter.test.tsx
@@ -139,6 +139,32 @@ describe('countText', () => {
   });
 });
 
+describe('disableBrowserAutocorrect', () => {
+  test('does not modify autocorrect features by default', () => {
+    const { wrapper } = renderTextFilter(<TextFilter filteringText="" />);
+    const input = wrapper.findInput().findNativeInput().getElement();
+
+    expect(input).not.toHaveAttribute('autocorrect');
+    expect(input).not.toHaveAttribute('autocapitalize');
+  });
+
+  test('does not modify autocorrect features when falsy', () => {
+    const { wrapper } = renderTextFilter(<TextFilter filteringText="" disableBrowserAutocorrect={false} />);
+    const input = wrapper.findInput().findNativeInput().getElement();
+
+    expect(input).not.toHaveAttribute('autocorrect');
+    expect(input).not.toHaveAttribute('autocapitalize');
+  });
+
+  test('can disabled autocorrect features when set', () => {
+    const { wrapper } = renderTextFilter(<TextFilter filteringText="" disableBrowserAutocorrect={true} />);
+    const input = wrapper.findInput().findNativeInput().getElement();
+
+    expect(input).toHaveAttribute('autocorrect', 'off');
+    expect(input).toHaveAttribute('autocapitalize', 'off');
+  });
+});
+
 test('check a11y', async () => {
   const { wrapper } = renderTextFilter(<TextFilter filteringText="" filteringAriaLabel="filter instances" />);
   await expect(wrapper.getElement()).toValidateA11y();

--- a/src/text-filter/index.tsx
+++ b/src/text-filter/index.tsx
@@ -13,7 +13,9 @@ import InternalTextFilter from './internal';
 export { TextFilterProps };
 
 const TextFilter = React.forwardRef((props: TextFilterProps, ref: React.Ref<TextFilterProps.Ref>) => {
-  const baseComponentProps = useBaseComponent('TextFilter');
+  const baseComponentProps = useBaseComponent('TextFilter', {
+    props: { disabled: props.disabled, disableBrowserAutocorrect: props.disableBrowserAutocorrect },
+  });
 
   const componentAnalyticsMetadata: GeneratedAnalyticsMetadataTextFilterComponent = {
     name: 'awsui.TextFilter',

--- a/src/text-filter/interfaces.ts
+++ b/src/text-filter/interfaces.ts
@@ -1,10 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { InputAutoCorrect } from '../input/interfaces';
 import { BaseComponentProps } from '../internal/base-component';
 import { FormFieldControlProps } from '../internal/context/form-field-context';
 import { NonCancelableEventHandler } from '../internal/events';
 
-export interface TextFilterProps extends BaseComponentProps, FormFieldControlProps {
+export interface TextFilterProps extends BaseComponentProps, FormFieldControlProps, InputAutoCorrect {
   /**
    * The current value of the filtering input.
    */

--- a/src/text-filter/internal.tsx
+++ b/src/text-filter/internal.tsx
@@ -30,6 +30,7 @@ const InternalTextFilter = React.forwardRef(
       ariaDescribedby,
       disabled,
       countText,
+      disableBrowserAutocorrect,
       onChange,
       onDelayedChange,
       __internalRootRef,
@@ -52,6 +53,7 @@ const InternalTextFilter = React.forwardRef(
       <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
         <InternalInput
           __inheritFormFieldProps={true}
+          disableBrowserAutocorrect={disableBrowserAutocorrect}
           ref={inputRef}
           className={styles.input}
           type="search"


### PR DESCRIPTION
### Description

To align with other input components

Related links, issue #, if available: fixes #2820

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
