### PR TITLE
fix: Tolerates numeric token values in default forms

### DIFF
--- a/src/property-filter/__tests__/property-filter-token-editor.test.tsx
+++ b/src/property-filter/__tests__/property-filter-token-editor.test.tsx
@@ -61,6 +61,7 @@ const filteringOptions: readonly FilteringOption[] = [
   { propertyKey: 'string', value: 'value1' },
   { propertyKey: 'other-string', value: 'value1' },
   { propertyKey: 'string', value: 'value2' },
+  { propertyKey: 'string', value: '3', label: 'value3' },
   { propertyKey: 'range', value: '1' },
   { propertyKey: 'range', value: '2' },
   { propertyKey: 'other-string', value: 'value2' },
@@ -170,7 +171,7 @@ describe.each([false, true])('token editor, expandToViewport=%s', expandToViewpo
           .findDropdown()
           .findOptions()!
           .map(optionWrapper => optionWrapper.getElement().textContent)
-      ).toEqual(['value1', 'value2']);
+      ).toEqual(['value1', 'value2', 'value3']);
     });
 
     test('with free text disabled', () => {
@@ -884,10 +885,11 @@ describe('token editor with groups', () => {
   });
 });
 
-test.each([0, 1.11])('tolerates numeric token values, value=%s', value => {
+test.each([0, 1.11, 3])('tolerates numeric token values, value=%s', value => {
+  const expectedValue = value === 3 ? 'value3' : value + '';
   renderComponent({
     query: { tokens: [{ propertyKey: 'string', operator: '=', value }], operation: 'or' },
   });
   const editor = openEditor(0, { expandToViewport: false });
-  expect(editor.valueAutosuggest().findNativeInput().getElement()).toHaveAttribute('value', value + '');
+  expect(editor.valueAutosuggest().findNativeInput().getElement()).toHaveAttribute('value', expectedValue);
 });

--- a/src/property-filter/__tests__/property-filter-token-editor.test.tsx
+++ b/src/property-filter/__tests__/property-filter-token-editor.test.tsx
@@ -883,3 +883,11 @@ describe('token editor with groups', () => {
     );
   });
 });
+
+test.each([0, 1.11])('tolerates numeric token values, value=%s', value => {
+  renderComponent({
+    query: { tokens: [{ propertyKey: 'string', operator: '=', value }], operation: 'or' },
+  });
+  const editor = openEditor(0, { expandToViewport: false });
+  expect(editor.valueAutosuggest().findNativeInput().getElement()).toHaveAttribute('value', value + '');
+});

--- a/src/property-filter/token-editor-inputs.tsx
+++ b/src/property-filter/token-editor-inputs.tsx
@@ -171,7 +171,7 @@ function ValueInputAuto({
   return (
     <InternalAutosuggest
       enteredTextLabel={i18nStrings.enteredTextLabel}
-      value={matchedOption?.label ?? value ?? ''}
+      value={matchedOption?.label ?? (value ?? '') + ''}
       clearAriaLabel={i18nStrings.clearAriaLabel}
       onChange={e => onChangeValue(e.detail.value)}
       disabled={!operator}

--- a/src/property-filter/token-editor-inputs.tsx
+++ b/src/property-filter/token-editor-inputs.tsx
@@ -148,21 +148,21 @@ export function ValueInput(props: ValueInputProps) {
 function ValueInputAuto({
   property,
   operator,
-  value,
+  value: unknownValue,
   onChangeValue,
   asyncProps,
   filteringOptions,
   onLoadItems,
   i18nStrings,
 }: ValueInputProps) {
+  const value = (unknownValue ?? '') + '';
   const valueOptions = property
     ? filteringOptions
         .filter(option => option.property?.propertyKey === property.propertyKey)
         .map(({ label, value }) => ({ label, value }))
     : [];
 
-  const valueFilter = typeof value === 'string' ? value : '';
-  const valueAutosuggestHandlers = useLoadItems(onLoadItems, '', property?.externalProperty, valueFilter, operator);
+  const valueAutosuggestHandlers = useLoadItems(onLoadItems, '', property?.externalProperty, value, operator);
   const asyncValueAutosuggestProps = property?.propertyKey
     ? { ...valueAutosuggestHandlers, ...asyncProps }
     : { empty: asyncProps.empty };

--- a/src/property-filter/token-editor-inputs.tsx
+++ b/src/property-filter/token-editor-inputs.tsx
@@ -171,7 +171,7 @@ function ValueInputAuto({
   return (
     <InternalAutosuggest
       enteredTextLabel={i18nStrings.enteredTextLabel}
-      value={matchedOption?.label ?? (value ?? '') + ''}
+      value={matchedOption?.label ?? value}
       clearAriaLabel={i18nStrings.clearAriaLabel}
       onChange={e => onChangeValue(e.detail.value)}
       disabled={!operator}


### PR DESCRIPTION
### Description

The PR addresses `.toLowerCase() is not a function` error thrown from the token editor in case token value is numeric (possible when a query is created programmatically).

Rel: AWSUI-59929

### How has this been tested?

* New unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
