### PR TITLE
chore: Test that unmountContent is called when app layout is unmounted

### DIFF
--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -609,6 +609,23 @@ describeEachAppLayout(({ theme, size }) => {
     expect(unmountContent).toHaveBeenCalledTimes(1);
   });
 
+  test('calls unmountContent when the whole app layout unmounts', async () => {
+    const mountContent = jest.fn();
+    const unmountContent = jest.fn();
+    awsuiPlugins.appLayout.registerDrawer({
+      ...drawerDefaults,
+      mountContent,
+      unmountContent,
+    });
+    const { wrapper, rerender } = await renderComponent(<AppLayout />);
+    expect(mountContent).toHaveBeenCalledTimes(0);
+    wrapper.findDrawerTriggerById(drawerDefaults.id)!.click();
+    expect(mountContent).toHaveBeenCalledTimes(1);
+    expect(unmountContent).toHaveBeenCalledTimes(0);
+    rerender(<></>);
+    expect(unmountContent).toHaveBeenCalledTimes(1);
+  });
+
   // skip these tests on mobile mode, because triggers will overflow
   (size === 'desktop' ? describe : describe.skip)('ordering', () => {
     test('renders multiple drawers in alphabetical order by default', async () => {


### PR DESCRIPTION
### Description

Make sure this case has a test

Related links, issue #, if available: P165315773

### How has this been tested?

This is a test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
