### PR TITLE
fix: Makes paddings equal on all sides in prompt input

### DIFF
--- a/pages/prompt-input/simple.page.tsx
+++ b/pages/prompt-input/simple.page.tsx
@@ -2,13 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useState } from 'react';
 
-import { AppLayout, Box, SplitPanel, TokenGroup } from '~components';
-import ButtonGroup from '~components/button-group';
-import Checkbox from '~components/checkbox';
-import ColumnLayout from '~components/column-layout';
-import FormField from '~components/form-field';
-import PromptInput from '~components/prompt-input';
-import SpaceBetween from '~components/space-between';
+import {
+  Alert,
+  AppLayout,
+  Box,
+  ButtonGroup,
+  Checkbox,
+  ColumnLayout,
+  FormField,
+  PromptInput,
+  SpaceBetween,
+  SplitPanel,
+} from '~components';
 
 import AppContext, { AppContextType } from '../app/app-context';
 import labels from '../app-layout/utils/labels';
@@ -188,13 +193,10 @@ export default function PromptInputPage() {
                   }
                   secondaryContent={
                     hasSecondaryContent ? (
-                      <TokenGroup
-                        onDismiss={({ detail: { itemIndex } }) => {
-                          setItems([...items.slice(0, itemIndex), ...items.slice(itemIndex + 1)]);
-                        }}
-                        items={items}
-                        readOnly={isReadOnly}
-                      />
+                      <Alert statusIconAriaLabel="Info" header="Known issues/limitations">
+                        Review the documentation to learn about potential compatibility issues with specific database
+                        versions.
+                      </Alert>
                     ) : undefined
                   }
                 />

--- a/src/prompt-input/styles.scss
+++ b/src/prompt-input/styles.scss
@@ -161,10 +161,10 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
   @include styles.control-border-radius-full();
 
   &.with-paddings {
-    padding-block-start: styles.$control-padding-vertical;
+    padding-block-start: awsui.$space-scaled-s;
     padding-block-end: awsui.$space-scaled-s;
     padding-inline-start: styles.$control-padding-horizontal;
-    padding-inline-end: calc(styles.$control-padding-horizontal / 2);
+    padding-inline-end: styles.$control-padding-horizontal;
 
     &.invalid,
     &.warning {


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Previously, the top and end paddings of the prompt input secondary content area were not equal. This created tense layouts that were exacerbated by the current file upload work. This makes the paddings equal on all sides, as well as placing a component without built-in paddings on the test page so that it is easy to tell.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
