### PR TITLE
feat: Allows table pending status for empty expandable rows

### DIFF
--- a/pages/table/expandable-rows.permutations.page.tsx
+++ b/pages/table/expandable-rows.permutations.page.tsx
@@ -66,6 +66,11 @@ const itemsMixed: Instance[] = [
       },
     ],
   },
+  {
+    name: 'Root-3',
+    description: 'Root item #3',
+    children: [],
+  },
 ];
 
 interface Permutation {
@@ -250,13 +255,15 @@ export default () => {
               expandableRows={{
                 getItemChildren: item => item.children ?? [],
                 isItemExpandable: item => !!item.children,
-                expandedItems: flatten(permutation.items).filter(item => item.children && item.children.length > 0),
+                expandedItems: flatten(permutation.items).filter(
+                  item => item.children && (item.children.length > 0 || item.name === 'Root-3')
+                ),
                 onExpandableItemToggle: () => {},
               }}
               getLoadingStatus={
                 permutation.progressiveLoading
                   ? item => {
-                      if (!item) {
+                      if (!item || item.name === 'Root-3') {
                         return 'pending';
                       }
                       if (item.name === 'Root-1') {

--- a/src/table/__tests__/progressive-loading.test.tsx
+++ b/src/table/__tests__/progressive-loading.test.tsx
@@ -240,25 +240,28 @@ describe('Progressive loading', () => {
     ]);
   });
 
-  test.each(['loading', 'error'] as const)('loader row with status="%s" is added after empty expanded item', status => {
-    const { table } = renderTable({
-      items: [
-        {
-          name: 'Root-1',
-          children: [],
+  test.each(['pending', 'loading', 'error'] as const)(
+    'loader row with status="%s" is added after empty expanded item',
+    status => {
+      const { table } = renderTable({
+        items: [
+          {
+            name: 'Root-1',
+            children: [],
+          },
+        ],
+        expandableRows: {
+          ...defaultExpandableRows,
+          expandedItems: [{ name: 'Root-1' }],
         },
-      ],
-      expandableRows: {
-        ...defaultExpandableRows,
-        expandedItems: [{ name: 'Root-1' }],
-      },
-      getLoadingStatus: () => status,
-    });
+        getLoadingStatus: () => status,
+      });
 
-    expect(getTextContent(table.findItemsLoaderByItemId('Root-1')!)).toBe(`[${status}] Loader for Root-1`);
-  });
+      expect(getTextContent(table.findItemsLoaderByItemId('Root-1')!)).toBe(`[${status}] Loader for Root-1`);
+    }
+  );
 
-  test.each([undefined, 'pending', 'finished'] as const)(
+  test.each([undefined, 'finished'] as const)(
     'loader row with status="%s" is not added after empty expanded item and a warning is shown',
     status => {
       const { table } = renderTable({
@@ -278,7 +281,7 @@ describe('Progressive loading', () => {
       expect(table.findItemsLoaderByItemId('Root-1')).toBe(null);
       expect(warnOnce).toHaveBeenCalledWith(
         'Table',
-        'Expanded items without children must have "loading" or "error" loading status.'
+        'Expanded items without children must not have "finished" loading status.'
       );
     }
   );

--- a/src/table/progressive-loading/progressive-loading-utils.ts
+++ b/src/table/progressive-loading/progressive-loading-utils.ts
@@ -31,10 +31,10 @@ export function useProgressiveLoadingProps<T>({
     // Insert empty expandable item loader
     if (isItemExpanded(items[i]) && getItemChildren(items[i]).length === 0) {
       const status = getLoadingStatus?.(items[i]);
-      if (status && (status === 'loading' || status === 'error')) {
+      if (status && status !== 'finished') {
         allRows.push({ type: 'loader', item: items[i], level: getItemLevel(items[i]), status, from: 0 });
       } else {
-        warnOnce('Table', 'Expanded items without children must have "loading" or "error" loading status.');
+        warnOnce('Table', 'Expanded items without children must not have "finished" loading status.');
       }
     }
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
