### PR TITLE
test: Separate mobile and desktop tests for recent scroll fix

### DIFF
--- a/src/app-layout/__integ__/runtime-drawers.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers.test.ts
@@ -225,24 +225,22 @@ describe('Visual refresh toolbar only', () => {
     })
   );
 
-  test(
-    'the content inside drawers should be scrollable',
-    setupTest(async page => {
-      await page.click(wrapper.findDrawerTriggerById('circle-global').toSelector());
-      await expect(page.isClickable(findDrawerById(wrapper, 'circle-global')!.toSelector())).resolves.toBe(true);
-      await expect(
-        page.isDisplayedInViewport(wrapper.find('[data-testid="circle-global-bottom-content"]')!.toSelector())
-      ).resolves.toBe(false);
-      await page.elementScrollTo(findDrawerContentById(wrapper, 'circle-global').toSelector(), { top: 2000 });
-      await expect(
-        page.isDisplayedInViewport(wrapper.find('[data-testid="circle-global-bottom-content"]')!.toSelector())
-      ).resolves.toBe(true);
-
-      await page.setWindowSize(viewports.mobile);
-
-      await expect(
-        page.isDisplayedInViewport(wrapper.find('[data-testid="circle-global-bottom-content"]')!.toSelector())
-      ).resolves.toBe(true);
-    })
-  );
+  for (const viewport of ['mobile', 'desktop']) {
+    test(
+      `the content inside drawers should be scrollable on ${viewport} view`,
+      setupTest(async page => {
+        await page.click(wrapper.findDrawerTriggerById('circle-global').toSelector());
+        if (viewport === 'mobile') {
+          await page.setWindowSize(viewports.mobile);
+        }
+        await expect(
+          page.isDisplayedInViewport(wrapper.find('[data-testid="circle-global-bottom-content"]')!.toSelector())
+        ).resolves.toBe(false);
+        await page.elementScrollTo(findDrawerContentById(wrapper, 'circle-global').toSelector(), { top: 2000 });
+        await expect(
+          page.isDisplayedInViewport(wrapper.find('[data-testid="circle-global-bottom-content"]')!.toSelector())
+        ).resolves.toBe(true);
+      })
+    );
+  }
 });


### PR DESCRIPTION
### Description

For more reliable test coverage, this separates mobile and desktop scroll tests for #2987 fix.

Related links, issue #, if available: n/a

### How has this been tested?

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
