### PR TITLE
feat: Adds file input type to button group component

### DIFF
--- a/pages/button-group/test.page.tsx
+++ b/pages/button-group/test.page.tsx
@@ -204,7 +204,6 @@ export default function ButtonGroupPage() {
   ].filter(canRenderItem);
 
   const onItemClick: ButtonGroupProps['onItemClick'] = ({ detail }) => {
-    console.log(detail);
     function addLog(text: string) {
       const entry = document.createElement('div');
       entry.textContent = text;
@@ -253,7 +252,7 @@ export default function ButtonGroupPage() {
   };
 
   const onFilesChange: ButtonGroupProps['onFilesChange'] = ({ detail }) => {
-    return setFiles(detail.files ? detail.files : []);
+    return setFiles(detail.files);
   };
 
   const onDismiss = (event: { detail: { fileIndex: number } }) => {

--- a/pages/button-group/test.page.tsx
+++ b/pages/button-group/test.page.tsx
@@ -247,10 +247,13 @@ export default function ButtonGroupPage() {
       case 'experimental-features':
         return syncAction(() => setUseExperimentalFeatures(!!detail.pressed));
       case 'file-input':
-        return syncAction(() => setFiles(detail.files ? detail.files : []));
       default:
         return syncAction();
     }
+  };
+
+  const onFilesChange: ButtonGroupProps['onFilesChange'] = ({ detail }) => {
+    return setFiles(detail.files ? detail.files : []);
   };
 
   const onDismiss = (event: { detail: { fileIndex: number } }) => {
@@ -273,6 +276,7 @@ export default function ButtonGroupPage() {
             variant="icon"
             items={items}
             onItemClick={onItemClick}
+            onFilesChange={onFilesChange}
             dropdownExpandToViewport={dropdownExpandToViewport}
           />
         </Box>

--- a/pages/button-group/test.page.tsx
+++ b/pages/button-group/test.page.tsx
@@ -73,6 +73,7 @@ export default function ButtonGroupPage() {
         id: 'file-input',
         text: 'Choose files',
         multiple: true,
+        accept: 'image/png, image/jpeg',
       },
     ],
   };

--- a/pages/button-group/test.page.tsx
+++ b/pages/button-group/test.page.tsx
@@ -73,6 +73,7 @@ export default function ButtonGroupPage() {
         id: 'file-input',
         text: 'Choose files',
         value: files,
+        multiple: true,
       },
     ],
   };
@@ -259,8 +260,6 @@ export default function ButtonGroupPage() {
     setFiles(newItems);
   };
 
-  console.log(files);
-
   return (
     <ScreenshotArea disableAnimations={true}>
       <SpaceBetween size="m">
@@ -293,6 +292,7 @@ export default function ButtonGroupPage() {
           }))}
           onDismiss={onDismiss}
           i18nStrings={i18nStrings}
+          alignment="horizontal"
         />
 
         <Box>

--- a/pages/button-group/test.page.tsx
+++ b/pages/button-group/test.page.tsx
@@ -246,7 +246,7 @@ export default function ButtonGroupPage() {
         return asyncAction();
       case 'experimental-features':
         return syncAction(() => setUseExperimentalFeatures(!!detail.pressed));
-      case 'icon-file-input':
+      case 'file-input':
       default:
         return syncAction();
     }

--- a/pages/button-group/test.page.tsx
+++ b/pages/button-group/test.page.tsx
@@ -72,7 +72,6 @@ export default function ButtonGroupPage() {
         type: 'file-input',
         id: 'file-input',
         text: 'Choose files',
-        value: files,
         multiple: true,
       },
     ],

--- a/pages/button-group/test.page.tsx
+++ b/pages/button-group/test.page.tsx
@@ -69,7 +69,7 @@ export default function ButtonGroupPage() {
     text: 'Files',
     items: [
       {
-        type: 'file-input',
+        type: 'icon-file-input',
         id: 'file-input',
         text: 'Choose files',
         multiple: true,
@@ -246,7 +246,7 @@ export default function ButtonGroupPage() {
         return asyncAction();
       case 'experimental-features':
         return syncAction(() => setUseExperimentalFeatures(!!detail.pressed));
-      case 'file-input':
+      case 'icon-file-input':
       default:
         return syncAction();
     }

--- a/pages/button-group/test.page.tsx
+++ b/pages/button-group/test.page.tsx
@@ -4,9 +4,11 @@
 import React, { useContext, useState } from 'react';
 
 import { Box, Button, ButtonGroup, ButtonGroupProps, Header, SpaceBetween, StatusIndicator } from '~components';
+import FileTokenGroup from '~components/file-token-group';
 
 import AppContext, { AppContextType } from '../app/app-context';
 import { enhanceWindow, WindowWithFlushResponse } from '../common/flush-response';
+import { i18nStrings } from '../file-upload/shared';
 import ScreenshotArea from '../utils/screenshot-area';
 
 declare const window: WindowWithFlushResponse;
@@ -31,6 +33,7 @@ export default function ButtonGroupPage() {
   const [loadingId, setLoading] = useState<null | string>(null);
   const [canSend, setCanSend] = useState(true);
   const [canRedo, setCanRedo] = useState(true);
+  const [files, setFiles] = useState<File[]>([]);
 
   const toggleTexts = {
     like: ['Like', 'Liked'],
@@ -57,6 +60,19 @@ export default function ButtonGroupPage() {
         pressedIconName: 'thumbs-down-filled',
         text: feedback === 'dislike' ? toggleTexts.dislike[1] : toggleTexts.dislike[0],
         pressed: feedback === 'dislike',
+      },
+    ],
+  };
+
+  const fileGroup: ButtonGroupProps.Group = {
+    type: 'group',
+    text: 'Files',
+    items: [
+      {
+        type: 'file-input',
+        id: 'file-input',
+        text: 'Choose files',
+        value: files,
       },
     ],
   };
@@ -176,6 +192,7 @@ export default function ButtonGroupPage() {
     return true;
   }
   const items = [
+    fileGroup,
     feedbackGroup,
     favoriteGroup,
     sendGroup,
@@ -187,6 +204,7 @@ export default function ButtonGroupPage() {
   ].filter(canRenderItem);
 
   const onItemClick: ButtonGroupProps['onItemClick'] = ({ detail }) => {
+    console.log(detail);
     function addLog(text: string) {
       const entry = document.createElement('div');
       entry.textContent = text;
@@ -228,10 +246,20 @@ export default function ButtonGroupPage() {
         return asyncAction();
       case 'experimental-features':
         return syncAction(() => setUseExperimentalFeatures(!!detail.pressed));
+      case 'file-input':
+        return syncAction(() => setFiles(detail.files ? detail.files : []));
       default:
         return syncAction();
     }
   };
+
+  const onDismiss = (event: { detail: { fileIndex: number } }) => {
+    const newItems = [...files];
+    newItems.splice(event.detail.fileIndex, 1);
+    setFiles(newItems);
+  };
+
+  console.log(files);
 
   return (
     <ScreenshotArea disableAnimations={true}>
@@ -258,6 +286,14 @@ export default function ButtonGroupPage() {
         <Button onClick={() => ref.current?.focus('more-actions')} data-testid="focus-on-more-actions">
           Focus on more actions
         </Button>
+
+        <FileTokenGroup
+          items={files.map(file => ({
+            file,
+          }))}
+          onDismiss={onDismiss}
+          i18nStrings={i18nStrings}
+        />
 
         <Box>
           <div id="log"></div>

--- a/pages/file-input/simple.page.tsx
+++ b/pages/file-input/simple.page.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 
-import { Box, ColumnLayout, FileInput } from '~components';
+import { Box, ColumnLayout, FileInput, FileInputProps } from '~components';
 
 import ScreenshotArea from '../utils/screenshot-area';
 
@@ -10,10 +10,13 @@ export default function DateInputScenario() {
   const [files, setFiles] = useState<File[]>([]);
   const [files2, setFiles2] = useState<File[]>([]);
 
+  const ref = React.useRef<FileInputProps.Ref>(null);
+
   return (
     <ScreenshotArea>
       <Box padding="l">
         <h1>File input</h1>
+        <button onClick={() => ref.current?.focus()}>Focus file input</button>
         <ColumnLayout columns={2}>
           <div>
             <FileInput
@@ -21,6 +24,7 @@ export default function DateInputScenario() {
               ariaLabel="prompt file input"
               variant="icon"
               value={files}
+              ref={ref}
               onChange={event => setFiles(event.detail.value)}
             />
 

--- a/pages/prompt-input/simple.page.tsx
+++ b/pages/prompt-input/simple.page.tsx
@@ -174,7 +174,7 @@ export default function PromptInputPage() {
                           onFilesChange={({ detail }) => detail.id.includes('files') && setFiles(detail.files)}
                           items={[
                             {
-                              type: 'file-input',
+                              type: 'icon-file-input',
                               id: 'files',
                               text: 'Upload files',
                               multiple: true,

--- a/pages/prompt-input/simple.page.tsx
+++ b/pages/prompt-input/simple.page.tsx
@@ -171,9 +171,7 @@ export default function PromptInputPage() {
                       <Box padding={{ left: 'xxs', top: 'xs' }}>
                         <ButtonGroup
                           ariaLabel="Chat actions"
-                          onFilesChange={({ detail }) =>
-                            detail.id.includes('files') && setFiles(detail.files ? detail.files : [])
-                          }
+                          onFilesChange={({ detail }) => detail.id.includes('files') && setFiles(detail.files)}
                           items={[
                             {
                               type: 'file-input',

--- a/pages/prompt-input/simple.page.tsx
+++ b/pages/prompt-input/simple.page.tsx
@@ -179,7 +179,6 @@ export default function PromptInputPage() {
                               type: 'file-input',
                               id: 'files',
                               text: 'Upload files',
-                              value: files,
                               multiple: true,
                             },
                             {

--- a/pages/prompt-input/simple.page.tsx
+++ b/pages/prompt-input/simple.page.tsx
@@ -3,12 +3,12 @@
 import React, { useContext, useEffect, useState } from 'react';
 
 import {
-  Alert,
   AppLayout,
   Box,
   ButtonGroup,
   Checkbox,
   ColumnLayout,
+  FileTokenGroup,
   FormField,
   PromptInput,
   SpaceBetween,
@@ -17,6 +17,7 @@ import {
 
 import AppContext, { AppContextType } from '../app/app-context';
 import labels from '../app-layout/utils/labels';
+import { i18nStrings } from '../file-upload/shared';
 
 const MAX_CHARS = 2000;
 
@@ -38,6 +39,7 @@ const placeholderText =
 export default function PromptInputPage() {
   const [textareaValue, setTextareaValue] = useState('');
   const [valueInSplitPanel, setValueInSplitPanel] = useState('');
+  const [files, setFiles] = useState<File[]>([]);
   const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
 
   const { isDisabled, isReadOnly, isInvalid, hasWarning, hasText, hasSecondaryActions, hasSecondaryContent } =
@@ -79,6 +81,12 @@ export default function PromptInputPage() {
   }, [isDisabled]);
 
   const ref = React.createRef<HTMLTextAreaElement>();
+
+  const onDismiss = (event: { detail: { fileIndex: number } }) => {
+    const newItems = [...files];
+    newItems.splice(event.detail.fileIndex, 1);
+    setFiles(newItems);
+  };
 
   return (
     <AppLayout
@@ -163,13 +171,16 @@ export default function PromptInputPage() {
                       <Box padding={{ left: 'xxs', top: 'xs' }}>
                         <ButtonGroup
                           ariaLabel="Chat actions"
+                          onItemClick={({ detail }) =>
+                            detail.id.includes('files') && setFiles(detail.files ? detail.files : [])
+                          }
                           items={[
                             {
-                              type: 'icon-button',
-                              id: 'copy',
-                              iconName: 'upload',
+                              type: 'file-input',
+                              id: 'files',
                               text: 'Upload files',
-                              disabled: isDisabled || isReadOnly,
+                              value: files,
+                              multiple: true,
                             },
                             {
                               type: 'icon-button',
@@ -192,11 +203,16 @@ export default function PromptInputPage() {
                     ) : undefined
                   }
                   secondaryContent={
-                    hasSecondaryContent ? (
-                      <Alert statusIconAriaLabel="Info" header="Known issues/limitations">
-                        Review the documentation to learn about potential compatibility issues with specific database
-                        versions.
-                      </Alert>
+                    hasSecondaryContent && files.length > 0 ? (
+                      <FileTokenGroup
+                        items={files.map(file => ({
+                          file,
+                        }))}
+                        showFileThumbnail={true}
+                        onDismiss={onDismiss}
+                        i18nStrings={i18nStrings}
+                        alignment="horizontal"
+                      />
                     ) : undefined
                   }
                 />

--- a/pages/prompt-input/simple.page.tsx
+++ b/pages/prompt-input/simple.page.tsx
@@ -6,6 +6,7 @@ import {
   AppLayout,
   Box,
   ButtonGroup,
+  ButtonGroupProps,
   Checkbox,
   ColumnLayout,
   FileTokenGroup,
@@ -82,6 +83,8 @@ export default function PromptInputPage() {
 
   const ref = React.createRef<HTMLTextAreaElement>();
 
+  const buttonGroupRef = React.useRef<ButtonGroupProps.Ref>(null);
+
   const onDismiss = (event: { detail: { fileIndex: number } }) => {
     const newItems = [...files];
     newItems.splice(event.detail.fileIndex, 1);
@@ -136,6 +139,8 @@ export default function PromptInputPage() {
             <button id="focus-button" onClick={() => ref.current?.focus()}>
               Focus component
             </button>
+
+            <button onClick={() => buttonGroupRef.current?.focus('files')}>Focus file input</button>
             <button onClick={() => ref.current?.select()}>Select all text</button>
 
             <ColumnLayout columns={2}>
@@ -170,6 +175,7 @@ export default function PromptInputPage() {
                     hasSecondaryActions ? (
                       <Box padding={{ left: 'xxs', top: 'xs' }}>
                         <ButtonGroup
+                          ref={buttonGroupRef}
                           ariaLabel="Chat actions"
                           onFilesChange={({ detail }) => detail.id.includes('files') && setFiles(detail.files)}
                           items={[

--- a/pages/prompt-input/simple.page.tsx
+++ b/pages/prompt-input/simple.page.tsx
@@ -171,7 +171,7 @@ export default function PromptInputPage() {
                       <Box padding={{ left: 'xxs', top: 'xs' }}>
                         <ButtonGroup
                           ariaLabel="Chat actions"
-                          onItemClick={({ detail }) =>
+                          onFilesChange={({ detail }) =>
                             detail.id.includes('files') && setFiles(detail.files ? detail.files : [])
                           }
                           items={[

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -3824,7 +3824,7 @@ exports[`Documenter definition for button-group matches the snapshot: button-gro
       "cancelable": false,
       "description": "Called when the user uploads files. The event detail object contains the id and files from the file input item.",
       "detailInlineType": {
-        "name": "InternalButtonGroupProps.FileChangeDetails",
+        "name": "InternalButtonGroupProps.FilesChangeDetails",
         "properties": [
           {
             "name": "files",
@@ -3839,7 +3839,7 @@ exports[`Documenter definition for button-group matches the snapshot: button-gro
         ],
         "type": "object",
       },
-      "detailType": "InternalButtonGroupProps.FileChangeDetails",
+      "detailType": "InternalButtonGroupProps.FilesChangeDetails",
       "name": "onFilesChange",
     },
     {

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -3822,6 +3822,28 @@ exports[`Documenter definition for button-group matches the snapshot: button-gro
   "events": [
     {
       "cancelable": false,
+      "description": "Called when the user uploads files. The event detail object contains the id and files from the file input item.",
+      "detailInlineType": {
+        "name": "InternalButtonGroupProps.FileChangeDetails",
+        "properties": [
+          {
+            "name": "files",
+            "optional": false,
+            "type": "Array<File>",
+          },
+          {
+            "name": "id",
+            "optional": false,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "detailType": "InternalButtonGroupProps.FileChangeDetails",
+      "name": "onFilesChange",
+    },
+    {
+      "cancelable": false,
       "description": "Called when the user clicks on an item, and the item is not disabled. The event detail object contains the id of the clicked item.",
       "detailInlineType": {
         "name": "InternalButtonGroupProps.ItemClickDetails",
@@ -3933,6 +3955,13 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
 * \`pressedIconSvg\` (optional, ReactNode) - Custom SVG icon in pressed state. Equivalent to the \`svg\` slot of the [icon component](/components/icon/).
 * \`popoverFeedback\` (optional, ReactNode) - Text that appears when the user clicks the button. Use to provide feedback to the user.
 * \`pressedPopoverFeedback\` (optional, ReactNode) - Text that appears when the user clicks the button in pressed state. Defaults to \`popoverFeedback\`.
+
+* ### file-input
+
+* \`id\` (string) - The unique identifier of the button, used as detail in \`onFilesChange\`.
+* \`text\` (string) - The name of the menu button shown as a tooltip.
+* \`accept\` (optional, string) - Specifies the native file input \`accept\` attribute to describe the allow-list of file types.
+* \`multiple\` (optional, string) - Specifies the native file input \`multiple\` attribute to allow users entering more than one file.
 
 ### menu-dropdown
 

--- a/src/button-group/__integ__/button-group.test.ts
+++ b/src/button-group/__integ__/button-group.test.ts
@@ -12,7 +12,7 @@ const likeButton = buttonGroup.findButtonById('like');
 const copyButton = buttonGroup.findButtonById('copy');
 const sendButton = buttonGroup.findButtonById('send');
 const actionsMenu = buttonGroup.findMenuById('more-actions');
-const fileInputButton = buttonGroup.findFileInputById('file-input').findNativeInput();
+const fileInput = buttonGroup.findFileInputById('file-input').findNativeInput();
 
 function setup(options: { dropdownExpandToViewport?: boolean }, testFn: (page: BasePageObject) => Promise<void>) {
   return useBrowser(async browser => {
@@ -51,7 +51,7 @@ test.each([false, true])(
       await page.click(createWrapper().find('[data-testid="focus-before"]').toSelector());
 
       await page.keys(['Tab']);
-      await expect(page.isFocused(fileInputButton.toSelector())).resolves.toBe(true);
+      await expect(page.isFocused(fileInput.toSelector())).resolves.toBe(true);
 
       await page.keys(range(9).map(() => 'ArrowRight'));
       await expect(page.isFocused(actionsMenu.find('button').toSelector())).resolves.toBe(true);
@@ -109,7 +109,7 @@ test(
   'keeps focus in button group when action gets removed',
   setup({}, async page => {
     await page.click(sendButton.toSelector());
-    await expect(page.isFocused(fileInputButton.toSelector())).resolves.toBe(true);
+    await expect(page.isFocused(fileInput.toSelector())).resolves.toBe(true);
   })
 );
 
@@ -119,7 +119,7 @@ test(
     await page.click(createWrapper().find('[data-testid="focus-before"]').toSelector());
 
     await page.keys(['Tab']);
-    await expect(page.isFocused(fileInputButton.toSelector())).resolves.toBe(true);
+    await expect(page.isFocused(fileInput.toSelector())).resolves.toBe(true);
 
     await page.keys(['ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowRight']);
     await expect(page.isFocused(copyButton.toSelector())).resolves.toBe(true);

--- a/src/button-group/__integ__/button-group.test.ts
+++ b/src/button-group/__integ__/button-group.test.ts
@@ -12,6 +12,7 @@ const likeButton = buttonGroup.findButtonById('like');
 const copyButton = buttonGroup.findButtonById('copy');
 const sendButton = buttonGroup.findButtonById('send');
 const actionsMenu = buttonGroup.findMenuById('more-actions');
+const fileInputButton = buttonGroup.findFileInputById('file-input').findNativeInput();
 
 function setup(options: { dropdownExpandToViewport?: boolean }, testFn: (page: BasePageObject) => Promise<void>) {
   return useBrowser(async browser => {
@@ -50,9 +51,9 @@ test.each([false, true])(
       await page.click(createWrapper().find('[data-testid="focus-before"]').toSelector());
 
       await page.keys(['Tab']);
-      await expect(page.isFocused(likeButton.toSelector())).resolves.toBe(true);
+      await expect(page.isFocused(fileInputButton.toSelector())).resolves.toBe(true);
 
-      await page.keys(range(8).map(() => 'ArrowRight'));
+      await page.keys(range(9).map(() => 'ArrowRight'));
       await expect(page.isFocused(actionsMenu.find('button').toSelector())).resolves.toBe(true);
 
       await page.keys(['Enter']);
@@ -108,7 +109,7 @@ test(
   'keeps focus in button group when action gets removed',
   setup({}, async page => {
     await page.click(sendButton.toSelector());
-    await expect(page.isFocused(likeButton.toSelector())).resolves.toBe(true);
+    await expect(page.isFocused(fileInputButton.toSelector())).resolves.toBe(true);
   })
 );
 
@@ -118,9 +119,9 @@ test(
     await page.click(createWrapper().find('[data-testid="focus-before"]').toSelector());
 
     await page.keys(['Tab']);
-    await expect(page.isFocused(likeButton.toSelector())).resolves.toBe(true);
+    await expect(page.isFocused(fileInputButton.toSelector())).resolves.toBe(true);
 
-    await page.keys(['ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowRight']);
+    await page.keys(['ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowRight']);
     await expect(page.isFocused(copyButton.toSelector())).resolves.toBe(true);
     await expect(page.getElementsCount(buttonGroup.findTooltip().toSelector())).resolves.toBe(1);
     await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Copy');

--- a/src/button-group/__tests__/button-group-dev.test.tsx
+++ b/src/button-group/__tests__/button-group-dev.test.tsx
@@ -146,7 +146,7 @@ test('handles file upload', () => {
   const onFilesChange = jest.fn();
 
   const { wrapper } = renderButtonGroup({
-    items: [{ type: 'file-input', id: 'file', text: 'Choose files' }],
+    items: [{ type: 'icon-file-input', id: 'file', text: 'Choose files' }],
     onFilesChange,
   });
 

--- a/src/button-group/__tests__/button-group-dev.test.tsx
+++ b/src/button-group/__tests__/button-group-dev.test.tsx
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { fireEvent } from '@testing-library/react';
+
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 import { ButtonGroupProps } from '../../../lib/components/button-group';
@@ -134,4 +136,23 @@ test('handles menu click', () => {
   wrapper.findMenuById('misc')!.openDropdown();
   wrapper.findMenuById('misc')!.findItemById('compact-mode')!.click();
   expect(onItemClick).toHaveBeenCalledWith(expect.objectContaining({ detail: { id: 'compact-mode', checked: false } }));
+});
+
+test('handles file upload', () => {
+  const file = new File([new Blob(['Test content'], { type: 'text/plain' })], 'test-file.txt', {
+    type: 'text/plain',
+    lastModified: 1590962400000,
+  });
+  const onFilesChange = jest.fn();
+
+  const { wrapper } = renderButtonGroup({
+    items: [{ type: 'file-input', id: 'file', text: 'Choose files' }],
+    onFilesChange,
+  });
+
+  const input = wrapper.findFileInputById('file')!.findNativeInput().getElement();
+  Object.defineProperty(input, 'files', { value: [file] });
+  fireEvent(input, new CustomEvent('change', { bubbles: true }));
+
+  expect(onFilesChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { id: 'file', files: [file] } }));
 });

--- a/src/button-group/__tests__/button-group-focus.test.tsx
+++ b/src/button-group/__tests__/button-group-focus.test.tsx
@@ -42,8 +42,6 @@ test('focuses on all item types', () => {
   const ref: { current: ButtonGroupProps.Ref | null } = { current: null };
   const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton, fileInput] }, ref);
 
-  window.HTMLElement.prototype.scrollIntoView = function () {};
-
   ref.current!.focus('copy');
   expect(wrapper.findButtonById('copy')!.getElement()).toHaveFocus();
 

--- a/src/button-group/__tests__/button-group-focus.test.tsx
+++ b/src/button-group/__tests__/button-group-focus.test.tsx
@@ -32,9 +32,15 @@ const menuButton: ButtonGroupProps.MenuDropdown = {
   items: [{ id: 'search', text: 'Search' }],
 };
 
+const fileInputButton: ButtonGroupProps.FileInput = {
+  type: 'file-input',
+  id: 'file',
+  text: 'Choose files',
+};
+
 test('focuses on all item types', () => {
   const ref: { current: ButtonGroupProps.Ref | null } = { current: null };
-  const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton] }, ref);
+  const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton, fileInputButton] }, ref);
 
   ref.current!.focus('copy');
   expect(wrapper.findButtonById('copy')!.getElement()).toHaveFocus();
@@ -44,6 +50,9 @@ test('focuses on all item types', () => {
 
   ref.current!.focus('menu');
   expect(wrapper.findMenuById('menu')!.findTriggerButton()!.getElement()).toHaveFocus();
+
+  ref.current!.focus('file');
+  expect(wrapper.findFileInputById('file')!.findNativeInput().getElement()).toHaveFocus();
 });
 
 test('moves focus to menu trigger after menu is dismissed', () => {

--- a/src/button-group/__tests__/button-group-focus.test.tsx
+++ b/src/button-group/__tests__/button-group-focus.test.tsx
@@ -33,7 +33,7 @@ const menuButton: ButtonGroupProps.MenuDropdown = {
 };
 
 const fileInput: ButtonGroupProps.IconFileInput = {
-  type: 'file-input',
+  type: 'icon-file-input',
   id: 'file',
   text: 'Choose files',
 };

--- a/src/button-group/__tests__/button-group-focus.test.tsx
+++ b/src/button-group/__tests__/button-group-focus.test.tsx
@@ -32,7 +32,7 @@ const menuButton: ButtonGroupProps.MenuDropdown = {
   items: [{ id: 'search', text: 'Search' }],
 };
 
-const fileInputButton: ButtonGroupProps.FileInput = {
+const fileInput: ButtonGroupProps.FileInput = {
   type: 'file-input',
   id: 'file',
   text: 'Choose files',
@@ -40,7 +40,7 @@ const fileInputButton: ButtonGroupProps.FileInput = {
 
 test('focuses on all item types', () => {
   const ref: { current: ButtonGroupProps.Ref | null } = { current: null };
-  const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton, fileInputButton] }, ref);
+  const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton, fileInput] }, ref);
 
   ref.current!.focus('copy');
   expect(wrapper.findButtonById('copy')!.getElement()).toHaveFocus();

--- a/src/button-group/__tests__/button-group-focus.test.tsx
+++ b/src/button-group/__tests__/button-group-focus.test.tsx
@@ -32,7 +32,7 @@ const menuButton: ButtonGroupProps.MenuDropdown = {
   items: [{ id: 'search', text: 'Search' }],
 };
 
-const fileInput: ButtonGroupProps.FileInput = {
+const fileInput: ButtonGroupProps.IconFileInput = {
   type: 'file-input',
   id: 'file',
   text: 'Choose files',

--- a/src/button-group/__tests__/button-group-focus.test.tsx
+++ b/src/button-group/__tests__/button-group-focus.test.tsx
@@ -42,6 +42,8 @@ test('focuses on all item types', () => {
   const ref: { current: ButtonGroupProps.Ref | null } = { current: null };
   const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton, fileInput] }, ref);
 
+  window.HTMLElement.prototype.scrollIntoView = function () {};
+
   ref.current!.focus('copy');
   expect(wrapper.findButtonById('copy')!.getElement()).toHaveFocus();
 

--- a/src/button-group/__tests__/button-group-keyboard.test.tsx
+++ b/src/button-group/__tests__/button-group-keyboard.test.tsx
@@ -51,6 +51,8 @@ test('navigates button dropdown with keyboard', () => {
   const ref: { current: ButtonGroupProps.Ref | null } = { current: null };
   const { wrapper } = renderButtonGroup({ items }, ref);
 
+  window.HTMLElement.prototype.scrollIntoView = function () {};
+
   ref.current?.focus('like');
 
   fireEvent.keyDown(wrapper.getElement(), { keyCode: KeyCode.right });

--- a/src/button-group/__tests__/button-group-keyboard.test.tsx
+++ b/src/button-group/__tests__/button-group-keyboard.test.tsx
@@ -51,8 +51,6 @@ test('navigates button dropdown with keyboard', () => {
   const ref: { current: ButtonGroupProps.Ref | null } = { current: null };
   const { wrapper } = renderButtonGroup({ items }, ref);
 
-  window.HTMLElement.prototype.scrollIntoView = function () {};
-
   ref.current?.focus('like');
 
   fireEvent.keyDown(wrapper.getElement(), { keyCode: KeyCode.right });

--- a/src/button-group/__tests__/button-group-keyboard.test.tsx
+++ b/src/button-group/__tests__/button-group-keyboard.test.tsx
@@ -35,7 +35,7 @@ const items: ButtonGroupProps.ItemOrGroup[] = [
     ],
   },
   { type: 'icon-button', id: 'copy', iconName: 'copy', text: 'Copy', popoverFeedback: 'Copied' },
-  { type: 'file-input', id: 'file', text: 'Choose files' },
+  { type: 'icon-file-input', id: 'file', text: 'Choose files' },
   {
     type: 'menu-dropdown',
     id: 'misc',

--- a/src/button-group/__tests__/button-group-keyboard.test.tsx
+++ b/src/button-group/__tests__/button-group-keyboard.test.tsx
@@ -35,6 +35,7 @@ const items: ButtonGroupProps.ItemOrGroup[] = [
     ],
   },
   { type: 'icon-button', id: 'copy', iconName: 'copy', text: 'Copy', popoverFeedback: 'Copied' },
+  { type: 'file-input', id: 'file', text: 'Choose files' },
   {
     type: 'menu-dropdown',
     id: 'misc',
@@ -59,6 +60,11 @@ test('navigates button dropdown with keyboard', () => {
   fireEvent.keyDown(wrapper.getElement(), { keyCode: KeyCode.left });
   expect(wrapper.findToggleButtonById('like')!.getElement()).toHaveFocus();
   expect(wrapper.findTooltip()!.getElement()).toHaveTextContent('Like');
+
+  fireEvent.keyDown(wrapper.getElement(), { keyCode: KeyCode.right });
+  fireEvent.keyDown(wrapper.getElement(), { keyCode: KeyCode.right });
+  expect(wrapper.findFileInputById('file')!.findNativeInput().getElement()).toHaveFocus();
+  expect(wrapper.findTooltip()!.getElement()).toHaveTextContent('Choose files');
 
   fireEvent.keyDown(wrapper.getElement(), { keyCode: KeyCode.end });
   expect(wrapper.findMenuById('misc')!.findTriggerButton()!.getElement()).toHaveFocus();

--- a/src/button-group/__tests__/button-group-states.test.tsx
+++ b/src/button-group/__tests__/button-group-states.test.tsx
@@ -25,6 +25,13 @@ const likeButton: ButtonGroupProps.IconToggleButton = {
   pressedPopoverFeedback: 'You like it',
 };
 
+const fileButton: ButtonGroupProps.FileInput = {
+  type: 'file-input',
+  id: 'file',
+  text: 'Choose files',
+  value: [],
+};
+
 const menuButton: ButtonGroupProps.MenuDropdown = {
   type: 'menu-dropdown',
   id: 'menu',
@@ -39,10 +46,11 @@ const feedbackGroup: ButtonGroupProps.Group = {
 };
 
 test('all item types have ARIA labels', () => {
-  const { wrapper } = renderButtonGroup({ items: [feedbackGroup, copyButton, menuButton] });
+  const { wrapper } = renderButtonGroup({ items: [feedbackGroup, copyButton, menuButton, fileButton] });
 
   expect(wrapper.find('[role="group"]')!.getElement()).toHaveAccessibleName('Feedback');
   expect(wrapper.findToggleButtonById('like')!.getElement()).toHaveAccessibleName('Like');
+  expect(wrapper.findFileInputById('file')!.findNativeInput().getElement()).toHaveAccessibleName('Choose files');
   expect(wrapper.findButtonById('copy')!.getElement()).toHaveAccessibleName('Copy');
   expect(wrapper.findMenuById('menu')!.findTriggerButton()!.getElement()).toHaveAccessibleName('More actions');
 });
@@ -59,7 +67,7 @@ test('toggle button has correct pressed label', () => {
   expect(wrapper.findToggleButtonById('like')!.getElement()).toHaveAccessibleName('Like');
 });
 
-test('all item types can be disabled', () => {
+test('all item types except file input can be disabled', () => {
   const { wrapper } = renderButtonGroup({
     items: [likeButton, copyButton, menuButton].map(item => ({ ...item, disabled: true })),
   });
@@ -69,7 +77,7 @@ test('all item types can be disabled', () => {
   expect(wrapper.findMenuById('menu')!.findTriggerButton()!.getElement()).toBeDisabled();
 });
 
-test('all item types can be loading', async () => {
+test('all item types except file input can be loading', async () => {
   const { wrapper } = renderButtonGroup({
     items: [likeButton, copyButton, menuButton].map(item => ({
       ...item,

--- a/src/button-group/__tests__/button-group-states.test.tsx
+++ b/src/button-group/__tests__/button-group-states.test.tsx
@@ -26,7 +26,7 @@ const likeButton: ButtonGroupProps.IconToggleButton = {
 };
 
 const fileButton: ButtonGroupProps.IconFileInput = {
-  type: 'file-input',
+  type: 'icon-file-input',
   id: 'file',
   text: 'Choose files',
 };

--- a/src/button-group/__tests__/button-group-states.test.tsx
+++ b/src/button-group/__tests__/button-group-states.test.tsx
@@ -29,7 +29,6 @@ const fileButton: ButtonGroupProps.FileInput = {
   type: 'file-input',
   id: 'file',
   text: 'Choose files',
-  value: [],
 };
 
 const menuButton: ButtonGroupProps.MenuDropdown = {

--- a/src/button-group/__tests__/button-group-states.test.tsx
+++ b/src/button-group/__tests__/button-group-states.test.tsx
@@ -25,7 +25,7 @@ const likeButton: ButtonGroupProps.IconToggleButton = {
   pressedPopoverFeedback: 'You like it',
 };
 
-const fileButton: ButtonGroupProps.FileInput = {
+const fileButton: ButtonGroupProps.IconFileInput = {
   type: 'file-input',
   id: 'file',
   text: 'Choose files',

--- a/src/button-group/__tests__/button-group-tooltips.test.tsx
+++ b/src/button-group/__tests__/button-group-tooltips.test.tsx
@@ -32,17 +32,23 @@ const menuButton: ButtonGroupProps.MenuDropdown = {
   items: [{ id: 'search', text: 'Search' }],
 };
 
+const fileInputButton: ButtonGroupProps.FileInput = {
+  type: 'file-input',
+  id: 'file',
+  text: 'Choose files',
+};
+
 test('tooltip not shown by default', () => {
-  const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton] });
+  const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton, fileInputButton] });
 
   expect(wrapper.findTooltip()).toBeNull();
 });
 
-test.each([copyButton, likeButton, menuButton])(
+test.each([copyButton, likeButton, menuButton, fileInputButton])(
   'shows the tooltip on pointer enter and hides on pointer leave, item id=$id',
   item => {
-    const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton] });
-    const button = wrapper.findButtonById(item.id)!;
+    const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton, fileInputButton] });
+    const button = item.id === 'file' ? wrapper.findFileInputById(item.id)! : wrapper.findButtonById(item.id)!;
 
     fireEvent.pointerEnter(button.getElement());
     expect(wrapper.findTooltip()!.getElement()).toHaveTextContent(item.text);

--- a/src/button-group/__tests__/button-group-tooltips.test.tsx
+++ b/src/button-group/__tests__/button-group-tooltips.test.tsx
@@ -33,7 +33,7 @@ const menuButton: ButtonGroupProps.MenuDropdown = {
 };
 
 const fileInput: ButtonGroupProps.IconFileInput = {
-  type: 'file-input',
+  type: 'icon-file-input',
   id: 'file',
   text: 'Choose files',
 };

--- a/src/button-group/__tests__/button-group-tooltips.test.tsx
+++ b/src/button-group/__tests__/button-group-tooltips.test.tsx
@@ -32,22 +32,22 @@ const menuButton: ButtonGroupProps.MenuDropdown = {
   items: [{ id: 'search', text: 'Search' }],
 };
 
-const fileInputButton: ButtonGroupProps.FileInput = {
+const fileInput: ButtonGroupProps.FileInput = {
   type: 'file-input',
   id: 'file',
   text: 'Choose files',
 };
 
 test('tooltip not shown by default', () => {
-  const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton, fileInputButton] });
+  const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton, fileInput] });
 
   expect(wrapper.findTooltip()).toBeNull();
 });
 
-test.each([copyButton, likeButton, menuButton, fileInputButton])(
+test.each([copyButton, likeButton, menuButton, fileInput])(
   'shows the tooltip on pointer enter and hides on pointer leave, item id=$id',
   item => {
-    const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton, fileInputButton] });
+    const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton, fileInput] });
     const button = item.id === 'file' ? wrapper.findFileInputById(item.id)! : wrapper.findButtonById(item.id)!;
 
     fireEvent.pointerEnter(button.getElement());

--- a/src/button-group/__tests__/button-group-tooltips.test.tsx
+++ b/src/button-group/__tests__/button-group-tooltips.test.tsx
@@ -32,7 +32,7 @@ const menuButton: ButtonGroupProps.MenuDropdown = {
   items: [{ id: 'search', text: 'Search' }],
 };
 
-const fileInput: ButtonGroupProps.FileInput = {
+const fileInput: ButtonGroupProps.IconFileInput = {
   type: 'file-input',
   id: 'file',
   text: 'Choose files',

--- a/src/button-group/file-input-item.tsx
+++ b/src/button-group/file-input-item.tsx
@@ -7,7 +7,6 @@ import { FileInputProps } from '../file-input/interfaces.js';
 import InternalFileInput from '../file-input/internal.js';
 import Tooltip from '../internal/components/tooltip/index.js';
 import { CancelableEventHandler, fireCancelableEvent } from '../internal/events/index.js';
-import InternalLiveRegion from '../live-region/internal.js';
 import { ButtonGroupProps } from './interfaces.js';
 
 import testUtilStyles from './test-classes/styles.css.js';
@@ -17,12 +16,10 @@ const FileInputItem = forwardRef(
     {
       item,
       showTooltip,
-      showFeedback,
       onItemClick,
     }: {
       item: ButtonGroupProps.FileInput;
       showTooltip: boolean;
-      showFeedback: boolean;
       onItemClick?: CancelableEventHandler<ButtonGroupProps.ItemClickDetails>;
     },
     ref: React.Ref<FileInputProps.Ref>
@@ -30,7 +27,6 @@ const FileInputItem = forwardRef(
     const containerRef = React.useRef<HTMLDivElement>(null);
 
     const canShowTooltip = Boolean(showTooltip);
-    const canShowFeedback = Boolean(showTooltip && showFeedback && item.popoverFeedback);
     return (
       <div ref={containerRef}>
         <InternalFileInput
@@ -42,17 +38,15 @@ const FileInputItem = forwardRef(
           onChange={event => fireCancelableEvent(onItemClick, { id: item.id, files: event.detail.value })}
           ref={ref}
           data-testid={item.id}
-          data-itemid={item.id}
-          className={clsx(testUtilStyles.item, testUtilStyles['button-group-item'])}
+          dataItemId={item.id}
+          className={clsx(testUtilStyles['button-group-item'])}
+          inputClassName={testUtilStyles.item}
         />
-        {(canShowTooltip || canShowFeedback) && (
+        {canShowTooltip && (
           <Tooltip
             trackRef={containerRef}
             trackKey={item.id}
-            value={
-              (showFeedback && <InternalLiveRegion tagName="span">{item.popoverFeedback}</InternalLiveRegion>) ||
-              item.text
-            }
+            value={item.text}
             className={clsx(testUtilStyles.tooltip, testUtilStyles['button-group-tooltip'])}
           />
         )}

--- a/src/button-group/file-input-item.tsx
+++ b/src/button-group/file-input-item.tsx
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { forwardRef } from 'react';
+import clsx from 'clsx';
+
+import { FileInputProps } from '../file-input/interfaces.js';
+import InternalFileInput from '../file-input/internal.js';
+import Tooltip from '../internal/components/tooltip/index.js';
+import { CancelableEventHandler, fireCancelableEvent } from '../internal/events/index.js';
+import InternalLiveRegion from '../live-region/internal.js';
+import { ButtonGroupProps } from './interfaces.js';
+
+import testUtilStyles from './test-classes/styles.css.js';
+
+const FileInputItem = forwardRef(
+  (
+    {
+      item,
+      showTooltip,
+      showFeedback,
+      onItemClick,
+    }: {
+      item: ButtonGroupProps.FileInput;
+      showTooltip: boolean;
+      showFeedback: boolean;
+      onItemClick?: CancelableEventHandler<ButtonGroupProps.ItemClickDetails>;
+    },
+    ref: React.Ref<FileInputProps.Ref>
+  ) => {
+    const containerRef = React.useRef<HTMLDivElement>(null);
+
+    const canShowTooltip = Boolean(showTooltip);
+    const canShowFeedback = Boolean(showTooltip && showFeedback && item.popoverFeedback);
+    return (
+      <div ref={containerRef}>
+        <InternalFileInput
+          variant="icon"
+          ariaLabel={item.text}
+          value={[]}
+          onChange={event => fireCancelableEvent(onItemClick, { id: item.id, files: event.detail.value })}
+          ref={ref}
+          data-testid={item.id}
+          data-itemid={item.id}
+          className={clsx(testUtilStyles.item, testUtilStyles['button-group-item'])}
+        />
+        {(canShowTooltip || canShowFeedback) && (
+          <Tooltip
+            trackRef={containerRef}
+            trackKey={item.id}
+            value={
+              (showFeedback && <InternalLiveRegion tagName="span">{item.popoverFeedback}</InternalLiveRegion>) ||
+              item.text
+            }
+            className={clsx(testUtilStyles.tooltip, testUtilStyles['button-group-tooltip'])}
+          />
+        )}
+      </div>
+    );
+  }
+);
+
+export default FileInputItem;

--- a/src/button-group/file-input-item.tsx
+++ b/src/button-group/file-input-item.tsx
@@ -16,11 +16,11 @@ const FileInputItem = forwardRef(
     {
       item,
       showTooltip,
-      onItemClick,
+      onFilesChange,
     }: {
       item: ButtonGroupProps.FileInput;
       showTooltip: boolean;
-      onItemClick?: CancelableEventHandler<ButtonGroupProps.ItemClickDetails>;
+      onFilesChange?: CancelableEventHandler<ButtonGroupProps.FileChangeDetails>;
     },
     ref: React.Ref<FileInputProps.Ref>
   ) => {
@@ -37,7 +37,7 @@ const FileInputItem = forwardRef(
           multiple={item.multiple}
           value={files}
           onChange={event => {
-            fireCancelableEvent(onItemClick, { id: item.id, files: event.detail.value });
+            fireCancelableEvent(onFilesChange, { id: item.id, files: event.detail.value });
             setFiles(event.detail.value);
           }}
           ref={ref}

--- a/src/button-group/file-input-item.tsx
+++ b/src/button-group/file-input-item.tsx
@@ -44,7 +44,7 @@ const FileInputItem = forwardRef(
             setFiles(event.detail.value);
           }}
           data-testid={item.id}
-          __nativeAttributes={{
+          __inputNativeAttributes={{
             'data-itemid': item.id,
           }}
           __inputClassName={testUtilStyles.item}

--- a/src/button-group/file-input-item.tsx
+++ b/src/button-group/file-input-item.tsx
@@ -18,9 +18,9 @@ const FileInputItem = forwardRef(
       showTooltip,
       onFilesChange,
     }: {
-      item: ButtonGroupProps.FileInput;
+      item: ButtonGroupProps.IconFileInput;
       showTooltip: boolean;
-      onFilesChange?: CancelableEventHandler<ButtonGroupProps.FileChangeDetails>;
+      onFilesChange?: CancelableEventHandler<ButtonGroupProps.FilesChangeDetails>;
     },
     ref: React.Ref<FileInputProps.Ref>
   ) => {

--- a/src/button-group/file-input-item.tsx
+++ b/src/button-group/file-input-item.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useState } from 'react';
 import clsx from 'clsx';
 
 import { FileInputProps } from '../file-input/interfaces.js';
@@ -24,6 +24,7 @@ const FileInputItem = forwardRef(
     },
     ref: React.Ref<FileInputProps.Ref>
   ) => {
+    const [files, setFiles] = useState<File[]>([]);
     const containerRef = React.useRef<HTMLDivElement>(null);
 
     const canShowTooltip = Boolean(showTooltip);
@@ -34,8 +35,11 @@ const FileInputItem = forwardRef(
           ariaLabel={item.text}
           accept={item.accept}
           multiple={item.multiple}
-          value={item.value}
-          onChange={event => fireCancelableEvent(onItemClick, { id: item.id, files: event.detail.value })}
+          value={files}
+          onChange={event => {
+            fireCancelableEvent(onItemClick, { id: item.id, files: event.detail.value });
+            setFiles(event.detail.value);
+          }}
           ref={ref}
           data-testid={item.id}
           dataItemId={item.id}

--- a/src/button-group/file-input-item.tsx
+++ b/src/button-group/file-input-item.tsx
@@ -31,6 +31,8 @@ const FileInputItem = forwardRef(
     return (
       <div ref={containerRef}>
         <InternalFileInput
+          className={clsx(testUtilStyles['button-group-item'])}
+          ref={ref}
           variant="icon"
           ariaLabel={item.text}
           accept={item.accept}
@@ -40,11 +42,11 @@ const FileInputItem = forwardRef(
             fireCancelableEvent(onFilesChange, { id: item.id, files: event.detail.value });
             setFiles(event.detail.value);
           }}
-          ref={ref}
           data-testid={item.id}
-          dataItemId={item.id}
-          className={clsx(testUtilStyles['button-group-item'])}
-          inputClassName={testUtilStyles.item}
+          __nativeAttributes={{
+            'data-itemid': item.id,
+          }}
+          __inputClassName={testUtilStyles.item}
         />
         {canShowTooltip && (
           <Tooltip

--- a/src/button-group/file-input-item.tsx
+++ b/src/button-group/file-input-item.tsx
@@ -28,6 +28,7 @@ const FileInputItem = forwardRef(
     const containerRef = React.useRef<HTMLDivElement>(null);
 
     const canShowTooltip = Boolean(showTooltip);
+
     return (
       <div ref={containerRef}>
         <InternalFileInput

--- a/src/button-group/file-input-item.tsx
+++ b/src/button-group/file-input-item.tsx
@@ -36,7 +36,9 @@ const FileInputItem = forwardRef(
         <InternalFileInput
           variant="icon"
           ariaLabel={item.text}
-          value={[]}
+          accept={item.accept}
+          multiple={item.multiple}
+          value={item.value}
           onChange={event => fireCancelableEvent(onItemClick, { id: item.id, files: event.detail.value })}
           ref={ref}
           data-testid={item.id}

--- a/src/button-group/interfaces.ts
+++ b/src/button-group/interfaces.ts
@@ -138,7 +138,7 @@ export namespace ButtonGroupProps {
   }
 
   export interface IconFileInput {
-    type: 'file-input';
+    type: 'icon-file-input';
     id: string;
     text: string;
     accept?: string;

--- a/src/button-group/interfaces.ts
+++ b/src/button-group/interfaces.ts
@@ -138,7 +138,6 @@ export namespace ButtonGroupProps {
     type: 'file-input';
     id: string;
     text: string;
-    value: File[];
     accept?: string;
     multiple?: boolean;
   }

--- a/src/button-group/interfaces.ts
+++ b/src/button-group/interfaces.ts
@@ -94,7 +94,7 @@ export interface ButtonGroupProps extends BaseComponentProps {
   /**
    * Called when the user uploads files. The event detail object contains the id and files from the file input item.
    */
-  onFilesChange?: NonCancelableEventHandler<ButtonGroupProps.FileChangeDetails>;
+  onFilesChange?: NonCancelableEventHandler<ButtonGroupProps.FilesChangeDetails>;
 }
 
 export interface InternalButtonGroupProps extends ButtonGroupProps, InternalBaseComponentProps {}
@@ -103,7 +103,7 @@ export namespace ButtonGroupProps {
   export type Variant = 'icon';
 
   export type ItemOrGroup = Item | Group;
-  export type Item = IconButton | IconToggleButton | FileInput | MenuDropdown;
+  export type Item = IconButton | IconToggleButton | IconFileInput | MenuDropdown;
 
   export interface IconButton {
     type: 'icon-button';
@@ -137,7 +137,7 @@ export namespace ButtonGroupProps {
     pressedPopoverFeedback?: React.ReactNode;
   }
 
-  export interface FileInput {
+  export interface IconFileInput {
     type: 'file-input';
     id: string;
     text: string;
@@ -167,7 +167,7 @@ export namespace ButtonGroupProps {
     checked?: boolean;
   }
 
-  export interface FileChangeDetails {
+  export interface FilesChangeDetails {
     id: string;
     files: File[];
   }

--- a/src/button-group/interfaces.ts
+++ b/src/button-group/interfaces.ts
@@ -65,6 +65,14 @@ export interface ButtonGroupProps extends BaseComponentProps {
    * * `popoverFeedback` (optional, ReactNode) - Text that appears when the user clicks the button. Use to provide feedback to the user.
    * * `pressedPopoverFeedback` (optional, ReactNode) - Text that appears when the user clicks the button in pressed state. Defaults to `popoverFeedback`.
    *
+   * * ### file-input
+   *
+   * * `id` (string) - The unique identifier of the button, used as detail in `onItemClick`.
+   * * `text` (string) - The name of the menu button shown as a tooltip.
+   * * `value` (File[]) - The file value of the input.
+   * * `accept` (optional, string) - Specifies the native file input `accept` attribute to describe the allow-list of file types.
+   * * `multiple` (optional, string) - Specifies the native file input `multiple` attribute to allow users entering more than one file.
+   *
    * ### menu-dropdown
    *
    * * `id` (string) - The unique identifier of the button, used as detail in `onItemClick`.
@@ -133,7 +141,6 @@ export namespace ButtonGroupProps {
     value: File[];
     accept?: string;
     multiple?: boolean;
-    popoverFeedback?: React.ReactNode;
   }
 
   export interface MenuDropdown {

--- a/src/button-group/interfaces.ts
+++ b/src/button-group/interfaces.ts
@@ -131,6 +131,8 @@ export namespace ButtonGroupProps {
     id: string;
     text: string;
     value: File[];
+    accept?: string;
+    multiple?: boolean;
     popoverFeedback?: React.ReactNode;
   }
 

--- a/src/button-group/interfaces.ts
+++ b/src/button-group/interfaces.ts
@@ -92,6 +92,10 @@ export interface ButtonGroupProps extends BaseComponentProps {
    * Called when the user clicks on an item, and the item is not disabled. The event detail object contains the id of the clicked item.
    */
   onItemClick?: NonCancelableEventHandler<ButtonGroupProps.ItemClickDetails>;
+  /**
+   * Called when the user uploads files. The event detail object contains the id and files from the file input item.
+   */
+  onFilesChange?: NonCancelableEventHandler<ButtonGroupProps.FileChangeDetails>;
 }
 
 export interface InternalButtonGroupProps extends ButtonGroupProps, InternalBaseComponentProps {}
@@ -162,7 +166,11 @@ export namespace ButtonGroupProps {
     id: string;
     pressed?: boolean;
     checked?: boolean;
-    files?: File[];
+  }
+
+  export interface FileChangeDetails {
+    id: string;
+    files: File[];
   }
 
   export interface Ref {

--- a/src/button-group/interfaces.ts
+++ b/src/button-group/interfaces.ts
@@ -92,7 +92,7 @@ export namespace ButtonGroupProps {
   export type Variant = 'icon';
 
   export type ItemOrGroup = Item | Group;
-  export type Item = IconButton | IconToggleButton | MenuDropdown;
+  export type Item = IconButton | IconToggleButton | FileInput | MenuDropdown;
 
   export interface IconButton {
     type: 'icon-button';
@@ -126,6 +126,14 @@ export namespace ButtonGroupProps {
     pressedPopoverFeedback?: React.ReactNode;
   }
 
+  export interface FileInput {
+    type: 'file-input';
+    id: string;
+    text: string;
+    value: File[];
+    popoverFeedback?: React.ReactNode;
+  }
+
   export interface MenuDropdown {
     type: 'menu-dropdown';
     id: string;
@@ -146,6 +154,7 @@ export namespace ButtonGroupProps {
     id: string;
     pressed?: boolean;
     checked?: boolean;
+    files?: File[];
   }
 
   export interface Ref {

--- a/src/button-group/interfaces.ts
+++ b/src/button-group/interfaces.ts
@@ -69,7 +69,6 @@ export interface ButtonGroupProps extends BaseComponentProps {
    *
    * * `id` (string) - The unique identifier of the button, used as detail in `onItemClick`.
    * * `text` (string) - The name of the menu button shown as a tooltip.
-   * * `value` (File[]) - The file value of the input.
    * * `accept` (optional, string) - Specifies the native file input `accept` attribute to describe the allow-list of file types.
    * * `multiple` (optional, string) - Specifies the native file input `multiple` attribute to allow users entering more than one file.
    *

--- a/src/button-group/interfaces.ts
+++ b/src/button-group/interfaces.ts
@@ -67,7 +67,7 @@ export interface ButtonGroupProps extends BaseComponentProps {
    *
    * * ### file-input
    *
-   * * `id` (string) - The unique identifier of the button, used as detail in `onItemClick`.
+   * * `id` (string) - The unique identifier of the button, used as detail in `onFilesChange`.
    * * `text` (string) - The name of the menu button shown as a tooltip.
    * * `accept` (optional, string) - Specifies the native file input `accept` attribute to describe the allow-list of file types.
    * * `multiple` (optional, string) - Specifies the native file input `multiple` attribute to allow users entering more than one file.

--- a/src/button-group/internal.tsx
+++ b/src/button-group/internal.tsx
@@ -28,6 +28,7 @@ const InternalButtonGroup = forwardRef(
     {
       items = [],
       onItemClick,
+      onFilesChange,
       ariaLabel,
       dropdownExpandToViewport,
       __internalRootRef = null,
@@ -157,6 +158,7 @@ const InternalButtonGroup = forwardRef(
                 tooltip={tooltip}
                 setTooltip={setTooltip}
                 onItemClick={onItemClick}
+                onFilesChange={onFilesChange}
                 ref={element => (itemsRef.current[item.id] = element)}
               />
             );

--- a/src/button-group/item-element.tsx
+++ b/src/button-group/item-element.tsx
@@ -5,6 +5,7 @@ import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react
 import { ButtonProps } from '../button/interfaces.js';
 import { fireCancelableEvent, NonCancelableEventHandler } from '../internal/events';
 import { nodeBelongs } from '../internal/utils/node-belongs';
+import FileInputItem from './file-input-item';
 import IconButtonItem from './icon-button-item';
 import IconToggleButtonItem from './icon-toggle-button-item.js';
 import { ButtonGroupProps } from './interfaces';
@@ -118,6 +119,15 @@ const ItemElement = forwardRef(
         )}
         {item.type === 'icon-toggle-button' && (
           <IconToggleButtonItem
+            ref={buttonRef}
+            item={item}
+            onItemClick={onClickHandler}
+            showTooltip={tooltip?.item === item.id}
+            showFeedback={!!tooltip?.feedback}
+          />
+        )}
+        {item.type === 'file-input' && (
+          <FileInputItem
             ref={buttonRef}
             item={item}
             onItemClick={onClickHandler}

--- a/src/button-group/item-element.tsx
+++ b/src/button-group/item-element.tsx
@@ -131,7 +131,7 @@ const ItemElement = forwardRef(
             showFeedback={!!tooltip?.feedback}
           />
         )}
-        {item.type === 'file-input' && (
+        {item.type === 'icon-file-input' && (
           <FileInputItem
             ref={buttonRef}
             item={item}

--- a/src/button-group/item-element.tsx
+++ b/src/button-group/item-element.tsx
@@ -132,7 +132,6 @@ const ItemElement = forwardRef(
             item={item}
             onItemClick={onClickHandler}
             showTooltip={tooltip?.item === item.id}
-            showFeedback={!!tooltip?.feedback}
           />
         )}
         {item.type === 'menu-dropdown' && (

--- a/src/button-group/item-element.tsx
+++ b/src/button-group/item-element.tsx
@@ -19,11 +19,12 @@ interface ItemElementProps {
   tooltip: null | { item: string; feedback: boolean };
   setTooltip: (tooltip: null | { item: string; feedback: boolean }) => void;
   onItemClick?: NonCancelableEventHandler<ButtonGroupProps.ItemClickDetails> | undefined;
+  onFilesChange?: NonCancelableEventHandler<ButtonGroupProps.FileChangeDetails> | undefined;
 }
 
 const ItemElement = forwardRef(
   (
-    { item, dropdownExpandToViewport, tooltip, setTooltip, onItemClick }: ItemElementProps,
+    { item, dropdownExpandToViewport, tooltip, setTooltip, onItemClick, onFilesChange }: ItemElementProps,
     ref: React.Ref<ButtonProps.Ref>
   ) => {
     const containerRef = useRef<HTMLDivElement>(null);
@@ -91,6 +92,10 @@ const ItemElement = forwardRef(
       fireCancelableEvent(onItemClick, event.detail, event);
     };
 
+    const onFilesChangeHandler = (event: CustomEvent<ButtonGroupProps.FileChangeDetails>) => {
+      fireCancelableEvent(onFilesChange, event.detail, event);
+    };
+
     return (
       <div
         key={item.id}
@@ -130,7 +135,7 @@ const ItemElement = forwardRef(
           <FileInputItem
             ref={buttonRef}
             item={item}
-            onItemClick={onClickHandler}
+            onFilesChange={onFilesChangeHandler}
             showTooltip={tooltip?.item === item.id}
           />
         )}

--- a/src/button-group/item-element.tsx
+++ b/src/button-group/item-element.tsx
@@ -28,17 +28,11 @@ const ItemElement = forwardRef(
     ref: React.Ref<ButtonProps.Ref>
   ) => {
     const containerRef = useRef<HTMLDivElement>(null);
-    const buttonRef = useRef<HTMLButtonElement>(null);
-    const inputRef = useRef<HTMLInputElement>(null);
+    const itemRef = useRef<HTMLButtonElement | HTMLInputElement>(null);
 
     useImperativeHandle(ref, () => ({
       focus: () => {
-        if (inputRef) {
-          inputRef.current?.focus();
-        }
-        if (buttonRef) {
-          buttonRef.current?.focus();
-        }
+        itemRef.current?.focus();
       },
     }));
 
@@ -123,7 +117,7 @@ const ItemElement = forwardRef(
       >
         {item.type === 'icon-button' && (
           <IconButtonItem
-            ref={buttonRef}
+            ref={itemRef}
             item={item}
             onItemClick={onClickHandler}
             showTooltip={tooltip?.item === item.id}
@@ -132,7 +126,7 @@ const ItemElement = forwardRef(
         )}
         {item.type === 'icon-toggle-button' && (
           <IconToggleButtonItem
-            ref={buttonRef}
+            ref={itemRef}
             item={item}
             onItemClick={onClickHandler}
             showTooltip={tooltip?.item === item.id}
@@ -141,7 +135,7 @@ const ItemElement = forwardRef(
         )}
         {item.type === 'icon-file-input' && (
           <FileInputItem
-            ref={inputRef}
+            ref={itemRef}
             item={item}
             onFilesChange={onFilesChangeHandler}
             showTooltip={tooltip?.item === item.id}
@@ -149,7 +143,7 @@ const ItemElement = forwardRef(
         )}
         {item.type === 'menu-dropdown' && (
           <MenuDropdownItem
-            ref={buttonRef}
+            ref={itemRef}
             item={item}
             showTooltip={tooltip?.item === item.id}
             onItemClick={onClickHandler}

--- a/src/button-group/item-element.tsx
+++ b/src/button-group/item-element.tsx
@@ -19,7 +19,7 @@ interface ItemElementProps {
   tooltip: null | { item: string; feedback: boolean };
   setTooltip: (tooltip: null | { item: string; feedback: boolean }) => void;
   onItemClick?: NonCancelableEventHandler<ButtonGroupProps.ItemClickDetails> | undefined;
-  onFilesChange?: NonCancelableEventHandler<ButtonGroupProps.FileChangeDetails> | undefined;
+  onFilesChange?: NonCancelableEventHandler<ButtonGroupProps.FilesChangeDetails> | undefined;
 }
 
 const ItemElement = forwardRef(
@@ -92,7 +92,7 @@ const ItemElement = forwardRef(
       fireCancelableEvent(onItemClick, event.detail, event);
     };
 
-    const onFilesChangeHandler = (event: CustomEvent<ButtonGroupProps.FileChangeDetails>) => {
+    const onFilesChangeHandler = (event: CustomEvent<ButtonGroupProps.FilesChangeDetails>) => {
       fireCancelableEvent(onFilesChange, event.detail, event);
     };
 

--- a/src/button-group/item-element.tsx
+++ b/src/button-group/item-element.tsx
@@ -29,10 +29,16 @@ const ItemElement = forwardRef(
   ) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const buttonRef = useRef<HTMLButtonElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
 
     useImperativeHandle(ref, () => ({
       focus: () => {
-        buttonRef.current?.focus();
+        if (inputRef) {
+          inputRef.current?.focus();
+        }
+        if (buttonRef) {
+          buttonRef.current?.focus();
+        }
       },
     }));
 
@@ -94,6 +100,8 @@ const ItemElement = forwardRef(
 
     const onFilesChangeHandler = (event: CustomEvent<ButtonGroupProps.FilesChangeDetails>) => {
       fireCancelableEvent(onFilesChange, event.detail, event);
+
+      setTooltip(null);
     };
 
     return (
@@ -133,7 +141,7 @@ const ItemElement = forwardRef(
         )}
         {item.type === 'icon-file-input' && (
           <FileInputItem
-            ref={buttonRef}
+            ref={inputRef}
             item={item}
             onFilesChange={onFilesChangeHandler}
             showTooltip={tooltip?.item === item.id}

--- a/src/file-input/__tests__/file-input.test.tsx
+++ b/src/file-input/__tests__/file-input.test.tsx
@@ -7,6 +7,7 @@ import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 import '../../__a11y__/to-validate-a11y';
 import InternalFileInput, { FileInputProps } from '../../../lib/components/file-input';
+import createWrapper from '../../../lib/components/test-utils/dom';
 import FileInputWrapper from '../../../lib/components/test-utils/dom/file-input';
 
 jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
@@ -131,6 +132,22 @@ describe('FileInput input', () => {
     // additional equality check, because `expect.objectContaining` above thinks file1 === file2
     expect((onChange as jest.Mock).mock.lastCall[0].detail.value[0]).toBe(file1);
     expect((onChange as jest.Mock).mock.lastCall[0].detail.value[1]).toBe(file2);
+  });
+});
+
+describe('ref', () => {
+  test('can be used to focus the component', () => {
+    const ref = React.createRef<FileInputProps.Ref>();
+    const { container } = testingLibraryRender(
+      <InternalFileInput {...defaultProps} ref={ref}>
+        Choose files
+      </InternalFileInput>
+    );
+
+    const wrapper = createWrapper(container).findFileInput()!;
+    expect(document.activeElement).not.toBe(wrapper.findNativeInput().getElement());
+    ref.current?.focus();
+    expect(document.activeElement).toBe(wrapper.findNativeInput().getElement());
   });
 });
 

--- a/src/file-input/__tests__/file-input.test.tsx
+++ b/src/file-input/__tests__/file-input.test.tsx
@@ -138,6 +138,9 @@ describe('FileInput input', () => {
 describe('ref', () => {
   test('can be used to focus the component', () => {
     const ref = React.createRef<FileInputProps.Ref>();
+
+    window.HTMLElement.prototype.scrollIntoView = function () {};
+
     const { container } = testingLibraryRender(
       <InternalFileInput {...defaultProps} ref={ref}>
         Choose files

--- a/src/file-input/__tests__/file-input.test.tsx
+++ b/src/file-input/__tests__/file-input.test.tsx
@@ -139,8 +139,6 @@ describe('ref', () => {
   test('can be used to focus the component', () => {
     const ref = React.createRef<FileInputProps.Ref>();
 
-    window.HTMLElement.prototype.scrollIntoView = function () {};
-
     const { container } = testingLibraryRender(
       <InternalFileInput {...defaultProps} ref={ref}>
         Choose files

--- a/src/file-input/internal.tsx
+++ b/src/file-input/internal.tsx
@@ -10,6 +10,7 @@ import InternalButton from '../button/internal';
 import { useFormFieldContext } from '../contexts/form-field';
 import { getBaseProps } from '../internal/base-component/index.js';
 import ScreenreaderOnly from '../internal/components/screenreader-only';
+import { useSingleTabStopNavigation } from '../internal/context/single-tab-stop-navigation-context';
 import { fireNonCancelableEvent } from '../internal/events';
 import checkControlled from '../internal/hooks/check-controlled';
 import useForwardFocus from '../internal/hooks/forward-focus';
@@ -19,6 +20,11 @@ import { joinStrings } from '../internal/utils/strings';
 import { FileInputProps } from './interfaces';
 
 import styles from './styles.css.js';
+
+interface InternalFileInputProps {
+  inputClassName?: string;
+  dataItemId?: string;
+}
 
 const InternalFileInput = React.forwardRef(
   (
@@ -32,8 +38,10 @@ const InternalFileInput = React.forwardRef(
       variant = 'button',
       children,
       __internalRootRef = null,
+      inputClassName,
+      dataItemId,
       ...restProps
-    }: FileInputProps & InternalBaseComponentProps,
+    }: FileInputProps & InternalBaseComponentProps & InternalFileInputProps,
     ref: Ref<FileInputProps.Ref>
   ) => {
     const baseProps = getBaseProps(restProps);
@@ -87,6 +95,8 @@ const InternalFileInput = React.forwardRef(
       }
     }, [value]);
 
+    const { tabIndex } = useSingleTabStopNavigation(uploadInputRef);
+
     return (
       <div {...baseProps} ref={__internalRootRef} className={clsx(baseProps.className, styles.root)}>
         {/* This is the actual interactive and accessible file-upload element. */}
@@ -101,7 +111,9 @@ const InternalFileInput = React.forwardRef(
           onChange={onUploadInputChange}
           onFocus={onUploadInputFocus}
           onBlur={onUploadInputBlur}
-          className={clsx(styles['file-input'], styles.hidden)}
+          className={clsx(styles['file-input'], styles.hidden, inputClassName)}
+          tabIndex={tabIndex}
+          data-itemid={dataItemId}
           {...nativeAttributes}
         />
 

--- a/src/file-input/internal.tsx
+++ b/src/file-input/internal.tsx
@@ -22,8 +22,8 @@ import { FileInputProps } from './interfaces';
 import styles from './styles.css.js';
 
 interface InternalFileInputProps {
-  inputClassName?: string;
-  dataItemId?: string;
+  __inputClassName?: string;
+  __nativeAttributes?: React.InputHTMLAttributes<HTMLInputElement> | Record<`data-${string}`, string>;
 }
 
 const InternalFileInput = React.forwardRef(
@@ -38,8 +38,8 @@ const InternalFileInput = React.forwardRef(
       variant = 'button',
       children,
       __internalRootRef = null,
-      inputClassName,
-      dataItemId,
+      __inputClassName,
+      __nativeAttributes,
       ...restProps
     }: FileInputProps & InternalBaseComponentProps & InternalFileInputProps,
     ref: Ref<FileInputProps.Ref>
@@ -68,6 +68,7 @@ const InternalFileInput = React.forwardRef(
       'aria-label': ariaLabel || children,
       'aria-labelledby': joinStrings(formFieldContext.ariaLabelledby, uploadButtonLabelId),
       'aria-describedby': formFieldContext.ariaDescribedby,
+      ...__nativeAttributes,
     };
     if (formFieldContext.invalid) {
       nativeAttributes['aria-invalid'] = true;
@@ -111,9 +112,8 @@ const InternalFileInput = React.forwardRef(
           onChange={onUploadInputChange}
           onFocus={onUploadInputFocus}
           onBlur={onUploadInputBlur}
-          className={clsx(styles['file-input'], styles.hidden, inputClassName)}
+          className={clsx(styles['file-input'], styles.hidden, __inputClassName)}
           tabIndex={tabIndex}
-          data-itemid={dataItemId}
           {...nativeAttributes}
         />
 

--- a/src/file-input/internal.tsx
+++ b/src/file-input/internal.tsx
@@ -15,6 +15,7 @@ import { fireNonCancelableEvent } from '../internal/events';
 import checkControlled from '../internal/hooks/check-controlled';
 import useForwardFocus from '../internal/hooks/forward-focus';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component/index.js';
+import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { joinStrings } from '../internal/utils/strings';
 import { FileInputProps } from './interfaces';
@@ -46,6 +47,9 @@ const InternalFileInput = React.forwardRef(
   ) => {
     const baseProps = getBaseProps(restProps);
     const uploadInputRef = useRef<HTMLInputElement>(null);
+    const containerRef = useRef<HTMLButtonElement>(null);
+    const mergedRef = useMergeRefs(__internalRootRef, containerRef);
+
     const uploadButtonLabelId = useUniqueId('upload-button-label');
     const formFieldContext = useFormFieldContext(restProps);
     const selfControlId = useUniqueId('upload-input');
@@ -55,7 +59,10 @@ const InternalFileInput = React.forwardRef(
 
     const [isFocused, setIsFocused] = useState(false);
     const onUploadButtonClick = () => uploadInputRef.current?.click();
-    const onUploadInputFocus = () => setIsFocused(true);
+    const onUploadInputFocus = () => {
+      setIsFocused(true);
+      containerRef.current?.scrollIntoView();
+    };
     const onUploadInputBlur = () => setIsFocused(false);
 
     const onUploadInputChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
@@ -99,7 +106,7 @@ const InternalFileInput = React.forwardRef(
     const { tabIndex } = useSingleTabStopNavigation(uploadInputRef);
 
     return (
-      <div {...baseProps} ref={__internalRootRef} className={clsx(baseProps.className, styles.root)}>
+      <div {...baseProps} ref={mergedRef} className={clsx(baseProps.className, styles.root)}>
         {/* This is the actual interactive and accessible file-upload element. */}
         {/* It is visually hidden to achieve the desired UX design. */}
         <input

--- a/src/file-input/internal.tsx
+++ b/src/file-input/internal.tsx
@@ -124,7 +124,10 @@ const InternalFileInput = React.forwardRef(
           variant={variant === 'icon' ? 'icon' : undefined}
           formAction="none"
           onClick={onUploadButtonClick}
-          className={clsx(styles['file-input-button'], isFocused && styles['force-focus-outline'])}
+          className={clsx(styles['file-input-button'], {
+            [styles['force-focus-outline-button']]: isFocused && variant === 'button',
+            [styles['force-focus-outline-icon']]: isFocused && variant === 'icon',
+          })}
           __nativeAttributes={{ tabIndex: -1, 'aria-hidden': true }}
         >
           {variant === 'button' && children}

--- a/src/file-input/internal.tsx
+++ b/src/file-input/internal.tsx
@@ -24,7 +24,7 @@ import styles from './styles.css.js';
 
 interface InternalFileInputProps {
   __inputClassName?: string;
-  __nativeAttributes?: React.InputHTMLAttributes<HTMLInputElement> | Record<`data-${string}`, string>;
+  __inputNativeAttributes?: React.InputHTMLAttributes<HTMLInputElement> | Record<`data-${string}`, string>;
 }
 
 const InternalFileInput = React.forwardRef(
@@ -40,7 +40,7 @@ const InternalFileInput = React.forwardRef(
       children,
       __internalRootRef = null,
       __inputClassName,
-      __nativeAttributes,
+      __inputNativeAttributes,
       ...restProps
     }: FileInputProps & InternalBaseComponentProps & InternalFileInputProps,
     ref: Ref<FileInputProps.Ref>
@@ -61,7 +61,7 @@ const InternalFileInput = React.forwardRef(
     const onUploadButtonClick = () => uploadInputRef.current?.click();
     const onUploadInputFocus = () => {
       setIsFocused(true);
-      containerRef.current?.scrollIntoView();
+      containerRef.current?.scrollIntoView?.();
     };
     const onUploadInputBlur = () => setIsFocused(false);
 
@@ -75,7 +75,7 @@ const InternalFileInput = React.forwardRef(
       'aria-label': ariaLabel || children,
       'aria-labelledby': joinStrings(formFieldContext.ariaLabelledby, uploadButtonLabelId),
       'aria-describedby': formFieldContext.ariaDescribedby,
-      ...__nativeAttributes,
+      ...__inputNativeAttributes,
     };
     if (formFieldContext.invalid) {
       nativeAttributes['aria-invalid'] = true;

--- a/src/file-input/styles.scss
+++ b/src/file-input/styles.scss
@@ -18,12 +18,18 @@
 .file-input-button {
   @include focus-visible.when-visible-unfocused {
     &.force-focus-outline {
-      @include styles.focus-highlight(
-        (
-          'vertical': awsui.$space-button-icon-focus-outline-gutter-vertical,
-          'horizontal': awsui.$space-button-focus-outline-gutter,
-        )
-      );
+      &-icon {
+        @include styles.focus-highlight(
+          (
+            'vertical': awsui.$space-button-icon-focus-outline-gutter-vertical,
+            'horizontal': awsui.$space-button-focus-outline-gutter,
+          )
+        );
+      }
+
+      &-button {
+        @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
+      }
     }
   }
 }

--- a/src/file-input/styles.scss
+++ b/src/file-input/styles.scss
@@ -18,7 +18,12 @@
 .file-input-button {
   @include focus-visible.when-visible-unfocused {
     &.force-focus-outline {
-      @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
+      @include styles.focus-highlight(
+        (
+          'vertical': awsui.$space-button-icon-focus-outline-gutter-vertical,
+          'horizontal': awsui.$space-button-focus-outline-gutter,
+        )
+      );
     }
   }
 }

--- a/src/test-utils/dom/button-group/index.ts
+++ b/src/test-utils/dom/button-group/index.ts
@@ -4,6 +4,7 @@ import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-
 
 import ButtonWrapper from '../button/index.js';
 import ButtonDropdownWrapper from '../button-dropdown/index.js';
+import FileInputWrapper from '../file-input/index.js';
 import createWrapper from '../index.js';
 import ToggleButtonWrapper from '../toggle-button/index.js';
 
@@ -35,6 +36,15 @@ export default class ButtonGroupWrapper extends ComponentWrapper {
     const inlineItemSelector = `.${testUtilStyles['button-group-item']}[data-testid="${id}"]`;
     const wrapper = this.find(inlineItemSelector) as ElementWrapper<HTMLButtonElement>;
     return wrapper && new ToggleButtonWrapper(wrapper.getElement());
+  }
+
+  /**
+   * Finds a file input item by its id.
+   */
+  findFileInputById(id: string): null | FileInputWrapper {
+    const inlineItemSelector = `.${testUtilStyles['button-group-item']}[data-testid="${id}"]`;
+    const wrapper = this.find(inlineItemSelector) as ElementWrapper<HTMLDivElement>;
+    return wrapper && new FileInputWrapper(wrapper.getElement());
   }
 
   /**

--- a/src/test-utils/dom/button-group/index.ts
+++ b/src/test-utils/dom/button-group/index.ts
@@ -24,7 +24,7 @@ export default class ButtonGroupWrapper extends ComponentWrapper {
    * Finds a button item by its id.
    */
   findButtonById(id: string): null | ButtonWrapper {
-    const inlineItemSelector = `.${testUtilStyles['button-group-item']}[data-testid="${id}"]`;
+    const inlineItemSelector = `.${testUtilStyles['button-group-item']}[data-testid="${CSS.escape(id)}"]`;
     const wrapper = this.find(inlineItemSelector) as ElementWrapper<HTMLButtonElement>;
     return wrapper && new ButtonWrapper(wrapper.getElement());
   }
@@ -33,7 +33,7 @@ export default class ButtonGroupWrapper extends ComponentWrapper {
    * Finds a toggle button item by its id.
    */
   findToggleButtonById(id: string): null | ToggleButtonWrapper {
-    const inlineItemSelector = `.${testUtilStyles['button-group-item']}[data-testid="${id}"]`;
+    const inlineItemSelector = `.${testUtilStyles['button-group-item']}[data-testid="${CSS.escape(id)}"]`;
     const wrapper = this.find(inlineItemSelector) as ElementWrapper<HTMLButtonElement>;
     return wrapper && new ToggleButtonWrapper(wrapper.getElement());
   }
@@ -42,7 +42,7 @@ export default class ButtonGroupWrapper extends ComponentWrapper {
    * Finds a file input item by its id.
    */
   findFileInputById(id: string): null | FileInputWrapper {
-    const inlineItemSelector = `.${testUtilStyles['button-group-item']}[data-testid="${id}"]`;
+    const inlineItemSelector = `.${testUtilStyles['button-group-item']}[data-testid="${CSS.escape(id)}"]`;
     const wrapper = this.find(inlineItemSelector) as ElementWrapper<HTMLDivElement>;
     return wrapper && new FileInputWrapper(wrapper.getElement());
   }
@@ -51,7 +51,7 @@ export default class ButtonGroupWrapper extends ComponentWrapper {
    * Finds a menu item by its id.
    */
   findMenuById(id: string): null | ButtonDropdownWrapper {
-    const inlineItemSelector = `.${testUtilStyles['button-group-item']}[data-testid="${id}"]`;
+    const inlineItemSelector = `.${testUtilStyles['button-group-item']}[data-testid="${CSS.escape(id)}"]`;
     const wrapper = this.find(inlineItemSelector);
     return wrapper && new ButtonDropdownWrapper(wrapper.getElement());
   }


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Adds file-input to the button group component.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
