### PR TITLE
fix: Remove unnecessary background color from wizard navigation

### DIFF
--- a/src/wizard/styles.scss
+++ b/src/wizard/styles.scss
@@ -36,7 +36,6 @@
 
   /* stylelint-disable selector-max-type */
   > ul.refresh {
-    background: awsui.$color-background-container-content;
     position: relative;
     margin-block: 0;
     margin-inline: 0;


### PR DESCRIPTION
### Description

Ticket: AWSUI-60000

The background of the wizard navigation is not correct and not necessary. This is not noticeable without theming because in Visual Refresh, `$color-background-container-content` and `$color-background-layout-main` have the same value, but the issue becomes apparent once they are themed to different values.

### How has this been tested?

Ran through my pipeline and caught the difference in a test for themed components. The new state is the correct one. Coverage already exists.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
