### PR TITLE
fix: Removes editable styles from expandable cells

### DIFF
--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -153,5 +153,9 @@ export function TableBodyCell<ItemType>(props: TableBodyCellProps<ItemType>) {
   }
 
   const { column, item } = props;
-  return <TableTdElement {...props}>{column.cell(item)}</TableTdElement>;
+  return (
+    <TableTdElement {...props} isEditable={false}>
+      {column.cell(item)}
+    </TableTdElement>
+  );
 }


### PR DESCRIPTION
### Description

Fixes a regression introduced in this commit: https://github.com/cloudscape-design/components/pull/3017/commits/3b2bdd646c1bcceeb6037ee996f799fc0cc7ff43

Explanation: a cell can be set as editable but we currently disable it if the cell is also expandable. For that reason it is necessary to explicitly pass isEditable={false} as otherwise the editable styles still apply.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
