### PR TITLE
fix: Key-value pair border not center-aligned

### DIFF
--- a/pages/column-layout/alignment.page.tsx
+++ b/pages/column-layout/alignment.page.tsx
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+
+import ColumnLayout from '~components/column-layout';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+export default function ColumnLayoutPage() {
+  return (
+    <>
+      <h1>Border alignment test</h1>
+      <p>
+        The vertical border line drawn between items should be in the center of the component, i.e. it must line up with
+        where the two coloured bars meet below.
+      </p>
+      <ScreenshotArea>
+        <ColumnLayout variant="text-grid" columns={2} minColumnWidth={150}>
+          <div>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+            ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+            nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum.
+          </div>
+          <div>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+            ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+            nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum.
+          </div>
+        </ColumnLayout>
+
+        <div style={{ display: 'flex', marginTop: 10 }}>
+          <div style={{ width: '50%', background: 'blue', height: '10px' }}></div>
+          <div style={{ width: '50%', background: 'orange', height: '10px' }}></div>
+        </div>
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/src/column-layout/flexible-column-layout/styles.scss
+++ b/src/column-layout/flexible-column-layout/styles.scss
@@ -19,12 +19,33 @@ dl.css-grid {
 
   &.grid-variant-text-grid {
     > .item {
-      border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
       padding-inline: awsui.$space-grid-gutter;
+      position: relative;
+
+      &::before {
+        content: '';
+        position: absolute;
+        inset-block-start: 0;
+        inset-block-end: 0;
+        inset-inline-start: 0;
+
+        border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+
+        transform: translateX(calc(-0.5 * awsui.$space-grid-gutter));
+      }
+
+      @include styles.with-direction('rtl') {
+        &::before {
+          transform: translateX(calc(0.5 * awsui.$space-grid-gutter));
+        }
+      }
 
       &.first-column {
-        border-inline-start: 0;
         padding-inline-start: 0;
+
+        &::before {
+          display: none;
+        }
       }
     }
   }


### PR DESCRIPTION
### Description

In the Key-Value-Pair component, the border between the columns was positioned with a slight horizontal offset. This happened because the border was placed at the left edge of a column.

This code change moves the border, so that it is positioned exactly in the middle of the two columns.

Related links, issue #, if available: AWSUI-59957

### How has this been tested?

Tested manually in the browser. Added a new dev page where the alignment of the border can be checked.

### Screenshots
#### Before
![image](https://github.com/user-attachments/assets/aeabb06b-b33d-4663-83dc-66a9b704226f)
#### After
![image](https://github.com/user-attachments/assets/5acf4c5f-4ce9-4a6b-ab4c-676a00bab935)



<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
