### PR TITLE
fix: Copy to clipboard misleading popover when clicking outside the corner

### DIFF
--- a/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
+++ b/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
@@ -85,6 +85,21 @@ describe('CopyToClipboard', () => {
       );
     });
 
+    test('copies to clipboard and shows success message when clicking on popover trigger', async () => {
+      const { container } = render(
+        <CopyToClipboard {...defaultProps} popoverRenderWithPortal={popoverRenderWithPortal} />
+      );
+      const copyToClipboardWrapper = createWrapper(container).findCopyToClipboard()!;
+      const popoverWrapper = createWrapper(container).findPopover();
+
+      popoverWrapper!.findTrigger().click();
+      await waitFor(() =>
+        expect(copyToClipboardWrapper.findStatusText({ popoverRenderWithPortal })!.getElement().textContent).toBe(
+          'Copied to clipboard'
+        )
+      );
+    });
+
     test('fails to copy to clipboard and shows error message', async () => {
       const { container } = render(
         <CopyToClipboard

--- a/src/copy-to-clipboard/internal.tsx
+++ b/src/copy-to-clipboard/internal.tsx
@@ -70,11 +70,11 @@ export default function InternalCopyToClipboard({
       dismissButton={false}
       renderWithPortal={popoverRenderWithPortal}
       content={<InternalStatusIndicator type={status}>{statusText}</InternalStatusIndicator>}
+      __onOpen={onClick}
     >
       <InternalButton
         ariaLabel={copyButtonAriaLabel ?? copyButtonText}
         iconName="copy"
-        onClick={onClick}
         variant={triggerVariant}
         wrapText={false}
         formAction="none"


### PR DESCRIPTION
### Description

AWSUI-60050

The root of this issue is that we have two trigger handlers for the copy-to-clipboard component: one attached to a custom trigger wrapper (within the popover component) and another to the trigger itself. Since these triggers have slightly different visual layouts - the outer wrapper lacks a border radius while the inner trigger has one, clicking just outside the inner button corners opens the popover but does not activate the copy-to-clipboard handler. This behavior led to the issue described in the ticket.  

This PR resolves the issue by attaching the existing copy-to-clipboard handler to the popover trigger event.


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
