### PR TITLE
chore: Allow more granular app layout deduplication control

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/multi-layout.ts
+++ b/src/app-layout/visual-refresh-toolbar/multi-layout.ts
@@ -11,7 +11,7 @@ import { Focusable } from '../utils/use-focus-control';
 import { SplitPanelToggleProps, ToolbarProps } from './toolbar';
 
 interface SharedProps {
-  forceDeduplicationType?: 'primary' | 'secondary';
+  forceDeduplicationType?: 'primary' | 'secondary' | 'suspended' | 'off';
   ariaLabels: AppLayoutProps.Labels | undefined;
   navigation: React.ReactNode;
   navigationOpen: boolean;
@@ -74,7 +74,11 @@ export function useMultiAppLayout(props: SharedProps, isEnabled: boolean) {
   const { forceDeduplicationType } = props;
 
   useLayoutEffect(() => {
-    if (!isEnabled) {
+    if (!isEnabled || forceDeduplicationType === 'suspended') {
+      return;
+    }
+    if (forceDeduplicationType === 'off') {
+      setRegistration({ type: 'primary', discoveredProps: [] });
       return;
     }
     return awsuiPluginsInternal.appLayoutWidget.register(forceDeduplicationType, props =>


### PR DESCRIPTION
### Description

Added two new `forceDeduplicationType` modes

1. `suspended` – temporary remove from deduplication, but without losing state. Already existed built-in via IntersectionObserver since #2906, but now it is possible to manually override this, if IntersectionObserver fails to detect for some reason
2. `off` – completely turn off deduplication. This instance won't communicate to other app layouts at all

Related links, issue #, if available: n/a

### How has this been tested?

Added unit tests for new modes

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
