### PR TITLE
fix: Q chat bug fixes

### DIFF
--- a/src/app-layout/constants.scss
+++ b/src/app-layout/constants.scss
@@ -33,4 +33,4 @@ $drawer-z-index-mobile: 1001;
 $toolbar-z-index: 1000;
 
 // Shared toolbar drawer component values
-$toolbar-vertical-panel-icon-offset: 10px;
+$toolbar-vertical-panel-icon-offset: 14px;

--- a/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
@@ -66,7 +66,7 @@
     grid-row: 1;
     display: grid;
     grid-template-columns: awsui.$space-m 1fr auto awsui.$space-m;
-    grid-template-rows: constants.$toolbar-vertical-panel-icon-offset auto 1fr;
+    grid-template-rows: constants.$toolbar-vertical-panel-icon-offset;
     overflow-y: auto;
 
     > .drawer-close-button {

--- a/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
@@ -66,7 +66,7 @@
     grid-row: 1;
     display: grid;
     grid-template-columns: awsui.$space-m 1fr auto awsui.$space-m;
-    grid-template-rows: constants.$toolbar-vertical-panel-icon-offset;
+    grid-template-rows: constants.$toolbar-vertical-panel-icon-offset auto auto;
     overflow-y: auto;
 
     > .drawer-close-button {
@@ -77,7 +77,7 @@
 
     > .drawer-content {
       grid-column: 1 / span 4;
-      grid-row: 1 / span 2;
+      grid-row: 1 / span 3;
       &.drawer-content-hidden {
         display: none;
       }

--- a/src/drawer/styles.scss
+++ b/src/drawer/styles.scss
@@ -13,9 +13,6 @@
   padding-block-end: awsui.$space-panel-content-bottom;
   padding-inline-start: awsui.$space-panel-side-left;
   padding-inline-end: awsui.$space-panel-side-right;
-  &.with-toolbar {
-    padding-block-start: awsui.$space-static-m;
-  }
 }
 
 .header {
@@ -31,7 +28,6 @@
   margin-inline-start: calc(-1 * #{awsui.$space-panel-side-left});
   .with-toolbar > & {
     border-color: transparent;
-    padding-block-end: awsui.$space-static-m;
     margin-block-end: 0px;
   }
 

--- a/src/help-panel/styles.scss
+++ b/src/help-panel/styles.scss
@@ -13,9 +13,6 @@
   padding-block-end: 0;
   padding-inline-end: awsui.$space-panel-side-right;
   padding-inline-start: awsui.$space-panel-side-left;
-  &.with-toolbar {
-    padding-block-start: awsui.$space-static-m;
-  }
 
   /* stylelint-disable @cloudscape-design/no-implicit-descendant, selector-max-type */
   hr {
@@ -135,7 +132,6 @@
   margin-inline-start: calc(-1 * #{awsui.$space-panel-side-left});
   .with-toolbar > & {
     border-color: transparent;
-    padding-block-end: awsui.$space-static-m;
     margin-block-end: 0px;
   }
 
@@ -155,15 +151,10 @@
 .content {
   color: awsui.$color-text-body-secondary;
 
-  /* stylelint-disable @cloudscape-design/no-implicit-descendant, selector-max-type */
-  h2:first-child,
-  h3:first-child,
-  h4:first-child,
-  h5:first-child,
-  h6:first-child {
+  & > :first-child {
     margin-block-start: 0;
   }
-
+  /* stylelint-disable @cloudscape-design/no-implicit-descendant, selector-max-type */
   a {
     @include styles.link-inline;
   }

--- a/src/side-navigation/styles.scss
+++ b/src/side-navigation/styles.scss
@@ -20,9 +20,6 @@
   padding-inline-start: awsui.$space-panel-nav-left;
   // Additional xl space to prevent text from overlapping the close button.
   padding-inline-end: calc(#{awsui.$space-scaled-xxl} + #{awsui.$space-xl});
-  .with-toolbar > & {
-    padding-block: awsui.$space-static-m;
-  }
 }
 
 .header-link {
@@ -53,15 +50,15 @@
 }
 
 .items-control {
-  margin-block-start: awsui.$space-panel-content-top;
   padding-inline: awsui.$space-l;
 }
 
 .list-container {
   margin-block-start: awsui.$space-panel-content-top;
-  .with-toolbar > & {
-    margin-block-start: 0px;
-  }
+}
+
+.with-toolbar > .list-container:not(.items-control + .list-container) {
+  margin-block-start: 0;
 }
 
 .list {
@@ -94,6 +91,9 @@
   padding-block: 0;
   padding-inline: 0;
   list-style: none;
+  .list-variant-root > &:first-child {
+    margin-block-start: 0px;
+  }
 }
 
 .section,
@@ -193,8 +193,10 @@
 
 .divider-header {
   margin-block-start: 0;
+  margin-block-end: awsui.$space-panel-content-top;
   border-block-start: awsui.$border-divider-section-width solid awsui.$color-border-panel-header;
   .with-toolbar > & {
     border-color: transparent;
+    margin-block-end: 0;
   }
 }


### PR DESCRIPTION
### Description

- Addresses double scrollbar issue in Q chat panel (AWSUI-59823). With updated grid layout, children should be able to set height to 100% and fill the entire panel content height. This will require an adjustment to the Q package to remove their custom calculation code. But I tested in Chrome and Safari that this change will not have any adverse affect until that change is made.
- This also adjusts the panel header padding to match original VR, to fix the misalignment of the Q settings icon and the panel close button. Originally it was reduced for the toolbar so that the headers and close icons could be aligned with the content in the toolbar. This was when the placement of the toolbar was between the panels, which is not the case anymore. It also reduces the space below panel headers so it is more uniform.

Related links, issue #, if available: AWSUI-59823

### How has this been tested?

Ran through dev pipeline. Tested the change manually in Q in the console. 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
