### PR TITLE
chore: Adds metadata metrics for collection preferences

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -5217,20 +5217,24 @@ You must set the current value in the \`preferences.contentDensity\` property.",
       "type": "CollectionPreferencesProps.ContentDensityPreference",
     },
     {
-      "description": "Configures the built-in content display preference for order and visibility of columns in a table.
-Once set, the component displays this preference in the modal.
+      "description": "Configures the built-in content display preference for order and visibility of the table columns.
+Recommended for table and not applicable for cards.
+
 Cannot be used together with \`visibleContentPreference\`.
+
+If you set it, the component displays this preference in the modal.
 
 It contains the following:
 - \`title\` (string) - Specifies the text displayed at the top of the preference.
 - \`description\` (string) - Specifies the description displayed below the title.
+- \`options\` - Specifies an array of options for reordering and visible content selection.
+- \`enableColumnFiltering\` (boolean) - Adds a columns filter.
 - \`liveAnnouncementDndStarted\` ((position: number, total: number) => string) - (Optional) Adds a message to be announced by screen readers when an option is picked.
 - \`liveAnnouncementDndDiscarded\` (string) - (Optional) Adds a message to be announced by screen readers when a reordering action is canceled.
 - \`liveAnnouncementDndItemReordered\` ((initialPosition: number, currentPosition: number, total: number) => string) - (Optional) Adds a message to be announced by screen readers when an item is being moved.
 - \`liveAnnouncementDndItemCommitted\` ((initialPosition: number, finalPosition: number, total: number) => string) - (Optional) Adds a message to be announced by screen readers when a reordering action is committed.
 - \`dragHandleAriaDescription\` (string) - (Optional) Adds an ARIA description for the drag handle.
 - \`dragHandleAriaLabel\` (string) - (Optional) Adds an ARIA label for the drag handle.
-- \`options\` - Specifies an array of options for reordering and visible content selection.
 
 Each option contains the following:
 - \`id\` (string) - Corresponds to a table column \`id\`.
@@ -5451,8 +5455,8 @@ of the most recent getModalRoot call as an argument.",
       "type": "(rootElement: HTMLElement) => void",
     },
     {
-      "description": "Configures the sticky columns preference.
-You can set it for both left and right columns.
+      "description": "Configures the sticky columns preference that can be set for both left and right columns.
+If you set it, the component displays this preference in the modal.
 
 It contains the following:
 - \`label\` (string) - Specifies the label for each radio group.
@@ -5518,9 +5522,12 @@ You must set the current value in the \`preferences.stripedRows\` property.",
       "type": "string",
     },
     {
-      "description": "Configures the built-in "visible content selection" preference (for example, visible sections in cards).
-If you set it, the component displays this preference in the modal.
+      "description": "Configures the built-in visible sections preference for cards or visible columns for table.
+Recommended for cards. For table use \`contentDisplayPreference\` instead.
+
 Cannot be used together with \`contentDisplayPreference\`.
+
+If you set it, the component displays this preference in the modal.
 
 It contains the following:
 - \`title\` (string) - Specifies the text displayed at the top of the preference.
@@ -5528,7 +5535,7 @@ It contains the following:
 
 Each group of options contains the following:
 - \`label\` (string) - The text to display as a title for the options group.
-- \`options\` - Specifies an aray of options in the group. Each option contains the following:
+- \`options\` - Specifies an array of options in the group. Each option contains the following:
   - \`id\` (string) - Corresponds to a column \`id\` for tables or to a section \`id\` for cards.
   - \`label\` (string) - Specifies a short description of the content.
   - \`editable\` (boolean) - (Optional) Determines whether the user is able to toggle its visibility. This is \`true\` by default.

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -68,6 +68,7 @@ const Cards = React.forwardRef(function <T = any>(
 ) {
   const { __internalRootRef } = useBaseComponent('Cards', {
     props: { entireCardClickable, selectionType, stickyHeader, variant },
+    metadata: { usesVisibleSections: !!visibleSections },
   });
   const baseProps = getBaseProps(rest);
   const isRefresh = useVisualRefresh();

--- a/src/collection-preferences/index.tsx
+++ b/src/collection-preferences/index.tsx
@@ -56,7 +56,6 @@ export default function CollectionPreferences({
   stripedRowsPreference,
   contentDensityPreference,
   stickyColumnsPreference,
-
   preferences,
   customPreference,
   getModalRoot,
@@ -73,6 +72,7 @@ export default function CollectionPreferences({
       hasContentDisplayPreference: !!contentDisplayPreference,
       hasContentDensityPreference: !!contentDensityPreference,
       hasStickyColumnsPreference: !!stickyColumnsPreference,
+      visibleContentOptionsCount: visibleContentPreference?.options?.length,
     },
   });
   checkControlled('CollectionPreferences', 'preferences', preferences, 'onConfirm', onConfirm);

--- a/src/collection-preferences/interfaces.ts
+++ b/src/collection-preferences/interfaces.ts
@@ -79,9 +79,9 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    */
   contentDensityPreference?: CollectionPreferencesProps.ContentDensityPreference;
   /**
-   * Configures the sticky columns preference.
+   * Configures the sticky columns preference that can be set for both left and right columns.
    *
-   * You can set it for both left and right columns.
+   * If you set it, the component displays this preference in the modal.
    *
    * It contains the following:
    * - `label` (string) - Specifies the label for each radio group.
@@ -91,21 +91,25 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    */
   stickyColumnsPreference?: CollectionPreferencesProps.StickyColumnsPreference;
   /**
-   * Configures the built-in content display preference for order and visibility of columns in a table.
+   * Configures the built-in content display preference for order and visibility of the table columns.
    *
-   * Once set, the component displays this preference in the modal.
+   * Recommended for table and not applicable for cards.
+   *
    * Cannot be used together with `visibleContentPreference`.
+   *
+   * If you set it, the component displays this preference in the modal.
    *
    * It contains the following:
    * - `title` (string) - Specifies the text displayed at the top of the preference.
    * - `description` (string) - Specifies the description displayed below the title.
+   * - `options` - Specifies an array of options for reordering and visible content selection.
+   * - `enableColumnFiltering` (boolean) - Adds a columns filter.
    * - `liveAnnouncementDndStarted` ((position: number, total: number) => string) - (Optional) Adds a message to be announced by screen readers when an option is picked.
    * - `liveAnnouncementDndDiscarded` (string) - (Optional) Adds a message to be announced by screen readers when a reordering action is canceled.
    * - `liveAnnouncementDndItemReordered` ((initialPosition: number, currentPosition: number, total: number) => string) - (Optional) Adds a message to be announced by screen readers when an item is being moved.
    * - `liveAnnouncementDndItemCommitted` ((initialPosition: number, finalPosition: number, total: number) => string) - (Optional) Adds a message to be announced by screen readers when a reordering action is committed.
    * - `dragHandleAriaDescription` (string) - (Optional) Adds an ARIA description for the drag handle.
    * - `dragHandleAriaLabel` (string) - (Optional) Adds an ARIA label for the drag handle.
-   * - `options` - Specifies an array of options for reordering and visible content selection.
    *
    * Each option contains the following:
    * - `id` (string) - Corresponds to a table column `id`.
@@ -117,10 +121,13 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    */
   contentDisplayPreference?: CollectionPreferencesProps.ContentDisplayPreference;
   /**
-   * Configures the built-in "visible content selection" preference (for example, visible sections in cards).
+   * Configures the built-in visible sections preference for cards or visible columns for table.
+   *
+   * Recommended for cards. For table use `contentDisplayPreference` instead.
+   *
+   * Cannot be used together with `contentDisplayPreference`.
    *
    * If you set it, the component displays this preference in the modal.
-   * Cannot be used together with `contentDisplayPreference`.
    *
    * It contains the following:
    * - `title` (string) - Specifies the text displayed at the top of the preference.
@@ -128,7 +135,7 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    *
    * Each group of options contains the following:
    * - `label` (string) - The text to display as a title for the options group.
-   * - `options` - Specifies an aray of options in the group. Each option contains the following:
+   * - `options` - Specifies an array of options in the group. Each option contains the following:
    *   - `id` (string) - Corresponds to a column `id` for tables or to a section `id` for cards.
    *   - `label` (string) - Specifies a short description of the content.
    *   - `editable` (boolean) - (Optional) Determines whether the user is able to toggle its visibility. This is `true` by default.

--- a/src/table/index.tsx
+++ b/src/table/index.tsx
@@ -58,6 +58,8 @@ const Table = React.forwardRef(
           hasPaginationSlot: !!props.pagination,
           itemsCount: items.length,
           hasInstanceIdentifier: Boolean(analyticsMetadata?.instanceIdentifier),
+          usesVisibleColumns: !!props.visibleColumns,
+          usesColumnDisplay: !!props.columnDisplay,
         },
       },
       analyticsMetadata


### PR DESCRIPTION
### Description

Adds additional metrics for collection preferences, table, and cards. Updates collection preferences API docs to reflect the expected usage of visible content and content display better.

Rel: [g7eCAnu4xJMH]

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
