### PR TITLE
fix: Fixes date changing on file token group page

### DIFF
--- a/pages/file-token-group/permutations.page.tsx
+++ b/pages/file-token-group/permutations.page.tsx
@@ -52,6 +52,9 @@ export default function FileTokenGroupPermutations() {
               onDismiss={() => {
                 /*empty handler to suppress react controlled property warning*/
               }}
+              i18nStrings={{
+                formatFileLastModified: () => '2020-01-01T00:00:00',
+              }}
               {...permutation}
             />
           )}


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Screenshot tests were failing due to the `lastModifiedDate` on file tokens changing dynamically. This adds a formatter so that the date is a constant.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
