### PR TITLE
fix: Button with disabled reason and href prop

### DIFF
--- a/pages/button/disabled-reason.page.tsx
+++ b/pages/button/disabled-reason.page.tsx
@@ -19,6 +19,14 @@ export default function ButtonsScenario() {
         <Button disabled={true} disabledReason="disabled reason">
           Default
         </Button>
+        <Button
+          disabled={true}
+          disabledReason="disabled reason"
+          href="https://smth.com"
+          data-testid="normal-button-with-href"
+        >
+          Button with href
+        </Button>
       </ScreenshotArea>
     </article>
   );

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -104,110 +104,116 @@ describe('Button Component', () => {
     });
   });
 
-  describe('disabled with reason', () => {
-    test('renders button as normal when disabledReason is set and button is not disabled', () => {
-      const wrapper = renderButton({ disabled: false, disabledReason: 'reason' });
+  describe.each(['primary', 'normal'] as const)('disabled with reason %s variant', variant => {
+    describe.each([true, false] as const)('with href %s', withHref => {
+      const defaultProps = {
+        variant,
+        href: withHref ? 'https://smth.com' : undefined,
+      };
+      test('renders button as normal when disabledReason is set and button is not disabled', () => {
+        const wrapper = renderButton({ ...defaultProps, disabled: false, disabledReason: 'reason' });
 
-      expect(wrapper.getElement()).not.toHaveAttribute('disabled');
-      expect(wrapper.getElement()).not.toHaveAttribute('aria-disabled');
-    });
+        expect(wrapper.getElement()).not.toHaveAttribute('disabled');
+        expect(wrapper.getElement()).not.toHaveAttribute('aria-disabled');
+      });
 
-    test('does not add disabled attribute when disabled with reason', () => {
-      const wrapper = renderButton({ disabled: true, disabledReason: 'reason' });
+      test('does not add disabled attribute when disabled with reason', () => {
+        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
 
-      expect(wrapper.getElement()).not.toHaveAttribute('disabled');
-      expect(wrapper.getElement()).toHaveAttribute('aria-disabled');
-    });
+        expect(wrapper.getElement()).not.toHaveAttribute('disabled');
+        expect(wrapper.getElement()).toHaveAttribute('aria-disabled');
+      });
 
-    test('has no tooltip open by default', () => {
-      const wrapper = renderButton({ disabled: true, disabledReason: 'reason' });
+      test('has no tooltip open by default', () => {
+        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
 
-      expect(wrapper.findDisabledReason()).toBe(null);
-    });
+        expect(wrapper.findDisabledReason()).toBe(null);
+      });
 
-    test('has no tooltip without disabledReason', () => {
-      const wrapper = renderButton({ disabled: true });
+      test('has no tooltip without disabledReason', () => {
+        const wrapper = renderButton({ ...defaultProps, disabled: true });
 
-      wrapper.getElement()!.focus();
+        wrapper.getElement()!.focus();
 
-      expect(wrapper.findDisabledReason()).toBeNull();
-    });
+        expect(wrapper.findDisabledReason()).toBeNull();
+      });
 
-    test('open tooltip on focus', () => {
-      const wrapper = renderButton({ disabled: true, disabledReason: 'reason' });
+      test('open tooltip on focus', () => {
+        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
 
-      wrapper.getElement()!.focus();
+        wrapper.getElement()!.focus();
 
-      expect(wrapper.findDisabledReason()).not.toBeNull();
-      expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
-    });
+        expect(wrapper.findDisabledReason()).not.toBeNull();
+        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+      });
 
-    test('closes tooltip on blur', () => {
-      const wrapper = renderButton({ disabled: true, disabledReason: 'reason' });
+      test('closes tooltip on blur', () => {
+        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
 
-      wrapper.getElement()!.focus();
+        wrapper.getElement()!.focus();
 
-      expect(wrapper.findDisabledReason()).not.toBeNull();
-      expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+        expect(wrapper.findDisabledReason()).not.toBeNull();
+        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
 
-      wrapper.getElement()!.blur();
+        wrapper.getElement()!.blur();
 
-      expect(wrapper.findDisabledReason()).toBeNull();
-    });
+        expect(wrapper.findDisabledReason()).toBeNull();
+      });
 
-    test('open tooltip on mouseenter', () => {
-      const wrapper = renderButton({ disabled: true, disabledReason: 'reason' });
+      test('open tooltip on mouseenter', () => {
+        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
 
-      fireEvent.mouseEnter(wrapper.getElement());
+        fireEvent.mouseEnter(wrapper.getElement());
 
-      expect(wrapper.findDisabledReason()).not.toBeNull();
-      expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
-    });
+        expect(wrapper.findDisabledReason()).not.toBeNull();
+        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+      });
 
-    test('close tooltip on mouseleave', () => {
-      const wrapper = renderButton({ disabled: true, disabledReason: 'reason' });
+      test('close tooltip on mouseleave', () => {
+        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
 
-      fireEvent.mouseEnter(wrapper.getElement());
+        fireEvent.mouseEnter(wrapper.getElement());
 
-      expect(wrapper.findDisabledReason()).not.toBeNull();
-      expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+        expect(wrapper.findDisabledReason()).not.toBeNull();
+        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
 
-      fireEvent.mouseLeave(wrapper.getElement());
+        fireEvent.mouseLeave(wrapper.getElement());
 
-      expect(wrapper.findDisabledReason()).toBeNull();
-    });
+        expect(wrapper.findDisabledReason()).toBeNull();
+      });
 
-    test('has no aria-describedby by default', () => {
-      const wrapper = renderButton({});
+      test('has no aria-describedby by default', () => {
+        const wrapper = renderButton({ ...defaultProps });
 
-      expect(wrapper.getElement()).not.toHaveAttribute('aria-describedby');
-    });
+        expect(wrapper.getElement()).not.toHaveAttribute('aria-describedby');
+      });
 
-    test('has no aria-describedby without disabledReason', () => {
-      const wrapper = renderButton({ disabled: true });
+      test('has no aria-describedby without disabledReason', () => {
+        const wrapper = renderButton({ ...defaultProps, disabled: true });
 
-      expect(wrapper.getElement()).not.toHaveAttribute('aria-describedby');
-    });
+        expect(wrapper.getElement()).not.toHaveAttribute('aria-describedby');
+      });
 
-    test('has aria-describedby with disabledReason', () => {
-      const wrapper = renderButton({ disabled: true, disabledReason: 'reason' });
+      test('has aria-describedby with disabledReason', () => {
+        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
 
-      expect(wrapper.getElement()).toHaveAttribute('aria-describedby');
-    });
+        expect(wrapper.getElement()).toHaveAttribute('aria-describedby');
+      });
 
-    test('has hidden element (linked to aria-describedby) with disabledReason', () => {
-      const wrapper = renderButton({ disabled: true, disabledReason: 'reason' });
+      test('has hidden element (linked to aria-describedby) with disabledReason', () => {
+        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
 
-      expect(wrapper.find('span[hidden]')!.getElement()).toHaveTextContent('reason');
-    });
+        expect(wrapper.find('span[hidden]')!.getElement()).toHaveTextContent('reason');
+      });
 
-    test('does not trigger onClick handler when disabled with reason', () => {
-      const onClick = jest.fn();
-      const wrapper = renderButton({ disabled: true, disabledReason: 'reason', onClick });
+      test('does not trigger onClick handler when disabled with reason', () => {
+        const onClick = jest.fn();
+        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason', onClick });
 
-      wrapper.click();
+        wrapper.click();
 
-      expect(onClick).not.toHaveBeenCalled();
+        expect(onClick).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -162,7 +162,6 @@ export const InternalButton = React.forwardRef(
       [styles['button-no-wrap']]: !wrapText,
       [styles['button-no-text']]: !shouldHaveContent,
       [styles['full-width']]: shouldHaveContent && fullWidth,
-      [styles.link]: isAnchor,
     });
 
     const explicitTabIndex =

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -236,6 +236,22 @@ export const InternalButton = React.forwardRef(
       }
     }, [loading, loadingButtonCount]);
 
+    const disabledReasonProps = {
+      onFocus: isDisabledWithReason ? () => setShowTooltip(true) : undefined,
+      onBlur: isDisabledWithReason ? () => setShowTooltip(false) : undefined,
+      onMouseEnter: isDisabledWithReason ? () => setShowTooltip(true) : undefined,
+      onMouseLeave: isDisabledWithReason ? () => setShowTooltip(false) : undefined,
+      ...(isDisabledWithReason ? targetProps : {}),
+    };
+    const disabledReasonContent = (
+      <>
+        {descriptionEl}
+        {showTooltip && (
+          <Tooltip className={testUtilStyles['disabled-reason-tooltip']} trackRef={buttonRef} value={disabledReason!} />
+        )}
+      </>
+    );
+
     if (isAnchor) {
       return (
         // https://github.com/yannickcr/eslint-plugin-react/issues/2962
@@ -249,8 +265,10 @@ export const InternalButton = React.forwardRef(
             rel={rel ?? (target === '_blank' ? 'noopener noreferrer' : undefined)}
             aria-disabled={isNotInteractive ? true : undefined}
             download={download}
+            {...disabledReasonProps}
           >
             {buttonContent}
+            {isDisabledWithReason && disabledReasonContent}
           </a>
           {loading && loadingText && (
             <InternalLiveRegion tagName="span" hidden={true}>
@@ -268,25 +286,10 @@ export const InternalButton = React.forwardRef(
           type={formAction === 'none' ? 'button' : 'submit'}
           disabled={disabled && !__focusable && !isDisabledWithReason}
           aria-disabled={hasAriaDisabled ? true : undefined}
-          onFocus={isDisabledWithReason ? () => setShowTooltip(true) : undefined}
-          onBlur={isDisabledWithReason ? () => setShowTooltip(false) : undefined}
-          onMouseEnter={isDisabledWithReason ? () => setShowTooltip(true) : undefined}
-          onMouseLeave={isDisabledWithReason ? () => setShowTooltip(false) : undefined}
-          {...(isDisabledWithReason ? targetProps : {})}
+          {...disabledReasonProps}
         >
           {buttonContent}
-          {isDisabledWithReason && (
-            <>
-              {descriptionEl}
-              {showTooltip && (
-                <Tooltip
-                  className={testUtilStyles['disabled-reason-tooltip']}
-                  trackRef={buttonRef}
-                  value={disabledReason!}
-                />
-              )}
-            </>
-          )}
+          {isDisabledWithReason && disabledReasonContent}
         </button>
         {loading && loadingText && (
           <InternalLiveRegion tagName="span" hidden={true}>

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -159,15 +159,17 @@ export const InternalButton = React.forwardRef(
 
     const buttonClass = clsx(props.className, styles.button, styles[`variant-${variant}`], {
       [styles.disabled]: isNotInteractive,
+      [styles['disabled-with-reason']]: isDisabledWithReason,
       [styles['button-no-wrap']]: !wrapText,
       [styles['button-no-text']]: !shouldHaveContent,
       [styles['full-width']]: shouldHaveContent && fullWidth,
+      [styles.link]: isAnchor,
     });
 
     const explicitTabIndex =
       __nativeAttributes && 'tabIndex' in __nativeAttributes ? __nativeAttributes.tabIndex : undefined;
     const { tabIndex } = useSingleTabStopNavigation(buttonRef, {
-      tabIndex: isAnchor && isNotInteractive ? -1 : explicitTabIndex,
+      tabIndex: isAnchor && isNotInteractive && !isDisabledWithReason ? -1 : explicitTabIndex,
     });
 
     const analyticsMetadata: GeneratedAnalyticsMetadataButtonFragment = disabled

--- a/src/button/styles.scss
+++ b/src/button/styles.scss
@@ -164,7 +164,3 @@
     inset-inline: 0;
   }
 }
-
-.link.disabled {
-  pointer-events: none;
-}

--- a/src/button/styles.scss
+++ b/src/button/styles.scss
@@ -164,3 +164,7 @@
     inset-inline: 0;
   }
 }
+
+.link.disabled:not(.disabled-with-reason) {
+  pointer-events: none;
+}


### PR DESCRIPTION
### Description

This PR addresses an issue with showing disabled reason tooltip for primary/normal button with `href` prop.
AWSUI-59893

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
