### PR TITLE
fix: Fixes table column min width when only width is set

### DIFF
--- a/pages/table/sticky-scrollbar-in-container.page.tsx
+++ b/pages/table/sticky-scrollbar-in-container.page.tsx
@@ -4,12 +4,12 @@ import React, { useContext } from 'react';
 
 import { useCollection } from '@cloudscape-design/collection-hooks';
 
-import { Checkbox, Container, Header, Pagination, SpaceBetween, Table } from '~components';
+import { Button, Checkbox, Container, Header, Pagination, SpaceBetween, Table } from '~components';
 
 import AppContext, { AppContextType } from '../app/app-context';
 import ScreenshotArea from '../utils/screenshot-area';
 import { generateItems } from './generate-data';
-import { columnsConfig, paginationLabels } from './shared-configs';
+import { columnsConfig as sharedColumnsConfig, paginationLabels } from './shared-configs';
 
 type PageContext = React.Context<
   AppContextType<{
@@ -20,6 +20,15 @@ type PageContext = React.Context<
 
 const allItems = generateItems();
 const PAGE_SIZE = 50;
+const columnsConfig = [
+  ...sharedColumnsConfig,
+  {
+    id: 'actions',
+    header: 'Fav',
+    cell: () => <Button variant="icon" iconName="star" ariaLabel="make favorite" />,
+    width: 70,
+  },
+];
 
 export default function App() {
   const {
@@ -44,6 +53,8 @@ export default function App() {
               footer={hasFooter ? <Pagination {...paginationProps} ariaLabels={paginationLabels} /> : undefined}
               columnDefinitions={columnsConfig}
               items={items}
+              stickyColumns={{ last: 1 }}
+              resizableColumns={true}
             />
           </Container>
         </div>

--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -212,6 +212,20 @@ test('should not allow to resize column below 120px if min width is not defined'
   expect(wrapper.findColumnHeaders()[0].getElement()).toHaveStyle({ width: '120px' });
 });
 
+test('takes width as min width if it is less than 120px and min width is not set', () => {
+  const props: TableProps<Item> = {
+    ...defaultProps,
+    columnDefinitions: [{ header: 'id', cell: item => item.id, width: 100 }, defaultProps.columnDefinitions[1]],
+  };
+  const { wrapper } = renderTable(<Table {...props} />);
+  expect(wrapper.findColumnHeaders()[0].getElement()).toHaveStyle({ width: '100px' });
+
+  fireMousedown(wrapper.findColumnResizer(1)!);
+  fireMouseMove(100);
+  fireMouseup(100);
+  expect(wrapper.findColumnHeaders()[0].getElement()).toHaveStyle({ width: '100px' });
+});
+
 test('should follow along each mouse move event', () => {
   const { wrapper } = renderTable(<Table {...defaultProps} />);
   expect(wrapper.findColumnHeaders()[0].getElement()).toHaveStyle({ width: '150px' });

--- a/src/table/use-column-widths.tsx
+++ b/src/table/use-column-widths.tsx
@@ -44,7 +44,13 @@ function updateWidths(
   columnId: PropertyKey
 ) {
   const column = visibleColumns.find(column => column.id === columnId);
-  const minWidth = typeof column?.minWidth === 'number' ? column.minWidth : DEFAULT_COLUMN_WIDTH;
+  let minWidth = DEFAULT_COLUMN_WIDTH;
+  if (typeof column?.width === 'number' && column.width < DEFAULT_COLUMN_WIDTH) {
+    minWidth = column?.width;
+  }
+  if (typeof column?.minWidth === 'number') {
+    minWidth = column?.minWidth;
+  }
   newWidth = Math.max(newWidth, minWidth);
   if (oldWidths.get(columnId) === newWidth) {
     return oldWidths;


### PR DESCRIPTION
### Description

Fixes table column width definition. Before, when only table column width is set and it is less than 120px - the min width is then set to 120px. That creates an unexpected effect when the column is resized: it immediately becomes 120px and cannot be resized below that.

Before:

https://github.com/user-attachments/assets/4f879d3a-aed5-4dd5-aa6a-0f3c70d629fa

After:


https://github.com/user-attachments/assets/f87040f7-6207-4ac3-9f99-9050e919a770



### How has this been tested?

* New unit test
* Manual testing in the updated test page

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
