### PR TITLE
fix: Move focus to the attribute editor add button even if currently disabled

### DIFF
--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -167,19 +167,26 @@ describe('Attribute Editor', () => {
     test('enables the add button by default', () => {
       const wrapper = renderAttributeEditor({ ...defaultProps });
       const buttonElement = wrapper.findAddButton().getElement();
-      expect(buttonElement).not.toHaveAttribute('disabled');
+      expect(buttonElement).not.toHaveAttribute('aria-disabled');
     });
 
     test('enables the add button when disableAddButton is false', () => {
       const wrapper = renderAttributeEditor({ ...defaultProps, disableAddButton: false });
       const buttonElement = wrapper.findAddButton().getElement();
-      expect(buttonElement).not.toHaveAttribute('disabled');
+      expect(buttonElement).not.toHaveAttribute('aria-disabled');
     });
 
     test('disables the add button when disableAddButton is true', () => {
       const wrapper = renderAttributeEditor({ ...defaultProps, disableAddButton: true });
       const buttonElement = wrapper.findAddButton().getElement();
-      expect(buttonElement).toHaveAttribute('disabled');
+      expect(buttonElement).toHaveAttribute('aria-disabled');
+    });
+
+    test('allows the add button to be focused manually when disableAddButton is true', () => {
+      const ref: React.Ref<AttributeEditorProps.Ref> = React.createRef();
+      const wrapper = renderAttributeEditor({ ...defaultProps, ref, disableAddButton: true });
+      ref.current!.focusAddButton();
+      expect(wrapper.findAddButton().getElement()).toHaveFocus();
     });
 
     test('has no aria-describedby if there is no additional info', () => {

--- a/src/attribute-editor/internal.tsx
+++ b/src/attribute-editor/internal.tsx
@@ -103,6 +103,11 @@ const InternalAttributeEditor = React.forwardRef(
         <InternalButton
           className={styles['add-button']}
           disabled={disableAddButton}
+          // Using aria-disabled="true" and tabindex="-1" instead of "disabled"
+          // because focus can be dynamically moved to this button by calling
+          // `focusAddButton()` on the ref.
+          __nativeAttributes={disableAddButton ? { tabIndex: -1 } : {}}
+          __focusable={true}
           onClick={onAddButtonClick}
           formAction="none"
           ref={addButtonRef}

--- a/src/tag-editor/__tests__/tag-editor.test.tsx
+++ b/src/tag-editor/__tests__/tag-editor.test.tsx
@@ -283,7 +283,7 @@ describe('Tag Editor component', () => {
     test('is not disabled by default ', () => {
       const { wrapper } = renderTagEditor();
 
-      expect(wrapper.findAddButton().getElement()).not.toHaveAttribute('disabled');
+      expect(wrapper.findAddButton().getElement()).not.toHaveAttribute('aria-disabled');
     });
 
     test('is disabled when tag limit has been reached', () => {
@@ -292,7 +292,7 @@ describe('Tag Editor component', () => {
         tagLimit: 1,
       });
 
-      expect(wrapper.findAddButton().getElement()).toHaveAttribute('disabled');
+      expect(wrapper.findAddButton().getElement()).toHaveAttribute('aria-disabled');
     });
 
     test('is disabled when tag limit has been exceeded', () => {
@@ -304,7 +304,7 @@ describe('Tag Editor component', () => {
         tagLimit: 1,
       });
 
-      expect(wrapper.findAddButton().getElement()).toHaveAttribute('disabled');
+      expect(wrapper.findAddButton().getElement()).toHaveAttribute('aria-disabled');
     });
 
     test('adds an empty tag when there are no tags', () => {


### PR DESCRIPTION
### Description

The original issue was that the focus wasn't being moved to the add button when `tagLimit={1}` and the user removes the only row. What was happening was that we would try to move focus imperatively in the remove handler, but at that moment, the add button is still disabled. It becomes enabled when the attribute editor rerenders after the row is removed.

We could solve this by "storing" the focus move and acting on it in the next render (in fact, we do something like this in the tag editor), but that is complex and hard to maintain. So why not just make it focusable (`aria-disabled` + `tabindex="-1"`)?

Related links, issue #, if available: AWSUI-59916

### How has this been tested?

Unit tests and manual checking in the dev pages.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
