### PR TITLE
chore: Remove @supports query for :has() pseudo-class in side nav

### DIFF
--- a/src/side-navigation/parts.tsx
+++ b/src/side-navigation/parts.tsx
@@ -217,8 +217,6 @@ export function NavigationItemsList({
     }
   });
 
-  const lastListIndex = lists.length - 1;
-
   return (
     <>
       {lists.map((list, index) => {
@@ -227,7 +225,7 @@ export function NavigationItemsList({
             <div
               key={`hr-${index}`}
               className={clsx(styles.list, styles[`list-variant-${variant}`], {
-                [styles['list-variant-root--last']]: list.listVariant === 'root' && index === lastListIndex,
+                [styles['list-variant-root--first']]: list.listVariant === 'root' && index === 0,
               })}
             >
               {list.element}
@@ -238,7 +236,7 @@ export function NavigationItemsList({
             <ul
               key={`list-${index}`}
               className={clsx(styles.list, styles[`list-variant-${list.listVariant}`], {
-                [styles['list-variant-root--last']]: list.listVariant === 'root' && index === lastListIndex,
+                [styles['list-variant-root--first']]: list.listVariant === 'root' && index === 0,
               })}
             >
               {list.items.map(item => item.element)}

--- a/src/side-navigation/styles.scss
+++ b/src/side-navigation/styles.scss
@@ -54,8 +54,14 @@
 }
 
 .list-container {
+  margin-block-end: awsui.$space-panel-content-bottom;
+}
+
+.items-control,
+.list-container {
   margin-block-start: awsui.$space-panel-content-top;
-  .with-toolbar > .divider + & {
+  // Toolbar removes margin for whichever one comes first after the header
+  .with-toolbar > .divider-header + & {
     margin-block-start: 0;
   }
 }
@@ -75,8 +81,8 @@
   padding-inline-start: awsui.$space-panel-nav-left;
   padding-inline-end: awsui.$space-panel-side-right;
 
-  &--last {
-    margin-block-end: awsui.$space-panel-content-bottom;
+  &--first {
+    margin-block-start: 0;
   }
 }
 
@@ -91,17 +97,8 @@
   padding-inline: 0;
   list-style: none;
 
-  @supports selector(:has(*)) {
-    /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
-    &:has(> .section:not(.refresh)) {
-      margin-block: calc(#{awsui.$space-scaled-2x-l} - #{awsui.$border-divider-section-width});
-    }
-    /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
-    &:has(> .section.refresh) {
-      margin-block: calc(#{awsui.$space-scaled-2x-m} - #{awsui.$border-divider-section-width});
-    }
-  }
-  .list-variant-root > &:first-child {
+  // Remove margin from first item in side nav, outer block margins are covered by list-container
+  .list-variant-root--first > &:first-child {
     margin-block-start: 0px;
   }
 }
@@ -116,11 +113,13 @@
 }
 
 .section {
-  @supports not selector(:has(*)) {
-    margin-block: calc(#{awsui.$space-scaled-2x-l} - #{awsui.$border-divider-section-width});
-    &.refresh {
-      margin-block: calc(#{awsui.$space-scaled-2x-m} - #{awsui.$border-divider-section-width});
-    }
+  margin-block: calc(#{awsui.$space-scaled-2x-l} - #{awsui.$border-divider-section-width});
+  &.refresh {
+    margin-block: calc(#{awsui.$space-scaled-2x-m} - #{awsui.$border-divider-section-width});
+  }
+  // Remove margin from section if it is the first item in side nav to prevent double margin stacking
+  .list-variant-root--first > .list-item:first-child > & {
+    margin-block-start: 0px;
   }
   // HACK: Remove padding from section header and content to rely on margin collapsing rules.
   /* stylelint-disable-next-line selector-max-type */
@@ -203,11 +202,9 @@
 }
 
 .divider-header {
-  margin-block-start: 0;
-  margin-block-end: awsui.$space-panel-content-top;
+  margin-block: 0;
   border-block-start: awsui.$border-divider-section-width solid awsui.$color-border-panel-header;
   .with-toolbar > & {
     border-color: transparent;
-    margin-block-end: 0;
   }
 }


### PR DESCRIPTION
### Description

There is a [known issue in autoprefixer](https://github.com/postcss/autoprefixer/issues/1391) when using the `@supports` css query with a pseudo-class. It has since been fixed, but many internal teams are using post css autoprefixer older than 10.2.5. This PR removes the use of the `:has()` pseudo-class in the side nav to unblock the pipeline.

Related links, issue #, if available: n/a

### How has this been tested?

Ran through dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
