### PR TITLE
chore: Uses the new selectors inside existing tests

### DIFF
--- a/pages/app-layout/refresh-content-width.page.tsx
+++ b/pages/app-layout/refresh-content-width.page.tsx
@@ -32,11 +32,11 @@ export default function () {
         breadcrumbs={<Breadcrumbs />}
         maxContentWidth={maxContentWidth}
         content={
-          <div className={styles.highlightBorder} data-test-id="content">
+          <div className={styles.highlightBorder} data-testid="content">
             <Box variant="h1">Demo page for layout types in visual refresh</Box>
             <SpaceBetween size={'l'}>
               <Button
-                data-test-id="button_width-400"
+                data-testid="button_width-400"
                 onClick={() => {
                   setMaxContentWidth(400);
                 }}
@@ -44,7 +44,7 @@ export default function () {
                 Set content width to 400
               </Button>
               <Button
-                data-test-id="button_width-number-max_value"
+                data-testid="button_width-number-max_value"
                 onClick={() => {
                   setMaxContentWidth(Number.MAX_VALUE);
                 }}
@@ -52,7 +52,7 @@ export default function () {
                 Set content width to Number.MAX_VALUE
               </Button>
               <Button
-                data-test-id="button_width-undef"
+                data-testid="button_width-undef"
                 onClick={() => {
                   setMaxContentWidth(undefined);
                 }}
@@ -60,7 +60,7 @@ export default function () {
                 Set content width to undef
               </Button>
               <Button
-                data-test-id="button_type-default"
+                data-testid="button_type-default"
                 onClick={() => {
                   setContentType('default');
                 }}
@@ -68,7 +68,7 @@ export default function () {
                 Set content type to default
               </Button>
               <Button
-                data-test-id="button_type-cards"
+                data-testid="button_type-cards"
                 onClick={() => {
                   setContentType('cards');
                 }}
@@ -76,7 +76,7 @@ export default function () {
                 Set content type to cards
               </Button>
               <Button
-                data-test-id="button_type-table"
+                data-testid="button_type-table"
                 onClick={() => {
                   setContentType('table');
                 }}
@@ -84,7 +84,7 @@ export default function () {
                 Set content type to table
               </Button>
               <Button
-                data-test-id="button_type-form"
+                data-testid="button_type-form"
                 onClick={() => {
                   setContentType('form');
                 }}
@@ -92,7 +92,7 @@ export default function () {
                 Set content type to form
               </Button>
               <Button
-                data-test-id="button_type-wizard"
+                data-testid="button_type-wizard"
                 onClick={() => {
                   setContentType('wizard');
                 }}
@@ -100,7 +100,7 @@ export default function () {
                 Set content type to wizard
               </Button>
               <Button
-                data-test-id="button_set-drawers-open"
+                data-testid="button_set-drawers-open"
                 onClick={() => {
                   setDrawersOpen(true);
                 }}

--- a/pages/app-layout/with-drawers.page.tsx
+++ b/pages/app-layout/with-drawers.page.tsx
@@ -41,7 +41,7 @@ export default function WithDrawers() {
         breadcrumbs={<Breadcrumbs />}
         content={
           <ContentLayout
-            data-test-id="content"
+            data-testid="content"
             header={
               <SpaceBetween size="m">
                 <Header variant="h1" description="Sometimes you need custom drawers to get the job done.">

--- a/pages/app-layout/with-one-open-drawer.page.tsx
+++ b/pages/app-layout/with-one-open-drawer.page.tsx
@@ -23,7 +23,7 @@ export default function WithDrawers() {
         navigationHide={true}
         content={
           <ContentLayout
-            data-test-id="content"
+            data-testid="content"
             header={
               <Header variant="h1" description="Sometimes you need custom drawers to get the job done.">
                 One drawer opened

--- a/src/alert/__integ__/runtime-content.test.ts
+++ b/src/alert/__integ__/runtime-content.test.ts
@@ -7,7 +7,7 @@ import createWrapper from '../../../lib/components/test-utils/selectors';
 
 class RuntimeContentPage extends BasePageObject {
   async rerenderAlerts() {
-    await this.click(createWrapper().findCheckbox('[data-testid="unmount-all"]').findNativeInput().toSelector());
+    await this.click(createWrapper().findCheckboxByTestId('unmount-all').findNativeInput().toSelector());
     await this.keys(['Space']);
   }
 }

--- a/src/annotation-context/__integ__/annotation-scroll.test.ts
+++ b/src/annotation-context/__integ__/annotation-scroll.test.ts
@@ -20,7 +20,7 @@ test(
     await page.waitForVisible(nextButtonSelector);
 
     const hotspotOneBox = await page.getBoundingBox(
-      wrapper.findHotspot('[data-testid="hotspot-2"]').findTrigger().toSelector()
+      wrapper.findHotspotByTestId('hotspot-2').findTrigger().toSelector()
     );
     const footerBox = await page.getBoundingBox('[data-testid="footer"]');
 
@@ -29,7 +29,7 @@ test(
     await page.click(annotationWrapper.findPreviousButton().toSelector());
 
     const hotspotOneTwoBox = await page.getBoundingBox(
-      wrapper.findHotspot('[data-testid="hotspot-1"]').findTrigger().toSelector()
+      wrapper.findHotspotByTestId('hotspot-1').findTrigger().toSelector()
     );
     const headerBox = await page.getBoundingBox('[data-testid="header"]');
 

--- a/src/app-layout/__integ__/app-layout-drawers.test.ts
+++ b/src/app-layout/__integ__/app-layout-drawers.test.ts
@@ -72,7 +72,9 @@ class AppLayoutDrawersPage extends BasePageObject {
   }
 
   async getMainContentWidth() {
-    const { width } = await this.getBoundingBox(wrapper.find('[data-test-id="content"]').toSelector());
+    const { width } = await this.getBoundingBox(
+      wrapper.findContentRegion().findContentLayoutByTestId('content').toSelector()
+    );
     return width;
   }
 

--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -201,7 +201,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
           'moves focus to close button when panel is opened from info link',
           setupTest(
             async page => {
-              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
+              await page.click(wrapper.findContentRegion().findLinkByTestId('info-link-1').toSelector());
               await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
             },
             { pageName: 'with-fixed-header-footer', theme, mobile }
@@ -212,8 +212,8 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
           'moves focus to close button when panel content is changed using second info link',
           setupTest(
             async page => {
-              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
-              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector());
+              await page.click(wrapper.findContentRegion().findLinkByTestId('info-link-1').toSelector());
+              await page.click(wrapper.findContentRegion().findLinkByTestId('info-link-2').toSelector());
               await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
             },
             { pageName: 'with-fixed-header-footer', theme, mobile }
@@ -224,8 +224,8 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
           'moves focus back to last opened info link when panel is closed',
           setupTest(
             async page => {
-              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
-              const infoLink = wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector();
+              await page.click(wrapper.findContentRegion().findLinkByTestId('info-link-1').toSelector());
+              const infoLink = wrapper.findContentRegion().findLinkByTestId('info-link-2').toSelector();
               await page.click(infoLink);
               await page.click(wrapper.findToolsClose().toSelector());
               await expect(page.isFocused(infoLink)).resolves.toBe(true);
@@ -238,7 +238,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
           'does not move focus back to last opened info link when panel has lost focus - instead focuses tools toggle',
           setupTest(
             async page => {
-              const infoLink = wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector();
+              const infoLink = wrapper.findContentRegion().findLinkByTestId('info-link-2').toSelector();
               await page.click(infoLink);
               await page.click(wrapper.findContentRegion().findContainer().toSelector());
               await page.click(wrapper.findToolsClose().toSelector());
@@ -255,15 +255,11 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
           'moves focus to close button when panel is opened from button',
           setupTest(
             async page => {
-              await page.click(
-                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-              );
+              await page.click(wrapper.findContentRegion().findButtonByTestId('open-drawer-button-2').toSelector());
               await expect(page.isFocused(wrapper.findActiveDrawerCloseButton().toSelector())).resolves.toBe(true);
               await page.keys('Enter');
               await expect(
-                page.isFocused(
-                  wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-                )
+                page.isFocused(wrapper.findContentRegion().findButtonByTestId('open-drawer-button-2').toSelector())
               ).resolves.toBe(true);
             },
             { pageName: 'with-drawers', theme, mobile }
@@ -275,12 +271,8 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
           'moves focus to close button when panel content is changed using second button',
           setupTest(
             async page => {
-              await page.click(
-                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button"]').toSelector()
-              );
-              await page.click(
-                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-              );
+              await page.click(wrapper.findContentRegion().findButtonByTestId('open-drawer-button').toSelector());
+              await page.click(wrapper.findContentRegion().findButtonByTestId('open-drawer-button-2').toSelector());
               await page.keys('Tab');
               await expect(page.isFocused(wrapper.findActiveDrawerCloseButton().toSelector())).resolves.toBe(true);
             },
@@ -293,19 +285,13 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
           setupTest(
             async page => {
               if (!mobile) {
-                await page.click(
-                  wrapper.findContentRegion().findButton('[data-testid="open-drawer-button"]').toSelector()
-                );
+                await page.click(wrapper.findContentRegion().findButtonByTestId('open-drawer-button').toSelector());
               }
-              await page.click(
-                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-              );
+              await page.click(wrapper.findContentRegion().findButtonByTestId('open-drawer-button-2').toSelector());
 
               await page.click(wrapper.findActiveDrawerCloseButton().toSelector());
               await expect(
-                page.isFocused(
-                  wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-                )
+                page.isFocused(wrapper.findContentRegion().findButtonByTestId('open-drawer-button-2').toSelector())
               ).resolves.toBe(true);
             },
             { pageName: 'with-drawers', theme, mobile }
@@ -317,10 +303,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
           'does not move focus back to last opened button when panel has lost focus - instead focuses drawer trigger',
           setupTest(
             async page => {
-              const infoLink = wrapper
-                .findContentRegion()
-                .findButton('[data-testid="open-drawer-button-2"]')
-                .toSelector();
+              const infoLink = wrapper.findContentRegion().findButtonByTestId('open-drawer-button-2').toSelector();
               await page.click(infoLink);
               await page.click(wrapper.findContentRegion().findContainer().toSelector());
               await page.click(wrapper.findActiveDrawerCloseButton().toSelector());

--- a/src/app-layout/__integ__/app-layout-refresh-content-width.test.ts
+++ b/src/app-layout/__integ__/app-layout-refresh-content-width.test.ts
@@ -11,19 +11,19 @@ const wrapper = createWrapper().findAppLayout();
 
 class AppLayoutRefreshNotoficationsPage extends BasePageObject {
   async setDrawersOpen() {
-    await this.click(createWrapper().findButton('[data-test-id="button_set-drawers-open"]').toSelector());
+    await this.click(createWrapper().findButtonByTestId('button_set-drawers-open').toSelector());
   }
   async setContentType(contentType: string) {
-    await this.click(createWrapper().findButton(`[data-test-id="button_type-${contentType}"]`).toSelector());
+    await this.click(createWrapper().findButtonByTestId(`button_type-${contentType}`).toSelector());
   }
   async setContentWidthTo400() {
-    await this.click(createWrapper().findButton('[data-test-id="button_width-400"]').toSelector());
+    await this.click(createWrapper().findButtonByTestId('button_width-400').toSelector());
   }
   async setContentWidthToMaxValue() {
-    await this.click(createWrapper().findButton('[data-test-id="button_width-number-max_value"]').toSelector());
+    await this.click(createWrapper().findButtonByTestId('button_width-number-max_value').toSelector());
   }
   async getContentWidth() {
-    const box = await this.getBoundingBox(wrapper.find('[data-test-id="content"]').toSelector());
+    const box = await this.getBoundingBox(wrapper.find('[data-testid="content"]').toSelector());
     return box.width;
   }
   async getNavigationWidth() {

--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -384,8 +384,8 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
       });
       await browser.url(`#/light/app-layout/with-split-panel?${params.toString()}`);
       await page.waitForVisible(content.toSelector());
-      await page.click(content.findContainer('[data-testid="container-1"]').findHeader().findButton().toSelector());
-      await page.click(content.findContainer('[data-testid="container-1"]').findHeader().findButton().toSelector());
+      await page.click(content.findContainerByTestId('container-1').findHeader().findButton().toSelector());
+      await page.click(content.findContainerByTestId('container-1').findHeader().findButton().toSelector());
 
       // Open split panel and ensure it is forced to the bottom.
       await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());

--- a/src/app-layout/__integ__/app-layout-sticky-elements.test.ts
+++ b/src/app-layout/__integ__/app-layout-sticky-elements.test.ts
@@ -85,7 +85,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as Theme[])('%s', theme 
         url: `#/light/app-layout/with-full-page-table-and-split-panel?${getUrlParams(theme)}&splitPanelPosition=side`,
       },
       async page => {
-        const popover = createWrapper().findPopover('[data-testid="split-panel"]');
+        const popover = createWrapper().findPopoverByTestId('split-panel');
         await page.click(popover.findTrigger().toSelector());
         await page.click(popover.findContent().findButton().toSelector());
         await expect(page.getAlertTextAndDismiss()).resolves.toEqual('It worked');
@@ -105,7 +105,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as Theme[])('%s', theme 
         // open help panel
         await page.click(wrapper.findToolsToggle().toSelector());
         // do the test
-        const popover = createWrapper().findPopover('[data-testid="help-panel"]');
+        const popover = createWrapper().findPopoverByTestId('help-panel');
         await page.click(popover.findTrigger().toSelector());
         await page.click(popover.findContent().findButton().toSelector());
         await expect(page.getAlertTextAndDismiss()).resolves.toEqual('It worked');

--- a/src/app-layout/__integ__/runtime-drawers-with-updates.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers-with-updates.test.ts
@@ -31,7 +31,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as Theme[])('%s', theme 
       expect(await page.getElementProperty(wrapper.findActiveDrawer().toSelector(), 'clientWidth')).toEqual(320);
 
       await page.click(
-        createWrapper().findToggle('[data-testid="increase-drawer-size-toggle"]').findNativeInput().toSelector()
+        createWrapper().findToggleByTestId('increase-drawer-size-toggle').findNativeInput().toSelector()
       );
 
       expect(await page.getElementProperty(wrapper.findActiveDrawer().toSelector(), 'clientWidth')).toEqual(440);
@@ -52,9 +52,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as Theme[])('%s', theme 
       await page.dragAndDrop(wrapper.findActiveDrawerResizeHandle().toSelector(), -200);
       await expect(page.getText('[data-testid="current-size"]')).resolves.toEqual('resized: true');
 
-      await page.click(
-        createWrapper().findToggle('[data-testid="turn-off-resize-toggle"]').findNativeInput().toSelector()
-      );
+      await page.click(createWrapper().findToggleByTestId('turn-off-resize-toggle').findNativeInput().toSelector());
 
       await expect(page.isExisting(wrapper.findActiveDrawerResizeHandle().toSelector())).resolves.toBe(false);
     })

--- a/src/autosuggest/__integ__/form-submit.test.ts
+++ b/src/autosuggest/__integ__/form-submit.test.ts
@@ -26,7 +26,7 @@ function setupTest(testFn: (page: FormSubmitPageObject) => Promise<void>) {
 test(
   'Should submit form on double enter key',
   setupTest(async page => {
-    const autosuggestNoKeydown = createWrapper().findAutosuggest('[data-testid="autosuggest-no-keydown"]');
+    const autosuggestNoKeydown = createWrapper().findAutosuggestByTestId('autosuggest-no-keydown');
     await page.click(autosuggestNoKeydown.findNativeInput().toSelector());
     await expect(page.isDropdownOpen(autosuggestNoKeydown)).resolves.toBe(true);
     await page.keys('Enter');
@@ -43,7 +43,7 @@ test(
 test(
   'Should allow preventing form submission',
   setupTest(async page => {
-    const autosuggestWithKeydown = createWrapper().findAutosuggest('[data-testid="autosuggest-with-keydown"]');
+    const autosuggestWithKeydown = createWrapper().findAutosuggestByTestId('autosuggest-with-keydown');
     await page.click(autosuggestWithKeydown.findNativeInput().toSelector());
     await expect(page.isDropdownOpen(autosuggestWithKeydown)).resolves.toBe(true);
     await page.keys('Enter');

--- a/src/button-dropdown/__integ__/button-dropdown-disabled-reason.test.ts
+++ b/src/button-dropdown/__integ__/button-dropdown-disabled-reason.test.ts
@@ -9,7 +9,7 @@ const wrapper = createWrapper();
 
 class ButtonDropdownDisabledReasonPage extends BasePageObject {
   findButtonDropdown() {
-    return wrapper.findButtonDropdown('[data-testid="buttonDropdown"]');
+    return wrapper.findButtonDropdownByTestId('buttonDropdown');
   }
   findDisabledReason() {
     return this.findButtonDropdown().findDisabledReason();

--- a/src/button-dropdown/__integ__/button-dropdown-events.test.ts
+++ b/src/button-dropdown/__integ__/button-dropdown-events.test.ts
@@ -81,7 +81,7 @@ describe('clicking on a ButtonDropdown item', () => {
   test(
     'main action can be pressed with Enter',
     useBrowser(async browser => {
-      const focusBefore = createWrapper().findButton('[data-testid="focus-before"]');
+      const focusBefore = createWrapper().findButtonByTestId('focus-before');
 
       const page = new BasePageObject(browser);
       await browser.url('#/light/button-dropdown/main-action');

--- a/src/button-group/__integ__/button-group.test.ts
+++ b/src/button-group/__integ__/button-group.test.ts
@@ -47,7 +47,7 @@ test.each([false, true])(
   'can navigate to menu and back with keyboard, dropdownExpandToViewport=%s',
   async dropdownExpandToViewport => {
     await setup({ dropdownExpandToViewport }, async page => {
-      await page.click(createWrapper().find('[data-testid="focus-before"]').toSelector());
+      await page.click(createWrapper().findButtonByTestId('focus-before').toSelector());
 
       await page.keys(['Tab']);
       await expect(page.isFocused(likeButton.toSelector())).resolves.toBe(true);
@@ -79,7 +79,7 @@ test(
     await page.click(likeButton.toSelector());
     await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Like');
 
-    await page.click(createWrapper().find('[data-testid="focus-on-copy"]').toSelector());
+    await page.click(createWrapper().findButtonByTestId('focus-on-copy').toSelector());
     await expect(page.isFocused(copyButton.toSelector())).resolves.toBe(true);
 
     await page.keys(['Tab', 'Enter']);
@@ -115,7 +115,7 @@ test(
 test(
   'shows one tooltip at a time',
   setup({}, async page => {
-    await page.click(createWrapper().find('[data-testid="focus-before"]').toSelector());
+    await page.click(createWrapper().findButtonByTestId('focus-before').toSelector());
 
     await page.keys(['Tab']);
     await expect(page.isFocused(likeButton.toSelector())).resolves.toBe(true);

--- a/src/button/__tests__/internal.test.tsx
+++ b/src/button/__tests__/internal.test.tsx
@@ -81,16 +81,19 @@ describe('Analytics', () => {
   });
 
   test('does not send an externalLinkInteracted metric when the button is not a link', () => {
+    const onClick = jest.fn();
     const { container } = render(
       <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
-        <Button iconName="external" data-testid="1" />
-        <Button target="_blank" data-testid="2" />
+        <Button iconName="external" onClick={onClick} />
+        <Button target="_blank" onClick={onClick} />
       </AnalyticsFunnel>
     );
     act(() => void jest.runAllTimers());
-    createWrapper(container).findButton('[data-testid="1"]')!.click();
-    createWrapper(container).findButton('[data-testid="2"]')!.click();
+    createWrapper(container)
+      .findAllButtons()
+      .forEach(wrapper => wrapper.click());
 
+    expect(onClick).toHaveBeenCalledTimes(2);
     expect(FunnelMetrics.externalLinkInteracted).not.toHaveBeenCalled();
   });
 

--- a/src/form-field/__tests__/form-field-control-id.test.tsx
+++ b/src/form-field/__tests__/form-field-control-id.test.tsx
@@ -198,13 +198,12 @@ describe('controlId', () => {
     test('generates unique ids for every form field component', () => {
       const renderResult = render(
         <>
-          <FormField data-testid="1" label="Label1"></FormField>
-          <FormField data-testid="2" label="Label2"></FormField>
+          <FormField label="Label1"></FormField>
+          <FormField label="Label2"></FormField>
         </>
       );
 
-      const wrapper1 = createWrapper(renderResult.container).findFormField('[data-testid="1"]')!;
-      const wrapper2 = createWrapper(renderResult.container).findFormField('[data-testid="2"]')!;
+      const [wrapper1, wrapper2] = createWrapper(renderResult.container).findAllFormFields();
       expect(wrapper1.findLabel()?.getElement().id).not.toBe(wrapper2.findLabel()?.getElement().id);
     });
 

--- a/src/form/__tests__/analytics.test.tsx
+++ b/src/form/__tests__/analytics.test.tsx
@@ -130,7 +130,7 @@ describe('Form Analytics', () => {
     const { container, unmount } = render(<Form actions={<Button data-testid="cancel">Cancel</Button>} />);
     act(() => void jest.runAllTimers());
     const formWrapper = createWrapper(container).findForm();
-    const cancelButton = formWrapper!.findActions()!.findButton('[data-testid="cancel"]');
+    const cancelButton = formWrapper!.findActions()!.findButtonByTestId('cancel');
 
     act(() => cancelButton!.click());
     unmount();
@@ -160,7 +160,7 @@ describe('Form Analytics', () => {
       </Form>
     );
     act(() => void jest.runAllTimers());
-    const submitButton = createWrapper(container.ownerDocument.body).findButton('[data-testid="submit"]');
+    const submitButton = createWrapper(container.ownerDocument.body).findButtonByTestId('submit');
 
     act(() => submitButton!.click());
 
@@ -180,7 +180,7 @@ describe('Form Analytics', () => {
     );
     act(() => void jest.runAllTimers());
     const formWrapper = createWrapper(container).findForm();
-    const submitButton = formWrapper!.findContent()!.findButton('[data-testid="submit"]');
+    const submitButton = formWrapper!.findContent()!.findButtonByTestId('submit');
 
     act(() => submitButton!.click());
     unmount();
@@ -222,7 +222,7 @@ describe('Form Analytics', () => {
     );
     act(() => void jest.runAllTimers());
     const formWrapper = createWrapper(container).findForm();
-    const submitButton = formWrapper!.findActions()!.findButton('[data-testid="submit"]');
+    const submitButton = formWrapper!.findActions()!.findButtonByTestId('submit');
 
     act(() => submitButton!.click());
     unmount();
@@ -264,7 +264,7 @@ describe('Form Analytics', () => {
     );
     act(() => void jest.runAllTimers());
     const formWrapper = createWrapper(container).findForm();
-    const submitButton = formWrapper!.findActions()!.findButton('[data-testid="submit"]');
+    const submitButton = formWrapper!.findActions()!.findButtonByTestId('submit');
 
     expect(getByTestId('submission-attempt').textContent).toBe('0');
 

--- a/src/internal/analytics/__integ__/static-multi-page-create.test.ts
+++ b/src/internal/analytics/__integ__/static-multi-page-create.test.ts
@@ -318,8 +318,9 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
   test(
     'Field error',
     setupTest(async page => {
-      await page.click('[data-testid=field1]');
-      await page.setValue(wrapper.findInput('[data-testid=field1]').findNativeInput().toSelector(), 'error');
+      const inputSelector = wrapper.findInputByTestId('field1').findNativeInput().toSelector();
+      await page.click(inputSelector);
+      await page.setValue(inputSelector, 'error');
       const { funnelLog, actions } = await page.getFunnelLog();
       expect(actions).toEqual(['funnelStart', 'funnelStepStart', 'funnelSubStepStart', 'funnelSubStepError']);
 
@@ -373,7 +374,7 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
   test(
     'Correct substep number when the step is unmounted before blurring the substep',
     setupTest(async page => {
-      await page.click(wrapper.findInput('[data-testid=field4]').findNativeInput().toSelector());
+      await page.click(wrapper.findInputByTestId('field4').findNativeInput().toSelector());
       await page.click(wrapper.findWizard().findPrimaryButton().toSelector());
 
       const funnelSubStepCompleteEvent = await page.getFunnelLogItem(6);

--- a/src/internal/analytics/__integ__/static-single-page-flow.test.ts
+++ b/src/internal/analytics/__integ__/static-single-page-flow.test.ts
@@ -98,7 +98,7 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
   test(
     'Starts and ends substep when navigating between containers',
     setupTest(async page => {
-      await page.click('[data-testid=field1]');
+      await page.click(wrapper.findInputByTestId('field1').toSelector());
       await page.keys('Tab'); // From Input -> S3 Resource selector Info
       await page.keys('Tab'); // S3 Resource selector Info -> S3 Resource Selector Input
       await page.keys('Tab'); // S3 Resource selector Input -> S3 Resource selector Browse button
@@ -210,7 +210,7 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
   test(
     'Form submission',
     setupTest(async page => {
-      await page.click('[data-testid=submit]');
+      await page.click(wrapper.findButtonByTestId('submit').toSelector());
       const { funnelLog, actions } = await page.getFunnelLog();
       expect(actions).toEqual([
         'funnelStart',
@@ -249,7 +249,7 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
   test(
     'Form cancelled',
     setupTest(async page => {
-      await page.click('[data-testid=cancel]');
+      await page.click(wrapper.findButtonByTestId('cancel').toSelector());
       const { funnelLog, actions } = await page.getFunnelLog();
       expect(actions).toEqual(['funnelStart', 'funnelStepStart', 'funnelCancelled']);
 
@@ -264,7 +264,7 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
   test(
     'Form abandoned',
     setupTest(async page => {
-      await page.click('[data-testid=unmount]');
+      await page.click(wrapper.findButtonByTestId('unmount').toSelector());
       const { funnelLog, actions } = await page.getFunnelLog();
       expect(actions).toEqual(['funnelStart', 'funnelStepStart', 'funnelCancelled']);
 
@@ -279,8 +279,7 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
   test(
     'Form inline error',
     setupTest(async page => {
-      await page.click('[data-testid=field1]');
-      await page.setValue(wrapper.findInput('[data-testid=field1]').findNativeInput().toSelector(), 'error');
+      await page.setValue(wrapper.findInputByTestId('field1').findNativeInput().toSelector(), 'error');
       const { funnelLog, actions } = await page.getFunnelLog();
       expect(actions).toEqual(['funnelStart', 'funnelStepStart', 'funnelSubStepStart', 'funnelSubStepError']); // FIXME: Missing funnelStepError?
 
@@ -316,9 +315,8 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
   test(
     'Form error',
     setupTest(async page => {
-      await page.click('[data-testid=field1]');
-      await page.setValue(wrapper.findInput('[data-testid=field1]').findNativeInput().toSelector(), 'error');
-      await page.click('[data-testid=submit]');
+      await page.setValue(wrapper.findInputByTestId('field1').findNativeInput().toSelector(), 'error');
+      await page.click(wrapper.findButtonByTestId('submit').toSelector());
 
       const { funnelLog, actions } = await page.getFunnelLog();
       expect(actions).toEqual([
@@ -342,7 +340,7 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
   test(
     'Form external link',
     setupTest(async page => {
-      await page.click('[data-testid=external-link]');
+      await page.click(wrapper.findLinkByTestId('external-link').toSelector());
       const { funnelLog, actions } = await page.getFunnelLog();
       expect(actions).toEqual(['funnelStart', 'funnelStepStart', 'externalLinkInteracted', 'funnelSubStepStart']);
 
@@ -374,7 +372,7 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
   test(
     'Form help panel link',
     setupTest(async page => {
-      await page.click('[data-testid=info-link]');
+      await page.click(wrapper.findLinkByTestId('info-link').toSelector());
       const { funnelLog, actions } = await page.getFunnelLog();
       expect(actions).toEqual(['funnelStart', 'funnelStepStart', 'helpPanelInteracted', 'funnelSubStepStart']);
 

--- a/src/modal/__tests__/analytics.test.tsx
+++ b/src/modal/__tests__/analytics.test.tsx
@@ -123,7 +123,7 @@ describe('Modal Analytics', () => {
     );
 
     const wrapper = createWrapper(container);
-    wrapper.findModal()!.findFooter()!.findButton('[data-testid="submit"]')?.click();
+    wrapper.findModal()!.findFooter()!.findButtonByTestId('submit')!.click();
     act(() => void jest.runAllTimers());
     expect(FunnelMetrics.funnelComplete).toHaveBeenCalledTimes(1);
     expect(FunnelMetrics.funnelComplete).toHaveBeenCalledWith(
@@ -154,7 +154,7 @@ describe('Modal Analytics', () => {
     act(() => void jest.runAllTimers());
 
     const wrapper = createWrapper(container);
-    wrapper.findModal()!.findFooter()!.findButton('[data-testid="submit"]')?.click();
+    wrapper.findModal()!.findFooter()!.findButtonByTestId('submit')!.click();
     rerender(
       <Modal
         header="Modal title"

--- a/src/table/__integ__/inline-actions.test.ts
+++ b/src/table/__integ__/inline-actions.test.ts
@@ -7,7 +7,7 @@ import createWrapper, { TableWrapper } from '../../../lib/components/test-utils/
 
 import styles from '../../../lib/components/table/styles.selectors.js';
 
-const tableWithDropdownActions = createWrapper().findTable('[data-testid="table-with-dropdown-actions"]')!;
+const tableWithDropdownActions = createWrapper().findTableByTestId('table-with-dropdown-actions')!;
 
 function getTableContainerSelector(tableWrapper: TableWrapper) {
   return tableWrapper.findByClassName(styles.wrapper);

--- a/src/table/__integ__/keyboard-scroll.test.ts
+++ b/src/table/__integ__/keyboard-scroll.test.ts
@@ -10,7 +10,7 @@ import styles from '../../../lib/components/table/styles.selectors.js';
 test(
   'allows to scroll overflowing table by focusing the wrapper',
   useBrowser({ width: 375, height: 871 }, async browser => {
-    const tableWrapper = createWrapper().findTable('[data-testid="items-table"]');
+    const tableWrapper = createWrapper().findTableByTestId('items-table');
     const wrapperSelector = tableWrapper.findAllByClassName(styles.wrapper).toSelector();
     await browser.url('#/light/table/keyboard-scroll');
     const page = new BasePageObject(browser);


### PR DESCRIPTION
### Description

Adds the usage of the newly added selectors in [this PR](https://github.com/cloudscape-design/components/pull/2932) to the existing tests.

Depends on: https://github.com/cloudscape-design/components/pull/2932

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: **Test utils API improvements project**

### How has this been tested?

N/A

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
