### PR TITLE
chore: Do not focus Wizard header on initial render

### DIFF
--- a/src/wizard/__integ__/wizard.test.ts
+++ b/src/wizard/__integ__/wizard.test.ts
@@ -35,6 +35,8 @@ describe('Wizard keyboard navigation', () => {
   test(
     'navigate to the first step from menu navigation link using the Enter key',
     setupTest(async page => {
+      // Initial render should not focus the header
+      await expect(page.getFocusedElementText()).resolves.not.toBe('Step 1');
       await page.clickPrimaryButton();
       await page.resetFocus();
       await page.keys(['Tab', 'Enter']);


### PR DESCRIPTION
### Description

As the focus is there to alert users of content change, focusing the header on the first render is not necessary. This change will only attempt to focus on the header on subsequent active index changes within the wizard.

Related links, issue #, if available: AWSUI-59850

### How has this been tested?

- Added additional integ test.

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
