### PR TITLE
feat: Adds table progressive loading empty state

### DIFF
--- a/pages/table/expandable-rows-test.page.tsx
+++ b/pages/table/expandable-rows-test.page.tsx
@@ -195,6 +195,7 @@ export default () => {
                 </Popover>
               </Box>
             )}
+            renderLoaderEmpty={() => <Box>No instances found</Box>}
           />
         }
       />
@@ -320,6 +321,8 @@ function useTableData() {
       const pages = loadingState.get(item.name)?.pages ?? 0;
       return children.slice(0, pages * NESTED_PAGE_SIZE);
     };
+    // Decorate isItemExpandable to allow expandable items with empty children.
+    collectionResult.collectionProps.expandableRows.isItemExpandable = item => item.type !== 'instance';
     // Decorate onExpandableItemToggle to trigger loading when expanded.
     collectionResult.collectionProps.expandableRows.onExpandableItemToggle = event => {
       onExpandableItemToggle!(event);
@@ -343,6 +346,9 @@ function useTableData() {
         const state = loadingState.get(id);
         if (settings.useServerMock && state && (state.status === 'loading' || state.status === 'error')) {
           return state.status;
+        }
+        if (item && item.type !== 'instance' && item.children === 0) {
+          return 'empty';
         }
         const pages = state?.pages ?? 0;
         const pageSize = item ? NESTED_PAGE_SIZE : ROOT_PAGE_SIZE;

--- a/pages/table/expandable-rows.permutations.page.tsx
+++ b/pages/table/expandable-rows.permutations.page.tsx
@@ -66,6 +66,11 @@ const itemsMixed: Instance[] = [
       },
     ],
   },
+  {
+    name: 'Root-3',
+    description: 'Root item #3',
+    children: [],
+  },
 ];
 
 interface Permutation {
@@ -250,13 +255,15 @@ export default () => {
               expandableRows={{
                 getItemChildren: item => item.children ?? [],
                 isItemExpandable: item => !!item.children,
-                expandedItems: flatten(permutation.items).filter(item => item.children && item.children.length > 0),
+                expandedItems: flatten(permutation.items).filter(
+                  item => item.children && (item.children.length > 0 || item.name === 'Root-3')
+                ),
                 onExpandableItemToggle: () => {},
               }}
               getLoadingStatus={
                 permutation.progressiveLoading
                   ? item => {
-                      if (!item) {
+                      if (!item || item.name === 'Root-3') {
                         return 'pending';
                       }
                       if (item.name === 'Root-1') {

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -15809,6 +15809,7 @@ table with \`item=null\` and then for each expanded item. The function result is
 * \`pending\` - Indicates that no request in progress, but more options may be loaded.
 * \`loading\` - Indicates that data fetching is in progress.
 * \`finished\` - Indicates that loading has finished and no more requests are expected.
+* \`empty\` - Indicates that the loading has successfully finished but no items were returned.
 * \`error\` - Indicates that an error occurred during fetch.",
       "inlineType": {
         "name": "TableProps.GetLoadingStatus",
@@ -15882,6 +15883,12 @@ Important: in tables with expandable rows the \`firstIndex\`, \`lastIndex\`, and
       "name": "renderAriaLive",
       "optional": true,
       "type": "(data: TableProps.LiveAnnouncement) => string",
+    },
+    {
+      "description": "Defines loader properties for empty state.",
+      "name": "renderLoaderEmpty",
+      "optional": true,
+      "type": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
     },
     {
       "description": "Defines loader properties for error state.",

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -363,6 +363,7 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * * `pending` - Indicates that no request in progress, but more options may be loaded.
    * * `loading` - Indicates that data fetching is in progress.
    * * `finished` - Indicates that loading has finished and no more requests are expected.
+   * * `empty` - Indicates that the loading has successfully finished but no items were returned.
    * * `error` - Indicates that an error occurred during fetch.
    **/
   getLoadingStatus?: TableProps.GetLoadingStatus<T>;
@@ -378,6 +379,10 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * Defines loader properties for error state.
    */
   renderLoaderError?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
+  /**
+   * Defines loader properties for empty state.
+   */
+  renderLoaderEmpty?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
 }
 
 export namespace TableProps {
@@ -552,7 +557,7 @@ export namespace TableProps {
 
   export type GetLoadingStatus<T> = (item: null | T) => TableProps.LoadingStatus;
 
-  export type LoadingStatus = 'pending' | 'loading' | 'error' | 'finished';
+  export type LoadingStatus = 'pending' | 'loading' | 'error' | 'empty' | 'finished';
 
   export interface RenderLoaderDetail<T> {
     item: null | T;

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -133,6 +133,7 @@ const InternalTable = React.forwardRef(
       renderLoaderPending,
       renderLoaderLoading,
       renderLoaderError,
+      renderLoaderEmpty,
       __funnelSubStepProps,
       ...rest
     }: InternalTableProps<T>,
@@ -678,6 +679,7 @@ const InternalTable = React.forwardRef(
                                   renderLoaderPending={renderLoaderPending}
                                   renderLoaderLoading={renderLoaderLoading}
                                   renderLoaderError={renderLoaderError}
+                                  renderLoaderEmpty={renderLoaderEmpty}
                                   trackBy={trackBy}
                                 />
                               ))}

--- a/src/table/progressive-loading/items-loader.tsx
+++ b/src/table/progressive-loading/items-loader.tsx
@@ -16,6 +16,7 @@ export interface ItemsLoaderProps<T> {
   renderLoaderPending?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
   renderLoaderLoading?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
   renderLoaderError?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
+  renderLoaderEmpty?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
   trackBy?: TableProps.TrackBy<T>;
 }
 
@@ -25,6 +26,7 @@ export function ItemsLoader<T>({
   renderLoaderPending,
   renderLoaderLoading,
   renderLoaderError,
+  renderLoaderEmpty,
   trackBy,
 }: ItemsLoaderProps<T>) {
   let content: React.ReactNode = null;
@@ -34,10 +36,12 @@ export function ItemsLoader<T>({
     content = <InternalLiveRegion tagName="span">{renderLoaderLoading({ item })}</InternalLiveRegion>;
   } else if (loadingStatus === 'error' && renderLoaderError) {
     content = <InternalLiveRegion tagName="span">{renderLoaderError({ item })}</InternalLiveRegion>;
+  } else if (loadingStatus === 'empty' && renderLoaderEmpty) {
+    content = <InternalLiveRegion tagName="span">{renderLoaderEmpty({ item })}</InternalLiveRegion>;
   } else {
     warnOnce(
       'Table',
-      'Must define `renderLoaderPending`, `renderLoaderLoading`, or `renderLoaderError` when using corresponding loading status.'
+      'Must define `renderLoaderPending`, `renderLoaderLoading`, `renderLoaderError`, or `renderLoaderEmpty` when using corresponding loading status.'
     );
   }
 

--- a/src/table/progressive-loading/loader-cell.tsx
+++ b/src/table/progressive-loading/loader-cell.tsx
@@ -16,6 +16,7 @@ export function TableLoaderCell<ItemType>({
   renderLoaderPending,
   renderLoaderLoading,
   renderLoaderError,
+  renderLoaderEmpty,
   trackBy,
   ...props
 }: TableLoaderCellProps<ItemType>) {
@@ -28,6 +29,7 @@ export function TableLoaderCell<ItemType>({
           renderLoaderPending={renderLoaderPending}
           renderLoaderLoading={renderLoaderLoading}
           renderLoaderError={renderLoaderError}
+          renderLoaderEmpty={renderLoaderEmpty}
           trackBy={trackBy}
         />
       ) : null}

--- a/src/table/progressive-loading/progressive-loading-utils.ts
+++ b/src/table/progressive-loading/progressive-loading-utils.ts
@@ -31,10 +31,10 @@ export function useProgressiveLoadingProps<T>({
     // Insert empty expandable item loader
     if (isItemExpanded(items[i]) && getItemChildren(items[i]).length === 0) {
       const status = getLoadingStatus?.(items[i]);
-      if (status && (status === 'loading' || status === 'error')) {
+      if (status && status !== 'finished') {
         allRows.push({ type: 'loader', item: items[i], level: getItemLevel(items[i]), status, from: 0 });
       } else {
-        warnOnce('Table', 'Expanded items without children must have "loading" or "error" loading status.');
+        warnOnce('Table', 'Expanded items without children must not have "finished" loading status.');
       }
     }
 


### PR DESCRIPTION
### Description

Adds empty state to currently existing pending, loading, error, and finished states of the table progressive loading. That is to support async row expand that results in an empty array of nested items.

Rel: [yCGlAk8AlAO9]

### How has this been tested?

* Enhanced unit tests
* Manual testing on the updated test page
* Dry run to ensure no TS issues caused by the type extension

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
