### PR TITLE
fix: Avoid width jump when resizing app layout (toolbar mode only)

### DIFF
--- a/src/app-layout/__integ__/app-layout-refresh-content-width.test.ts
+++ b/src/app-layout/__integ__/app-layout-refresh-content-width.test.ts
@@ -63,7 +63,7 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
           `Browser viewPortWidth ${viewPortWidth}: contentType '${contentType}' has default width for content, navigation and tools slot.`,
           setupTest(viewPortWidth, async page => {
             await page.setContentType(contentType);
-            await expect(page.getContentWidth()).resolves.toBe(contentWidth);
+            await expect(page.getContentWidth()).resolves.toBe(theme === 'refresh' ? contentWidth : 1620);
 
             // Open the drawers and check their width
             await page.setDrawersOpen();

--- a/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
@@ -2,6 +2,7 @@
  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  SPDX-License-Identifier: Apache-2.0
 */
+@use 'sass:map' as map;
 @use '../../../internal/styles' as styles;
 @use '../../../internal/styles/tokens' as awsui;
 @use '../../../internal/generated/custom-css-properties/index.scss' as custom-props;
@@ -61,11 +62,7 @@
     grid-template-rows: min-content min-content 1fr min-content;
 
     &.has-adaptive-widths-default {
-      @each $breakpoint, $width in constants.$adaptive-content-widths {
-        @include styles.media-breakpoint-up($breakpoint) {
-          #{custom-props.$maxContentWidth}: $width;
-        }
-      }
+      #{custom-props.$maxContentWidth}: map.get(constants.$adaptive-content-widths, styles.$breakpoint-xx-large);
     }
 
     &.has-adaptive-widths-dashboard {


### PR DESCRIPTION
### Description

Avoid this content jump when resizing the screen

https://github.com/user-attachments/assets/53e6ab70-3d0c-46f8-bb28-8a486cfef4a3


Related links, issue #, if available: n/a

### How has this been tested?

* Locally, no jump anymore
* Screenshot tests in my dev pipeline for unexpected regressions

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
