### PR TITLE
fix: Extra scrollbars in drawers

### DIFF
--- a/pages/app-layout/runtime-drawers.page.tsx
+++ b/pages/app-layout/runtime-drawers.page.tsx
@@ -97,11 +97,7 @@ export default function WithDrawers() {
                   Use Tools
                 </Toggle>
 
-                <Toggle
-                  checked={hasDrawers}
-                  onChange={({ detail }) => setUrlParams({ hasDrawers: detail.checked })}
-                  data-testid="use-drawers-toggle"
-                >
+                <Toggle checked={hasDrawers} onChange={({ detail }) => setUrlParams({ hasDrawers: detail.checked })}>
                   Use Drawers
                 </Toggle>
 

--- a/pages/app-layout/runtime-drawers.page.tsx
+++ b/pages/app-layout/runtime-drawers.page.tsx
@@ -6,7 +6,6 @@ import {
   AppLayout,
   Button,
   ContentLayout,
-  Drawer,
   Header,
   HelpPanel,
   Link,
@@ -19,7 +18,7 @@ import awsuiPlugins from '~components/internal/plugins';
 
 import './utils/external-widget';
 import AppContext, { AppContextType } from '../app/app-context';
-import { Breadcrumbs, Containers } from './utils/content-blocks';
+import { Breadcrumbs, Containers, CustomDrawerContent } from './utils/content-blocks';
 import appLayoutLabels from './utils/labels';
 
 type DemoContext = React.Context<
@@ -98,7 +97,11 @@ export default function WithDrawers() {
                   Use Tools
                 </Toggle>
 
-                <Toggle checked={hasDrawers} onChange={({ detail }) => setUrlParams({ hasDrawers: detail.checked })}>
+                <Toggle
+                  checked={hasDrawers}
+                  onChange={({ detail }) => setUrlParams({ hasDrawers: detail.checked })}
+                  data-testid="use-drawers-toggle"
+                >
                   Use Drawers
                 </Toggle>
 
@@ -173,5 +176,5 @@ function Info({ helpPathSlug }: { helpPathSlug: string }) {
 }
 
 function ProHelp() {
-  return <Drawer header={<h2>Pro Help</h2>}>Need some Pro Help? We got you.</Drawer>;
+  return <CustomDrawerContent />;
 }

--- a/pages/app-layout/runtime-drawers.page.tsx
+++ b/pages/app-layout/runtime-drawers.page.tsx
@@ -105,7 +105,10 @@ export default function WithDrawers() {
                   Use Drawers
                 </Toggle>
 
-                <Button onClick={() => awsuiPlugins.appLayout.openDrawer('circle4-global')}>
+                <Button
+                  onClick={() => awsuiPlugins.appLayout.openDrawer('circle4-global')}
+                  data-testid="open-drawer-button"
+                >
                   Open a drawer without a trigger
                 </Button>
                 <Button onClick={() => awsuiPlugins.appLayout.closeDrawer('circle4-global')}>

--- a/pages/app-layout/styles.scss
+++ b/pages/app-layout/styles.scss
@@ -80,3 +80,29 @@
     margin-block-start: 4rem;
   }
 }
+
+.custom-drawer-wrapper {
+  display: flex;
+  flex-direction: column;
+  block-size: 100%;
+  overflow-y: hidden;
+}
+
+.drawer-sticky-header,
+.drawer-scrollable-content,
+.drawer-sticky-footer {
+  padding-inline: 24px;
+}
+
+.drawer-sticky-header {
+  border-block-end: 2px solid grey;
+}
+.drawer-scrollable-content {
+  flex: 1;
+  overflow-y: auto;
+  padding-block: 8px;
+}
+.drawer-sticky-footer {
+  border-block-start: 2px solid grey;
+  padding-block: 16px;
+}

--- a/pages/app-layout/utils/content-blocks.tsx
+++ b/pages/app-layout/utils/content-blocks.tsx
@@ -12,6 +12,7 @@ import Header from '~components/header';
 import HelpPanel from '~components/help-panel';
 import SideNavigation from '~components/side-navigation';
 import SpaceBetween from '~components/space-between';
+import TextContent from '~components/text-content';
 
 import styles from '../styles.scss';
 
@@ -84,5 +85,60 @@ export function Footer({ legacyConsoleNav }: { legacyConsoleNav: boolean }) {
         © 2008 - 2020, Amazon Web Services, Inc. or its affiliates. All rights reserved
       </footer>
     </>
+  );
+}
+
+export function ScrollableDrawerContent() {
+  return (
+    <div className={styles['drawer-scrollable-content']}>
+      <TextContent>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Augue neque gravida in fermentum. Suspendisse sed nisi lacus sed viverra tellus in hac. Nec
+          sagittis aliquam malesuada bibendum arcu vitae elementum. Lectus proin nibh nisl condimentum id venenatis.
+          Penatibus et magnis dis parturient montes nascetur ridiculus mus mauris. Nisi porta lorem mollis aliquam ut
+          porttitor leo a. Facilisi morbi tempus iaculis urna. Odio tempor orci dapibus ultrices in iaculis nunc.
+        </p>
+        <div data-testid="scroll-me">The end</div>
+        <p>
+          Ut diam quam nulla porttitor massa id neque. Duis at tellus at urna condimentum mattis pellentesque id nibh.
+          Metus vulputate eu scelerisque felis imperdiet proin fermentum.
+        </p>
+        <h3>Another h3</h3>
+        <p>
+          Orci porta non pulvinar neque laoreet suspendisse interdum consectetur libero. Varius quam quisque id diam
+          vel. Risus viverra adipiscing at in. Orci sagittis eu volutpat odio facilisis mauris. Mauris vitae ultricies
+          leo integer malesuada nunc. Sem et tortor consequat id porta nibh. Semper auctor neque vitae tempus quam
+          pellentesque.
+        </p>
+        <p>Ante in nibh mauris cursus mattis molestie.</p>
+        <p>
+          Pharetra et ultrices neque ornare. Bibendum neque egestas congue quisque egestas diam in arcu cursus.
+          Porttitor eget dolor morbi non arcu risus quis. Integer quis auctor elit sed vulputate mi sit. Mauris nunc
+          congue nisi vitae suscipit tellus mauris a diam. Diam donec adipiscing tristique risus nec feugiat in. Arcu
+          felis bibendum ut tristique et egestas quis. Nulla porttitor massa id neque aliquam vestibulum morbi blandit.
+          In hac habitasse platea dictumst quisque sagittis. Sollicitudin tempor id eu nisl nunc mi ipsum. Ornare aenean
+          euismod elementum nisi quis. Elementum curabitur vitae nunc sed velit dignissim sodales. Amet tellus cras
+          adipiscing enim eu. Id interdum velit laoreet id donec ultrices tincidunt. Ullamcorper eget nulla facilisi
+          etiam. Sodales neque sodales ut etiam sit amet nisl purus. Auctor urna nunc id cursus metus aliquam eleifend
+          mi in. Urna condimentum mattis pellentesque id. Porta lorem mollis aliquam ut porttitor leo a. Lectus quam id
+          leo in vitae turpis massa sed. Pharetra pharetra massa massa ultricies mi.
+        </p>
+      </TextContent>
+    </div>
+  );
+}
+
+export function CustomDrawerContent() {
+  return (
+    <div className={styles['custom-drawer-wrapper']}>
+      <div className={styles['drawer-sticky-header']} data-testid="drawer-sticky-header">
+        <h2>Header</h2>
+      </div>
+      <ScrollableDrawerContent />
+      <div className={styles['drawer-sticky-footer']} data-testid="drawer-sticky-footer">
+        <p>This is a sticky footer, it should always be visisble when the panel is open.</p>
+      </div>
+    </div>
   );
 }

--- a/pages/app-layout/utils/external-widget.tsx
+++ b/pages/app-layout/utils/external-widget.tsx
@@ -6,6 +6,8 @@ import ReactDOM, { unmountComponentAtNode } from 'react-dom';
 import Drawer from '~components/drawer';
 import awsuiPlugins from '~components/internal/plugins';
 
+import { CustomDrawerContent } from './content-blocks';
+
 const searchParams = new URL(location.hash.substring(1), location.href).searchParams;
 
 const Content = React.forwardRef((props, ref) => {
@@ -233,7 +235,7 @@ awsuiPlugins.appLayout.registerDrawer({
   },
 
   mountContent: container => {
-    ReactDOM.render(<div>global widget content circle 3 (without trigger button)</div>, container);
+    ReactDOM.render(<CustomDrawerContent />, container);
   },
   unmountContent: container => unmountComponentAtNode(container),
 });

--- a/src/app-layout/__integ__/runtime-drawers.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers.test.ts
@@ -49,6 +49,26 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
     );
 
     test(
+      'should show sticky elements on scroll in drawer',
+      setupTest(async page => {
+        await page.setWindowSize(viewports.desktop);
+        await page.click(createWrapper().findToggle('[data-testid="use-drawers-toggle"]').toSelector());
+        await page.waitForVisible(wrapper.findDrawerTriggerById('pro-help').toSelector(), true);
+
+        await expect(page.isDisplayed('[data-testid="drawer-sticky-footer"]')).resolves.toBe(false);
+        await page.click(wrapper.findDrawerTriggerById('pro-help').toSelector());
+        await expect(page.isDisplayedInViewport('[data-testid="drawer-sticky-footer"]')).resolves.toBe(true);
+
+        const getScrollPosition = () => page.getBoundingBox('[data-testid="drawer-sticky-header"]');
+        const scrollBefore = await getScrollPosition();
+
+        await page.elementScrollTo(wrapper.findActiveDrawer().toSelector(), { top: 100 });
+        await expect(getScrollPosition()).resolves.toEqual(scrollBefore);
+        await expect(page.isDisplayed('[data-testid="drawer-sticky-header"]')).resolves.toBe(true);
+      })
+    );
+
+    test(
       'renders according to defaultSize property',
       setupTest(async page => {
         await page.setWindowSize(viewports.desktop);

--- a/src/app-layout/__integ__/runtime-drawers.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers.test.ts
@@ -49,26 +49,6 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
     );
 
     test(
-      'should show sticky elements on scroll in drawer',
-      setupTest(async page => {
-        await page.setWindowSize(viewports.desktop);
-        await page.click(createWrapper().findToggle('[data-testid="use-drawers-toggle"]').toSelector());
-        await page.waitForVisible(wrapper.findDrawerTriggerById('pro-help').toSelector(), true);
-
-        await expect(page.isDisplayed('[data-testid="drawer-sticky-footer"]')).resolves.toBe(false);
-        await page.click(wrapper.findDrawerTriggerById('pro-help').toSelector());
-        await expect(page.isDisplayedInViewport('[data-testid="drawer-sticky-footer"]')).resolves.toBe(true);
-
-        const getScrollPosition = () => page.getBoundingBox('[data-testid="drawer-sticky-header"]');
-        const scrollBefore = await getScrollPosition();
-
-        await page.elementScrollTo(wrapper.findActiveDrawer().toSelector(), { top: 100 });
-        await expect(getScrollPosition()).resolves.toEqual(scrollBefore);
-        await expect(page.isDisplayed('[data-testid="drawer-sticky-header"]')).resolves.toBe(true);
-      })
-    );
-
-    test(
       'renders according to defaultSize property',
       setupTest(async page => {
         await page.setWindowSize(viewports.desktop);
@@ -91,6 +71,28 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
 
         await page.dragAndDrop(wrapper.findActiveDrawerResizeHandle().toSelector(), -200);
         await expect(page.getText('[data-testid="current-size"]')).resolves.toEqual('resized: true');
+      })
+    );
+
+    test(
+      'should show sticky elements on scroll in drawer',
+      setupTest(async page => {
+        await page.setWindowSize(viewports.desktop);
+        await page.click(
+          createWrapper().findToggle('[data-testid="use-drawers-toggle"]').findNativeInput().toSelector()
+        );
+        await page.waitForVisible(wrapper.findDrawerTriggerById('pro-help').toSelector(), true);
+
+        await expect(page.isDisplayed('[data-testid="drawer-sticky-footer"]')).resolves.toBe(false);
+        await page.click(wrapper.findDrawerTriggerById('pro-help').toSelector());
+        await expect(page.isDisplayed('[data-testid="drawer-sticky-footer"]')).resolves.toBe(true);
+
+        const getScrollPosition = () => page.getBoundingBox('[data-testid="drawer-sticky-header"]');
+        const scrollBefore = await getScrollPosition();
+
+        await page.elementScrollTo(wrapper.findActiveDrawer().toSelector(), { top: 100 });
+        await expect(getScrollPosition()).resolves.toEqual(scrollBefore);
+        await expect(page.isDisplayed('[data-testid="drawer-sticky-header"]')).resolves.toBe(true);
       })
     );
   });
@@ -239,6 +241,25 @@ describe('Visual refresh toolbar only', () => {
       await expect(page.isClickable(findDrawerById(wrapper, 'circle2-global')!.toSelector())).resolves.toBe(true);
       await expect(page.isClickable(findDrawerById(wrapper, 'circle3-global')!.toSelector())).resolves.toBe(true);
       await expect(page.hasHorizontalScroll()).resolves.toBe(false);
+    })
+  );
+
+  test(
+    'should show sticky elements on scroll in global drawer',
+    setupTest(async page => {
+      await page.setWindowSize(viewports.desktop);
+      await expect(page.isDisplayed('[data-testid="drawer-sticky-footer"]')).resolves.toBe(false);
+
+      await page.click(createWrapper().findButton('[data-testid="open-drawer-button"]').toSelector());
+      await page.waitForVisible(findDrawerById(wrapper, 'circle4-global')!.toSelector(), true);
+      await expect(page.isDisplayed('[data-testid="drawer-sticky-footer"]')).resolves.toBe(true);
+
+      const getScrollPosition = () => page.getBoundingBox('[data-testid="drawer-sticky-header"]');
+      const scrollBefore = await getScrollPosition();
+
+      await page.elementScrollTo(wrapper.findActiveDrawer().toSelector(), { top: 100 });
+      await expect(getScrollPosition()).resolves.toEqual(scrollBefore);
+      await expect(page.isDisplayed('[data-testid="drawer-sticky-header"]')).resolves.toBe(true);
     })
   );
 });

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -121,6 +121,9 @@ export const Drawer = React.forwardRef(
             className={clsx(resizeHandle && styles['drawer-resize-content'])}
             aria-label={mainLabel}
             aria-hidden={!isOpen}
+            style={{
+              ['blockSize']: `calc(100vh - ${(topOffset || 0) + (bottomOffset || 0)}px)`,
+            }}
           >
             {!isMobile && isOpen && <div className={styles['resize-handle-wrapper']}>{resizeHandle}</div>}
             <CloseButton

--- a/src/app-layout/resize/styles.scss
+++ b/src/app-layout/resize/styles.scss
@@ -10,7 +10,7 @@
   @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
     @include styles.with-motion {
       transition: awsui.$motion-duration-refresh-only-medium;
-      transition-property: border-color, opacity, block-size, inline-size, inset-block-start;
+      transition-property: border-color, opacity, inline-size, inset-block-start;
     }
   }
 }

--- a/src/app-layout/visual-refresh-toolbar/compute-layout.ts
+++ b/src/app-layout/visual-refresh-toolbar/compute-layout.ts
@@ -110,10 +110,15 @@ export function computeVerticalLayout({
   return { toolbar, notifications, header, drawers };
 }
 
-export function getDrawerTopOffset(
+export function getDrawerStyles(
   verticalOffsets: VerticalLayoutOutput,
   isMobile: boolean,
   placement: AppLayoutPropsWithDefaults['placement']
-) {
-  return isMobile ? verticalOffsets.toolbar : verticalOffsets.drawers ?? placement.insetBlockStart;
+): {
+  drawerTopOffset: number;
+  drawerHeight: string;
+} {
+  const drawerTopOffset = isMobile ? verticalOffsets.toolbar : verticalOffsets.drawers ?? placement.insetBlockStart;
+  const drawerHeight = `calc(100vh - ${drawerTopOffset}px - ${placement.insetBlockEnd}px)`;
+  return { drawerTopOffset, drawerHeight };
 }

--- a/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
@@ -133,7 +133,12 @@ function AppLayoutGlobalDrawerImplementation({
                   variant="icon"
                 />
               </div>
-              <div className={styles['drawer-content']}>{activeGlobalDrawer?.content}</div>
+              <div
+                className={styles['drawer-content']}
+                style={{ blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)` }}
+              >
+                {activeGlobalDrawer?.content}
+              </div>
             </div>
           </aside>
         );

--- a/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
@@ -10,7 +10,7 @@ import { NonCancelableEventHandler } from '../../../internal/events';
 import customCssProps from '../../../internal/generated/custom-css-properties';
 import { getLimitedValue } from '../../../split-panel/utils/size-utils';
 import { AppLayoutProps } from '../../interfaces';
-import { getDrawerTopOffset } from '../compute-layout';
+import { getDrawerStyles } from '../compute-layout';
 import { AppLayoutInternals } from '../interfaces';
 import { useResize } from './use-resize';
 
@@ -52,7 +52,7 @@ function AppLayoutGlobalDrawerImplementation({
     content: activeGlobalDrawer ? activeGlobalDrawer.ariaLabels?.drawerName : ariaLabels?.tools,
   };
 
-  const drawersTopOffset = getDrawerTopOffset(verticalOffsets, isMobile, placement);
+  const { drawerTopOffset, drawerHeight } = getDrawerStyles(verticalOffsets, isMobile, placement);
   const activeDrawerSize = (activeDrawerId ? activeGlobalDrawersSizes[activeDrawerId] : 0) ?? 0;
   const minDrawerSize = (activeDrawerId ? minGlobalDrawersSizes[activeDrawerId] : 0) ?? 0;
   const maxDrawerSize = (activeDrawerId ? maxGlobalDrawersSizes[activeDrawerId] : 0) ?? 0;
@@ -98,8 +98,8 @@ function AppLayoutGlobalDrawerImplementation({
               }
             }}
             style={{
-              blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)`,
-              insetBlockStart: drawersTopOffset,
+              blockSize: drawerHeight,
+              insetBlockStart: drawerTopOffset,
               ...(!isMobile && {
                 [customCssProps.drawerSize]: `${['entering', 'entered'].includes(state) ? size : 0}px`,
               }),
@@ -133,10 +133,7 @@ function AppLayoutGlobalDrawerImplementation({
                   variant="icon"
                 />
               </div>
-              <div
-                className={styles['drawer-content']}
-                style={{ blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)` }}
-              >
+              <div className={styles['drawer-content']} style={{ blockSize: drawerHeight }}>
                 {activeGlobalDrawer?.content}
               </div>
             </div>

--- a/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
@@ -131,7 +131,12 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
               {toolsContent}
             </div>
             {activeDrawerId !== TOOLS_DRAWER_ID && (
-              <div className={styles['drawer-content']}>{activeDrawer?.content}</div>
+              <div
+                className={styles['drawer-content']}
+                style={{ blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)` }}
+              >
+                {activeDrawer?.content}
+              </div>
             )}
           </div>
         </aside>

--- a/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
@@ -10,7 +10,7 @@ import customCssProps from '../../../internal/generated/custom-css-properties';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { getLimitedValue } from '../../../split-panel/utils/size-utils';
 import { TOOLS_DRAWER_ID } from '../../utils/use-drawers';
-import { getDrawerTopOffset } from '../compute-layout';
+import { getDrawerStyles } from '../compute-layout';
 import { AppLayoutInternals } from '../interfaces';
 import { useResize } from './use-resize';
 
@@ -46,7 +46,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
     content: activeDrawer ? activeDrawer.ariaLabels?.drawerName : ariaLabels?.tools,
   };
 
-  const drawersTopOffset = getDrawerTopOffset(verticalOffsets, isMobile, placement);
+  const { drawerTopOffset, drawerHeight } = getDrawerStyles(verticalOffsets, isMobile, placement);
   const toolsOnlyMode = drawers.length === 1 && drawers[0].id === TOOLS_DRAWER_ID;
   const isToolsDrawer = activeDrawer?.id === TOOLS_DRAWER_ID || toolsOnlyMode;
   const toolsContent = drawers?.find(drawer => drawer.id === TOOLS_DRAWER_ID)?.content;
@@ -85,8 +85,8 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
             }
           }}
           style={{
-            blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)`,
-            insetBlockStart: drawersTopOffset,
+            blockSize: drawerHeight,
+            insetBlockStart: drawerTopOffset,
             ...(!isMobile &&
               !isLegacyDrawer && {
                 [customCssProps.drawerSize]: `${['entering', 'entered'].includes(state) ? size : 0}px`,
@@ -131,10 +131,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
               {toolsContent}
             </div>
             {activeDrawerId !== TOOLS_DRAWER_ID && (
-              <div
-                className={styles['drawer-content']}
-                style={{ blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)` }}
-              >
+              <div className={styles['drawer-content']} style={{ blockSize: drawerHeight }}>
                 {activeDrawer?.content}
               </div>
             )}

--- a/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
@@ -7,7 +7,7 @@ import { findUpUntil } from '@cloudscape-design/component-toolkit/dom';
 
 import { InternalButton } from '../../../button/internal';
 import { createWidgetizedComponent } from '../../../internal/widgets';
-import { getDrawerTopOffset } from '../compute-layout';
+import { getDrawerStyles } from '../compute-layout';
 import { AppLayoutInternals } from '../interfaces';
 
 import sharedStyles from '../../resize/styles.css.js';
@@ -30,7 +30,7 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
     verticalOffsets,
   } = appLayoutInternals;
 
-  const drawersTopOffset = getDrawerTopOffset(verticalOffsets, isMobile, placement);
+  const { drawerTopOffset, drawerHeight } = getDrawerStyles(verticalOffsets, isMobile, placement);
 
   // Close the Navigation drawer on mobile when a user clicks a link inside.
   const onNavigationClick = (event: React.MouseEvent) => {
@@ -58,8 +58,8 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
       aria-hidden={!navigationOpen}
       onClick={onNavigationClick}
       style={{
-        blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)`,
-        insetBlockStart: drawersTopOffset,
+        blockSize: drawerHeight,
+        insetBlockStart: drawerTopOffset,
       }}
     >
       <div className={clsx(styles['animated-content'])}>

--- a/src/app-layout/visual-refresh-toolbar/split-panel/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/split-panel/index.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { SplitPanelProvider, SplitPanelProviderProps } from '../../split-panel';
+import { getDrawerStyles } from '../compute-layout';
 import { AppLayoutInternals } from '../interfaces';
 
 import styles from './styles.css.js';
@@ -19,15 +20,16 @@ export function AppLayoutSplitPanelDrawerSideImplementation({
   appLayoutInternals,
   splitPanelInternals,
 }: AppLayoutSplitPanelDrawerSideImplementationProps) {
-  const { splitPanelControlId, placement, verticalOffsets } = appLayoutInternals;
-  const drawerTopOffset = verticalOffsets.drawers ?? placement.insetBlockStart;
+  const { splitPanelControlId, placement, verticalOffsets, isMobile } = appLayoutInternals;
+  const { drawerTopOffset, drawerHeight } = getDrawerStyles(verticalOffsets, isMobile, placement);
+
   return (
     <SplitPanelProvider {...splitPanelInternals}>
       <section
         id={splitPanelControlId}
         className={styles['split-panel-side']}
         style={{
-          blockSize: `calc(100vh - ${drawerTopOffset}px - ${placement.insetBlockEnd}px)`,
+          blockSize: drawerHeight,
           insetBlockStart: drawerTopOffset,
         }}
       >

--- a/src/app-layout/visual-refresh/drawers.scss
+++ b/src/app-layout/visual-refresh/drawers.scss
@@ -142,6 +142,7 @@
 
     > .drawer-content {
       grid-column: 1 / span 4;
+      block-size: var(#{custom-props.$contentHeight});
       &.drawer-content-hidden {
         display: none;
       }

--- a/src/internal/plugins/helpers/runtime-content-wrapper.tsx
+++ b/src/internal/plugins/helpers/runtime-content-wrapper.tsx
@@ -5,6 +5,8 @@ import React, { useContext, useEffect, useRef } from 'react';
 import { ActiveDrawersContext } from '../../../app-layout/utils/visibility-context';
 import { MountContentContext } from '../controllers/drawers';
 
+import styles from './styles.css.js';
+
 type VisibilityCallback = (isVisible: boolean) => void;
 
 interface RuntimeContentWrapperProps {
@@ -37,5 +39,5 @@ export function RuntimeContentWrapper({ mountContent, unmountContent, id }: Runt
     visibilityChangeCallback.current?.(isVisible);
   }, [isVisible]);
 
-  return <div ref={ref}></div>;
+  return <div ref={ref} className={styles['runtime-content-wrapper']}></div>;
 }

--- a/src/internal/plugins/helpers/styles.scss
+++ b/src/internal/plugins/helpers/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.runtime-content-wrapper {
+  display: contents;
+}

--- a/src/internal/plugins/helpers/styles.scss
+++ b/src/internal/plugins/helpers/styles.scss
@@ -4,5 +4,5 @@
 */
 
 .runtime-content-wrapper {
-  display: contents;
+  block-size: 100%;
 }


### PR DESCRIPTION
### Description

- Addresses double scrollbar issue in Q chat panel (AWSUI-59823). 
- This also fixes the flickering scrollbar issue at page load or when resizing vertically, due to motion being applied to height changes.
With this change, drawer children should be able to set height to 100% and fill the entire panel content height. This will still require an adjustment to the Q package to remove their custom calculation code. But I manually tested in Chrome and Safari that this change will not have any adverse affect until then, so it is safe to merge beforehand.

Related links, issue #, if available: AWSUI-59823, TT: V1549419424, TT: D169004346

### How has this been tested?

Running through dev pipeline (wip). Tested the change manually in Q in the console. Fixing failing tests (wip).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
