### PR TITLE
fix: Scroll inside global drawers

### DIFF
--- a/pages/app-layout/utils/external-widget.tsx
+++ b/pages/app-layout/utils/external-widget.tsx
@@ -157,6 +157,10 @@ awsuiPlugins.appLayout.registerDrawer({
     ReactDOM.render(
       <AutoIncrementCounter onVisibilityChange={mountContext?.onVisibilityChange}>
         global widget content circle 1
+        {new Array(100).fill(null).map((_, index) => (
+          <div key={index}>{index}</div>
+        ))}
+        <div data-testid="circle-global-bottom-content">circle-global bottom content</div>
       </AutoIncrementCounter>,
       container
     );

--- a/src/app-layout/__integ__/runtime-drawers.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers.test.ts
@@ -10,6 +10,9 @@ const wrapper = createWrapper().findAppLayout();
 const findDrawerById = (wrapper: AppLayoutWrapper, id: string) => {
   return wrapper.find(`[data-testid="awsui-app-layout-drawer-${id}"]`);
 };
+const findDrawerContentById = (wrapper: AppLayoutWrapper, id: string) => {
+  return wrapper.find(`[data-testid="awsui-app-layout-drawer-content-${id}"]`);
+};
 
 describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme => {
   function setupTest(testFn: (page: BasePageObject) => Promise<void>) {
@@ -219,6 +222,27 @@ describe('Visual refresh toolbar only', () => {
       await expect(page.isClickable(findDrawerById(wrapper, 'circle2-global')!.toSelector())).resolves.toBe(true);
       await expect(page.isClickable(findDrawerById(wrapper, 'circle3-global')!.toSelector())).resolves.toBe(true);
       await expect(page.hasHorizontalScroll()).resolves.toBe(false);
+    })
+  );
+
+  test(
+    'the content inside drawers should be scrollable',
+    setupTest(async page => {
+      await page.click(wrapper.findDrawerTriggerById('circle-global').toSelector());
+      await expect(page.isClickable(findDrawerById(wrapper, 'circle-global')!.toSelector())).resolves.toBe(true);
+      await expect(
+        page.isDisplayedInViewport(wrapper.find('[data-testid="circle-global-bottom-content"]')!.toSelector())
+      ).resolves.toBe(false);
+      await page.elementScrollTo(findDrawerContentById(wrapper, 'circle-global').toSelector(), { top: 2000 });
+      await expect(
+        page.isDisplayedInViewport(wrapper.find('[data-testid="circle-global-bottom-content"]')!.toSelector())
+      ).resolves.toBe(true);
+
+      await page.setWindowSize(viewports.mobile);
+
+      await expect(
+        page.isDisplayedInViewport(wrapper.find('[data-testid="circle-global-bottom-content"]')!.toSelector())
+      ).resolves.toBe(true);
     })
   );
 });

--- a/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
@@ -125,7 +125,10 @@ function AppLayoutGlobalDrawerImplementation({
                 />
               </div>
             )}
-            <div className={clsx(styles['drawer-content-container'], sharedStyles['with-motion-horizontal'])}>
+            <div
+              className={clsx(styles['drawer-content-container'], sharedStyles['with-motion-horizontal'])}
+              data-testid={`awsui-app-layout-drawer-content-${activeDrawerId}`}
+            >
               <div className={clsx(styles['drawer-close-button'])}>
                 <InternalButton
                   ariaLabel={computedAriaLabels.closeButton}

--- a/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
@@ -52,7 +52,7 @@
       display: none;
 
       &.last-opened {
-        display: block;
+        display: grid;
       }
     }
   }

--- a/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
@@ -49,10 +49,8 @@
 
   &.drawer-global {
     @include mobile-only {
-      display: none;
-
-      &.last-opened {
-        display: grid;
+      &:not(.last-opened) {
+        display: none;
       }
     }
   }


### PR DESCRIPTION
### Description

This PR resolves an issue with global drawer content not scrolling when it exceeds the drawer container height and should be scrollable by user

https://github.com/user-attachments/assets/5866df39-7d8a-49c1-bc47-0866bf0f0019

 action. 

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
