### PR TITLE
fix: Render drawers bar if only global drawers are present

### DIFF
--- a/pages/app-layout/runtime-drawers-with-only-global.page.tsx
+++ b/pages/app-layout/runtime-drawers-with-only-global.page.tsx
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import ReactDOM, { unmountComponentAtNode } from 'react-dom';
+
+import { AppLayout } from '~components';
+import awsuiPlugins from '~components/internal/plugins';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+awsuiPlugins.appLayout.registerDrawer({
+  id: 'circle-global',
+  type: 'global',
+  defaultActive: false,
+  resizable: true,
+  defaultSize: 350,
+  preserveInactiveContent: true,
+
+  ariaLabels: {
+    closeButton: 'Close button',
+    content: 'Content',
+    triggerButton: 'Trigger button',
+    resizeHandle: 'Resize handle',
+  },
+
+  trigger: {
+    iconSvg: `<svg viewBox="0 0 16 16" focusable="false">
+      <circle stroke-width="2" stroke="currentColor" fill="none" cx="8" cy="8" r="7" />
+      <circle stroke-width="2" stroke="currentColor" fill="none" cx="8" cy="8" r="3" />
+    </svg>`,
+  },
+
+  onResize: event => {
+    console.log('resize', event.detail);
+  },
+
+  mountContent: container => {
+    ReactDOM.render(<div data-testid="circle-global-bottom-content">circle-global bottom content</div>, container);
+  },
+  unmountContent: container => unmountComponentAtNode(container),
+});
+
+export default function WithDrawersGlobalOnly() {
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout toolsHide={true} />
+    </ScreenshotArea>
+  );
+}

--- a/pages/app-layout/runtime-drawers-with-only-global.page.tsx
+++ b/pages/app-layout/runtime-drawers-with-only-global.page.tsx
@@ -7,6 +7,7 @@ import { AppLayout } from '~components';
 import awsuiPlugins from '~components/internal/plugins';
 
 import ScreenshotArea from '../utils/screenshot-area';
+import labels from './utils/labels';
 
 awsuiPlugins.appLayout.registerDrawer({
   id: 'circle-global',
@@ -43,7 +44,15 @@ awsuiPlugins.appLayout.registerDrawer({
 export default function WithDrawersGlobalOnly() {
   return (
     <ScreenshotArea gutters={false}>
-      <AppLayout toolsHide={true} />
+      <AppLayout
+        ariaLabels={labels}
+        toolsHide={true}
+        content={
+          <div>
+            <h1>Content title</h1>
+          </div>
+        }
+      />
     </ScreenshotArea>
   );
 }

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -1103,6 +1103,20 @@ describe('toolbar mode only features', () => {
       expect(wrapper.findActiveDrawer()!.getElement()).toHaveTextContent('runtime drawer content');
     });
 
+    test('should render trigger buttons for global drawers even if local drawers are not present', async () => {
+      const { wrapper } = await renderComponent(<AppLayout toolsHide={true} />);
+
+      awsuiPlugins.appLayout.registerDrawer({
+        ...drawerDefaults,
+        id: 'global1',
+        type: 'global',
+      });
+
+      await delay();
+
+      expect(wrapper.findDrawerTriggerById('global1')!.getElement()).toBeInTheDocument();
+    });
+
     describe('dynamically registered drawers with defaultActive: true', () => {
       test('should open if there are already open local drawer on the page', async () => {
         const { wrapper, globalDrawersWrapper } = await renderComponent(<AppLayout drawers={[testDrawer]} />);

--- a/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
@@ -178,7 +178,9 @@ export function DrawerTriggers({
             />
           );
         })}
-        {visibleItems.length > globalDrawersStartIndex && <div className={styles['group-divider']}></div>}
+        {globalDrawersStartIndex > 0 && visibleItems.length > globalDrawersStartIndex && (
+          <div className={styles['group-divider']}></div>
+        )}
         {visibleItems.slice(globalDrawersStartIndex).map(item => {
           const isForPreviousActiveDrawer = previousActiveGlobalDrawersIds?.current.includes(item.id);
           return (

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -200,7 +200,7 @@ export function AppLayoutToolbarImplementation({
             />
           </div>
         )}
-        {((drawers && drawers.length > 0) || (hasSplitPanel && splitPanelToggleProps?.displayed)) && (
+        {(drawers?.length || globalDrawers?.length || (hasSplitPanel && splitPanelToggleProps?.displayed)) && (
           <div className={clsx(styles['universal-toolbar-drawers'])}>
             <DrawerTriggers
               ariaLabels={ariaLabels}


### PR DESCRIPTION
### Description

When only global drawers are present, the panel still should render

Related links, issue #, if available: AWSUI-59981

### How has this been tested?

Locally. More tests later

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
