### PR TITLE
chore: Renaming and separating components in calendar grid

### DIFF
--- a/src/date-range-picker/calendar/grids/grid-cell.tsx
+++ b/src/date-range-picker/calendar/grids/grid-cell.tsx
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { forwardRef, TdHTMLAttributes, useRef, useState } from 'react';
+
+import Tooltip from '../../../internal/components/tooltip';
+import useHiddenDescription from '../../../internal/hooks/use-hidden-description';
+import { useMergeRefs } from '../../../internal/hooks/use-merge-refs';
+import { applyDisplayName } from '../../../internal/utils/apply-display-name';
+
+import styles from './styles.css.js';
+
+interface GridCellProps extends TdHTMLAttributes<HTMLTableCellElement> {
+  disabledReason?: string;
+}
+
+export const GridCell = forwardRef((props: GridCellProps, focusedDateRef: React.Ref<HTMLTableCellElement>) => {
+  const { disabledReason, ...rest } = props;
+  const isDisabledWithReason = !!disabledReason;
+  const { targetProps, descriptionEl } = useHiddenDescription(disabledReason);
+  const ref = useRef<HTMLTableCellElement>(null);
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  return (
+    <td
+      ref={useMergeRefs(focusedDateRef, ref)}
+      {...rest}
+      {...(isDisabledWithReason ? targetProps : {})}
+      onFocus={event => {
+        if (rest.onFocus) {
+          rest.onFocus(event);
+        }
+
+        if (isDisabledWithReason) {
+          setShowTooltip(true);
+        }
+      }}
+      onBlur={event => {
+        if (rest.onBlur) {
+          rest.onBlur(event);
+        }
+
+        if (isDisabledWithReason) {
+          setShowTooltip(false);
+        }
+      }}
+      onMouseEnter={event => {
+        if (rest.onMouseEnter) {
+          rest.onMouseEnter(event);
+        }
+
+        if (isDisabledWithReason) {
+          setShowTooltip(true);
+        }
+      }}
+      onMouseLeave={event => {
+        if (rest.onMouseLeave) {
+          rest.onMouseLeave(event);
+        }
+
+        if (isDisabledWithReason) {
+          setShowTooltip(false);
+        }
+      }}
+    >
+      {props.children}
+      {isDisabledWithReason && (
+        <>
+          {descriptionEl}
+          {showTooltip && (
+            <Tooltip className={styles['disabled-reason-tooltip']} trackRef={ref} value={disabledReason!} />
+          )}
+        </>
+      )}
+    </td>
+  );
+});
+
+applyDisplayName(GridCell, 'GridCell');

--- a/src/date-range-picker/calendar/grids/index.tsx
+++ b/src/date-range-picker/calendar/grids/index.tsx
@@ -11,7 +11,7 @@ import { hasValue } from '../../../internal/utils/has-value';
 import InternalSpaceBetween from '../../../space-between/internal';
 import { DateRangePickerProps, DayIndex } from '../../interfaces';
 import { findDateToFocus } from '../utils';
-import { Grid } from './grid';
+import { MonthlyGrid } from './monthly-grid';
 
 import styles from '../../styles.css.js';
 
@@ -168,7 +168,7 @@ export const Grids = ({
     <div ref={containerRef} onFocus={onGridFocus} onBlur={onGridBlur}>
       <InternalSpaceBetween size="xs" direction="horizontal">
         {!isSingleGrid && (
-          <Grid
+          <MonthlyGrid
             className={styles['first-grid']}
             baseDate={addMonths(baseDate, -1)}
             selectedEndDate={selectedEndDate}
@@ -188,7 +188,7 @@ export const Grids = ({
             ariaLabelledby={`${headingIdPrefix}-prevmonth`}
           />
         )}
-        <Grid
+        <MonthlyGrid
           className={styles['second-grid']}
           baseDate={baseDate}
           selectedEndDate={selectedEndDate}

--- a/src/date-range-picker/calendar/grids/monthly-grid.tsx
+++ b/src/date-range-picker/calendar/grids/monthly-grid.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { forwardRef, TdHTMLAttributes, useMemo, useRef, useState } from 'react';
+import React, { useMemo } from 'react';
 import clsx from 'clsx';
 import {
   addDays,
@@ -17,12 +17,9 @@ import { getCalendarMonth } from 'mnth';
 
 import { getDateLabel, renderDayName } from '../../../calendar/utils/intl';
 import ScreenreaderOnly from '../../../internal/components/screenreader-only/index.js';
-import Tooltip from '../../../internal/components/tooltip';
-import useHiddenDescription from '../../../internal/hooks/use-hidden-description';
-import { useMergeRefs } from '../../../internal/hooks/use-merge-refs';
-import { applyDisplayName } from '../../../internal/utils/apply-display-name';
 import { formatDate } from '../../../internal/utils/date-time';
 import { DateRangePickerProps, DayIndex } from '../../interfaces';
+import { GridCell } from './grid-cell';
 
 import styles from './styles.css.js';
 
@@ -67,75 +64,7 @@ export interface GridProps {
   className?: string;
 }
 
-interface GridCellProps extends TdHTMLAttributes<HTMLTableCellElement> {
-  disabledReason?: string;
-}
-
-const GridCell = forwardRef((props: GridCellProps, focusedDateRef: React.Ref<HTMLTableCellElement>) => {
-  const { disabledReason, ...rest } = props;
-  const isDisabledWithReason = !!disabledReason;
-  const { targetProps, descriptionEl } = useHiddenDescription(disabledReason);
-  const ref = useRef<HTMLTableCellElement>(null);
-  const [showTooltip, setShowTooltip] = useState(false);
-
-  return (
-    <td
-      ref={useMergeRefs(focusedDateRef, ref)}
-      {...rest}
-      {...(isDisabledWithReason ? targetProps : {})}
-      onFocus={event => {
-        if (rest.onFocus) {
-          rest.onFocus(event);
-        }
-
-        if (isDisabledWithReason) {
-          setShowTooltip(true);
-        }
-      }}
-      onBlur={event => {
-        if (rest.onBlur) {
-          rest.onBlur(event);
-        }
-
-        if (isDisabledWithReason) {
-          setShowTooltip(false);
-        }
-      }}
-      onMouseEnter={event => {
-        if (rest.onMouseEnter) {
-          rest.onMouseEnter(event);
-        }
-
-        if (isDisabledWithReason) {
-          setShowTooltip(true);
-        }
-      }}
-      onMouseLeave={event => {
-        if (rest.onMouseLeave) {
-          rest.onMouseLeave(event);
-        }
-
-        if (isDisabledWithReason) {
-          setShowTooltip(false);
-        }
-      }}
-    >
-      {props.children}
-      {isDisabledWithReason && (
-        <>
-          {descriptionEl}
-          {showTooltip && (
-            <Tooltip className={styles['disabled-reason-tooltip']} trackRef={ref} value={disabledReason!} />
-          )}
-        </>
-      )}
-    </td>
-  );
-});
-
-applyDisplayName(GridCell, 'GridCell');
-
-export function Grid({
+export function MonthlyGrid({
   baseDate,
   selectedStartDate,
   selectedEndDate,


### PR DESCRIPTION
First step in preparation for adding a yearly-grid for the date-range-picker

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
