### PR TITLE
feat: Adds test id to select items 

### DIFF
--- a/src/internal/components/option/index.tsx
+++ b/src/internal/components/option/index.tsx
@@ -79,7 +79,14 @@ const Option = ({
     : undefined;
 
   return (
-    <span data-value={option.value} className={className} lang={option.lang} {...genericGroupProps} {...baseProps}>
+    <span
+      data-testid={option.testId}
+      data-value={option.value}
+      className={className}
+      lang={option.lang}
+      {...genericGroupProps}
+      {...baseProps}
+    >
       {icon}
       <span className={styles.content}>
         <span className={styles['label-content']}>

--- a/src/internal/components/option/interfaces.ts
+++ b/src/internal/components/option/interfaces.ts
@@ -19,6 +19,14 @@ export interface BaseOption {
   iconName?: IconProps.Name;
   iconUrl?: string;
   iconSvg?: React.ReactNode;
+
+  /**
+   * Test ID of the option item.
+   * Assigns this value to the `data-testid` attribute of the option's root element.
+   *
+   * Note: In autosuggest component, test id is not applied to the option groups.
+   */
+  testId?: string;
 }
 
 export interface OptionDefinition extends BaseOption {

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -816,3 +816,22 @@ test('group options can have description, label tag, tags, disabled reason', () 
   expect(groupOption.findTags()![1].getElement().textContent).toBe('Tag 2');
   expect(groupOption.findDisabledReason()!.getElement().textContent).toBe('Disabled reason');
 });
+
+test('assigns test-id to the options', () => {
+  const { wrapper } = renderMultiselect(
+    <Multiselect
+      selectedOptions={defaultOptions.slice(0, 2)}
+      options={[
+        { label: 'First', value: '1', testId: 'option-1-test-id' },
+        { label: 'Second', value: '2', testId: 'option-2-test-id' },
+      ]}
+    />
+  );
+  wrapper.openDropdown();
+  const optionTestIds = wrapper
+    .findDropdown()
+    .findOptions()
+    .map(option => option.getElement().getAttribute('data-testid'));
+
+  expect(optionTestIds).toEqual(['option-1-test-id', 'option-2-test-id']);
+});

--- a/src/multiselect/__tests__/test-utils.test.tsx
+++ b/src/multiselect/__tests__/test-utils.test.tsx
@@ -9,15 +9,22 @@ import createWrapper from '../../../lib/components/test-utils/dom';
 import { MultiselectProps } from '../interfaces';
 
 const options: MultiselectProps.Options = [
-  { label: 'First option', value: '1' },
+  {
+    label: 'First option',
+    value: '1',
+    testId: 'option-1-test-id',
+  },
   {
     label: 'First group',
+    testId: 'group-test-id',
     options: [
       {
+        testId: 'option-2-test-id',
         label: 'Second option',
         value: '2',
       },
       {
+        testId: 'option-3-test-id',
         label: 'Third option',
         value: '3',
       },
@@ -54,6 +61,7 @@ describe('test utils', () => {
     expect(groups[0].getElement()).toHaveTextContent('First group');
     expect(groups[1].getElement()).toHaveTextContent('Second group');
   });
+
   describe('findGroup', () => {
     test('returns a group by 1-based index', () => {
       const { wrapper } = renderMultiselect();
@@ -61,6 +69,45 @@ describe('test utils', () => {
       const dropdown = wrapper.findDropdown()!;
       expect(dropdown.findGroup(1)!.getElement()).toHaveTextContent('First group');
       expect(dropdown.findGroup(2)!.getElement()).toHaveTextContent('Second group');
+    });
+  });
+
+  describe('findGroupByTestId', () => {
+    test('returns the group by test id', () => {
+      const { wrapper } = renderMultiselect();
+      wrapper.openDropdown();
+      const dropdown = wrapper.findDropdown()!;
+
+      expect(dropdown.findGroupByTestId('group-test-id')!.getElement()).toHaveTextContent('First group');
+    });
+
+    test('does not return non-group options even if test id matches', () => {
+      const { wrapper } = renderMultiselect();
+      wrapper.openDropdown();
+      const dropdown = wrapper.findDropdown()!;
+
+      expect(dropdown.findGroupByTestId('option-2-test-id')).toBeNull();
+    });
+  });
+
+  describe('findOptionByTestId', () => {
+    test('returns the option by test id', () => {
+      const { wrapper } = renderMultiselect();
+      wrapper.openDropdown();
+      const dropdown = wrapper.findDropdown()!;
+      const topLevelOption = dropdown.findOptionByTestId('option-1-test-id')!.getElement();
+      const subLevelOption = dropdown.findOptionByTestId('option-2-test-id')!.getElement();
+
+      expect(topLevelOption).toHaveTextContent('First option');
+      expect(subLevelOption).toHaveTextContent('Second option');
+    });
+
+    test('does not return the group even if the test id matches', () => {
+      const { wrapper } = renderMultiselect();
+      wrapper.openDropdown();
+      const dropdown = wrapper.findDropdown()!;
+
+      expect(dropdown.findOptionByTestId('group-test-id')).not.toBeTruthy();
     });
   });
 });

--- a/src/select/__tests__/common.ts
+++ b/src/select/__tests__/common.ts
@@ -5,19 +5,22 @@ import { SelectProps } from '../../../lib/components/select';
 export const VALUE_WITH_SPECIAL_CHARS = 'Option 4, test"2';
 
 export const defaultOptions: SelectProps.Options = [
-  { label: 'First', value: '1' },
-  { label: 'Second', value: '2' },
+  { label: 'First', value: '1', testId: 'option-1-test-id' },
+  { label: 'Second', value: '2', testId: 'option-2-test-id' },
   {
     label: 'Group',
+    testId: 'group-test-id',
     options: [
       {
         label: 'Third',
         value: '3',
         lang: 'de',
+        testId: 'option-3-test-id',
       },
       {
         label: 'Forth',
         value: VALUE_WITH_SPECIAL_CHARS,
+        testId: 'option-4-test-id',
       },
     ],
   },

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -97,6 +97,17 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
     );
   });
 
+  test('assigns test-id to the options', () => {
+    const { wrapper } = renderSelect();
+    wrapper.openDropdown();
+    const optionTestIds = wrapper
+      .findDropdown({ expandToViewport })
+      .findOptions()
+      .map(option => option.getElement().getAttribute('data-testid'));
+
+    expect(optionTestIds).toEqual(['option-1-test-id', 'option-2-test-id', 'option-3-test-id', 'option-4-test-id']);
+  });
+
   test('throws an error when attempting to select an option with closed dropdown', () => {
     const { wrapper } = renderSelect();
     expect(() => wrapper.selectOption(1, { expandToViewport })).toThrow(

--- a/src/test-utils/dom/autosuggest/index.ts
+++ b/src/test-utils/dom/autosuggest/index.ts
@@ -36,6 +36,22 @@ export class AutosuggestDropdownWrapper extends ComponentWrapper {
   }
 
   /**
+   * Returns the wrapper of the first option that matches the specified test ID.
+   * Looks for the `data-testid` attribute on the option element.
+   * If no matching option is found, returns `null`.
+   *
+   * @param {string} testId
+   * @returns {OptionWrapper | null}
+   */
+  findOptionByTestId(testId: string): OptionWrapper | null {
+    const escapedTestId = escapeSelector(testId);
+    return this.findComponent(
+      `.${selectableStyles['selectable-item']} .${OptionWrapper.rootSelector}[data-testid="${escapedTestId}"]`,
+      OptionWrapper
+    );
+  }
+
+  /**
    * Returns an option from the autosuggest by it's value
    *
    * @param value The 'value' of the option.

--- a/src/test-utils/dom/internal/dropdown-host.ts
+++ b/src/test-utils/dom/internal/dropdown-host.ts
@@ -166,6 +166,22 @@ export class DropdownContentWrapper extends ComponentWrapper {
     );
   }
 
+  /**
+   * Returns the wrapper of the option that matches the specified test ID.
+   * Looks for the `data-testid` attribute on the option element.
+   * If no matching option is found, returns `null`.
+   *
+   * @param {string} testId
+   * @returns {OptionWrapper | null}
+   */
+  findOptionByTestId(testId: string): OptionWrapper | null {
+    const escapedTestId = escapeSelector(testId);
+    return this.findComponent(
+      `.${selectableStyles['selectable-item']}[data-test-index] .${OptionWrapper.rootSelector}[data-testid="${escapedTestId}"]`,
+      OptionWrapper
+    );
+  }
+
   findOptionByValue(value: string): OptionWrapper | null {
     const toReplace = escapeSelector(value);
     return this.findComponent(`.${OptionWrapper.rootSelector}[data-value="${toReplace}"]`, OptionWrapper);
@@ -210,6 +226,21 @@ export class DropdownContentWrapper extends ComponentWrapper {
    */
   findGroup(index: number): ElementWrapper | null {
     return this.find(`.${selectableStyles['selectable-item']}[data-group-index="${index}"]`);
+  }
+
+  /**
+   * Returns the wrapper of the group option that matches the specified test ID.
+   * Looks for the `data-testid` attribute on the group option element.
+   * If no matching group option is found, returns `null`.
+   *
+   * @param {string} testId
+   * @returns {ElementWrapper | null}
+   */
+  findGroupByTestId(testId: string): ElementWrapper | null {
+    const escapedTestId = escapeSelector(testId);
+    return this.find(
+      `.${selectableStyles['selectable-item']}[data-group-index]:not([data-test-index]) [data-testid=${escapedTestId}]`
+    );
   }
 
   /**


### PR DESCRIPTION
### Description

Adds `testId` prop to option component.
The change will be reflected in select, multi-select, autosuggest and property filter components.

Since `Option` is being used in several components, this PR adds test id to:
* Select
* Multiselect
* Autosuggest

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available:

Collective PR: https://github.com/cloudscape-design/components/pull/2985
Project: Improving test utils API

### How has this been tested?

<!-- How did you test to verify your changes? -->

Tests added to cover the change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
