### PR TITLE
chore: Allow drawer content to use full height

### DIFF
--- a/pages/app-layout/runtime-drawers.page.tsx
+++ b/pages/app-layout/runtime-drawers.page.tsx
@@ -6,7 +6,6 @@ import {
   AppLayout,
   Button,
   ContentLayout,
-  Drawer,
   Header,
   HelpPanel,
   Link,
@@ -19,7 +18,7 @@ import awsuiPlugins from '~components/internal/plugins';
 
 import './utils/external-widget';
 import AppContext, { AppContextType } from '../app/app-context';
-import { Breadcrumbs, Containers } from './utils/content-blocks';
+import { Breadcrumbs, Containers, CustomDrawerContent } from './utils/content-blocks';
 import appLayoutLabels from './utils/labels';
 
 type DemoContext = React.Context<
@@ -51,7 +50,7 @@ export default function WithDrawers() {
               triggerButton: 'ProHelp trigger button',
               resizeHandle: 'ProHelp resize handle',
             },
-            content: <ProHelp />,
+            content: <CustomDrawerContent />,
             id: 'pro-help',
             trigger: {
               iconName: 'contact',
@@ -102,7 +101,10 @@ export default function WithDrawers() {
                   Use Drawers
                 </Toggle>
 
-                <Button onClick={() => awsuiPlugins.appLayout.openDrawer('circle4-global')}>
+                <Button
+                  onClick={() => awsuiPlugins.appLayout.openDrawer('circle4-global')}
+                  data-testid="open-drawer-button"
+                >
                   Open a drawer without a trigger
                 </Button>
                 <Button onClick={() => awsuiPlugins.appLayout.closeDrawer('circle4-global')}>
@@ -170,8 +172,4 @@ export default function WithDrawers() {
 
 function Info({ helpPathSlug }: { helpPathSlug: string }) {
   return <HelpPanel header={<h2>Info</h2>}>Here is some info for you: {helpPathSlug}</HelpPanel>;
-}
-
-function ProHelp() {
-  return <Drawer header={<h2>Pro Help</h2>}>Need some Pro Help? We got you.</Drawer>;
 }

--- a/pages/app-layout/styles.scss
+++ b/pages/app-layout/styles.scss
@@ -80,3 +80,31 @@
     margin-block-start: 4rem;
   }
 }
+
+.custom-drawer-wrapper {
+  display: flex;
+  flex-direction: column;
+  block-size: 100%;
+  overflow-y: hidden;
+}
+
+.drawer-sticky-header,
+.drawer-scrollable-content,
+.drawer-sticky-footer {
+  padding-inline: 24px;
+}
+
+.drawer-sticky-header {
+  background-color: peachpuff;
+  border-block-end: 2px solid grey;
+}
+.drawer-scrollable-content {
+  flex: 1;
+  overflow-y: auto;
+  padding-block: 8px;
+}
+.drawer-sticky-footer {
+  background-color: lightpink;
+  border-block-start: 2px solid grey;
+  padding-block: 12px;
+}

--- a/pages/app-layout/styles.scss
+++ b/pages/app-layout/styles.scss
@@ -97,14 +97,15 @@
 .drawer-sticky-header {
   background-color: peachpuff;
   border-block-end: 2px solid grey;
+  padding-block: awsui.$space-scaled-l;
 }
 .drawer-scrollable-content {
   flex: 1;
   overflow-y: auto;
-  padding-block: 8px;
+  padding-block: awsui.$space-scaled-s;
 }
 .drawer-sticky-footer {
   background-color: lightpink;
   border-block-start: 2px solid grey;
-  padding-block: 12px;
+  padding-block: awsui.$space-scaled-s;
 }

--- a/pages/app-layout/utils/content-blocks.tsx
+++ b/pages/app-layout/utils/content-blocks.tsx
@@ -182,7 +182,9 @@ export function CustomDrawerContent() {
   return (
     <div className={styles['custom-drawer-wrapper']}>
       <div className={styles['drawer-sticky-header']} data-testid="drawer-sticky-header">
-        <h2>Header</h2>
+        <Box variant="h3" tagOverride="h2" padding="n">
+          Sticky header
+        </Box>
       </div>
       <div className={styles['drawer-scrollable-content']}>
         <ScrollableDrawerContent />

--- a/pages/app-layout/utils/content-blocks.tsx
+++ b/pages/app-layout/utils/content-blocks.tsx
@@ -4,6 +4,9 @@ import React, { useState } from 'react';
 import clsx from 'clsx';
 import range from 'lodash/range';
 
+import { getIsRtl } from '@cloudscape-design/component-toolkit/internal';
+
+import { Box } from '~components';
 import BreadcrumbGroup from '~components/breadcrumb-group';
 import Button from '~components/button';
 import Container from '~components/container';
@@ -12,6 +15,7 @@ import Header from '~components/header';
 import HelpPanel from '~components/help-panel';
 import SideNavigation from '~components/side-navigation';
 import SpaceBetween from '~components/space-between';
+import TextContent from '~components/text-content';
 
 import styles from '../styles.scss';
 
@@ -84,5 +88,108 @@ export function Footer({ legacyConsoleNav }: { legacyConsoleNav: boolean }) {
         © 2008 - 2020, Amazon Web Services, Inc. or its affiliates. All rights reserved
       </footer>
     </>
+  );
+}
+
+export function ScrollableDrawerContent({ contentType = 'text' }: { contentType?: 'text' | 'image' }) {
+  return contentType === 'image' ? (
+    <SpaceBetween size="l">
+      <div className={styles.contentPlaceholder} />
+      <div className={styles.contentPlaceholder} />
+      <div className={styles.contentPlaceholder} />
+    </SpaceBetween>
+  ) : (
+    <TextContent>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua. Augue neque gravida in fermentum. Suspendisse sed nisi lacus sed viverra tellus in hac. Nec
+        sagittis aliquam malesuada bibendum arcu vitae elementum. Lectus proin nibh nisl condimentum id venenatis.
+        Penatibus et magnis dis parturient montes nascetur ridiculus mus mauris. Nisi porta lorem mollis aliquam ut
+        porttitor leo a. Facilisi morbi tempus iaculis urna. Odio tempor orci dapibus ultrices in iaculis nunc.
+      </p>
+      <div data-testid="scroll-me">The end</div>
+      <p>
+        Ut diam quam nulla porttitor massa id neque. Duis at tellus at urna condimentum mattis pellentesque id nibh.
+        Metus vulputate eu scelerisque felis imperdiet proin fermentum.
+      </p>
+      <h3>Another h3</h3>
+      <p>
+        Orci porta non pulvinar neque laoreet suspendisse interdum consectetur libero. Varius quam quisque id diam vel.
+        Risus viverra adipiscing at in. Orci sagittis eu volutpat odio facilisis mauris. Mauris vitae ultricies leo
+        integer malesuada nunc. Sem et tortor consequat id porta nibh. Semper auctor neque vitae tempus quam
+        pellentesque.
+      </p>
+      <p>Ante in nibh mauris cursus mattis molestie.</p>
+      <p>
+        Pharetra et ultrices neque ornare. Bibendum neque egestas congue quisque egestas diam in arcu cursus. Porttitor
+        eget dolor morbi non arcu risus quis. Integer quis auctor elit sed vulputate mi sit. Mauris nunc congue nisi
+        vitae suscipit tellus mauris a diam. Diam donec adipiscing tristique risus nec feugiat in. Arcu felis bibendum
+        ut tristique et egestas quis. Nulla porttitor massa id neque aliquam vestibulum morbi blandit. In hac habitasse
+        platea dictumst quisque sagittis. Sollicitudin tempor id eu nisl nunc mi ipsum. Ornare aenean euismod elementum
+        nisi quis. Elementum curabitur vitae nunc sed velit dignissim sodales. Amet tellus cras adipiscing enim eu. Id
+        interdum velit laoreet id donec ultrices tincidunt. Ullamcorper eget nulla facilisi etiam. Sodales neque sodales
+        ut etiam sit amet nisl purus. Auctor urna nunc id cursus metus aliquam eleifend mi in. Urna condimentum mattis
+        pellentesque id. Porta lorem mollis aliquam ut porttitor leo a. Lectus quam id leo in vitae turpis massa sed.
+        Pharetra pharetra massa massa ultricies mi.
+      </p>
+    </TextContent>
+  );
+}
+
+export function ContentFill() {
+  return (
+    <div style={{ minBlockSize: '100%', position: 'relative' }}>
+      <div
+        style={{
+          position: 'absolute',
+          insetBlockStart: '50%',
+          insetInlineStart: '50%',
+          transform: getIsRtl(document.body) ? 'translate(50%, -50%)' : 'translate(-50%, -50%)',
+        }}
+      >
+        <Box fontSize="heading-m">
+          In Visual Refresh, there should be a cross exactly in each corner of <br />
+          the content area, without any scrollbars.
+        </Box>
+      </div>
+      <CornerMarker insetBlockStart={0} insetInlineStart={0} />
+      <CornerMarker insetBlockEnd={0} insetInlineStart={0} />
+      <CornerMarker insetBlockStart={0} insetInlineEnd={0} />
+      <CornerMarker insetBlockEnd={0} insetInlineEnd={0} />
+    </div>
+  );
+}
+
+function CornerMarker(props: {
+  insetBlockStart?: number;
+  insetInlineEnd?: number;
+  insetInlineStart?: number;
+  insetBlockEnd?: number;
+}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 10 10"
+      style={{ inlineSize: '50px', blockSize: '50px', position: 'absolute', ...props }}
+    >
+      <line x1="0" y1="0" x2="10" y2="10" stroke="currentColor" strokeWidth="1" />
+      <line x1="0" y1="10" x2="10" y2="0" stroke="currentColor" strokeWidth="1" />
+    </svg>
+  );
+}
+
+export function CustomDrawerContent() {
+  return (
+    <div className={styles['custom-drawer-wrapper']}>
+      <div className={styles['drawer-sticky-header']} data-testid="drawer-sticky-header">
+        <h2>Header</h2>
+      </div>
+      <div className={styles['drawer-scrollable-content']}>
+        <ScrollableDrawerContent />
+      </div>
+      <div className={styles['drawer-sticky-footer']} data-testid="drawer-sticky-footer">
+        <p>This is a sticky footer, it should always be visisble when the panel is open.</p>
+      </div>
+    </div>
   );
 }

--- a/pages/app-layout/utils/external-widget.tsx
+++ b/pages/app-layout/utils/external-widget.tsx
@@ -6,6 +6,8 @@ import ReactDOM, { unmountComponentAtNode } from 'react-dom';
 import Drawer from '~components/drawer';
 import awsuiPlugins from '~components/internal/plugins';
 
+import { CustomDrawerContent } from './content-blocks';
+
 const searchParams = new URL(location.hash.substring(1), location.href).searchParams;
 
 const Content = React.forwardRef((props, ref) => {
@@ -237,7 +239,7 @@ awsuiPlugins.appLayout.registerDrawer({
   },
 
   mountContent: container => {
-    ReactDOM.render(<div>global widget content circle 3 (without trigger button)</div>, container);
+    ReactDOM.render(<CustomDrawerContent />, container);
   },
   unmountContent: container => unmountComponentAtNode(container),
 });

--- a/pages/app-layout/with-drawers-scrollable.page.tsx
+++ b/pages/app-layout/with-drawers-scrollable.page.tsx
@@ -19,6 +19,7 @@ import { AppLayoutProps } from '~components/app-layout';
 import awsuiPlugins from '~components/internal/plugins';
 
 import AppContext, { AppContextType } from '../app/app-context';
+import ScreenshotArea from '../utils/screenshot-area';
 import {
   Breadcrumbs,
   Containers,
@@ -45,9 +46,9 @@ const getAriaLabels = (title: string) => {
 };
 
 awsuiPlugins.appLayout.registerDrawer({
-  id: 'circle',
+  id: 'circle1-global',
   type: 'global',
-  ariaLabels: getAriaLabels('global drawer'),
+  ariaLabels: getAriaLabels('global drawer 1'),
   defaultActive: true,
   resizable: true,
   defaultSize: 320,
@@ -59,6 +60,25 @@ awsuiPlugins.appLayout.registerDrawer({
   },
   mountContent: container => {
     ReactDOM.render(<CustomDrawerContent />, container);
+  },
+  unmountContent: container => unmountComponentAtNode(container),
+});
+awsuiPlugins.appLayout.registerDrawer({
+  id: 'circle2-global',
+  type: 'global',
+  defaultActive: false,
+  resizable: true,
+  defaultSize: 320,
+
+  ariaLabels: getAriaLabels('global drawer 2'),
+
+  mountContent: container => {
+    ReactDOM.render(
+      <Drawer header="Global drawer">
+        <ScrollableDrawerContent contentType="text" />
+      </Drawer>,
+      container
+    );
   },
   unmountContent: container => unmountComponentAtNode(container),
 });
@@ -162,65 +182,74 @@ export default function WithDrawersScrollable() {
   };
 
   return (
-    <AppLayout
-      ariaLabels={appLayoutLabels}
-      breadcrumbs={<Breadcrumbs />}
-      navigation={sideNavContents}
-      ref={appLayoutRef}
-      content={
-        <ContentLayout
-          disableOverlap={true}
-          header={
-            <SpaceBetween size="m">
-              <Header variant="h1" description="Many drawers with scrollable content">
-                Testing Scrollable Drawers
-              </Header>
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        ariaLabels={appLayoutLabels}
+        breadcrumbs={<Breadcrumbs />}
+        navigation={sideNavContents}
+        ref={appLayoutRef}
+        content={
+          <ContentLayout
+            disableOverlap={true}
+            header={
+              <SpaceBetween size="m">
+                <Header variant="h1" description="Many drawers with scrollable content">
+                  Testing Scrollable Drawers
+                </Header>
 
-              <SpaceBetween size="xs">
-                <Toggle checked={sideNavFill} onChange={({ detail }) => setUrlParams({ sideNavFill: detail.checked })}>
-                  Fill side nav content area
-                </Toggle>
+                <SpaceBetween size="xs">
+                  <Toggle
+                    checked={sideNavFill}
+                    onChange={({ detail }) => setUrlParams({ sideNavFill: detail.checked })}
+                    data-testid="toggle-side-nav-content"
+                  >
+                    Fill side nav content area
+                  </Toggle>
 
-                <Button onClick={() => awsuiPlugins.appLayout.openDrawer('circle1-global')}>
-                  Open a drawer without a trigger
-                </Button>
+                  <Button
+                    onClick={() => awsuiPlugins.appLayout.openDrawer('circle2-global')}
+                    data-testid="open-global-drawer-button"
+                  >
+                    Open a drawer without a trigger
+                  </Button>
+                </SpaceBetween>
               </SpaceBetween>
+            }
+          >
+            <Containers />
+          </ContentLayout>
+        }
+        splitPanel={
+          <SplitPanel
+            header="Split panel header"
+            i18nStrings={{
+              preferencesTitle: 'Preferences',
+              preferencesPositionLabel: 'Split panel position',
+              preferencesPositionDescription: 'Choose the default split panel position for the service.',
+              preferencesPositionSide: 'Side',
+              preferencesPositionBottom: 'Bottom',
+              preferencesConfirm: 'Confirm',
+              preferencesCancel: 'Cancel',
+              closeButtonAriaLabel: 'Close panel',
+              openButtonAriaLabel: 'Open panel',
+              resizeHandleAriaLabel: 'Slider',
+            }}
+          >
+            <SpaceBetween size="l">
+              <ScrollableDrawerContent />
+              <ScrollableDrawerContent contentType="image" />
             </SpaceBetween>
-          }
-        >
-          <Containers />
-        </ContentLayout>
-      }
-      splitPanel={
-        <SplitPanel
-          header="Split panel header"
-          i18nStrings={{
-            preferencesTitle: 'Preferences',
-            preferencesPositionLabel: 'Split panel position',
-            preferencesPositionDescription: 'Choose the default split panel position for the service.',
-            preferencesPositionSide: 'Side',
-            preferencesPositionBottom: 'Bottom',
-            preferencesConfirm: 'Confirm',
-            preferencesCancel: 'Cancel',
-            closeButtonAriaLabel: 'Close panel',
-            openButtonAriaLabel: 'Open panel',
-            resizeHandleAriaLabel: 'Slider',
-          }}
-        >
-          <SpaceBetween size="l">
-            <ScrollableDrawerContent />
-            <ScrollableDrawerContent contentType="image" />
-          </SpaceBetween>
-        </SplitPanel>
-      }
-      splitPanelPreferences={{
-        position: urlParams.splitPanelPosition,
-      }}
-      onSplitPanelPreferencesChange={event => {
-        const { position } = event.detail;
-        setUrlParams({ splitPanelPosition: position === 'side' ? position : undefined });
-      }}
-      {...drawersProps}
-    />
+          </SplitPanel>
+        }
+        splitPanelPreferences={{
+          position: urlParams.splitPanelPosition,
+        }}
+        onSplitPanelPreferencesChange={event => {
+          const { position } = event.detail;
+          setUrlParams({ splitPanelPosition: position === 'side' ? position : undefined });
+        }}
+        {...drawersProps}
+      />
+    </ScreenshotArea>
   );
 }

--- a/pages/app-layout/with-drawers-scrollable.page.tsx
+++ b/pages/app-layout/with-drawers-scrollable.page.tsx
@@ -1,0 +1,226 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext, useRef, useState } from 'react';
+import ReactDOM, { unmountComponentAtNode } from 'react-dom';
+
+import {
+  AppLayout,
+  Button,
+  ContentLayout,
+  Drawer,
+  Header,
+  HelpPanel,
+  SideNavigation,
+  SpaceBetween,
+  SplitPanel,
+  Toggle,
+} from '~components';
+import { AppLayoutProps } from '~components/app-layout';
+import awsuiPlugins from '~components/internal/plugins';
+
+import AppContext, { AppContextType } from '../app/app-context';
+import {
+  Breadcrumbs,
+  Containers,
+  ContentFill,
+  CustomDrawerContent,
+  ScrollableDrawerContent,
+} from './utils/content-blocks';
+import appLayoutLabels from './utils/labels';
+
+type DemoContext = React.Context<
+  AppContextType<{
+    sideNavFill: boolean | undefined;
+    splitPanelPosition: AppLayoutProps.SplitPanelPreferences['position'];
+  }>
+>;
+
+const getAriaLabels = (title: string) => {
+  return {
+    closeButton: `${title} close button`,
+    drawerName: `${title}`,
+    triggerButton: `${title} trigger button`,
+    resizeHandle: `${title} resize handle`,
+  };
+};
+
+awsuiPlugins.appLayout.registerDrawer({
+  id: 'circle',
+  type: 'global',
+  ariaLabels: getAriaLabels('global drawer'),
+  defaultActive: true,
+  resizable: true,
+  defaultSize: 320,
+  trigger: {
+    iconSvg: `<svg viewBox="0 0 16 16" focusable="false">
+      <circle stroke-width="2" stroke="currentColor" fill="none" cx="8" cy="8" r="7" />
+      <circle stroke-width="2" stroke="currentColor" fill="none" cx="8" cy="8" r="3" />
+    </svg>`,
+  },
+  mountContent: container => {
+    ReactDOM.render(<CustomDrawerContent />, container);
+  },
+  unmountContent: container => unmountComponentAtNode(container),
+});
+
+awsuiPlugins.appLayout.registerDrawer({
+  id: 'security',
+  ariaLabels: getAriaLabels('runtime drawer'),
+  resizable: true,
+  defaultSize: 320,
+  trigger: {
+    iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+      <rect x="2" y="7" width="12" height="7" fill="none" stroke="currentColor" stroke-width="2" />
+      <path d="M4,7V5a4,4,0,0,1,8,0V7" fill="none" stroke="currentColor" stroke-width="2" />
+    </svg>`,
+  },
+  mountContent: container => {
+    ReactDOM.render(
+      <Drawer>
+        <>
+          <p>This is a headerless drawer in a runtime local drawer.</p>
+          <ScrollableDrawerContent />
+        </>
+      </Drawer>,
+      container
+    );
+  },
+  unmountContent: container => unmountComponentAtNode(container),
+});
+
+export default function WithDrawersScrollable() {
+  const [activeDrawerId, setActiveDrawerId] = useState<string | null>('settings');
+  const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
+  const sideNavFill = urlParams.sideNavFill ?? false;
+  const appLayoutRef = useRef<AppLayoutProps.Ref>(null);
+
+  const sideNavContents: JSX.Element = sideNavFill ? (
+    <ContentFill />
+  ) : (
+    <SideNavigation
+      items={[
+        {
+          type: 'section',
+          text: 'Section 1',
+          items: [
+            { type: 'link', text: 'Page 4', href: '#/page4' },
+            { type: 'link', text: 'Page 5', href: '#/page5' },
+            { type: 'link', text: 'Page 6', href: '#/page6' },
+          ],
+        },
+        {
+          type: 'section',
+          text: 'Section 2',
+          items: [
+            { type: 'link', text: 'Page 7', href: '#/page7' },
+            { type: 'link', text: 'Page 8', href: '#/page8' },
+            { type: 'link', text: 'Page 9', href: '#/page9' },
+          ],
+        },
+      ]}
+    />
+  );
+
+  const drawersProps: Pick<AppLayoutProps, 'activeDrawerId' | 'onDrawerChange' | 'drawers'> | null = {
+    activeDrawerId: activeDrawerId,
+    drawers: [
+      {
+        id: 'chat',
+        ariaLabels: getAriaLabels('chat'),
+        content: <CustomDrawerContent />,
+        trigger: {
+          iconName: 'contact',
+        },
+      },
+      {
+        id: 'settings',
+        ariaLabels: getAriaLabels('fill content'),
+        content: <ContentFill />,
+        trigger: {
+          iconName: 'settings',
+        },
+      },
+      {
+        id: 'help',
+        ariaLabels: getAriaLabels('headerless help'),
+        content: (
+          <HelpPanel>
+            <>
+              <p>This is a headerless help panel in a local drawer.</p>
+              <ScrollableDrawerContent contentType="image" />
+            </>
+          </HelpPanel>
+        ),
+        trigger: {
+          iconName: 'status-info',
+        },
+      },
+    ],
+    onDrawerChange: event => {
+      setActiveDrawerId(event.detail.activeDrawerId);
+    },
+  };
+
+  return (
+    <AppLayout
+      ariaLabels={appLayoutLabels}
+      breadcrumbs={<Breadcrumbs />}
+      navigation={sideNavContents}
+      ref={appLayoutRef}
+      content={
+        <ContentLayout
+          disableOverlap={true}
+          header={
+            <SpaceBetween size="m">
+              <Header variant="h1" description="Many drawers with scrollable content">
+                Testing Scrollable Drawers
+              </Header>
+
+              <SpaceBetween size="xs">
+                <Toggle checked={sideNavFill} onChange={({ detail }) => setUrlParams({ sideNavFill: detail.checked })}>
+                  Fill side nav content area
+                </Toggle>
+
+                <Button onClick={() => awsuiPlugins.appLayout.openDrawer('circle1-global')}>
+                  Open a drawer without a trigger
+                </Button>
+              </SpaceBetween>
+            </SpaceBetween>
+          }
+        >
+          <Containers />
+        </ContentLayout>
+      }
+      splitPanel={
+        <SplitPanel
+          header="Split panel header"
+          i18nStrings={{
+            preferencesTitle: 'Preferences',
+            preferencesPositionLabel: 'Split panel position',
+            preferencesPositionDescription: 'Choose the default split panel position for the service.',
+            preferencesPositionSide: 'Side',
+            preferencesPositionBottom: 'Bottom',
+            preferencesConfirm: 'Confirm',
+            preferencesCancel: 'Cancel',
+            closeButtonAriaLabel: 'Close panel',
+            openButtonAriaLabel: 'Open panel',
+            resizeHandleAriaLabel: 'Slider',
+          }}
+        >
+          <SpaceBetween size="l">
+            <ScrollableDrawerContent />
+            <ScrollableDrawerContent contentType="image" />
+          </SpaceBetween>
+        </SplitPanel>
+      }
+      splitPanelPreferences={{
+        position: urlParams.splitPanelPosition,
+      }}
+      onSplitPanelPreferencesChange={event => {
+        const { position } = event.detail;
+        setUrlParams({ splitPanelPosition: position === 'side' ? position : undefined });
+      }}
+      {...drawersProps}
+    />
+  );
+}

--- a/src/app-layout/__integ__/awsui-applayout.test.ts
+++ b/src/app-layout/__integ__/awsui-applayout.test.ts
@@ -189,7 +189,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as Theme[])('%s', theme 
     })
   );
 
-  test.only(
+  test(
     'Side nav does not display a scrollbar when there is no header',
     setupTest({ pageName: 'with-drawers-scrollable' }, async page => {
       const navBefore = await page.getNavPosition();

--- a/src/app-layout/__integ__/awsui-applayout.test.ts
+++ b/src/app-layout/__integ__/awsui-applayout.test.ts
@@ -19,7 +19,7 @@ class AppLayoutPage extends BasePageObject {
   }
 
   getNavPosition() {
-    return this.getBoundingBox(wrapper.findNavigation().findSideNavigation().findHeaderLink().toSelector());
+    return this.getBoundingBox(wrapper.findNavigation().findSideNavigation().findItemByIndex(1).toSelector());
   }
 
   getContentPosition() {
@@ -186,6 +186,15 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as Theme[])('%s', theme 
       ).resolves.toBe(0);
       const { top: contentTop } = await page.getBoundingBox('[data-testid="content-root"]');
       expect(contentTop).toEqual(expectedOffset);
+    })
+  );
+
+  test.only(
+    'Side nav does not display a scrollbar when there is no header',
+    setupTest({ pageName: 'with-drawers-scrollable' }, async page => {
+      const navBefore = await page.getNavPosition();
+      await page.elementScrollTo(wrapper.findNavigation().toSelector(), { top: 100 });
+      await expect(page.getNavPosition()).resolves.toEqual(navBefore);
     })
   );
 });

--- a/src/app-layout/__integ__/runtime-drawers.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers.test.ts
@@ -5,6 +5,7 @@ import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper, { AppLayoutWrapper } from '../../../lib/components/test-utils/selectors';
 import { viewports } from './constants';
+import { getUrlParams, Theme } from './utils';
 
 const wrapper = createWrapper().findAppLayout();
 const findDrawerById = (wrapper: AppLayoutWrapper, id: string) => {
@@ -14,19 +15,17 @@ const findDrawerContentById = (wrapper: AppLayoutWrapper, id: string) => {
   return wrapper.find(`[data-testid="awsui-app-layout-drawer-content-${id}"]`);
 };
 
-describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme => {
-  function setupTest(testFn: (page: BasePageObject) => Promise<void>) {
+describe.each(['classic', 'refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
+  function setupTest({ hasDrawers = 'false' }, testFn: (page: BasePageObject) => Promise<void>) {
     return useBrowser(async browser => {
       const page = new BasePageObject(browser);
 
       await browser.url(
-        `#/light/app-layout/runtime-drawers?${new URLSearchParams({
-          hasDrawers: 'false',
+        `#/light/app-layout/runtime-drawers?${getUrlParams(theme, {
+          hasDrawers: hasDrawers,
           hasTools: 'true',
           splitPanelPosition: 'side',
-          visualRefresh: `${theme !== 'classic'}`,
-          appLayoutToolbar: `${theme === 'refresh-toolbar'}`,
-        }).toString()}`
+        })}`
       );
       await page.waitForVisible(wrapper.findDrawerTriggerById('security').toSelector(), true);
       await testFn(page);
@@ -37,7 +36,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
   describe('desktop', () => {
     test(
       'should resize equally with tools or drawers',
-      setupTest(async page => {
+      setupTest({}, async page => {
         await page.setWindowSize({ ...viewports.desktop, width: 1800 });
         await page.click(wrapper.findToolsToggle().toSelector());
         await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
@@ -53,7 +52,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
 
     test(
       'renders according to defaultSize property',
-      setupTest(async page => {
+      setupTest({}, async page => {
         await page.setWindowSize(viewports.desktop);
         await page.click(wrapper.findDrawerTriggerById('security').toSelector());
         // using `clientWidth` to neglect possible border width set on this element
@@ -64,7 +63,7 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
 
     test(
       'should call resize handler',
-      setupTest(async page => {
+      setupTest({}, async page => {
         await page.setWindowSize(viewports.desktop);
         // close navigation panel to give drawer more room to resize
         await page.click(wrapper.findNavigationClose().toSelector());
@@ -74,6 +73,25 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
 
         await page.dragAndDrop(wrapper.findActiveDrawerResizeHandle().toSelector(), -200);
         await expect(page.getText('[data-testid="current-size"]')).resolves.toEqual('resized: true');
+      })
+    );
+
+    test(
+      'should show sticky elements on scroll in drawer',
+      setupTest({ hasDrawers: 'true' }, async page => {
+        await page.setWindowSize(viewports.desktop);
+        await page.waitForVisible(wrapper.findDrawerTriggerById('pro-help').toSelector(), true);
+
+        await expect(page.isDisplayed('[data-testid="drawer-sticky-footer"]')).resolves.toBe(false);
+        await page.click(wrapper.findDrawerTriggerById('pro-help').toSelector());
+        await expect(page.isDisplayed('[data-testid="drawer-sticky-footer"]')).resolves.toBe(true);
+
+        const getScrollPosition = () => page.getBoundingBox('[data-testid="drawer-sticky-header"]');
+        const scrollBefore = await getScrollPosition();
+
+        await page.elementScrollTo(wrapper.findActiveDrawer().toSelector(), { top: 100 });
+        await expect(getScrollPosition()).resolves.toEqual(scrollBefore);
+        await expect(page.isDisplayed('[data-testid="drawer-sticky-header"]')).resolves.toBe(true);
       })
     );
   });
@@ -90,13 +108,11 @@ describe('Visual refresh toolbar only', () => {
       const page = new PageObject(browser);
 
       await browser.url(
-        `#/light/app-layout/runtime-drawers?${new URLSearchParams({
+        `#/light/app-layout/runtime-drawers?${getUrlParams('refresh-toolbar', {
           hasDrawers: 'false',
           hasTools: 'true',
           splitPanelPosition: 'side',
-          visualRefresh: 'true',
-          appLayoutToolbar: 'true',
-        }).toString()}`
+        })}`
       );
       await page.waitForVisible(wrapper.findDrawerTriggerById('security').toSelector(), true);
       await testFn(page);
@@ -243,4 +259,23 @@ describe('Visual refresh toolbar only', () => {
       })
     );
   }
+
+  test(
+    'should show sticky elements on scroll in custom global drawer',
+    setupTest(async page => {
+      await page.setWindowSize(viewports.desktop);
+      await expect(page.isDisplayed('[data-testid="drawer-sticky-footer"]')).resolves.toBe(false);
+
+      await page.click(createWrapper().findButton('[data-testid="open-drawer-button"]').toSelector());
+      await page.waitForVisible(findDrawerById(wrapper, 'circle4-global')!.toSelector(), true);
+      await expect(page.isDisplayed('[data-testid="drawer-sticky-footer"]')).resolves.toBe(true);
+
+      const getScrollPosition = () => page.getBoundingBox('[data-testid="drawer-sticky-header"]');
+      const scrollBefore = await getScrollPosition();
+
+      await page.elementScrollTo(wrapper.findActiveDrawer().toSelector(), { top: 100 });
+      await expect(getScrollPosition()).resolves.toEqual(scrollBefore);
+      await expect(page.isDisplayed('[data-testid="drawer-sticky-header"]')).resolves.toBe(true);
+    })
+  );
 });

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -123,7 +123,7 @@ export const Drawer = React.forwardRef(
             aria-label={mainLabel}
             aria-hidden={!isOpen}
             style={{
-              ['blockSize']: `calc(100vh - ${(topOffset || 0) + (bottomOffset || 0)}px)`,
+              blockSize: `calc(100vh - ${(topOffset || 0) + (bottomOffset || 0)}px)`,
             }}
           >
             {!isMobile && isOpen && <div className={styles['resize-handle-wrapper']}>{resizeHandle}</div>}

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -119,9 +119,12 @@ export const Drawer = React.forwardRef(
         >
           {!isMobile && !hideOpenButton && regularOpenButton}
           <TagName
-            className={clsx(resizeHandle && styles['drawer-resize-content'])}
+            className={clsx(resizeHandle && styles['drawer-resize-content'], styles['drawer-content-wrapper'])}
             aria-label={mainLabel}
             aria-hidden={!isOpen}
+            style={{
+              ['blockSize']: `calc(100vh - ${(topOffset || 0) + (bottomOffset || 0)}px)`,
+            }}
           >
             {!isMobile && isOpen && <div className={styles['resize-handle-wrapper']}>{resizeHandle}</div>}
             <CloseButton

--- a/src/app-layout/drawer/styles.scss
+++ b/src/app-layout/drawer/styles.scss
@@ -36,6 +36,8 @@
   position: fixed;
   overflow: auto;
   background-color: awsui.$color-background-layout-panel-content;
+  display: flex;
+  flex-direction: column;
   .drawer-mobile > & {
     z-index: constants.$drawer-z-index-mobile;
     inset: 0;
@@ -58,8 +60,8 @@
     block-size: 100%;
     position: relative;
   }
-  > .drawer-content-wrapper[aria-hidden='false'] {
-    display: contents;
+  > .drawer-content-wrapper {
+    flex: 1;
   }
 }
 

--- a/src/app-layout/drawer/styles.scss
+++ b/src/app-layout/drawer/styles.scss
@@ -58,6 +58,9 @@
     block-size: 100%;
     position: relative;
   }
+  > .drawer-content-wrapper[aria-hidden='false'] {
+    display: contents;
+  }
 }
 
 .drawer-triggers-wrapper {

--- a/src/app-layout/visual-refresh-toolbar/compute-layout.ts
+++ b/src/app-layout/visual-refresh-toolbar/compute-layout.ts
@@ -110,10 +110,15 @@ export function computeVerticalLayout({
   return { toolbar, notifications, header, drawers };
 }
 
-export function getDrawerTopOffset(
+export function getDrawerStyles(
   verticalOffsets: VerticalLayoutOutput,
   isMobile: boolean,
   placement: AppLayoutPropsWithDefaults['placement']
-) {
-  return isMobile ? verticalOffsets.toolbar : verticalOffsets.drawers ?? placement.insetBlockStart;
+): {
+  drawerTopOffset: number;
+  drawerHeight: string;
+} {
+  const drawerTopOffset = isMobile ? verticalOffsets.toolbar : verticalOffsets.drawers ?? placement.insetBlockStart;
+  const drawerHeight = `calc(100vh - ${drawerTopOffset}px - ${placement.insetBlockEnd}px)`;
+  return { drawerTopOffset, drawerHeight };
 }

--- a/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
@@ -10,7 +10,7 @@ import { NonCancelableEventHandler } from '../../../internal/events';
 import customCssProps from '../../../internal/generated/custom-css-properties';
 import { getLimitedValue } from '../../../split-panel/utils/size-utils';
 import { AppLayoutProps } from '../../interfaces';
-import { getDrawerTopOffset } from '../compute-layout';
+import { getDrawerStyles } from '../compute-layout';
 import { AppLayoutInternals } from '../interfaces';
 import { useResize } from './use-resize';
 
@@ -52,7 +52,7 @@ function AppLayoutGlobalDrawerImplementation({
     content: activeGlobalDrawer ? activeGlobalDrawer.ariaLabels?.drawerName : ariaLabels?.tools,
   };
 
-  const drawersTopOffset = getDrawerTopOffset(verticalOffsets, isMobile, placement);
+  const { drawerTopOffset, drawerHeight } = getDrawerStyles(verticalOffsets, isMobile, placement);
   const activeDrawerSize = (activeDrawerId ? activeGlobalDrawersSizes[activeDrawerId] : 0) ?? 0;
   const minDrawerSize = (activeDrawerId ? minGlobalDrawersSizes[activeDrawerId] : 0) ?? 0;
   const maxDrawerSize = (activeDrawerId ? maxGlobalDrawersSizes[activeDrawerId] : 0) ?? 0;
@@ -104,8 +104,8 @@ function AppLayoutGlobalDrawerImplementation({
               }
             }}
             style={{
-              blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)`,
-              insetBlockStart: drawersTopOffset,
+              blockSize: drawerHeight,
+              insetBlockStart: drawerTopOffset,
               ...(!isMobile && {
                 [customCssProps.drawerSize]: `${['entering', 'entered'].includes(state) ? size : 0}px`,
               }),
@@ -142,7 +142,9 @@ function AppLayoutGlobalDrawerImplementation({
                   variant="icon"
                 />
               </div>
-              <div className={styles['drawer-content']}>{activeGlobalDrawer?.content}</div>
+              <div className={styles['drawer-content']} style={{ blockSize: drawerHeight }}>
+                {activeGlobalDrawer?.content}
+              </div>
             </div>
           </aside>
         );

--- a/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
@@ -10,7 +10,7 @@ import customCssProps from '../../../internal/generated/custom-css-properties';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { getLimitedValue } from '../../../split-panel/utils/size-utils';
 import { TOOLS_DRAWER_ID } from '../../utils/use-drawers';
-import { getDrawerTopOffset } from '../compute-layout';
+import { getDrawerStyles } from '../compute-layout';
 import { AppLayoutInternals } from '../interfaces';
 import { useResize } from './use-resize';
 
@@ -46,7 +46,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
     content: activeDrawer ? activeDrawer.ariaLabels?.drawerName : ariaLabels?.tools,
   };
 
-  const drawersTopOffset = getDrawerTopOffset(verticalOffsets, isMobile, placement);
+  const { drawerTopOffset, drawerHeight } = getDrawerStyles(verticalOffsets, isMobile, placement);
   const toolsOnlyMode = drawers.length === 1 && drawers[0].id === TOOLS_DRAWER_ID;
   const isToolsDrawer = activeDrawer?.id === TOOLS_DRAWER_ID || toolsOnlyMode;
   const toolsContent = drawers?.find(drawer => drawer.id === TOOLS_DRAWER_ID)?.content;
@@ -85,8 +85,8 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
             }
           }}
           style={{
-            blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)`,
-            insetBlockStart: drawersTopOffset,
+            blockSize: drawerHeight,
+            insetBlockStart: drawerTopOffset,
             ...(!isMobile &&
               !isLegacyDrawer && {
                 [customCssProps.drawerSize]: `${['entering', 'entered'].includes(state) ? size : 0}px`,
@@ -127,11 +127,14 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
                 styles['drawer-content'],
                 activeDrawerId !== TOOLS_DRAWER_ID && styles['drawer-content-hidden']
               )}
+              style={{ blockSize: drawerHeight }}
             >
               {toolsContent}
             </div>
             {activeDrawerId !== TOOLS_DRAWER_ID && (
-              <div className={styles['drawer-content']}>{activeDrawer?.content}</div>
+              <div className={styles['drawer-content']} style={{ blockSize: drawerHeight }}>
+                {activeDrawer?.content}
+              </div>
             )}
           </div>
         </aside>

--- a/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
@@ -62,7 +62,7 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
         insetBlockStart: drawerTopOffset,
       }}
     >
-      <div className={clsx(styles['content-container'], styles['animated-content'])}>
+      <div className={styles['animated-content']}>
         <div className={clsx(styles['hide-navigation'])}>
           <InternalButton
             ariaLabel={ariaLabels?.navigationClose ?? undefined}

--- a/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
@@ -62,7 +62,7 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
         insetBlockStart: drawerTopOffset,
       }}
     >
-      <div className={styles['animated-content']}>
+      <div className={clsx(styles['content-container'], styles['animated-content'])}>
         <div className={clsx(styles['hide-navigation'])}>
           <InternalButton
             ariaLabel={ariaLabels?.navigationClose ?? undefined}

--- a/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
@@ -7,7 +7,7 @@ import { findUpUntil } from '@cloudscape-design/component-toolkit/dom';
 
 import { InternalButton } from '../../../button/internal';
 import { createWidgetizedComponent } from '../../../internal/widgets';
-import { getDrawerTopOffset } from '../compute-layout';
+import { getDrawerStyles } from '../compute-layout';
 import { AppLayoutInternals } from '../interfaces';
 
 import sharedStyles from '../../resize/styles.css.js';
@@ -30,7 +30,7 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
     verticalOffsets,
   } = appLayoutInternals;
 
-  const drawersTopOffset = getDrawerTopOffset(verticalOffsets, isMobile, placement);
+  const { drawerTopOffset, drawerHeight } = getDrawerStyles(verticalOffsets, isMobile, placement);
 
   // Close the Navigation drawer on mobile when a user clicks a link inside.
   const onNavigationClick = (event: React.MouseEvent) => {
@@ -58,11 +58,11 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
       aria-hidden={!navigationOpen}
       onClick={onNavigationClick}
       style={{
-        blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)`,
-        insetBlockStart: drawersTopOffset,
+        blockSize: drawerHeight,
+        insetBlockStart: drawerTopOffset,
       }}
     >
-      <div className={clsx(styles['animated-content'])}>
+      <div className={clsx(styles['content-container'], styles['animated-content'])}>
         <div className={clsx(styles['hide-navigation'])}>
           <InternalButton
             ariaLabel={ariaLabels?.navigationClose ?? undefined}

--- a/src/app-layout/visual-refresh-toolbar/navigation/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/navigation/styles.scss
@@ -28,6 +28,10 @@
     display: none;
   }
 
+  &.is-navigation-open > .content-container {
+    display: contents;
+  }
+
   /*
   A non-semantic node is added with a fixed width equal to the final Navigation
   width. This will create the visual appearance of horizontal movement and

--- a/src/app-layout/visual-refresh-toolbar/navigation/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/navigation/styles.scss
@@ -20,16 +20,13 @@
   overscroll-behavior-y: contain;
   word-wrap: break-word;
   pointer-events: auto;
+  display: flex;
 
   // All content is hidden by the overflow-x property
   &:not(.is-navigation-open) {
     inline-size: 0px;
     // We need to hide the closed panel to make containing focusable elements not focusable anymore.
     display: none;
-  }
-
-  &.is-navigation-open > .content-container {
-    display: contents;
   }
 
   /*

--- a/src/app-layout/visual-refresh-toolbar/navigation/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/navigation/styles.scss
@@ -21,12 +21,17 @@
   word-wrap: break-word;
   pointer-events: auto;
   display: flex;
+  flex-direction: column;
 
   // All content is hidden by the overflow-x property
   &:not(.is-navigation-open) {
     inline-size: 0px;
     // We need to hide the closed panel to make containing focusable elements not focusable anymore.
     display: none;
+  }
+
+  & > .content-container {
+    flex-grow: 1;
   }
 
   /*

--- a/src/app-layout/visual-refresh-toolbar/split-panel/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/split-panel/index.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { SplitPanelProvider, SplitPanelProviderProps } from '../../split-panel';
+import { getDrawerStyles } from '../compute-layout';
 import { AppLayoutInternals } from '../interfaces';
 
 import styles from './styles.css.js';
@@ -19,15 +20,16 @@ export function AppLayoutSplitPanelDrawerSideImplementation({
   appLayoutInternals,
   splitPanelInternals,
 }: AppLayoutSplitPanelDrawerSideImplementationProps) {
-  const { splitPanelControlId, placement, verticalOffsets } = appLayoutInternals;
-  const drawerTopOffset = verticalOffsets.drawers ?? placement.insetBlockStart;
+  const { splitPanelControlId, placement, verticalOffsets, isMobile } = appLayoutInternals;
+  const { drawerTopOffset, drawerHeight } = getDrawerStyles(verticalOffsets, isMobile, placement);
+
   return (
     <SplitPanelProvider {...splitPanelInternals}>
       <section
         id={splitPanelControlId}
         className={styles['split-panel-side']}
         style={{
-          blockSize: `calc(100vh - ${drawerTopOffset}px - ${placement.insetBlockEnd}px)`,
+          blockSize: drawerHeight,
           insetBlockStart: drawerTopOffset,
         }}
       >

--- a/src/app-layout/visual-refresh/drawers.scss
+++ b/src/app-layout/visual-refresh/drawers.scss
@@ -142,6 +142,7 @@
 
     > .drawer-content {
       grid-column: 1 / span 4;
+      block-size: var(#{custom-props.$contentHeight});
       &.drawer-content-hidden {
         display: none;
       }

--- a/src/app-layout/visual-refresh/navigation.scss
+++ b/src/app-layout/visual-refresh/navigation.scss
@@ -93,6 +93,7 @@ nav.navigation {
   word-wrap: break-word;
   pointer-events: auto;
   border-inline-end: solid awsui.$border-divider-section-width awsui.$color-border-divider-default;
+  display: flex;
 
   // Animation for the Navigation opacity and width when it is added to the DOM
   @keyframes openNavigation {

--- a/src/app-layout/visual-refresh/navigation.scss
+++ b/src/app-layout/visual-refresh/navigation.scss
@@ -94,6 +94,7 @@ nav.navigation {
   pointer-events: auto;
   border-inline-end: solid awsui.$border-divider-section-width awsui.$color-border-divider-default;
   display: flex;
+  flex-direction: column;
 
   // Animation for the Navigation opacity and width when it is added to the DOM
   @keyframes openNavigation {
@@ -131,6 +132,10 @@ nav.navigation {
   */
   > .animated-content {
     inline-size: var(#{custom-props.$navigationWidth});
+  }
+
+  & > .content-container {
+    flex-grow: 1;
   }
 
   // The Navigation drawer will take up the entire viewport on mobile

--- a/src/app-layout/visual-refresh/navigation.tsx
+++ b/src/app-layout/visual-refresh/navigation.tsx
@@ -100,7 +100,7 @@ export default function Navigation() {
               onNavigationClick && onNavigationClick(event);
             }}
           >
-            <div className={styles['animated-content']}>
+            <div className={clsx(styles['content-container'], styles['animated-content'])}>
               <div className={styles['hide-navigation']}>
                 <InternalButton
                   ariaLabel={ariaLabels?.navigationClose ?? undefined}


### PR DESCRIPTION
### Description

This is a follow up from https://github.com/cloudscape-design/components/pull/2924 that addresses double scrollbar issue in Q chat panel (AWSUI-59823).
It also addresses an issue in Firefox where side nav would have a scrollbar when there was no side nav header present, the original reason for revert. The other issue regarding flashing scrollbar has been extracted from this PR.

Related links, issue #, if available: AWSUI-59823, TT: V1549419424, TT: D169004346, 

### How has this been tested?
Related screenshot tests added in CR-158701022
Ran through dev pipeline screenshot approvals: 
- 1st: 833b9bfc-f87e-462e-b8e9-3d6f48d73c2a
- 2nd: 42b2f287-623e-4d54-ba8d-29edf66bea4d

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
