### PR TITLE
fix: Page crash on closing popover

### DIFF
--- a/pages/app-layout/multi-layout-iframe.page.tsx
+++ b/pages/app-layout/multi-layout-iframe.page.tsx
@@ -3,12 +3,9 @@
 import React from 'react';
 
 import AppLayout from '~components/app-layout';
-import Button from '~components/button';
 import Header from '~components/header';
 import ScreenreaderOnly from '~components/internal/components/screenreader-only';
-import KeyValuePairs from '~components/key-value-pairs';
 import Link from '~components/link';
-import Popover from '~components/popover';
 import SpaceBetween from '~components/space-between';
 
 import { IframeWrapper } from '../utils/iframe-wrapper';
@@ -34,59 +31,6 @@ function InnerApp() {
           <Link external={true} href="#">
             External link
           </Link>
-
-          <Popover
-            header="Network interface eth0"
-            size="large"
-            triggerType="custom"
-            content={
-              <KeyValuePairs
-                columns={2}
-                items={[
-                  {
-                    label: 'Interface ID',
-                    value: (
-                      <Link href="#" variant="primary">
-                        eni-055da457bed9bbbe6
-                      </Link>
-                    ),
-                  },
-                  {
-                    label: 'Private IP address',
-                    value: '192.0.2.0',
-                  },
-                  { label: 'VPC ID', value: 'vpc-626163728' },
-                  {
-                    label: 'Private DNS name',
-                    value: 'example.com',
-                  },
-                  {
-                    label: 'Attachment owner',
-                    value: 'vpc-626163728',
-                  },
-                  {
-                    label: 'Public IP address',
-                    value: '198.51.100.0',
-                  },
-                  {
-                    label: 'Attached',
-                    value: 'May 4, 2010, 04:56 (UTC+3:30)',
-                  },
-                  {
-                    label: 'Source/Dest. check',
-                    value: 'true',
-                  },
-                  {
-                    label: 'Delete on terminate',
-                    value: 'true',
-                  },
-                  { label: 'Description', value: '-' },
-                ]}
-              />
-            }
-          >
-            <Button ariaLabel="metricInformation" iconName="status-info" variant="icon" />
-          </Popover>
 
           <Containers />
         </SpaceBetween>

--- a/pages/app-layout/multi-layout-iframe.page.tsx
+++ b/pages/app-layout/multi-layout-iframe.page.tsx
@@ -3,9 +3,12 @@
 import React from 'react';
 
 import AppLayout from '~components/app-layout';
+import Button from '~components/button';
 import Header from '~components/header';
 import ScreenreaderOnly from '~components/internal/components/screenreader-only';
+import KeyValuePairs from '~components/key-value-pairs';
 import Link from '~components/link';
+import Popover from '~components/popover';
 import SpaceBetween from '~components/space-between';
 
 import { IframeWrapper } from '../utils/iframe-wrapper';
@@ -31,6 +34,59 @@ function InnerApp() {
           <Link external={true} href="#">
             External link
           </Link>
+
+          <Popover
+            header="Network interface eth0"
+            size="large"
+            triggerType="custom"
+            content={
+              <KeyValuePairs
+                columns={2}
+                items={[
+                  {
+                    label: 'Interface ID',
+                    value: (
+                      <Link href="#" variant="primary">
+                        eni-055da457bed9bbbe6
+                      </Link>
+                    ),
+                  },
+                  {
+                    label: 'Private IP address',
+                    value: '192.0.2.0',
+                  },
+                  { label: 'VPC ID', value: 'vpc-626163728' },
+                  {
+                    label: 'Private DNS name',
+                    value: 'example.com',
+                  },
+                  {
+                    label: 'Attachment owner',
+                    value: 'vpc-626163728',
+                  },
+                  {
+                    label: 'Public IP address',
+                    value: '198.51.100.0',
+                  },
+                  {
+                    label: 'Attached',
+                    value: 'May 4, 2010, 04:56 (UTC+3:30)',
+                  },
+                  {
+                    label: 'Source/Dest. check',
+                    value: 'true',
+                  },
+                  {
+                    label: 'Delete on terminate',
+                    value: 'true',
+                  },
+                  { label: 'Description', value: '-' },
+                ]}
+              />
+            }
+          >
+            <Button ariaLabel="metricInformation" iconName="status-info" variant="icon" />
+          </Popover>
 
           <Containers />
         </SpaceBetween>

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -191,7 +191,7 @@ const DatePicker = React.forwardRef(
           >
             {isDropDownOpen && (
               <FocusLock className={styles['focus-lock']} autoFocus={true}>
-                <div tabIndex={0} className={styles.calendar} role="dialog" aria-modal="true">
+                <div tabIndex={0} className={styles.calendar} role="dialog">
                   <InternalCalendar
                     value={value}
                     onChange={e => {

--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -157,7 +157,6 @@ export function DateRangePickerDropdown({
           className={styles.dropdown}
           tabIndex={0}
           role="dialog"
-          aria-modal="true"
           aria-label={i18nStrings?.ariaLabel}
           aria-labelledby={ariaLabelledby ?? i18nStrings?.ariaLabelledby}
           aria-describedby={ariaDescribedby ?? i18nStrings?.ariaDescribedby}

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -240,7 +240,6 @@ function PortaledModal({
               isRefresh && styles.refresh
             )}
             role="dialog"
-            aria-modal={true}
             aria-labelledby={headerId}
             onMouseDown={onOverlayMouseDown}
             onClick={onOverlayClick}

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -284,18 +284,6 @@ describe('ARIA labels', () => {
     expect(wrapper.find('[aria-live="polite"]')).toBeTruthy();
   });
 
-  it('sets aria-modal to true when a dismiss button is present', () => {
-    const wrapper = renderPopover({ children: 'Trigger', content: 'Popover' });
-    wrapper.findTrigger().click();
-    expect(wrapper.findBody()!.getElement()).toHaveAttribute('aria-modal', 'true');
-  });
-
-  it('does not set aria-modal when a dismiss button is not present', () => {
-    const wrapper = renderPopover({ children: 'Trigger', content: 'Popover', dismissButton: false });
-    wrapper.findTrigger().click();
-    expect(wrapper.findBody()!.getElement()).not.toHaveAttribute('aria-modal');
-  });
-
   it('does not pass the dismissAriaLabel to the dismiss button if not defined', () => {
     const wrapper = renderPopover({ children: 'Trigger', content: 'Popover' });
     wrapper.findTrigger().click();

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -90,7 +90,7 @@ export default function PopoverBody({
   const dialogProps = isDialog
     ? {
         role: 'dialog',
-        'aria-modal': shouldTrapFocus ? true : undefined,
+
         'aria-labelledby': ariaLabelledby ?? (header ? labelledById : undefined),
       }
     : {};

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -90,7 +90,6 @@ export default function PopoverBody({
   const dialogProps = isDialog
     ? {
         role: 'dialog',
-
         'aria-labelledby': ariaLabelledby ?? (header ? labelledById : undefined),
       }
     : {};


### PR DESCRIPTION
### Description

Ticket V1595368753

A page crashes on chrome 131 when closing popover by clicking on close button. Closing via keyboard (by pressing enter on close button) or clicking outside of popover does not cause such a crash.
The issue occurs when both `aria-modal="true"` and `role="dialog"` are present. Removing either of them resolves the problem.
I wasn’t able to reproduce this issue in the integration test environment, so no tests are available for it.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
