### PR TITLE
fix: S3 resource selector findModal selector test util returning incorrect modal

### DIFF
--- a/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -482,7 +482,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_browse-button_1vtzr",
     "awsui_layout-uri_1vtzr",
     "awsui_layout-version_1vtzr",
-    "awsui_modal-root_12hyz",
+    "awsui_modal-root_rkh1e",
     "awsui_root_1u0yw",
     "awsui_root_1vtzr",
     "awsui_submit-button_12hyz",

--- a/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -482,6 +482,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_browse-button_1vtzr",
     "awsui_layout-uri_1vtzr",
     "awsui_layout-version_1vtzr",
+    "awsui_modal-root_12hyz",
     "awsui_root_1u0yw",
     "awsui_root_1vtzr",
     "awsui_submit-button_12hyz",

--- a/src/s3-resource-selector/s3-modal/index.tsx
+++ b/src/s3-resource-selector/s3-modal/index.tsx
@@ -16,6 +16,7 @@ import { BucketsTable } from './buckets-table';
 import { ObjectsTable } from './objects-table';
 import { VersionsTable } from './versions-table';
 
+import testUtilStyles from '../test-classes/styles.css.js';
 import styles from './styles.css.js';
 
 export interface S3ModalProps {
@@ -125,7 +126,7 @@ export function S3Modal({
   return (
     <div>
       <InternalModal
-        className={styles['modal-root']}
+        className={testUtilStyles['modal-root']}
         visible={true}
         size="max"
         getModalRoot={getModalRoot}

--- a/src/s3-resource-selector/s3-modal/index.tsx
+++ b/src/s3-resource-selector/s3-modal/index.tsx
@@ -125,6 +125,7 @@ export function S3Modal({
   return (
     <div>
       <InternalModal
+        className={styles['modal-root']}
         visible={true}
         size="max"
         getModalRoot={getModalRoot}

--- a/src/s3-resource-selector/s3-modal/styles.scss
+++ b/src/s3-resource-selector/s3-modal/styles.scss
@@ -5,10 +5,6 @@
 @use '../../internal/styles/tokens.scss' as awsui;
 @use '../../internal/styles' as styles;
 
-.modal-root {
-  /* used in test-utils */
-}
-
 .modal-actions {
   justify-content: flex-end;
 }

--- a/src/s3-resource-selector/s3-modal/styles.scss
+++ b/src/s3-resource-selector/s3-modal/styles.scss
@@ -5,6 +5,10 @@
 @use '../../internal/styles/tokens.scss' as awsui;
 @use '../../internal/styles' as styles;
 
+.modal-root {
+  /* used in test-utils */
+}
+
 .modal-actions {
   justify-content: flex-end;
 }

--- a/src/s3-resource-selector/test-classes/styles.scss
+++ b/src/s3-resource-selector/test-classes/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.modal-root {
+  /* used in test-utils */
+}

--- a/src/test-utils/dom/s3-resource-selector/index.ts
+++ b/src/test-utils/dom/s3-resource-selector/index.ts
@@ -12,6 +12,7 @@ import TableWrapper from '../table';
 import inContextStyles from '../../../s3-resource-selector/s3-in-context/styles.selectors.js';
 import modalStyles from '../../../s3-resource-selector/s3-modal/styles.selectors.js';
 import styles from '../../../s3-resource-selector/styles.selectors.js';
+import testUtilStyles from '../../../s3-resource-selector/test-classes/styles.selectors.js';
 
 class S3ModalWrapper extends ModalWrapper {
   findSubmitButton(): ButtonWrapper {
@@ -50,7 +51,7 @@ export default class S3ResourceSelectorWrapper extends ComponentWrapper {
   }
 
   findModal(): S3ModalWrapper | null {
-    const modal = createWrapper().findModal(`.${modalStyles['modal-root']}`);
+    const modal = createWrapper().findModal(`.${testUtilStyles['modal-root']}`);
     return modal && new S3ModalWrapper(modal.getElement());
   }
 

--- a/src/test-utils/dom/s3-resource-selector/index.ts
+++ b/src/test-utils/dom/s3-resource-selector/index.ts
@@ -50,7 +50,7 @@ export default class S3ResourceSelectorWrapper extends ComponentWrapper {
   }
 
   findModal(): S3ModalWrapper | null {
-    const modal = createWrapper().findModal();
+    const modal = createWrapper().findModal(`.${modalStyles['modal-root']}`);
     return modal && new S3ModalWrapper(modal.getElement());
   }
 


### PR DESCRIPTION
### Description

When rendering an S3 Resource Selector with a regular Modal using the visible property set to false the test util selector would return the first Modal it finds. This change makes the test util selector more specific to be able to find the associated S3 Modal.

E.g.
```
<Modal visible={false} />
<S3ResourceSelector {...s3ResourceSelectorProps} />
```

Related links, issue #, if available: n/a

### How has this been tested?

Modified a dev page to include a Modal and checked before and after the change. Since its just a once off fix, it does not make sense to add this in as a regression test. This can better be tested in a package like demos where various components are tested together and the test utils are used from a customer's perspective.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
