### PR TITLE
feat: Adds test id to cards

### DIFF
--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -271,6 +271,7 @@ const CardsList = <T,>({
             [styles['card-selected']]: selectable && isItemSelected(item),
           })}
           key={getItemKey(trackBy, item, index)}
+          data-testid={cardDefinition.testId?.(item)}
           onFocus={onFocus}
           {...(focusMarkers && focusMarkers.item)}
           role={listItemRole}
@@ -301,8 +302,13 @@ const CardsList = <T,>({
                 </div>
               )}
             </div>
-            {visibleSectionsDefinition.map(({ width = 100, header, content, id }, index) => (
-              <div key={id || index} className={styles.section} style={{ width: `${width}%` }}>
+            {visibleSectionsDefinition.map(({ width = 100, header, content, id, testId }, index) => (
+              <div
+                key={id || index}
+                className={styles.section}
+                style={{ width: `${width}%` }}
+                data-testid={testId?.(item)}
+              >
                 {header ? <div className={styles['section-header']}>{header}</div> : ''}
                 {content ? <div className={styles['section-content']}>{content(item)}</div> : ''}
               </div>

--- a/src/cards/interfaces.tsx
+++ b/src/cards/interfaces.tsx
@@ -223,6 +223,15 @@ export namespace CardsProps {
   export interface CardDefinition<T> {
     header?(item: T): React.ReactNode;
     sections?: ReadonlyArray<SectionDefinition<T>>;
+
+    /**
+     * Returns the test ID for each card item.
+     * Returned value is assigned to the `data-testid` attribute of the card's root element.
+     *
+     * @param {T} item Single item from the specified `items` array.
+     * @returns {string} Test id to be assigned to the corresponding card.
+     */
+    testId?(item: T): string;
   }
 
   export interface SectionDefinition<T> {
@@ -230,6 +239,15 @@ export namespace CardsProps {
     header?: React.ReactNode;
     content?(item: T): React.ReactNode;
     width?: number;
+
+    /**
+     * Returns the test ID for each section item.
+     * Returned value is assigned to the `data-testid` attribute of the section's root element.
+     *
+     * @param {T} item Single item from the specified `items` array.
+     * @returns {string} Test id to be assigned to the corresponding section.
+     */
+    testId?(item: T): string;
   }
 
   export interface CardsLayout {

--- a/src/test-utils/dom/cards/index.ts
+++ b/src/test-utils/dom/cards/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { escapeSelector } from '@cloudscape-design/test-utils-core/utils';
 
 import CollectionPreferencesWrapper from '../collection-preferences';
 import ContainerWrapper from '../container';
@@ -30,6 +31,19 @@ export class CardWrapper extends ComponentWrapper {
     return this.findAllByClassName(styles.section).map(c => new CardSectionWrapper(c.getElement()));
   }
 
+  /**
+   * Returns the wrapper of the first card section that matches the specified test ID.
+   * Looks for the `data-testid` attribute that is assigned via `sections.testId` prop.
+   * If no matching card section is found, returns `null`.
+   *
+   * @param {string} testId
+   * @returns {CardSectionWrapper | null}
+   */
+  findSectionByTestId(testId: string): CardSectionWrapper | null {
+    const escapedTestId = escapeSelector(testId);
+    return this.findComponent(`.${styles.section}[data-testid="${escapedTestId}"]`, CardSectionWrapper);
+  }
+
   findCardHeader(): ElementWrapper | null {
     return this.findByClassName(styles['card-header-inner']);
   }
@@ -46,6 +60,19 @@ export default class CardsWrapper extends ComponentWrapper {
 
   findItems(): Array<CardWrapper> {
     return this.findAllByClassName(styles.card).map(c => new CardWrapper(c.getElement()));
+  }
+
+  /**
+   * Returns the wrapper of the first card that matches the specified test ID.
+   * Looks for the `data-testid` attribute that is assigned via `cardDefinition.testId` prop.
+   * If no matching card is found, returns `null`.
+   *
+   * @param {string} testId
+   * @returns {CardWrapper | null}
+   */
+  findItemByTestId(testId: string): CardWrapper | null {
+    const escapedTestId = escapeSelector(testId);
+    return this.findComponent(`.${styles.card}[data-testid="${escapedTestId}"]`, CardWrapper);
   }
 
   findSelectedItems(): Array<CardWrapper> {


### PR DESCRIPTION
### Description

Adds `testId` extractor function to cards inside the card component. Unlike other components, cards can't have a single `testId` prop as the `items` are generic with no base types. For this reason we use a function to extract test id for every individual item.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available:

Collective PR: https://github.com/cloudscape-design/components/pull/2985
Project: Improving test utils API


### How has this been tested?

Tests added to cover the change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
