### PR TITLE
revert: Container overflow constrained to the content slot (#2864)

### DIFF
--- a/pages/table/sticky-scrollbar-in-container.page.tsx
+++ b/pages/table/sticky-scrollbar-in-container.page.tsx
@@ -1,62 +1,37 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext } from 'react';
+import React from 'react';
 
 import { useCollection } from '@cloudscape-design/collection-hooks';
 
-import { Checkbox, Container, Header, Pagination, SpaceBetween, Table } from '~components';
+import Header from '~components/header';
+import Table from '~components/table';
 
-import AppContext, { AppContextType } from '../app/app-context';
 import ScreenshotArea from '../utils/screenshot-area';
-import { generateItems } from './generate-data';
-import { columnsConfig, paginationLabels } from './shared-configs';
-
-type PageContext = React.Context<
-  AppContextType<{
-    fitHeight?: boolean;
-    hasFooter?: boolean;
-  }>
->;
+import { generateItems, Instance } from './generate-data';
+import { columnsConfig } from './shared-configs';
 
 const allItems = generateItems();
 const PAGE_SIZE = 50;
 
 export default function App() {
-  const {
-    urlParams: { fitHeight = true, hasFooter = false },
-    setUrlParams,
-  } = useContext(AppContext as PageContext);
-
-  const { items, paginationProps } = useCollection(allItems, { pagination: { pageSize: PAGE_SIZE }, sorting: {} });
-
+  const { items } = useCollection(allItems, {
+    pagination: { pageSize: PAGE_SIZE },
+    sorting: {},
+  });
   return (
     <ScreenshotArea>
-      <SpaceBetween size="m" direction="horizontal">
-        <div style={{ blockSize: '500px', inlineSize: '500px', overflow: 'scroll' }}>
-          <Container fitHeight={fitHeight}>
-            <Table
-              variant="borderless"
-              header={
-                <Header headingTagOverride="h1" counter={`(${allItems.length})`}>
-                  Sticky Scrollbar Example
-                </Header>
-              }
-              footer={hasFooter ? <Pagination {...paginationProps} ariaLabels={paginationLabels} /> : undefined}
-              columnDefinitions={columnsConfig}
-              items={items}
-            />
-          </Container>
-        </div>
-
-        <SpaceBetween size="s">
-          <Checkbox checked={fitHeight} onChange={({ detail }) => setUrlParams({ fitHeight: detail.checked })}>
-            fitHeight
-          </Checkbox>
-          <Checkbox checked={hasFooter} onChange={({ detail }) => setUrlParams({ hasFooter: detail.checked })}>
-            hasFooter
-          </Checkbox>
-        </SpaceBetween>
-      </SpaceBetween>
+      <div style={{ blockSize: '400px', overflow: 'scroll' }}>
+        <Table<Instance>
+          header={
+            <Header headingTagOverride="h1" counter={`(${allItems.length})`}>
+              Sticky Scrollbar Example
+            </Header>
+          }
+          columnDefinitions={columnsConfig}
+          items={items}
+        />
+      </div>
     </ScreenshotArea>
   );
 }

--- a/pages/table/sticky-scrollbar-in-container.page.tsx
+++ b/pages/table/sticky-scrollbar-in-container.page.tsx
@@ -1,37 +1,62 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useContext } from 'react';
 
 import { useCollection } from '@cloudscape-design/collection-hooks';
 
-import Header from '~components/header';
-import Table from '~components/table';
+import { Checkbox, Container, Header, Pagination, SpaceBetween, Table } from '~components';
 
+import AppContext, { AppContextType } from '../app/app-context';
 import ScreenshotArea from '../utils/screenshot-area';
-import { generateItems, Instance } from './generate-data';
-import { columnsConfig } from './shared-configs';
+import { generateItems } from './generate-data';
+import { columnsConfig, paginationLabels } from './shared-configs';
+
+type PageContext = React.Context<
+  AppContextType<{
+    fitHeight?: boolean;
+    hasFooter?: boolean;
+  }>
+>;
 
 const allItems = generateItems();
 const PAGE_SIZE = 50;
 
 export default function App() {
-  const { items } = useCollection(allItems, {
-    pagination: { pageSize: PAGE_SIZE },
-    sorting: {},
-  });
+  const {
+    urlParams: { fitHeight = true, hasFooter = false },
+    setUrlParams,
+  } = useContext(AppContext as PageContext);
+
+  const { items, paginationProps } = useCollection(allItems, { pagination: { pageSize: PAGE_SIZE }, sorting: {} });
+
   return (
     <ScreenshotArea>
-      <div style={{ blockSize: '400px', overflow: 'scroll' }}>
-        <Table<Instance>
-          header={
-            <Header headingTagOverride="h1" counter={`(${allItems.length})`}>
-              Sticky Scrollbar Example
-            </Header>
-          }
-          columnDefinitions={columnsConfig}
-          items={items}
-        />
-      </div>
+      <SpaceBetween size="m" direction="horizontal">
+        <div style={{ blockSize: '500px', inlineSize: '500px', overflow: 'scroll' }}>
+          <Container fitHeight={fitHeight}>
+            <Table
+              variant="borderless"
+              header={
+                <Header headingTagOverride="h1" counter={`(${allItems.length})`}>
+                  Sticky Scrollbar Example
+                </Header>
+              }
+              footer={hasFooter ? <Pagination {...paginationProps} ariaLabels={paginationLabels} /> : undefined}
+              columnDefinitions={columnsConfig}
+              items={items}
+            />
+          </Container>
+        </div>
+
+        <SpaceBetween size="s">
+          <Checkbox checked={fitHeight} onChange={({ detail }) => setUrlParams({ fitHeight: detail.checked })}>
+            fitHeight
+          </Checkbox>
+          <Checkbox checked={hasFooter} onChange={({ detail }) => setUrlParams({ hasFooter: detail.checked })}>
+            hasFooter
+          </Checkbox>
+        </SpaceBetween>
+      </SpaceBetween>
     </ScreenshotArea>
   );
 }

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -16,7 +16,6 @@
     display: flex;
     flex-direction: column;
     block-size: 100%;
-
     &.with-side-media {
       flex-direction: row;
     }
@@ -38,7 +37,6 @@
       border-end-start-radius: 0;
       border-block-end-width: 0;
     }
-
     // Meld container top corners into preceding container
     &-stacked + &-stacked,
     &-stacked + &-stacked::before,
@@ -46,7 +44,6 @@
       border-start-start-radius: 0;
       border-start-end-radius: 0;
     }
-
     // Replace container border with a divider
     &-stacked + &-stacked:not(.refresh)::before {
       @include shared.divider;
@@ -58,7 +55,6 @@
     &::before {
       inset-block-start: calc(-1 * #{awsui.$border-container-top-width});
     }
-
     &.variant-stacked::before {
       inset-block-start: calc(-1 * #{awsui.$border-divider-section-width});
     }
@@ -79,7 +75,6 @@
   display: flex;
   flex-direction: column;
   inline-size: 100%;
-
   &-fit-height {
     block-size: 100%;
     overflow: hidden;
@@ -108,7 +103,6 @@
     border-block: 0;
     border-inline: 0;
   }
-
   // stylelint-enable @cloudscape-design/no-implicit-descendant, selector-max-type
 
   // reduce border-radius size to fill the visual gap between the parent border and image
@@ -129,14 +123,12 @@
   background-color: awsui.$color-background-container-header;
   border-start-start-radius: awsui.$border-radius-container;
   border-start-end-radius: awsui.$border-radius-container;
-
   &.header-full-page {
     background-color: awsui.$color-background-layout-main;
   }
 
   &.header-with-media {
     background: none;
-
     &:not(:empty) {
       border-block-end: none;
     }
@@ -166,7 +158,6 @@
       border-block: 0;
       border-inline: 0;
     }
-
     &:not(.header-variant-cards) {
       box-shadow: awsui.$shadow-sticky-embedded;
     }
@@ -200,7 +191,6 @@
   &-variant-cards {
     // Border and shadows are applied with ::before and ::after elements (respectively)
     @include styles.container-style;
-
     &:not(.header-sticky-enabled) {
       position: relative;
     }
@@ -254,21 +244,17 @@
 
 .content {
   flex: 1;
-
   &-fit-height {
     overflow: auto;
   }
-
-  // Using margins instead of paddings so that the content overflow works correctly.
   &.with-paddings {
-    margin-block: awsui.$space-scaled-l;
-    margin-inline: awsui.$space-container-horizontal;
+    padding-block: awsui.$space-scaled-l;
+    padding-inline: awsui.$space-container-horizontal;
 
     .header + & {
-      margin-block-start: awsui.$space-container-content-top;
-
+      padding-block-start: awsui.$space-container-content-top;
       &.content-with-media {
-        margin-block-start: 0;
+        padding-block-start: 0;
       }
     }
   }

--- a/src/table/__integ__/sticky-scrollbar.test.ts
+++ b/src/table/__integ__/sticky-scrollbar.test.ts
@@ -4,18 +4,23 @@ import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objec
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper from '../../../lib/components/test-utils/selectors';
-
+const tableWrapper = createWrapper().findTable();
 import scrollbarStyles from '../../../lib/components/table/sticky-scrollbar/styles.selectors.js';
 
 const scrollbarSelector = `.${scrollbarStyles['sticky-scrollbar-visible']}`;
 
-const tableWrapper = createWrapper().findTable();
-const containerWrapper = createWrapper().findContainer();
-const scrollbarWrapper = tableWrapper.find(scrollbarSelector);
+class StickyScrollbarPage extends BasePageObject {
+  findVisibleScrollbar() {
+    return tableWrapper.find(scrollbarSelector).toSelector();
+  }
+  findTable() {
+    return tableWrapper.toSelector();
+  }
+}
 
-const setupTest = (testFn: (page: BasePageObject) => Promise<void>, isVisualRefresh?: boolean) => {
+const setupTest = (testFn: (page: StickyScrollbarPage) => Promise<void>, isVisualRefresh?: boolean) => {
   return useBrowser(async browser => {
-    const page = new BasePageObject(browser);
+    const page = new StickyScrollbarPage(browser);
     await page.setWindowSize({ width: 600, height: 400 });
     await browser.url(
       `#/light/table/sticky-scrollbar?${isVisualRefresh ? 'visualRefresh=true' : 'visualRefresh=false'}`
@@ -29,62 +34,49 @@ describe('Sticky scrollbar', () => {
   test(
     `is visible, when the table is in view, but it's bottom is not`,
     setupTest(async page => {
-      await expect(page.isExisting(scrollbarWrapper.toSelector())).resolves.toEqual(true);
+      await expect(page.isExisting(await page.findVisibleScrollbar())).resolves.toEqual(true);
     })
   );
 
   [false, true].forEach(visualRefresh =>
     describe(`visualRefresh=${visualRefresh}`, () => {
       test(
-        'scrollbarWidth is equal to tableWidth',
+        `scrollbarWidth is equal to tableWidth`,
         setupTest(async page => {
-          const { width: scrollbarWidth } = await page.getBoundingBox(scrollbarWrapper.toSelector());
-          const { width: tableWidth } = await page.getBoundingBox(tableWrapper.toSelector());
+          const { width: scrollbarWidth } = await page.getBoundingBox(await page.findVisibleScrollbar());
+          const { width: tableWidth } = await page.getBoundingBox(await page.findTable());
           const borderOffset = visualRefresh ? 2 : 0;
           expect(scrollbarWidth).toEqual(tableWidth - borderOffset);
         }, visualRefresh)
       );
-
-      test(
-        'sticky scrollbar is at the bottom when rendered inside container with fit-height',
-        useBrowser(async browser => {
-          const page = new BasePageObject(browser);
-          await browser.url(
-            `#/light/table/sticky-scrollbar-in-container?visualRefresh=${visualRefresh}&fitHeight=true`
-          );
-          const { bottom: containerBottom } = await page.getBoundingBox(containerWrapper.findContent().toSelector());
-          const { bottom: scrollbarBottom } = await page.getBoundingBox(scrollbarWrapper.toSelector());
-          expect(scrollbarBottom).toBe(containerBottom);
-        })
-      );
     })
   );
 
   test(
-    'is hidden, when page is resized and table fits into the screen',
+    `is hidden, when page is resized and table fits into the screen`,
     setupTest(async page => {
       await page.setWindowSize({ width: 1600, height: 400 });
-      await expect(page.isExisting(scrollbarWrapper.toSelector())).resolves.toEqual(false);
+      await expect(page.isExisting(await page.findVisibleScrollbar())).resolves.toEqual(false);
     })
   );
   test(
-    'appears when screen is resized',
+    `appears when screen is resized`,
     setupTest(async page => {
       await page.setWindowSize({ width: 1600, height: 400 });
-      await expect(page.isExisting(scrollbarWrapper.toSelector())).resolves.toEqual(false);
+      await expect(page.isExisting(await page.findVisibleScrollbar())).resolves.toEqual(false);
       await page.setWindowSize({ width: 600, height: 400 });
-      await expect(page.isExisting(scrollbarWrapper.toSelector())).resolves.toEqual(true);
+      await expect(page.isExisting(await page.findVisibleScrollbar())).resolves.toEqual(true);
     })
   );
   test(
-    'scrollbar position updates when window resizes',
+    `scrollbar position updates when window resizes`,
     setupTest(async page => {
       await page.setWindowSize({ width: 600, height: 600 });
-      const { bottom: bottom1 } = await page.getBoundingBox(scrollbarWrapper.toSelector());
+      const { bottom: bottom1 } = await page.getBoundingBox(page.findVisibleScrollbar());
       expect(bottom1).toEqual((await page.getViewportSize()).height);
 
       await page.setWindowSize({ width: 600, height: 400 });
-      const { bottom: bottom2 } = await page.getBoundingBox(scrollbarWrapper.toSelector());
+      const { bottom: bottom2 } = await page.getBoundingBox(page.findVisibleScrollbar());
       expect(bottom1 - bottom2).toBe(200);
     })
   );

--- a/src/table/__integ__/sticky-scrollbar.test.ts
+++ b/src/table/__integ__/sticky-scrollbar.test.ts
@@ -4,23 +4,18 @@ import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objec
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper from '../../../lib/components/test-utils/selectors';
-const tableWrapper = createWrapper().findTable();
+
 import scrollbarStyles from '../../../lib/components/table/sticky-scrollbar/styles.selectors.js';
 
 const scrollbarSelector = `.${scrollbarStyles['sticky-scrollbar-visible']}`;
 
-class StickyScrollbarPage extends BasePageObject {
-  findVisibleScrollbar() {
-    return tableWrapper.find(scrollbarSelector).toSelector();
-  }
-  findTable() {
-    return tableWrapper.toSelector();
-  }
-}
+const tableWrapper = createWrapper().findTable();
+const containerWrapper = createWrapper().findContainer();
+const scrollbarWrapper = tableWrapper.find(scrollbarSelector);
 
-const setupTest = (testFn: (page: StickyScrollbarPage) => Promise<void>, isVisualRefresh?: boolean) => {
+const setupTest = (testFn: (page: BasePageObject) => Promise<void>, isVisualRefresh?: boolean) => {
   return useBrowser(async browser => {
-    const page = new StickyScrollbarPage(browser);
+    const page = new BasePageObject(browser);
     await page.setWindowSize({ width: 600, height: 400 });
     await browser.url(
       `#/light/table/sticky-scrollbar?${isVisualRefresh ? 'visualRefresh=true' : 'visualRefresh=false'}`
@@ -34,49 +29,63 @@ describe('Sticky scrollbar', () => {
   test(
     `is visible, when the table is in view, but it's bottom is not`,
     setupTest(async page => {
-      await expect(page.isExisting(await page.findVisibleScrollbar())).resolves.toEqual(true);
+      await expect(page.isExisting(scrollbarWrapper.toSelector())).resolves.toEqual(true);
     })
   );
 
   [false, true].forEach(visualRefresh =>
     describe(`visualRefresh=${visualRefresh}`, () => {
       test(
-        `scrollbarWidth is equal to tableWidth`,
+        'scrollbarWidth is equal to tableWidth',
         setupTest(async page => {
-          const { width: scrollbarWidth } = await page.getBoundingBox(await page.findVisibleScrollbar());
-          const { width: tableWidth } = await page.getBoundingBox(await page.findTable());
+          const { width: scrollbarWidth } = await page.getBoundingBox(scrollbarWrapper.toSelector());
+          const { width: tableWidth } = await page.getBoundingBox(tableWrapper.toSelector());
           const borderOffset = visualRefresh ? 2 : 0;
           expect(scrollbarWidth).toEqual(tableWidth - borderOffset);
         }, visualRefresh)
+      );
+
+      // Skipped because #2864 is reverted.
+      test.skip(
+        'sticky scrollbar is at the bottom when rendered inside container with fit-height',
+        useBrowser(async browser => {
+          const page = new BasePageObject(browser);
+          await browser.url(
+            `#/light/table/sticky-scrollbar-in-container?visualRefresh=${visualRefresh}&fitHeight=true`
+          );
+          const { bottom: containerBottom } = await page.getBoundingBox(containerWrapper.findContent().toSelector());
+          const { bottom: scrollbarBottom } = await page.getBoundingBox(scrollbarWrapper.toSelector());
+          expect(scrollbarBottom).toBe(containerBottom);
+        })
       );
     })
   );
 
   test(
-    `is hidden, when page is resized and table fits into the screen`,
+    'is hidden, when page is resized and table fits into the screen',
     setupTest(async page => {
       await page.setWindowSize({ width: 1600, height: 400 });
-      await expect(page.isExisting(await page.findVisibleScrollbar())).resolves.toEqual(false);
+      await expect(page.isExisting(scrollbarWrapper.toSelector())).resolves.toEqual(false);
     })
   );
   test(
-    `appears when screen is resized`,
+    'appears when screen is resized',
     setupTest(async page => {
       await page.setWindowSize({ width: 1600, height: 400 });
-      await expect(page.isExisting(await page.findVisibleScrollbar())).resolves.toEqual(false);
+      await expect(page.isExisting(scrollbarWrapper.toSelector())).resolves.toEqual(false);
       await page.setWindowSize({ width: 600, height: 400 });
-      await expect(page.isExisting(await page.findVisibleScrollbar())).resolves.toEqual(true);
+      await expect(page.isExisting(scrollbarWrapper.toSelector())).resolves.toEqual(true);
     })
   );
   test(
-    `scrollbar position updates when window resizes`,
+    'scrollbar position updates when window resizes',
     setupTest(async page => {
       await page.setWindowSize({ width: 600, height: 600 });
-      const { bottom: bottom1 } = await page.getBoundingBox(page.findVisibleScrollbar());
+      const { bottom: bottom1 } = await page.getBoundingBox(scrollbarWrapper.toSelector());
       expect(bottom1).toEqual((await page.getViewportSize()).height);
 
       await page.setWindowSize({ width: 600, height: 400 });
-      const { bottom: bottom2 } = await page.getBoundingBox(page.findVisibleScrollbar());
+      const { bottom: bottom2 } = await page.getBoundingBox(scrollbarWrapper.toSelector());
       expect(bottom1 - bottom2).toBe(200);
     })
   );


### PR DESCRIPTION
This reverts commit 11df6c3e9a129851193a39d46fa02357ad35c54c.

### Description

Reverting because of impact on the dashboard demos that need to be resolved first.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
