### PR TITLE
fix: Fixes container overflow padding

### DIFF
--- a/pages/container/content-overflow.page.tsx
+++ b/pages/container/content-overflow.page.tsx
@@ -1,0 +1,244 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useContext } from 'react';
+
+import {
+  Alert,
+  BarChart,
+  Box,
+  Checkbox,
+  ColumnLayout,
+  Container,
+  ContainerProps,
+  FormField,
+  Header,
+  KeyValuePairs,
+  Link,
+  Slider,
+  SpaceBetween,
+  Table,
+} from '~components';
+
+import AppContext, { AppContextType } from '../app/app-context';
+import {
+  barChartInstructions,
+  commonProps as barChartCommonProps,
+  data3 as barChartData,
+} from '../mixed-line-bar-chart/common';
+import { generateItems } from '../table/generate-data';
+import { ARIA_LABELS, columnsConfig } from '../table/shared-configs';
+import ScreenshotArea from '../utils/screenshot-area';
+
+type DemoContext = React.Context<
+  AppContextType<{
+    hideHeaders: boolean;
+    hideFooters: boolean;
+    customSpacing: boolean;
+    height: string;
+    columns: string;
+  }>
+>;
+
+const instances = generateItems(10);
+
+function useSettings() {
+  const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
+  const hideHeaders = urlParams.hideHeaders ?? false;
+  const hideFooters = urlParams.hideFooters ?? false;
+  const customSpacing = urlParams.customSpacing ?? false;
+  const height = parseInt(urlParams.height ?? '') || 225;
+  const columns = parseInt(urlParams.columns ?? '') || 4;
+  return { hideHeaders, hideFooters, customSpacing, height, columns, setUrlParams };
+}
+
+function ContainerPlayground(props: ContainerProps) {
+  const settings = useSettings();
+  return (
+    <div style={{ blockSize: settings.height }}>
+      <Container
+        {...props}
+        fitHeight={true}
+        header={settings.hideHeaders ? null : <Header headingTagOverride="h2">{props.header}</Header>}
+        footer={settings.hideFooters ? null : 'Footer'}
+        disableContentPaddings={settings.customSpacing}
+      >
+        {settings.customSpacing ? (
+          <Box padding={{ horizontal: 'l', top: 'xxs', bottom: 'l' }}>{props.children}</Box>
+        ) : (
+          props.children
+        )}
+      </Container>
+    </div>
+  );
+}
+
+export default function () {
+  const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
+  const columns = parseInt(urlParams.columns ?? '') || 3;
+  const blockSize = parseInt(urlParams.height ?? '') || 225;
+  return (
+    <Box margin="m">
+      <h1>Container content overflow demo</h1>
+
+      <Box margin={{ bottom: 'm' }}>
+        <SpaceBetween size="s">
+          <SpaceBetween size="s" direction="horizontal">
+            <Checkbox
+              checked={urlParams.hideHeaders ?? false}
+              onChange={event => setUrlParams({ hideHeaders: event.detail.checked })}
+            >
+              Hide headers
+            </Checkbox>
+
+            <Checkbox
+              checked={urlParams.hideFooters ?? false}
+              onChange={event => setUrlParams({ hideFooters: event.detail.checked })}
+            >
+              Hide footers
+            </Checkbox>
+
+            <Checkbox
+              checked={urlParams.customSpacing ?? false}
+              onChange={event => setUrlParams({ customSpacing: event.detail.checked })}
+            >
+              Custom spacing
+            </Checkbox>
+          </SpaceBetween>
+
+          <FormField label="Height">
+            <Slider
+              value={blockSize}
+              onChange={({ detail }) => setUrlParams({ height: detail.value.toString() })}
+              min={50}
+              max={700}
+            />
+          </FormField>
+
+          <FormField label="Columns">
+            <Slider
+              value={columns}
+              onChange={({ detail }) => setUrlParams({ columns: detail.value.toString() })}
+              min={1}
+              max={4}
+            />
+          </FormField>
+        </SpaceBetween>
+      </Box>
+
+      <ScreenshotArea gutters={false}>
+        <ColumnLayout columns={columns}>
+          <ContainerPlayground header="Paragraph">
+            <p>
+              Lorem ipsum dolor sit amet,consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+              dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+              ea commodo consequat. Duis aute irure dolor in
+              reprehenderitinvoluptatevelitessereprehenderitinvoluptatevelitessereprehenderitinvoluptatevelitessereprehenderitinvoluptatevelitesse
+              cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+              officia deserunt mollit anim id est <Link>laborum</Link>.
+            </p>
+          </ContainerPlayground>
+
+          <ContainerPlayground header="Key-value pairs">
+            <ServiceOverview />
+          </ContainerPlayground>
+
+          <ContainerPlayground header="Alert">
+            <Alert statusIconAriaLabel="Info">
+              Lorem ipsum dolor sit amet,consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+              dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+              ea commodo consequat. Duis aute irure dolor in
+              reprehenderitinvoluptatevelitessereprehenderitinvoluptatevelitessereprehenderitinvoluptatevelitessereprehenderitinvoluptatevelitesse
+              cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+              officia deserunt mollit anim id est <Link>laborum</Link>.
+            </Alert>
+          </ContainerPlayground>
+
+          <ContainerPlayground header="Table">
+            <InstancesTable label="Instances 1" />
+          </ContainerPlayground>
+
+          <ContainerPlayground header="Bar chart">
+            <CaloriesBarChart />
+          </ContainerPlayground>
+        </ColumnLayout>
+      </ScreenshotArea>
+    </Box>
+  );
+}
+
+function ServiceOverview() {
+  return (
+    <KeyValuePairs
+      columns={4}
+      items={[
+        {
+          label: 'Running instances',
+          value: (
+            <Link variant="awsui-value-large" href="#" ariaLabel="Running instances (14)">
+              14
+            </Link>
+          ),
+        },
+        {
+          label: 'Volumes',
+          value: (
+            <Link variant="awsui-value-large" href="#" ariaLabel="Volumes (126)">
+              126
+            </Link>
+          ),
+        },
+        {
+          label: 'Security groups',
+          value: (
+            <Link variant="awsui-value-large" href="#" ariaLabel="Security groups (116)">
+              116
+            </Link>
+          ),
+        },
+        {
+          label: 'Load balancers',
+          value: (
+            <Link variant="awsui-value-large" href="#" ariaLabel="Load balancers (28)">
+              28
+            </Link>
+          ),
+        },
+      ]}
+    />
+  );
+}
+
+function InstancesTable({ label }: { label: string }) {
+  return (
+    <Table
+      ariaLabels={{ ...ARIA_LABELS, tableLabel: label }}
+      variant="borderless"
+      columnDefinitions={columnsConfig}
+      items={instances}
+    />
+  );
+}
+
+function CaloriesBarChart() {
+  return (
+    <BarChart
+      {...barChartCommonProps}
+      height={200}
+      fitHeight={true}
+      hideFilter={true}
+      hideLegend={true}
+      series={[
+        { title: 'Calories', type: 'bar', data: barChartData },
+        { title: 'Threshold', type: 'threshold', y: 400 },
+      ]}
+      xDomain={['Potatoes', 'Tangerines', 'Chocolate', 'Apples', 'Oranges']}
+      yDomain={[0, 700]}
+      xTitle="Food"
+      yTitle="Calories (kcal)"
+      xScaleType="categorical"
+      ariaLabel="Bar chart"
+      ariaDescription={barChartInstructions}
+    />
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -182,7 +182,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_item_zqq3x",
   ],
   "container": [
-    "awsui_content-inner_14iqq",
+    "awsui_content-inner_1mwlm",
     "awsui_content-wrapper_14iqq",
     "awsui_content_14iqq",
     "awsui_footer_14iqq",

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -182,6 +182,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_item_zqq3x",
   ],
   "container": [
+    "awsui_content-inner_14iqq",
     "awsui_content-wrapper_14iqq",
     "awsui_content_14iqq",
     "awsui_footer_14iqq",

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -19,6 +19,7 @@ import { StickyHeaderContext, useStickyHeader } from './use-sticky-header';
 
 import analyticsSelectors from './analytics-metadata/styles.css.js';
 import styles from './styles.css.js';
+import testStyles from './test-classes/styles.css.js';
 
 export interface InternalContainerProps extends Omit<ContainerProps, 'variant'>, InternalBaseComponentProps {
   __stickyHeader?: boolean;
@@ -167,7 +168,7 @@ export default function InternalContainer({
         )}
         <div className={clsx(styles.content, fitHeight && styles['content-fit-height'])}>
           <div
-            className={clsx(styles['content-inner'], {
+            className={clsx(styles['content-inner'], testStyles['content-inner'], {
               [styles['with-paddings']]: !disableContentPaddings,
               [styles['with-header']]: !!header,
             })}

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -165,12 +165,15 @@ export default function InternalContainer({
             </StickyHeaderContext.Provider>
           </ContainerHeaderContextProvider>
         )}
-        <div
-          className={clsx(styles.content, fitHeight && styles['content-fit-height'], {
-            [styles['with-paddings']]: !disableContentPaddings,
-          })}
-        >
-          {children}
+        <div className={clsx(styles.content, fitHeight && styles['content-fit-height'])}>
+          <div
+            className={clsx(styles['content-inner'], {
+              [styles['with-paddings']]: !disableContentPaddings,
+              [styles['with-header']]: !!header,
+            })}
+          >
+            {children}
+          </div>
         </div>
         {footer && (
           <div

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -254,8 +254,7 @@
   flex: 1;
 
   &.with-paddings {
-    padding-block-start: awsui.$space-scaled-l;
-    padding-block-end: awsui.$space-scaled-l;
+    padding-block: awsui.$space-scaled-l;
     padding-inline: awsui.$space-container-horizontal;
 
     &.with-header {

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -246,16 +246,20 @@
   flex: 1;
   &-fit-height {
     overflow: auto;
+    display: flex;
+    flex-direction: column;
   }
+}
+.content-inner {
+  flex: 1;
+
   &.with-paddings {
-    padding-block: awsui.$space-scaled-l;
+    padding-block-start: awsui.$space-scaled-l;
+    padding-block-end: awsui.$space-scaled-l;
     padding-inline: awsui.$space-container-horizontal;
 
-    .header + & {
+    &.with-header {
       padding-block-start: awsui.$space-container-content-top;
-      &.content-with-media {
-        padding-block-start: 0;
-      }
     }
   }
 }

--- a/src/container/test-classes/styles.scss
+++ b/src/container/test-classes/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.content-inner {
+  /* used in test-utils */
+}

--- a/src/test-utils/dom/expandable-section/index.ts
+++ b/src/test-utils/dom/expandable-section/index.ts
@@ -26,7 +26,7 @@ export default class ExpandableSectionWrapper extends ComponentWrapper {
 
   findExpandedContent(): ElementWrapper | null {
     return this.find(
-      `:scope > .${styles['content-expanded']}, :scope > .${containerStyles['content-wrapper']} > .${containerStyles.content} > .${styles['content-expanded']}`
+      `:scope > .${styles['content-expanded']}, :scope > .${containerStyles['content-wrapper']} > .${containerStyles.content} > .${containerStyles['content-inner']} > .${styles['content-expanded']}`
     );
   }
 

--- a/src/test-utils/dom/expandable-section/index.ts
+++ b/src/test-utils/dom/expandable-section/index.ts
@@ -3,6 +3,7 @@
 import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 
 import containerStyles from '../../../container/styles.selectors.js';
+import containerTestStyles from '../../../container/test-classes/styles.selectors.js';
 import styles from '../../../expandable-section/styles.selectors.js';
 import headerStyles from '../../../header/styles.selectors.js';
 
@@ -26,7 +27,7 @@ export default class ExpandableSectionWrapper extends ComponentWrapper {
 
   findExpandedContent(): ElementWrapper | null {
     return this.find(
-      `:scope > .${styles['content-expanded']}, :scope > .${containerStyles['content-wrapper']} > .${containerStyles.content} > .${containerStyles['content-inner']} > .${styles['content-expanded']}`
+      `:scope > .${styles['content-expanded']}, :scope > .${containerStyles['content-wrapper']} > .${containerStyles.content} > .${containerTestStyles['content-inner']} > .${styles['content-expanded']}`
     );
   }
 


### PR DESCRIPTION
### Description

The PR fixes an issue when the container padding caused table scrollbar to display incorrectly. It also improves the handling of fit-height charts that do not fit the container.

Rel: AWSUI-54814

Before:


https://github.com/user-attachments/assets/10c1fd07-8be4-4bea-9f2f-9be3f21be495



After:


https://github.com/user-attachments/assets/358fe6f2-1a43-47c1-8d94-84a3e4def387



### How has this been tested?

* Screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
