### PR TITLE
chore: Render breadcrumbs slot in the skeleton state

### DIFF
--- a/src/app-layout/__tests__/global-breadcrumbs.test.tsx
+++ b/src/app-layout/__tests__/global-breadcrumbs.test.tsx
@@ -281,11 +281,11 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         <DestructibleLayout />
       </>
     );
-    expect(wrapper.find('[data-testid="local-breadcrumbs"]')!.getElement()).toBeEmptyDOMElement();
+    expect(wrapper.find('[data-testid="local-breadcrumbs"]')!.findBreadcrumbGroup()).toBeFalsy();
 
     wrapper.find('[data-testid="unmount"]')!.click();
     await waitFor(() => {
-      expect(wrapper.find('[data-testid="local-breadcrumbs"]')!.getElement()).not.toBeEmptyDOMElement();
+      expect(wrapper.find('[data-testid="local-breadcrumbs"]')!.findBreadcrumbGroup()).toBeTruthy();
     });
   });
 

--- a/src/app-layout/__tests__/skeleton.test.tsx
+++ b/src/app-layout/__tests__/skeleton.test.tsx
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+/* eslint-disable simple-import-sort/imports */
+import React from 'react';
+
+import { describeEachAppLayout, renderComponent } from './utils';
+import AppLayout from '../../../lib/components/app-layout';
+import BreadcrumbGroup from '../../../lib/components/breadcrumb-group';
+import { getFunnelKeySelector } from '../../internal/analytics/selectors';
+
+let widgetMockEnabled = false;
+function createWidgetizedComponentMock(Implementation: React.ComponentType, Skeleton: React.ComponentType) {
+  return () => {
+    return function Widgetized(props: any) {
+      if (!widgetMockEnabled) {
+        return <Implementation {...props} />;
+      }
+      if (Skeleton) {
+        return <Skeleton {...props} />;
+      }
+      return null;
+    };
+  };
+}
+
+jest.mock('../../../lib/components/internal/widgets', () => ({
+  createWidgetizedComponent: createWidgetizedComponentMock,
+}));
+
+describeEachAppLayout({ themes: ['refresh-toolbar'] }, () => {
+  it('renders complete component by default', () => {
+    const { wrapper } = renderComponent(
+      <AppLayout
+        navigation="test nav"
+        notifications="test notifications"
+        breadcrumbs={<BreadcrumbGroup items={[{ text: 'Home', href: '' }]} />}
+        tools="test tools"
+      />
+    );
+    expect(wrapper.findToolbar()).toBeTruthy();
+    expect(wrapper.findNavigation()).toBeTruthy();
+    expect(wrapper.findBreadcrumbs()).toBeTruthy();
+    expect(wrapper.find(getFunnelKeySelector('funnel-name'))).toBeTruthy();
+    expect(wrapper.findNotifications()).toBeTruthy();
+    expect(wrapper.findTools()).toBeTruthy();
+    expect(wrapper.findContentRegion()).toBeTruthy();
+  });
+
+  describe('in loading state', () => {
+    beforeEach(() => {
+      widgetMockEnabled = true;
+    });
+    afterEach(() => {
+      widgetMockEnabled = false;
+    });
+
+    it('renders skeleton parts only', () => {
+      const { wrapper } = renderComponent(
+        <AppLayout
+          navigation="test nav"
+          notifications="test notifications"
+          breadcrumbs={<BreadcrumbGroup items={[{ text: 'Home', href: '' }]} />}
+          tools="test tools"
+        />
+      );
+      expect(wrapper.findToolbar()).toBeFalsy();
+      expect(wrapper.findNavigation()).toBeFalsy();
+      expect(wrapper.findBreadcrumbs()).toBeFalsy();
+      expect(wrapper.find(getFunnelKeySelector('funnel-name'))).toBeTruthy();
+      expect(wrapper.findNotifications()).toBeFalsy();
+      expect(wrapper.findTools()).toBeFalsy();
+      expect(wrapper.findContentRegion()).toBeTruthy();
+    });
+  });
+});

--- a/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
@@ -9,6 +9,7 @@ import { InternalButton } from '../../../button/internal';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { getDrawerStyles } from '../compute-layout';
 import { AppLayoutInternals } from '../interfaces';
+import { NotificationsSlot } from '../skeleton/slot-wrappers';
 
 import sharedStyles from '../../resize/styles.css.js';
 import testutilStyles from '../../test-classes/styles.css.js';
@@ -80,4 +81,7 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
   );
 }
 
-export const createWidgetizedAppLayoutNavigation = createWidgetizedComponent(AppLayoutNavigationImplementation);
+export const createWidgetizedAppLayoutNavigation = createWidgetizedComponent(
+  AppLayoutNavigationImplementation,
+  NotificationsSlot
+);

--- a/src/app-layout/visual-refresh-toolbar/notifications/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/notifications/index.tsx
@@ -9,12 +9,13 @@ import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal
 import { highContrastHeaderClassName } from '../../../internal/utils/content-header-utils';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { AppLayoutInternals } from '../interfaces';
+import { NotificationsSkeleton } from '../skeleton/slot-skeletons';
 import { NotificationsSlot } from '../skeleton/slot-wrappers';
 
 import testutilStyles from '../../test-classes/styles.css.js';
 import styles from './styles.css.js';
 
-interface AppLayoutNotificationsImplementationProps {
+export interface AppLayoutNotificationsImplementationProps {
   appLayoutInternals: AppLayoutInternals;
   children: React.ReactNode;
 }
@@ -59,4 +60,7 @@ export function AppLayoutNotificationsImplementation({
   );
 }
 
-export const createWidgetizedAppLayoutNotifications = createWidgetizedComponent(AppLayoutNotificationsImplementation);
+export const createWidgetizedAppLayoutNotifications = createWidgetizedComponent(
+  AppLayoutNotificationsImplementation,
+  NotificationsSkeleton
+);

--- a/src/app-layout/visual-refresh-toolbar/skeleton/breadcrumbs/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/breadcrumbs/index.tsx
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { BreadcrumbGroupImplementation } from '../../../../breadcrumb-group/implementation';
+import { BreadcrumbGroupProps } from '../../../../breadcrumb-group/interfaces';
+import { BreadcrumbsSlotContext } from '../../contexts';
+
+import styles from './styles.css.js';
+
+interface BreadcrumbsSlotProps {
+  ownBreadcrumbs: React.ReactNode;
+  discoveredBreadcrumbs: BreadcrumbGroupProps | null;
+}
+
+export function BreadcrumbsSlot({ ownBreadcrumbs, discoveredBreadcrumbs }: BreadcrumbsSlotProps) {
+  return (
+    <BreadcrumbsSlotContext.Provider value={{ isInToolbar: true }}>
+      <div className={styles['breadcrumbs-own']}>{ownBreadcrumbs}</div>
+      {discoveredBreadcrumbs && (
+        <div className={styles['breadcrumbs-discovered']}>
+          <BreadcrumbGroupImplementation
+            {...discoveredBreadcrumbs}
+            data-awsui-discovered-breadcrumbs={true}
+            __injectAnalyticsComponentMetadata={true}
+          />
+        </div>
+      )}
+    </BreadcrumbsSlotContext.Provider>
+  );
+}

--- a/src/app-layout/visual-refresh-toolbar/skeleton/breadcrumbs/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/breadcrumbs/styles.scss
@@ -1,0 +1,9 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+// backward compatibility before this commit: 7a4b7b3e3b1d50830383805a8f4ab6cd93c9701f
+.breadcrumbs-own:not(:empty) + .breadcrumbs-discovered {
+  display: none;
+}

--- a/src/app-layout/visual-refresh-toolbar/skeleton/slot-skeletons.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/slot-skeletons.tsx
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { AppLayoutNotificationsImplementationProps } from '../notifications';
+import { AppLayoutToolbarImplementationProps } from '../toolbar';
+import { BreadcrumbsSlot } from './breadcrumbs';
+import { NotificationsSlot, ToolbarSlot } from './slot-wrappers';
+
+export const ToolbarSkeleton = React.forwardRef<HTMLElement, AppLayoutToolbarImplementationProps>(
+  ({ appLayoutInternals }: AppLayoutToolbarImplementationProps, ref) => (
+    <ToolbarSlot ref={ref}>
+      <BreadcrumbsSlot
+        ownBreadcrumbs={appLayoutInternals.breadcrumbs}
+        discoveredBreadcrumbs={appLayoutInternals.discoveredBreadcrumbs}
+      />
+    </ToolbarSlot>
+  )
+);
+
+export const NotificationsSkeleton = React.forwardRef<HTMLElement, AppLayoutNotificationsImplementationProps>(
+  (props: AppLayoutNotificationsImplementationProps, ref) => <NotificationsSlot ref={ref} />
+);

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -5,12 +5,12 @@ import clsx from 'clsx';
 
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
-import { BreadcrumbGroupImplementation } from '../../../breadcrumb-group/implementation';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { AppLayoutProps } from '../../interfaces';
 import { Focusable, FocusControlMultipleStates } from '../../utils/use-focus-control';
-import { BreadcrumbsSlotContext } from '../contexts';
 import { AppLayoutInternals } from '../interfaces';
+import { BreadcrumbsSlot } from '../skeleton/breadcrumbs';
+import { ToolbarSkeleton } from '../skeleton/slot-skeletons';
 import { ToolbarSlot } from '../skeleton/slot-wrappers';
 import { DrawerTriggers, SplitPanelToggleProps } from './drawer-triggers';
 import TriggerButton from './trigger-button';
@@ -48,7 +48,7 @@ export interface ToolbarProps {
   onActiveGlobalDrawersChange?: ((drawerId: string) => void) | undefined;
 }
 
-interface AppLayoutToolbarImplementationProps {
+export interface AppLayoutToolbarImplementationProps {
   appLayoutInternals: AppLayoutInternals;
   toolbarProps: ToolbarProps;
 }
@@ -194,18 +194,10 @@ export function AppLayoutToolbarImplementation({
         )}
         {(breadcrumbs || discoveredBreadcrumbs) && (
           <div className={clsx(styles['universal-toolbar-breadcrumbs'], testutilStyles.breadcrumbs)}>
-            <BreadcrumbsSlotContext.Provider value={{ isInToolbar: true }}>
-              <div className={styles['breadcrumbs-own']}>{breadcrumbs}</div>
-              {discoveredBreadcrumbs && (
-                <div className={styles['breadcrumbs-discovered']}>
-                  <BreadcrumbGroupImplementation
-                    {...discoveredBreadcrumbs}
-                    data-awsui-discovered-breadcrumbs={true}
-                    __injectAnalyticsComponentMetadata={true}
-                  />
-                </div>
-              )}
-            </BreadcrumbsSlotContext.Provider>
+            <BreadcrumbsSlot
+              ownBreadcrumbs={appLayoutInternals.breadcrumbs}
+              discoveredBreadcrumbs={appLayoutInternals.discoveredBreadcrumbs}
+            />
           </div>
         )}
         {((drawers && drawers.length > 0) || (hasSplitPanel && splitPanelToggleProps?.displayed)) && (
@@ -232,4 +224,7 @@ export function AppLayoutToolbarImplementation({
   );
 }
 
-export const createWidgetizedAppLayoutToolbar = createWidgetizedComponent(AppLayoutToolbarImplementation);
+export const createWidgetizedAppLayoutToolbar = createWidgetizedComponent(
+  AppLayoutToolbarImplementation,
+  ToolbarSkeleton
+);

--- a/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
@@ -100,11 +100,6 @@
   }
 }
 
-// backward compatibility before this commit: 7a4b7b3e3b1d50830383805a8f4ab6cd93c9701f
-.breadcrumbs-own:not(:empty) + .breadcrumbs-discovered {
-  display: none;
-}
-
 .block-body-scroll {
   overflow: hidden;
 }

--- a/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
@@ -5,7 +5,8 @@ import { act, render } from '@testing-library/react';
 
 import BreadcrumbGroup, { BreadcrumbGroupProps } from '../../../lib/components/breadcrumb-group';
 import TestI18nProvider from '../../../lib/components/i18n/testing';
-import createWrapper, { BreadcrumbGroupWrapper } from '../../../lib/components/test-utils/dom';
+import { DATA_ATTR_RESOURCE_TYPE, getFunnelNameSelector } from '../../../lib/components/internal/analytics/selectors';
+import createWrapper, { BreadcrumbGroupWrapper, ElementWrapper } from '../../../lib/components/test-utils/dom';
 
 import itemStyles from '../../../lib/components/breadcrumb-group/item/styles.css.js';
 import styles from '../../../lib/components/breadcrumb-group/styles.css.js';
@@ -229,6 +230,51 @@ describe('BreadcrumbGroup Component', () => {
       anchors.forEach(anchor => {
         expect(anchor).toHaveAttribute('tabindex', '-1');
       });
+    });
+  });
+
+  describe('funnel attributes', () => {
+    function getElementsText(elements: Array<ElementWrapper>) {
+      return Array.from(elements).map(element => element.getElement().textContent);
+    }
+
+    function getFunnelNameElements(wrapper: BreadcrumbGroupWrapper) {
+      return wrapper.findAll(getFunnelNameSelector());
+    }
+
+    function getResourceTypeElements(wrapper: BreadcrumbGroupWrapper) {
+      return wrapper.findAll(`[${DATA_ATTR_RESOURCE_TYPE}]`);
+    }
+
+    test('should add funnel name and resource type attributes', () => {
+      const wrapper = renderBreadcrumbGroup({
+        items: [
+          { text: 'Home', href: '/home' },
+          { text: 'Resource', href: '/resource' },
+          { text: 'Name', href: '/resource/name' },
+        ],
+      });
+      expect(getElementsText(getResourceTypeElements(wrapper))).toEqual(['Resource']);
+      expect(getElementsText(getFunnelNameElements(wrapper))).toEqual(['Name']);
+    });
+
+    test('allows funnel name and resource type to be the same item', () => {
+      const wrapper = renderBreadcrumbGroup({
+        items: [
+          { text: 'Home', href: '/home' },
+          { text: 'Page', href: '/page' },
+        ],
+      });
+      expect(getElementsText(getResourceTypeElements(wrapper))).toEqual(['Page']);
+      expect(getElementsText(getFunnelNameElements(wrapper))).toEqual(['Page']);
+    });
+
+    test('only adds funnel name if there is only one item', () => {
+      const wrapper = renderBreadcrumbGroup({
+        items: [{ text: 'Home', href: '/home' }],
+      });
+      expect(getElementsText(getResourceTypeElements(wrapper))).toEqual([]);
+      expect(getElementsText(getFunnelNameElements(wrapper))).toEqual(['Home']);
     });
   });
 });

--- a/src/breadcrumb-group/__tests__/breadcrumb-item.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-item.test.tsx
@@ -7,7 +7,6 @@ import { ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 
 import BreadcrumbGroup, { BreadcrumbGroupProps } from '../../../lib/components/breadcrumb-group';
 import { BreadcrumbItem } from '../../../lib/components/breadcrumb-group/item/item';
-import { DATA_ATTR_FUNNEL_KEY, FUNNEL_KEY_FUNNEL_NAME } from '../../../lib/components/internal/analytics/selectors';
 import createWrapper, { BreadcrumbGroupWrapper } from '../../../lib/components/test-utils/dom';
 
 import breadcrumbItemStyles from '../../../lib/components/breadcrumb-group/item/styles.selectors.js';
@@ -128,17 +127,16 @@ describe('BreadcrumbGroup Item', () => {
       lastLink.click();
       expect(onFollowSpy).not.toHaveBeenCalled();
     });
-
-    test('should add a data-analytics attribute for the funnel name to the last item', () => {
-      const expectedFunnelName = items[items.length - 1].text;
-      const element = wrapper.find(`[${DATA_ATTR_FUNNEL_KEY}="${FUNNEL_KEY_FUNNEL_NAME}"]`)!.getElement();
-      expect(element.innerHTML).toBe(expectedFunnelName);
-    });
   });
 
   test('displays tooltip', () => {
     const { container } = render(
-      <BreadcrumbItem item={{ text: 'Long Breadcrumb text', href: '#' }} isTruncated={true} />
+      <BreadcrumbItem
+        itemIndex={0}
+        totalCount={1}
+        item={{ text: 'Long Breadcrumb text', href: '#' }}
+        isTruncated={true}
+      />
     );
     const elementAnchor = createWrapper(container).find(`.${breadcrumbItemStyles.anchor}`)!.getElement();
     elementAnchor.focus();

--- a/src/breadcrumb-group/__tests__/widgetized-breadcrumbs.test.tsx
+++ b/src/breadcrumb-group/__tests__/widgetized-breadcrumbs.test.tsx
@@ -5,9 +5,11 @@ import { render } from '@testing-library/react';
 
 import { BreadcrumbGroupProps } from '../../../lib/components/breadcrumb-group';
 import { createWidgetizedBreadcrumbGroup } from '../../../lib/components/breadcrumb-group/implementation';
+import { InternalBreadcrumbGroupProps } from '../../../lib/components/breadcrumb-group/interfaces';
 import { BreadcrumbGroupSkeleton } from '../../../lib/components/breadcrumb-group/skeleton';
-import { getFunnelNameSelector } from '../../../lib/components/internal/analytics/selectors';
+import { DATA_ATTR_RESOURCE_TYPE, getFunnelNameSelector } from '../../../lib/components/internal/analytics/selectors';
 import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-visual-mode';
+import { FunctionComponent } from '../../../lib/components/internal/widgets';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { describeWithAppLayoutFeatureFlagEnabled } from '../../internal/widgets/__tests__/utils';
 
@@ -21,14 +23,25 @@ function renderComponent(jsx: React.ReactElement) {
 const defaultProps: BreadcrumbGroupProps = {
   items: [
     { href: '#', text: 'Root' },
+    { href: '#', text: 'Resource' },
     { href: '#', text: 'Page name' },
   ],
 };
 
-const WidgetizedBreadcrumbs = createWidgetizedBreadcrumbGroup(BreadcrumbGroupSkeleton);
+const WidgetizedBreadcrumbs = createWidgetizedBreadcrumbGroup(
+  BreadcrumbGroupSkeleton as FunctionComponent<InternalBreadcrumbGroupProps<any>>
+);
+
+function getElementsText(elements: NodeListOf<Element>) {
+  return Array.from(elements).map(element => element.textContent);
+}
 
 function getFunnelNameElements(container: HTMLElement) {
   return container.querySelectorAll(getFunnelNameSelector());
+}
+
+function getResourceTypeElements(container: HTMLElement) {
+  return container.querySelectorAll(`[${DATA_ATTR_RESOURCE_TYPE}]`);
 }
 
 jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => ({
@@ -43,8 +56,8 @@ describe('Classic design', () => {
   test('should render normal layout by default', () => {
     const { wrapper, container } = renderComponent(<WidgetizedBreadcrumbs {...defaultProps} />);
     expect(wrapper).toBeTruthy();
-    expect(getFunnelNameElements(container).length).toEqual(1);
-    expect(getFunnelNameElements(container)[0]).toHaveTextContent('Page name');
+    expect(getElementsText(getResourceTypeElements(container))).toEqual(['Resource']);
+    expect(getElementsText(getFunnelNameElements(container))).toEqual(['Page name']);
   });
 });
 
@@ -56,22 +69,23 @@ describe('Refresh design', () => {
   test('should render normal layout by default', () => {
     const { wrapper, container } = renderComponent(<WidgetizedBreadcrumbs {...defaultProps} />);
     expect(wrapper).toBeTruthy();
-    expect(getFunnelNameElements(container).length).toEqual(1);
-    expect(getFunnelNameElements(container)[0]).toHaveTextContent('Page name');
+    expect(getElementsText(getResourceTypeElements(container))).toEqual(['Resource']);
+    expect(getElementsText(getFunnelNameElements(container))).toEqual(['Page name']);
   });
 
   describeWithAppLayoutFeatureFlagEnabled(() => {
-    test('should render funnel name using loader', () => {
+    test('should render funnel markers using loader', () => {
       const { wrapper, container } = renderComponent(<WidgetizedBreadcrumbs {...defaultProps} />);
       expect(wrapper).toBeFalsy();
-      expect(getFunnelNameElements(container).length).toEqual(1);
-      expect(getFunnelNameElements(container)[0]).toHaveTextContent('Page name');
+      expect(getElementsText(getResourceTypeElements(container))).toEqual(['Resource']);
+      expect(getElementsText(getFunnelNameElements(container))).toEqual(['Page name']);
     });
 
-    test('should not render funnel name if breadcrumbs list is empty', () => {
+    test('should not render funnel markers if breadcrumbs list is empty', () => {
       const { wrapper, container } = renderComponent(<WidgetizedBreadcrumbs items={[]} />);
       expect(wrapper).toBeFalsy();
-      expect(getFunnelNameElements(container).length).toEqual(0);
+      expect(getElementsText(getResourceTypeElements(container))).toEqual([]);
+      expect(getElementsText(getFunnelNameElements(container))).toEqual([]);
     });
   });
 });

--- a/src/breadcrumb-group/implementation.tsx
+++ b/src/breadcrumb-group/implementation.tsx
@@ -23,6 +23,7 @@ import {
 } from './analytics-metadata/interfaces';
 import { BreadcrumbGroupProps, EllipsisDropdownProps, InternalBreadcrumbGroupProps } from './interfaces';
 import { BreadcrumbItem } from './item/item';
+import { BreadcrumbGroupSkeleton } from './skeleton';
 import { getEventDetail, getItemsDisplayProperties } from './utils';
 
 import analyticsSelectors from './analytics-metadata/styles.css.js';
@@ -191,21 +192,19 @@ export function BreadcrumbGroupImplementation<T extends BreadcrumbGroupProps.Ite
           item={item}
           onClick={onClick}
           onFollow={onFollow}
-          isLast={isLast}
+          itemIndex={index}
+          totalCount={items.length}
           isTruncated={itemsWidths.ghost[index] - itemsWidths.real[index] > 0}
         />
       </li>
     );
   });
 
-  const hiddenBreadcrumbItems = items.map((item, index) => {
-    const isLast = index === items.length - 1;
-    return (
-      <li className={styles['ghost-item']} key={index} ref={node => setBreadcrumb('ghost', `${index}`, node)}>
-        <BreadcrumbItem item={item} isLast={isLast} isGhost={true} />
-      </li>
-    );
-  });
+  const hiddenBreadcrumbItems = items.map((item, index) => (
+    <li className={styles['ghost-item']} key={index} ref={node => setBreadcrumb('ghost', `${index}`, node)}>
+      <BreadcrumbItem item={item} itemIndex={index} totalCount={items.length} isGhost={true} />
+    </li>
+  ));
 
   const getEventItem = (e: CustomEvent<{ id: string }>) => {
     const { id } = e.detail;
@@ -263,4 +262,7 @@ export function BreadcrumbGroupImplementation<T extends BreadcrumbGroupProps.Ite
   );
 }
 
-export const createWidgetizedBreadcrumbGroup = createWidgetizedComponent(BreadcrumbGroupImplementation);
+export const createWidgetizedBreadcrumbGroup = createWidgetizedComponent(
+  BreadcrumbGroupImplementation,
+  BreadcrumbGroupSkeleton
+);

--- a/src/breadcrumb-group/index.tsx
+++ b/src/breadcrumb-group/index.tsx
@@ -7,6 +7,7 @@ import { useSetGlobalBreadcrumbs } from '../internal/plugins/helpers/use-global-
 import { applyDisplayName } from '../internal/utils/apply-display-name.js';
 import { BreadcrumbGroupProps } from './interfaces';
 import { InternalBreadcrumbGroup } from './internal';
+import { BreadcrumbGroupSkeleton } from './skeleton';
 
 export { BreadcrumbGroupProps };
 
@@ -18,7 +19,7 @@ export default function BreadcrumbGroup<T extends BreadcrumbGroupProps.Item = Br
   const baseComponentProps = useBaseComponent('BreadcrumbGroup');
 
   if (registeredGlobally) {
-    return <></>;
+    return <BreadcrumbGroupSkeleton items={items} />;
   }
 
   return (

--- a/src/breadcrumb-group/interfaces.ts
+++ b/src/breadcrumb-group/interfaces.ts
@@ -63,8 +63,9 @@ export type InternalBreadcrumbGroupProps<T extends BreadcrumbGroupProps.Item = B
 
 export interface BreadcrumbItemProps<T extends BreadcrumbGroupProps.Item> {
   item: T;
+  itemIndex: number;
+  totalCount: number;
   isTruncated?: boolean;
-  isLast?: boolean;
   isGhost?: boolean;
   onClick?: CancelableEventHandler<BreadcrumbGroupProps.ClickDetail<T>>;
   onFollow?: CancelableEventHandler<BreadcrumbGroupProps.ClickDetail<T>>;

--- a/src/breadcrumb-group/item/funnel.tsx
+++ b/src/breadcrumb-group/item/funnel.tsx
@@ -3,29 +3,38 @@
 import React from 'react';
 import clsx from 'clsx';
 
-import { DATA_ATTR_FUNNEL_KEY, FUNNEL_KEY_FUNNEL_NAME } from '../../internal/analytics/selectors';
+import {
+  DATA_ATTR_FUNNEL_KEY,
+  DATA_ATTR_RESOURCE_TYPE,
+  FUNNEL_KEY_FUNNEL_NAME,
+} from '../../internal/analytics/selectors';
 
 import analyticsSelectors from '../analytics-metadata/styles.css.js';
-import styles from './styles.css.js';
 
 interface FunnelBreadcrumbItemProps {
+  className?: string;
   text: string;
-  last: boolean;
-  hidden?: boolean;
-  ghost?: boolean;
+  itemIndex: number;
+  totalCount: number;
+  disableAnalytics?: boolean;
 }
 
 export const FunnelBreadcrumbItem = React.forwardRef<HTMLSpanElement, FunnelBreadcrumbItemProps>(
-  ({ text, hidden, last, ghost }, ref) => {
+  ({ className, text, itemIndex, totalCount, disableAnalytics }, ref) => {
     const funnelAttributes: Record<string, string> = {};
-    if (last && !ghost) {
-      funnelAttributes[DATA_ATTR_FUNNEL_KEY] = FUNNEL_KEY_FUNNEL_NAME;
+    if (!disableAnalytics) {
+      if (itemIndex === totalCount - 1) {
+        funnelAttributes[DATA_ATTR_FUNNEL_KEY] = FUNNEL_KEY_FUNNEL_NAME;
+      }
+      if (itemIndex === 1) {
+        funnelAttributes[DATA_ATTR_RESOURCE_TYPE] = 'true';
+      }
     }
 
     return (
       <span
         {...funnelAttributes}
-        className={clsx(styles.text, hidden && styles['text-hidden'], !ghost && analyticsSelectors['breadcrumb-item'])}
+        className={clsx(className, !disableAnalytics && analyticsSelectors['breadcrumb-item'])}
         ref={ref}
       >
         {text}

--- a/src/breadcrumb-group/item/styles.scss
+++ b/src/breadcrumb-group/item/styles.scss
@@ -49,7 +49,3 @@
     }
   }
 }
-
-.text-hidden {
-  display: none;
-}

--- a/src/breadcrumb-group/skeleton.tsx
+++ b/src/breadcrumb-group/skeleton.tsx
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import { BreadcrumbGroupProps, InternalBreadcrumbGroupProps } from './interfaces';
+import { InternalBreadcrumbGroupProps } from './interfaces';
 import { FunnelBreadcrumbItem } from './item/funnel';
 
-export function BreadcrumbGroupSkeleton<T extends BreadcrumbGroupProps.Item = BreadcrumbGroupProps.Item>({
-  items,
-}: InternalBreadcrumbGroupProps<T>) {
-  const lastItem = items[items.length - 1];
-  if (!lastItem) {
-    return <></>;
-  }
-  return <FunnelBreadcrumbItem hidden={true} last={true} text={lastItem.text} />;
-}
+import styles from './styles.css.js';
+
+export const BreadcrumbGroupSkeleton = React.forwardRef<HTMLElement, InternalBreadcrumbGroupProps>(({ items }, ref) => (
+  <div ref={ref as React.Ref<HTMLDivElement>} className={styles['breadcrumbs-skeleton']}>
+    {items.map((item, index) => (
+      <FunnelBreadcrumbItem itemIndex={index} totalCount={items.length} text={item.text} key={index} />
+    ))}
+  </div>
+));

--- a/src/breadcrumb-group/styles.scss
+++ b/src/breadcrumb-group/styles.scss
@@ -60,3 +60,7 @@
     }
   }
 }
+
+.breadcrumbs-skeleton {
+  display: none;
+}

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -28,7 +28,7 @@ import {
 } from '../interfaces';
 import {
   DATA_ATTR_FUNNEL_STEP,
-  getBreadcrumbLinkSelector,
+  DATA_ATTR_RESOURCE_TYPE,
   getFunnelNameSelector,
   getSubStepAllSelector,
   getSubStepNameSelector,
@@ -169,7 +169,7 @@ const InnerAnalyticsFunnel = ({ mounted = true, children, stepConfiguration, ...
         componentTheme: isVisualRefresh ? 'vr' : 'classic',
         funnelVersion: FUNNEL_VERSION,
         stepConfiguration: stepConfiguration ?? singleStepFlowStepConfiguration,
-        resourceType: props.funnelResourceType || getTextFromSelector(getBreadcrumbLinkSelector(3)),
+        resourceType: props.funnelResourceType || getTextFromSelector(`[${DATA_ATTR_RESOURCE_TYPE}]`),
       });
 
       setFunnelInteractionId(funnelInteractionId);
@@ -344,7 +344,7 @@ function useStepChangeListener(stepNumber: number, handler: (stepConfiguration: 
     };
   }, [stepNumber]);
 
-  /* We debounce this handler, so that multiple containers can change at once without causing 
+  /* We debounce this handler, so that multiple containers can change at once without causing
   too many events. */
   const stepChangeCallback = useDebounceCallback(() => {
     // We don't want to emit the event after the component has been unmounted.
@@ -597,7 +597,7 @@ export const AnalyticsFunnelSubStep = ({
         Some mouse events result in an element being focused. However,
         this happens only _after_ the onMouseUp event. We yield the
         event loop here, so that `document.activeElement` has the
-        correct new value.      
+        correct new value.
       */
       await new Promise(r => setTimeout(r, 1));
 

--- a/src/internal/analytics/selectors.ts
+++ b/src/internal/analytics/selectors.ts
@@ -1,17 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import breadcrumbGroupItemStyles from '../../breadcrumb-group/item/styles.css.js';
-import breadcrumbGroupStyles from '../../breadcrumb-group/styles.css.js';
-
-export const getBreadcrumbLinkSelector = (index: number) =>
-  `.${breadcrumbGroupStyles['breadcrumb-group']} .${breadcrumbGroupStyles.item}:nth-child(${index}) .${breadcrumbGroupItemStyles.anchor}`;
-
 export const DATA_ATTR_FUNNEL = 'data-analytics-funnel';
 export const DATA_ATTR_FUNNEL_INTERACTION_ID = `${DATA_ATTR_FUNNEL}-interaction-id`;
 export const DATA_ATTR_FUNNEL_KEY = `${DATA_ATTR_FUNNEL}-key`;
 export const DATA_ATTR_FUNNEL_VALUE = `${DATA_ATTR_FUNNEL}-value`;
 export const DATA_ATTR_FUNNEL_STEP = `${DATA_ATTR_FUNNEL}-step`;
 export const DATA_ATTR_FUNNEL_SUBSTEP = `${DATA_ATTR_FUNNEL}-substep`;
+export const DATA_ATTR_RESOURCE_TYPE = `${DATA_ATTR_FUNNEL}-resource-type`;
 
 export const DATA_ATTR_FIELD_LABEL = 'data-analytics-field-label';
 export const DATA_ATTR_FIELD_ERROR = 'data-analytics-field-error';
@@ -35,4 +30,4 @@ export const getSubStepNameSelector = (subStepId?: string) =>
 export const getFieldSlotSeletor = (id: string | undefined) => (id ? `[id="${id}"]` : undefined);
 
 export const getTextFromSelector = (selector: string | undefined): string | undefined =>
-  selector ? document.querySelector<HTMLElement>(selector)?.innerText?.trim() : undefined;
+  selector ? document.querySelector<HTMLElement>(selector)?.textContent?.trim() : undefined;

--- a/src/internal/widgets/index.tsx
+++ b/src/internal/widgets/index.tsx
@@ -7,14 +7,19 @@ import { getGlobalFlag } from '@cloudscape-design/component-toolkit/internal';
 import { useVisualRefresh } from '../hooks/use-visual-mode';
 
 // Built-in React.FunctionComponent has always present `children` property which is not desired
-type FunctionComponent<Props> = (props: Props) => JSX.Element;
+export type FunctionComponent<Props> = (props: Props) => JSX.Element;
+type PropsType<Component extends FunctionComponent<any>> =
+  Component extends FunctionComponent<infer Props> ? Props : never;
 
-export function createWidgetizedComponent<Component extends FunctionComponent<any>>(Implementation: Component) {
+export function createWidgetizedComponent<Component extends FunctionComponent<any>>(
+  Implementation: Component,
+  Skeleton?: React.ForwardRefExoticComponent<PropsType<Component> & React.RefAttributes<HTMLElement>>
+) {
   return (Loader?: Component): Component => {
     return (props => {
       const isRefresh = useVisualRefresh();
       if (isRefresh && getGlobalFlag('appLayoutWidget') && Loader) {
-        return <Loader {...(props as any)} />;
+        return <Loader Skeleton={Skeleton} {...(props as any)} />;
       }
 
       return <Implementation {...(props as any)} />;

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -11,6 +11,7 @@ import { FunnelMetrics } from '../internal/analytics';
 import { useFunnel } from '../internal/analytics/hooks/use-funnel';
 import {
   DATA_ATTR_FUNNEL_KEY,
+  FUNNEL_KEY_FUNNEL_NAME,
   FUNNEL_KEY_STEP_NAME,
   getSubStepAllSelector,
   getTextFromSelector,
@@ -156,7 +157,7 @@ export default function InternalWizard({
     name: 'awsui.Wizard',
     label: {
       root: 'body',
-      selector: '[data-analytics-funnel-key="funnel-name"]',
+      selector: `[${DATA_ATTR_FUNNEL_KEY}="${FUNNEL_KEY_FUNNEL_NAME}"]`,
     },
     properties: {
       stepsCount: `${(steps || []).length}`,


### PR DESCRIPTION
### Description

Make breadcrumbs slot rendered even when the app layout widget is in the loading state, because it is important for funnel metrics tracking

Related links, issue #, if available: n/a

### How has this been tested?

* Added extra unit tests
* Also tested end-to-end in my dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
