### PR TITLE
chore: Reset panel header spacing and fix make content alignment more consistent

### DIFF
--- a/src/app-layout/constants.scss
+++ b/src/app-layout/constants.scss
@@ -33,4 +33,4 @@ $drawer-z-index-mobile: 1001;
 $toolbar-z-index: 1000;
 
 // Shared toolbar drawer component values
-$toolbar-vertical-panel-icon-offset: 10px;
+$toolbar-vertical-panel-icon-offset: 14px;

--- a/src/drawer/implementation.tsx
+++ b/src/drawer/implementation.tsx
@@ -42,7 +42,7 @@ export function DrawerImplementation({
   ) : (
     <div {...containerProps} ref={__internalRootRef}>
       {header && <div className={styles.header}>{header}</div>}
-      <div className={styles['test-utils-drawer-content']}>{children}</div>
+      <div className={clsx(styles['test-utils-drawer-content'], styles.content)}>{children}</div>
     </div>
   );
 }

--- a/src/drawer/styles.scss
+++ b/src/drawer/styles.scss
@@ -9,29 +9,19 @@
 .drawer {
   @include styles.styles-reset;
   word-wrap: break-word;
-  padding-block-start: awsui.$space-panel-header-vertical;
-  padding-block-end: awsui.$space-panel-content-bottom;
-  padding-inline-start: awsui.$space-panel-side-left;
-  padding-inline-end: awsui.$space-panel-side-right;
-  &.with-toolbar {
-    padding-block-start: awsui.$space-static-m;
-  }
 }
 
 .header {
   @include styles.font-panel-header;
   color: awsui.$color-text-heading-default;
-  padding-block-end: awsui.$space-panel-header-vertical;
+  padding-block: awsui.$space-panel-header-vertical;
   padding-inline: awsui.$space-panel-side-left calc(#{awsui.$space-xl} + #{awsui.$space-scaled-xxl});
   // padding to make sure the header doesn't overlap with the close icon
   border-block-end: awsui.$border-divider-section-width solid awsui.$color-border-panel-header;
   margin-block-start: 0;
   margin-block-end: awsui.$space-panel-content-top;
-  margin-inline-end: calc(-1 * #{awsui.$space-panel-side-right});
-  margin-inline-start: calc(-1 * #{awsui.$space-panel-side-left});
   .with-toolbar > & {
     border-color: transparent;
-    padding-block-end: awsui.$space-static-m;
     margin-block-end: 0px;
   }
 
@@ -46,6 +36,12 @@
     margin-block: 0;
   }
   /* stylelint-enable @cloudscape-design/no-implicit-descendant, selector-max-type */
+}
+
+.content:not(:empty) {
+  padding-inline-start: awsui.$space-panel-side-left;
+  padding-inline-end: awsui.$space-panel-side-right;
+  padding-block-end: awsui.$space-panel-content-bottom;
 }
 
 .test-utils-drawer-content {

--- a/src/help-panel/implementation.tsx
+++ b/src/help-panel/implementation.tsx
@@ -35,7 +35,7 @@ export function HelpPanelImplementation({
       baseProps.className,
       styles['help-panel'],
       isToolbar && styles['with-toolbar'],
-      loading && styles.content
+      loading && styles.loading
     ),
   };
   return loading ? (

--- a/src/help-panel/implementation.tsx
+++ b/src/help-panel/implementation.tsx
@@ -31,7 +31,12 @@ export function HelpPanelImplementation({
   const i18n = useInternalI18n('help-panel');
   const containerProps = {
     ...baseProps,
-    className: clsx(baseProps.className, styles['help-panel'], isToolbar && styles['with-toolbar']),
+    className: clsx(
+      baseProps.className,
+      styles['help-panel'],
+      isToolbar && styles['with-toolbar'],
+      loading && styles.content
+    ),
   };
   return loading ? (
     <div {...containerProps} ref={__internalRootRef}>
@@ -45,7 +50,12 @@ export function HelpPanelImplementation({
       <LinkDefaultVariantContext.Provider value={{ defaultVariant: 'primary' }}>
         <div className={styles.content}>{children}</div>
       </LinkDefaultVariantContext.Provider>
-      {footer && <div className={styles.footer}>{footer}</div>}
+      {footer && (
+        <div className={styles.footer}>
+          <hr role="presentation" />
+          {footer}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/help-panel/styles.scss
+++ b/src/help-panel/styles.scss
@@ -11,11 +11,6 @@
   word-wrap: break-word;
   padding-block-start: awsui.$space-panel-header-vertical;
   padding-block-end: 0;
-  padding-inline-end: awsui.$space-panel-side-right;
-  padding-inline-start: awsui.$space-panel-side-left;
-  &.with-toolbar {
-    padding-block-start: awsui.$space-static-m;
-  }
 
   /* stylelint-disable @cloudscape-design/no-implicit-descendant, selector-max-type */
   hr {
@@ -131,11 +126,8 @@
   border-block-end: awsui.$border-divider-section-width solid awsui.$color-border-panel-header;
   margin-block-start: 0;
   margin-block-end: awsui.$space-panel-content-top;
-  margin-inline-end: calc(-1 * #{awsui.$space-panel-side-right});
-  margin-inline-start: calc(-1 * #{awsui.$space-panel-side-left});
   .with-toolbar > & {
     border-color: transparent;
-    padding-block-end: awsui.$space-static-m;
     margin-block-end: 0px;
   }
 
@@ -154,13 +146,16 @@
 
 .content {
   color: awsui.$color-text-body-secondary;
+  padding-inline-start: awsui.$space-panel-side-left;
+  padding-inline-end: awsui.$space-panel-side-right;
 
   /* stylelint-disable @cloudscape-design/no-implicit-descendant, selector-max-type */
   h2:first-child,
   h3:first-child,
   h4:first-child,
   h5:first-child,
-  h6:first-child {
+  h6:first-child,
+  p:first-child {
     margin-block-start: 0;
   }
 
@@ -172,14 +167,9 @@
 
 .footer {
   color: awsui.$color-text-body-secondary;
-  border-block-start: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
-  margin-block: awsui.$space-scaled-xl;
-  margin-inline: calc(-1 * #{awsui.$space-panel-divider-margin-horizontal});
   padding-block: 0;
-  padding-inline: awsui.$space-panel-divider-margin-horizontal;
-  > :first-child {
-    margin-block-start: awsui.$space-scaled-xl;
-  }
+  padding-inline-start: awsui.$space-panel-side-left;
+  padding-inline-end: awsui.$space-panel-side-right;
   /* stylelint-disable @cloudscape-design/no-implicit-descendant, selector-max-type */
   ul {
     list-style: none;

--- a/src/help-panel/styles.scss
+++ b/src/help-panel/styles.scss
@@ -115,6 +115,11 @@
   /* stylelint-enable @cloudscape-design/no-implicit-descendant, selector-max-type */
 }
 
+.loading {
+  padding-inline-start: awsui.$space-panel-side-left;
+  padding-inline-end: awsui.$space-panel-side-right;
+}
+
 .header {
   @include styles.font-panel-header;
   color: awsui.$color-text-heading-default;

--- a/src/side-navigation/styles.scss
+++ b/src/side-navigation/styles.scss
@@ -93,11 +93,11 @@
 
   @supports selector(:has(*)) {
     /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
-    &:has(.section:not(.refresh)) {
+    &:has(> .section:not(.refresh)) {
       margin-block: calc(#{awsui.$space-scaled-2x-l} - #{awsui.$border-divider-section-width});
     }
     /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
-    &:has(.section.refresh) {
+    &:has(> .section.refresh) {
       margin-block: calc(#{awsui.$space-scaled-2x-m} - #{awsui.$border-divider-section-width});
     }
   }

--- a/src/side-navigation/styles.scss
+++ b/src/side-navigation/styles.scss
@@ -55,10 +55,9 @@
 
 .list-container {
   margin-block-start: awsui.$space-panel-content-top;
-}
-
-.with-toolbar > .list-container:not(.items-control + .list-container) {
-  margin-block-start: 0;
+  .with-toolbar > .divider + & {
+    margin-block-start: 0;
+  }
 }
 
 .list {

--- a/src/side-navigation/styles.scss
+++ b/src/side-navigation/styles.scss
@@ -20,9 +20,6 @@
   padding-inline-start: awsui.$space-panel-nav-left;
   // Additional xl space to prevent text from overlapping the close button.
   padding-inline-end: calc(#{awsui.$space-scaled-xxl} + #{awsui.$space-xl});
-  .with-toolbar > & {
-    padding-block: awsui.$space-static-m;
-  }
 }
 
 .header-link {
@@ -53,15 +50,15 @@
 }
 
 .items-control {
-  margin-block-start: awsui.$space-panel-content-top;
   padding-inline: awsui.$space-l;
 }
 
 .list-container {
   margin-block-start: awsui.$space-panel-content-top;
-  .with-toolbar > & {
-    margin-block-start: 0px;
-  }
+}
+
+.with-toolbar > .list-container:not(.items-control + .list-container) {
+  margin-block-start: 0;
 }
 
 .list {
@@ -94,6 +91,20 @@
   padding-block: 0;
   padding-inline: 0;
   list-style: none;
+
+  @supports selector(:has(*)) {
+    /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
+    &:has(.section:not(.refresh)) {
+      margin-block: calc(#{awsui.$space-scaled-2x-l} - #{awsui.$border-divider-section-width});
+    }
+    /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
+    &:has(.section.refresh) {
+      margin-block: calc(#{awsui.$space-scaled-2x-m} - #{awsui.$border-divider-section-width});
+    }
+  }
+  .list-variant-root > &:first-child {
+    margin-block-start: 0px;
+  }
 }
 
 .section,
@@ -106,11 +117,12 @@
 }
 
 .section {
-  margin-block: calc(#{awsui.$space-scaled-2x-l} - #{awsui.$border-divider-section-width});
-  &.refresh {
-    margin-block: calc(#{awsui.$space-scaled-2x-m} - #{awsui.$border-divider-section-width});
+  @supports not selector(:has(*)) {
+    margin-block: calc(#{awsui.$space-scaled-2x-l} - #{awsui.$border-divider-section-width});
+    &.refresh {
+      margin-block: calc(#{awsui.$space-scaled-2x-m} - #{awsui.$border-divider-section-width});
+    }
   }
-
   // HACK: Remove padding from section header and content to rely on margin collapsing rules.
   /* stylelint-disable-next-line selector-max-type */
   > div {
@@ -193,8 +205,10 @@
 
 .divider-header {
   margin-block-start: 0;
+  margin-block-end: awsui.$space-panel-content-top;
   border-block-start: awsui.$border-divider-section-width solid awsui.$color-border-panel-header;
   .with-toolbar > & {
     border-color: transparent;
+    margin-block-end: 0;
   }
 }


### PR DESCRIPTION
### Description

Adjusts the panel header padding to match original VR, in order to fix the misalignment of the Q settings icon and the panel close button. Originally the panel header height was reduced for the toolbar so that the headers and close icons could be aligned with the content in the toolbar. This was when the placement of the toolbar was between the panels, which is not the case anymore. This resets the headers to align with the rest of the elements on the page (flashbars, page headers, table headers, etc).
This change also reduces the space below panel headers so it is more uniform, which fixes a visual bug in side nav where control item had too much space around it and sections that were first in the nav list had too much space above them (in both VR and toolbar).

Related links, issue #, if available: n/a

### How has this been tested?

Ran through dev pipeline screenshot tests. Expected screenshot failures can be seen in pipeline approval attempts: 
1. e644f799-c0a2-404e-97f2-a087b7b71a70
2. 989fe3d1-f018-4e29-a5ba-e318c856a4da

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
