### PR TITLE
fix: Pass global drawers' data to toolbar via dedupe api

### DIFF
--- a/pages/app-layout/multi-layout-global-drawer-child-layout.page.tsx
+++ b/pages/app-layout/multi-layout-global-drawer-child-layout.page.tsx
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect } from 'react';
+import ReactDOM, { unmountComponentAtNode } from 'react-dom';
+
+import AppLayout from '~components/app-layout';
+import Header from '~components/header';
+import ScreenreaderOnly from '~components/internal/components/screenreader-only';
+import awsuiPlugins from '~components/internal/plugins';
+import Link from '~components/link';
+import SpaceBetween from '~components/space-between';
+
+import { IframeWrapper } from '../utils/iframe-wrapper';
+import ScreenshotArea from '../utils/screenshot-area';
+import { Breadcrumbs, Containers, Navigation, Tools } from './utils/content-blocks';
+import labels from './utils/labels';
+import * as toolsContent from './utils/tools-content';
+
+function InnerApp() {
+  useEffect(() => {
+    awsuiPlugins.appLayout.registerDrawer({
+      id: 'circle-global',
+      type: 'global',
+      defaultActive: true,
+      resizable: true,
+      defaultSize: 320,
+
+      ariaLabels: {
+        closeButton: 'Close button',
+        content: 'Content',
+        triggerButton: 'Trigger button',
+        resizeHandle: 'Resize handle',
+      },
+
+      trigger: {
+        iconSvg: `<svg viewBox="0 0 16 16" focusable="false">
+      <circle stroke-width="2" stroke="currentColor" fill="none" cx="8" cy="8" r="7" />
+      <circle stroke-width="2" stroke="currentColor" fill="none" cx="8" cy="8" r="3" />
+    </svg>`,
+      },
+
+      mountContent: container => {
+        ReactDOM.render(<div>global widget content circle 2</div>, container);
+      },
+      unmountContent: container => unmountComponentAtNode(container),
+    });
+  }, []);
+
+  return (
+    <AppLayout
+      data-testid="secondary-layout"
+      ariaLabels={labels}
+      breadcrumbs={<Breadcrumbs />}
+      navigationHide={true}
+      content={
+        <SpaceBetween size="s">
+          <Header variant="h1" description="This page contains nested app layout instances with an iframe">
+            Multiple app layouts with iframe
+          </Header>
+
+          <Link external={true} href="#">
+            External link
+          </Link>
+
+          <Containers />
+        </SpaceBetween>
+      }
+      tools={<Tools>{toolsContent.long}</Tools>}
+    />
+  );
+}
+
+export default function () {
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        {...{ __disableRuntimeDrawers: true }}
+        data-testid="main-layout"
+        ariaLabels={labels}
+        navigation={<Navigation />}
+        toolsHide={true}
+        disableContentPaddings={true}
+        content={
+          <>
+            <ScreenreaderOnly>
+              <h1>Multiple app layouts with iframe</h1>
+            </ScreenreaderOnly>
+            <IframeWrapper id="inner-iframe" AppComponent={InnerApp} />
+          </>
+        }
+      />
+    </ScreenshotArea>
+  );
+}

--- a/src/app-layout/__integ__/multi-app-layout-global-drawer-child.test.ts
+++ b/src/app-layout/__integ__/multi-app-layout-global-drawer-child.test.ts
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+import createWrapper, { AppLayoutWrapper } from '../../../lib/components/test-utils/selectors';
+
+const iframeId = '#inner-iframe';
+const wrapper = createWrapper().findAppLayout();
+const findDrawerById = (wrapper: AppLayoutWrapper, id: string) => {
+  return wrapper.find(`[data-testid="awsui-app-layout-drawer-${id}"]`);
+};
+
+describe('Visual refresh toolbar only', () => {
+  const secondaryLayout = createWrapper().find('[data-testid="secondary-layout"]').findAppLayout();
+  function setupTest(testFn: (page: BasePageObject) => Promise<void>) {
+    return useBrowser(async browser => {
+      const page = new BasePageObject(browser);
+
+      await browser.url(
+        `#/light/app-layout/multi-layout-global-drawer-child-layout?${new URLSearchParams({
+          visualRefresh: 'true',
+          appLayoutToolbar: 'true',
+        }).toString()}`
+      );
+      await page.runInsideIframe(iframeId, true, async () => {
+        await page.waitForVisible(secondaryLayout.findContentRegion().toSelector());
+      });
+      await testFn(page);
+    });
+  }
+
+  test(
+    'global drawers registered from child AppLayout render correctly when __disableRuntimeDrawers is set to true for parent AppLayout',
+    setupTest(async page => {
+      await expect(page.isClickable(wrapper.findDrawerTriggerById('circle-global').toSelector())).resolves.toBe(true);
+      await page.runInsideIframe(iframeId, true, async () => {
+        await expect(page.isDisplayed(findDrawerById(secondaryLayout, 'circle-global').toSelector())).resolves.toBe(
+          true
+        );
+      });
+    })
+  );
+});

--- a/src/app-layout/__tests__/multi-layout-props.test.tsx
+++ b/src/app-layout/__tests__/multi-layout-props.test.tsx
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import {
-  mergeProps,
-  SharedProps,
-} from '../../../lib/components/app-layout/visual-refresh-toolbar/multi-layout';
+import { mergeProps, SharedProps } from '../../../lib/components/app-layout/visual-refresh-toolbar/multi-layout';
 
 describe('mergeMultiAppLayoutProps', () => {
   const mockParentNavigationToggle = jest.fn();

--- a/src/app-layout/__tests__/multi-layout-props.test.tsx
+++ b/src/app-layout/__tests__/multi-layout-props.test.tsx
@@ -7,6 +7,7 @@ import { mergeProps, SharedProps } from '../../../lib/components/app-layout/visu
 describe('mergeMultiAppLayoutProps', () => {
   const mockParentNavigationToggle = jest.fn();
   const mockParentActiveDrawerChange = jest.fn();
+  const mockParentActiveGlobalDrawerChange = jest.fn();
   const mockParentSplitPanelToggle = jest.fn();
   const ownProps: SharedProps = {
     forceDeduplicationType: 'primary',
@@ -54,6 +55,15 @@ describe('mergeMultiAppLayoutProps', () => {
         },
       ],
       activeDrawerId: 'drawer2',
+      activeGlobalDrawersIds: ['drawer-global'],
+      globalDrawers: [
+        {
+          id: 'drawer-global',
+          ariaLabels: { drawerName: 'Global Drawer' },
+          content: <div>Global Drawer Content</div>,
+        },
+      ],
+      onActiveGlobalDrawersChange: mockParentActiveGlobalDrawerChange,
     },
     {
       splitPanelToggleProps: {
@@ -95,6 +105,15 @@ describe('mergeMultiAppLayoutProps', () => {
       drawers: ownProps.drawers,
       drawersFocusRef: ownProps.drawersFocusRef,
       onActiveDrawerChange: mockParentActiveDrawerChange,
+      activeGlobalDrawersIds: ['drawer-global'],
+      globalDrawers: [
+        {
+          id: 'drawer-global',
+          ariaLabels: { drawerName: 'Global Drawer' },
+          content: <div>Global Drawer Content</div>,
+        },
+      ],
+      onActiveGlobalDrawersChange: mockParentActiveGlobalDrawerChange,
     });
   });
 

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -262,6 +262,10 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
         activeDrawerId: activeDrawer?.id ?? null,
         // only pass it down if there are non-empty drawers or tools
         drawers: drawers?.length || !toolsHide ? drawers : undefined,
+        globalDrawersFocusControl,
+        globalDrawers,
+        activeGlobalDrawersIds,
+        onActiveGlobalDrawersChange,
         onActiveDrawerChange: onActiveDrawerChangeHandler,
         drawersFocusRef: drawersFocusControl.refs.toggle,
         splitPanel,

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -263,7 +263,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
         // only pass it down if there are non-empty drawers or tools
         drawers: drawers?.length || !toolsHide ? drawers : undefined,
         globalDrawersFocusControl,
-        globalDrawers,
+        globalDrawers: globalDrawers?.length ? globalDrawers : undefined,
         activeGlobalDrawersIds,
         onActiveGlobalDrawersChange,
         onActiveDrawerChange: onActiveDrawerChangeHandler,

--- a/src/app-layout/visual-refresh-toolbar/multi-layout.ts
+++ b/src/app-layout/visual-refresh-toolbar/multi-layout.ts
@@ -7,7 +7,7 @@ import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import { awsuiPluginsInternal } from '../../internal/plugins/api';
 import { RegistrationState } from '../../internal/plugins/controllers/app-layout-widget';
 import { AppLayoutProps } from '../interfaces';
-import { Focusable } from '../utils/use-focus-control';
+import { Focusable, FocusControlMultipleStates } from '../utils/use-focus-control';
 import { SplitPanelToggleProps, ToolbarProps } from './toolbar';
 
 export interface SharedProps {
@@ -20,6 +20,10 @@ export interface SharedProps {
   breadcrumbs: React.ReactNode;
   activeDrawerId: string | null;
   drawers: ReadonlyArray<AppLayoutProps.Drawer> | undefined;
+  globalDrawersFocusControl: FocusControlMultipleStates;
+  globalDrawers: ReadonlyArray<AppLayoutProps.Drawer>;
+  activeGlobalDrawersIds: Array<string>;
+  onActiveGlobalDrawersChange: (newDrawerId: string) => void;
   onActiveDrawerChange: ((drawerId: string | null) => void) | undefined;
   drawersFocusRef: React.Ref<Focusable> | undefined;
   splitPanel: React.ReactNode;
@@ -51,6 +55,12 @@ export function mergeProps(
       toolbar.activeDrawerId = props.activeDrawerId;
       toolbar.drawersFocusRef = props.drawersFocusRef;
       toolbar.onActiveDrawerChange = props.onActiveDrawerChange;
+    }
+    if (props.globalDrawers && !checkAlreadyExists(!!toolbar.globalDrawers, 'globalDrawers')) {
+      toolbar.globalDrawersFocusControl = props.globalDrawersFocusControl;
+      toolbar.globalDrawers = props.globalDrawers;
+      toolbar.activeGlobalDrawersIds = props.activeGlobalDrawersIds;
+      toolbar.onActiveGlobalDrawersChange = props.onActiveGlobalDrawersChange;
     }
     if (props.navigation && !checkAlreadyExists(!!toolbar.hasNavigation, 'navigation')) {
       // there is never a case where navigation will exist and a toggle will not so toolbar

--- a/src/app-layout/visual-refresh-toolbar/multi-layout.ts
+++ b/src/app-layout/visual-refresh-toolbar/multi-layout.ts
@@ -20,12 +20,12 @@ export interface SharedProps {
   breadcrumbs: React.ReactNode;
   activeDrawerId: string | null;
   drawers: ReadonlyArray<AppLayoutProps.Drawer> | undefined;
-  globalDrawersFocusControl: FocusControlMultipleStates;
-  globalDrawers: ReadonlyArray<AppLayoutProps.Drawer>;
-  activeGlobalDrawersIds: Array<string>;
-  onActiveGlobalDrawersChange: (newDrawerId: string) => void;
   onActiveDrawerChange: ((drawerId: string | null) => void) | undefined;
   drawersFocusRef: React.Ref<Focusable> | undefined;
+  globalDrawersFocusControl?: FocusControlMultipleStates | undefined;
+  globalDrawers?: ReadonlyArray<AppLayoutProps.Drawer> | undefined;
+  activeGlobalDrawersIds?: Array<string> | undefined;
+  onActiveGlobalDrawersChange?: ((newDrawerId: string) => void) | undefined;
   splitPanel: React.ReactNode;
   splitPanelToggleProps: SplitPanelToggleProps;
   splitPanelFocusRef: React.Ref<Focusable> | undefined;

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -95,7 +95,6 @@ export function AppLayoutToolbarImplementation({
     toolbarState,
     setToolbarState,
     setToolbarHeight,
-    globalDrawersFocusControl,
   } = appLayoutInternals;
   const {
     ariaLabels,
@@ -103,6 +102,7 @@ export function AppLayoutToolbarImplementation({
     drawers,
     drawersFocusRef,
     onActiveDrawerChange,
+    globalDrawersFocusControl,
     globalDrawers,
     activeGlobalDrawersIds,
     onActiveGlobalDrawersChange,


### PR DESCRIPTION
### Description

This PR addresses an issue when a global drawer is registered, but its associated trigger button is not displayed in the toolbar

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
