### PR TITLE
fix: Improve hidden breadcrumbs detection

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/toolbar/breadcrumbs.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/breadcrumbs.tsx
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+
+import { useContainerQuery } from '@cloudscape-design/component-toolkit';
+
+import { BreadcrumbGroupImplementation } from '../../../breadcrumb-group/implementation';
+import { BreadcrumbGroupProps } from '../../../breadcrumb-group/interfaces';
+
+import styles from './styles.css.js';
+
+interface BreadcrumbsSlotProps {
+  ownBreadcrumbs: React.ReactNode;
+  discoveredBreadcrumbs: BreadcrumbGroupProps | null;
+}
+
+export function BreadcrumbsSlot({ ownBreadcrumbs, discoveredBreadcrumbs }: BreadcrumbsSlotProps) {
+  const [ownBreadcrumbsExist, ref] = useContainerQuery(entry => entry.borderBoxHeight > 0);
+  return (
+    <>
+      <div ref={ref}>{ownBreadcrumbs}</div>
+      {discoveredBreadcrumbs && (
+        <div className={clsx(ownBreadcrumbsExist && styles['breadcrumbs-discovered-hide'])}>
+          <BreadcrumbGroupImplementation
+            {...discoveredBreadcrumbs}
+            data-awsui-discovered-breadcrumbs={true}
+            __injectAnalyticsComponentMetadata={true}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -5,13 +5,13 @@ import clsx from 'clsx';
 
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
-import { BreadcrumbGroupImplementation } from '../../../breadcrumb-group/implementation';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { AppLayoutProps } from '../../interfaces';
 import { Focusable, FocusControlMultipleStates } from '../../utils/use-focus-control';
 import { BreadcrumbsSlotContext } from '../contexts';
 import { AppLayoutInternals } from '../interfaces';
 import { ToolbarSlot } from '../skeleton/slot-wrappers';
+import { BreadcrumbsSlot } from './breadcrumbs';
 import { DrawerTriggers, SplitPanelToggleProps } from './drawer-triggers';
 import TriggerButton from './trigger-button';
 
@@ -195,16 +195,7 @@ export function AppLayoutToolbarImplementation({
         {(breadcrumbs || discoveredBreadcrumbs) && (
           <div className={clsx(styles['universal-toolbar-breadcrumbs'], testutilStyles.breadcrumbs)}>
             <BreadcrumbsSlotContext.Provider value={{ isInToolbar: true }}>
-              <div className={styles['breadcrumbs-own']}>{breadcrumbs}</div>
-              {discoveredBreadcrumbs && (
-                <div className={styles['breadcrumbs-discovered']}>
-                  <BreadcrumbGroupImplementation
-                    {...discoveredBreadcrumbs}
-                    data-awsui-discovered-breadcrumbs={true}
-                    __injectAnalyticsComponentMetadata={true}
-                  />
-                </div>
-              )}
+              <BreadcrumbsSlot ownBreadcrumbs={breadcrumbs} discoveredBreadcrumbs={discoveredBreadcrumbs} />
             </BreadcrumbsSlotContext.Provider>
           </div>
         )}

--- a/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
@@ -101,7 +101,7 @@
 }
 
 // backward compatibility before this commit: 7a4b7b3e3b1d50830383805a8f4ab6cd93c9701f
-.breadcrumbs-own:not(:empty) + .breadcrumbs-discovered {
+.breadcrumbs-discovered-hide {
   display: none;
 }
 


### PR DESCRIPTION
### Description

`:empty` selector does not match when there is an empty DOM element: `<AppLayout breadcrumbs={<div />}>`. Fix this by replacing CSS selector with Javascript

Related links, issue #, if available: n/a

### How has this been tested?

Deployed to my dev pipeline to reproduce the original issue. Fixed now

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
