### PR TITLE
chore: Add size-limit check for app layout widget entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,17 @@
     {
       "path": "lib/components/internal/plugins/index.js",
       "limit": "2.5 kB"
+    },
+    {
+      "path": [
+        "lib/components/app-layout/visual-refresh-toolbar/exports.js",
+        "lib/components/split-panel/implementation.js",
+        "lib/components/breadcrumb-group/implementation.js",
+        "lib/components/drawer/implementation.js",
+        "lib/components/side-navigation/implementation.js",
+        "lib/components/help-panel/implementation.js"
+      ],
+      "limit": "140 kB"
     }
   ],
   "browserslist": [


### PR DESCRIPTION
### Description

Make the build fail, if assets to bundle in app layout widget grow too high

Related links, issue #, if available: n/a

### How has this been tested?

PR build passes

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
