### PR TITLE
chore: Pre-release the live region component API internally

### DIFF
--- a/pages/live-region-content-test.page.tsx
+++ b/pages/live-region-content-test.page.tsx
@@ -33,7 +33,7 @@ export default function LiveRegionContentTestPage() {
           <strong>Live region</strong>
 
           <div style={{ padding: 8, border: '1px solid black' }}>
-            <LiveRegion visible={true}>
+            <LiveRegion>
               <article>
                 <div>Before list</div>
                 <ul>

--- a/pages/live-region.page.tsx
+++ b/pages/live-region.page.tsx
@@ -8,7 +8,7 @@ export default function LiveRegionXSS() {
   return (
     <>
       <h1>Live region</h1>
-      <LiveRegion delay={0}>
+      <LiveRegion hidden={true}>
         {`<p>Testing</p>`}
         <p>Testing</p>
       </LiveRegion>

--- a/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -360,6 +360,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_root_1kjc7",
     "awsui_root_1qprf",
     "awsui_root_1t44z",
+    "awsui_root_3bgfn",
     "awsui_root_qwoo0",
     "awsui_root_vrgzu",
     "awsui_selectable-item_15o6u",

--- a/src/attribute-editor/additional-info.tsx
+++ b/src/attribute-editor/additional-info.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 
 import styles from './styles.css.js';
 
@@ -12,9 +12,9 @@ interface AdditionalInfoProps {
 }
 
 export const AdditionalInfo = ({ children, id }: AdditionalInfoProps) => (
-  <LiveRegion visible={true} tagName="div" data-testid="info-live-region">
+  <InternalLiveRegion data-testid="info-live-region">
     <div id={id} className={styles['additional-info']}>
       {children}
     </div>
-  </LiveRegion>
+  </InternalLiveRegion>
 );

--- a/src/attribute-editor/internal.tsx
+++ b/src/attribute-editor/internal.tsx
@@ -7,7 +7,7 @@ import InternalBox from '../box/internal';
 import { ButtonProps } from '../button/interfaces';
 import { InternalButton } from '../button/internal';
 import { getBaseProps } from '../internal/base-component';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
@@ -110,9 +110,15 @@ const InternalAttributeEditor = React.forwardRef(
         >
           {addButtonText}
         </InternalButton>
-        <LiveRegion data-testid="removal-announcement" delay={5} key={items.length}>
+        <InternalLiveRegion
+          data-testid="removal-announcement"
+          tagName="span"
+          hidden={true}
+          delay={5}
+          key={items.length}
+        >
           {removalAnnouncement}
-        </LiveRegion>
+        </InternalLiveRegion>
         {!!additionalInfo && <AdditionalInfo id={infoAriaDescribedBy}>{additionalInfo}</AdditionalInfo>}
       </div>
     );

--- a/src/button-group/icon-button-item.tsx
+++ b/src/button-group/icon-button-item.tsx
@@ -7,7 +7,7 @@ import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 import { ButtonProps } from '../button/interfaces.js';
 import { InternalButton } from '../button/internal.js';
-import LiveRegion from '../internal/components/live-region/index.js';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import Tooltip from '../internal/components/tooltip/index.js';
 import { CancelableEventHandler, ClickDetail } from '../internal/events/index.js';
 import { ButtonGroupProps } from './interfaces.js';
@@ -60,7 +60,10 @@ const IconButtonItem = forwardRef(
           <Tooltip
             trackRef={containerRef}
             trackKey={item.id}
-            value={(showFeedback && <LiveRegion visible={true}>{item.popoverFeedback}</LiveRegion>) || item.text}
+            value={
+              (showFeedback && <InternalLiveRegion tagName="span">{item.popoverFeedback}</InternalLiveRegion>) ||
+              item.text
+            }
             className={clsx(testUtilStyles.tooltip, testUtilStyles['button-group-tooltip'])}
           />
         )}

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -6,6 +6,7 @@ import { act, fireEvent, render } from '@testing-library/react';
 import Button, { ButtonProps } from '../../../lib/components/button';
 import InternalButton from '../../../lib/components/button/internal';
 import createWrapper, { ButtonWrapper } from '../../../lib/components/test-utils/dom';
+import LiveRegionWrapper from '../../../lib/components/test-utils/selectors/internal/live-region';
 import { buttonRelExpectations, buttonTargetExpectations } from '../../__tests__/target-rel-test-helper';
 import { renderWithSingleTabStopNavigation } from '../../internal/context/__tests__/utils';
 
@@ -58,6 +59,19 @@ describe('Button Component', () => {
     const wrapper = createWrapper(renderResult.container);
     button!.focus();
     expect(document.activeElement).toBe(wrapper.findButton()!.getElement());
+  });
+
+  describe.each([true, false])('loadingText property, with href: %s', withHref => {
+    test('renders loadingText in a LiveRegion', () => {
+      renderButton({ children: 'Button', loading: true, loadingText: 'Loading', href: withHref ? '#' : undefined });
+      expect(createWrapper().findByClassName(LiveRegionWrapper.rootSelector)!.getElement()).toHaveTextContent(
+        'Loading'
+      );
+    });
+    test('does not render loadingText if loading is false', () => {
+      renderButton({ children: 'Button', loading: false, loadingText: 'Loading', href: withHref ? '#' : undefined });
+      expect(createWrapper().findByClassName(LiveRegionWrapper.rootSelector)).toBeNull();
+    });
   });
 
   describe('disabled property', () => {

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -16,7 +16,7 @@ import {
   getSubStepAllSelector,
   getTextFromSelector,
 } from '../internal/analytics/selectors';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import Tooltip from '../internal/components/tooltip/index.js';
 import { useButtonContext } from '../internal/context/button-context';
 import { useSingleTabStopNavigation } from '../internal/context/single-tab-stop-navigation-context';
@@ -250,7 +250,11 @@ export const InternalButton = React.forwardRef(
           >
             {buttonContent}
           </a>
-          {loading && loadingText && <LiveRegion>{loadingText}</LiveRegion>}
+          {loading && loadingText && (
+            <InternalLiveRegion tagName="span" hidden={true}>
+              {loadingText}
+            </InternalLiveRegion>
+          )}
         </>
       );
     }
@@ -282,7 +286,11 @@ export const InternalButton = React.forwardRef(
             </>
           )}
         </button>
-        {loading && loadingText && <LiveRegion>{loadingText}</LiveRegion>}
+        {loading && loadingText && (
+          <InternalLiveRegion tagName="span" hidden={true}>
+            {loadingText}
+          </InternalLiveRegion>
+        )}
       </>
     );
   }

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -9,7 +9,7 @@ import { InternalContainerAsSubstep } from '../container/internal';
 import { useInternalI18n } from '../i18n/context';
 import { AnalyticsFunnelSubStep } from '../internal/analytics/components/analytics-funnel';
 import { getBaseProps } from '../internal/base-component';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import { CollectionLabelContext } from '../internal/context/collection-label-context';
 import { LinkDefaultVariantContext } from '../internal/context/link-default-variant-context';
 import useBaseComponent from '../internal/hooks/use-base-component';
@@ -132,7 +132,7 @@ const Cards = React.forwardRef(function <T = any>(
     status = (
       <div className={styles.loading}>
         <InternalStatusIndicator type="loading">
-          <LiveRegion visible={true}>{loadingText}</LiveRegion>
+          <InternalLiveRegion tagName="span">{loadingText}</InternalLiveRegion>
         </InternalStatusIndicator>
       </div>
     );
@@ -178,11 +178,11 @@ const Cards = React.forwardRef(function <T = any>(
               )}
             >
               {!!renderAriaLive && !!firstIndex && (
-                <LiveRegion>
+                <InternalLiveRegion hidden={true} tagName="span">
                   <span>
                     {renderAriaLive({ totalItemsCount, firstIndex, lastIndex: firstIndex + items.length - 1 })}
                   </span>
-                </LiveRegion>
+                </InternalLiveRegion>
               )}
               {status ?? (
                 <CardsList

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -9,7 +9,7 @@ import { useCurrentMode } from '@cloudscape-design/component-toolkit/internal';
 
 import { useInternalI18n } from '../i18n/context';
 import { getBaseProps } from '../internal/base-component';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import { useFormFieldContext } from '../internal/context/form-field-context';
 import { fireNonCancelableEvent } from '../internal/events';
 import useForwardFocus from '../internal/hooks/forward-focus';
@@ -196,7 +196,9 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
     >
       {loading && (
         <LoadingScreen>
-          <LiveRegion visible={true}>{i18n('i18nStrings.loadingState', i18nStrings?.loadingState)}</LiveRegion>
+          <InternalLiveRegion tagName="span">
+            {i18n('i18nStrings.loadingState', i18nStrings?.loadingState)}
+          </InternalLiveRegion>
         </LoadingScreen>
       )}
 

--- a/src/code-editor/status-bar.tsx
+++ b/src/code-editor/status-bar.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 
 import { InternalButton } from '../button/internal';
 import { useInternalI18n } from '../i18n/context.js';
-import LiveRegion from '../internal/components/live-region/index';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import { CodeEditorProps } from './interfaces';
 import { TabButton } from './tab-button';
 import { getStatusButtonId, PaneStatus } from './util';
@@ -107,10 +107,10 @@ export function StatusBar({
             isRefresh={isRefresh}
           />
         </div>
-        <LiveRegion assertive={true}>
+        <InternalLiveRegion assertive={true} hidden={true} tagName="span">
           <span>{errorText} </span>
           <span>{warningText}</span>
-        </LiveRegion>
+        </InternalLiveRegion>
       </div>
 
       <div className={styles['status-bar__right']}>

--- a/src/collection-preferences/content-display/__integ__/pages/content-display-page.ts
+++ b/src/collection-preferences/content-display/__integ__/pages/content-display-page.ts
@@ -10,12 +10,10 @@ export default class ContentDisplayPageObject extends CollectionPreferencesPageO
   }
 
   async expectAnnouncement(announcement: string) {
-    const liveRegion = await this.browser.$(
-      this.wrapper.findModal().findContentDisplayPreference().find('[aria-live="assertive"]').toSelector()
-    );
+    const liveRegion = await this.browser.$('[aria-live="assertive"]');
     // Using getHTML because getText returns an empty string if the live region is outside the viewport.
     // See https://webdriver.io/docs/api/element/getText/
-    return expect(liveRegion.getHTML()).resolves.toContain(announcement);
+    return this.waitForAssertion(() => expect(liveRegion.getHTML()).resolves.toContain(announcement));
   }
 
   findDragHandle(index = 0) {

--- a/src/date-picker/__integ__/date-picker.test.ts
+++ b/src/date-picker/__integ__/date-picker.test.ts
@@ -190,7 +190,7 @@ describe('Date Picker', () => {
       await page.initLiveAnnouncementsObserver();
       await page.setInputValue('2024/02/20', false);
       await page.clickOpenCalendar();
-      await expect(page.getLiveAnnouncements()).resolves.toContain('February 2024');
+      await page.waitForAssertion(() => expect(page.getLiveAnnouncements()).resolves.toContain('February 2024'));
     })
   );
 });

--- a/src/date-picker/__integ__/month-granularity.test.ts
+++ b/src/date-picker/__integ__/month-granularity.test.ts
@@ -14,6 +14,7 @@ describe('Date picker at month granularity', () => {
       await page.initLiveAnnouncementsObserver();
       await page.waitForLoad();
       await page.clickOpenCalendar();
+      await new Promise(resolve => setTimeout(resolve, 2000)); // Wait for live region timeout
       await expect(page.getLiveAnnouncements()).resolves.toContain('2024');
     })
   );

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -13,7 +13,7 @@ import { InputProps } from '../input/interfaces';
 import { getBaseProps } from '../internal/base-component';
 import Dropdown from '../internal/components/dropdown';
 import FocusLock from '../internal/components/focus-lock';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import { fireNonCancelableEvent } from '../internal/events';
 import checkControlled from '../internal/hooks/check-controlled';
 import useForwardFocus from '../internal/hooks/forward-focus';
@@ -213,9 +213,9 @@ const DatePicker = React.forwardRef(
                       previousMonthAriaLabel: i18nStrings?.previousMonthAriaLabel ?? previousMonthAriaLabel,
                     }}
                   />
-                  <LiveRegion id={calendarDescriptionId}>
+                  <InternalLiveRegion id={calendarDescriptionId} hidden={true} tagName="span">
                     {getBaseDateLabel({ date: baseDate, granularity, locale: normalizedLocale })}
-                  </LiveRegion>
+                  </InternalLiveRegion>
                 </div>
               </FocusLock>
             )}

--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -9,6 +9,7 @@ import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import DateRangePicker, { DateRangePickerProps } from '../../../lib/components/date-range-picker';
 import FormField from '../../../lib/components/form-field';
 import TestI18nProvider from '../../../lib/components/i18n/testing';
+import { LiveRegionController } from '../../../lib/components/internal/components/live-region/controller.js';
 import { NonCancelableEventHandler } from '../../../lib/components/internal/events';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import DateRangePickerWrapper from '../../../lib/components/test-utils/dom/date-range-picker';
@@ -16,8 +17,9 @@ import { changeMode } from './change-mode';
 import { i18nStrings } from './i18n-strings';
 import { isValidRange } from './is-valid-range';
 
-import styles from '../../../lib/components/date-range-picker/styles.css.js';
 import segmentedStyles from '../../../lib/components/segmented-control/styles.css.js';
+
+LiveRegionController.defaultDelay = 0;
 
 jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
   ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
@@ -256,7 +258,7 @@ describe('Date range picker', () => {
 
       wrapper.findDropdown()!.findApplyButton().click();
       expect(wrapper.findDropdown()!.findValidationError()?.getElement()).toHaveTextContent('10 is not allowed.');
-      expect(wrapper.findDropdown()!.findByClassName(styles['validation-section'])!.find('[aria-live]')).not.toBe(null);
+      expect(createWrapper().findAll('[aria-live]')[1]!.getElement()).toHaveTextContent('10 is not allowed.');
     });
 
     test('after rendering the error once, displays subsequent errors in real time', () => {

--- a/src/date-range-picker/calendar/header/index.tsx
+++ b/src/date-range-picker/calendar/header/index.tsx
@@ -5,7 +5,7 @@ import { add } from 'date-fns';
 
 import { renderMonthAndYear } from '../../../calendar/utils/intl';
 import { useInternalI18n } from '../../../i18n/context.js';
-import LiveRegion from '../../../internal/components/live-region';
+import InternalLiveRegion from '../../../internal/components/live-region/internal';
 import { NextMonthButton, PrevMonthButton } from './header-button';
 
 import styles from '../../styles.css.js';
@@ -57,7 +57,7 @@ export default function CalendarHeader({
           onChangeMonth={onChangeMonth}
         />
       </div>
-      <LiveRegion>{isSingleGrid ? currentMonthLabel : `${prevMonthLabel}, ${currentMonthLabel}`}</LiveRegion>
+      <InternalLiveRegion message={isSingleGrid ? currentMonthLabel : `${prevMonthLabel}, ${currentMonthLabel}`} />
     </>
   );
 }

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -9,7 +9,7 @@ import { getDateLabel, renderTimeLabel } from '../../calendar/utils/intl';
 import { getBaseDay } from '../../calendar/utils/navigation';
 import { useInternalI18n } from '../../i18n/context.js';
 import { BaseComponentProps } from '../../internal/base-component';
-import LiveRegion from '../../internal/components/live-region';
+import InternalLiveRegion from '../../internal/components/live-region/internal';
 import { useMobile } from '../../internal/hooks/use-mobile/index.js';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { formatDateTime, parseDate, splitDateTime } from '../../internal/utils/date-time';
@@ -271,7 +271,10 @@ export default function DateRangePickerCalendar({
           {customAbsoluteRangeControl && <div>{customAbsoluteRangeControl(value, interceptedSetValue)}</div>}
         </SpaceBetween>
       </div>
-      <LiveRegion className={styles['calendar-aria-live']}>{announcement}</LiveRegion>
+      {/* Can't use message here because the contents are checked in tests */}
+      <InternalLiveRegion className={styles['calendar-aria-live']} hidden={true} tagName="span">
+        {announcement}
+      </InternalLiveRegion>
     </>
   );
 }

--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -10,7 +10,7 @@ import { ButtonProps } from '../button/interfaces';
 import { InternalButton } from '../button/internal';
 import { useInternalI18n } from '../i18n/context';
 import FocusLock from '../internal/components/focus-lock';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import InternalSpaceBetween from '../space-between/internal';
 import Calendar from './calendar';
 import { DateRangePickerProps } from './interfaces';
@@ -222,7 +222,9 @@ export function DateRangePickerDropdown({
                       >
                         <span className={styles['validation-error']}>{validationResult.errorMessage}</span>
                       </InternalAlert>
-                      <LiveRegion>{validationResult.errorMessage}</LiveRegion>
+                      <InternalLiveRegion hidden={true} tagName="span">
+                        {validationResult.errorMessage}
+                      </InternalLiveRegion>
                     </>
                   )}
                 </InternalBox>

--- a/src/drawer/implementation.tsx
+++ b/src/drawer/implementation.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 import { useAppLayoutToolbarEnabled } from '../app-layout/utils/feature-flags';
 import { useInternalI18n } from '../i18n/context';
 import { getBaseProps } from '../internal/base-component';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { createWidgetizedComponent } from '../internal/widgets';
 import InternalStatusIndicator from '../status-indicator/internal';
@@ -34,7 +34,9 @@ export function DrawerImplementation({
   return loading ? (
     <div {...containerProps} ref={__internalRootRef}>
       <InternalStatusIndicator type="loading">
-        <LiveRegion visible={true}>{i18n('i18nStrings.loadingText', i18nStrings?.loadingText)}</LiveRegion>
+        <InternalLiveRegion tagName="span">
+          {i18n('i18nStrings.loadingText', i18nStrings?.loadingText)}
+        </InternalLiveRegion>
       </InternalStatusIndicator>
     </div>
   ) : (

--- a/src/flashbar/__tests__/flashbar.test.tsx
+++ b/src/flashbar/__tests__/flashbar.test.tsx
@@ -7,6 +7,7 @@ import { disableMotion } from '@cloudscape-design/global-styles';
 
 import Button from '../../../lib/components/button';
 import Flashbar, { FlashbarProps } from '../../../lib/components/flashbar';
+import { LiveRegionController } from '../../../lib/components/internal/components/live-region/controller.js';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { mockInnerText } from '../../internal/analytics/__tests__/mocks';
 import { createFlashbarWrapper, findList, testFlashDismissal } from './common';
@@ -23,6 +24,8 @@ jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => {
     useVisualRefresh: (...args: any) => useVisualRefresh || originalVisualModeModule.useVisualRefresh(...args),
   };
 });
+
+LiveRegionController.defaultDelay = 0;
 
 mockInnerText();
 
@@ -410,7 +413,7 @@ describe('Flashbar component', () => {
       });
 
       test('renders the label, header, and content in an aria-live region for ariaRole="status"', async () => {
-        const { rerender, container } = reactRender(<Flashbar items={[]} />);
+        const { rerender } = reactRender(<Flashbar items={[]} />);
         rerender(
           <Flashbar
             items={[
@@ -427,7 +430,7 @@ describe('Flashbar component', () => {
         );
 
         await waitFor(() => {
-          expect(container.querySelector('span[aria-live]')).toHaveTextContent('Error The header The content');
+          expect(document.querySelector('[aria-live="polite"]')).toHaveTextContent('Error The header The content');
         });
       });
     });

--- a/src/flashbar/flash.tsx
+++ b/src/flashbar/flash.tsx
@@ -12,7 +12,7 @@ import { InternalButton } from '../button/internal';
 import InternalIcon from '../icon/internal';
 import { DATA_ATTR_ANALYTICS_FLASHBAR } from '../internal/analytics/selectors';
 import { BasePropsWithAnalyticsMetadata, getAnalyticsMetadataProps } from '../internal/base-component';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import { getVisualContextClassname } from '../internal/components/visual-context';
 import { PACKAGE_VERSION } from '../internal/environment';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
@@ -231,7 +231,9 @@ export const Flash = React.forwardRef(
           />
         </div>
         {dismissible && dismissButton(dismissLabel, handleDismiss)}
-        {ariaRole === 'status' && <LiveRegion source={[statusIconAriaLabel, headerRefObject, contentRefObject]} />}
+        {ariaRole === 'status' && (
+          <InternalLiveRegion sources={[statusIconAriaLabel, headerRefObject, contentRefObject]} />
+        )}
       </div>
     );
   }

--- a/src/form-field/__tests__/form-field-rendering.test.tsx
+++ b/src/form-field/__tests__/form-field-rendering.test.tsx
@@ -147,27 +147,21 @@ describe('FormField component', () => {
     test('Should render live region for error text', () => {
       const errorText = 'Nope do it again';
       const errorIconAriaLabel = 'Error';
-      const wrapper = renderFormField({
-        errorText,
-        i18nStrings: { errorIconAriaLabel },
-      });
+      renderFormField({ errorText, i18nStrings: { errorIconAriaLabel } });
 
       // Since live region in this componennt uses 'source' prop
       // it is too complex to successfully assert the aria live message
-      expect(wrapper.findByClassName(liveRegionStyles.root)?.getElement()).toBeInTheDocument();
+      expect(createWrapper().findByClassName(liveRegionStyles.announcer)?.getElement()).toBeInTheDocument();
     });
 
     test('Should render live region for warning text', () => {
       const warningText = 'Are you sure?';
       const warningIconAriaLabel = 'Warning';
-      const wrapper = renderFormField({
-        warningText,
-        i18nStrings: { warningIconAriaLabel },
-      });
+      renderFormField({ warningText, i18nStrings: { warningIconAriaLabel } });
 
       // Since live region in this componennt uses 'source' prop
       // it is too complex to successfully assert the aria live message
-      expect(wrapper.findByClassName(liveRegionStyles.root)?.getElement()).toBeInTheDocument();
+      expect(createWrapper().findByClassName(liveRegionStyles.announcer)?.getElement()).toBeInTheDocument();
     });
   });
 });

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -19,7 +19,7 @@ import {
   getTextFromSelector,
 } from '../internal/analytics/selectors';
 import { getBaseProps } from '../internal/base-component';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import { FormFieldContext, useFormFieldContext } from '../internal/context/form-field-context';
 import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
@@ -61,7 +61,7 @@ export function FormFieldError({ id, children, errorIconAriaLabel }: FormFieldEr
         </span>
       </div>
 
-      <LiveRegion assertive={true} source={[i18nErrorIconAriaLabel, contentRef]} />
+      <InternalLiveRegion assertive={true} tagName="span" sources={[i18nErrorIconAriaLabel, contentRef]} />
     </>
   );
 }
@@ -84,7 +84,7 @@ export function FormFieldWarning({ id, children, warningIconAriaLabel }: FormFie
         </span>
       </div>
 
-      <LiveRegion assertive={true} source={[i18nWarningIconAriaLabel, contentRef]} />
+      <InternalLiveRegion assertive={true} tagName="span" sources={[i18nWarningIconAriaLabel, contentRef]} />
     </>
   );
 }

--- a/src/form/internal.tsx
+++ b/src/form/internal.tsx
@@ -9,7 +9,7 @@ import InternalAlert from '../alert/internal';
 import InternalBox from '../box/internal';
 import { useInternalI18n } from '../i18n/context';
 import { getBaseProps } from '../internal/base-component';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { GeneratedAnalyticsMetadataFormFragment } from './analytics-metadata/interfaces';
 import { FormProps } from './interfaces';
@@ -70,9 +70,9 @@ export default function InternalForm({
         </div>
       )}
       {errorText && (
-        <LiveRegion assertive={true}>
+        <InternalLiveRegion hidden={true} tagName="span" assertive={true}>
           {errorIconAriaLabel}, {errorText}
-        </LiveRegion>
+        </InternalLiveRegion>
       )}
     </div>
   );

--- a/src/help-panel/implementation.tsx
+++ b/src/help-panel/implementation.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 import { useAppLayoutToolbarEnabled } from '../app-layout/utils/feature-flags';
 import { useInternalI18n } from '../i18n/context';
 import { getBaseProps } from '../internal/base-component';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import { LinkDefaultVariantContext } from '../internal/context/link-default-variant-context';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { createWidgetizedComponent } from '../internal/widgets';
@@ -36,7 +36,7 @@ export function HelpPanelImplementation({
   return loading ? (
     <div {...containerProps} ref={__internalRootRef}>
       <InternalStatusIndicator type="loading">
-        <LiveRegion visible={true}>{i18n('loadingText', loadingText)}</LiveRegion>
+        <InternalLiveRegion tagName="span">{i18n('loadingText', loadingText)}</InternalLiveRegion>
       </InternalStatusIndicator>
     </div>
   ) : (

--- a/src/internal/components/chart-plot/index.tsx
+++ b/src/internal/components/chart-plot/index.tsx
@@ -7,7 +7,7 @@ import { useInternalI18n } from '../../../i18n/context';
 import { useUniqueId } from '../../hooks/use-unique-id';
 import { KeyCode } from '../../keycode';
 import { Offset } from '../interfaces';
-import LiveRegion from '../live-region/index';
+import InternalLiveRegion from '../live-region/internal';
 import ApplicationController, { ApplicationRef } from './application-controller';
 import FocusOutline from './focus-outline';
 
@@ -224,7 +224,9 @@ function ChartPlot(
         </g>
       </svg>
 
-      <LiveRegion>{ariaLiveRegion}</LiveRegion>
+      <InternalLiveRegion hidden={true} tagName="span">
+        {ariaLiveRegion}
+      </InternalLiveRegion>
     </>
   );
 }

--- a/src/internal/components/chart-status-container/__tests__/chart-status-container.test.tsx
+++ b/src/internal/components/chart-status-container/__tests__/chart-status-container.test.tsx
@@ -25,17 +25,6 @@ function renderStatusContainer(jsx: React.ReactElement) {
 }
 
 describe('Chart status container', () => {
-  it('is always an ARIA live region', () => {
-    const { wrapper, rerender } = renderStatusContainer(
-      <ChartStatusContainer {...commonProps} isEmpty={true} statusType="finished" />
-    );
-
-    (['finished', 'loading', 'error'] as const).forEach(statusType => {
-      rerender(<ChartStatusContainer {...commonProps} isEmpty={true} statusType={statusType} />);
-      expect(wrapper.getElement()).toHaveAttribute('aria-live', 'polite');
-    });
-  });
-
   it('renders empty state', () => {
     const { wrapper } = renderStatusContainer(
       <ChartStatusContainer {...commonProps} isEmpty={true} statusType="finished" />

--- a/src/internal/components/chart-status-container/index.tsx
+++ b/src/internal/components/chart-status-container/index.tsx
@@ -7,6 +7,7 @@ import InternalLink from '../../../link/internal';
 import InternalStatusIndicator from '../../../status-indicator/internal';
 import { BaseComponentProps } from '../../base-component';
 import { fireNonCancelableEvent, NonCancelableEventHandler } from '../../events';
+import InternalLiveRegion from '../live-region/internal';
 
 import styles from './styles.css.js';
 
@@ -90,8 +91,8 @@ export default function ChartStatusContainer({
   }, [i18n, statusType, onRecoveryClick, isEmpty, isNoMatch, recoveryText, loadingText, errorText, empty, noMatch]);
 
   return (
-    <div className={styles.root} aria-live="polite" aria-atomic="true">
-      {!showChart && statusContainer}
+    <div className={styles.root}>
+      <InternalLiveRegion>{!showChart && statusContainer}</InternalLiveRegion>
     </div>
   );
 }

--- a/src/internal/components/dropdown-footer/__tests__/dropdown-footer.test.tsx
+++ b/src/internal/components/dropdown-footer/__tests__/dropdown-footer.test.tsx
@@ -29,11 +29,4 @@ describe('Dropdown footer', () => {
     expect(element).toHaveClass(dropdownFooterStyles.root);
     expect(element).toHaveClass(dropdownFooterStyles.hidden);
   });
-
-  test('adds correct aria attributes', () => {
-    const { wrapper } = renderComponent(<DropdownFooter />);
-    const element = wrapper.find('span')!.getElement();
-    expect(element.firstElementChild).toHaveAttribute('aria-live', 'polite');
-    expect(element.firstElementChild).toHaveAttribute('aria-atomic', 'true');
-  });
 });

--- a/src/internal/components/dropdown-footer/index.tsx
+++ b/src/internal/components/dropdown-footer/index.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import clsx from 'clsx';
 
 import DropdownStatus from '../dropdown-status/index.js';
-import LiveRegion from '../live-region/index.js';
+import InternalLiveRegion from '../live-region/internal';
 
 import styles from './styles.css.js';
 
@@ -16,9 +16,7 @@ interface DropdownFooter {
 
 const DropdownFooter: React.FC<DropdownFooter> = ({ content, id, hasItems = true }: DropdownFooter) => (
   <div className={clsx(styles.root, { [styles.hidden]: content === null, [styles['no-items']]: !hasItems })}>
-    <LiveRegion visible={true} tagName="div" id={id}>
-      {content && <DropdownStatus>{content}</DropdownStatus>}
-    </LiveRegion>
+    <InternalLiveRegion id={id}>{content && <DropdownStatus>{content}</DropdownStatus>}</InternalLiveRegion>
   </div>
 );
 

--- a/src/internal/components/live-region/__integ__/live-region.test.ts
+++ b/src/internal/components/live-region/__integ__/live-region.test.ts
@@ -24,7 +24,9 @@ describe('Live region', () => {
   test(
     `Live region doesn't render child contents as HTML`,
     setupTest(async page => {
-      await expect(page.getInnerHTML('[aria-live]')).resolves.toBe('&lt;p&gt;Testing&lt;/p&gt; Testing');
+      // Wait for live region to debounce after page load
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      await expect(page.getInnerHTML('[aria-live]')).resolves.toBe('&lt;p&gt;Testing&lt;/p&gt;Testing');
     })
   );
 });

--- a/src/internal/components/live-region/controller.ts
+++ b/src/internal/components/live-region/controller.ts
@@ -1,0 +1,90 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import styles from './styles.css.js';
+
+/**
+ * The controller that manages a single live region container. It has a timer
+ * to make sure announcements are throttled correctly. It can also make sure
+ * that a message is announced again even if it matches the previous content
+ * of the live region.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
+ */
+export class LiveRegionController {
+  /**
+   * The default delay for announcements when no delay is explicitly provided.
+   * During internal unit testing, you can import this and explicitly set it to
+   * 0 to make the live region update the DOM without waiting for a timer.
+   */
+  public static defaultDelay = 2;
+
+  private _element: HTMLElement;
+  private _timeoutId: number | undefined;
+  private _lastAnnouncement: string | undefined;
+  private _addedTerminalPeriod = false;
+  private _nextAnnouncement = '';
+
+  constructor(
+    public readonly politeness: 'polite' | 'assertive',
+    public readonly delay = LiveRegionController.defaultDelay
+  ) {
+    this._element = document.createElement('div');
+    this._element.className = styles.announcer;
+    this._element.setAttribute('aria-live', this.politeness);
+    this._element.setAttribute('aria-atomic', 'true');
+    this._element.setAttribute('data-awsui-live-announcer', 'true');
+    document.body.appendChild(this._element);
+  }
+
+  /**
+   * Reset the state of the controller and clear any active announcements.
+   */
+  destroy() {
+    this._element?.remove();
+    if (this._timeoutId !== undefined) {
+      clearTimeout(this._timeoutId);
+      this._timeoutId = undefined;
+    }
+  }
+
+  announce({ message, forceReannounce = false }: { message?: string; delay?: number; forceReannounce?: boolean }) {
+    if (!message) {
+      return;
+    }
+
+    this._nextAnnouncement = message.trim();
+
+    if (this.delay === 0 || forceReannounce) {
+      // If the delay is 0, just skip the timeout shenanigans and update the
+      // element synchronously. Great for tests.
+      return this._updateElement(forceReannounce);
+    }
+
+    if (this._timeoutId === undefined) {
+      this._timeoutId = setTimeout(() => this._updateElement(false), this.delay * 1000);
+    }
+  }
+
+  private _updateElement(forceReannounce: boolean) {
+    if (this._nextAnnouncement !== this._lastAnnouncement) {
+      // The aria-atomic does not work properly in Voice Over, causing
+      // certain parts of the content to be ignored. To fix that,
+      // we assign the source text content as a single node.
+      this._element.textContent = this._nextAnnouncement;
+      this._addedTerminalPeriod = false;
+    } else if (forceReannounce) {
+      // A (generally) safe way of forcing re-announcements is toggling the
+      // terminal period. If we only keep adding periods, it's going to be
+      // eventually interpreted as an ellipsis.
+      this._element.textContent = this._nextAnnouncement + (this._addedTerminalPeriod ? '' : '.');
+      this._addedTerminalPeriod = !this._addedTerminalPeriod;
+    }
+
+    // Track the announced text for deduplication.
+    this._lastAnnouncement = this._nextAnnouncement;
+
+    // Reset the state for the next announcement.
+    this._timeoutId = undefined;
+  }
+}

--- a/src/internal/components/live-region/index.tsx
+++ b/src/internal/components/live-region/index.tsx
@@ -1,176 +1,31 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/* eslint-disable @cloudscape-design/prefer-live-region */
+import React from 'react';
 
-import React, { memo, useEffect, useRef } from 'react';
-import clsx from 'clsx';
+// import useBaseComponent from '../../hooks/use-base-component';
+import { applyDisplayName } from '../../utils/apply-display-name';
+import { LiveRegionProps } from './interfaces';
+import InternalLiveRegion from './internal';
 
-import ScreenreaderOnly, { ScreenreaderOnlyProps } from '../screenreader-only';
+export { LiveRegionProps };
 
-import styles from './styles.css.js';
-
-export interface LiveRegionProps extends ScreenreaderOnlyProps {
-  assertive?: boolean;
-  delay?: number;
-  visible?: boolean;
-  tagName?: 'span' | 'div';
-  id?: string;
-  /**
-   * Use a list of strings and/or existing DOM elements for building the
-   * announcement text. This avoids rendering separate content just for this
-   * LiveRegion.
-   *
-   * If this property is set, the `children` will be ignored.
-   */
-  source?: Array<string | React.RefObject<HTMLElement> | undefined>;
-}
-
-/**
- * The live region is hidden in the layout, but visible for screen readers.
- * It's purpose it to announce changes e.g. when custom navigation logic is used.
- *
- * The way live region works differently in different browsers and screen readers and
- * it is recommended to manually test every new implementation.
- *
- * If you notice there are different words being merged together,
- * check if there are text nodes not being wrapped in elements, like:
- * ```
- * <LiveRegion>
- *   {title}
- *   <span><Details /></span>
- * </LiveRegion>
- * ```
- *
- * To fix, wrap "title" in an element:
- * ```
- * <LiveRegion>
- *   <span>{title}</span>
- *   <span><Details /></span>
- * </LiveRegion>
- * ```
- *
- * Or create a single text node if possible:
- * ```
- * <LiveRegion>
- *   {`${title} ${details}`}
- * </LiveRegion>
- * ```
- *
- * The live region is always atomic, because non-atomic regions can be treated by screen readers
- * differently and produce unexpected results. To imitate non-atomic announcements simply use
- * multiple live regions:
- * ```
- * <>
- *   <LiveRegion>{title}</LiveRegion>
- *   <LiveRegion><Details /></LiveRegion>
- * </>
- * ```
- *
- * If you place interactive content inside the LiveRegion, the content will still be
- * interactive (e.g. as a tab stop). Consider using the `source` property instead.
- */
-export default memo(LiveRegion);
-
-function LiveRegion({
-  assertive = false,
-  delay = 10,
-  visible = false,
-  tagName: TagName = 'span',
-  children,
-  id,
-  source,
-  ...restProps
-}: LiveRegionProps) {
-  const sourceRef = useRef<HTMLSpanElement & HTMLDivElement>(null);
-  const targetRef = useRef<HTMLSpanElement & HTMLDivElement>(null);
-
-  /*
-    When React state changes, React often produces too many DOM updates, causing NVDA to
-    issue many announcements for the same logical event (See https://github.com/nvaccess/nvda/issues/7996).
-
-    The code below imitates a debouncing, scheduling a callback every time new React state
-    update is detected. When a callback resolves, it copies content from a muted element
-    to the live region, which is recognized by screen readers as an update.
-
-    If the use case requires no announcement to be ignored, use delay = 0, but ensure it
-    does not impact the performance. If it does, prefer using a string as children prop.
-  */
-  useEffect(() => {
-    function getSourceContent() {
-      if (source) {
-        return source
-          .map(item => {
-            if (!item) {
-              return undefined;
-            }
-            if (typeof item === 'string') {
-              return item;
-            }
-            if (item.current) {
-              return extractInnerText(item.current);
-            }
-          })
-          .filter(Boolean)
-          .join(' ');
-      }
-
-      if (sourceRef.current) {
-        return extractInnerText(sourceRef.current);
-      }
-    }
-    function updateLiveRegion() {
-      const sourceContent = getSourceContent();
-
-      if (targetRef.current && sourceContent) {
-        const targetContent = extractInnerText(targetRef.current);
-        if (targetContent !== sourceContent) {
-          // The aria-atomic does not work properly in Voice Over, causing
-          // certain parts of the content to be ignored. To fix that,
-          // we assign the source text content as a single node.
-          targetRef.current.innerText = sourceContent;
-        }
-      }
-    }
-
-    let timeoutId: null | number;
-    if (delay) {
-      timeoutId = setTimeout(updateLiveRegion, delay);
-    } else {
-      updateLiveRegion();
-    }
-
-    return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    };
-  });
+function LiveRegion({ assertive = false, hidden = false, tagName = 'div', ...restProps }: LiveRegionProps) {
+  // TODO: Switch this out when moving this component out of internal
+  // const baseComponentProps = useBaseComponent('LiveRegion');
+  const baseComponentProps = { __internalRootRef: React.useRef() };
 
   return (
-    <>
-      {visible && !source && (
-        <TagName ref={sourceRef} id={id} className={styles.source}>
-          {children}
-        </TagName>
-      )}
-
-      <ScreenreaderOnly {...restProps} className={clsx(styles.root, restProps.className)}>
-        {!visible && !source && (
-          <TagName ref={sourceRef} aria-hidden="true" className={styles.source}>
-            {children}
-          </TagName>
-        )}
-
-        <span ref={targetRef} aria-atomic="true" aria-live={assertive ? 'assertive' : 'polite'}></span>
-      </ScreenreaderOnly>
-    </>
+    <InternalLiveRegion
+      assertive={assertive}
+      hidden={hidden}
+      tagName={tagName}
+      {...baseComponentProps}
+      {...restProps}
+    />
   );
 }
 
-// This only extracts text content from the node including all its children which is enough for now.
-// To make it more powerful, it is possible to create a more sophisticated extractor with respect to
-// ARIA properties to ignore aria-hidden nodes and read ARIA labels from the live content.
-function extractInnerText(node: HTMLElement) {
-  return (node.innerText || '').replace(/\s+/g, ' ').trim();
-}
+applyDisplayName(LiveRegion, 'LiveRegion');
+
+export default LiveRegion;

--- a/src/internal/components/live-region/interfaces.ts
+++ b/src/internal/components/live-region/interfaces.ts
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { BaseComponentProps } from '../../base-component';
+
+export interface LiveRegionProps extends BaseComponentProps {
+  /**
+   * The string for the aria-live announcement text. When this content
+   * changes, the text will be re-announced to assistive technologies. If this
+   * property is provided, it will be used for the live announcement instead of
+   * the `children` slot.
+   */
+  message?: string;
+
+  /**
+   * Whether the announcements should be made using assertive aria-live.
+   * Assertive announcements interrupt the user's action, so they should only
+   * be used when absolutely necessary.
+   */
+  assertive?: boolean;
+
+  /**
+   * The tag name to use for the wrapper around the `children` slot.
+   */
+  tagName?: LiveRegionProps.TagName;
+
+  /**
+   * Defines whether to visually hide the contents of the `children` slot.
+   */
+  hidden?: boolean;
+
+  /**
+   * Use the rendered content as the source for the announcement text.
+   * Prefer `message` if announcement text can be provided as a string.
+   */
+  children?: React.ReactNode;
+}
+
+export namespace LiveRegionProps {
+  export type TagName = 'span' | 'div';
+}

--- a/src/internal/components/live-region/internal.tsx
+++ b/src/internal/components/live-region/internal.tsx
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useEffect, useImperativeHandle, useRef } from 'react';
+import clsx from 'clsx';
+
+import { getBaseProps } from '../../base-component';
+import { InternalBaseComponentProps } from '../../hooks/use-base-component';
+import { useMergeRefs } from '../../hooks/use-merge-refs';
+import { LiveRegionController } from './controller';
+import { LiveRegionProps } from './interfaces';
+
+import styles from './styles.css.js';
+
+export interface InternalLiveRegionProps extends InternalBaseComponentProps, LiveRegionProps {
+  /**
+   * The delay between each announcement from this live region. You should
+   * leave this set to the default unless this live region is commonly
+   * interrupted by other actions (like text entry in text filtering).
+   */
+  delay?: number;
+
+  /**
+   * Use a list of strings and/or refs to existing elements for building the
+   * announcement text. If this property is set, `children` and `message` will
+   * be ignored.
+   */
+  sources?: ReadonlyArray<string | React.RefObject<HTMLElement> | undefined>;
+}
+
+export interface InternalLiveRegionRef {
+  /**
+   * Force the live region to announce the message, even if it's the same as
+   * the previously announced message.
+   *
+   * This is useful when making status updates after a change (e.g. filtering)
+   * where the new message might be the same as the old one, but the announcement
+   * also serves to tell screen reader users that the action was performed.
+   */
+  reannounce(): void;
+}
+
+export default React.forwardRef(function InternalLiveRegion(
+  {
+    assertive = false,
+    hidden = false,
+    tagName: TagName = 'div',
+    delay,
+    sources,
+    message,
+    children,
+    __internalRootRef,
+    className,
+    ...restProps
+  }: InternalLiveRegionProps,
+  ref: React.Ref<InternalLiveRegionRef>
+) {
+  const baseProps = getBaseProps(restProps);
+  const childrenRef = useRef<HTMLSpanElement & HTMLDivElement>(null);
+  const mergedRef = useMergeRefs(childrenRef, __internalRootRef);
+
+  useEffect(() => {
+    // We have to do this because `inert` isn't properly supported until
+    // React 19 and this seems much more maintainable than version detection.
+    // `inert` is better than `hidden` because it also blocks pointer and
+    // focus events as well as hiding the contents from screen readers.
+    // https://github.com/facebook/react/issues/17157
+    if (childrenRef.current) {
+      childrenRef.current.inert = hidden;
+    }
+  }, [hidden]);
+
+  // Initialize the live region controller inside an effect. We have to do this
+  // because the controller depends on DOM elements, which aren't available on the
+  // server.
+  const liveRegionControllerRef = useRef<LiveRegionController | undefined>();
+  useEffect(() => {
+    const liveRegionController = new LiveRegionController(assertive ? 'assertive' : 'polite');
+    liveRegionControllerRef.current = liveRegionController;
+    return () => {
+      liveRegionController.destroy();
+      liveRegionControllerRef.current = undefined;
+    };
+  }, [assertive]);
+
+  const getContent = () => {
+    return sources
+      ? getSourceContent(sources)
+      : message
+        ? message
+        : childrenRef.current
+          ? extractTextContent(childrenRef.current)
+          : undefined;
+  };
+
+  // Call the controller on every render. The controller will deduplicate the
+  // message against the previous announcement internally.
+  useEffect(() => {
+    liveRegionControllerRef.current?.announce({ message: getContent(), delay });
+  });
+
+  useImperativeHandle(ref, () => ({
+    reannounce() {
+      liveRegionControllerRef.current?.announce({ message: getContent(), delay, forceReannounce: true });
+    },
+  }));
+
+  return (
+    <TagName ref={mergedRef} {...baseProps} className={clsx(styles.root, className)} hidden={hidden}>
+      {children}
+    </TagName>
+  );
+});
+
+function extractTextContent(node: HTMLElement): string {
+  // We use the text content of the node as the announcement text.
+  // This only extracts text content from the node including all its children which is enough for now.
+  // To make it more powerful, it is possible to create a more sophisticated extractor with respect to
+  // ARIA properties to ignore aria-hidden nodes and read ARIA labels from the live content.
+  return (node.textContent || '').replace(/\s+/g, ' ').trim();
+}
+
+function getSourceContent(source: ReadonlyArray<string | React.RefObject<HTMLElement> | undefined>): string {
+  return source
+    .map(item => {
+      if (!item || typeof item === 'string') {
+        return item;
+      }
+      if (item.current) {
+        return extractTextContent(item.current);
+      }
+    })
+    .filter(Boolean)
+    .join(' ');
+}

--- a/src/internal/components/live-region/styles.scss
+++ b/src/internal/components/live-region/styles.scss
@@ -3,9 +3,16 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
+@use '../../styles' as styles;
+
 .root {
-  /* used in test-utils */
+  display: contents;
 }
-.source {
-  /* used in test-utils */
+
+.root[hidden] {
+  display: none;
+}
+
+.announcer {
+  @include styles.awsui-util-hide;
 }

--- a/src/pie-chart/__integ__/with-links.test.ts
+++ b/src/pie-chart/__integ__/with-links.test.ts
@@ -36,7 +36,9 @@ describe('Pie chart with links in key-value pairs', () => {
         await page.click('#focus-target');
         await page.keys(['Tab']); // Focus the chart
         await page.keys(['Enter']); // Focus the first chart segment
-        await expect(page.getLiveAnnouncements()).resolves.toContain('Popularity 50% Calories per 100g 77 kcal');
+        await new Promise(resolve => setTimeout(resolve, 2000)); // Wait for live region timeout
+        const announcements = await page.getLiveAnnouncements();
+        expect(announcements.some(text => /Popularity\s*50%\s*Calories per 100g\s*77 kcal/.test(text))).toBe(true);
       })
     );
   });

--- a/src/pie-chart/pie-chart.tsx
+++ b/src/pie-chart/pie-chart.tsx
@@ -13,7 +13,7 @@ import ChartPopover from '../internal/components/chart-popover';
 import ChartPopoverFooter from '../internal/components/chart-popover-footer';
 import SeriesDetails from '../internal/components/chart-series-details';
 import SeriesMarker from '../internal/components/chart-series-marker';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import { useHeightMeasure } from '../internal/hooks/container-queries/use-height-measure';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
@@ -396,7 +396,7 @@ export default <T extends PieChartProps.Datum>({
           {detailPopoverFooterContent && <ChartPopoverFooter>{detailPopoverFooterContent}</ChartPopoverFooter>}
         </ChartPopover>
       )}
-      <LiveRegion source={[popoverContentRef]} />
+      <InternalLiveRegion sources={[popoverContentRef]} />
     </div>
   );
 };

--- a/src/progress-bar/__tests__/progress-bar.test.tsx
+++ b/src/progress-bar/__tests__/progress-bar.test.tsx
@@ -81,8 +81,8 @@ allVariants.forEach(variant => {
 
     describe('ARIA live region', () => {
       test('is present in the DOM while in-progress', () => {
-        const wrapper = renderProgressBar({ variant, value: 0 });
-        expect(wrapper.find('[aria-live]')).not.toBeNull();
+        renderProgressBar({ variant, value: 0 });
+        expect(createWrapper().find('[aria-live]')).not.toBeNull();
       });
 
       test('contains result text', () => {

--- a/src/progress-bar/index.tsx
+++ b/src/progress-bar/index.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 import { getBaseProps } from '../internal/base-component';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import { fireNonCancelableEvent } from '../internal/events';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
@@ -97,11 +97,11 @@ export default function ProgressBar({
                 )}
                 isInFlash={isInFlash}
               />
-              <LiveRegion delay={0}>
+              <InternalLiveRegion hidden={true} tagName="span" delay={0}>
                 {label}
                 {label ? ': ' : null}
                 {announcedValue}
-              </LiveRegion>
+              </InternalLiveRegion>
             </>
           ) : (
             <ResultState

--- a/src/s3-resource-selector/s3-in-context/index.tsx
+++ b/src/s3-resource-selector/s3-in-context/index.tsx
@@ -147,17 +147,15 @@ export const S3InContext = React.forwardRef(
           </div>
         </div>
 
-        <div role="alert" aria-live="assertive" aria-atomic="true">
+        <LiveRegion assertive={true}>
           {loading && (
             <InternalBox margin={{ top: 's' }}>
               <InternalStatusIndicator type="loading">
-                <LiveRegion visible={true}>
-                  {i18n('i18nStrings.inContextLoadingText', i18nStrings?.inContextLoadingText)}
-                </LiveRegion>
+                {i18n('i18nStrings.inContextLoadingText', i18nStrings?.inContextLoadingText)}
               </InternalStatusIndicator>
             </InternalBox>
           )}
-        </div>
+        </LiveRegion>
       </div>
     );
   }

--- a/src/s3-resource-selector/s3-modal/__tests__/fetching.test.tsx
+++ b/src/s3-resource-selector/s3-modal/__tests__/fetching.test.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 
+import { LiveRegionController } from '../../../../lib/components/internal/components/live-region/controller.js';
 import { S3Modal } from '../../../../lib/components/s3-resource-selector/s3-modal';
 import createWrapper, { ElementWrapper } from '../../../../lib/components/test-utils/dom';
 import { buckets, i18nStrings, objects, versions, waitForFetch } from '../../__tests__/fixtures';
@@ -10,6 +11,7 @@ import { getElementsText, modalDefaultProps, navigateToTableItem } from './utils
 
 import styles from '../../../../lib/components/s3-resource-selector/s3-modal/styles.css.js';
 
+LiveRegionController.defaultDelay = 0;
 jest.setTimeout(30_000);
 
 async function renderModal(jsx: React.ReactElement) {
@@ -152,17 +154,11 @@ describe('last updated status text', () => {
   });
 
   test('renders the last updated time within the aria-live region', async () => {
-    const wrapper = await renderModal(<S3Modal {...modalDefaultProps} />);
+    await renderModal(<S3Modal {...modalDefaultProps} />);
     await clickRefreshAndWaitForFetch();
-
-    const lastUpdated = wrapper.findByClassName(styles['last-updated-caption'])!.find('[aria-live]')!.getElement();
     await waitFor(() => {
-      /**
-       * <LiveRegion /> component is using innerText for setting the span element's text content.
-       * To populate the textContent from innerText, layout engine is required which JSDom doesn't have.
-       * So falling back to assert against innerText rather than the textContent.
-       */
-      expect(lastUpdated.innerText).toBe('Last updated January 2, 2024, 10:00:00 (UTC)');
+      const lastUpdated = createWrapper().find('[aria-live="polite"]')!.getElement();
+      expect(lastUpdated.textContent).toBe('Last updated January 2, 2024, 10:00:00 (UTC)');
     });
   });
 

--- a/src/s3-resource-selector/s3-modal/basic-table.tsx
+++ b/src/s3-resource-selector/s3-modal/basic-table.tsx
@@ -8,7 +8,7 @@ import { useStableCallback } from '@cloudscape-design/component-toolkit/internal
 import { InternalButton } from '../../button/internal';
 import InternalHeader from '../../header/internal';
 import { ComponentFormatFunction } from '../../i18n/context';
-import LiveRegion from '../../internal/components/live-region';
+import InternalLiveRegion from '../../internal/components/live-region/internal';
 import useForwardFocus, { ForwardFocusRef } from '../../internal/hooks/forward-focus';
 import formatDateLocalized from '../../internal/utils/date-time/format-date-localized';
 import { PaginationProps } from '../../pagination/interfaces';
@@ -210,7 +210,7 @@ export function InternalHeaderActions<T>({ i18nStrings, reloadData, lastUpdated 
         {i18nStrings.lastUpdatedText}
         <br />
         {formattedDate}
-        <LiveRegion visible={false} source={[i18nStrings.lastUpdatedText, formattedDate]} />
+        <InternalLiveRegion tagName="span" sources={[i18nStrings.lastUpdatedText, formattedDate]} />
       </div>
     );
   }

--- a/src/table/__integ__/inline-editing.test.ts
+++ b/src/table/__integ__/inline-editing.test.ts
@@ -6,6 +6,7 @@ import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objec
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper from '../../../lib/components/test-utils/selectors';
+import LiveRegionWrapper from '../../../lib/components/test-utils/selectors/internal/live-region';
 
 import styles from '../../../lib/components/table/body-cell/styles.selectors.js';
 
@@ -34,7 +35,7 @@ const bodyCellError = bodyCell.findFormField().findError().toSelector();
 
 const disabledCell = tableWrapper.findBodyCell(4, 4);
 const disabledCell$ = disabledCell.toSelector();
-const disabledCellLiveRegion$ = createWrapper().find('[aria-live]').toSelector();
+const disabledCellLiveRegion$ = new LiveRegionWrapper(`.${LiveRegionWrapper.rootSelector}`).toSelector();
 
 interface TestOptions {
   enableKeyboardNavigation?: boolean;

--- a/src/table/__tests__/body-cell.test.tsx
+++ b/src/table/__tests__/body-cell.test.tsx
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
+import { LiveRegionController } from '../../../lib/components/internal/components/live-region/controller.js';
 import { TableBodyCell, TableBodyCellProps } from '../../../lib/components/table/body-cell';
 import { useStickyColumns } from '../../../lib/components/table/sticky-columns';
 import wrapper from '../../../lib/components/test-utils/dom';
@@ -17,6 +18,8 @@ const tableRole = 'table';
 const testItem = {
   test: 'testData',
 };
+
+LiveRegionController.defaultDelay = 0;
 
 const stickyCellRef = jest.fn();
 
@@ -180,13 +183,13 @@ describe('TableBodyCell', () => {
       expect(container.querySelector(bodyCellSuccessIcon$)!).not.toBeInTheDocument();
     });
 
-    test('should render success icon and live region after a successful edit', () => {
+    test('should render success icon and live region after a successful edit', async () => {
       const { container } = render(<TestComponent successfulEdit={true} />);
       // Success icon is shown when cell is focused.
       screen.getByRole('button', { name: 'Edit testData test' }).focus();
 
       expect(container.querySelector(bodyCellSuccessIcon$)!).toBeInTheDocument();
-      expect(screen.getByText('edit successful')).toBeInTheDocument();
+      await waitFor(() => expect(screen.getByText('edit successful')).toBeInTheDocument());
     });
 
     test('should not render success icon when cell lost focus and get focused again', () => {
@@ -252,17 +255,14 @@ describe('TableBodyCell', () => {
       expect(disabledButton).toHaveAttribute('aria-disabled');
     });
 
-    test('activates live region when disabled cell is activated', () => {
-      const { baseElement } = render(
-        <TestComponent {...commonProps} column={disableInlineEditColumn} isEditing={true} />
-      );
+    test('activates live region when disabled cell is activated', async () => {
+      render(<TestComponent {...commonProps} column={disableInlineEditColumn} isEditing={true} />);
 
       const disabledButton = screen.getByRole('button', { name: 'Edit testData test' });
       expect(disabledButton).toHaveAccessibleDescription('Cannot edit');
       expect(disabledButton).toHaveAttribute('aria-disabled');
 
-      const liveRegion = baseElement.querySelector('[aria-live]');
-      expect(liveRegion).toHaveTextContent('Cannot edit');
+      await waitFor(() => expect(document.querySelector('[aria-live]')).toHaveTextContent('Cannot edit'));
     });
 
     test('dynamically disables inline edit based on disabledReason callback', () => {

--- a/src/table/__tests__/progressive-loading.test.tsx
+++ b/src/table/__tests__/progressive-loading.test.tsx
@@ -92,7 +92,7 @@ function findParentRow(element: HTMLElement): HTMLTableRowElement {
 
 const getTextContent = (w: ComponentWrapper) => w.getElement().textContent?.trim();
 const getAriaLevel = (w: ComponentWrapper) => findParentRow(w.getElement()).getAttribute('aria-level');
-const getAriaLive = (w: ComponentWrapper) => w.findByClassName(liveRegionStyles.source)!.getElement().textContent;
+const getAriaLive = (w: ComponentWrapper) => w.findByClassName(liveRegionStyles.root)!.getElement().textContent;
 
 describe('Progressive loading', () => {
   test('renders loaders in correct order for normal table', () => {

--- a/src/table/body-cell/disabled-inline-editor.tsx
+++ b/src/table/body-cell/disabled-inline-editor.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useState } from 'react';
 import clsx from 'clsx';
 
 import Icon from '../../icon/internal';
+import InternalLiveRegion from '../../internal/components/live-region/internal';
 import Portal from '../../internal/components/portal';
 import { useSingleTabStopNavigation } from '../../internal/context/single-tab-stop-navigation-context';
 import useHiddenDescription from '../../internal/hooks/use-hidden-description';
@@ -126,7 +127,7 @@ export function DisabledInlineEditor<ItemType>({
                   onDismiss={() => {}}
                   overflowVisible="both"
                 >
-                  <span aria-live="polite">{editDisabledReason}</span>
+                  <InternalLiveRegion tagName="span">{editDisabledReason}</InternalLiveRegion>
                 </PopoverBody>
               </PopoverContainer>
             </span>

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 
 import { useInternalI18n } from '../../i18n/context';
 import Icon from '../../icon/internal';
-import LiveRegion from '../../internal/components/live-region/index.js';
+import InternalLiveRegion from '../../internal/components/live-region/internal';
 import { useSingleTabStopNavigation } from '../../internal/context/single-tab-stop-navigation-context.js';
 import { usePrevious } from '../../internal/hooks/use-previous';
 import { TableProps } from '../interfaces';
@@ -130,9 +130,10 @@ function TableCellEditable<ItemType>({
               >
                 <Icon name="status-positive" variant="success" />
               </span>
-              <LiveRegion>
-                {i18n('ariaLabels.successfulEditLabel', ariaLabels?.successfulEditLabel?.(column))}
-              </LiveRegion>
+              <InternalLiveRegion
+                tagName="span"
+                message={i18n('ariaLabels.successfulEditLabel', ariaLabels?.successfulEditLabel?.(column))}
+              />
             </>
           )}
 

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -6,7 +6,7 @@ import Button from '../../button/internal';
 import FormField from '../../form-field/internal';
 import { useInternalI18n } from '../../i18n/context';
 import FocusLock, { FocusLockRef } from '../../internal/components/focus-lock';
-import LiveRegion from '../../internal/components/live-region';
+import InternalLiveRegion from '../../internal/components/live-region/internal';
 import { Optional } from '../../internal/types';
 import SpaceBetween from '../../space-between/internal';
 import { TableProps } from '../interfaces';
@@ -145,11 +145,14 @@ export function InlineEditor<ItemType>({
                     loading={currentEditLoading}
                   />
                 </SpaceBetween>
-                <LiveRegion>
-                  {currentEditLoading
-                    ? i18n('ariaLabels.submittingEditText', ariaLabels?.submittingEditText?.(column))
-                    : ''}
-                </LiveRegion>
+                <InternalLiveRegion
+                  tagName="span"
+                  message={
+                    currentEditLoading
+                      ? i18n('ariaLabels.submittingEditText', ariaLabels?.submittingEditText?.(column))
+                      : ''
+                  }
+                />
               </span>
             </div>
           </FormField>

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -13,7 +13,7 @@ import {
 import InternalContainer, { InternalContainerProps } from '../container/internal';
 import { useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
 import { getAnalyticsMetadataProps, getBaseProps } from '../internal/base-component';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import { getVisualContextClassname } from '../internal/components/visual-context';
 import { CollectionLabelContext } from '../internal/context/collection-label-context';
 import { LinkDefaultVariantContext } from '../internal/context/link-default-variant-context';
@@ -470,7 +470,7 @@ const InternalTable = React.forwardRef(
               >
                 <div className={styles['wrapper-content-measure']} ref={wrapperMeasureMergedRef}></div>
                 {!!renderAriaLive && !!firstIndex && (
-                  <LiveRegion>
+                  <InternalLiveRegion hidden={true} tagName="span">
                     <span>
                       {renderAriaLive({
                         firstIndex,
@@ -479,7 +479,7 @@ const InternalTable = React.forwardRef(
                         totalItemsCount,
                       })}
                     </span>
-                  </LiveRegion>
+                  </InternalLiveRegion>
                 )}
                 <GridNavigationProvider
                   keyboardNavigation={!!enableKeyboardNavigation}

--- a/src/table/no-data-cell.tsx
+++ b/src/table/no-data-cell.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import InternalStatusIndicator from '../status-indicator/internal';
 
 import styles from './styles.css.js';
@@ -45,7 +45,7 @@ export function NoDataCell({
       <div ref={cellContentRef} className={styles['cell-merged-content']} data-awsui-table-suppress-navigation={true}>
         {loading ? (
           <InternalStatusIndicator type="loading" className={styles.loading} wrapText={true}>
-            <LiveRegion visible={true}>{loadingText}</LiveRegion>
+            <InternalLiveRegion tagName="span">{loadingText}</InternalLiveRegion>
           </InternalStatusIndicator>
         ) : (
           <div className={styles.empty}>{empty}</div>

--- a/src/table/progressive-loading/items-loader.tsx
+++ b/src/table/progressive-loading/items-loader.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
-import LiveRegion from '../../internal/components/live-region';
+import InternalLiveRegion from '../../internal/components/live-region/internal';
 import { TableProps } from '../interfaces';
 import { applyTrackBy } from '../utils';
 
@@ -31,9 +31,9 @@ export function ItemsLoader<T>({
   if (loadingStatus === 'pending' && renderLoaderPending) {
     content = renderLoaderPending({ item });
   } else if (loadingStatus === 'loading' && renderLoaderLoading) {
-    content = <LiveRegion visible={true}>{renderLoaderLoading({ item })}</LiveRegion>;
+    content = <InternalLiveRegion tagName="span">{renderLoaderLoading({ item })}</InternalLiveRegion>;
   } else if (loadingStatus === 'error' && renderLoaderError) {
-    content = <LiveRegion visible={true}>{renderLoaderError({ item })}</LiveRegion>;
+    content = <InternalLiveRegion tagName="span">{renderLoaderError({ item })}</InternalLiveRegion>;
   } else {
     warnOnce(
       'Table',

--- a/src/tag-editor/index.tsx
+++ b/src/tag-editor/index.tsx
@@ -13,7 +13,7 @@ import { FormFieldError } from '../form-field/internal';
 import { useInternalI18n } from '../i18n/context';
 import { InputProps } from '../input/interfaces';
 import { getBaseProps } from '../internal/base-component';
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 import { fireNonCancelableEvent, NonCancelableCustomEvent } from '../internal/events';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
@@ -284,7 +284,7 @@ const TagEditor = React.forwardRef(
       return (
         <div className={styles.root} ref={baseComponentProps.__internalRootRef}>
           <InternalStatusIndicator className={styles.loading} type="loading">
-            <LiveRegion visible={true}>{i18n('i18nStrings.loading', i18nStrings?.loading)}</LiveRegion>
+            <InternalLiveRegion tagName="span">{i18n('i18nStrings.loading', i18nStrings?.loading)}</InternalLiveRegion>
           </InternalStatusIndicator>
         </div>
       );

--- a/src/test-utils/dom/internal/live-region.ts
+++ b/src/test-utils/dom/internal/live-region.ts
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ComponentWrapper } from '@cloudscape-design/test-utils-core/dom';
+
+import styles from '../../../internal/components/live-region/styles.selectors.js';
+
+export default class LiveRegionWrapper extends ComponentWrapper {
+  static rootSelector: string = styles.root;
+}

--- a/src/text-filter/search-results.tsx
+++ b/src/text-filter/search-results.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import LiveRegion from '../internal/components/live-region';
+import InternalLiveRegion from '../internal/components/live-region/internal';
 
 import styles from './styles.css.js';
 
@@ -18,9 +18,9 @@ interface SearchResultsProps {
 export function SearchResults({ id, children }: SearchResultsProps) {
   return (
     <span className={styles.results}>
-      <LiveRegion delay={LIVE_REGION_DELAY} visible={true}>
+      <InternalLiveRegion delay={LIVE_REGION_DELAY} tagName="span">
         <span id={id}>{children}</span>
-      </LiveRegion>
+      </InternalLiveRegion>
     </span>
   );
 }

--- a/src/tutorial-panel/components/tutorial-list/index.tsx
+++ b/src/tutorial-panel/components/tutorial-list/index.tsx
@@ -9,7 +9,7 @@ import { HotspotContext } from '../../../annotation-context/context.js';
 import InternalBox from '../../../box/internal';
 import { InternalButton } from '../../../button/internal';
 import InternalIcon from '../../../icon/internal';
-import LiveRegion from '../../../internal/components/live-region/index.js';
+import InternalLiveRegion from '../../../internal/components/live-region/internal';
 import { fireNonCancelableEvent } from '../../../internal/events/index.js';
 import { useUniqueId } from '../../../internal/hooks/use-unique-id/index.js';
 import { useVisualRefresh } from '../../../internal/hooks/use-visual-mode';
@@ -68,7 +68,7 @@ export default function TutorialList({
           )}
           {loading ? (
             <InternalStatusIndicator type="loading">
-              <LiveRegion visible={true}>{i18nStrings.loadingText}</LiveRegion>
+              <InternalLiveRegion tagName="span">{i18nStrings.loadingText}</InternalLiveRegion>
             </InternalStatusIndicator>
           ) : (
             <ul className={styles['tutorial-list']} role="list">


### PR DESCRIPTION
### Description

*58 files, but they're mostly just import path changes and renames!*

The important changes are in [`src/internal/components/live-region`](https://github.com/cloudscape-design/components/pull/2914/files#diff-0bd914bc4a690dca7f4cdf1732d17728fc131eff66e565d59d38e9a3d37276f9).

- Split LiveRegion into a "public" LiveRegion and an internal "InternalLiveRegion" as we do with other components, along with documented API definitions.
- Update tests that expect `[aria-live]` inside the component.
- There's also another crucial improvement: the aria-live element is rendered in a separate element *at the end of the DOM* so that it doesn't cause screen readers to read live region content twice (once as an announcement, and again as they navigate inside the hidden element). The previous implementation used a centralized singleton to manage announcements globally, but this was backwards incompatible with many consumer's tests (e.g. those that rely on React's lifecycle management and test for text in DOM, like `screen.getByText()`).

There will be a pure path update PR when the component should _actually_ be merged.

Related links, issue #, if available: n/a

### How has this been tested?

Updated unit tests in the live region component, and where components expect a "local" aria-live region.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
