### PR TITLE
feat: Adds table progressive loading empty state

### DIFF
--- a/pages/table/expandable-rows-test.page.tsx
+++ b/pages/table/expandable-rows-test.page.tsx
@@ -191,7 +191,9 @@ export default () => {
                   }
                   renderWithPortal={true}
                 >
-                  <StatusIndicator type="error">Failed to load instances</StatusIndicator>
+                  <StatusIndicator type="error" iconAriaLabel="Error">
+                    Failed to load instances
+                  </StatusIndicator>
                 </Popover>
               </Box>
             )}

--- a/pages/table/expandable-rows-test.page.tsx
+++ b/pages/table/expandable-rows-test.page.tsx
@@ -195,6 +195,7 @@ export default () => {
                 </Popover>
               </Box>
             )}
+            renderLoaderEmpty={() => <Box>No instances found</Box>}
           />
         }
       />
@@ -320,6 +321,8 @@ function useTableData() {
       const pages = loadingState.get(item.name)?.pages ?? 0;
       return children.slice(0, pages * NESTED_PAGE_SIZE);
     };
+    // Decorate isItemExpandable to allow expandable items with empty children.
+    collectionResult.collectionProps.expandableRows.isItemExpandable = item => item.type !== 'instance';
     // Decorate onExpandableItemToggle to trigger loading when expanded.
     collectionResult.collectionProps.expandableRows.onExpandableItemToggle = event => {
       onExpandableItemToggle!(event);

--- a/pages/table/expandable-rows.permutations.page.tsx
+++ b/pages/table/expandable-rows.permutations.page.tsx
@@ -66,6 +66,11 @@ const itemsMixed: Instance[] = [
       },
     ],
   },
+  {
+    name: 'Root-3',
+    description: 'Root item #3',
+    children: [],
+  },
 ];
 
 interface Permutation {
@@ -250,13 +255,15 @@ export default () => {
               expandableRows={{
                 getItemChildren: item => item.children ?? [],
                 isItemExpandable: item => !!item.children,
-                expandedItems: flatten(permutation.items).filter(item => item.children && item.children.length > 0),
+                expandedItems: flatten(permutation.items).filter(
+                  item => item.children && (item.children.length > 0 || item.name === 'Root-3')
+                ),
                 onExpandableItemToggle: () => {},
               }}
               getLoadingStatus={
                 permutation.progressiveLoading
                   ? item => {
-                      if (!item) {
+                      if (!item || item.name === 'Root-3') {
                         return 'pending';
                       }
                       if (item.name === 'Root-1') {

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -15914,19 +15914,29 @@ Important: in tables with expandable rows the \`firstIndex\`, \`lastIndex\`, and
       "type": "(data: TableProps.LiveAnnouncement) => string",
     },
     {
-      "description": "Defines loader properties for error state.",
+      "description": "Renders loader row content for empty row state: the loading status is "finished",
+and the row is expanded but has empty children array.
+The empty loader state is only supported for expandable rows. Use \`empty\` slot if
+the table items array is empty.
+",
+      "name": "renderLoaderEmpty",
+      "optional": true,
+      "type": "(detail: TableProps.RenderLoaderEmptyDetail<T>) => React.ReactNode",
+    },
+    {
+      "description": "Renders loader row content for error state.",
       "name": "renderLoaderError",
       "optional": true,
       "type": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
     },
     {
-      "description": "Defines loader properties for loading state.",
+      "description": "Renders loader row content for loading state.",
       "name": "renderLoaderLoading",
       "optional": true,
       "type": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
     },
     {
-      "description": "Defines loader properties for pending state.",
+      "description": "Renders loader row content for pending state.",
       "name": "renderLoaderPending",
       "optional": true,
       "type": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",

--- a/src/table/__tests__/progressive-loading.test.tsx
+++ b/src/table/__tests__/progressive-loading.test.tsx
@@ -57,10 +57,14 @@ const nestedItems: Instance[] = [
       },
     ],
   },
+  {
+    name: 'Root-3',
+    children: [],
+  },
 ];
 
 const defaultExpandableRows: TableProps.ExpandableRows<Instance> = {
-  isItemExpandable: item => (item.children ? item.children.length > 0 : false),
+  isItemExpandable: item => !!item.children,
   expandedItems: [],
   getItemChildren: item => item.children ?? [],
   onExpandableItemToggle: () => {},
@@ -75,6 +79,7 @@ function renderTable(tableProps: Partial<TableProps<Instance>>) {
       renderLoaderPending={({ item }) => `[pending] Loader for ${item?.name ?? 'TABLE ROOT'}`}
       renderLoaderLoading={({ item }) => `[loading] Loader for ${item?.name ?? 'TABLE ROOT'}`}
       renderLoaderError={({ item }) => `[error] Loader for ${item?.name ?? 'TABLE ROOT'}`}
+      renderLoaderEmpty={({ item }) => `[finished] Loader for ${item?.name ?? 'TABLE ROOT'}`}
       {...tableProps}
     />
   );
@@ -101,7 +106,12 @@ describe('Progressive loading', () => {
   test('renders loaders in correct order for normal table', () => {
     const { table } = renderTable({ getLoadingStatus: () => 'pending' });
 
-    expect(table.findRows().map(getTextContent)).toEqual(['Root-1v0', 'Root-2v0', '[pending] Loader for TABLE ROOT']);
+    expect(table.findRows().map(getTextContent)).toEqual([
+      'Root-1v0',
+      'Root-2v0',
+      'Root-3v0',
+      '[pending] Loader for TABLE ROOT',
+    ]);
   });
 
   test('renders loaders in correct order for expandable table', () => {
@@ -114,6 +124,7 @@ describe('Progressive loading', () => {
           { name: 'Root-2' },
           { name: 'Nested-2.1' },
           { name: 'Nested-2.2' },
+          { name: 'Root-3' },
         ],
       },
       getLoadingStatus: () => 'pending',
@@ -137,6 +148,8 @@ describe('Progressive loading', () => {
       'Nested-2.2.2v0',
       '[pending] Loader for Nested-2.2',
       '[pending] Loader for Root-2',
+      'Root-3v0',
+      '[pending] Loader for Root-3',
       '[pending] Loader for TABLE ROOT',
     ]);
   });
@@ -147,9 +160,9 @@ describe('Progressive loading', () => {
       const { table } = renderTable({
         expandableRows: {
           ...defaultExpandableRows,
-          expandedItems: [{ name: 'Root-1' }, { name: 'Nested-1.2' }],
+          expandedItems: [{ name: 'Root-1' }, { name: 'Nested-1.2' }, { name: 'Root-3' }],
         },
-        getLoadingStatus: () => status,
+        getLoadingStatus: item => (item?.name === 'Root-3' ? 'finished' : status),
       });
 
       expect(table.findRootItemsLoader()).not.toBe(null);
@@ -159,6 +172,7 @@ describe('Progressive loading', () => {
       expect(table.findItemsLoaderByItemId('Nested-1.2')).not.toBe(null);
       expect(table.findItemsLoaderByItemId('Nested-1.2.1')).toBe(null);
       expect(table.findItemsLoaderByItemId('Nested-1.2.2')).toBe(null);
+      expect(table.findItemsLoaderByItemId('Root-3')).not.toBe(null);
 
       expect(getTextContent(table.findRootItemsLoader()!)).toBe(`[${status}] Loader for TABLE ROOT`);
       expect(getAriaLevel(table.findRootItemsLoader()!)).toBe(null);
@@ -168,6 +182,9 @@ describe('Progressive loading', () => {
 
       expect(getTextContent(table.findItemsLoaderByItemId('Nested-1.2')!)).toBe(`[${status}] Loader for Nested-1.2`);
       expect(getAriaLevel(table.findItemsLoaderByItemId('Nested-1.2')!)).toBe('2');
+
+      expect(getTextContent(table.findItemsLoaderByItemId('Root-3')!)).toBe(`[finished] Loader for Root-3`);
+      expect(getAriaLevel(table.findItemsLoaderByItemId('Root-3')!)).toBe('1');
     }
   );
 
@@ -189,37 +206,21 @@ describe('Progressive loading', () => {
     expect(table.findItemsLoaderByItemId('Nested-1.2.2')).toBe(null);
   });
 
-  test.each(['loading', 'error'] as const)('loader content for status="%s" is announced with aria-live', status => {
-    const { table } = renderTable({
-      expandableRows: {
-        ...defaultExpandableRows,
-        expandedItems: [{ name: 'Root-1' }, { name: 'Nested-1.2' }],
-      },
-      getLoadingStatus: () => status,
-    });
-
-    expect(getAriaLive(table.findRootItemsLoader()!)).toBe(`[${status}] Loader for TABLE ROOT`);
-    expect(getAriaLive(table.findItemsLoaderByItemId('Root-1')!)).toBe(`[${status}] Loader for Root-1`);
-    expect(getAriaLive(table.findItemsLoaderByItemId('Nested-1.2')!)).toBe(`[${status}] Loader for Nested-1.2`);
-  });
-
-  test.each(['pending', 'loading', 'error'] as const)(
-    'warns when table requires a loader but the render function is missing',
+  test.each(['finished', 'loading', 'error'] as const)(
+    'loader content for status="%s" is announced with aria-live',
     status => {
-      render(
-        <Table
-          items={nestedItems}
-          columnDefinitions={columnDefinitions}
-          getLoadingStatus={() => status}
-          renderLoaderPending={status === 'pending' ? undefined : () => ({ buttonLabel: 'Load more' })}
-          renderLoaderLoading={status === 'loading' ? undefined : () => ({ loadingText: 'Loading' })}
-          renderLoaderError={status === 'error' ? undefined : () => ({ cellContent: 'Error' })}
-        />
-      );
-      expect(warnOnce).toHaveBeenCalledWith(
-        'Table',
-        'Must define `renderLoaderPending`, `renderLoaderLoading`, or `renderLoaderError` when using corresponding loading status.'
-      );
+      const { table } = renderTable({
+        expandableRows: {
+          ...defaultExpandableRows,
+          expandedItems: [{ name: 'Root-3' }],
+        },
+        getLoadingStatus: () => status,
+      });
+
+      if (status !== 'finished') {
+        expect(getAriaLive(table.findRootItemsLoader()!)).toBe(`[${status}] Loader for TABLE ROOT`);
+      }
+      expect(getAriaLive(table.findItemsLoaderByItemId('Root-3')!)).toBe(`[${status}] Loader for Root-3`);
     }
   );
 
@@ -241,51 +242,60 @@ describe('Progressive loading', () => {
         [true, 'Nested-1.2v0'],
         [false, '[pending] Loader for Root-1'],
         [true, 'Root-2v0'],
+        [true, 'Root-3v0'],
         [false, '[pending] Loader for TABLE ROOT'],
       ]);
     }
   );
 
-  test.each(['loading', 'error'] as const)('loader row with status="%s" is added after empty expanded item', status => {
-    const { table } = renderTable({
-      items: [
-        {
-          name: 'Root-1',
-          children: [],
-        },
-      ],
-      expandableRows: {
-        ...defaultExpandableRows,
-        expandedItems: [{ name: 'Root-1' }],
-      },
-      getLoadingStatus: () => status,
-    });
-
-    expect(getTextContent(table.findItemsLoaderByItemId('Root-1')!)).toBe(`[${status}] Loader for Root-1`);
-  });
-
-  test.each([undefined, 'pending', 'finished'] as const)(
-    'loader row with status="%s" is not added after empty expanded item and a warning is shown',
+  test.each(['finished', 'pending', 'loading', 'error'] as const)(
+    'loader row with status="%s" is added after empty expanded item',
     status => {
       const { table } = renderTable({
-        items: [
-          {
-            name: 'Root-1',
-            children: [],
-          },
-        ],
         expandableRows: {
           ...defaultExpandableRows,
-          expandedItems: [{ name: 'Root-1' }],
+          expandedItems: [{ name: 'Root-3' }],
         },
-        getLoadingStatus: status ? () => status : undefined,
+        getLoadingStatus: () => status,
       });
 
-      expect(table.findItemsLoaderByItemId('Root-1')).toBe(null);
+      expect(getTextContent(table.findItemsLoaderByItemId('Root-3')!)).toBe(`[${status}] Loader for Root-3`);
+    }
+  );
+
+  test.each(['pending', 'loading', 'error', 'finished'] as const)(
+    'warns when table requires a loader but the render function is missing for status="%s"',
+    status => {
+      render(
+        <Table
+          items={nestedItems}
+          columnDefinitions={columnDefinitions}
+          trackBy="name"
+          expandableRows={{ ...defaultExpandableRows, expandedItems: [{ name: 'Root-3' }] }}
+          getLoadingStatus={() => status}
+          renderLoaderPending={status === 'pending' ? undefined : () => 'Load more'}
+          renderLoaderLoading={status === 'loading' ? undefined : () => 'Loading'}
+          renderLoaderError={status === 'error' ? undefined : () => 'Error'}
+          renderLoaderEmpty={status === 'finished' ? undefined : () => 'Finished'}
+        />
+      );
       expect(warnOnce).toHaveBeenCalledWith(
         'Table',
-        'Expanded items without children must have "loading" or "error" loading status.'
+        'Must define `renderLoaderPending`, `renderLoaderLoading`, `renderLoaderError`, or `renderLoaderEmpty` when using corresponding loading status.'
       );
     }
   );
+
+  test('warns when rendering an empty expanded row with no loading status', () => {
+    const { table } = renderTable({
+      expandableRows: {
+        ...defaultExpandableRows,
+        expandedItems: [{ name: 'Root-3' }],
+      },
+      getLoadingStatus: undefined,
+    });
+
+    expect(table.findItemsLoaderByItemId('Root-3')).toBe(null);
+    expect(warnOnce).toHaveBeenCalledWith('Table', 'Expanded items without children must have a loading status.');
+  });
 });

--- a/src/table/__tests__/progressive-loading.test.tsx
+++ b/src/table/__tests__/progressive-loading.test.tsx
@@ -127,7 +127,7 @@ describe('Progressive loading', () => {
           { name: 'Root-3' },
         ],
       },
-      getLoadingStatus: () => 'pending',
+      getLoadingStatus: () => 'error',
     });
 
     expect(table.findRows().map(getTextContent)).toEqual([
@@ -136,21 +136,21 @@ describe('Progressive loading', () => {
       'Nested-1.2v0',
       'Nested-1.2.1v0',
       'Nested-1.2.2v0',
-      '[pending] Loader for Nested-1.2',
-      '[pending] Loader for Root-1',
+      '[error] Loader for Nested-1.2',
+      '[error] Loader for Root-1',
       'Root-2v0',
       'Nested-2.1v0',
       'Nested-2.1.1v0',
       'Nested-2.1.2v0',
-      '[pending] Loader for Nested-2.1',
+      '[error] Loader for Nested-2.1',
       'Nested-2.2v0',
       'Nested-2.2.1v0',
       'Nested-2.2.2v0',
-      '[pending] Loader for Nested-2.2',
-      '[pending] Loader for Root-2',
+      '[error] Loader for Nested-2.2',
+      '[error] Loader for Root-2',
       'Root-3v0',
-      '[pending] Loader for Root-3',
-      '[pending] Loader for TABLE ROOT',
+      '[error] Loader for Root-3',
+      '[error] Loader for TABLE ROOT',
     ]);
   });
 
@@ -248,7 +248,7 @@ describe('Progressive loading', () => {
     }
   );
 
-  test.each(['finished', 'pending', 'loading', 'error'] as const)(
+  test.each(['finished', 'loading', 'error'] as const)(
     'loader row with status="%s" is added after empty expanded item',
     status => {
       const { table } = renderTable({
@@ -286,16 +286,22 @@ describe('Progressive loading', () => {
     }
   );
 
-  test('warns when rendering an empty expanded row with no loading status', () => {
-    const { table } = renderTable({
-      expandableRows: {
-        ...defaultExpandableRows,
-        expandedItems: [{ name: 'Root-3' }],
-      },
-      getLoadingStatus: undefined,
-    });
+  test.each([undefined, 'pending'] as const)(
+    'warns when rendering an empty expanded row with loading status = "%s"',
+    status => {
+      const { table } = renderTable({
+        expandableRows: {
+          ...defaultExpandableRows,
+          expandedItems: [{ name: 'Root-3' }],
+        },
+        getLoadingStatus: !status ? undefined : () => status,
+      });
 
-    expect(table.findItemsLoaderByItemId('Root-3')).toBe(null);
-    expect(warnOnce).toHaveBeenCalledWith('Table', 'Expanded items without children must have a loading status.');
-  });
+      expect(table.findItemsLoaderByItemId('Root-3')).toBe(null);
+      expect(warnOnce).toHaveBeenCalledWith(
+        'Table',
+        'Expanded items without children must have "loading", "finished", or "error" loading status.'
+      );
+    }
+  );
 });

--- a/src/table/__tests__/progressive-loading.test.tsx
+++ b/src/table/__tests__/progressive-loading.test.tsx
@@ -279,6 +279,7 @@ describe('Progressive loading', () => {
           renderLoaderEmpty={status === 'finished' ? undefined : () => 'Finished'}
         />
       );
+      expect(createWrapper().findTable()!.findRows()).toHaveLength(nestedItems.length);
       expect(warnOnce).toHaveBeenCalledWith(
         'Table',
         'Must define `renderLoaderPending`, `renderLoaderLoading`, `renderLoaderError`, or `renderLoaderEmpty` when using corresponding loading status.'

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -367,17 +367,25 @@ export interface TableProps<T = any> extends BaseComponentProps {
    **/
   getLoadingStatus?: TableProps.GetLoadingStatus<T>;
   /**
-   * Defines loader properties for pending state.
+   * Renders loader row content for pending state.
    */
   renderLoaderPending?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
   /**
-   * Defines loader properties for loading state.
+   * Renders loader row content for loading state.
    */
   renderLoaderLoading?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
   /**
-   * Defines loader properties for error state.
+   * Renders loader row content for error state.
    */
   renderLoaderError?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
+  /**
+   * Renders loader row content for empty row state: the loading status is "finished",
+   * and the row is expanded but has empty children array.
+   *
+   * The empty loader state is only supported for expandable rows. Use `empty` slot if
+   * the table items array is empty.
+   */
+  renderLoaderEmpty?: (detail: TableProps.RenderLoaderEmptyDetail<T>) => React.ReactNode;
 }
 
 export namespace TableProps {
@@ -556,6 +564,10 @@ export namespace TableProps {
 
   export interface RenderLoaderDetail<T> {
     item: null | T;
+  }
+
+  export interface RenderLoaderEmptyDetail<T> {
+    item: T;
   }
 }
 

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -36,6 +36,7 @@ import { checkColumnWidths } from './column-widths-utils';
 import { useExpandableTableProps } from './expandable-rows/expandable-rows-utils';
 import { TableForwardRefType, TableProps, TableRow } from './interfaces';
 import { NoDataCell } from './no-data-cell';
+import { getLoaderContent } from './progressive-loading/items-loader';
 import { TableLoaderCell } from './progressive-loading/loader-cell';
 import { useProgressiveLoadingProps } from './progressive-loading/progressive-loading-utils';
 import { ResizeTracker } from './resizer';
@@ -656,34 +657,42 @@ const InternalTable = React.forwardRef(
                               </tr>
                             );
                           }
+
+                          const loaderContent = getLoaderContent({
+                            item: row.item,
+                            loadingStatus: row.status,
+                            renderLoaderPending,
+                            renderLoaderLoading,
+                            renderLoaderError,
+                            renderLoaderEmpty,
+                          });
                           return (
-                            <tr
-                              key={(row.item ? getTableItemKey(row.item) : 'root-' + rowIndex) + '-' + row.from}
-                              className={styles.row}
-                              {...rowRoleProps}
-                            >
-                              {getItemSelectionProps && (
-                                <TableBodySelectionCell {...sharedCellProps} columnId={selectionColumnId} />
-                              )}
-                              {visibleColumnDefinitions.map((column, colIndex) => (
-                                <TableLoaderCell
-                                  key={getColumnKey(column, colIndex)}
-                                  {...sharedCellProps}
-                                  wrapLines={false}
-                                  columnId={column.id ?? colIndex}
-                                  colIndex={colIndex + colIndexOffset}
-                                  isRowHeader={colIndex === 0}
-                                  level={row.level}
-                                  item={row.item}
-                                  loadingStatus={row.status}
-                                  renderLoaderPending={renderLoaderPending}
-                                  renderLoaderLoading={renderLoaderLoading}
-                                  renderLoaderError={renderLoaderError}
-                                  renderLoaderEmpty={renderLoaderEmpty}
-                                  trackBy={trackBy}
-                                />
-                              ))}
-                            </tr>
+                            loaderContent && (
+                              <tr
+                                key={(row.item ? getTableItemKey(row.item) : 'root-' + rowIndex) + '-' + row.from}
+                                className={styles.row}
+                                {...rowRoleProps}
+                              >
+                                {getItemSelectionProps && (
+                                  <TableBodySelectionCell {...sharedCellProps} columnId={selectionColumnId} />
+                                )}
+                                {visibleColumnDefinitions.map((column, colIndex) => (
+                                  <TableLoaderCell
+                                    key={getColumnKey(column, colIndex)}
+                                    {...sharedCellProps}
+                                    wrapLines={false}
+                                    columnId={column.id ?? colIndex}
+                                    colIndex={colIndex + colIndexOffset}
+                                    isRowHeader={colIndex === 0}
+                                    level={row.level}
+                                    item={row.item}
+                                    trackBy={trackBy}
+                                  >
+                                    {loaderContent}
+                                  </TableLoaderCell>
+                                ))}
+                              </tr>
+                            )
                           );
                         })
                       )}

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -133,6 +133,7 @@ const InternalTable = React.forwardRef(
       renderLoaderPending,
       renderLoaderLoading,
       renderLoaderError,
+      renderLoaderEmpty,
       __funnelSubStepProps,
       ...rest
     }: InternalTableProps<T>,
@@ -678,6 +679,7 @@ const InternalTable = React.forwardRef(
                                   renderLoaderPending={renderLoaderPending}
                                   renderLoaderLoading={renderLoaderLoading}
                                   renderLoaderError={renderLoaderError}
+                                  renderLoaderEmpty={renderLoaderEmpty}
                                   trackBy={trackBy}
                                 />
                               ))}

--- a/src/table/progressive-loading/items-loader.tsx
+++ b/src/table/progressive-loading/items-loader.tsx
@@ -16,6 +16,7 @@ export interface ItemsLoaderProps<T> {
   renderLoaderPending?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
   renderLoaderLoading?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
   renderLoaderError?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
+  renderLoaderEmpty?: (detail: TableProps.RenderLoaderEmptyDetail<T>) => React.ReactNode;
   trackBy?: TableProps.TrackBy<T>;
 }
 
@@ -25,6 +26,7 @@ export function ItemsLoader<T>({
   renderLoaderPending,
   renderLoaderLoading,
   renderLoaderError,
+  renderLoaderEmpty,
   trackBy,
 }: ItemsLoaderProps<T>) {
   let content: React.ReactNode = null;
@@ -34,10 +36,12 @@ export function ItemsLoader<T>({
     content = <InternalLiveRegion tagName="span">{renderLoaderLoading({ item })}</InternalLiveRegion>;
   } else if (loadingStatus === 'error' && renderLoaderError) {
     content = <InternalLiveRegion tagName="span">{renderLoaderError({ item })}</InternalLiveRegion>;
+  } else if (loadingStatus === 'finished' && renderLoaderEmpty && item) {
+    content = <InternalLiveRegion tagName="span">{renderLoaderEmpty({ item })}</InternalLiveRegion>;
   } else {
     warnOnce(
       'Table',
-      'Must define `renderLoaderPending`, `renderLoaderLoading`, or `renderLoaderError` when using corresponding loading status.'
+      'Must define `renderLoaderPending`, `renderLoaderLoading`, `renderLoaderError`, or `renderLoaderEmpty` when using corresponding loading status.'
     );
   }
 

--- a/src/table/progressive-loading/items-loader.tsx
+++ b/src/table/progressive-loading/items-loader.tsx
@@ -12,23 +12,37 @@ import styles from './styles.css.js';
 
 export interface ItemsLoaderProps<T> {
   item: null | T;
+  trackBy?: TableProps.TrackBy<T>;
+  children: React.ReactNode;
+}
+
+export interface ItemsLoaderContentProps<T> {
+  item: null | T;
   loadingStatus: TableProps.LoadingStatus;
   renderLoaderPending?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
   renderLoaderLoading?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
   renderLoaderError?: (detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode;
   renderLoaderEmpty?: (detail: TableProps.RenderLoaderEmptyDetail<T>) => React.ReactNode;
-  trackBy?: TableProps.TrackBy<T>;
 }
 
-export function ItemsLoader<T>({
+export function ItemsLoader<T>({ item, trackBy, children }: ItemsLoaderProps<T>) {
+  let parentTrackId = item && trackBy ? applyTrackBy(trackBy, item) : undefined;
+  parentTrackId = typeof parentTrackId === 'string' ? parentTrackId : undefined;
+  return (
+    <div data-root={item ? 'false' : 'true'} data-parentrow={parentTrackId} className={styles['items-loader']}>
+      {children}
+    </div>
+  );
+}
+
+export function getLoaderContent<T>({
   item,
   loadingStatus,
   renderLoaderPending,
   renderLoaderLoading,
   renderLoaderError,
   renderLoaderEmpty,
-  trackBy,
-}: ItemsLoaderProps<T>) {
+}: ItemsLoaderContentProps<T>) {
   let content: React.ReactNode = null;
   if (loadingStatus === 'pending' && renderLoaderPending) {
     content = renderLoaderPending({ item });
@@ -44,12 +58,5 @@ export function ItemsLoader<T>({
       'Must define `renderLoaderPending`, `renderLoaderLoading`, `renderLoaderError`, or `renderLoaderEmpty` when using corresponding loading status.'
     );
   }
-
-  let parentTrackId = item && trackBy ? applyTrackBy(trackBy, item) : undefined;
-  parentTrackId = typeof parentTrackId === 'string' ? parentTrackId : undefined;
-  return (
-    <div data-root={item ? 'false' : 'true'} data-parentrow={parentTrackId} className={styles['items-loader']}>
-      {content}
-    </div>
-  );
+  return content;
 }

--- a/src/table/progressive-loading/loader-cell.tsx
+++ b/src/table/progressive-loading/loader-cell.tsx
@@ -16,6 +16,7 @@ export function TableLoaderCell<ItemType>({
   renderLoaderPending,
   renderLoaderLoading,
   renderLoaderError,
+  renderLoaderEmpty,
   trackBy,
   ...props
 }: TableLoaderCellProps<ItemType>) {
@@ -28,6 +29,7 @@ export function TableLoaderCell<ItemType>({
           renderLoaderPending={renderLoaderPending}
           renderLoaderLoading={renderLoaderLoading}
           renderLoaderError={renderLoaderError}
+          renderLoaderEmpty={renderLoaderEmpty}
           trackBy={trackBy}
         />
       ) : null}

--- a/src/table/progressive-loading/loader-cell.tsx
+++ b/src/table/progressive-loading/loader-cell.tsx
@@ -6,32 +6,17 @@ import React from 'react';
 import { TableTdElement, TableTdElementProps } from '../body-cell/td-element';
 import { ItemsLoader, ItemsLoaderProps } from './items-loader';
 
-interface TableLoaderCellProps<ItemType>
-  extends Omit<TableTdElementProps, 'isEditable' | 'isEditing'>,
+export interface TableLoaderCellProps<ItemType>
+  extends Omit<TableTdElementProps, 'isEditable' | 'isEditing' | 'children'>,
     ItemsLoaderProps<ItemType> {}
 
-export function TableLoaderCell<ItemType>({
-  item,
-  loadingStatus,
-  renderLoaderPending,
-  renderLoaderLoading,
-  renderLoaderError,
-  renderLoaderEmpty,
-  trackBy,
-  ...props
-}: TableLoaderCellProps<ItemType>) {
+export function TableLoaderCell<ItemType>({ item, trackBy, children, ...props }: TableLoaderCellProps<ItemType>) {
   return (
     <TableTdElement {...props} isEditable={false} isEditing={false}>
       {props.isRowHeader ? (
-        <ItemsLoader
-          item={item}
-          loadingStatus={loadingStatus}
-          renderLoaderPending={renderLoaderPending}
-          renderLoaderLoading={renderLoaderLoading}
-          renderLoaderError={renderLoaderError}
-          renderLoaderEmpty={renderLoaderEmpty}
-          trackBy={trackBy}
-        />
+        <ItemsLoader item={item} trackBy={trackBy}>
+          {children}
+        </ItemsLoader>
       ) : null}
     </TableTdElement>
   );

--- a/src/table/progressive-loading/progressive-loading-utils.ts
+++ b/src/table/progressive-loading/progressive-loading-utils.ts
@@ -31,10 +31,13 @@ export function useProgressiveLoadingProps<T>({
     // Insert empty expandable item loader
     if (isItemExpanded(items[i]) && getItemChildren(items[i]).length === 0) {
       const status = getLoadingStatus?.(items[i]);
-      if (status) {
+      if (status === 'loading' || status === 'finished' || status === 'error') {
         allRows.push({ type: 'loader', item: items[i], level: getItemLevel(items[i]), status, from: 0 });
       } else {
-        warnOnce('Table', 'Expanded items without children must have a loading status.');
+        warnOnce(
+          'Table',
+          'Expanded items without children must have "loading", "finished", or "error" loading status.'
+        );
       }
     }
 

--- a/src/table/progressive-loading/progressive-loading-utils.ts
+++ b/src/table/progressive-loading/progressive-loading-utils.ts
@@ -31,10 +31,10 @@ export function useProgressiveLoadingProps<T>({
     // Insert empty expandable item loader
     if (isItemExpanded(items[i]) && getItemChildren(items[i]).length === 0) {
       const status = getLoadingStatus?.(items[i]);
-      if (status && (status === 'loading' || status === 'error')) {
+      if (status) {
         allRows.push({ type: 'loader', item: items[i], level: getItemLevel(items[i]), status, from: 0 });
       } else {
-        warnOnce('Table', 'Expanded items without children must have "loading" or "error" loading status.');
+        warnOnce('Table', 'Expanded items without children must have a loading status.');
       }
     }
 


### PR DESCRIPTION
### Description

Adds empty state to currently existing pending, loading, error, and finished states of the table progressive loading. That is to support async row expand that results in an empty array of nested items.

Rel: [yCGlAk8AlAO9]

Related links, issue #, if available: n/a

### How has this been tested?

* Enhanced unit tests
* Manual testing on the updated test page
* Dry run to ensure no TS issues caused by the type extension

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
