### PR TITLE
chore: Remove additional git-secrets job from actions

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -19,24 +19,6 @@ permissions:
   deployments: write
 
 jobs:
-  git-secrets:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        name: Checkout code with history
-        with:
-          fetch-depth: 100
-      - name: Install git-secrets
-        run: |
-          wget -O /usr/local/bin/git-secrets https://raw.githubusercontent.com/awslabs/git-secrets/master/git-secrets
-          chmod +x /usr/local/bin/git-secrets
-          git secrets --register-aws --global
-      - name: Run git-secrets
-        run: |
-          git rev-parse HEAD
-          git secrets --scan-history
   build:
     uses: cloudscape-design/actions/.github/workflows/build-lint-test.yml@main
     secrets: inherit


### PR DESCRIPTION
### Description

This job is already run as part of the [shared build-lint-test workflow](https://github.com/cloudscape-design/actions/blob/main/.github/workflows/build-lint-test.yml#L35). Removing as it does not need to run twice

![image](https://github.com/user-attachments/assets/9caf1719-ddc1-45de-928e-54d688009962)


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
