### PR TITLE
fix: Fixes property filter group editor when free text is disabled

### DIFF
--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -205,7 +205,10 @@ export function TokenEditor({
             mainAction={{
               text: i18nStrings.tokenEditorAddNewTokenLabel ?? '',
               onClick: () => {
-                onChangeTempGroup([...tempGroup, { property: null, operator: ':', value: null }]);
+                const lastTokenInGroup = tempGroup[tempGroup.length - 1];
+                const property = lastTokenInGroup ? lastTokenInGroup.property : null;
+                const operator = property?.defaultOperator ?? ':';
+                onChangeTempGroup([...tempGroup, { property, operator, value: null }]);
                 setNextFocusIndex(groups.length);
               },
             }}


### PR DESCRIPTION
### Description

When a new filter is added to the group is now takes the same property as the last filter in the group. That improves the UX and fixes a bug when the added filter is always a free-text one which should not happen when free text is disabled.

Rel: AWSUI-59876

### How has this been tested?

* New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
