### PR TITLE
chore: Test analytics metadata in a table with empty header

### DIFF
--- a/src/table/__tests__/analytics-metadata.test.tsx
+++ b/src/table/__tests__/analytics-metadata.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata/utils';
 
+import ButtonDropdown from '../../../lib/components/button-dropdown';
 import Header from '../../../lib/components/header';
 import Table, { TableProps } from '../../../lib/components/table';
 import InternalTable from '../../../lib/components/table/internal';
@@ -46,6 +47,20 @@ const columnDefinitions: TableProps['columnDefinitions'] = [
     cell: item => item.description,
     sortingComparator,
   },
+  {
+    id: 'actions',
+    header: 'Actions',
+    cell: () => (
+      <ButtonDropdown
+        items={[
+          { text: 'Delete', id: 'rm', disabled: false },
+          { text: 'Move', id: 'mv', disabled: false },
+        ]}
+        variant="inline-icon"
+        ariaLabel="Control instance"
+      />
+    ),
+  },
 ];
 
 const isItemDisabled = (item: TableItem) => item.value === 'second';
@@ -60,9 +75,13 @@ function renderTable(props: Partial<TableProps>) {
       columnDefinitions={columnDefinitions}
       trackBy="value"
       header={
-        <Header variant="h2" counter="2" info="Info">
-          {componentLabel}
-        </Header>
+        typeof props.header !== 'undefined' ? (
+          props.header
+        ) : (
+          <Header variant="h2" counter="2" info="Info">
+            {componentLabel}
+          </Header>
+        )
       }
       isItemDisabled={isItemDisabled}
     />
@@ -249,6 +268,46 @@ describe('Table renders correct analytics metadata', () => {
           variant: 'container',
         })
       );
+    });
+  });
+  describe('table without header', () => {
+    test('parses table label as an empty string', () => {
+      const wrapper = renderTable({ header: null });
+      const actionButton = wrapper.findBodyCell(1, 3)!.findButtonDropdown()!.getElement();
+      expect(getGeneratedAnalyticsMetadata(actionButton)).toEqual({
+        contexts: [
+          {
+            type: 'component',
+            detail: {
+              label: 'Control instance',
+              name: 'awsui.ButtonDropdown',
+              properties: {
+                disabled: 'false',
+                variant: 'inline-icon',
+              },
+            },
+          },
+          {
+            type: 'component',
+            detail: {
+              innerContext: {
+                columnId: 'actions',
+                columnLabel: 'Actions',
+                item: 'first',
+                position: '1,3',
+              },
+              name: 'awsui.Table',
+              label: '',
+              properties: {
+                itemsCount: '3',
+                selectedItemsCount: '0',
+                selectionType: 'none',
+                variant: 'container',
+              },
+            },
+          },
+        ],
+      });
     });
   });
 });


### PR DESCRIPTION
### Description

Add a test to cover use case from this [PR](https://github.com/cloudscape-design/component-toolkit/pull/105).

Related links, issue #, if available: AWSUI-59898

### How has this been tested?
locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
