### PR TITLE
fix: Fixes button group item states

### DIFF
--- a/pages/button-group/test.page.tsx
+++ b/pages/button-group/test.page.tsx
@@ -3,177 +3,239 @@
 
 import React, { useContext, useState } from 'react';
 
-import Box from '~components/box';
-import Button from '~components/button';
-import ButtonGroup, { ButtonGroupProps } from '~components/button-group';
-import SpaceBetween from '~components/space-between';
-import StatusIndicator from '~components/status-indicator';
+import { Box, Button, ButtonGroup, ButtonGroupProps, Header, SpaceBetween, StatusIndicator } from '~components';
 
 import AppContext, { AppContextType } from '../app/app-context';
+import { enhanceWindow, WindowWithFlushResponse } from '../common/flush-response';
 import ScreenshotArea from '../utils/screenshot-area';
+
+declare const window: WindowWithFlushResponse;
+enhanceWindow();
 
 type PageContext = React.Context<
   AppContextType<{
     dropdownExpandToViewport?: boolean;
+    manualServerMock?: boolean;
   }>
 >;
 
-const likeButton: ButtonGroupProps.Item = {
-  type: 'icon-button',
-  id: 'like',
-  iconName: 'thumbs-up',
-  text: 'Like',
-  popoverFeedback: <StatusIndicator type="success">Liked</StatusIndicator>,
-};
-
-const dislikeButton: ButtonGroupProps.Item = {
-  type: 'icon-button',
-  id: 'dislike',
-  iconName: 'thumbs-down',
-  text: 'Dislike',
-  popoverFeedback: <StatusIndicator type="error">Disliked</StatusIndicator>,
-};
-
-const feedbackGroup: ButtonGroupProps.Group = {
-  type: 'group',
-  text: 'Vote',
-  items: [likeButton, dislikeButton],
-};
-
-const copyButton: ButtonGroupProps.Item = {
-  type: 'icon-button',
-  id: 'copy',
-  iconName: 'copy',
-  text: 'Copy',
-  popoverFeedback: <StatusIndicator type="success">Copied</StatusIndicator>,
-};
-
-const addButton: ButtonGroupProps.Item = {
-  type: 'icon-button',
-  id: 'add',
-  iconName: 'add-plus',
-  text: 'Add',
-  popoverFeedback: 'Added',
-  disabled: true,
-};
-
-const sendButton: ButtonGroupProps.Item = {
-  type: 'icon-button',
-  id: 'send',
-  iconName: 'send',
-  text: 'Send',
-};
-
-const removeButton: ButtonGroupProps.Item = {
-  type: 'icon-button',
-  id: 'remove',
-  iconName: 'remove',
-  text: 'Remove',
-};
-
-const redoButton: ButtonGroupProps.Item = {
-  type: 'icon-button',
-  id: 'redo',
-  iconName: 'redo',
-  text: 'Redo',
-};
-
-const moreActionsMenu: ButtonGroupProps.MenuDropdown = {
-  type: 'menu-dropdown',
-  id: 'more-actions',
-  text: 'More actions',
-  items: [
-    {
-      id: 'cut',
-      iconName: 'delete-marker',
-      text: 'Cut',
-    },
-    {
-      id: 'paste',
-      iconName: 'add-plus',
-      text: 'Paste',
-      disabled: true,
-      disabledReason: 'No content to paste',
-    },
-    {
-      text: 'Misc',
-      items: [
-        { id: 'edit', iconName: 'edit', text: 'Edit' },
-        { id: 'open', iconName: 'file-open', text: 'Open' },
-        { id: 'search', iconName: 'search', text: 'Search' },
-      ],
-    },
-  ],
-};
-
 export default function ButtonGroupPage() {
   const {
-    urlParams: { dropdownExpandToViewport = true },
+    urlParams: { dropdownExpandToViewport = true, manualServerMock = false },
   } = useContext(AppContext as PageContext);
-  const ref = React.useRef<ButtonGroupProps.Ref>(null);
 
-  const [items, setItems] = useState([
+  const ref = React.useRef<ButtonGroupProps.Ref>(null);
+  const [feedback, setFeedback] = useState<'none' | 'like' | 'dislike'>('none');
+  const [isFavorite, setFavorite] = useState(false);
+  const [loadingId, setLoading] = useState<null | string>(null);
+  const [canSend, setCanSend] = useState(true);
+  const [canRedo, setCanRedo] = useState(true);
+
+  const feedbackGroup: ButtonGroupProps.Group = {
+    type: 'group',
+    text: 'Vote',
+    items: [
+      {
+        type: 'icon-button',
+        id: 'like',
+        iconName: feedback === 'like' ? 'thumbs-up-filled' : 'thumbs-up',
+        text: 'Like',
+      },
+      {
+        type: 'icon-button',
+        id: 'dislike',
+        iconName: feedback === 'dislike' ? 'thumbs-down-filled' : 'thumbs-down',
+        text: 'Dislike',
+      },
+    ],
+  };
+
+  const favoriteGroup: ButtonGroupProps.Group = {
+    type: 'group',
+    text: 'Favorite',
+    items: [
+      {
+        type: 'icon-button',
+        id: 'favorite',
+        iconName: isFavorite ? 'star-filled' : 'star',
+        text: 'Add to favorites',
+        loading: loadingId === 'favorite',
+        popoverFeedback: loadingId === 'favorite' ? '...' : isFavorite ? 'Set as favorite' : 'Removed',
+      },
+    ],
+  };
+
+  const sendGroup: ButtonGroupProps.Group = {
+    type: 'group',
+    text: 'Send',
+    items: [
+      {
+        type: 'icon-button',
+        id: 'send',
+        iconName: 'send',
+        text: 'Send',
+      },
+    ],
+  };
+
+  const copyButton: ButtonGroupProps.Item = {
+    type: 'icon-button',
+    id: 'copy',
+    iconName: 'copy',
+    text: 'Copy',
+    popoverFeedback: <StatusIndicator type="success">Copied</StatusIndicator>,
+  };
+
+  const addButton: ButtonGroupProps.Item = {
+    type: 'icon-button',
+    id: 'add',
+    iconName: 'add-plus',
+    text: 'Add',
+    loading: loadingId === 'add',
+  };
+
+  const removeButton: ButtonGroupProps.Item = {
+    type: 'icon-button',
+    id: 'remove',
+    iconName: 'remove',
+    text: 'Remove',
+    disabled: loadingId === 'remove',
+    popoverFeedback:
+      loadingId === 'remove' ? (
+        <StatusIndicator type="loading">Removing</StatusIndicator>
+      ) : (
+        <StatusIndicator>Removed</StatusIndicator>
+      ),
+  };
+
+  const redoButton: ButtonGroupProps.Item = {
+    type: 'icon-button',
+    id: 'redo',
+    iconName: 'redo',
+    text: 'Redo',
+    disabled: !canRedo,
+  };
+
+  const moreActionsMenu: ButtonGroupProps.MenuDropdown = {
+    type: 'menu-dropdown',
+    id: 'more-actions',
+    text: 'More actions',
+    loading: !!(loadingId && ['cut', 'paste', 'edit', 'open', 'search'].includes(loadingId)),
+    items: [
+      {
+        id: 'cut',
+        iconName: 'delete-marker',
+        text: 'Cut',
+      },
+      {
+        id: 'paste',
+        iconName: 'add-plus',
+        text: 'Paste',
+        disabled: true,
+        disabledReason: 'No content to paste',
+      },
+      {
+        text: 'Misc',
+        items: [
+          { id: 'edit', iconName: 'edit', text: 'Edit' },
+          { id: 'open', iconName: 'file-open', text: 'Open' },
+          { id: 'search', iconName: 'search', text: 'Search' },
+        ],
+      },
+    ],
+  };
+
+  function canRenderItem(item: ButtonGroupProps.ItemOrGroup) {
+    if (item.type === 'group' && item.text === 'Send' && !canSend) {
+      return false;
+    }
+    return true;
+  }
+  const items = [
     feedbackGroup,
+    favoriteGroup,
+    sendGroup,
     copyButton,
     addButton,
-    sendButton,
-    redoButton,
     removeButton,
+    redoButton,
     moreActionsMenu,
-  ]);
+  ].filter(canRenderItem);
 
-  const onItemClick: ButtonGroupProps['onItemClick'] = event => {
-    document.querySelector('#last-clicked')!.textContent = event.detail.id;
-
-    if (event.detail.id === 'dislike') {
-      setItems(prev => prev.filter(item => item.type !== 'group'));
+  const onItemClick: ButtonGroupProps['onItemClick'] = ({ detail }) => {
+    function addLog(text: string) {
+      const entry = document.createElement('div');
+      entry.textContent = text;
+      document.querySelector('#log')!.append(entry);
     }
-    if (event.detail.id === 'redo') {
-      setItems(prev =>
-        prev.map(item => (item.type === 'icon-button' && item.id === 'redo' ? { ...item, disabled: true } : item))
-      );
-    }
-    if (event.detail.id === 'remove') {
-      setItems(prev =>
-        prev.map(item => (item.type === 'icon-button' && item.id === 'remove' ? { ...item, loading: true } : item))
-      );
-    }
-  };
 
-  const onFocusOnCopyButtonClick = () => {
-    ref.current?.focus('copy');
-  };
+    function syncAction(action?: () => void) {
+      addLog(detail.id);
+      action?.();
+    }
 
-  const onFocusOnMoreActionsButtonClick = () => {
-    ref.current?.focus('more-actions');
+    function asyncAction(action?: () => void) {
+      setLoading(detail.id);
+      const callback = () => {
+        setLoading(null);
+        addLog(detail.id);
+        action?.();
+      };
+      if (manualServerMock) {
+        window.__pendingCallbacks.push(callback);
+      } else {
+        setTimeout(callback, 1000);
+      }
+    }
+
+    switch (detail.id) {
+      case 'like':
+      case 'dislike':
+        return syncAction(() => setFeedback(prev => (prev !== detail.id ? (detail.id as 'like' | 'dislike') : 'none')));
+      case 'favorite':
+        return asyncAction(() => setFavorite(prev => !prev));
+      case 'send':
+        return syncAction(() => setCanSend(false));
+      case 'redo':
+        return syncAction(() => setCanRedo(false));
+      case 'add':
+      case 'remove':
+      case 'open':
+        return asyncAction();
+      default:
+        return syncAction();
+    }
   };
 
   return (
     <ScreenshotArea disableAnimations={true}>
-      <h1>Button Group test page</h1>
-      <SpaceBetween size="m" direction="vertical">
+      <SpaceBetween size="m">
+        <Header variant="h1">Button Group test page</Header>
+
         <Button data-testid="focus-before">Focus before</Button>
 
         <Box margin={{ vertical: 'xl' }}>
           <ButtonGroup
+            ref={ref}
             ariaLabel="Chat actions"
             variant="icon"
             items={items}
             onItemClick={onItemClick}
-            ref={ref}
             dropdownExpandToViewport={dropdownExpandToViewport}
           />
         </Box>
 
-        <Button onClick={onFocusOnCopyButtonClick} data-testid="focus-on-copy">
+        <Button onClick={() => ref.current?.focus('copy')} data-testid="focus-on-copy">
           Focus on copy
         </Button>
 
-        <Button onClick={onFocusOnMoreActionsButtonClick} data-testid="focus-on-more-actions">
+        <Button onClick={() => ref.current?.focus('more-actions')} data-testid="focus-on-more-actions">
           Focus on more actions
         </Button>
 
-        <div id="last-clicked"></div>
+        <Box>
+          <div id="log"></div>
+        </Box>
       </SpaceBetween>
     </ScreenshotArea>
   );

--- a/src/button-group/__integ__/button-group.test.ts
+++ b/src/button-group/__integ__/button-group.test.ts
@@ -1,5 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { range } from 'lodash';
+
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
@@ -7,7 +9,6 @@ import createWrapper from '../../../lib/components/test-utils/selectors';
 
 const buttonGroup = createWrapper().findButtonGroup();
 const likeButton = buttonGroup.findButtonById('like');
-const dislikeButton = buttonGroup.findButtonById('dislike');
 const copyButton = buttonGroup.findButtonById('copy');
 const sendButton = buttonGroup.findButtonById('send');
 const actionsMenu = buttonGroup.findMenuById('more-actions');
@@ -26,10 +27,10 @@ function setup(options: { dropdownExpandToViewport?: boolean }, testFn: (page: B
 test(
   'shows popover after clicking on inline button',
   setup({}, async page => {
-    await page.click(likeButton.toSelector());
+    await page.click(copyButton.toSelector());
     await page.waitForVisible(buttonGroup.findTooltip().toSelector());
-    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Liked');
-    await expect(page.getText('#last-clicked')).resolves.toBe('like');
+    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Copied');
+    await expect(page.getText('#log')).resolves.toBe('copy');
   })
 );
 
@@ -38,7 +39,7 @@ test(
   setup({}, async page => {
     await page.click(actionsMenu.toSelector());
     await page.click(actionsMenu.findItemById('edit').toSelector());
-    await expect(page.getText('#last-clicked')).resolves.toBe('edit');
+    await expect(page.getText('#log')).resolves.toBe('edit');
   })
 );
 
@@ -51,7 +52,7 @@ test.each([false, true])(
       await page.keys(['Tab']);
       await expect(page.isFocused(likeButton.toSelector())).resolves.toBe(true);
 
-      await page.keys(['ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowRight']);
+      await page.keys(range(8).map(() => 'ArrowRight'));
       await expect(page.isFocused(actionsMenu.find('button').toSelector())).resolves.toBe(true);
 
       await page.keys(['Enter']);
@@ -76,7 +77,7 @@ test(
   'shows tooltip when a button is focused',
   setup({}, async page => {
     await page.click(likeButton.toSelector());
-    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Liked');
+    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Like');
 
     await page.click(createWrapper().find('[data-testid="focus-on-copy"]').toSelector());
     await expect(page.isFocused(copyButton.toSelector())).resolves.toBe(true);
@@ -91,14 +92,14 @@ test(
   'hides popover after clicking outside',
   setup({}, async page => {
     await page.click(likeButton.toSelector());
-    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Liked');
+    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Like');
 
-    await page.click(createWrapper().find('#last-clicked').toSelector());
+    await page.click(createWrapper().find('#log').toSelector());
     await expect(page.isExisting(buttonGroup.findTooltip().toSelector())).resolves.toBe(false);
 
     await page.click(actionsMenu.toSelector());
     await page.click(actionsMenu.findItemById('cut').toSelector());
-    await page.click(createWrapper().find('#last-clicked').toSelector());
+    await page.click(createWrapper().find('#log').toSelector());
     await expect(page.isExisting(buttonGroup.findTooltip().toSelector())).resolves.toBe(false);
   })
 );
@@ -106,8 +107,8 @@ test(
 test(
   'keeps focus in button group when action gets removed',
   setup({}, async page => {
-    await page.click(dislikeButton.toSelector());
-    await expect(page.isFocused(copyButton.toSelector())).resolves.toBe(true);
+    await page.click(sendButton.toSelector());
+    await expect(page.isFocused(likeButton.toSelector())).resolves.toBe(true);
   })
 );
 
@@ -119,7 +120,7 @@ test(
     await page.keys(['Tab']);
     await expect(page.isFocused(likeButton.toSelector())).resolves.toBe(true);
 
-    await page.keys(['ArrowRight', 'ArrowRight']);
+    await page.keys(['ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowRight']);
     await expect(page.isFocused(copyButton.toSelector())).resolves.toBe(true);
     await expect(page.getElementsCount(buttonGroup.findTooltip().toSelector())).resolves.toBe(1);
     await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Copy');
@@ -130,7 +131,7 @@ test(
 
     await page.keys(['ArrowRight']);
     await expect(page.getElementsCount(buttonGroup.findTooltip().toSelector())).resolves.toBe(1);
-    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Send');
+    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Add');
 
     await page.keys(['ArrowRight', 'ArrowRight', 'ArrowRight']);
     await expect(page.getElementsCount(buttonGroup.findTooltip().toSelector())).resolves.toBe(1);
@@ -141,11 +142,11 @@ test(
 test(
   'keeps showing tooltip after clicking on a button with no popover feedback',
   setup({}, async page => {
-    await page.hoverElement(sendButton.toSelector());
-    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Send');
+    await page.hoverElement(likeButton.toSelector());
+    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Like');
 
-    await page.click(sendButton.toSelector());
-    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Send');
+    await page.click(likeButton.toSelector());
+    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Like');
   })
 );
 

--- a/src/button-group/icon-button-item.tsx
+++ b/src/button-group/icon-button-item.tsx
@@ -8,7 +8,7 @@ import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import { ButtonProps } from '../button/interfaces.js';
 import { InternalButton } from '../button/internal.js';
 import Tooltip from '../internal/components/tooltip/index.js';
-import { CancelableEventHandler, ClickDetail } from '../internal/events/index.js';
+import { CancelableEventHandler, fireCancelableEvent } from '../internal/events/index.js';
 import InternalLiveRegion from '../live-region/internal.js';
 import { ButtonGroupProps } from './interfaces.js';
 
@@ -25,7 +25,7 @@ const IconButtonItem = forwardRef(
       item: ButtonGroupProps.IconButton;
       showTooltip: boolean;
       showFeedback: boolean;
-      onItemClick?: CancelableEventHandler<ClickDetail>;
+      onItemClick?: CancelableEventHandler<ButtonGroupProps.ItemClickDetails>;
     },
     ref: React.Ref<ButtonProps.Ref>
   ) => {
@@ -36,6 +36,8 @@ const IconButtonItem = forwardRef(
       warnOnce('ButtonGroup', `Missing icon for item with id: ${item.id}`);
     }
 
+    const canShowTooltip = Boolean(showTooltip && !item.disabled && !item.loading);
+    const canShowFeedback = Boolean(showTooltip && showFeedback && item.popoverFeedback);
     return (
       <div ref={containerRef}>
         <InternalButton
@@ -43,11 +45,13 @@ const IconButtonItem = forwardRef(
           loading={item.loading}
           loadingText={item.loadingText}
           disabled={item.disabled}
+          __focusable={canShowFeedback}
           iconName={hasIcon ? item.iconName : 'close'}
-          iconAlt={item.text}
+          iconUrl={item.iconUrl}
           iconSvg={item.iconSvg}
+          iconAlt={item.text}
           ariaLabel={item.text}
-          onClick={onItemClick}
+          onClick={event => fireCancelableEvent(onItemClick, { id: item.id }, event)}
           ref={ref}
           data-testid={item.id}
           data-itemid={item.id}
@@ -56,7 +60,7 @@ const IconButtonItem = forwardRef(
         >
           {item.text}
         </InternalButton>
-        {showTooltip && !item.disabled && !item.loading && (!showFeedback || item.popoverFeedback) && (
+        {(canShowTooltip || canShowFeedback) && (
           <Tooltip
             trackRef={containerRef}
             trackKey={item.id}

--- a/src/button-group/item-element.tsx
+++ b/src/button-group/item-element.tsx
@@ -3,7 +3,7 @@
 import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 
 import { ButtonProps } from '../button/interfaces.js';
-import { ClickDetail, fireCancelableEvent, NonCancelableEventHandler } from '../internal/events';
+import { fireCancelableEvent, NonCancelableEventHandler } from '../internal/events';
 import { nodeBelongs } from '../internal/utils/node-belongs';
 import IconButtonItem from './icon-button-item';
 import { ButtonGroupProps } from './interfaces';
@@ -79,14 +79,14 @@ const ItemElement = forwardRef(
       setTooltip(show ? { item: item.id, feedback: false } : null);
     };
 
-    const onClickHandler = (event: CustomEvent<ButtonGroupProps.ItemClickDetails | ClickDetail>) => {
+    const onClickHandler = (event: CustomEvent<ButtonGroupProps.ItemClickDetails>) => {
       const hasPopoverFeedback = 'popoverFeedback' in item && item.popoverFeedback;
 
       if (hasPopoverFeedback) {
         setTooltip({ item: item.id, feedback: true });
       }
 
-      fireCancelableEvent(onItemClick, { id: 'id' in event.detail ? event.detail.id : item.id }, event);
+      fireCancelableEvent(onItemClick, event.detail, event);
     };
 
     return (

--- a/src/button-group/menu-dropdown-item.tsx
+++ b/src/button-group/menu-dropdown-item.tsx
@@ -33,9 +33,6 @@ const MenuDropdownItem = React.forwardRef(
       <ButtonDropdown
         ref={ref}
         variant="icon"
-        loading={item.loading}
-        loadingText={item.loadingText}
-        disabled={item.disabled}
         items={item.items}
         onItemClick={onClickHandler}
         expandToViewport={expandToViewport}
@@ -60,6 +57,9 @@ const MenuDropdownItem = React.forwardRef(
               ariaExpanded={ariaExpanded}
               className={clsx(testUtilStyles.item, testUtilsClass)}
               iconName="ellipsis"
+              loading={item.loading}
+              loadingText={item.loadingText}
+              disabled={item.disabled}
               onClick={onClick}
               __title=""
             />


### PR DESCRIPTION
### Description

The PR includes the following fixes:
1. Menu items can be set as loading or disabled
2. Popover feedback can be shown for disabled and loading items

Related links, issue #, if available: n/a

### How has this been tested?

* New unit tests
* Improved test page and adjusted integ tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
