### PR TITLE
feat: Adds i18n provider to file upload and file token group

### DIFF
--- a/pages/file-token-group/permutations.page.tsx
+++ b/pages/file-token-group/permutations.page.tsx
@@ -34,6 +34,7 @@ const permutations = createPermutations<Omit<FileTokenGroupProps, 'onDismiss' | 
     showFileLastModified: [true, false],
     showFileSize: [true, false],
     alignment: ['horizontal', 'vertical'],
+    limit: [undefined, 0],
   },
 ]);
 
@@ -47,13 +48,13 @@ export default function FileTokenGroupPermutations() {
           render={permutation => (
             <FileTokenGroup
               i18nStrings={{
-                errorIconAriaLabel: 'Error',
-                warningIconAriaLabel: 'Warning',
-                removeFileAriaLabel: (fileIndex: number) => `Remove file ${fileIndex + 1}`,
+                // errorIconAriaLabel: 'Error',
+                // warningIconAriaLabel: 'Warning',
+                // removeFileAriaLabel: (fileIndex: number) => `Remove file ${fileIndex + 1}`,
                 formatFileSize: () => `1.01 MB`,
                 formatFileLastModified: () => '2020-01-01T00:00:00',
-                limitShowFewer: 'Show fewer',
-                limitShowMore: 'Show more',
+                // limitShowFewer: 'Show fewer',
+                // limitShowMore: 'Show more',
               }}
               onDismiss={() => {
                 /*empty handler to suppress react controlled property warning*/

--- a/pages/file-token-group/permutations.page.tsx
+++ b/pages/file-token-group/permutations.page.tsx
@@ -3,6 +3,8 @@
 import React from 'react';
 
 import FileTokenGroup, { FileTokenGroupProps } from '~components/file-token-group';
+import { I18nProvider } from '~components/i18n';
+import messages from '~components/i18n/messages/all.en';
 
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
@@ -11,7 +13,7 @@ import ScreenshotArea from '../utils/screenshot-area';
 const file1 = new File([new Blob(['demo content 1'])], 'demo file 1', { type: 'image/*' });
 const file2 = new File([new Blob(['demo content 2'])], 'demo file 2 long name here test', { type: 'image/*' });
 
-const permutations = createPermutations<Omit<FileTokenGroupProps, 'onDismiss' | 'i18nStrings'>>([
+const permutations = createPermutations<Omit<FileTokenGroupProps, 'onDismiss'>>([
   {
     items: [[{ file: file1 }]],
     showFileLastModified: [true, false],
@@ -40,22 +42,13 @@ const permutations = createPermutations<Omit<FileTokenGroupProps, 'onDismiss' | 
 
 export default function FileTokenGroupPermutations() {
   return (
-    <>
+    <I18nProvider messages={[messages]} locale="en">
       <h1>FileTokenGroup permutations</h1>
       <ScreenshotArea disableAnimations={true}>
         <PermutationsView
           permutations={permutations}
           render={permutation => (
             <FileTokenGroup
-              i18nStrings={{
-                // errorIconAriaLabel: 'Error',
-                // warningIconAriaLabel: 'Warning',
-                // removeFileAriaLabel: (fileIndex: number) => `Remove file ${fileIndex + 1}`,
-                formatFileSize: () => `1.01 MB`,
-                formatFileLastModified: () => '2020-01-01T00:00:00',
-                // limitShowFewer: 'Show fewer',
-                // limitShowMore: 'Show more',
-              }}
               onDismiss={() => {
                 /*empty handler to suppress react controlled property warning*/
               }}
@@ -64,6 +57,6 @@ export default function FileTokenGroupPermutations() {
           )}
         />
       </ScreenshotArea>
-    </>
+    </I18nProvider>
   );
 }

--- a/pages/file-upload/scenario-standalone.page.tsx
+++ b/pages/file-upload/scenario-standalone.page.tsx
@@ -3,12 +3,11 @@
 import React, { useEffect, useRef, useState } from 'react';
 
 import { Alert, Box, Checkbox, FileUpload, FileUploadProps, FormField, Header } from '~components';
-import SpaceBetween from '~components/space-between';
 import { I18nProvider } from '~components/i18n';
 import messages from '~components/i18n/messages/all.en';
+import SpaceBetween from '~components/space-between';
 
 import { PageNotifications, useContractFilesForm } from './page-helpers';
-import { i18nStrings } from './shared';
 import { validateContractFiles } from './validations';
 
 export default function FileUploadScenarioStandalone() {
@@ -66,7 +65,6 @@ export default function FileUploadScenarioStandalone() {
               showFileSize={true}
               showFileLastModified={true}
               showFileThumbnail={true}
-              //i18nStrings={i18nStrings}
               {...contractsErrors}
               constraintText="File size must not exceed 250 KB. Combined file size must not exceed 750 KB"
             />

--- a/pages/file-upload/scenario-standalone.page.tsx
+++ b/pages/file-upload/scenario-standalone.page.tsx
@@ -4,6 +4,8 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { Alert, Box, Checkbox, FileUpload, FileUploadProps, FormField, Header } from '~components';
 import SpaceBetween from '~components/space-between';
+import { I18nProvider } from '~components/i18n';
+import messages from '~components/i18n/messages/all.en';
 
 import { PageNotifications, useContractFilesForm } from './page-helpers';
 import { i18nStrings } from './shared';
@@ -26,49 +28,51 @@ export default function FileUploadScenarioStandalone() {
   }, [hasError]);
 
   return (
-    <Box margin="xl">
-      <SpaceBetween size="xl">
-        <Header variant="h1">File upload scenario: Standalone</Header>
+    <I18nProvider messages={[messages]} locale="en">
+      <Box margin="xl">
+        <SpaceBetween size="xl">
+          <Header variant="h1">File upload scenario: Standalone</Header>
 
-        <Alert statusIconAriaLabel="Info" header="Scenario description">
-          File upload is used as a standalone component. It supports synchronous client-side validation as per
-          constraints. Additionally, the component imitates server-side validation triggered for image files.
-        </Alert>
+          <Alert statusIconAriaLabel="Info" header="Scenario description">
+            File upload is used as a standalone component. It supports synchronous client-side validation as per
+            constraints. Additionally, the component imitates server-side validation triggered for image files.
+          </Alert>
 
-        <PageNotifications status={formState.status} />
+          <PageNotifications status={formState.status} />
 
-        <Checkbox checked={acceptMultiple} onChange={event => setAcceptMultiple(event.detail.checked)}>
-          Accept multiple files
-        </Checkbox>
+          <Checkbox checked={acceptMultiple} onChange={event => setAcceptMultiple(event.detail.checked)}>
+            Accept multiple files
+          </Checkbox>
 
-        <Checkbox checked={verticalAlignment} onChange={event => setVerticalAlignment(event.detail.checked)}>
-          Vertical alignment
-        </Checkbox>
+          <Checkbox checked={verticalAlignment} onChange={event => setVerticalAlignment(event.detail.checked)}>
+            Vertical alignment
+          </Checkbox>
 
-        <FormField
-          label={acceptMultiple ? 'Contracts' : 'Contract'}
-          description={acceptMultiple ? 'Upload your contract with all amendments' : 'Upload your contract'}
-        >
-          <FileUpload
-            fileTokenAlignment={verticalAlignment ? 'vertical' : 'horizontal'}
-            ref={contractsRef}
-            multiple={acceptMultiple}
-            tokenLimit={3}
-            value={formState.files}
-            onChange={event => {
-              formState.onFilesChange(event.detail.value);
-              formState.onUploadFiles(!validateContractFiles(event.detail.value) ? event.detail.value : []);
-            }}
-            accept="application/pdf, image/png, image/jpeg"
-            showFileSize={true}
-            showFileLastModified={true}
-            showFileThumbnail={true}
-            i18nStrings={i18nStrings}
-            {...contractsErrors}
-            constraintText="File size must not exceed 250 KB. Combined file size must not exceed 750 KB"
-          />
-        </FormField>
-      </SpaceBetween>
-    </Box>
+          <FormField
+            label={acceptMultiple ? 'Contracts' : 'Contract'}
+            description={acceptMultiple ? 'Upload your contract with all amendments' : 'Upload your contract'}
+          >
+            <FileUpload
+              fileTokenAlignment={verticalAlignment ? 'vertical' : 'horizontal'}
+              ref={contractsRef}
+              multiple={acceptMultiple}
+              tokenLimit={3}
+              value={formState.files}
+              onChange={event => {
+                formState.onFilesChange(event.detail.value);
+                formState.onUploadFiles(!validateContractFiles(event.detail.value) ? event.detail.value : []);
+              }}
+              accept="application/pdf, image/png, image/jpeg"
+              showFileSize={true}
+              showFileLastModified={true}
+              showFileThumbnail={true}
+              //i18nStrings={i18nStrings}
+              {...contractsErrors}
+              constraintText="File size must not exceed 250 KB. Combined file size must not exceed 750 KB"
+            />
+          </FormField>
+        </SpaceBetween>
+      </Box>
+    </I18nProvider>
   );
 }

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -7675,7 +7675,7 @@ exports[`Documenter definition for file-token-group matches the snapshot: file-t
           },
           {
             "name": "removeFileAriaLabel",
-            "optional": false,
+            "optional": true,
             "type": "(fileIndex: number) => string",
           },
           {
@@ -7687,7 +7687,7 @@ exports[`Documenter definition for file-token-group matches the snapshot: file-t
         "type": "object",
       },
       "name": "i18nStrings",
-      "optional": false,
+      "optional": true,
       "type": "FileTokenGroupProps.I18nStrings",
     },
     {
@@ -7889,7 +7889,7 @@ is provided by its parent form field component.
         "properties": [
           {
             "name": "dropzoneText",
-            "optional": false,
+            "optional": true,
             "type": "(multiple: boolean) => string",
           },
           {
@@ -7909,22 +7909,22 @@ is provided by its parent form field component.
           },
           {
             "name": "limitShowFewer",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           {
             "name": "limitShowMore",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           {
             "name": "removeFileAriaLabel",
-            "optional": false,
+            "optional": true,
             "type": "(fileIndex: number) => string",
           },
           {
             "name": "uploadButtonText",
-            "optional": false,
+            "optional": true,
             "type": "(multiple: boolean) => string",
           },
           {
@@ -7936,7 +7936,7 @@ is provided by its parent form field component.
         "type": "object",
       },
       "name": "i18nStrings",
-      "optional": false,
+      "optional": true,
       "type": "FileUploadProps.I18nStrings",
     },
     {

--- a/src/file-token-group/__tests__/file-token-group.test.tsx
+++ b/src/file-token-group/__tests__/file-token-group.test.tsx
@@ -1,10 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
-import { act, fireEvent, render as testingLibraryRender } from '@testing-library/react';
+import { act, fireEvent, render as testingLibraryRender, screen } from '@testing-library/react';
 
 import '../../__a11y__/to-validate-a11y';
 import FileTokenGroup, { FileTokenGroupProps } from '../../../lib/components/file-token-group';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
 import styles from '../../../lib/components/file-token-group/styles.css.js';
@@ -137,7 +138,6 @@ describe('File upload tokens', () => {
       items: [{ file: file1 }],
       showFileSize: true,
       i18nStrings: {
-        ...defaultProps.i18nStrings,
         formatFileSize: sizeInBytes => `${sizeInBytes} bytes`,
       },
     });
@@ -257,6 +257,39 @@ describe('Focusing behavior', () => {
     wrapper.findFileToken(2)!.findRemoveButton().click();
 
     expect(wrapper.findFileToken(1)!.findRemoveButton().getElement()).toHaveFocus();
+  });
+});
+
+describe('i18n', () => {
+  test('has default i18n strings', () => {
+    const { container } = testingLibraryRender(
+      <FileTokenGroup items={[{ file: file1 }]} limit={0} onDismiss={onDismiss} />
+    );
+
+    screen.debug();
+
+    const wrapper = createWrapper(container).findFileTokenGroup()!;
+    expect(wrapper.getElement()).toHaveTextContent('Show more');
+  });
+
+  test('supports providing custom i18n strings', () => {
+    const { container } = testingLibraryRender(
+      <TestI18nProvider
+        messages={{
+          'file-token-group': {
+            'i18nStrings.limitShowFewer': 'Custom show fewer',
+            'i18nStrings.limitShowMore': 'Custom show more',
+          },
+        }}
+      >
+        <FileTokenGroup items={[{ file: file1 }]} limit={0} onDismiss={onDismiss} />
+      </TestI18nProvider>
+    );
+
+    screen.debug();
+
+    const wrapper = createWrapper(container).findFileTokenGroup()!;
+    expect(wrapper.getElement()).toHaveTextContent('Custom show more');
   });
 });
 

--- a/src/file-token-group/__tests__/file-token-group.test.tsx
+++ b/src/file-token-group/__tests__/file-token-group.test.tsx
@@ -267,17 +267,26 @@ describe('i18n', () => {
         messages={{
           'file-token-group': {
             'i18nStrings.limitShowMore': 'Custom show more',
+            'i18nStrings.removeFileAriaLabel': `Custom remove file {fileIndex}`,
+            'i18nStrings.errorIconAriaLabel': 'Custom error',
+            'i18nStrings.warningIconAriaLabel': 'Custom warning',
           },
         }}
       >
-        <FileTokenGroup items={[{ file: file1 }]} limit={0} onDismiss={onDismiss} />
+        <FileTokenGroup
+          items={[{ file: file1, errorText: 'Error' }, { file: file2, warningText: 'Warning' }, { file: file2 }]}
+          limit={2}
+          onDismiss={onDismiss}
+        />
       </TestI18nProvider>
     );
 
-    screen.debug();
-
     const wrapper = createWrapper(container).findFileTokenGroup()!;
+
     expect(wrapper.getElement()).toHaveTextContent('Custom show more');
+    expect(wrapper.findFileToken(1)!.findRemoveButton()!.getElement()).toHaveAccessibleName('Custom remove file 1');
+    expect(screen.getByLabelText('Custom error')).not.toBeNull();
+    expect(screen.getByLabelText('Custom warning')).not.toBeNull();
   });
 });
 

--- a/src/file-token-group/__tests__/file-token-group.test.tsx
+++ b/src/file-token-group/__tests__/file-token-group.test.tsx
@@ -261,23 +261,11 @@ describe('Focusing behavior', () => {
 });
 
 describe('i18n', () => {
-  test('has default i18n strings', () => {
-    const { container } = testingLibraryRender(
-      <FileTokenGroup items={[{ file: file1 }]} limit={0} onDismiss={onDismiss} />
-    );
-
-    screen.debug();
-
-    const wrapper = createWrapper(container).findFileTokenGroup()!;
-    expect(wrapper.getElement()).toHaveTextContent('Show more');
-  });
-
   test('supports providing custom i18n strings', () => {
     const { container } = testingLibraryRender(
       <TestI18nProvider
         messages={{
           'file-token-group': {
-            'i18nStrings.limitShowFewer': 'Custom show fewer',
             'i18nStrings.limitShowMore': 'Custom show more',
           },
         }}

--- a/src/file-token-group/file-token.tsx
+++ b/src/file-token-group/file-token.tsx
@@ -21,7 +21,7 @@ import testUtilStyles from './test-classes/styles.css.js';
 
 export namespace FileTokenProps {
   export interface I18nStrings {
-    removeFileAriaLabel?: string;
+    removeFileAriaLabel?: (fileIndex: number) => string;
     errorIconAriaLabel?: string;
     warningIconAriaLabel?: string;
     formatFileSize?: (sizeInBytes: number) => string;
@@ -74,6 +74,10 @@ function InternalFileToken({
   const fileNameRef = useRef<HTMLSpanElement>(null);
   const fileNameContainerRef = useRef<HTMLDivElement>(null);
   const [showTooltip, setShowTooltip] = useState(false);
+
+  const getDismissLabel = (fileIndex: number) => {
+    return i18nStrings?.removeFileAriaLabel?.(fileIndex);
+  };
 
   function isEllipsisActive() {
     const span = fileNameRef.current;
@@ -166,9 +170,7 @@ function InternalFileToken({
             </InternalSpaceBetween>
           </div>
         </InternalBox>
-        {onDismiss && !readOnly && (
-          <DismissButton dismissLabel={i18nStrings?.removeFileAriaLabel} onDismiss={onDismiss} />
-        )}
+        {onDismiss && !readOnly && <DismissButton dismissLabel={getDismissLabel(index)} onDismiss={onDismiss} />}
       </div>
       {errorText && (
         <FormFieldError id={errorId} errorIconAriaLabel={i18nStrings?.errorIconAriaLabel}>

--- a/src/file-token-group/file-token.tsx
+++ b/src/file-token-group/file-token.tsx
@@ -21,7 +21,7 @@ import testUtilStyles from './test-classes/styles.css.js';
 
 export namespace FileTokenProps {
   export interface I18nStrings {
-    removeFileAriaLabel: (fileIndex: number) => string;
+    removeFileAriaLabel?: string;
     errorIconAriaLabel?: string;
     warningIconAriaLabel?: string;
     formatFileSize?: (sizeInBytes: number) => string;
@@ -39,7 +39,7 @@ export interface FileTokenProps extends BaseComponentProps {
   warningText?: React.ReactNode;
   loading?: boolean;
   readOnly?: boolean;
-  i18nStrings: FileTokenProps.I18nStrings;
+  i18nStrings?: FileTokenProps.I18nStrings;
   dismissLabel?: string;
   alignment?: TokenGroupProps.Alignment;
   groupContainsImage?: boolean;
@@ -63,8 +63,8 @@ function InternalFileToken({
   isImage,
   index,
 }: FileTokenProps) {
-  const formatFileSize = i18nStrings.formatFileSize ?? defaultFormatters.formatFileSize;
-  const formatFileLastModified = i18nStrings.formatFileLastModified ?? defaultFormatters.formatFileLastModified;
+  const formatFileSize = i18nStrings?.formatFileSize ?? defaultFormatters.formatFileSize;
+  const formatFileLastModified = i18nStrings?.formatFileLastModified ?? defaultFormatters.formatFileLastModified;
 
   const errorId = useUniqueId('error');
   const warningId = useUniqueId('warning');
@@ -167,16 +167,16 @@ function InternalFileToken({
           </div>
         </InternalBox>
         {onDismiss && !readOnly && (
-          <DismissButton dismissLabel={i18nStrings.removeFileAriaLabel(index)} onDismiss={onDismiss} />
+          <DismissButton dismissLabel={i18nStrings?.removeFileAriaLabel} onDismiss={onDismiss} />
         )}
       </div>
       {errorText && (
-        <FormFieldError id={errorId} errorIconAriaLabel={i18nStrings.errorIconAriaLabel}>
+        <FormFieldError id={errorId} errorIconAriaLabel={i18nStrings?.errorIconAriaLabel}>
           {errorText}
         </FormFieldError>
       )}
       {showWarning && (
-        <FormFieldWarning id={warningId} warningIconAriaLabel={i18nStrings.warningIconAriaLabel}>
+        <FormFieldWarning id={warningId} warningIconAriaLabel={i18nStrings?.warningIconAriaLabel}>
           {warningText}
         </FormFieldWarning>
       )}

--- a/src/file-token-group/interfaces.ts
+++ b/src/file-token-group/interfaces.ts
@@ -66,7 +66,7 @@ export interface FileTokenGroupProps extends BaseComponentProps {
    * * `formatFileSize` (function): (Optional) A function that takes file size in bytes, and produces a formatted string.
    * * `formatFileLastModified` (function): (Optional) A function that takes the files last modified date, and produces a formatted string.
    */
-  i18nStrings: FileTokenGroupProps.I18nStrings;
+  i18nStrings?: FileTokenGroupProps.I18nStrings;
 }
 
 export namespace FileTokenGroupProps {
@@ -78,7 +78,7 @@ export namespace FileTokenGroupProps {
     limitShowFewer?: string;
     limitShowMore?: string;
 
-    removeFileAriaLabel: (fileIndex: number) => string;
+    removeFileAriaLabel?: (fileIndex: number) => string;
     errorIconAriaLabel?: string;
     warningIconAriaLabel?: string;
     formatFileSize?: (sizeInBytes: number) => string;

--- a/src/file-token-group/internal.tsx
+++ b/src/file-token-group/internal.tsx
@@ -4,6 +4,7 @@
 import React, { useState } from 'react';
 import clsx from 'clsx';
 
+import { useInternalI18n } from '../i18n/context';
 import { getBaseProps } from '../internal/base-component/index.js';
 import TokenList from '../internal/components/token-list/index.js';
 import { fireNonCancelableEvent } from '../internal/events/index.js';
@@ -50,6 +51,8 @@ function InternalFileTokenGroup({
   const isImage = (file: File) => file.type.startsWith('image/');
   const groupContainsImage = items.filter(item => isImage(item.file)).length > 0;
 
+  const i18n = useInternalI18n('file-token-group');
+
   return (
     <div {...baseProps} ref={mergedRef} className={clsx(baseProps.className, styles.root, testStyles.root)}>
       <TokenList
@@ -67,7 +70,17 @@ function InternalFileTokenGroup({
             }}
             errorText={file.errorText}
             warningText={file.warningText}
-            i18nStrings={i18nStrings}
+            i18nStrings={{
+              removeFileAriaLabel: i18n(
+                'i18nStrings.removeFileAriaLabel',
+                i18nStrings?.removeFileAriaLabel?.(fileIndex),
+                format => format({ fileIndex })
+              ),
+              errorIconAriaLabel: i18n('i18nStrings.errorIconAriaLabel', i18nStrings?.errorIconAriaLabel),
+              warningIconAriaLabel: i18n('i18nStrings.warningIconAriaLabel', i18nStrings?.warningIconAriaLabel),
+              formatFileSize: i18nStrings?.formatFileSize,
+              formatFileLastModified: i18nStrings?.formatFileLastModified,
+            }}
             loading={file.loading}
             readOnly={readOnly}
             alignment={alignment}
@@ -78,8 +91,8 @@ function InternalFileTokenGroup({
         )}
         limit={limit}
         i18nStrings={{
-          limitShowFewer: i18nStrings.limitShowFewer,
-          limitShowMore: i18nStrings.limitShowMore,
+          limitShowFewer: i18n('i18nStrings.limitShowFewer', i18nStrings?.limitShowFewer),
+          limitShowMore: i18n('i18nStrings.limitShowMore', i18nStrings?.limitShowMore),
         }}
       />
     </div>

--- a/src/file-token-group/internal.tsx
+++ b/src/file-token-group/internal.tsx
@@ -74,7 +74,7 @@ function InternalFileTokenGroup({
               removeFileAriaLabel: i18n(
                 'i18nStrings.removeFileAriaLabel',
                 i18nStrings?.removeFileAriaLabel?.(fileIndex),
-                format => format({ fileIndex })
+                format => format({ fileIndex: fileIndex + 1 })
               ),
               errorIconAriaLabel: i18n('i18nStrings.errorIconAriaLabel', i18nStrings?.errorIconAriaLabel),
               warningIconAriaLabel: i18n('i18nStrings.warningIconAriaLabel', i18nStrings?.warningIconAriaLabel),

--- a/src/file-token-group/internal.tsx
+++ b/src/file-token-group/internal.tsx
@@ -73,8 +73,8 @@ function InternalFileTokenGroup({
             i18nStrings={{
               removeFileAriaLabel: i18n(
                 'i18nStrings.removeFileAriaLabel',
-                i18nStrings?.removeFileAriaLabel?.(fileIndex),
-                format => format({ fileIndex: fileIndex + 1 })
+                i18nStrings?.removeFileAriaLabel,
+                format => fileIndex => format({ fileIndex: fileIndex + 1 })
               ),
               errorIconAriaLabel: i18n('i18nStrings.errorIconAriaLabel', i18nStrings?.errorIconAriaLabel),
               warningIconAriaLabel: i18n('i18nStrings.warningIconAriaLabel', i18nStrings?.warningIconAriaLabel),

--- a/src/file-upload/__tests__/file-upload.test.tsx
+++ b/src/file-upload/__tests__/file-upload.test.tsx
@@ -280,6 +280,8 @@ describe('i18n', () => {
             'i18nStrings.warningIconAriaLabel': 'Custom warning',
             'i18nStrings.uploadButtonText':
               '{multiple, select, true {Custom choose files} false {Custom choose file} other {}}',
+            'i18nStrings.dropzoneText':
+              '{multiple, select, true {Custom drop files} false {Custom drop file} other {}}',
           },
         }}
       >
@@ -298,6 +300,9 @@ describe('i18n', () => {
     expect(screen.getByLabelText('Custom error')).not.toBeNull();
     expect(screen.getByLabelText('Custom warning')).not.toBeNull();
     expect(wrapper.findUploadButton().getElement()).toHaveTextContent('Custom choose file');
+
+    fireEvent(document, createDragEvent('dragover'));
+    expect(wrapper.getElement()).toHaveTextContent('Custom drop file');
   });
 });
 

--- a/src/file-upload/__tests__/file-upload.test.tsx
+++ b/src/file-upload/__tests__/file-upload.test.tsx
@@ -7,6 +7,7 @@ import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 import '../../__a11y__/to-validate-a11y';
 import FileUpload, { FileUploadProps } from '../../../lib/components/file-upload';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import FileDropzoneWrapper from '../../../lib/components/test-utils/dom/file-dropzone';
 
@@ -266,6 +267,38 @@ describe('Focusing behavior', () => {
       expect(wrapper.findNativeInput().getElement()).toHaveFocus();
     }
   );
+});
+
+describe('i18n', () => {
+  test('supports providing custom i18n strings', () => {
+    const { container } = testingLibraryRender(
+      <TestI18nProvider
+        messages={{
+          'file-upload': {
+            'i18nStrings.removeFileAriaLabel': `Custom remove file {fileIndex}`,
+            'i18nStrings.errorIconAriaLabel': 'Custom error',
+            'i18nStrings.warningIconAriaLabel': 'Custom warning',
+            'i18nStrings.uploadButtonText': `Custom {multiple}`,
+            'i18nStrings.dropzoneText': `Custom {multiple}`,
+          },
+        }}
+      >
+        <FileUpload
+          value={[file1, file2]}
+          fileErrors={['File 1 error']}
+          fileWarnings={['', 'File 2 warning']}
+          onChange={onChange}
+        />
+      </TestI18nProvider>
+    );
+
+    const wrapper = createWrapper(container).findFileUpload()!;
+
+    expect(wrapper.findFileToken(1)!.findRemoveButton()!.getElement()).toHaveAccessibleName('Custom remove file 1');
+    expect(screen.getByLabelText('Custom error')).not.toBeNull();
+    expect(screen.getByLabelText('Custom warning')).not.toBeNull();
+    expect(wrapper.findUploadButton().getElement()).toHaveTextContent('Custom false');
+  });
 });
 
 describe('a11y', () => {

--- a/src/file-upload/__tests__/file-upload.test.tsx
+++ b/src/file-upload/__tests__/file-upload.test.tsx
@@ -278,8 +278,8 @@ describe('i18n', () => {
             'i18nStrings.removeFileAriaLabel': `Custom remove file {fileIndex}`,
             'i18nStrings.errorIconAriaLabel': 'Custom error',
             'i18nStrings.warningIconAriaLabel': 'Custom warning',
-            'i18nStrings.uploadButtonText': `Custom {multiple}`,
-            'i18nStrings.dropzoneText': `Custom {multiple}`,
+            'i18nStrings.uploadButtonText':
+              '{multiple, select, true {Custom choose files} false {Custom choose file} other {}}',
           },
         }}
       >
@@ -297,7 +297,7 @@ describe('i18n', () => {
     expect(wrapper.findFileToken(1)!.findRemoveButton()!.getElement()).toHaveAccessibleName('Custom remove file 1');
     expect(screen.getByLabelText('Custom error')).not.toBeNull();
     expect(screen.getByLabelText('Custom warning')).not.toBeNull();
-    expect(wrapper.findUploadButton().getElement()).toHaveTextContent('Custom false');
+    expect(wrapper.findUploadButton().getElement()).toHaveTextContent('Custom choose file');
   });
 });
 

--- a/src/file-upload/interfaces.ts
+++ b/src/file-upload/interfaces.ts
@@ -80,7 +80,7 @@ export interface FileUploadProps extends BaseComponentProps, FormFieldCommonVali
    * * `formatFileSize` (function): (Optional) A function that takes file size in bytes, and produces a formatted string.
    * * `formatFileLastModified` (function): (Optional) A function that takes the files last modified date, and produces a formatted string.
    */
-  i18nStrings: FileUploadProps.I18nStrings;
+  i18nStrings?: FileUploadProps.I18nStrings;
 }
 
 export namespace FileUploadProps {
@@ -96,11 +96,11 @@ export namespace FileUploadProps {
   export type FileTokenAlignment = 'vertical' | 'horizontal';
 
   export interface I18nStrings {
-    uploadButtonText: (multiple: boolean) => string;
-    dropzoneText: (multiple: boolean) => string;
-    removeFileAriaLabel: (fileIndex: number) => string;
-    limitShowFewer: string;
-    limitShowMore: string;
+    uploadButtonText?: (multiple: boolean) => string;
+    dropzoneText?: (multiple: boolean) => string;
+    removeFileAriaLabel?: (fileIndex: number) => string;
+    limitShowFewer?: string;
+    limitShowMore?: string;
     errorIconAriaLabel?: string;
     warningIconAriaLabel?: string;
     formatFileSize?: (sizeInBytes: number) => string;

--- a/src/file-upload/internal.tsx
+++ b/src/file-upload/internal.tsx
@@ -6,8 +6,6 @@ import clsx from 'clsx';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
-import { useInternalI18n } from '../i18n/context';
-
 import InternalBox from '../box/internal';
 import { ButtonProps } from '../button/interfaces';
 import { useFormFieldContext } from '../contexts/form-field';
@@ -16,6 +14,7 @@ import { useFilesDragging } from '../file-dropzone/use-files-dragging';
 import InternalFileInput from '../file-input/internal';
 import InternalFileTokenGroup from '../file-token-group/internal';
 import { ConstraintText, FormFieldError, FormFieldWarning } from '../form-field/internal';
+import { useInternalI18n } from '../i18n/context';
 import { getBaseProps } from '../internal/base-component';
 import { fireNonCancelableEvent } from '../internal/events';
 import checkControlled from '../internal/hooks/check-controlled';
@@ -129,7 +128,9 @@ function InternalFileUpload(
         {areFilesDragging ? (
           <InternalFileDropzone onChange={event => handleFilesChange(event.detail.value)}>
             {/* {i18nStrings.dropzoneText(multiple)} */}
-            {i18n('i18nStrings.dropzoneText', i18nStrings?.dropzoneText?.(multiple), format => format({ multiple }))}
+            {i18n('i18nStrings.dropzoneText', i18nStrings?.dropzoneText?.(multiple), format =>
+              format({ multiple: `${multiple}` })
+            )}
           </InternalFileDropzone>
         ) : (
           <InternalFileInput
@@ -146,7 +147,7 @@ function InternalFileUpload(
           >
             {/* {i18nStrings.uploadButtonText(multiple)} */}
             {i18n('i18nStrings.uploadButtonText', i18nStrings?.uploadButtonText?.(multiple), format =>
-              format({ multiple })
+              format({ multiple: `${multiple}` })
             )}
           </InternalFileInput>
         )}
@@ -191,10 +192,11 @@ function InternalFileUpload(
           showFileSize={metadata.showFileSize}
           showFileThumbnail={metadata.showFileThumbnail}
           i18nStrings={{
-            removeFileAriaLabel: (fileIndex: number) =>
-              i18n('i18nStrings.removeFileAriaLabel', i18nStrings?.removeFileAriaLabel?.(fileIndex), format =>
-                format({ fileIndex: fileIndex + 1 })
-              ),
+            removeFileAriaLabel: i18n(
+              'i18nStrings.removeFileAriaLabel',
+              i18nStrings?.removeFileAriaLabel,
+              format => fileIndex => format({ fileIndex: fileIndex + 1 })
+            ),
             limitShowFewer: i18n('i18nStrings.limitShowFewer', i18nStrings?.limitShowFewer),
             limitShowMore: i18n('i18nStrings.limitShowMore', i18nStrings?.limitShowMore),
             formatFileSize: i18nStrings?.formatFileSize,

--- a/src/file-upload/internal.tsx
+++ b/src/file-upload/internal.tsx
@@ -6,6 +6,8 @@ import clsx from 'clsx';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
+import { useInternalI18n } from '../i18n/context';
+
 import InternalBox from '../box/internal';
 import { ButtonProps } from '../button/interfaces';
 import { useFormFieldContext } from '../contexts/form-field';
@@ -68,6 +70,7 @@ function InternalFileUpload(
     fallbackSelector: `.${fileInputStyles['file-input']}`,
   });
 
+  const i18n = useInternalI18n('file-upload');
   const baseProps = getBaseProps(restProps);
   const metadata = { showFileSize, showFileLastModified, showFileThumbnail };
 
@@ -125,7 +128,8 @@ function InternalFileUpload(
       <InternalBox>
         {areFilesDragging ? (
           <InternalFileDropzone onChange={event => handleFilesChange(event.detail.value)}>
-            {i18nStrings.dropzoneText(multiple)}
+            {/* {i18nStrings.dropzoneText(multiple)} */}
+            {i18n('i18nStrings.dropzoneText', i18nStrings?.dropzoneText?.(multiple), format => format({ multiple }))}
           </InternalFileDropzone>
         ) : (
           <InternalFileInput
@@ -140,19 +144,28 @@ function InternalFileUpload(
             ariaDescribedby={ariaDescribedBy}
             invalid={invalid}
           >
-            {i18nStrings.uploadButtonText(multiple)}
+            {/* {i18nStrings.uploadButtonText(multiple)} */}
+            {i18n('i18nStrings.uploadButtonText', i18nStrings?.uploadButtonText?.(multiple), format =>
+              format({ multiple })
+            )}
           </InternalFileInput>
         )}
 
         {(constraintText || errorText || warningText) && (
           <div className={styles.hints}>
             {errorText && (
-              <FormFieldError id={errorId} errorIconAriaLabel={i18nStrings?.errorIconAriaLabel}>
+              <FormFieldError
+                id={errorId}
+                errorIconAriaLabel={i18n('i18nStrings.errorIconAriaLabel', i18nStrings?.errorIconAriaLabel)}
+              >
                 {errorText}
               </FormFieldError>
             )}
             {showWarning && (
-              <FormFieldWarning id={warningId} warningIconAriaLabel={i18nStrings?.warningIconAriaLabel}>
+              <FormFieldWarning
+                id={warningId}
+                warningIconAriaLabel={i18n('i18nStrings.warningIconAriaLabel', i18nStrings?.warningIconAriaLabel)}
+              >
                 {warningText}
               </FormFieldWarning>
             )}
@@ -177,7 +190,16 @@ function InternalFileUpload(
           showFileLastModified={metadata.showFileLastModified}
           showFileSize={metadata.showFileSize}
           showFileThumbnail={metadata.showFileThumbnail}
-          i18nStrings={i18nStrings}
+          i18nStrings={{
+            removeFileAriaLabel: (fileIndex: number) =>
+              i18n('i18nStrings.removeFileAriaLabel', i18nStrings?.removeFileAriaLabel?.(fileIndex), format =>
+                format({ fileIndex: fileIndex + 1 })
+              ),
+            limitShowFewer: i18n('i18nStrings.limitShowFewer', i18nStrings?.limitShowFewer),
+            limitShowMore: i18n('i18nStrings.limitShowMore', i18nStrings?.limitShowMore),
+            formatFileSize: i18nStrings?.formatFileSize,
+            formatFileLastModified: i18nStrings?.formatFileLastModified,
+          }}
           onDismiss={event => onFileRemove(event.detail.fileIndex)}
         />
       ) : null}

--- a/src/file-upload/internal.tsx
+++ b/src/file-upload/internal.tsx
@@ -201,6 +201,8 @@ function InternalFileUpload(
             limitShowMore: i18n('i18nStrings.limitShowMore', i18nStrings?.limitShowMore),
             formatFileSize: i18nStrings?.formatFileSize,
             formatFileLastModified: i18nStrings?.formatFileLastModified,
+            errorIconAriaLabel: i18n('i18nStrings.errorIconAriaLabel', i18nStrings?.errorIconAriaLabel),
+            warningIconAriaLabel: i18n('i18nStrings.warningIconAriaLabel', i18nStrings?.warningIconAriaLabel),
           }}
           onDismiss={event => onFileRemove(event.detail.fileIndex)}
         />

--- a/src/file-upload/internal.tsx
+++ b/src/file-upload/internal.tsx
@@ -127,7 +127,6 @@ function InternalFileUpload(
       <InternalBox>
         {areFilesDragging ? (
           <InternalFileDropzone onChange={event => handleFilesChange(event.detail.value)}>
-            {/* {i18nStrings.dropzoneText(multiple)} */}
             {i18n('i18nStrings.dropzoneText', i18nStrings?.dropzoneText?.(multiple), format =>
               format({ multiple: `${multiple}` })
             )}
@@ -145,7 +144,6 @@ function InternalFileUpload(
             ariaDescribedby={ariaDescribedBy}
             invalid={invalid}
           >
-            {/* {i18nStrings.uploadButtonText(multiple)} */}
             {i18n('i18nStrings.uploadButtonText', i18nStrings?.uploadButtonText?.(multiple), format =>
               format({ multiple: `${multiple}` })
             )}

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -187,6 +187,30 @@ export interface I18nFormatArgTypes {
   "drawer": {
     "i18nStrings.loadingText": never;
   }
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": never;
+    "i18nStrings.limitShowMore": never;
+    "i18nStrings.removeFileAriaLabel": {
+      "fileIndex": string | number;
+    }
+    "i18nStrings.errorIconAriaLabel": never;
+    "i18nStrings.warningIconAriaLabel": never;
+  }
+  "file-upload": {
+    "i18nStrings.limitShowFewer": never;
+    "i18nStrings.limitShowMore": never;
+    "i18nStrings.removeFileAriaLabel": {
+      "fileIndex": string | number;
+    }
+    "i18nStrings.errorIconAriaLabel": never;
+    "i18nStrings.warningIconAriaLabel": never;
+    "i18nStrings.uploadButtonText": {
+      "multiple": string;
+    }
+    "i18nStrings.dropzoneText": {
+      "multiple": string;
+    }
+  }
   "flashbar": {
     "i18nStrings.ariaLabel": never;
     "i18nStrings.errorIconAriaLabel": never;

--- a/src/i18n/messages/all.ar.json
+++ b/src/i18n/messages/all.ar.json
@@ -142,6 +142,22 @@
   "drawer": {
     "i18nStrings.loadingText": "جار تحميل المحتوى"
   },
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": "إظهار عدد أقل من عوامل التصفية",
+    "i18nStrings.limitShowMore": "عرض المزيد من عوامل التصفية",
+    "i18nStrings.removeFileAriaLabel": "إزالة الملف {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "خطأ",
+    "i18nStrings.warningIconAriaLabel": "تحذير"
+  },
+  "file-upload": {
+    "i18nStrings.limitShowFewer": "إظهار عدد أقل من عوامل التصفية",
+    "i18nStrings.limitShowMore": "عرض المزيد من عوامل التصفية",
+    "i18nStrings.removeFileAriaLabel": "إزالة الملف {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "خطأ",
+    "i18nStrings.warningIconAriaLabel": "تحذير",
+    "i18nStrings.uploadButtonText": "{multiple, select, true {اختيار الملفات} false {اختيار ملف} other {}}",
+    "i18nStrings.dropzoneText": "{multiple, select, true {إفلات الملفات لتحميلها} false {إفلات الملف لتحميله} other {}}"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "الإشعارات",
     "i18nStrings.errorIconAriaLabel": "خطأ",

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -142,6 +142,22 @@
   "drawer": {
     "i18nStrings.loadingText": "Inhalte werden geladen"
   },
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": "Weniger anzeigen",
+    "i18nStrings.limitShowMore": "Mehr anzeigen",
+    "i18nStrings.removeFileAriaLabel": "Datei {fileIndex} entfernen",
+    "i18nStrings.errorIconAriaLabel": "Fehler",
+    "i18nStrings.warningIconAriaLabel": "Warnung"
+  },
+  "file-upload": {
+    "i18nStrings.limitShowFewer": "Weniger anzeigen",
+    "i18nStrings.limitShowMore": "Mehr anzeigen",
+    "i18nStrings.removeFileAriaLabel": "Datei {fileIndex} entfernen",
+    "i18nStrings.errorIconAriaLabel": "Fehler",
+    "i18nStrings.warningIconAriaLabel": "Warnung",
+    "i18nStrings.uploadButtonText": "{multiple, select, true {Dateien auswählen} false {Datei auswählen} other {}}",
+    "i18nStrings.dropzoneText": "{multiple, select, true {Dateien zum Hochladen ablegen} false {Datei zum Hochladen ablegen} other {}}"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Benachrichtigungen",
     "i18nStrings.errorIconAriaLabel": "Fehler",

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -142,6 +142,22 @@
   "drawer": {
     "i18nStrings.loadingText": "Loading content"
   },
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": "Show fewer",
+    "i18nStrings.limitShowMore": "Show more",
+    "i18nStrings.removeFileAriaLabel": "Remove file {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Error",
+    "i18nStrings.warningIconAriaLabel": "Warning"
+  },
+  "file-upload": {
+    "i18nStrings.limitShowFewer": "Show fewer",
+    "i18nStrings.limitShowMore": "Show more",
+    "i18nStrings.removeFileAriaLabel": "Remove file {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Error",
+    "i18nStrings.warningIconAriaLabel": "Warning",
+    "i18nStrings.uploadButtonText": "{multiple, select, true {Choose files} false {Choose file} other {}}",
+    "i18nStrings.dropzoneText": "{multiple, select, true {Drop files to upload} false {Drop file to upload} other {}}"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifications",
     "i18nStrings.errorIconAriaLabel": "Error",

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -142,6 +142,22 @@
   "drawer": {
     "i18nStrings.loadingText": "Loading content"
   },
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": "Show fewer",
+    "i18nStrings.limitShowMore": "Show more",
+    "i18nStrings.removeFileAriaLabel": "Remove file {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Error",
+    "i18nStrings.warningIconAriaLabel": "Warning"
+  },
+  "file-upload": {
+    "i18nStrings.limitShowFewer": "Show fewer",
+    "i18nStrings.limitShowMore": "Show more",
+    "i18nStrings.removeFileAriaLabel": "Remove file {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Error",
+    "i18nStrings.warningIconAriaLabel": "Warning",
+    "i18nStrings.uploadButtonText": "{multiple, select, true {Choose files} false {Choose file} other {}}",
+    "i18nStrings.dropzoneText": "{multiple, select, true {Drop files to upload} false {Drop file to upload} other {}}"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifications",
     "i18nStrings.errorIconAriaLabel": "Error",

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -142,6 +142,22 @@
   "drawer": {
     "i18nStrings.loadingText": "Cargando contenido"
   },
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": "Mostrar menos",
+    "i18nStrings.limitShowMore": "Mostrar más",
+    "i18nStrings.removeFileAriaLabel": "Eliminar archivo {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Error",
+    "i18nStrings.warningIconAriaLabel": "Aviso"
+  },
+  "file-upload": {
+    "i18nStrings.limitShowFewer": "Mostrar menos",
+    "i18nStrings.limitShowMore": "Mostrar más",
+    "i18nStrings.removeFileAriaLabel": "Eliminar archivo{fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Error",
+    "i18nStrings.warningIconAriaLabel": "Aviso",
+    "i18nStrings.uploadButtonText": "{multiple, select, true {Elegir archivos} false {Elegir archivo} other {}}",
+    "i18nStrings.dropzoneText": "{multiple, select, true {Arrastrar los archivos para cargarlos} false {Arrastrar el archivo para cargarlo} other {}}"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notificaciones",
     "i18nStrings.errorIconAriaLabel": "Error",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -142,6 +142,22 @@
   "drawer": {
     "i18nStrings.loadingText": "Chargement du contenu en cours"
   },
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": "Afficher moins",
+    "i18nStrings.limitShowMore": "Afficher plus",
+    "i18nStrings.removeFileAriaLabel": "Supprimer le fichier {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Erreur",
+    "i18nStrings.warningIconAriaLabel": "Avertissement"
+  },
+  "file-upload": {
+    "i18nStrings.limitShowFewer": "Afficher moins",
+    "i18nStrings.limitShowMore": "Afficher plus",
+    "i18nStrings.removeFileAriaLabel": "Supprimer le fichier {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Erreur",
+    "i18nStrings.warningIconAriaLabel": "Avertissement",
+    "i18nStrings.uploadButtonText": "{multiple, select, true {Choisir les fichiers} false {Choisir un fichier} other {}}",
+    "i18nStrings.dropzoneText": "{multiple, select, true {Déposer les fichiers à charger} false {Déposer le fichier à charger} other {}}"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifications",
     "i18nStrings.errorIconAriaLabel": "Erreur",

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -142,6 +142,22 @@
   "drawer": {
     "i18nStrings.loadingText": "Memuat konten"
   },
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": "Tampilkan lebih sedikit",
+    "i18nStrings.limitShowMore": "Tampilkan selengkapnya",
+    "i18nStrings.removeFileAriaLabel": "Hapus file {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Kesalahan",
+    "i18nStrings.warningIconAriaLabel": "Peringatan"
+  },
+  "file-upload": {
+    "i18nStrings.limitShowFewer": "Tampilkan lebih sedikit",
+    "i18nStrings.limitShowMore": "Tampilkan selengkapnya",
+    "i18nStrings.removeFileAriaLabel": "Hapus file {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Kesalahan",
+    "i18nStrings.warningIconAriaLabel": "Peringatan",
+    "i18nStrings.uploadButtonText": "{multiple, select, true {Pilih file} false {Pilih file} other {}}",
+    "i18nStrings.dropzoneText": "{multiple, select, true {Letakkan file untuk diunggah} false {Letakkan file untuk diunggah} other {}}"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifikasi",
     "i18nStrings.errorIconAriaLabel": "Kesalahan",

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -142,6 +142,22 @@
   "drawer": {
     "i18nStrings.loadingText": "Caricamento dei contenuti"
   },
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": "Mostra meno",
+    "i18nStrings.limitShowMore": "Mostra altro",
+    "i18nStrings.removeFileAriaLabel": "Rimuovi file {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Errore",
+    "i18nStrings.warningIconAriaLabel": "Avviso"
+  },
+  "file-upload": {
+    "i18nStrings.limitShowFewer": "Mostra meno",
+    "i18nStrings.limitShowMore": "Mostra altro",
+    "i18nStrings.removeFileAriaLabel": "Rimuovi file {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Errore",
+    "i18nStrings.warningIconAriaLabel": "Avviso",
+    "i18nStrings.uploadButtonText": "{multiple, select, true {Scegli file} false {Scegli file} other {}}",
+    "i18nStrings.dropzoneText": "{multiple, select, true {Trascina i file da caricare} false {Trascina il file da caricare} other {}}"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifiche",
     "i18nStrings.errorIconAriaLabel": "Errore",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -142,6 +142,22 @@
   "drawer": {
     "i18nStrings.loadingText": "コンテンツのロード中"
   },
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": "少なく表示",
+    "i18nStrings.limitShowMore": "さらに表示",
+    "i18nStrings.removeFileAriaLabel": "ファイル {fileIndex} を削除",
+    "i18nStrings.errorIconAriaLabel": "エラー",
+    "i18nStrings.warningIconAriaLabel": "警告"
+  },
+  "file-upload": {
+    "i18nStrings.limitShowFewer": "少なく表示",
+    "i18nStrings.limitShowMore": "さらに表示",
+    "i18nStrings.removeFileAriaLabel": "ファイル {fileIndex} を削除",
+    "i18nStrings.errorIconAriaLabel": "エラー",
+    "i18nStrings.warningIconAriaLabel": "警告",
+    "i18nStrings.uploadButtonText": "{multiple, select, true {ファイルを選択} false {ファイルを選択} other {}}",
+    "i18nStrings.dropzoneText": "{multiple, select, true {ファイルをドロップしてアップロード} false {ファイルをドロップしてアップロード} other {}}"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "通知",
     "i18nStrings.errorIconAriaLabel": "エラー",

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -142,6 +142,22 @@
   "drawer": {
     "i18nStrings.loadingText": "콘텐츠 로드 중"
   },
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": "간단히 표시",
+    "i18nStrings.limitShowMore": "자세히 표시",
+    "i18nStrings.removeFileAriaLabel": "파일 {fileIndex} 제거",
+    "i18nStrings.errorIconAriaLabel": "오류",
+    "i18nStrings.warningIconAriaLabel": "경고"
+  },
+  "file-upload": {
+    "i18nStrings.limitShowFewer": "간단히 표시",
+    "i18nStrings.limitShowMore": "자세히 표시",
+    "i18nStrings.removeFileAriaLabel": "파일 {fileIndex} 제거",
+    "i18nStrings.errorIconAriaLabel": "오류",
+    "i18nStrings.warningIconAriaLabel": "경고",
+    "i18nStrings.uploadButtonText": "{multiple, select, true {파일 선택} false {파일 선택} other {}}",
+    "i18nStrings.dropzoneText": "{multiple, select, true {업로드할 파일 가져다 놓기} false {업로드할 파일 가져다 놓기} other {}}"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "알림",
     "i18nStrings.errorIconAriaLabel": "오류",

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -142,6 +142,22 @@
   "drawer": {
     "i18nStrings.loadingText": "Carregando conteúdo"
   },
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": "Mostrar menos",
+    "i18nStrings.limitShowMore": "Mostrar mais",
+    "i18nStrings.removeFileAriaLabel": "Remover o arquivo {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Erro",
+    "i18nStrings.warningIconAriaLabel": "Aviso"
+  },
+  "file-upload": {
+    "i18nStrings.limitShowFewer": "Mostrar menos",
+    "i18nStrings.limitShowMore": "Mostrar mais",
+    "i18nStrings.removeFileAriaLabel": "Remover o arquivo {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Erro",
+    "i18nStrings.warningIconAriaLabel": "Aviso",
+    "i18nStrings.uploadButtonText": "{multiple, select, true {Escolher arquivos} false {Escolher arquivo} other {}}",
+    "i18nStrings.dropzoneText": "{multiple, select, true {Solte os arquivos para fazer upload} false {Solte o arquivo para fazer upload} other {}}"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notificações",
     "i18nStrings.errorIconAriaLabel": "Erro",

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -142,6 +142,22 @@
   "drawer": {
     "i18nStrings.loadingText": "İçerik yükleniyor"
   },
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": "Daha az göster",
+    "i18nStrings.limitShowMore": "Daha fazla göster",
+    "i18nStrings.removeFileAriaLabel": "Dosyayı kaldır {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Hata",
+    "i18nStrings.warningIconAriaLabel": "Uyarı"
+  },
+  "file-upload": {
+    "i18nStrings.limitShowFewer": "Daha az göster",
+    "i18nStrings.limitShowMore": "Daha fazla göster",
+    "i18nStrings.removeFileAriaLabel": "Dosyayı kaldır {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "Hata",
+    "i18nStrings.warningIconAriaLabel": "Uyarı",
+    "i18nStrings.uploadButtonText": "{multiple, select, true {Dosyaları seç} false {Dosya seç} other {}}",
+    "i18nStrings.dropzoneText": "{multiple, select, true {Yüklenecek dosyaları buraya bırakın} false {Yüklenecek dosyayı buraya bırakın} other {}}"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Bildirimler",
     "i18nStrings.errorIconAriaLabel": "Hata",

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -142,6 +142,22 @@
   "drawer": {
     "i18nStrings.loadingText": "正在加载内容"
   },
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": "显示更少",
+    "i18nStrings.limitShowMore": "显示更多",
+    "i18nStrings.removeFileAriaLabel": "移除文件 {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "错误",
+    "i18nStrings.warningIconAriaLabel": "警告"
+  },
+  "file-upload": {
+    "i18nStrings.limitShowFewer": "显示更少",
+    "i18nStrings.limitShowMore": "显示更多",
+    "i18nStrings.removeFileAriaLabel": "移除文件 {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "错误",
+    "i18nStrings.warningIconAriaLabel": "警告",
+    "i18nStrings.uploadButtonText": "{multiple, select, true {选择文件} false {选择文件} other {}}",
+    "i18nStrings.dropzoneText": "{multiple, select, true {删除要上传的文件} false {删除要上传的文件} other {}}"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "通知",
     "i18nStrings.errorIconAriaLabel": "错误",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -142,6 +142,22 @@
   "drawer": {
     "i18nStrings.loadingText": "載入內容"
   },
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": "顯示較少",
+    "i18nStrings.limitShowMore": "顯示更多",
+    "i18nStrings.removeFileAriaLabel": "移除檔案 {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "錯誤",
+    "i18nStrings.warningIconAriaLabel": "警告"
+  },
+  "file-upload": {
+    "i18nStrings.limitShowFewer": "顯示較少",
+    "i18nStrings.limitShowMore": "顯示更多",
+    "i18nStrings.removeFileAriaLabel": "移除檔案 {fileIndex}",
+    "i18nStrings.errorIconAriaLabel": "錯誤",
+    "i18nStrings.warningIconAriaLabel": "警告",
+    "i18nStrings.uploadButtonText": "{multiple, select, true {選擇檔案} false {選擇檔案} other {}}",
+    "i18nStrings.dropzoneText": "{multiple, select, true {拖曳檔案以上傳} false {拖曳檔案以上傳} other {}}"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "通知",
     "i18nStrings.errorIconAriaLabel": "錯誤",


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

This adds default provided strings from the i18nStrings messages to file token group and file upload, and in turn makes those properties optional instead of required.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
