### PR TITLE
refactor: Componentizes table cell types and adds permutations

### DIFF
--- a/pages/table/cell-permutations.page.tsx
+++ b/pages/table/cell-permutations.page.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext, useRef, useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { range } from 'lodash';
 
 import {
@@ -15,15 +15,9 @@ import {
   Slider,
   SpaceBetween,
   StatusIndicator,
+  Table,
   TableProps,
 } from '~components';
-import { useMergeRefs } from '~components/internal/hooks/use-merge-refs';
-import { TableBodyCell, TableBodyCellProps } from '~components/table/body-cell';
-import { TableHeaderCell, TableHeaderCellProps } from '~components/table/header-cell';
-import { NoDataCell } from '~components/table/no-data-cell';
-import { TableLoaderCell, TableLoaderCellProps } from '~components/table/progressive-loading/loader-cell';
-import { TableBodySelectionCell, TableHeaderSelectionCell } from '~components/table/selection/selection-cell';
-import { StickyColumnsModel, useStickyColumns } from '~components/table/sticky-columns';
 
 import AppContext, { AppContextType } from '../app/app-context';
 import ScreenshotArea from '../utils/screenshot-area';
@@ -34,7 +28,6 @@ type PageContext = React.Context<
     verticalAlignTop?: boolean;
     sortingDisabled?: boolean;
     resizableColumns?: boolean;
-    resizableColumnWidth?: string;
     isExpandable?: boolean;
     isExpanded?: boolean;
     isEditable?: boolean;
@@ -154,15 +147,6 @@ export default function InlineEditorPermutations() {
             </SpaceBetween>
 
             <SpaceBetween size="m" direction="horizontal" alignItems="center">
-              <FormField label="Resizable column width">
-                <Slider
-                  value={settings.resizableColumnWidth}
-                  onChange={event => setUrlParams({ resizableColumnWidth: event.detail.value.toString() })}
-                  min={50}
-                  max={300}
-                />
-              </FormField>
-
               <FormField label="Sticky columns first">
                 <Slider
                   value={settings.stickyColumnsFirst}
@@ -184,290 +168,118 @@ export default function InlineEditorPermutations() {
           </SpaceBetween>
         </ExpandableSection>
 
-        <Container variant="stacked" header={<Header variant="h2">Standard cells</Header>}>
-          <StandardCellsTable />
+        <Container variant="stacked" header={<Header variant="h2">Actual table demo</Header>}>
+          <TableCellsDemo />
         </Container>
       </ScreenshotArea>
     </Box>
   );
 }
 
-function StandardCellsTable() {
+function TableCellsDemo() {
   const { settings } = usePageSettings();
-  const containerRefObject = useRef<HTMLDivElement>(null);
-  const containerRef = useMergeRefs(containerRefObject, settings.stickyState.refs.wrapper);
-  const tableRefObject = useRef<HTMLTableElement>(null);
-  const tableRef = useMergeRefs(tableRefObject, settings.stickyState.refs.table);
-  return (
-    <div ref={containerRef} style={{ overflowX: 'auto', ...settings.stickyState.style.wrapper }}>
-      <table ref={tableRef} style={{ tableLayout: 'fixed', borderSpacing: 0, width: '100%' }}>
-        <thead>
-          <TextHeaders {...settings} />
-        </thead>
-        <tbody>
-          {settings.tableEmpty || settings.tableLoading ? (
-            <tr>
-              <NoDataCell
-                totalColumnsCount={columns.length}
-                hasFooter={settings.hasFooter}
-                loading={settings.tableLoading}
-                loadingText="Loading"
-                empty="Empty"
-                containerRef={containerRefObject}
-                tableRef={tableRefObject}
-              />
-            </tr>
-          ) : (
-            <>
-              <TextColumns {...settings} level={1} isEvenRow={false} isFirstRow={true} />
-              <TextColumns {...settings} level={2} isEvenRow={true} />
-              <TextColumns {...settings} level={3} isEvenRow={false} isNextSelected={true} />
-              <TextColumns {...settings} level={4} isEvenRow={true} isSelected={true} />
-              <TextColumns {...settings} level={5} isEvenRow={false} isPrevSelected={true} isNextSelected={true} />
-              <TextColumns {...settings} level={1} isEvenRow={true} isSelected={true} isNextSelected={true} />
-              <TextColumns {...settings} level={2} isEvenRow={false} isSelected={true} isPrevSelected={true} />
-              <TextColumns {...settings} level={3} isEvenRow={true} isPrevSelected={true} />
-              <LoaderColumns {...settings} level={3} isEvenRow={false} loadingStatus="pending" />
-              <LoaderColumns {...settings} level={2} isEvenRow={false} loadingStatus="loading" />
-              <LoaderColumns {...settings} level={1} isEvenRow={false} isLastRow={true} loadingStatus="error" />
-            </>
-          )}
-        </tbody>
-      </table>
-    </div>
-  );
-}
+  const [editedValues, setEditedValues] = useState<Record<string, string>>({});
 
-function TextHeaders(
-  props: Partial<TableHeaderCellProps<string>> & {
-    stickyState: StickyColumnsModel;
-    resizableColumnWidth?: number;
-    isExpandable?: boolean;
-    hasSelection?: boolean;
-    multiSelection?: boolean;
-  }
-) {
-  return (
-    <tr>
-      {props.hasSelection && (
-        <TableHeaderSelectionCell
-          {...defaultCellProps()}
-          {...props}
-          onFocusMove={() => {}}
-          columnId="selection"
-          getSelectAllProps={
-            props.multiSelection
-              ? () => ({
-                  name: 'select-all',
-                  disabled: false,
-                  selectionType: 'multi',
-                  indeterminate: true,
-                  checked: false,
-                  onChange: () => {},
-                })
-              : undefined
+  const items = [0, 1, 2, 3, 4, 5, 6, 7];
+  const itemLevels = [1, 2, 3, 4, 5, 1, 2, 3];
+  const itemChildren: Record<number, number[]> = { 0: [1], 1: [2], 2: [3], 3: [4], 5: [6], 6: [7] };
+  const itemLoading = new Map<null | number, TableProps.LoadingStatus>([
+    [3, 'pending'],
+    [6, 'error'],
+    [null, 'loading'],
+  ]);
+  const selectedItems = [3, 5, 6];
+
+  const columnDefinitions: TableProps.ColumnDefinition<number>[] = columns.map(index => {
+    const columnId = index.toString();
+    const cellContent = (item: number) =>
+      editedValues[`${columnId}:${item}`] ??
+      `Body cell content ${item}:${index}${index === 1 ? ` (L=${itemLevels[item]})` : ''}${index === 8 ? ' with longer text' : ''}`;
+    return {
+      id: columnId,
+      header: `Header cell content ${index}${index === 8 ? ' with longer text' : ''}`,
+      sortingField: index === 2 ? 'field-1' : index === 3 ? 'field-2' : undefined,
+      activeSorting: index === 3,
+      cell: cellContent,
+      verticalAlign: settings.verticalAlign,
+      editConfig: settings.isEditable
+        ? {
+            ariaLabel: 'Edit dialog aria label',
+            editIconAriaLabel: 'Edit icon label',
+            errorIconAriaLabel: 'Edit error icon label',
+            validation(_item, value = '') {
+              if (value.trim() && value.toLowerCase().includes('content')) {
+                return 'Must not include "content"';
+              }
+            },
+            editingCell(item, { currentValue, setValue }: TableProps.CellContext<string>) {
+              return (
+                <Input
+                  autoFocus={true}
+                  value={currentValue ?? cellContent(item)}
+                  onChange={event => setValue(event.detail.value)}
+                />
+              );
+            },
           }
-        />
-      )}
-      {columns.map(index => (
-        <PlaygroundHeaderCell
-          key={index}
-          {...props}
-          colIndex={index}
-          isExpandable={index === 1 && props.isExpandable}
-          sortable={[2, 3, 4, 5].includes(index)}
-          activeSorting={[4, 5].includes(index)}
-          sortingDescending={[3, 5].includes(index)}
-        >
-          {`Header cell content ${index}${index === 8 ? ' with longer text' : ''}`}
-        </PlaygroundHeaderCell>
-      ))}
-    </tr>
-  );
-}
+        : undefined,
+    };
+  });
 
-function TextColumns(
-  props: Partial<TableBodyCellProps<string>> & {
-    level: number;
-    stickyState: StickyColumnsModel;
-    isExpandable?: boolean;
-    isExpanded?: boolean;
-    multiSelection?: boolean;
+  let expandableRows: undefined | TableProps.ExpandableRows<number> = undefined;
+  if (settings.isExpandable) {
+    expandableRows = {
+      getItemChildren: item => itemChildren[item] ?? [],
+      isItemExpandable: item => !!itemChildren[item],
+      expandedItems: settings.isExpanded ? items : [],
+      onExpandableItemToggle: () => {},
+    };
   }
-) {
-  return (
-    <tr>
-      {props.hasSelection && (
-        <TableBodySelectionCell
-          {...defaultCellProps()}
-          {...props}
-          columnId="selection"
-          isExpandable={false}
-          selectionControlProps={{
-            name: 'select-one',
-            disabled: false,
-            selectionType: props.multiSelection ? 'multi' : 'single',
-            checked: !!props.isSelected,
-            onChange: () => {},
-          }}
-        />
-      )}
-      {columns.map(index => (
-        <PlaygroundBodyCell
-          key={index}
-          {...props}
-          colIndex={index}
-          level={index === 1 && props.isExpandable ? props.level : 0}
-          isExpandable={index === 1 && props.isExpandable}
-          isExpanded={index === 1 && props.isExpanded}
-        >
-          {`Body cell content ${index}${index === 1 ? ` (L=${props.level})` : ''}${index === 8 ? ' with longer text' : ''}`}
-        </PlaygroundBodyCell>
-      ))}
-    </tr>
-  );
-}
 
-function LoaderColumns(
-  props: Partial<TableLoaderCellProps<string>> & {
-    level: number;
-    stickyState: StickyColumnsModel;
-    loadingStatus: TableProps.LoadingStatus;
+  let selectionType: undefined | TableProps.SelectionType = undefined;
+  if (settings.hasSelection) {
+    selectionType = settings.multiSelection ? 'multi' : 'single';
   }
-) {
-  return (
-    <tr>
-      {props.hasSelection && (
-        <TableBodySelectionCell {...defaultCellProps()} {...props} columnId="selection" isExpandable={false} />
-      )}
-      {columns.map(index => (
-        <TableLoaderCell
-          {...defaultCellProps()}
-          {...props}
-          key={index}
-          colIndex={index}
-          columnId={index.toString()}
-          level={index === 1 && props.isExpandable ? props.level - 1 : 0}
-          isRowHeader={index === 1}
-          isExpandable={false}
-          isExpanded={false}
-          item={''}
-          renderLoaderPending={() => <Button>Load more</Button>}
-          renderLoaderLoading={() => <StatusIndicator type="loading">Loading more</StatusIndicator>}
-          renderLoaderError={() => <StatusIndicator type="error">Error when loading more</StatusIndicator>}
-        />
-      ))}
-    </tr>
-  );
-}
 
-function PlaygroundHeaderCell(
-  props: Partial<TableHeaderCellProps<string>> & {
-    children: React.ReactNode;
-    colIndex: number;
-    resizableColumnWidth?: number;
-    stickyState: StickyColumnsModel;
-    sortable?: boolean;
-    activeSorting?: boolean;
-  }
-) {
-  const column: TableProps.ColumnDefinition<string> = {
-    id: props.colIndex.toString(),
-    header: props.children,
-    cell: () => '',
-    sortingField: props.sortable ? 'field' : undefined,
-  };
   return (
-    <TableHeaderCell
-      style={{ width: props.resizableColumns ? props.resizableColumnWidth : undefined }}
-      tabIndex={-1}
-      column={column}
-      activeSortingColumn={props.activeSorting ? column : undefined}
-      columnId={props.colIndex.toString()}
-      hidden={false}
-      {...defaultCellProps()}
-      onResizeFinish={() => {}}
-      updateColumn={() => {}}
-      onClick={() => {}}
-      cellRef={() => {}}
-      tableRole="grid"
-      {...props}
-    />
-  );
-}
-
-function PlaygroundBodyCell(
-  props: Partial<TableBodyCellProps<string>> & {
-    children: React.ReactNode;
-    stickyState: StickyColumnsModel;
-    colIndex: number;
-    isEditable?: boolean;
-  }
-) {
-  const [isEditing, setIsEditing] = useState(false);
-  const [successfulEdit, setSuccessfulEdit] = useState(false);
-  const [editedValue, setEditedValue] = useState('');
-  return (
-    <TableBodyCell
+    <Table
       ariaLabels={{
-        activateEditLabel: column => `Edit ${column.header}`,
-        cancelEditLabel: column => `Cancel editing ${column.header}`,
-        submitEditLabel: column => `Submit edit ${column.header}`,
-        successfulEditLabel: () => 'Edit successful',
+        selectionGroupLabel: 'selectionGroupLabel',
+        activateEditLabel: () => 'activateEditLabel',
+        cancelEditLabel: () => 'cancelEditLabel',
+        submitEditLabel: () => 'submitEditLabel',
+        allItemsSelectionLabel: () => 'allItemsSelectionLabel',
+        itemSelectionLabel: () => 'itemSelectionLabel',
+        tableLabel: 'tableLabel',
+        expandButtonLabel: () => 'expand row',
+        collapseButtonLabel: () => 'collapse row',
       }}
-      column={{
-        id: props.colIndex.toString(),
-        header: '',
-        cell: () => editedValue || props.children,
-        editConfig: {
-          ariaLabel: 'Edit dialog aria label',
-          editIconAriaLabel: 'Edit icon label',
-          errorIconAriaLabel: 'Edit error icon label',
-          validation(_item, value = '') {
-            if (value.trim() && value.toLowerCase().includes('content')) {
-              return 'Must not include "content"';
-            }
-          },
-          editingCell(_item, { currentValue, setValue }: TableProps.CellContext<string>) {
-            return (
-              <Input
-                autoFocus={true}
-                value={currentValue ?? (typeof props.children === 'string' ? props.children : '')}
-                onChange={event => setValue(event.detail.value)}
-              />
-            );
-          },
-        },
-      }}
-      isEditing={isEditing}
-      successfulEdit={successfulEdit}
-      onEditStart={() => setIsEditing(true)}
-      onEditEnd={() => {
-        setIsEditing(false);
-        setSuccessfulEdit(true);
-      }}
-      submitEdit={(_item, _column, newValue) => new Promise(resolve => resolve(setEditedValue(newValue as any)))}
-      columnId={props.colIndex.toString()}
-      item={''}
-      {...defaultCellProps()}
-      {...props}
+      columnDefinitions={columnDefinitions}
+      items={settings.tableEmpty ? [] : settings.isExpandable ? [0, 5] : items}
+      wrapLines={settings.wrapLines}
+      sortingDisabled={settings.sortingDisabled}
+      sortingColumn={{ sortingField: 'field-2' }}
+      resizableColumns={settings.resizableColumns}
+      stripedRows={settings.stripedRows}
+      footer={settings.hasFooter ? <Box>Table footer</Box> : null}
+      stickyColumns={{ first: settings.stickyColumnsFirst, last: settings.stickyColumnsLast }}
+      selectionType={selectionType}
+      selectedItems={selectedItems}
+      empty="Empty"
+      loading={settings.tableLoading}
+      loadingText="Loading"
+      submitEdit={(item, column, newValue) =>
+        new Promise(resolve =>
+          resolve(setEditedValues(prev => ({ ...prev, [`${column.id}:${item}`]: newValue as string })))
+        )
+      }
+      expandableRows={expandableRows}
+      getLoadingStatus={item => itemLoading.get(item) ?? 'finished'}
+      renderLoaderPending={() => <Button>Load more</Button>}
+      renderLoaderLoading={() => <StatusIndicator type="loading">Loading more</StatusIndicator>}
+      renderLoaderError={() => <StatusIndicator type="error">Error when loading more</StatusIndicator>}
     />
   );
-}
-
-function defaultCellProps() {
-  return {
-    isFirstRow: false,
-    isLastRow: false,
-    isSelected: false,
-    isNextSelected: false,
-    isPrevSelected: false,
-    wrapLines: false,
-    isEditable: false,
-    resizableColumns: false,
-    tableRole: 'grid' as const,
-    variant: 'container' as const,
-  };
 }
 
 function usePageSettings() {
@@ -478,7 +290,6 @@ function usePageSettings() {
     isEditable: urlParams.isEditable ?? false,
     sortingDisabled: urlParams.sortingDisabled ?? false,
     resizableColumns: urlParams.resizableColumns ?? true,
-    resizableColumnWidth: parseInt(urlParams.resizableColumnWidth || '') || 150,
     wrapLines: urlParams.wrapLines ?? false,
     stripedRows: urlParams.stripedRows ?? false,
     hasSelection: urlParams.hasSelection ?? true,
@@ -490,10 +301,5 @@ function usePageSettings() {
     tableEmpty: urlParams.tableEmpty ?? false,
     tableLoading: urlParams.tableLoading ?? false,
   };
-  const stickyState = useStickyColumns({
-    visibleColumns: columns.map(index => index.toString()),
-    stickyColumnsFirst: settings.stickyColumnsFirst,
-    stickyColumnsLast: settings.stickyColumnsLast,
-  });
-  return { settings: { ...settings, stickyState }, setUrlParams };
+  return { settings, setUrlParams };
 }

--- a/pages/table/cell-permutations.page.tsx
+++ b/pages/table/cell-permutations.page.tsx
@@ -1,0 +1,499 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext, useRef, useState } from 'react';
+import { range } from 'lodash';
+
+import {
+  Box,
+  Button,
+  Checkbox,
+  Container,
+  ExpandableSection,
+  FormField,
+  Header,
+  Input,
+  Slider,
+  SpaceBetween,
+  StatusIndicator,
+  TableProps,
+} from '~components';
+import { useMergeRefs } from '~components/internal/hooks/use-merge-refs';
+import { TableBodyCell, TableBodyCellProps } from '~components/table/body-cell';
+import { TableHeaderCell, TableHeaderCellProps } from '~components/table/header-cell';
+import { NoDataCell } from '~components/table/no-data-cell';
+import { TableLoaderCell, TableLoaderCellProps } from '~components/table/progressive-loading/loader-cell';
+import { TableBodySelectionCell, TableHeaderSelectionCell } from '~components/table/selection/selection-cell';
+import { StickyColumnsModel, useStickyColumns } from '~components/table/sticky-columns';
+
+import AppContext, { AppContextType } from '../app/app-context';
+import ScreenshotArea from '../utils/screenshot-area';
+
+type PageContext = React.Context<
+  AppContextType<{
+    wrapLines?: boolean;
+    verticalAlignTop?: boolean;
+    sortingDisabled?: boolean;
+    resizableColumns?: boolean;
+    resizableColumnWidth?: string;
+    isExpandable?: boolean;
+    isExpanded?: boolean;
+    isEditable?: boolean;
+    stripedRows?: boolean;
+    hasSelection?: boolean;
+    multiSelection?: boolean;
+    hasFooter?: boolean;
+    stickyColumnsFirst?: string;
+    stickyColumnsLast?: string;
+    tableEmpty?: boolean;
+    tableLoading?: boolean;
+  }>
+>;
+
+const columns = range(0, 10).map(index => index + 1);
+
+export default function InlineEditorPermutations() {
+  const { settings, setUrlParams } = usePageSettings();
+  return (
+    <Box margin="m">
+      <h1>Table cell permutations</h1>
+
+      <ScreenshotArea gutters={false}>
+        <ExpandableSection variant="stacked" headerText="Settings" headingTagOverride="h2" defaultExpanded={true}>
+          <SpaceBetween size="m">
+            <SpaceBetween size="m" direction="horizontal" alignItems="center">
+              <Checkbox
+                checked={settings.wrapLines}
+                onChange={event => setUrlParams({ wrapLines: event.detail.checked })}
+              >
+                Wrap lines
+              </Checkbox>
+
+              <Checkbox
+                checked={settings.isExpandable}
+                onChange={event => setUrlParams({ isExpandable: event.detail.checked })}
+              >
+                Is expandable
+              </Checkbox>
+
+              <Checkbox
+                checked={settings.isExpanded}
+                onChange={event => setUrlParams({ isExpanded: event.detail.checked })}
+              >
+                Is expanded
+              </Checkbox>
+
+              <Checkbox
+                checked={settings.isEditable}
+                onChange={event => setUrlParams({ isEditable: event.detail.checked })}
+              >
+                Editable
+              </Checkbox>
+
+              <Checkbox
+                checked={settings.sortingDisabled}
+                onChange={event => setUrlParams({ sortingDisabled: event.detail.checked })}
+              >
+                Sorting disabled
+              </Checkbox>
+
+              <Checkbox
+                checked={settings.verticalAlign === 'top'}
+                onChange={event => setUrlParams({ verticalAlignTop: event.detail.checked })}
+              >
+                Vertical align top
+              </Checkbox>
+
+              <Checkbox
+                checked={settings.stripedRows}
+                onChange={event => setUrlParams({ stripedRows: event.detail.checked })}
+              >
+                Striped rows
+              </Checkbox>
+
+              <Checkbox
+                checked={settings.hasSelection}
+                onChange={event => setUrlParams({ hasSelection: event.detail.checked })}
+              >
+                Has selection
+              </Checkbox>
+
+              <Checkbox
+                checked={settings.multiSelection}
+                onChange={event => setUrlParams({ multiSelection: event.detail.checked })}
+              >
+                Multi selection
+              </Checkbox>
+
+              <Checkbox
+                checked={settings.hasFooter}
+                onChange={event => setUrlParams({ hasFooter: event.detail.checked })}
+              >
+                Has footer
+              </Checkbox>
+
+              <Checkbox
+                checked={settings.resizableColumns}
+                onChange={event => setUrlParams({ resizableColumns: event.detail.checked })}
+              >
+                Resizable columns
+              </Checkbox>
+
+              <Checkbox
+                checked={settings.tableEmpty}
+                onChange={event => setUrlParams({ tableEmpty: event.detail.checked })}
+              >
+                Table empty
+              </Checkbox>
+
+              <Checkbox
+                checked={settings.tableLoading}
+                onChange={event => setUrlParams({ tableLoading: event.detail.checked })}
+              >
+                Table loading
+              </Checkbox>
+            </SpaceBetween>
+
+            <SpaceBetween size="m" direction="horizontal" alignItems="center">
+              <FormField label="Resizable column width">
+                <Slider
+                  value={settings.resizableColumnWidth}
+                  onChange={event => setUrlParams({ resizableColumnWidth: event.detail.value.toString() })}
+                  min={50}
+                  max={300}
+                />
+              </FormField>
+
+              <FormField label="Sticky columns first">
+                <Slider
+                  value={settings.stickyColumnsFirst}
+                  onChange={event => setUrlParams({ stickyColumnsFirst: event.detail.value.toString() })}
+                  min={0}
+                  max={3}
+                />
+              </FormField>
+
+              <FormField label="Sticky columns last">
+                <Slider
+                  value={settings.stickyColumnsLast}
+                  onChange={event => setUrlParams({ stickyColumnsLast: event.detail.value.toString() })}
+                  min={0}
+                  max={3}
+                />
+              </FormField>
+            </SpaceBetween>
+          </SpaceBetween>
+        </ExpandableSection>
+
+        <Container variant="stacked" header={<Header variant="h2">Standard cells</Header>}>
+          <StandardCellsTable />
+        </Container>
+      </ScreenshotArea>
+    </Box>
+  );
+}
+
+function StandardCellsTable() {
+  const { settings } = usePageSettings();
+  const containerRefObject = useRef<HTMLDivElement>(null);
+  const containerRef = useMergeRefs(containerRefObject, settings.stickyState.refs.wrapper);
+  const tableRefObject = useRef<HTMLTableElement>(null);
+  const tableRef = useMergeRefs(tableRefObject, settings.stickyState.refs.table);
+  return (
+    <div ref={containerRef} style={{ overflowX: 'auto', ...settings.stickyState.style.wrapper }}>
+      <table ref={tableRef} style={{ tableLayout: 'fixed', borderSpacing: 0, width: '100%' }}>
+        <thead>
+          <TextHeaders {...settings} />
+        </thead>
+        <tbody>
+          {settings.tableEmpty || settings.tableLoading ? (
+            <tr>
+              <NoDataCell
+                totalColumnsCount={columns.length}
+                hasFooter={settings.hasFooter}
+                loading={settings.tableLoading}
+                loadingText="Loading"
+                empty="Empty"
+                containerRef={containerRefObject}
+                tableRef={tableRefObject}
+              />
+            </tr>
+          ) : (
+            <>
+              <TextColumns {...settings} level={1} isEvenRow={false} isFirstRow={true} />
+              <TextColumns {...settings} level={2} isEvenRow={true} />
+              <TextColumns {...settings} level={3} isEvenRow={false} isNextSelected={true} />
+              <TextColumns {...settings} level={4} isEvenRow={true} isSelected={true} />
+              <TextColumns {...settings} level={5} isEvenRow={false} isPrevSelected={true} isNextSelected={true} />
+              <TextColumns {...settings} level={1} isEvenRow={true} isSelected={true} isNextSelected={true} />
+              <TextColumns {...settings} level={2} isEvenRow={false} isSelected={true} isPrevSelected={true} />
+              <TextColumns {...settings} level={3} isEvenRow={true} isPrevSelected={true} />
+              <LoaderColumns {...settings} level={3} isEvenRow={false} loadingStatus="pending" />
+              <LoaderColumns {...settings} level={2} isEvenRow={false} loadingStatus="loading" />
+              <LoaderColumns {...settings} level={1} isEvenRow={false} isLastRow={true} loadingStatus="error" />
+            </>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function TextHeaders(
+  props: Partial<TableHeaderCellProps<string>> & {
+    stickyState: StickyColumnsModel;
+    resizableColumnWidth?: number;
+    isExpandable?: boolean;
+    hasSelection?: boolean;
+    multiSelection?: boolean;
+  }
+) {
+  return (
+    <tr>
+      {props.hasSelection && (
+        <TableHeaderSelectionCell
+          {...defaultCellProps()}
+          {...props}
+          onFocusMove={() => {}}
+          columnId="selection"
+          getSelectAllProps={
+            props.multiSelection
+              ? () => ({
+                  name: 'select-all',
+                  disabled: false,
+                  selectionType: 'multi',
+                  indeterminate: true,
+                  checked: false,
+                  onChange: () => {},
+                })
+              : undefined
+          }
+        />
+      )}
+      {columns.map(index => (
+        <PlaygroundHeaderCell
+          key={index}
+          {...props}
+          colIndex={index}
+          isExpandable={index === 1 && props.isExpandable}
+          sortable={[2, 3, 4, 5].includes(index)}
+          activeSorting={[4, 5].includes(index)}
+          sortingDescending={[3, 5].includes(index)}
+        >
+          {`Header cell content ${index}${index === 8 ? ' with longer text' : ''}`}
+        </PlaygroundHeaderCell>
+      ))}
+    </tr>
+  );
+}
+
+function TextColumns(
+  props: Partial<TableBodyCellProps<string>> & {
+    level: number;
+    stickyState: StickyColumnsModel;
+    isExpandable?: boolean;
+    isExpanded?: boolean;
+    multiSelection?: boolean;
+  }
+) {
+  return (
+    <tr>
+      {props.hasSelection && (
+        <TableBodySelectionCell
+          {...defaultCellProps()}
+          {...props}
+          columnId="selection"
+          isExpandable={false}
+          selectionControlProps={{
+            name: 'select-one',
+            disabled: false,
+            selectionType: props.multiSelection ? 'multi' : 'single',
+            checked: !!props.isSelected,
+            onChange: () => {},
+          }}
+        />
+      )}
+      {columns.map(index => (
+        <PlaygroundBodyCell
+          key={index}
+          {...props}
+          colIndex={index}
+          level={index === 1 && props.isExpandable ? props.level : 0}
+          isExpandable={index === 1 && props.isExpandable}
+          isExpanded={index === 1 && props.isExpanded}
+        >
+          {`Body cell content ${index}${index === 1 ? ` (L=${props.level})` : ''}${index === 8 ? ' with longer text' : ''}`}
+        </PlaygroundBodyCell>
+      ))}
+    </tr>
+  );
+}
+
+function LoaderColumns(
+  props: Partial<TableLoaderCellProps<string>> & {
+    level: number;
+    stickyState: StickyColumnsModel;
+    loadingStatus: TableProps.LoadingStatus;
+  }
+) {
+  return (
+    <tr>
+      {props.hasSelection && (
+        <TableBodySelectionCell {...defaultCellProps()} {...props} columnId="selection" isExpandable={false} />
+      )}
+      {columns.map(index => (
+        <TableLoaderCell
+          {...defaultCellProps()}
+          {...props}
+          key={index}
+          colIndex={index}
+          columnId={index.toString()}
+          level={index === 1 && props.isExpandable ? props.level - 1 : 0}
+          isRowHeader={index === 1}
+          isExpandable={false}
+          isExpanded={false}
+          item={''}
+          renderLoaderPending={() => <Button>Load more</Button>}
+          renderLoaderLoading={() => <StatusIndicator type="loading">Loading more</StatusIndicator>}
+          renderLoaderError={() => <StatusIndicator type="error">Error when loading more</StatusIndicator>}
+        />
+      ))}
+    </tr>
+  );
+}
+
+function PlaygroundHeaderCell(
+  props: Partial<TableHeaderCellProps<string>> & {
+    children: React.ReactNode;
+    colIndex: number;
+    resizableColumnWidth?: number;
+    stickyState: StickyColumnsModel;
+    sortable?: boolean;
+    activeSorting?: boolean;
+  }
+) {
+  const column: TableProps.ColumnDefinition<string> = {
+    id: props.colIndex.toString(),
+    header: props.children,
+    cell: () => '',
+    sortingField: props.sortable ? 'field' : undefined,
+  };
+  return (
+    <TableHeaderCell
+      style={{ width: props.resizableColumns ? props.resizableColumnWidth : undefined }}
+      tabIndex={-1}
+      column={column}
+      activeSortingColumn={props.activeSorting ? column : undefined}
+      columnId={props.colIndex.toString()}
+      hidden={false}
+      {...defaultCellProps()}
+      onResizeFinish={() => {}}
+      updateColumn={() => {}}
+      onClick={() => {}}
+      cellRef={() => {}}
+      tableRole="grid"
+      {...props}
+    />
+  );
+}
+
+function PlaygroundBodyCell(
+  props: Partial<TableBodyCellProps<string>> & {
+    children: React.ReactNode;
+    stickyState: StickyColumnsModel;
+    colIndex: number;
+    isEditable?: boolean;
+  }
+) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [successfulEdit, setSuccessfulEdit] = useState(false);
+  const [editedValue, setEditedValue] = useState('');
+  return (
+    <TableBodyCell
+      ariaLabels={{
+        activateEditLabel: column => `Edit ${column.header}`,
+        cancelEditLabel: column => `Cancel editing ${column.header}`,
+        submitEditLabel: column => `Submit edit ${column.header}`,
+        successfulEditLabel: () => 'Edit successful',
+      }}
+      column={{
+        id: props.colIndex.toString(),
+        header: '',
+        cell: () => editedValue || props.children,
+        editConfig: {
+          ariaLabel: 'Edit dialog aria label',
+          editIconAriaLabel: 'Edit icon label',
+          errorIconAriaLabel: 'Edit error icon label',
+          validation(_item, value = '') {
+            if (value.trim() && value.toLowerCase().includes('content')) {
+              return 'Must not include "content"';
+            }
+          },
+          editingCell(_item, { currentValue, setValue }: TableProps.CellContext<string>) {
+            return (
+              <Input
+                autoFocus={true}
+                value={currentValue ?? (typeof props.children === 'string' ? props.children : '')}
+                onChange={event => setValue(event.detail.value)}
+              />
+            );
+          },
+        },
+      }}
+      isEditing={isEditing}
+      successfulEdit={successfulEdit}
+      onEditStart={() => setIsEditing(true)}
+      onEditEnd={() => {
+        setIsEditing(false);
+        setSuccessfulEdit(true);
+      }}
+      submitEdit={(_item, _column, newValue) => new Promise(resolve => resolve(setEditedValue(newValue as any)))}
+      columnId={props.colIndex.toString()}
+      item={''}
+      {...defaultCellProps()}
+      {...props}
+    />
+  );
+}
+
+function defaultCellProps() {
+  return {
+    isFirstRow: false,
+    isLastRow: false,
+    isSelected: false,
+    isNextSelected: false,
+    isPrevSelected: false,
+    wrapLines: false,
+    isEditable: false,
+    resizableColumns: false,
+    tableRole: 'grid' as const,
+    variant: 'container' as const,
+  };
+}
+
+function usePageSettings() {
+  const { urlParams, setUrlParams } = useContext(AppContext as PageContext);
+  const settings = {
+    isExpandable: urlParams.isExpandable ?? false,
+    isExpanded: urlParams.isExpanded ?? false,
+    isEditable: urlParams.isEditable ?? false,
+    sortingDisabled: urlParams.sortingDisabled ?? false,
+    resizableColumns: urlParams.resizableColumns ?? true,
+    resizableColumnWidth: parseInt(urlParams.resizableColumnWidth || '') || 150,
+    wrapLines: urlParams.wrapLines ?? false,
+    stripedRows: urlParams.stripedRows ?? false,
+    hasSelection: urlParams.hasSelection ?? true,
+    multiSelection: urlParams.multiSelection ?? true,
+    hasFooter: urlParams.hasFooter ?? false,
+    verticalAlign: (urlParams.verticalAlignTop ? 'top' : 'middle') as 'top' | 'middle',
+    stickyColumnsFirst: parseInt(urlParams.stickyColumnsFirst ?? '') || 0,
+    stickyColumnsLast: parseInt(urlParams.stickyColumnsLast ?? '') || 0,
+    tableEmpty: urlParams.tableEmpty ?? false,
+    tableLoading: urlParams.tableLoading ?? false,
+  };
+  const stickyState = useStickyColumns({
+    visibleColumns: columns.map(index => index.toString()),
+    stickyColumnsFirst: settings.stickyColumnsFirst,
+    stickyColumnsLast: settings.stickyColumnsLast,
+  });
+  return { settings: { ...settings, stickyState }, setUrlParams };
+}

--- a/src/table/__tests__/header-cell.test.tsx
+++ b/src/table/__tests__/header-cell.test.tsx
@@ -72,6 +72,7 @@ function TestComponent(props: Partial<TableHeaderCellProps<typeof testItem>>) {
       columnId="id"
       cellRef={() => {}}
       tableRole={tableRole}
+      variant="container"
       {...props}
     />
   );

--- a/src/table/__tests__/progressive-loading.test.tsx
+++ b/src/table/__tests__/progressive-loading.test.tsx
@@ -25,7 +25,10 @@ interface Instance {
   children?: Instance[];
 }
 
-const columnDefinitions: TableProps.ColumnDefinition<Instance>[] = [{ header: 'name', cell: item => item.name }];
+const columnDefinitions: TableProps.ColumnDefinition<Instance>[] = [
+  { header: 'name', cell: item => item.name },
+  { header: 'version', cell: () => 'v0' },
+];
 
 const nestedItems: Instance[] = [
   {
@@ -98,7 +101,7 @@ describe('Progressive loading', () => {
   test('renders loaders in correct order for normal table', () => {
     const { table } = renderTable({ getLoadingStatus: () => 'pending' });
 
-    expect(table.findRows().map(getTextContent)).toEqual(['Root-1', 'Root-2', '[pending] Loader for TABLE ROOT']);
+    expect(table.findRows().map(getTextContent)).toEqual(['Root-1v0', 'Root-2v0', '[pending] Loader for TABLE ROOT']);
   });
 
   test('renders loaders in correct order for expandable table', () => {
@@ -117,21 +120,21 @@ describe('Progressive loading', () => {
     });
 
     expect(table.findRows().map(getTextContent)).toEqual([
-      'Root-1',
-      'Nested-1.1',
-      'Nested-1.2',
-      'Nested-1.2.1',
-      'Nested-1.2.2',
+      'Root-1v0',
+      'Nested-1.1v0',
+      'Nested-1.2v0',
+      'Nested-1.2.1v0',
+      'Nested-1.2.2v0',
       '[pending] Loader for Nested-1.2',
       '[pending] Loader for Root-1',
-      'Root-2',
-      'Nested-2.1',
-      'Nested-2.1.1',
-      'Nested-2.1.2',
+      'Root-2v0',
+      'Nested-2.1v0',
+      'Nested-2.1.1v0',
+      'Nested-2.1.2v0',
       '[pending] Loader for Nested-2.1',
-      'Nested-2.2',
-      'Nested-2.2.1',
-      'Nested-2.2.2',
+      'Nested-2.2v0',
+      'Nested-2.2.1v0',
+      'Nested-2.2.2v0',
       '[pending] Loader for Nested-2.2',
       '[pending] Loader for Root-2',
       '[pending] Loader for TABLE ROOT',
@@ -220,25 +223,28 @@ describe('Progressive loading', () => {
     }
   );
 
-  test.each(['single', 'multi'] as const)('selection control is not rendered for loader rows', selectionType => {
-    const { table } = renderTable({
-      expandableRows: {
-        ...defaultExpandableRows,
-        expandedItems: [{ name: 'Root-1' }],
-      },
-      getLoadingStatus: () => 'pending',
-      selectionType,
-    });
+  test.each(['single', 'multi'] as const)(
+    'selection control is not rendered for loader rows, selectionType=%s',
+    selectionType => {
+      const { table } = renderTable({
+        expandableRows: {
+          ...defaultExpandableRows,
+          expandedItems: [{ name: 'Root-1' }],
+        },
+        getLoadingStatus: () => 'pending',
+        selectionType,
+      });
 
-    expect(table.findRows().map(w => [!!w.find('input'), getTextContent(w)])).toEqual([
-      [true, 'Root-1'],
-      [true, 'Nested-1.1'],
-      [true, 'Nested-1.2'],
-      [false, '[pending] Loader for Root-1'],
-      [true, 'Root-2'],
-      [false, '[pending] Loader for TABLE ROOT'],
-    ]);
-  });
+      expect(table.findRows().map(w => [!!w.find('input'), getTextContent(w)])).toEqual([
+        [true, 'Root-1v0'],
+        [true, 'Nested-1.1v0'],
+        [true, 'Nested-1.2v0'],
+        [false, '[pending] Loader for Root-1'],
+        [true, 'Root-2v0'],
+        [false, '[pending] Loader for TABLE ROOT'],
+      ]);
+    }
+  );
 
   test.each(['loading', 'error'] as const)('loader row with status="%s" is added after empty expanded item', status => {
     const { table } = renderTable({

--- a/src/table/body-cell/disabled-inline-editor.tsx
+++ b/src/table/body-cell/disabled-inline-editor.tsx
@@ -8,7 +8,6 @@ import Portal from '../../internal/components/portal';
 import { useSingleTabStopNavigation } from '../../internal/context/single-tab-stop-navigation-context';
 import useHiddenDescription from '../../internal/hooks/use-hidden-description';
 import { usePortalModeClasses } from '../../internal/hooks/use-portal-mode-classes';
-import { useVisualRefresh } from '../../internal/hooks/use-visual-mode';
 import InternalLiveRegion from '../../live-region/internal';
 import Arrow from '../../popover/arrow';
 import PopoverBody from '../../popover/body';
@@ -24,7 +23,6 @@ interface DisabledInlineEditorProps<ItemType> extends TableBodyCellProps<ItemTyp
 }
 
 export function DisabledInlineEditor<ItemType>({
-  className,
   item,
   column,
   ariaLabels,
@@ -32,10 +30,8 @@ export function DisabledInlineEditor<ItemType>({
   onEditStart,
   onEditEnd,
   editDisabledReason,
-  resizableColumns = false,
   ...rest
 }: DisabledInlineEditorProps<ItemType>) {
-  const isVisualRefresh = useVisualRefresh();
   const clickAwayRef = useClickAway(() => {
     if (isEditing) {
       onEditEnd(true);
@@ -73,13 +69,8 @@ export function DisabledInlineEditor<ItemType>({
       nativeAttributes={
         { 'data-inline-editing-active': isEditing.toString() } as TableTdElementProps['nativeAttributes']
       }
-      className={clsx(
-        className,
-        styles['body-cell-editable'],
-        resizableColumns && styles['resizable-columns'],
-        isEditing && styles['body-cell-edit-disabled-popover'],
-        isVisualRefresh && styles['is-visual-refresh']
-      )}
+      isEditing={isEditing}
+      isEditingDisabled={true}
       onClick={!isEditing ? onClick : undefined}
       onMouseEnter={() => setHasHover(true)}
       onMouseLeave={() => setHasHover(false)}

--- a/src/table/body-cell/disabled-inline-editor.tsx
+++ b/src/table/body-cell/disabled-inline-editor.tsx
@@ -8,6 +8,7 @@ import Portal from '../../internal/components/portal';
 import { useSingleTabStopNavigation } from '../../internal/context/single-tab-stop-navigation-context';
 import useHiddenDescription from '../../internal/hooks/use-hidden-description';
 import { usePortalModeClasses } from '../../internal/hooks/use-portal-mode-classes';
+import { useVisualRefresh } from '../../internal/hooks/use-visual-mode';
 import InternalLiveRegion from '../../live-region/internal';
 import Arrow from '../../popover/arrow';
 import PopoverBody from '../../popover/body';
@@ -31,10 +32,10 @@ export function DisabledInlineEditor<ItemType>({
   onEditStart,
   onEditEnd,
   editDisabledReason,
-  isVisualRefresh,
   resizableColumns = false,
   ...rest
 }: DisabledInlineEditorProps<ItemType>) {
+  const isVisualRefresh = useVisualRefresh();
   const clickAwayRef = useClickAway(() => {
     if (isEditing) {
       onEditEnd(true);

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -1,13 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useRef, useState } from 'react';
-import clsx from 'clsx';
 
 import { useInternalI18n } from '../../i18n/context';
 import Icon from '../../icon/internal';
 import { useSingleTabStopNavigation } from '../../internal/context/single-tab-stop-navigation-context.js';
 import { usePrevious } from '../../internal/hooks/use-previous';
-import { useVisualRefresh } from '../../internal/hooks/use-visual-mode';
 import InternalLiveRegion from '../../live-region/internal';
 import { TableProps } from '../interfaces';
 import { DisabledInlineEditor } from './disabled-inline-editor';
@@ -23,8 +21,6 @@ const submitHandlerFallback = () => {
 export interface TableBodyCellProps<ItemType> extends TableTdElementProps {
   column: TableProps.ColumnDefinition<ItemType>;
   item: ItemType;
-  isEditing: boolean;
-  resizableColumns?: boolean;
   successfulEdit?: boolean;
   onEditStart: () => void;
   onEditEnd: (cancelled: boolean) => void;
@@ -33,7 +29,6 @@ export interface TableBodyCellProps<ItemType> extends TableTdElementProps {
 }
 
 function TableCellEditable<ItemType>({
-  className,
   item,
   column,
   isEditing,
@@ -41,12 +36,10 @@ function TableCellEditable<ItemType>({
   onEditEnd,
   submitEdit,
   ariaLabels,
-  resizableColumns = false,
   successfulEdit = false,
   ...rest
 }: TableBodyCellProps<ItemType>) {
   const i18n = useInternalI18n('table');
-  const isVisualRefresh = useVisualRefresh();
   const editActivateRef = useRef<HTMLButtonElement>(null);
   const tdNativeAttributes = {
     'data-inline-editing-active': isEditing.toString(),
@@ -86,14 +79,8 @@ function TableCellEditable<ItemType>({
     <TableTdElement
       {...rest}
       nativeAttributes={tdNativeAttributes as TableTdElementProps['nativeAttributes']}
-      className={clsx(
-        className,
-        styles['body-cell-editable'],
-        resizableColumns && styles['resizable-columns'],
-        isEditing && styles['body-cell-edit-active'],
-        showSuccessIcon && showIcon && styles['body-cell-has-success'],
-        isVisualRefresh && styles['is-visual-refresh']
-      )}
+      isEditing={isEditing}
+      hasSuccessIcon={showSuccessIcon && showIcon}
       onClick={!isEditing ? onEditStart : undefined}
       onMouseEnter={() => setHasHover(true)}
       onMouseLeave={() => setHasHover(false)}
@@ -152,22 +139,23 @@ function TableCellEditable<ItemType>({
   );
 }
 
-export function TableBodyCell<ItemType>({
-  isEditable,
-  ...rest
-}: TableBodyCellProps<ItemType> & { isEditable: boolean }) {
-  const isExpandableColumnCell = rest.level !== undefined;
-  const editDisabledReason = rest.column.editConfig?.disabledReason?.(rest.item);
+export function TableBodyCell<ItemType>(props: TableBodyCellProps<ItemType>) {
+  const isExpandableColumnCell = props.level !== undefined;
+  const editDisabledReason = props.column.editConfig?.disabledReason?.(props.item);
 
   // Inline editing is deactivated for expandable column because editable cells are interactive
   // and cannot include interactive content such as expand toggles.
   if (editDisabledReason && !isExpandableColumnCell) {
-    return <DisabledInlineEditor editDisabledReason={editDisabledReason} {...rest} />;
+    return <DisabledInlineEditor editDisabledReason={editDisabledReason} {...props} isEditable={true} />;
   }
-  if ((isEditable || rest.isEditing) && !isExpandableColumnCell) {
-    return <TableCellEditable {...rest} />;
+  if ((props.isEditable || props.isEditing) && !isExpandableColumnCell) {
+    return <TableCellEditable {...props} isEditable={true} />;
   }
 
-  const { column, item } = rest;
-  return <TableTdElement {...rest}>{column.cell(item)}</TableTdElement>;
+  const { column, item } = props;
+  return (
+    <TableTdElement {...props} isEditable={false}>
+      {column.cell(item)}
+    </TableTdElement>
+  );
 }

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -146,16 +146,12 @@ export function TableBodyCell<ItemType>(props: TableBodyCellProps<ItemType>) {
   // Inline editing is deactivated for expandable column because editable cells are interactive
   // and cannot include interactive content such as expand toggles.
   if (editDisabledReason && !isExpandableColumnCell) {
-    return <DisabledInlineEditor editDisabledReason={editDisabledReason} {...props} isEditable={true} />;
+    return <DisabledInlineEditor editDisabledReason={editDisabledReason} {...props} />;
   }
   if ((props.isEditable || props.isEditing) && !isExpandableColumnCell) {
-    return <TableCellEditable {...props} isEditable={true} />;
+    return <TableCellEditable {...props} />;
   }
 
   const { column, item } = props;
-  return (
-    <TableTdElement {...props} isEditable={false}>
-      {column.cell(item)}
-    </TableTdElement>
-  );
+  return <TableTdElement {...props}>{column.cell(item)}</TableTdElement>;
 }

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -7,6 +7,7 @@ import { useInternalI18n } from '../../i18n/context';
 import Icon from '../../icon/internal';
 import { useSingleTabStopNavigation } from '../../internal/context/single-tab-stop-navigation-context.js';
 import { usePrevious } from '../../internal/hooks/use-previous';
+import { useVisualRefresh } from '../../internal/hooks/use-visual-mode';
 import InternalLiveRegion from '../../live-region/internal';
 import { TableProps } from '../interfaces';
 import { DisabledInlineEditor } from './disabled-inline-editor';
@@ -40,12 +41,12 @@ function TableCellEditable<ItemType>({
   onEditEnd,
   submitEdit,
   ariaLabels,
-  isVisualRefresh,
   resizableColumns = false,
   successfulEdit = false,
   ...rest
 }: TableBodyCellProps<ItemType>) {
   const i18n = useInternalI18n('table');
+  const isVisualRefresh = useVisualRefresh();
   const editActivateRef = useRef<HTMLButtonElement>(null);
   const tdNativeAttributes = {
     'data-inline-editing-active': isEditing.toString(),
@@ -155,15 +156,14 @@ export function TableBodyCell<ItemType>({
   isEditable,
   ...rest
 }: TableBodyCellProps<ItemType> & { isEditable: boolean }) {
-  const isExpandableColumnCell = rest.level !== undefined;
   const editDisabledReason = rest.column.editConfig?.disabledReason?.(rest.item);
 
   // Inline editing is deactivated for expandable column because editable cells are interactive
   // and cannot include interactive content such as expand toggles.
-  if (editDisabledReason && !isExpandableColumnCell) {
+  if (editDisabledReason) {
     return <DisabledInlineEditor editDisabledReason={editDisabledReason} {...rest} />;
   }
-  if ((isEditable || rest.isEditing) && !isExpandableColumnCell) {
+  if (isEditable || rest.isEditing) {
     return <TableCellEditable {...rest} />;
   }
 

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -156,14 +156,15 @@ export function TableBodyCell<ItemType>({
   isEditable,
   ...rest
 }: TableBodyCellProps<ItemType> & { isEditable: boolean }) {
+  const isExpandableColumnCell = rest.level !== undefined;
   const editDisabledReason = rest.column.editConfig?.disabledReason?.(rest.item);
 
   // Inline editing is deactivated for expandable column because editable cells are interactive
   // and cannot include interactive content such as expand toggles.
-  if (editDisabledReason) {
+  if (editDisabledReason && !isExpandableColumnCell) {
     return <DisabledInlineEditor editDisabledReason={editDisabledReason} {...rest} />;
   }
-  if (isEditable || rest.isEditing) {
+  if ((isEditable || rest.isEditing) && !isExpandableColumnCell) {
     return <TableCellEditable {...rest} />;
   }
 

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -7,6 +7,7 @@ import { copyAnalyticsMetadataAttribute } from '@cloudscape-design/component-too
 
 import { useSingleTabStopNavigation } from '../../internal/context/single-tab-stop-navigation-context';
 import { useMergeRefs } from '../../internal/hooks/use-merge-refs';
+import { useVisualRefresh } from '../../internal/hooks/use-visual-mode';
 import { ExpandToggleButton } from '../expandable-rows/expand-toggle-button';
 import { TableProps } from '../interfaces.js';
 import { StickyColumnsModel, useStickyCellStyles } from '../sticky-columns';
@@ -40,7 +41,6 @@ export interface TableTdElementProps {
   columnId: PropertyKey;
   colIndex: number;
   stickyState: StickyColumnsModel;
-  isVisualRefresh?: boolean;
   tableRole: TableRole;
   level?: number;
   isExpandable?: boolean;
@@ -70,7 +70,6 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
       onMouseLeave,
       isEvenRow,
       stripedRows,
-      isVisualRefresh,
       hasSelection,
       hasFooter,
       columnId,
@@ -89,6 +88,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
     ref
   ) => {
     const Element = isRowHeader ? 'th' : 'td';
+    const isVisualRefresh = useVisualRefresh();
 
     nativeAttributes = { ...nativeAttributes, ...getTableCellRoleProps({ tableRole, isRowHeader, colIndex }) };
 

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -14,10 +14,10 @@ import { StickyColumnsModel, useStickyCellStyles } from '../sticky-columns';
 import { getTableCellRoleProps, TableRole } from '../table-role';
 import { getStickyClassNames } from '../utils';
 
+import tableStyles from '../styles.css.js';
 import styles from './styles.css.js';
 
 export interface TableTdElementProps {
-  className?: string;
   style?: React.CSSProperties;
   wrapLines: boolean | undefined;
   isRowHeader?: boolean;
@@ -36,6 +36,7 @@ export interface TableTdElementProps {
   children?: React.ReactNode;
   isEvenRow?: boolean;
   stripedRows?: boolean;
+  isSelection?: boolean;
   hasSelection?: boolean;
   hasFooter?: boolean;
   columnId: PropertyKey;
@@ -49,12 +50,16 @@ export interface TableTdElementProps {
   expandButtonLabel?: string;
   collapseButtonLabel?: string;
   verticalAlign?: TableProps.VerticalAlign;
+  resizableColumns?: boolean;
+  isEditable: boolean;
+  isEditing: boolean;
+  isEditingDisabled?: boolean;
+  hasSuccessIcon?: boolean;
 }
 
 export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElementProps>(
   (
     {
-      className,
       style,
       children,
       wrapLines,
@@ -70,6 +75,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
       onMouseLeave,
       isEvenRow,
       stripedRows,
+      isSelection,
       hasSelection,
       hasFooter,
       columnId,
@@ -83,6 +89,11 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
       expandButtonLabel,
       collapseButtonLabel,
       verticalAlign,
+      resizableColumns,
+      isEditable,
+      isEditing,
+      isEditingDisabled,
+      hasSuccessIcon,
       ...rest
     },
     ref
@@ -106,7 +117,6 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
       <Element
         style={{ ...style, ...stickyStyles.style }}
         className={clsx(
-          className,
           styles['body-cell'],
           wrapLines && styles['body-cell-wrap'],
           isFirstRow && styles['body-cell-first-row'],
@@ -117,8 +127,14 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
           !isEvenRow && stripedRows && styles['body-cell-shaded'],
           stripedRows && styles['has-striped-rows'],
           isVisualRefresh && styles['is-visual-refresh'],
+          isSelection && tableStyles['selection-control'],
           hasSelection && styles['has-selection'],
           hasFooter && styles['has-footer'],
+          resizableColumns && styles['resizable-columns'],
+          isEditable && styles['body-cell-editable'],
+          isEditing && !isEditingDisabled && styles['body-cell-edit-active'],
+          isEditing && isEditingDisabled && styles['body-cell-edit-disabled-popover'],
+          hasSuccessIcon && styles['body-cell-has-success'],
           level !== undefined && styles['body-cell-expandable'],
           level !== undefined && styles[`expandable-level-${getLevelClassSuffix(level)}`],
           verticalAlign === 'top' && styles['body-cell-align-top'],

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -32,7 +32,10 @@ export interface TableHeaderCellProps<ItemType> {
   sortingDescending?: boolean;
   sortingDisabled?: boolean;
   wrapLines?: boolean;
+  stuck?: boolean;
+  sticky?: boolean;
   hidden?: boolean;
+  stripedRows?: boolean;
   onClick(detail: TableProps.SortingState<any>): void;
   onResizeFinish: () => void;
   colIndex: number;
@@ -47,6 +50,7 @@ export interface TableHeaderCellProps<ItemType> {
   resizerRoleDescription?: string;
   isExpandable?: boolean;
   hasDynamicContent?: boolean;
+  variant: TableProps.Variant;
 }
 
 export function TableHeaderCell<ItemType>({
@@ -59,7 +63,10 @@ export function TableHeaderCell<ItemType>({
   sortingDisabled,
   wrapLines,
   focusedComponent,
+  stuck,
+  sticky,
   hidden,
+  stripedRows,
   onClick,
   colIndex,
   updateColumn,
@@ -73,6 +80,7 @@ export function TableHeaderCell<ItemType>({
   resizerRoleDescription,
   isExpandable,
   hasDynamicContent,
+  variant,
 }: TableHeaderCellProps<ItemType>) {
   const i18n = useInternalI18n('table');
   const sortable = !!column.sortingComparator || !!column.sortingField;
@@ -120,11 +128,15 @@ export function TableHeaderCell<ItemType>({
       sortingStatus={sortingStatus}
       sortingDisabled={sortingDisabled}
       focusedComponent={focusedComponent}
+      stuck={stuck}
+      sticky={sticky}
       hidden={hidden}
+      stripedRows={stripedRows}
       colIndex={colIndex}
       columnId={columnId}
       stickyState={stickyState}
       tableRole={tableRole}
+      variant={variant}
       {...(sortingDisabled
         ? {}
         : getAnalyticsMetadataAttribute({

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -24,7 +24,6 @@ import analyticsSelectors from '../analytics-metadata/styles.css.js';
 import styles from './styles.css.js';
 
 export interface TableHeaderCellProps<ItemType> {
-  className?: string;
   style?: React.CSSProperties;
   tabIndex: number;
   column: TableProps.ColumnDefinition<ItemType>;
@@ -54,7 +53,6 @@ export interface TableHeaderCellProps<ItemType> {
 }
 
 export function TableHeaderCell<ItemType>({
-  className,
   style,
   tabIndex,
   column,
@@ -122,7 +120,6 @@ export function TableHeaderCell<ItemType>({
 
   return (
     <TableThElement
-      className={className}
       style={style}
       cellRef={cellRefCombined}
       sortingStatus={sortingStatus}

--- a/src/table/header-cell/th-element.tsx
+++ b/src/table/header-cell/th-element.tsx
@@ -14,10 +14,10 @@ import { getTableColHeaderRoleProps, TableRole } from '../table-role';
 import { getStickyClassNames } from '../utils';
 import { SortingStatus } from './utils';
 
+import tableStyles from '../styles.css.js';
 import styles from './styles.css.js';
 
 export interface TableThElementProps {
-  className?: string;
   style?: React.CSSProperties;
   sortingStatus?: SortingStatus;
   sortingDisabled?: boolean;
@@ -26,6 +26,7 @@ export interface TableThElementProps {
   sticky?: boolean;
   hidden?: boolean;
   stripedRows?: boolean;
+  isSelection?: boolean;
   colIndex: number;
   columnId: PropertyKey;
   stickyState: StickyColumnsModel;
@@ -36,7 +37,6 @@ export interface TableThElementProps {
 }
 
 export function TableThElement({
-  className,
   style,
   sortingStatus,
   sortingDisabled,
@@ -45,6 +45,7 @@ export function TableThElement({
   sticky,
   hidden,
   stripedRows,
+  isSelection,
   colIndex,
   columnId,
   stickyState,
@@ -76,7 +77,7 @@ export function TableThElement({
         stuck && styles['header-cell-stuck'],
         stripedRows && styles['has-striped-rows'],
         isVisualRefresh && styles['is-visual-refresh'],
-        className,
+        isSelection && clsx(tableStyles['selection-control'], tableStyles['selection-control-header']),
         {
           [styles['header-cell-fake-focus']]: focusedComponent === `header-${String(columnId)}`,
           [styles['header-cell-sortable']]: sortingStatus,

--- a/src/table/header-cell/th-element.tsx
+++ b/src/table/header-cell/th-element.tsx
@@ -7,6 +7,8 @@ import { copyAnalyticsMetadataAttribute } from '@cloudscape-design/component-too
 
 import { useSingleTabStopNavigation } from '../../internal/context/single-tab-stop-navigation-context';
 import { useMergeRefs } from '../../internal/hooks/use-merge-refs';
+import { useVisualRefresh } from '../../internal/hooks/use-visual-mode';
+import { TableProps } from '../interfaces';
 import { StickyColumnsModel, useStickyCellStyles } from '../sticky-columns';
 import { getTableColHeaderRoleProps, TableRole } from '../table-role';
 import { getStickyClassNames } from '../utils';
@@ -14,19 +16,23 @@ import { SortingStatus } from './utils';
 
 import styles from './styles.css.js';
 
-interface TableThElementProps {
+export interface TableThElementProps {
   className?: string;
   style?: React.CSSProperties;
   sortingStatus?: SortingStatus;
   sortingDisabled?: boolean;
   focusedComponent?: null | string;
+  stuck?: boolean;
+  sticky?: boolean;
   hidden?: boolean;
+  stripedRows?: boolean;
   colIndex: number;
   columnId: PropertyKey;
   stickyState: StickyColumnsModel;
   cellRef?: React.RefCallback<HTMLElement> | null;
   tableRole: TableRole;
   children: React.ReactNode;
+  variant: TableProps.Variant;
 }
 
 export function TableThElement({
@@ -35,15 +41,21 @@ export function TableThElement({
   sortingStatus,
   sortingDisabled,
   focusedComponent,
+  stuck,
+  sticky,
   hidden,
+  stripedRows,
   colIndex,
   columnId,
   stickyState,
   cellRef,
   tableRole,
   children,
+  variant,
   ...props
 }: TableThElementProps) {
+  const isVisualRefresh = useVisualRefresh();
+
   const stickyStyles = useStickyCellStyles({
     stickyColumns: stickyState,
     columnId,
@@ -58,6 +70,12 @@ export function TableThElement({
     <th
       data-focus-id={`header-${String(columnId)}`}
       className={clsx(
+        styles['header-cell'],
+        styles[`header-cell-variant-${variant}`],
+        sticky && styles['header-cell-sticky'],
+        stuck && styles['header-cell-stuck'],
+        stripedRows && styles['has-striped-rows'],
+        isVisualRefresh && styles['is-visual-refresh'],
         className,
         {
           [styles['header-cell-fake-focus']]: focusedComponent === `header-${String(columnId)}`,

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -32,15 +32,15 @@ import { SomeRequired } from '../internal/types';
 import InternalLiveRegion from '../live-region/internal';
 import { GeneratedAnalyticsMetadataTableComponent } from './analytics-metadata/interfaces';
 import { TableBodyCell } from './body-cell';
-import { TableTdElement } from './body-cell/td-element';
 import { checkColumnWidths } from './column-widths-utils';
 import { useExpandableTableProps } from './expandable-rows/expandable-rows-utils';
 import { TableForwardRefType, TableProps, TableRow } from './interfaces';
 import { NoDataCell } from './no-data-cell';
-import { ItemsLoader } from './progressive-loading/items-loader';
+import { TableLoaderCell } from './progressive-loading/loader-cell';
 import { useProgressiveLoadingProps } from './progressive-loading/progressive-loading-utils';
 import { ResizeTracker } from './resizer';
-import { focusMarkers, SelectionControl, useSelection, useSelectionFocusMove } from './selection';
+import { focusMarkers, useSelection, useSelectionFocusMove } from './selection';
+import { TableBodySelectionCell } from './selection/selection-cell';
 import { useStickyColumns } from './sticky-columns';
 import StickyHeader, { StickyHeaderRef } from './sticky-header';
 import { StickyScrollbar } from './sticky-scrollbar';
@@ -550,7 +550,6 @@ const InternalTable = React.forwardRef(
                           });
                           const getTableItemKey = (item: T) => getItemKey(trackBy, item, rowIndex);
                           const sharedCellProps = {
-                            isVisualRefresh,
                             isFirstRow,
                             isLastRow,
                             isSelected: hasSelection && isRowSelected(row),
@@ -584,21 +583,17 @@ const InternalTable = React.forwardRef(
                                 {...rowRoleProps}
                               >
                                 {getItemSelectionProps && (
-                                  <TableTdElement
+                                  <TableBodySelectionCell
                                     {...sharedCellProps}
-                                    className={styles['selection-control']}
-                                    wrapLines={false}
                                     columnId={selectionColumnId}
-                                    colIndex={0}
-                                  >
-                                    <SelectionControl
-                                      onFocusDown={moveFocusDown}
-                                      onFocusUp={moveFocusUp}
-                                      {...getItemSelectionProps(row.item)}
-                                      rowIndex={rowIndex}
-                                      itemKey={`${getTableItemKey(row.item)}`}
-                                    />
-                                  </TableTdElement>
+                                    selectionControlProps={{
+                                      ...getItemSelectionProps(row.item),
+                                      onFocusDown: moveFocusDown,
+                                      onFocusUp: moveFocusUp,
+                                      rowIndex,
+                                      itemKey: `${getTableItemKey(row.item)}`,
+                                    }}
+                                  />
                                 )}
 
                                 {visibleColumnDefinitions.map((column, colIndex) => {
@@ -667,18 +662,10 @@ const InternalTable = React.forwardRef(
                               {...rowRoleProps}
                             >
                               {getItemSelectionProps && (
-                                <TableTdElement
-                                  {...sharedCellProps}
-                                  className={styles['selection-control']}
-                                  wrapLines={false}
-                                  columnId={selectionColumnId}
-                                  colIndex={0}
-                                >
-                                  {null}
-                                </TableTdElement>
+                                <TableBodySelectionCell {...sharedCellProps} columnId={selectionColumnId} />
                               )}
                               {visibleColumnDefinitions.map((column, colIndex) => (
-                                <TableTdElement
+                                <TableLoaderCell
                                   key={getColumnKey(column, colIndex)}
                                   {...sharedCellProps}
                                   wrapLines={false}
@@ -686,18 +673,13 @@ const InternalTable = React.forwardRef(
                                   colIndex={colIndex + colIndexOffset}
                                   isRowHeader={colIndex === 0}
                                   level={row.level}
-                                >
-                                  {colIndex === 0 ? (
-                                    <ItemsLoader
-                                      item={row.item}
-                                      loadingStatus={row.status}
-                                      renderLoaderPending={renderLoaderPending}
-                                      renderLoaderLoading={renderLoaderLoading}
-                                      renderLoaderError={renderLoaderError}
-                                      trackBy={trackBy}
-                                    />
-                                  ) : null}
-                                </TableTdElement>
+                                  item={row.item}
+                                  loadingStatus={row.status}
+                                  renderLoaderPending={renderLoaderPending}
+                                  renderLoaderLoading={renderLoaderLoading}
+                                  renderLoaderError={renderLoaderError}
+                                  trackBy={trackBy}
+                                />
                               ))}
                             </tr>
                           );

--- a/src/table/no-data-cell.tsx
+++ b/src/table/no-data-cell.tsx
@@ -10,7 +10,7 @@ import InternalStatusIndicator from '../status-indicator/internal';
 
 import styles from './styles.css.js';
 
-interface NoDataCellProps {
+export interface NoDataCellProps {
   totalColumnsCount: number;
   hasFooter: boolean;
   loading?: boolean;

--- a/src/table/no-data-cell.tsx
+++ b/src/table/no-data-cell.tsx
@@ -10,7 +10,7 @@ import InternalStatusIndicator from '../status-indicator/internal';
 
 import styles from './styles.css.js';
 
-export interface NoDataCellProps {
+interface NoDataCellProps {
   totalColumnsCount: number;
   hasFooter: boolean;
   loading?: boolean;

--- a/src/table/progressive-loading/items-loader.tsx
+++ b/src/table/progressive-loading/items-loader.tsx
@@ -10,7 +10,7 @@ import { applyTrackBy } from '../utils';
 
 import styles from './styles.css.js';
 
-interface ItemsLoaderProps<T> {
+export interface ItemsLoaderProps<T> {
   item: null | T;
   loadingStatus: TableProps.LoadingStatus;
   renderLoaderPending?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;

--- a/src/table/progressive-loading/loader-cell.tsx
+++ b/src/table/progressive-loading/loader-cell.tsx
@@ -6,7 +6,9 @@ import React from 'react';
 import { TableTdElement, TableTdElementProps } from '../body-cell/td-element';
 import { ItemsLoader, ItemsLoaderProps } from './items-loader';
 
-export interface TableLoaderCellProps<ItemType> extends TableTdElementProps, ItemsLoaderProps<ItemType> {}
+export interface TableLoaderCellProps<ItemType>
+  extends Omit<TableTdElementProps, 'isEditable' | 'isEditing'>,
+    ItemsLoaderProps<ItemType> {}
 
 export function TableLoaderCell<ItemType>({
   item,
@@ -18,7 +20,7 @@ export function TableLoaderCell<ItemType>({
   ...props
 }: TableLoaderCellProps<ItemType>) {
   return (
-    <TableTdElement {...props}>
+    <TableTdElement {...props} isEditable={false} isEditing={false}>
       {props.isRowHeader ? (
         <ItemsLoader
           item={item}

--- a/src/table/progressive-loading/loader-cell.tsx
+++ b/src/table/progressive-loading/loader-cell.tsx
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+import { TableTdElement, TableTdElementProps } from '../body-cell/td-element';
+import { ItemsLoader, ItemsLoaderProps } from './items-loader';
+
+export interface TableLoaderCellProps<ItemType> extends TableTdElementProps, ItemsLoaderProps<ItemType> {}
+
+export function TableLoaderCell<ItemType>({
+  item,
+  loadingStatus,
+  renderLoaderPending,
+  renderLoaderLoading,
+  renderLoaderError,
+  trackBy,
+  ...props
+}: TableLoaderCellProps<ItemType>) {
+  return (
+    <TableTdElement {...props}>
+      {props.isRowHeader ? (
+        <ItemsLoader
+          item={item}
+          loadingStatus={loadingStatus}
+          renderLoaderPending={renderLoaderPending}
+          renderLoaderLoading={renderLoaderLoading}
+          renderLoaderError={renderLoaderError}
+          trackBy={trackBy}
+        />
+      ) : null}
+    </TableTdElement>
+  );
+}

--- a/src/table/selection/selection-cell.tsx
+++ b/src/table/selection/selection-cell.tsx
@@ -31,13 +31,7 @@ export function TableHeaderSelectionCell({
   ...props
 }: TableHeaderSelectionCellProps) {
   return (
-    <TableThElement
-      {...props}
-      hidden={props.hidden}
-      isSelection={true}
-      colIndex={0}
-      focusedComponent={focusedComponent}
-    >
+    <TableThElement {...props} isSelection={true} colIndex={0} focusedComponent={focusedComponent}>
       {getSelectAllProps ? (
         <SelectionControl
           onFocusDown={event => {

--- a/src/table/selection/selection-cell.tsx
+++ b/src/table/selection/selection-cell.tsx
@@ -1,17 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import clsx from 'clsx';
 
 import ScreenreaderOnly from '../../internal/components/screenreader-only';
-import { useVisualRefresh } from '../../internal/hooks/use-visual-mode';
 import { TableTdElement, TableTdElementProps } from '../body-cell/td-element';
 import { TableThElement, TableThElementProps } from '../header-cell/th-element';
 import { Divider } from '../resizer';
 import { SelectionProps } from './interfaces';
 import { SelectionControl, SelectionControlProps } from './selection-control';
 
-import headerCellStyles from '../header-cell/styles.css.js';
 import styles from '../styles.css.js';
 
 interface TableHeaderSelectionCellProps extends Omit<TableThElementProps, 'children' | 'colIndex'> {
@@ -21,7 +18,8 @@ interface TableHeaderSelectionCellProps extends Omit<TableThElementProps, 'child
   onFocusMove: ((sourceElement: HTMLElement, fromIndex: number, direction: -1 | 1) => void) | undefined;
 }
 
-interface TableBodySelectionCellProps extends Omit<TableTdElementProps, 'children' | 'colIndex' | 'wrapLines'> {
+interface TableBodySelectionCellProps
+  extends Omit<TableTdElementProps, 'children' | 'colIndex' | 'wrapLines' | 'isEditable' | 'isEditing'> {
   selectionControlProps?: SelectionControlProps;
 }
 
@@ -32,16 +30,11 @@ export function TableHeaderSelectionCell({
   onFocusMove,
   ...props
 }: TableHeaderSelectionCellProps) {
-  const isVisualRefresh = useVisualRefresh();
-  const selectionCellClass = clsx(
-    styles['selection-control'],
-    styles['selection-control-header'],
-    isVisualRefresh && styles['is-visual-refresh']
-  );
   return (
     <TableThElement
       {...props}
-      className={clsx(selectionCellClass, props.hidden && headerCellStyles['header-cell-hidden'])}
+      hidden={props.hidden}
+      isSelection={true}
       colIndex={0}
       focusedComponent={focusedComponent}
     >
@@ -64,7 +57,7 @@ export function TableHeaderSelectionCell({
 
 export function TableBodySelectionCell({ selectionControlProps, ...props }: TableBodySelectionCellProps) {
   return (
-    <TableTdElement {...props} className={styles['selection-control']} wrapLines={false} colIndex={0}>
+    <TableTdElement {...props} isSelection={true} wrapLines={false} isEditable={false} isEditing={false} colIndex={0}>
       {selectionControlProps ? <SelectionControl {...selectionControlProps} /> : null}
     </TableTdElement>
   );

--- a/src/table/selection/selection-cell.tsx
+++ b/src/table/selection/selection-cell.tsx
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+
+import ScreenreaderOnly from '../../internal/components/screenreader-only';
+import { useVisualRefresh } from '../../internal/hooks/use-visual-mode';
+import { TableTdElement, TableTdElementProps } from '../body-cell/td-element';
+import { TableThElement, TableThElementProps } from '../header-cell/th-element';
+import { Divider } from '../resizer';
+import { SelectionProps } from './interfaces';
+import { SelectionControl, SelectionControlProps } from './selection-control';
+
+import headerCellStyles from '../header-cell/styles.css.js';
+import styles from '../styles.css.js';
+
+interface TableHeaderSelectionCellProps extends Omit<TableThElementProps, 'children' | 'colIndex'> {
+  focusedComponent?: null | string;
+  singleSelectionHeaderAriaLabel?: string;
+  getSelectAllProps?: () => SelectionProps;
+  onFocusMove: ((sourceElement: HTMLElement, fromIndex: number, direction: -1 | 1) => void) | undefined;
+}
+
+interface TableBodySelectionCellProps extends Omit<TableTdElementProps, 'children' | 'colIndex' | 'wrapLines'> {
+  selectionControlProps?: SelectionControlProps;
+}
+
+export function TableHeaderSelectionCell({
+  focusedComponent,
+  singleSelectionHeaderAriaLabel,
+  getSelectAllProps,
+  onFocusMove,
+  ...props
+}: TableHeaderSelectionCellProps) {
+  const isVisualRefresh = useVisualRefresh();
+  const selectionCellClass = clsx(
+    styles['selection-control'],
+    styles['selection-control-header'],
+    isVisualRefresh && styles['is-visual-refresh']
+  );
+  return (
+    <TableThElement
+      {...props}
+      className={clsx(selectionCellClass, props.hidden && headerCellStyles['header-cell-hidden'])}
+      colIndex={0}
+      focusedComponent={focusedComponent}
+    >
+      {getSelectAllProps ? (
+        <SelectionControl
+          onFocusDown={event => {
+            onFocusMove!(event.target as HTMLElement, -1, +1);
+          }}
+          focusedComponent={focusedComponent}
+          {...getSelectAllProps()}
+          {...(props.sticky ? { tabIndex: -1 } : {})}
+        />
+      ) : (
+        <ScreenreaderOnly>{singleSelectionHeaderAriaLabel}</ScreenreaderOnly>
+      )}
+      <Divider className={styles['resize-divider']} />
+    </TableThElement>
+  );
+}
+
+export function TableBodySelectionCell({ selectionControlProps, ...props }: TableBodySelectionCellProps) {
+  return (
+    <TableTdElement {...props} className={styles['selection-control']} wrapLines={false} colIndex={0}>
+      {selectionControlProps ? <SelectionControl {...selectionControlProps} /> : null}
+    </TableTdElement>
+  );
+}

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -6,21 +6,17 @@ import clsx from 'clsx';
 import { findUpUntil } from '@cloudscape-design/component-toolkit/dom';
 import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
-import ScreenreaderOnly from '../internal/components/screenreader-only';
 import { fireNonCancelableEvent, NonCancelableEventHandler } from '../internal/events';
-import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { GeneratedAnalyticsMetadataTableSelectAll } from './analytics-metadata/interfaces';
 import { TableHeaderCell } from './header-cell';
-import { TableThElement } from './header-cell/th-element';
 import { TableProps } from './interfaces';
-import { Divider } from './resizer';
-import { focusMarkers, SelectionControl, SelectionProps } from './selection';
+import { focusMarkers, SelectionProps } from './selection';
+import { TableHeaderSelectionCell } from './selection/selection-cell';
 import { StickyColumnsModel } from './sticky-columns';
 import { getTableHeaderRowRoleProps, TableRole } from './table-role';
 import { useColumnWidths } from './use-column-widths';
 import { getColumnKey } from './utils';
 
-import headerCellStyles from './header-cell/styles.css.js';
 import styles from './styles.css.js';
 
 export interface TheadProps {
@@ -82,24 +78,17 @@ const Thead = React.forwardRef(
     }: TheadProps,
     outerRef: React.Ref<HTMLTableRowElement>
   ) => {
-    const isVisualRefresh = useVisualRefresh();
-
-    const headerCellClass = clsx(
-      headerCellStyles['header-cell'],
-      headerCellStyles[`header-cell-variant-${variant}`],
-      sticky && headerCellStyles['header-cell-sticky'],
-      stuck && headerCellStyles['header-cell-stuck'],
-      stripedRows && headerCellStyles['has-striped-rows'],
-      isVisualRefresh && headerCellStyles['is-visual-refresh']
-    );
-
-    const selectionCellClass = clsx(
-      styles['selection-control'],
-      styles['selection-control-header'],
-      isVisualRefresh && styles['is-visual-refresh']
-    );
-
     const { getColumnStyles, columnWidths, updateColumn, setCell } = useColumnWidths();
+
+    const commonCellProps = {
+      stuck,
+      sticky,
+      hidden,
+      stripedRows,
+      tableRole,
+      variant,
+      stickyState,
+    };
 
     return (
       <thead className={clsx(!hidden && styles['thead-active'])}>
@@ -116,41 +105,26 @@ const Thead = React.forwardRef(
           onBlur={() => onFocusedComponentChange?.(null)}
         >
           {selectionType ? (
-            <TableThElement
-              className={clsx(headerCellClass, selectionCellClass, hidden && headerCellStyles['header-cell-hidden'])}
-              hidden={hidden}
-              tableRole={tableRole}
-              colIndex={0}
+            <TableHeaderSelectionCell
+              {...commonCellProps}
               focusedComponent={focusedComponent}
               columnId={selectionColumnId}
-              stickyState={stickyState}
+              getSelectAllProps={getSelectAllProps}
+              onFocusMove={onFocusMove}
+              singleSelectionHeaderAriaLabel={singleSelectionHeaderAriaLabel}
               {...getAnalyticsMetadataAttribute({
                 action: 'selectAll',
               } as Partial<GeneratedAnalyticsMetadataTableSelectAll>)}
-            >
-              {getSelectAllProps ? (
-                <SelectionControl
-                  onFocusDown={event => {
-                    onFocusMove!(event.target as HTMLElement, -1, +1);
-                  }}
-                  focusedComponent={focusedComponent}
-                  {...getSelectAllProps()}
-                  {...(sticky ? { tabIndex: -1 } : {})}
-                />
-              ) : (
-                <ScreenreaderOnly>{singleSelectionHeaderAriaLabel}</ScreenreaderOnly>
-              )}
-              <Divider className={styles['resize-divider']} />
-            </TableThElement>
+            />
           ) : null}
 
           {columnDefinitions.map((column, colIndex) => {
             const columnId = getColumnKey(column, colIndex);
             return (
               <TableHeaderCell
+                {...commonCellProps}
                 key={columnId}
                 style={getColumnStyles(sticky, columnId)}
-                className={headerCellClass}
                 tabIndex={sticky ? -1 : 0}
                 focusedComponent={focusedComponent}
                 column={column}
@@ -158,7 +132,6 @@ const Thead = React.forwardRef(
                 sortingDescending={sortingDescending}
                 sortingDisabled={sortingDisabled}
                 wrapLines={wrapLines}
-                hidden={hidden}
                 colIndex={selectionType ? colIndex + 1 : colIndex}
                 columnId={columnId}
                 updateColumn={updateColumn}
@@ -169,7 +142,6 @@ const Thead = React.forwardRef(
                   fireNonCancelableEvent(onSortingChange, detail);
                 }}
                 isEditable={!!column.editConfig}
-                stickyState={stickyState}
                 cellRef={node => setCell(sticky, columnId, node)}
                 tableRole={tableRole}
                 resizerRoleDescription={resizerRoleDescription}


### PR DESCRIPTION
### Description

In the PR I am creating components for all types of table cells, including selection header cell, selection body cell, loader cell. This helps ensure the styles are consistently assigned and not propagated from the outside as className or style.

### How has this been tested?

* Screenshot tests (no changes expected);
* New permutations page that reproduces all available header and body cell styles.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
