### PR TITLE
fix: remove unexpected transitions in app layout panels

### DIFF
--- a/src/app-layout/resize/styles.scss
+++ b/src/app-layout/resize/styles.scss
@@ -6,11 +6,19 @@
 @use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;
 
-.with-motion {
+.with-motion-vertical {
   @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
     @include styles.with-motion {
       transition: awsui.$motion-duration-refresh-only-medium;
-      transition-property: border-color, opacity, block-size, inline-size, inset-block-start;
+      transition-property: border-color, opacity, block-size, inset-block-start;
+    }
+  }
+}
+.with-motion-horizontal {
+  @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
+    @include styles.with-motion {
+      transition: awsui.$motion-duration-refresh-only-medium;
+      transition-property: border-color, opacity, inline-size, inset-inline-start;
     }
   }
 }
@@ -21,7 +29,8 @@
   &-active * {
     user-select: none;
     // stylelint-disable-next-line @cloudscape-design/no-implicit-descendant
-    .with-motion {
+    .with-motion-vertical,
+    .with-motion-horizontal {
       // stylelint-disable-next-line @cloudscape-design/no-motion-outside-of-mixin
       transition: none;
       // stylelint-disable-next-line @cloudscape-design/no-motion-outside-of-mixin

--- a/src/app-layout/utils/interfaces.ts
+++ b/src/app-layout/utils/interfaces.ts
@@ -7,5 +7,4 @@ export interface SizeControlProps {
   panelRef?: React.RefObject<HTMLDivElement>;
   handleRef?: React.RefObject<HTMLDivElement>;
   onResize: (newSize: number) => void;
-  hasTransitions?: boolean;
 }

--- a/src/app-layout/utils/use-pointer-events.ts
+++ b/src/app-layout/utils/use-pointer-events.ts
@@ -12,20 +12,12 @@ import { SizeControlProps } from './interfaces';
 
 import styles from '../resize/styles.css.js';
 
-export const usePointerEvents = ({
-  position,
-  panelRef,
-  handleRef,
-  onResize,
-  hasTransitions = false,
-}: SizeControlProps) => {
+export const usePointerEvents = ({ position, panelRef, handleRef, onResize }: SizeControlProps) => {
   const onDocumentPointerMove = useCallback(
     (event: PointerEvent) => {
       if (!panelRef || !panelRef.current || !handleRef || !handleRef.current) {
         return;
       }
-
-      panelRef.current.classList.remove(styles['with-motion']);
 
       if (position === 'side') {
         const mouseClientX = getLogicalClientX(event, getIsRtl(panelRef.current)) || 0;
@@ -53,14 +45,11 @@ export const usePointerEvents = ({
       return;
     }
 
-    if (hasTransitions) {
-      panelRef.current.classList.add(styles['with-motion']);
-    }
     document.body.classList.remove(styles['resize-active']);
     document.body.classList.remove(styles[`resize-${position}`]);
     document.removeEventListener('pointerup', onDocumentPointerUp);
     document.removeEventListener('pointermove', onDocumentPointerMove);
-  }, [panelRef, onDocumentPointerMove, position, hasTransitions]);
+  }, [panelRef, onDocumentPointerMove, position]);
 
   const onSliderPointerDown = useCallback(() => {
     document.body.classList.add(styles['resize-active']);

--- a/src/app-layout/utils/use-resize.tsx
+++ b/src/app-layout/utils/use-resize.tsx
@@ -63,7 +63,6 @@ function useResize(
     panelRef: drawerRefObject,
     handleRef: drawersRefs.slider,
     onResize: setSidePanelWidth,
-    hasTransitions: true,
   };
 
   const onSliderPointerDown = usePointerEvents(sizeControlProps);

--- a/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
@@ -77,11 +77,17 @@ function AppLayoutGlobalDrawerImplementation({
             id={activeDrawerId}
             aria-hidden={!show}
             aria-label={computedAriaLabels.content}
-            className={clsx(styles.drawer, styles['drawer-global'], styles[state], sharedStyles['with-motion'], {
-              [styles['drawer-hidden']]: !show,
-              [styles['last-opened']]: lastOpenedDrawerId === activeDrawerId,
-              [testutilStyles['active-drawer']]: show,
-            })}
+            className={clsx(
+              styles.drawer,
+              styles['drawer-global'],
+              styles[state],
+              sharedStyles['with-motion-horizontal'],
+              {
+                [styles['drawer-hidden']]: !show,
+                [styles['last-opened']]: lastOpenedDrawerId === activeDrawerId,
+                [testutilStyles['active-drawer']]: show,
+              }
+            )}
             ref={drawerRef}
             onBlur={e => {
               // Drawers with trigger buttons follow this restore focus logic:
@@ -119,7 +125,7 @@ function AppLayoutGlobalDrawerImplementation({
                 />
               </div>
             )}
-            <div className={clsx(styles['drawer-content-container'], sharedStyles['with-motion'])}>
+            <div className={clsx(styles['drawer-content-container'], sharedStyles['with-motion-horizontal'])}>
               <div className={clsx(styles['drawer-close-button'])}>
                 <InternalButton
                   ariaLabel={computedAriaLabels.closeButton}

--- a/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
@@ -70,7 +70,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
           id={activeDrawerId}
           aria-hidden={!activeDrawer}
           aria-label={computedAriaLabels.content}
-          className={clsx(styles.drawer, sharedStyles['with-motion'], {
+          className={clsx(styles.drawer, sharedStyles['with-motion-horizontal'], {
             [styles['last-opened']]: lastOpenedDrawerId === activeDrawerId,
             [styles.legacy]: isLegacyDrawer,
             [testutilStyles['active-drawer']]: !toolsOnlyMode && activeDrawerId,
@@ -107,7 +107,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
               />
             </div>
           )}
-          <div className={clsx(styles['drawer-content-container'], sharedStyles['with-motion'])}>
+          <div className={clsx(styles['drawer-content-container'], sharedStyles['with-motion-horizontal'])}>
             <div className={clsx(styles['drawer-close-button'])}>
               <InternalButton
                 ariaLabel={computedAriaLabels.closeButton}

--- a/src/app-layout/visual-refresh-toolbar/drawer/use-resize.ts
+++ b/src/app-layout/visual-refresh-toolbar/drawer/use-resize.ts
@@ -30,7 +30,6 @@ export function useResize({ currentWidth, minWidth, maxWidth, panelRef, handleRe
     panelRef,
     handleRef,
     onResize: onResizeHandler,
-    hasTransitions: true,
   };
 
   const clampedWidth = getLimitedValue(minWidth, currentWidth, maxWidth);

--- a/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
@@ -53,7 +53,7 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
           [testutilStyles['drawer-closed']]: !navigationOpen,
         },
         testutilStyles.navigation,
-        sharedStyles['with-motion']
+        sharedStyles['with-motion-horizontal']
       )}
       aria-hidden={!navigationOpen}
       onClick={onNavigationClick}

--- a/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
@@ -92,7 +92,7 @@ export const SkeletonLayout = React.forwardRef<HTMLDivElement, SkeletonLayoutPro
               styles.navigation,
               !navigationOpen && styles['panel-hidden'],
               toolsOpen && styles['unfocusable-mobile'],
-              sharedStyles['with-motion']
+              sharedStyles['with-motion-horizontal']
             )}
           >
             {navigation}
@@ -130,7 +130,7 @@ export const SkeletonLayout = React.forwardRef<HTMLDivElement, SkeletonLayoutPro
           className={clsx(
             styles.tools,
             !toolsOpen && styles['panel-hidden'],
-            sharedStyles['with-motion'],
+            sharedStyles['with-motion-horizontal'],
             navigationOpen && !toolsOpen && styles['unfocusable-mobile'],
             toolsOpen && styles['tools-open']
           )}

--- a/src/split-panel/bottom.tsx
+++ b/src/split-panel/bottom.tsx
@@ -59,7 +59,7 @@ export function SplitPanelContentBottom({
         styles.drawer,
         styles['position-bottom'],
         testUtilStyles.root,
-        sharedStyles['with-motion'],
+        sharedStyles['with-motion-vertical'],
         {
           [testUtilStyles['open-position-bottom']]: isOpen,
           [styles['drawer-closed']]: !isOpen,

--- a/src/split-panel/implementation.tsx
+++ b/src/split-panel/implementation.tsx
@@ -78,7 +78,6 @@ export function SplitPanelImplementation({
     panelRef: splitPanelRefObject,
     handleRef: refs.slider,
     onResize,
-    hasTransitions: true,
   };
   const onSliderPointerDown = usePointerEvents(sizeControlProps);
   const onKeyDown = useKeyboardEvents(sizeControlProps);

--- a/src/split-panel/side.tsx
+++ b/src/split-panel/side.tsx
@@ -44,7 +44,7 @@ export function SplitPanelContentSide({
         styles.drawer,
         styles['position-side'],
         testUtilStyles.root,
-        sharedStyles['with-motion'],
+        sharedStyles['with-motion-horizontal'],
         {
           [testUtilStyles['open-position-side']]: isOpen,
           [styles['drawer-closed']]: !isOpen,


### PR DESCRIPTION
### Description

Fixing this issue: AWSUI-59756

On initial load, there are some unexpected transitions playing. Fixed it by splitting up the animated properties 1) `inline-size` aka `width` for side panels (navigation, tools, side split panel, and others) 2) `block-size` aka `height` for bottom split panel

Related links, issue #, if available: AWSUI-59756

### How has this been tested?

* Manually tested all 3 app layout designs, all transitions work as expected (and nothing is animated on classic app layout as expected too)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
