### PR TITLE
chore: Update modal performance data to include modal header

### DIFF
--- a/src/modal/__integ__/modal.test.ts
+++ b/src/modal/__integ__/modal.test.ts
@@ -139,6 +139,7 @@ test(
 
     metrics = await getModalPerformanceMetrics();
     expect(metrics[0].instanceIdentifier).not.toBeNull();
+    expect(metrics[0].componentIdentifier).not.toBeNull();
     expect(metrics[0].timeToContentReadyInModal).not.toBeNull();
   })
 );
@@ -166,6 +167,7 @@ test(
 
     const metrics = await getModalPerformanceMetrics();
     expect(metrics[0].instanceIdentifier).not.toBeNull();
+    expect(metrics[0].componentIdentifier).not.toBeNull();
     expect(metrics[0].timeToContentReadyInModal).toBe(0);
   })
 );
@@ -189,6 +191,7 @@ test(
     let metrics = await getModalPerformanceMetrics();
     expect(metrics[0].instanceIdentifier).not.toBeNull();
     expect(metrics[0].timeToContentReadyInModal).not.toBeNull();
+    expect(metrics[0].componentIdentifier).not.toBeNull();
 
     //reload the components
     await page.click(buttonLoadingCheckBox);

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -156,6 +156,7 @@ function PortaledModal({
       PerformanceMetrics.modalPerformanceData({
         timeToContentReadyInModal,
         instanceIdentifier: instanceUniqueId,
+        componentIdentifier: headerRef.current?.innerHTML,
       });
       performanceMetricLogged.current = true;
     }
@@ -215,6 +216,7 @@ function PortaledModal({
   // Add extra scroll padding to account for the height of the sticky footer,
   // to prevent it from covering focused elements.
   const [footerHeight, footerRef] = useContainerQuery(rect => rect.borderBoxHeight);
+  const headerRef = useRef<HTMLDivElement>(null);
   const { subStepRef } = useFunnelSubStep();
 
   return (
@@ -279,7 +281,7 @@ function PortaledModal({
                         </div>
                       }
                     >
-                      <span id={headerId} className={styles['header--text']}>
+                      <span ref={headerRef} id={headerId} className={styles['header--text']}>
                         {header}
                       </span>
                     </InternalHeader>

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -153,10 +153,11 @@ function PortaledModal({
       !performanceMetricLogged.current
     ) {
       const timeToContentReadyInModal = loadCompleteTime - loadStartTime.current;
+      console.log('componentIdentifier', headerRef.current?.textContent);
       PerformanceMetrics.modalPerformanceData({
         timeToContentReadyInModal,
         instanceIdentifier: instanceUniqueId,
-        componentIdentifier: headerRef.current?.innerHTML,
+        componentIdentifier: headerRef.current?.textContent || '',
       });
       performanceMetricLogged.current = true;
     }

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -153,7 +153,6 @@ function PortaledModal({
       !performanceMetricLogged.current
     ) {
       const timeToContentReadyInModal = loadCompleteTime - loadStartTime.current;
-      console.log('componentIdentifier', headerRef.current?.textContent);
       PerformanceMetrics.modalPerformanceData({
         timeToContentReadyInModal,
         instanceIdentifier: instanceUniqueId,


### PR DESCRIPTION
Description
The change involves adding modal header text as Component identifier to modal metric - timeToContentReadyInModal when a modal is loaded.

Related links, issue #, if available: n/a

Related links, issue #, if available: n/a

How has this been tested?
manually tested the change
integration test updated to verify component header text.

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_ existing 
- _Changes are covered with new/existing integration tests?_ updated integration tests
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
