### PR TITLE
feat: Adds test id to side navigation

### DIFF
--- a/src/side-navigation/__tests__/complex-side-navigation.test.tsx
+++ b/src/side-navigation/__tests__/complex-side-navigation.test.tsx
@@ -22,18 +22,26 @@ it('Side navigation with all possible items', async () => {
         type: 'link',
         text: 'Page 1',
         href: '#/page1',
+        // this test id deliberately contains double quotes
+        // to test the selector escaping
+        testId: '"link-page-1"',
         info: <Badge>1</Badge>,
       },
       {
         type: 'divider',
+        testId: 'divider-1',
       },
       {
         type: 'section',
         text: 'Section 1',
+        testId: 'section-1',
         items: [
           {
             type: 'link',
             text: 'Page 2',
+            // this test id deliberately contains double quotes
+            // to test the selector escaping
+            testId: '"link-page-2"',
             href: '#/page2',
             info: (
               <Popover content="very new feature" renderWithPortal={true}>
@@ -47,48 +55,57 @@ it('Side navigation with all possible items', async () => {
             href: '#/page3',
             external: true,
             externalIconAriaLabel: 'Opens in a new tab',
+            testId: 'link-page-3',
           },
           { type: 'divider' },
           {
             type: 'link',
             text: 'Page 4',
             href: '#/page4',
+            testId: 'link-page-4',
           },
           {
             type: 'link',
             text: 'Page 5',
             href: '#/page5',
+            testId: 'link-page-5',
           },
         ],
       },
-      { type: 'divider' },
+      { type: 'divider', testId: 'divider-2' },
       {
         type: 'section-group',
+        testId: 'section-group-1',
         title: 'Section group 1',
         items: [
           {
             type: 'link',
             text: 'Page 6',
             href: '#/page6',
+            testId: 'link-page-6',
           },
           {
             type: 'link',
             text: 'Page 7',
             href: '#/page7',
+            testId: 'link-page-7',
           },
           {
             type: 'section',
             text: 'Section 2',
+            testId: 'section-2',
             items: [
               {
                 type: 'link',
                 text: 'Page 8',
                 href: '#/page8',
+                testId: 'link-page-8',
               },
               {
                 type: 'link',
                 text: 'Page 9',
                 href: '#/page9',
+                testId: 'link-page-9',
               },
             ],
           },
@@ -97,67 +114,85 @@ it('Side navigation with all possible items', async () => {
             text: 'Expandable link group',
             href: '#/exp-link-group',
             defaultExpanded: true,
+            testId: 'expandable-link-group-1',
             items: [
               {
                 type: 'link',
                 text: 'Page 10',
                 href: '#/page10',
+                testId: 'link-page-10',
               },
               {
                 type: 'link',
                 text: 'Page 11',
                 href: '#/page11',
+                testId: 'link-page-11',
               },
-              { type: 'divider' },
+              {
+                type: 'divider',
+                testId: 'divider-3',
+              },
               {
                 type: 'link',
                 text: 'Page 12',
                 href: '#/page12',
+                testId: 'link-page-12',
               },
               {
                 type: 'link',
                 text: 'Page 13',
                 href: '#/page13',
+                testId: 'link-page-13',
               },
             ],
           },
         ],
       },
-      { type: 'divider' },
+      {
+        type: 'divider',
+        testId: 'divider-4',
+      },
       {
         type: 'section-group',
         title: 'Section group 2',
+        testId: 'section-group-2',
         items: [
           {
             type: 'link',
             text: 'Page 14',
             href: '#/page14',
+            testId: 'link-page-14',
           },
           {
             type: 'link-group',
             text: 'Link group',
             href: '#/link-group',
+            testId: 'link-group-1',
             items: [
               {
                 type: 'link',
                 text: 'Page 15',
                 href: '#/page15',
+                testId: 'link-page-15',
               },
               {
                 type: 'link',
                 text: 'Page 16',
                 href: '#/page16',
+                testId: 'link-page-16',
               },
-              { type: 'divider' },
+              { type: 'divider', testId: 'divider-5' },
               {
                 type: 'link',
                 text: 'Page 17',
                 href: '#/page17',
+                testId: 'link-page-17',
               },
               {
                 type: 'link',
                 text: 'Page 18',
                 href: '#/page18',
+                testId: 'link-page-18',
               },
             ],
           },
@@ -176,8 +211,10 @@ it('Side navigation with all possible items', async () => {
   });
 
   expect(wrapper.findItemByIndex(1)!.findLink()!.getElement()).toHaveTextContent('Page 1');
+  expect(wrapper.findItemByTestId('"link-page-1"')!.findLink()!.getElement()).toHaveTextContent('Page 1');
 
   expect(wrapper.findItemByIndex(2)!.findDivider()).toBeTruthy();
+  expect(wrapper.findItemByTestId('divider-1')).toBeTruthy();
 
   // Section 1 with 1 divider
   expect(wrapper.findItemByIndex(3)!.findSectionTitle()!.getElement()).toHaveTextContent('Section 1');
@@ -185,11 +222,19 @@ it('Side navigation with all possible items', async () => {
   expect(wrapper.findItemByIndex(3)!.findItemByIndex(3)!.findDivider()).toBeTruthy();
   expect(wrapper.findItemByIndex(3)!.findItemByIndex(4)!.findLink()!.getElement()).toHaveTextContent('Page 4');
 
+  // Using test ids
+  expect(wrapper.findItemByTestId('section-1')!.getElement()).toHaveTextContent('Section 1');
+  expect(wrapper.findItemByTestId('section-1')!.findItemByTestId('"link-page-2"')!.getElement()).toHaveTextContent(
+    'Page 2'
+  );
+  expect(wrapper.findItemByTestId('"link-page-2"')!.getElement()).toHaveTextContent('Page 2');
+
   expect(wrapper.findItemByIndex(4)!.findDivider()).toBeTruthy();
 
   // Section group 1
   expect(wrapper.findItemByIndex(5)!.findSectionGroupTitle()!.getElement()).toHaveTextContent('Section group 1');
   expect(wrapper.findItemByIndex(5)!.findItemByIndex(1)!.findLink()!.getElement()).toHaveTextContent('Page 6');
+
   // Section 2 inside Section group 1
   expect(wrapper.findItemByIndex(5)!.findItemByIndex(3)!.findSectionTitle()!.getElement()).toHaveTextContent(
     'Section 2'
@@ -197,6 +242,18 @@ it('Side navigation with all possible items', async () => {
   expect(
     wrapper.findItemByIndex(5)!.findItemByIndex(3)!.findItemByIndex(1)!.findLink()!.getElement()
   ).toHaveTextContent('Page 8');
+
+  // Using test ids
+  expect(wrapper.findItemByTestId('section-group-1')!.getElement()).toHaveTextContent('Section group 1');
+  expect(wrapper.findItemByTestId('link-page-8')!.getElement()).toHaveTextContent('Page 8');
+  expect(
+    wrapper
+      .findItemByTestId('section-group-1')!
+      .findItemByTestId('section-2')!
+      .findItemByTestId('link-page-8')!
+      .getElement()
+  ).toHaveTextContent('Page 8');
+
   // Expandable link group inside Section group 1
   expect(wrapper.findItemByIndex(5)!.findItemByIndex(4)!.findExpandableLinkGroup()).toBeTruthy();
   expect(
@@ -212,6 +269,16 @@ it('Side navigation with all possible items', async () => {
   ).toHaveTextContent('Page 10');
 
   expect(wrapper.findItemByIndex(6)!.findDivider()).toBeTruthy();
+
+  // Using test ids
+  expect(
+    wrapper
+      .findItemByTestId('section-group-1')!
+      .findItemByTestId('expandable-link-group-1')!
+      .findItemByTestId('link-page-10')!
+      .getElement()
+  ).toHaveTextContent('Page 10');
+  expect(wrapper.findItemByTestId('link-page-10')!.getElement()).toHaveTextContent('Page 10');
 
   // Section group 2
   expect(wrapper.findItemByIndex(7)!.findSectionGroupTitle()!.getElement()).toHaveTextContent('Section group 2');

--- a/src/side-navigation/__tests__/side-navigation.test.tsx
+++ b/src/side-navigation/__tests__/side-navigation.test.tsx
@@ -40,14 +40,6 @@ describe('SideNavigation', () => {
     expect(wrapper.findItemByIndex(2)?.findLink()?.getElement()).toHaveTextContent('Page 2');
   });
 
-  it('renders dividers', () => {
-    const wrapper = renderSideNavigation({
-      items: [{ type: 'divider' }],
-    });
-
-    expect(wrapper.findItemByIndex(1)?.findDivider()).toBeTruthy();
-  });
-
   it('re-renders different section types correctly', () => {
     const { wrapper, rerender } = renderUpdatableSideNavigation({
       items: [
@@ -191,6 +183,31 @@ describe('SideNavigation', () => {
     });
   });
 
+  describe('Divider', () => {
+    it('renders dividers', () => {
+      const wrapper = renderSideNavigation({
+        items: [{ type: 'divider' }],
+      });
+
+      expect(wrapper.findItemByIndex(1)?.findDivider()).toBeTruthy();
+    });
+
+    it('assigns test ids to the dividers', () => {
+      const wrapper = renderSideNavigation({
+        items: [
+          { type: 'divider', testId: 'divider-1-test-id' },
+          { type: 'divider', testId: 'divider-2-test-id' },
+        ],
+      });
+
+      const firstDivider = wrapper.findItemByIndex(1)!.getElement();
+      const secondDivider = wrapper.findItemByIndex(2)!.getElement();
+
+      expect(firstDivider).toHaveAttribute('data-testid', 'divider-1-test-id');
+      expect(secondDivider).toHaveAttribute('data-testid', 'divider-2-test-id');
+    });
+  });
+
   describe('Section Group', () => {
     it('has specified title', () => {
       const wrapper = renderSideNavigation({ items: [{ type: 'section-group', title: 'Section Group', items: [] }] });
@@ -201,6 +218,21 @@ describe('SideNavigation', () => {
       const wrapper = renderSideNavigation({ items: [{ type: 'section-group', title: 'Section Group', items: [] }] });
       expect(wrapper.findItemByIndex(1)?.findSectionGroup()!.getElement()!.children[0]!.tagName).toBe('H3');
       expect(wrapper.find('h3')!.getElement()).toHaveTextContent('Section Group');
+    });
+
+    it('assigns test ids to the section groups', () => {
+      const wrapper = renderSideNavigation({
+        items: [
+          { type: 'section-group', title: 'Section Group', testId: 'section-group-1-test-id', items: [] },
+          { type: 'section-group', title: 'Section Group', testId: 'section-group-2-test-id', items: [] },
+        ],
+      });
+
+      const firstGroup = wrapper.findItemByIndex(1)!.getElement();
+      const secondGroup = wrapper.findItemByIndex(2)!.getElement();
+
+      expect(firstGroup).toHaveAttribute('data-testid', 'section-group-1-test-id');
+      expect(secondGroup).toHaveAttribute('data-testid', 'section-group-2-test-id');
     });
   });
 
@@ -292,6 +324,21 @@ describe('SideNavigation', () => {
       });
 
       expect(wrapper.findItemByIndex(1)?.findLink()?.getElement()).toHaveTextContent('Page 1');
+    });
+
+    it('assigns test ids to the links', () => {
+      const wrapper = renderSideNavigation({
+        items: [
+          { type: 'link', href: 'http://link/1', text: 'Page 1', testId: 'link-1-test-id' },
+          { type: 'link', href: 'http://link/2', text: 'Page 2', testId: 'link-2-test-id' },
+        ],
+      });
+
+      const firstLink = wrapper.findItemByIndex(1)!.getElement();
+      const secondLink = wrapper.findItemByIndex(2)!.getElement();
+
+      expect(firstLink).toHaveAttribute('data-testid', 'link-1-test-id');
+      expect(secondLink).toHaveAttribute('data-testid', 'link-2-test-id');
     });
   });
 
@@ -602,6 +649,21 @@ describe('SideNavigation', () => {
         expect(onChange).toHaveBeenCalledTimes(2);
       });
     });
+
+    it('assigns test ids to the sections', () => {
+      const wrapper = renderSideNavigation({
+        items: [
+          { type: 'section', text: 'Page 1', testId: 'link-1-test-id', items: [] },
+          { type: 'section', text: 'Page 2', testId: 'link-2-test-id', items: [] },
+        ],
+      });
+
+      const firstSection = wrapper.findItemByIndex(1)!.getElement();
+      const secondSection = wrapper.findItemByIndex(2)!.getElement();
+
+      expect(firstSection).toHaveAttribute('data-testid', 'link-1-test-id');
+      expect(secondSection).toHaveAttribute('data-testid', 'link-2-test-id');
+    });
   });
 
   describe('LinkGroup', () => {
@@ -669,6 +731,21 @@ describe('SideNavigation', () => {
       expect(wrapper.findItemByIndex(1)?.find('[data-testid="info"]')?.getElement()).toHaveTextContent(
         'Additional info'
       );
+    });
+
+    it('assigns test ids to the link group', () => {
+      const wrapper = renderSideNavigation({
+        items: [
+          { type: 'link-group', text: 'Page 1', href: 'http://link/1', testId: 'link-1-test-id', items: [] },
+          { type: 'link-group', text: 'Page 2', href: 'http://link/2', testId: 'link-2-test-id', items: [] },
+        ],
+      });
+
+      const firstLinkGroup = wrapper.findItemByIndex(1)!.getElement();
+      const secondLinkGroup = wrapper.findItemByIndex(2)!.getElement();
+
+      expect(firstLinkGroup).toHaveAttribute('data-testid', 'link-1-test-id');
+      expect(secondLinkGroup).toHaveAttribute('data-testid', 'link-2-test-id');
     });
   });
 
@@ -988,6 +1065,21 @@ describe('SideNavigation', () => {
       expect(wrapper.findItemByIndex(1)?.findLink()?.getElement()).toHaveAttribute('aria-expanded', 'true');
 
       expect(wrapper.findItemByIndex(2)?.findLink()?.getElement()).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('assigns test ids to the expandable links', () => {
+      const wrapper = renderSideNavigation({
+        items: [
+          { type: 'expandable-link-group', href: 'http://link/1', text: 'Page 1', testId: 'link-1-test-id', items: [] },
+          { type: 'expandable-link-group', href: 'http://link/2', text: 'Page 2', testId: 'link-2-test-id', items: [] },
+        ],
+      });
+
+      const firstLink = wrapper.findItemByIndex(1)!.getElement();
+      const secondLink = wrapper.findItemByIndex(2)!.getElement();
+
+      expect(firstLink).toHaveAttribute('data-testid', 'link-1-test-id');
+      expect(secondLink).toHaveAttribute('data-testid', 'link-2-test-id');
     });
 
     describe('when clicking on the title link', () => {

--- a/src/side-navigation/interfaces.tsx
+++ b/src/side-navigation/interfaces.tsx
@@ -139,6 +139,12 @@ export namespace SideNavigationProps {
 
   export interface Divider {
     type: 'divider';
+
+    /**
+     * Test ID of the divider.
+     * Assigns this value to the `data-testid` attribute of the divider's root element.
+     */
+    testId?: string;
   }
 
   export interface Link {
@@ -148,6 +154,12 @@ export namespace SideNavigationProps {
     external?: boolean;
     externalIconAriaLabel?: string;
     info?: React.ReactNode;
+
+    /**
+     * Test ID of the link.
+     * Assigns this value to the `data-testid` attribute of the link's root element.
+     */
+    testId?: string;
   }
 
   export interface Section {
@@ -155,12 +167,24 @@ export namespace SideNavigationProps {
     text: string;
     items: ReadonlyArray<Item>;
     defaultExpanded?: boolean;
+
+    /**
+     * Test ID of the section item.
+     * Assigns this value to the `data-testid` attribute of the section's root element.
+     */
+    testId?: string;
   }
 
   export interface SectionGroup {
     type: 'section-group';
     title: string;
     items: ReadonlyArray<Section | Link | LinkGroup | ExpandableLinkGroup>;
+
+    /**
+     * Test ID of the section group.
+     * Assigns this value to the `data-testid` attribute of the section group's root element.
+     */
+    testId?: string;
   }
   export interface LinkGroup {
     type: 'link-group';
@@ -168,6 +192,12 @@ export namespace SideNavigationProps {
     href: string;
     info?: React.ReactNode;
     items: ReadonlyArray<Item>;
+
+    /**
+     * Test ID of the link group item.
+     * Assigns this value to the `data-testid` attribute of the link group's root element.
+     */
+    testId?: string;
   }
 
   export interface ExpandableLinkGroup {
@@ -176,6 +206,12 @@ export namespace SideNavigationProps {
     href: string;
     items: ReadonlyArray<Item>;
     defaultExpanded?: boolean;
+
+    /**
+     * Test ID of the expandable link group item.
+     * Assigns this value to the `data-testid` attribute of the expandable link group's root element.
+     */
+    testId?: string;
   }
 
   export type Item = Divider | Link | Section | LinkGroup | ExpandableLinkGroup | SectionGroup;

--- a/src/side-navigation/parts.tsx
+++ b/src/side-navigation/parts.tsx
@@ -120,7 +120,7 @@ export function NavigationItemsList({
         const dividerIndex = lists.length;
         lists[dividerIndex] = {
           element: (
-            <div data-itemid={`item-${itemid}`}>
+            <div data-itemid={`item-${itemid}`} data-testid={item.testId}>
               <Divider variant="default" />
             </div>
           ),
@@ -135,7 +135,7 @@ export function NavigationItemsList({
       case 'link': {
         lists[currentListIndex].items?.push({
           element: (
-            <li key={index} data-itemid={`item-${itemid}`} className={styles['list-item']}>
+            <li key={index} data-itemid={`item-${itemid}`} data-testid={item.testId} className={styles['list-item']}>
               <Link
                 definition={item}
                 activeHref={activeHref}
@@ -151,7 +151,7 @@ export function NavigationItemsList({
       case 'section': {
         lists[currentListIndex].items?.push({
           element: (
-            <li key={index} data-itemid={`item-${itemid}`} className={styles['list-item']}>
+            <li key={index} data-itemid={`item-${itemid}`} data-testid={item.testId} className={styles['list-item']}>
               <Section
                 definition={item}
                 activeHref={activeHref}
@@ -168,7 +168,7 @@ export function NavigationItemsList({
       case 'section-group': {
         lists[currentListIndex].items?.push({
           element: (
-            <li key={index} data-itemid={`item-${itemid}`} className={styles['list-item']}>
+            <li key={index} data-itemid={`item-${itemid}`} data-testid={item.testId} className={styles['list-item']}>
               <SectionGroup
                 definition={item}
                 activeHref={activeHref}
@@ -184,7 +184,7 @@ export function NavigationItemsList({
       case 'link-group': {
         lists[currentListIndex].items?.push({
           element: (
-            <li key={index} data-itemid={`item-${itemid}`} className={styles['list-item']}>
+            <li key={index} data-itemid={`item-${itemid}`} data-testid={item.testId} className={styles['list-item']}>
               <LinkGroup
                 definition={item}
                 activeHref={activeHref}
@@ -200,7 +200,7 @@ export function NavigationItemsList({
       case 'expandable-link-group': {
         lists[currentListIndex].items?.push({
           element: (
-            <li key={index} data-itemid={`item-${itemid}`} className={styles['list-item']}>
+            <li key={index} data-itemid={`item-${itemid}`} data-testid={item.testId} className={styles['list-item']}>
               <ExpandableLinkGroup
                 definition={item}
                 activeHref={activeHref}

--- a/src/test-utils/dom/side-navigation/index.ts
+++ b/src/test-utils/dom/side-navigation/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { escapeSelector } from '@cloudscape-design/test-utils-core/utils';
 
 import ExpandableSectionWrapper from '../expandable-section';
 
@@ -32,6 +33,22 @@ export default class SideNavigationWrapper extends ComponentWrapper {
   findItemByIndex(index: number): SideNavigationItemWrapper | null {
     return this.findComponent(
       `.${styles['list-variant-root']} > [data-itemid="item-${index}"]`,
+      SideNavigationItemWrapper
+    );
+  }
+
+  /**
+   * Returns the wrapper of the first item that matches the specified test ID.
+   * Looks for the `data-testid` attribute that is assigned via `items` prop.
+   * If no matching item is found, returns `null`.
+   *
+   * @param {string} testId
+   * @returns {SideNavigationItemWrapper | null}
+   */
+  findItemByTestId(testId: string): SideNavigationItemWrapper | null {
+    const escapedTestId = escapeSelector(testId);
+    return this.findComponent(
+      `.${styles['list-variant-root']} [data-testid="${escapedTestId}"]`,
       SideNavigationItemWrapper
     );
   }
@@ -68,6 +85,19 @@ export class SideNavigationItemWrapper extends ElementWrapper {
 
   findItemByIndex(index: number): SideNavigationItemWrapper | null {
     return this.findComponent(`[data-itemid="item-${index}"]`, SideNavigationItemWrapper);
+  }
+
+  /**
+   * Returns the wrapper of the first item that matches the specified test ID.
+   * Looks for the `data-testid` attribute that is assigned via `items` prop.
+   * If no matching item is found, returns `null`.
+   *
+   * @param {string} testId
+   * @returns {SideNavigationItemWrapper | null}
+   */
+  findItemByTestId(testId: string): SideNavigationItemWrapper | null {
+    const escapedTestId = escapeSelector(testId);
+    return this.findComponent(`[data-testid="${escapedTestId}"]`, SideNavigationItemWrapper);
   }
 
   findItems(): Array<SideNavigationItemWrapper> {


### PR DESCRIPTION
### Description

Adds `testId` prop to option inside the side navigation component.
The change will be reflected in select, multi-select, autosuggest and property filter components.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available:

Collective PR: https://github.com/cloudscape-design/components/pull/2985
Project: Improving test utils API


### How has this been tested?

Tests added to cover the change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
