### PR TITLE
feat: Adds test id to flashbar dom selector

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`test-utils selectors 1`] = `
   ],
   "anchor-navigation": [
     "awsui_anchor-item--active_17oho",
+    "awsui_anchor-item_17oho",
     "awsui_anchor-link-info_17oho",
     "awsui_anchor-link-text_17oho",
     "awsui_anchor-link_17oho",

--- a/src/flashbar/__tests__/collapsible.test.tsx
+++ b/src/flashbar/__tests__/collapsible.test.tsx
@@ -151,6 +151,85 @@ describe('Collapsible Flashbar', () => {
       });
     });
 
+    test('assigns data-testid to flash items', () => {
+      const wrapper = renderFlashbar({
+        items: [
+          {
+            testId: 'flash-item-1',
+            content: 'first flash item',
+          },
+          {
+            testId: 'flash-item-2',
+            content: 'second flash item',
+          },
+        ],
+      });
+      findNotificationBar(wrapper)!.click();
+      const flashbarItemsTestIds = wrapper
+        .findItems()
+        .map(flashbar => flashbar.getElement()!.getAttribute('data-testid'));
+
+      expect(flashbarItemsTestIds).toEqual(['flash-item-1', 'flash-item-2']);
+    });
+
+    test('findItemByTestId', () => {
+      const wrapper = renderFlashbar({
+        items: [
+          {
+            testId: 'flash-item-1',
+            content: 'first flash item',
+          },
+          {
+            testId: 'flash-item-2',
+            content: 'second flash item',
+          },
+        ],
+      });
+      findNotificationBar(wrapper)!.click();
+      const secondFlashItemFromTestId = wrapper.findItemByTestId('flash-item-2')!.getElement();
+
+      expect(secondFlashItemFromTestId).toHaveTextContent('second flash item');
+    });
+
+    test('findItemByTestId returns the item even if the test ID contains double quotes', () => {
+      const wrapper = renderFlashbar({
+        items: [
+          {
+            testId: '"flash-item-1"',
+            content: 'first flash item',
+          },
+          {
+            testId: '"flash-item-2"',
+            content: 'second flash item',
+          },
+        ],
+      });
+      findNotificationBar(wrapper)!.click();
+      const flashItem = wrapper.findItemByTestId('"flash-item-1"')!.getElement();
+
+      expect(flashItem).toHaveTextContent('first flash item');
+    });
+
+    test('findItemByTestId doesn not return the next items if the collapsible is not expanded', () => {
+      const wrapper = renderFlashbar({
+        items: [
+          {
+            testId: 'flash-item-1',
+            content: 'first flash item',
+          },
+          {
+            testId: 'flash-item-2',
+            content: 'second flash item',
+          },
+        ],
+      });
+      const fistFlashItem = wrapper.findItemByTestId('flash-item-1');
+      const secondFlashItem = wrapper.findItemByTestId('flash-item-2');
+
+      expect(fistFlashItem).toBeTruthy();
+      expect(secondFlashItem).not.toBeTruthy();
+    });
+
     test('findItemsByType', () => {
       {
         const wrapper = createFlashbarWrapper(

--- a/src/flashbar/__tests__/flashbar.test.tsx
+++ b/src/flashbar/__tests__/flashbar.test.tsx
@@ -196,6 +196,67 @@ describe('Flashbar component', () => {
       }
     });
 
+    test('assigns data-testid to flash items', () => {
+      const { container } = reactRender(
+        <Flashbar
+          items={[
+            {
+              testId: 'flash-item-1',
+              content: 'first flash item',
+            },
+            {
+              testId: 'flash-item-2',
+              content: 'second flash item',
+            },
+          ]}
+        />
+      );
+      const wrapper = createWrapper(container);
+      const flashbarItemsTestIds = wrapper
+        .findFlashbar()!
+        .findItems()
+        .map(flashbar => flashbar.getElement()!.getAttribute('data-testid'));
+
+      expect(flashbarItemsTestIds).toEqual(['flash-item-1', 'flash-item-2']);
+    });
+
+    test('findItemByTestId', () => {
+      const { container } = reactRender(
+        <Flashbar
+          items={[
+            {
+              testId: 'flash-item-1',
+              content: 'first flash item',
+            },
+            {
+              testId: 'flash-item-2',
+              content: 'second flash item',
+            },
+          ]}
+        />
+      );
+      const wrapper = createWrapper(container);
+      const secondFlashItemFromTestId = wrapper.findFlashbar()!.findItemByTestId('flash-item-2')!.getElement();
+      expect(secondFlashItemFromTestId).toHaveTextContent('second flash item');
+    });
+
+    test('findItemByTestId returns the item even if the test ID contains double quotes', () => {
+      const { container } = reactRender(
+        <Flashbar
+          items={[
+            {
+              testId: '"flash-item-test-id"',
+              content: 'flash item',
+            },
+          ]}
+        />
+      );
+      const wrapper = createWrapper(container);
+      const flashItem = wrapper.findFlashbar()?.findItemByTestId('"flash-item-test-id"')!.getElement();
+
+      expect(flashItem).toHaveTextContent('flash item');
+    });
+
     test('findItemsByType', () => {
       const wrapper = createFlashbarWrapper(
         <Flashbar

--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -250,6 +250,7 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
             {(state: string, transitionRootElement: React.Ref<HTMLDivElement> | undefined) => (
               <li
                 aria-hidden={!showInnerContent(item)}
+                data-testid={item.testId}
                 className={
                   showInnerContent(item)
                     ? clsx(

--- a/src/flashbar/flash.tsx
+++ b/src/flashbar/flash.tsx
@@ -72,7 +72,7 @@ export const focusFlashById = throttle(
   { trailing: false }
 );
 
-export interface FlashProps extends FlashbarProps.MessageDefinition {
+export interface FlashProps extends Omit<FlashbarProps.MessageDefinition, 'testId'> {
   className: string;
   transitionState?: string;
   i18nStrings?: FlashbarProps.I18nStrings;

--- a/src/flashbar/interfaces.ts
+++ b/src/flashbar/interfaces.ts
@@ -20,6 +20,13 @@ export namespace FlashbarProps {
     buttonText?: ButtonProps['children'];
     onButtonClick?: ButtonProps['onClick'];
     onDismiss?: ButtonProps['onClick'];
+
+    /**
+     * Test ID of the flash list item.
+     * Assigns this value to the `data-testid` attribute of the flash list item.
+     * Flash component is the direct child of the flash list item.
+     */
+    testId?: string;
   }
 
   export interface I18nStrings {

--- a/src/flashbar/non-collapsible-flashbar.tsx
+++ b/src/flashbar/non-collapsible-flashbar.tsx
@@ -62,7 +62,7 @@ export default function NonCollapsibleFlashbar({ items, i18nStrings, ...restProp
             in={true}
           >
             {(state: string, transitionRootElement: React.Ref<HTMLDivElement> | undefined) => (
-              <li className={styles['flash-list-item']}>
+              <li className={styles['flash-list-item']} data-testid={item.testId}>
                 {renderItem(item, item.id ?? index, transitionRootElement, state)}
               </li>
             )}
@@ -91,6 +91,7 @@ export default function NonCollapsibleFlashbar({ items, i18nStrings, ...restProp
           <li
             key={item.id ?? index}
             className={styles['flash-list-item']}
+            data-testid={item.testId}
             {...getAnalyticsMetadataAttribute(getItemAnalyticsMetadata(index + 1, item.type || 'info', item.id))}
           >
             {renderItem(item, item.id ?? index)}

--- a/src/test-utils/dom/anchor-navigation/index.ts
+++ b/src/test-utils/dom/anchor-navigation/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper, ElementWrapper, usesDom } from '@cloudscape-design/test-utils-core/dom';
+import { escapeSelector } from '@cloudscape-design/test-utils-core/utils.js';
 
 import testUtilStyles from '../../../anchor-navigation/test-classes/styles.selectors.js';
 
@@ -42,10 +43,8 @@ export default class AnchorNavigationWrapper extends ComponentWrapper {
    * @returns {AnchorItemWrapper | null}
    */
   findAnchorByTestId(testId: string): AnchorItemWrapper | null {
-    return this.findComponent(
-      `.${testUtilStyles['anchor-item']}[data-testid="${CSS.escape(testId)}"]`,
-      AnchorItemWrapper
-    );
+    const escapedTestId = escapeSelector(testId);
+    return this.findComponent(`.${testUtilStyles['anchor-item']}[data-testid="${escapedTestId}"]`, AnchorItemWrapper);
   }
 }
 

--- a/src/test-utils/dom/flashbar/index.ts
+++ b/src/test-utils/dom/flashbar/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { escapeSelector } from '@cloudscape-design/test-utils-core/utils';
 
 import FlashWrapper from './flash';
 
@@ -29,6 +30,21 @@ export default class FlashbarWrapper extends ComponentWrapper {
     return this.findAll(`.${styles['flash-list-item']} .${styles[`flash-type-${type}`]}`).map(
       item => new FlashWrapper(item.getElement())
     );
+  }
+
+  /**
+   * Returns the wrapper of the first flash list item that matches the specified test ID.
+   * If the items are stacked, the hidden items will not be returned.
+   *
+   * Looks for the `data-testid` attribute that is assigned via `items` prop.
+   * If no matching flash list item is found, returns `null`.
+   *
+   * @param {string} testId
+   * @returns {FlashbarWrapper | null}
+   */
+  findItemByTestId(testId: string): FlashWrapper | null {
+    const escapedTestId = escapeSelector(testId);
+    return this.findComponent(`.${styles['flash-list-item']}[data-testid="${escapedTestId}"]`, FlashWrapper);
   }
 
   /**


### PR DESCRIPTION
### Description

Adds `testId` prop to flash items inside the flashbar component.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available:

Collective PR: https://github.com/cloudscape-design/components/pull/2985
Project: Improving test utils API

### How has this been tested?

<!-- How did you test to verify your changes? -->

Tests added to cover the change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
