### PR TITLE
fix: Toolbar close button height extending full height of page

### DIFF
--- a/pages/app-layout/utils/drawers.tsx
+++ b/pages/app-layout/utils/drawers.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import { AppLayoutProps, Drawer, SpaceBetween } from '~components';
+import { AppLayoutProps, Box, Drawer, SpaceBetween } from '~components';
 
 import { drawerIds } from './drawer-ids';
 
@@ -24,6 +24,9 @@ function Security() {
         <div className={styles.contentPlaceholder} />
         <div className={styles.contentPlaceholder} />
         <div className={styles.contentPlaceholder} />
+        <Box float="right">
+          <button data-testid="drawer-button">🦆</button>
+        </Box>
       </SpaceBetween>
     </Drawer>
   );

--- a/src/app-layout/__integ__/app-layout-drawers.test.ts
+++ b/src/app-layout/__integ__/app-layout-drawers.test.ts
@@ -247,6 +247,16 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
       })
     );
 
+    test(
+      'close button does not overlap drawer content',
+      setupTest({ theme }, async page => {
+        await page.openFirstDrawer();
+        await expect(
+          page.isClickable(wrapper.findActiveDrawer().find('[data-testid=drawer-button]').toSelector())
+        ).resolves.toBe(true);
+      })
+    );
+
     testIf(theme === 'classic')(
       'pushes content over with disableContentPaddings',
       setupTest({ disableContentPaddings: 'true', theme }, async page => {

--- a/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
@@ -71,6 +71,7 @@
       grid-column: 3;
       grid-row: 2;
       z-index: 1;
+      align-self: start;
     }
 
     > .drawer-content {


### PR DESCRIPTION
### Description

Current styling stretches this elements vertical height to fill the page height. Given its z-index it can block elements below.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
