### PR TITLE
feat: Adds test id to breadcrumb items

### DIFF
--- a/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
@@ -39,14 +39,17 @@ describe('BreadcrumbGroup Component', () => {
         {
           text: 'Item 1',
           href: '/#1',
+          testId: 'breadcrumb-item-1',
         },
         {
           text: 'Item 2',
           href: '/#3',
+          testId: 'breadcrumb-item-2',
         },
         {
           text: 'Item 3',
           href: '/#3',
+          testId: 'breadcrumb-item-3',
         },
       ];
       wrapper = renderBreadcrumbGroup({ items });
@@ -107,6 +110,48 @@ describe('BreadcrumbGroup Component', () => {
 
       expect(breadcrumbs.findBreadcrumbLink(1)?.getElement()).toHaveTextContent(items[0].text);
       expect(breadcrumbs.findBreadcrumbLink(2)?.getElement()).toHaveTextContent(items[1].text);
+    });
+
+    test('test-utils findBreadcrumbLinkByTestId finds the item with test id', () => {
+      const { container } = render(<BreadcrumbGroup items={items} />);
+      const breadcrumbItem = createWrapper(container)
+        .findBreadcrumbGroup()!
+        .findBreadcrumbLinkByTestId('breadcrumb-item-2')!
+        .getElement()!;
+
+      expect(breadcrumbItem).toHaveTextContent('Item 2');
+    });
+
+    test('test-utils findBreadcrumbLinkByTestId finds the item with test id, even if test id contains quotes', () => {
+      const { container } = render(
+        <BreadcrumbGroup
+          items={[
+            {
+              text: 'Breadcrumb item',
+              href: '/#1',
+              testId: '"breadcrumb-item-test-id"',
+            },
+          ]}
+        />
+      );
+      const breadcrumbItem = createWrapper(container)
+        .findBreadcrumbGroup()!
+        .findBreadcrumbLinkByTestId('"breadcrumb-item-test-id"')!
+        .getElement()!;
+
+      expect(breadcrumbItem).toHaveTextContent('Breadcrumb item');
+    });
+
+    test('assigns data-test id to the breadcrumb items', () => {
+      const { container } = render(<BreadcrumbGroup items={items} />);
+      const [firstItem, secondItem] = createWrapper(container)
+        .findAll(`.${itemStyles.breadcrumb}`)
+        .map(item => item.getElement());
+
+      expect(firstItem).toHaveAttribute('data-testid', 'breadcrumb-item-1');
+      expect(firstItem).toHaveTextContent('Item 1');
+      expect(secondItem).toHaveAttribute('data-testid', 'breadcrumb-item-2');
+      expect(secondItem).toHaveTextContent('Item 2');
     });
 
     // Test for AWSUI-6738
@@ -229,6 +274,24 @@ describe('BreadcrumbGroup Component', () => {
       anchors.forEach(anchor => {
         expect(anchor).toHaveAttribute('tabindex', '-1');
       });
+    });
+
+    test('breadcrumb items do not receive data-testid', () => {
+      const breadCrumbGroup = renderBreadcrumbGroup({
+        items: [
+          {
+            text: 'Item 1',
+            href: '/#1',
+            testId: 'breadcrumb-item-test-id',
+          },
+        ],
+      });
+
+      const actualBreadcrumb = breadCrumbGroup.find(`.${itemStyles.breadcrumb}`)!.getElement();
+      const ghostBreadcrumb = breadCrumbGroup.find(`.${itemStyles['ghost-breadcrumb']}`)!.getElement();
+
+      expect(actualBreadcrumb).toHaveAttribute('data-testid', 'breadcrumb-item-test-id');
+      expect(ghostBreadcrumb).not.toHaveAttribute('data-testid', 'breadcrumb-item-test-id');
     });
   });
 });

--- a/src/breadcrumb-group/interfaces.ts
+++ b/src/breadcrumb-group/interfaces.ts
@@ -45,6 +45,12 @@ export namespace BreadcrumbGroupProps {
   export interface Item {
     text: string;
     href: string;
+
+    /**
+     * Test ID of the breadcrumb item.
+     * Assigns this value to the `data-testid` attribute of the breadcrumb item.
+     */
+    testId?: string;
   }
 
   export interface ClickDetail<T extends BreadcrumbGroupProps.Item = BreadcrumbGroupProps.Item>

--- a/src/breadcrumb-group/item/item.tsx
+++ b/src/breadcrumb-group/item/item.tsx
@@ -98,7 +98,10 @@ export function BreadcrumbItem<T extends BreadcrumbGroupProps.Item>({
   }
 
   return (
-    <div className={clsx(!isGhost && styles.breadcrumb, isGhost && styles['ghost-breadcrumb'], isLast && styles.last)}>
+    <div
+      className={clsx(!isGhost && styles.breadcrumb, isGhost && styles['ghost-breadcrumb'], isLast && styles.last)}
+      data-testid={isGhost ? undefined : item.testId}
+    >
       {isTruncated && !isGhost ? (
         <BreadcrumbItemWithPopover item={item} isLast={isLast} anchorAttributes={anchorAttributes} />
       ) : (

--- a/src/test-utils/dom/breadcrumb-group/index.ts
+++ b/src/test-utils/dom/breadcrumb-group/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { escapeSelector } from '@cloudscape-design/test-utils-core/utils';
 
 import ButtonDropdownWrapper from '../button-dropdown';
 
@@ -34,6 +35,19 @@ export default class BreadcrumbGroupWrapper extends ComponentWrapper {
       index++;
     }
     return this.find(`.${styles.item}:nth-child(${index}) .${itemStyles.anchor}`);
+  }
+
+  /**
+   * Returns the wrapper of the first breadcrumb link that matches the specified test ID.
+   * Looks for the `data-testid` attribute that is assigned via `items` prop.
+   * If no matching breadcrumb link is found, returns `null`.
+   *
+   * @param {string} testId
+   * @returns {ElementWrapper | null}
+   */
+  findBreadcrumbLinkByTestId(testId: string): ElementWrapper | null {
+    const escapedTestId = escapeSelector(testId);
+    return this.find(`.${itemStyles.breadcrumb}[data-testid="${escapedTestId}"] .${itemStyles.anchor}`);
   }
 
   findDropdown(): ButtonDropdownWrapper | null {


### PR DESCRIPTION
### Description

Adds `testId` prop to breadcrumb items inside the breadcrumb group component.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available:

Collective PR: https://github.com/cloudscape-design/components/pull/2985
Project: Improving test utils API

### How has this been tested?

<!-- How did you test to verify your changes? -->

Tests added to cover the change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
