### PR TITLE
fix: Respect toolsOpen after opening Tools via drawer

### DIFF
--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 /* eslint simple-import-sort/imports: 0 */
 import React, { useState } from 'react';
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import {
   describeEachAppLayout,
   findActiveDrawerLandmark,
@@ -314,11 +314,21 @@ describeEachAppLayout(({ theme, size }) => {
     expect(wrapper.findTools()).toBeFalsy();
     wrapper.findToolsToggle().click();
 
-    await waitFor(() => expect(wrapper.findTools().getElement()).toHaveTextContent('Tools content'));
+    expect(wrapper.findTools().getElement()).toHaveTextContent('Tools content');
 
     createWrapper().find('[data-testid="toggle-tools-drawer"]')!.click();
 
-    await waitFor(() => expect(wrapper.findTools()).toBeFalsy());
+    expect(wrapper.findTools()).toBeFalsy();
+  });
+
+  test('does not open tools panel on toggle click for partially controllable tools', async () => {
+    awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
+
+    const { wrapper } = await renderComponent(<AppLayout tools="Tools content" toolsOpen={false} />);
+    expect(wrapper.findTools()).toBeFalsy();
+
+    wrapper.findToolsToggle().click();
+    expect(wrapper.findTools()).toBeFalsy();
   });
 
   test('opens tools drawer via ref', async () => {

--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -256,7 +256,12 @@ export function useDrawers(
     ? [...localBefore, ...drawers, ...localAfter]
     : applyToolsDrawer(toolsProps, runtimeDrawers);
   // support toolsOpen in runtime-drawers-only mode
-  let activeDrawerIdResolved = toolsProps?.toolsOpen && !hasOwnDrawers ? TOOLS_DRAWER_ID : activeDrawerId;
+  let activeDrawerIdResolved =
+    toolsProps?.toolsOpen && !hasOwnDrawers
+      ? TOOLS_DRAWER_ID
+      : activeDrawerId !== TOOLS_DRAWER_ID
+        ? activeDrawerId
+        : null;
   const activeDrawer = combinedLocalDrawers?.find(drawer => drawer.id === activeDrawerIdResolved);
   // ensure that id is only defined when the drawer exists
   activeDrawerIdResolved = activeDrawer?.id ?? null;


### PR DESCRIPTION
### Description
Currently, if we have controllable tools and runtime drawers, after clicking on the trigger of the info panel, it ignores updates to the `toolsOpen` value. That happens because `activeDrawerId` is controlled separately and it still points to the tools drawer.

Related links, issue #, if available: AWSUI-57748

### How has this been tested?

- new unit test added

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
