### PR TITLE
feat: Adds test id to radio group buttons

### DIFF
--- a/src/radio-group/__tests__/radio-group.test.tsx
+++ b/src/radio-group/__tests__/radio-group.test.tsx
@@ -104,10 +104,14 @@ describe('items', () => {
   test('does not trigger change handler if disabled', () => {
     const onChange = jest.fn();
     const { wrapper } = renderRadioGroup(
-      <RadioGroup value={null} items={[defaultItems[0], { ...defaultItems[1], disabled: true }]} onChange={onChange} />
+      <RadioGroup
+        value={null}
+        items={[defaultItems[0], { ...defaultItems[1], disabled: true, testId: 'disabled-button' }]}
+        onChange={onChange}
+      />
     );
 
-    act(() => wrapper.findButtons()[1].findLabel().click());
+    act(() => wrapper.findButtonByTestId('disabled-button')!.findLabel().click());
     expect(onChange).not.toHaveBeenCalled();
   });
 
@@ -159,29 +163,53 @@ describe('items', () => {
   });
 
   test('displays the proper label', () => {
-    const { wrapper } = renderRadioGroup(<RadioGroup value={null} items={[{ value: '1', label: 'Please select' }]} />);
+    const { wrapper } = renderRadioGroup(
+      <RadioGroup value={null} items={[{ value: '1', label: 'Please select', testId: 'test-button' }]} />
+    );
 
-    expect(wrapper.findButtons()[0].findLabel().getElement()).toHaveTextContent('Please select');
+    expect(wrapper.findButtonByTestId('test-button')!.findLabel().getElement()).toHaveTextContent('Please select');
   });
 
   test('displays no label text when label is empty', () => {
-    const { wrapper } = renderRadioGroup(<RadioGroup value={null} items={[{ value: '1', label: '' }]} />);
-    expect(wrapper.findButtons()[0].findLabel().getElement()).toHaveTextContent('');
+    const { wrapper } = renderRadioGroup(
+      <RadioGroup value={null} items={[{ value: '1', label: '', testId: 'test-button' }]} />
+    );
+    expect(wrapper.findButtonByTestId('test-button')!.findLabel().getElement()).toHaveTextContent('');
   });
 
   test('displays the description', () => {
     const { wrapper } = renderRadioGroup(
       <RadioGroup
         value={null}
-        items={[{ value: '1', label: 'Please select', description: 'Radio description test' }]}
+        items={[{ value: '1', label: 'Please select', description: 'Radio description test', testId: 'test-button' }]}
       />
     );
-    expect(wrapper.findButtons()[0].findDescription()!.getElement()).toHaveTextContent('Radio description test');
+    expect(wrapper.findButtonByTestId('test-button')!.findDescription()!.getElement()).toHaveTextContent(
+      'Radio description test'
+    );
   });
 
   test('does not display description when it is not defined', () => {
-    const { wrapper } = renderRadioGroup(<RadioGroup value={null} items={[{ value: '1', label: 'Please select' }]} />);
-    expect(wrapper.findButtons()[0].findDescription()).toBeNull();
+    const { wrapper } = renderRadioGroup(
+      <RadioGroup value={null} items={[{ value: '1', label: 'Please select', testId: 'test-button' }]} />
+    );
+    expect(wrapper.findButtonByTestId('test-button')!.findDescription()).toBeNull();
+  });
+
+  test('adds test id to items when specified', () => {
+    const { wrapper } = renderRadioGroup(
+      <RadioGroup
+        value={null}
+        items={[
+          { value: '1', label: 'Item 1', testId: 'item-1' },
+          { value: '2', label: 'Item 2', testId: 'item-2' },
+          { value: '3', label: 'Item 3', testId: 'item-3' },
+        ]}
+      />
+    );
+
+    const buttonTestIds = wrapper.findButtons().map(button => button.getElement()!.getAttribute('data-testid'));
+    expect(buttonTestIds).toEqual(['item-1', 'item-2', 'item-3']);
   });
 });
 
@@ -289,14 +317,14 @@ describe('value', () => {
         <RadioGroup
           value="val2"
           items={[
-            { value: 'val1', label: 'Option one', controlId: 'control-id-1' },
-            { value: 'val2', label: 'Option two', controlId: 'control-id-2' },
+            { value: 'val1', label: 'Option one', controlId: 'control-id-1', testId: 'radio-button-1' },
+            { value: 'val2', label: 'Option two', controlId: 'control-id-2', testId: 'radio-button-2' },
           ]}
         />
       );
 
-      check(wrapper.findButtons()[0], 'control-id-1');
-      check(wrapper.findButtons()[1], 'control-id-2');
+      check(wrapper.findButtonByTestId('radio-button-1')!, 'control-id-1');
+      check(wrapper.findButtonByTestId('radio-button-2')!, 'control-id-2');
     });
 
     test('generates a own unique ids for setting up label relations when controlId is not set', () => {
@@ -320,16 +348,16 @@ describe('value', () => {
         <RadioGroup
           value="val2"
           items={[
-            { value: 'val1', label: 'Option one', controlId: id1 },
-            { value: 'val2', label: 'Option two' },
+            { value: 'val1', label: 'Option one', controlId: id1, testId: 'option-1' },
+            { value: 'val2', label: 'Option two', testId: 'option-2' },
           ]}
         />
       );
 
-      const button2 = wrapper.findButtons()[1];
+      const button2 = wrapper.findButtonByTestId('option-2')!;
       const id2 = button2.findNativeInput().getElement().id;
 
-      check(wrapper.findButtons()[0], id1);
+      check(wrapper.findButtonByTestId('option-1')!, id1);
       check(button2, id2);
       expect(id1).not.toBe(id2);
     });
@@ -380,5 +408,29 @@ describe('table grid navigation support', () => {
     setCurrentTarget(getRadioInput('#radio1'));
     expect(getRadioInput('#radio1')).toHaveAttribute('tabIndex', '0');
     expect(getRadioInput('#radio2')).toHaveAttribute('tabIndex', '-1');
+  });
+});
+
+describe('test utils', () => {
+  test('findButtonByTestId selects the button with the specified test id', () => {
+    const { wrapper } = renderRadioGroup(
+      <RadioGroup
+        value={null}
+        items={[
+          { value: '1', label: 'one', testId: 'button-1' },
+          { value: '2', label: 'two', testId: 'button-2' },
+        ]}
+      />
+    );
+
+    expect(wrapper.findButtonByTestId('button-2')!.getElement()).toHaveTextContent('two');
+  });
+
+  test('findButtonByTestId selects the button even if test id contains quote character', () => {
+    const { wrapper } = renderRadioGroup(
+      <RadioGroup value={null} items={[{ value: '1', label: 'Test button', testId: 'test-"button"' }]} />
+    );
+
+    expect(wrapper.findButtonByTestId('test-"button"')!.getElement()).toHaveTextContent('Test button');
   });
 });

--- a/src/radio-group/interfaces.ts
+++ b/src/radio-group/interfaces.ts
@@ -72,6 +72,12 @@ export namespace RadioGroupProps {
     description?: React.ReactNode;
     disabled?: boolean;
     controlId?: string;
+
+    /**
+     * Test ID of the radio button.
+     * Assigns this value to the `data-testid` attribute of the radio button's root element.
+     */
+    testId?: string;
   }
 
   export interface ChangeDetail {

--- a/src/radio-group/internal.tsx
+++ b/src/radio-group/internal.tsx
@@ -67,6 +67,7 @@ const InternalRadioGroup = React.forwardRef(
               onChange={onChange}
               controlId={item.controlId}
               readOnly={readOnly}
+              testId={item.testId}
               {...getAnalyticsMetadataAttribute(
                 !item.disabled && !readOnly
                   ? {

--- a/src/radio-group/radio-button.tsx
+++ b/src/radio-group/radio-button.tsx
@@ -34,6 +34,7 @@ export default React.forwardRef(function RadioButton(
     onChange,
     readOnly,
     className,
+    testId,
     ...rest
   }: RadioButtonProps,
   ref: React.Ref<HTMLInputElement>
@@ -54,6 +55,7 @@ export default React.forwardRef(function RadioButton(
       disabled={disabled}
       readOnly={readOnly}
       controlId={controlId}
+      data-testid={testId}
       {...copyAnalyticsMetadataAttribute(rest)}
       nativeControl={nativeControlProps => (
         <input

--- a/src/test-utils/dom/radio-group/index.ts
+++ b/src/test-utils/dom/radio-group/index.ts
@@ -14,6 +14,19 @@ export default class RadioGroupWrapper extends ComponentWrapper {
     return this.findAllByClassName(styles.radio).map(r => new RadioButtonWrapper(r.getElement()));
   }
 
+  /**
+   * Returns the wrapper of the first radio button that matches the specified test ID.
+   * Looks for the `data-testid` attribute that is assigned via `items` prop.
+   * If no matching radio button is found, returns `null`.
+   *
+   * @param {string} testId
+   * @returns {RadioButtonWrapper | null}
+   */
+  findButtonByTestId(testId: string): RadioButtonWrapper | null {
+    const escapedTestId = escapeSelector(testId);
+    return this.findComponent(`.${styles.radio}[data-testid="${escapedTestId}"]`, RadioButtonWrapper);
+  }
+
   findInputByValue(value: string): ElementWrapper<HTMLInputElement> | null {
     const safeValue = escapeSelector(value);
     return this.find(`input[value="${safeValue}"]`);


### PR DESCRIPTION
### Description

Adds `testId` to radio group items.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available:

Collective PR: https://github.com/cloudscape-design/components/pull/2985
Project: Improving test utils API

### How has this been tested?

Tests added to cover the change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
