### PR TITLE
chore: Add extra tests on tools/drawer alias behavior

### DIFF
--- a/src/app-layout/__tests__/common.test.tsx
+++ b/src/app-layout/__tests__/common.test.tsx
@@ -11,7 +11,7 @@ jest.mock('@cloudscape-design/component-toolkit', () => ({
   useContainerQuery: () => [100, () => {}],
 }));
 
-describeEachAppLayout({ themes: ['classic', 'refresh', 'refresh-toolbar'] }, ({ theme, size }) => {
+describeEachAppLayout(({ theme, size }) => {
   test('Default state', () => {
     const { wrapper } = renderComponent(<AppLayout />);
 
@@ -36,6 +36,12 @@ describeEachAppLayout({ themes: ['classic', 'refresh', 'refresh-toolbar'] }, ({ 
   test('should render breadcrumbs', () => {
     const { wrapper } = renderComponent(<AppLayout breadcrumbs="Breadcrumbs" />);
     expect(wrapper.findBreadcrumbs()).toBeTruthy();
+  });
+
+  test('should not find tools slot as findActiveDrawer utility', () => {
+    const { wrapper } = renderComponent(<AppLayout toolsOpen={true} tools="test content" />);
+    expect(wrapper.findTools()!.getElement()).toHaveTextContent('test content');
+    expect(wrapper.findActiveDrawer()).toBeFalsy();
   });
 
   [

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -84,6 +84,20 @@ describeEachAppLayout(({ theme, size }) => {
     expect(wrapper.findDrawersTriggers()).toHaveLength(2);
   });
 
+  test('should find tools slot as findActiveDrawer when local runtime drawers are present', async () => {
+    awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
+    const { wrapper } = await renderComponent(<AppLayout toolsOpen={true} tools="test content" />);
+    expect(wrapper.findActiveDrawer()!.getElement()).toEqual(wrapper.findTools()!.getElement());
+    expect(wrapper.findActiveDrawer()!.getElement()).toHaveTextContent('test content');
+  });
+
+  test('should not find tools slot as findActiveDrawer when only global runtime drawers are present', async () => {
+    awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, type: 'global' });
+    const { wrapper } = await renderComponent(<AppLayout toolsOpen={true} tools="test content" />);
+    expect(wrapper.findTools().getElement()).toHaveTextContent('test content');
+    expect(wrapper.findActiveDrawer()).toBeFalsy();
+  });
+
   test('update rendered drawers via runtime config', async () => {
     awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, resizable: true });
     const { wrapper } = await renderComponent(<AppLayout />);


### PR DESCRIPTION
### Description

Ensure `findTools` and `findActiveDrawer` test utils always work as expected

Related links, issue #, if available: AWSUI-59987

### How has this been tested?

Test only change

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
