### PR TITLE
chore: U test for checking overridden classes

### DIFF
--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -713,6 +713,24 @@ describeEachAppLayout(({ theme, size }) => {
 
 describe('toolbar mode only features', () => {
   describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () => {
+    test('should contain overridden in AWS-UI-Widget-Global-Navigation css classes for drawers', async () => {
+      const { wrapper } = await renderComponent(<AppLayout drawers={[testDrawer]} />);
+
+      awsuiPlugins.appLayout.registerDrawer({
+        ...drawerDefaults,
+        id: 'global-drawer',
+        type: 'global',
+        mountContent: container => (container.textContent = 'global drawer content 1'),
+      });
+
+      await delay();
+
+      wrapper.findDrawerTriggerById('global-drawer')!.click();
+
+      expect(wrapper!.find('[class*="awsui_drawer-close-button"]')).toBeTruthy();
+      expect(wrapper!.find('[class*="awsui_drawer-global"][class*="awsui_last-opened"]')).toBeTruthy();
+    });
+
     test('registerDrawer registers local drawers if type is not specified', async () => {
       awsuiPlugins.appLayout.registerDrawer({
         ...drawerDefaults,

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -727,8 +727,8 @@ describe('toolbar mode only features', () => {
 
       wrapper.findDrawerTriggerById('global-drawer')!.click();
 
-      expect(wrapper!.find('[class*="awsui_drawer-close-button"]')).toBeTruthy();
-      expect(wrapper!.find('[class*="awsui_drawer-global"][class*="awsui_last-opened"]')).toBeTruthy();
+      expect(wrapper!.find('[class*="awsui_drawer-close-button_12i0j"]')).toBeTruthy();
+      expect(wrapper!.find('[class*="awsui_drawer-global_12i0j"][class*="awsui_last-opened_12i0j"]')).toBeTruthy();
     });
 
     test('registerDrawer registers local drawers if type is not specified', async () => {


### PR DESCRIPTION
### Description

This PR adds a unit test for global drawers to ensure that classes overridden in another package remain as is. The goal of this test is to avoid any unnoticed modifications to these classes.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
