### PR TITLE
chore: Move table task interaction id to root of component

### DIFF
--- a/pages/funnel-analytics/table.page.tsx
+++ b/pages/funnel-analytics/table.page.tsx
@@ -20,14 +20,17 @@ setComponentMetrics({
 
 export default function () {
   return (
-    <Table
-      items={[]}
-      columnDefinitions={[]}
-      header={
-        <Header info={<Link variant="info">Info</Link>} counter="(10)">
-          Table title
-        </Header>
-      }
-    />
+    <>
+      <h1>Table analytics</h1>
+      <Table
+        items={[]}
+        columnDefinitions={[]}
+        header={
+          <Header info={<Link variant="info">Info</Link>} counter="(10)">
+            Table title
+          </Header>
+        }
+      />
+    </>
   );
 }

--- a/pages/funnel-analytics/table.page.tsx
+++ b/pages/funnel-analytics/table.page.tsx
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { Header, Link, Table } from '~components';
+import { setComponentMetrics } from '~components/internal/analytics';
+
+const componentMetricsLog: any[] = [];
+(window as any).__awsuiComponentlMetrics__ = componentMetricsLog;
+
+setComponentMetrics({
+  componentMounted: props => {
+    componentMetricsLog.push(props);
+    return props.taskInteractionId || 'mocked-task-interaction-id';
+  },
+  componentUpdated: props => {
+    componentMetricsLog.push(props);
+  },
+});
+
+export default function () {
+  return (
+    <Table
+      items={[]}
+      columnDefinitions={[]}
+      header={
+        <Header info={<Link variant="info">Info</Link>} counter="(10)">
+          Table title
+        </Header>
+      }
+    />
+  );
+}

--- a/src/table/__integ__/component-metrics.test.ts
+++ b/src/table/__integ__/component-metrics.test.ts
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+interface ExtendedWindow extends Window {
+  __awsuiComponentlMetrics__: Array<any>;
+}
+declare const window: ExtendedWindow;
+
+class TableWithAnalyticsPageObject extends BasePageObject {
+  async getComponentMetricsLog() {
+    const componentsLog = await this.browser.execute(() => window.__awsuiComponentlMetrics__);
+    return componentsLog;
+  }
+}
+
+test(
+  'component mount event includes table title without additional header slot information',
+  useBrowser(async browser => {
+    await browser.url('#/light/funnel-analytics/table');
+    const page = new TableWithAnalyticsPageObject(browser);
+    const componentsLog = await page.getComponentMetricsLog();
+    expect(componentsLog.length).toBe(1);
+    expect(componentsLog[0]).toMatchObject({
+      componentConfiguration: {
+        taskName: 'Table title',
+      },
+      componentName: 'table',
+      taskInteractionId: expect.any(String),
+    });
+  })
+);

--- a/src/table/__tests__/component-metrics.test.tsx
+++ b/src/table/__tests__/component-metrics.test.tsx
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import Table from '../../../lib/components/table';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import { mockComponentMetrics } from '../../internal/analytics/__tests__/mocks';
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  mockComponentMetrics();
+});
+
+test('should add data-analytics-task-interaction-id to root of Table component', () => {
+  const { container } = render(<Table items={[]} columnDefinitions={[]} />);
+  const tableElement = createWrapper(container).findTable()!.getElement();
+  expect(tableElement).toHaveAttribute('data-analytics-task-interaction-id');
+});

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -410,6 +410,7 @@ const InternalTable = React.forwardRef(
           >
             <InternalContainer
               {...baseProps}
+              {...tableInteractionAttributes}
               __internalRootRef={__internalRootRef}
               className={clsx(baseProps.className, styles.root)}
               __funnelSubStepProps={__funnelSubStepProps}
@@ -502,7 +503,6 @@ const InternalTable = React.forwardRef(
                 >
                   <table
                     {...performanceMarkAttributes}
-                    {...tableInteractionAttributes}
                     ref={tableRef}
                     className={clsx(
                       styles.table,


### PR DESCRIPTION
### Description
 
- Move table task interaction id to root of component to allow components in table actions slots to be aware of this id
- Added an additional integ test to check the information received from the table mount event

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

- Added additional unit test for data attribute
- Added additional integ test for taskName value

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
