### PR TITLE
chore: Replaces the test utils generation with centralized code from test-utils package

### DIFF
--- a/build-tools/tasks/test-utils.js
+++ b/build-tools/tasks/test-utils.js
@@ -1,162 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-const { src, dest, series, parallel } = require('gulp');
+const { series, parallel } = require('gulp');
 const execa = require('execa');
 const path = require('path');
 const { pascalCase } = require('change-case');
-const { default: convertToSelectorUtil } = require('@cloudscape-design/test-utils-converter');
-const { through, task } = require('../utils/gulp-utils');
-const { writeFile, listPublicItems } = require('../utils/files');
+const { generateTestUtils } = require('@cloudscape-design/test-utils-converter');
+const { task } = require('../utils/gulp-utils');
+const { listPublicItems } = require('../utils/files');
 const { pluralizeComponentName } = require('../utils/pluralize');
 const themes = require('../utils/themes');
 
-function toWrapper(componentClass) {
-  return `${componentClass}Wrapper`;
-}
-
 const testUtilsSrcDir = path.resolve('src/test-utils');
-const configs = {
-  common: {
-    buildFinder: ({ componentName, componentNamePlural }) => `
-      ElementWrapper.prototype.find${componentName} = function(selector) {
-        const rootSelector = \`.$\{${toWrapper(componentName)}.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ${toWrapper(componentName)});
-      };
-
-      ElementWrapper.prototype.findAll${componentNamePlural} = function(selector) {
-        return this.findAllComponents(${toWrapper(componentName)}, selector);
-      };`,
-  },
-  dom: {
-    defaultExport: `export default function wrapper(root: Element = document.body) { if (document && document.body && !document.body.contains(root)) { console.warn('[AwsUi] [test-utils] provided element is not part of the document body, interactions may work incorrectly')}; return new ElementWrapper(root); }`,
-    buildFinderInterface: ({ componentName, componentNamePlural }) => `
-       /**
-        * Returns the wrapper of the first ${componentName} that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first ${componentName}.
-        * If no matching ${componentName} is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {${toWrapper(componentName)} | null}
-        */
-       find${componentName}(selector?: string): ${toWrapper(componentName)} | null;
-
-       /**
-        * Returns an array of ${componentName} wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the ${componentNamePlural} inside the current wrapper.
-        * If no matching ${componentName} is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<${toWrapper(componentName)}>}
-        */
-       findAll${componentNamePlural}(selector?: string): Array<${toWrapper(componentName)}>;`,
-  },
-  selectors: {
-    defaultExport: `export default function wrapper(root: string = 'body') { return new ElementWrapper(root); }`,
-    buildFinderInterface: ({ componentName, componentNamePlural }) => `
-       /**
-        * Returns a wrapper that matches the ${componentNamePlural} with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches ${componentNamePlural}.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {${toWrapper(componentName)}}
-        */
-       find${componentName}(selector?: string): ${toWrapper(componentName)};
-
-       /**
-        * Returns a multi-element wrapper that matches ${componentNamePlural} with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches ${componentNamePlural}.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<${toWrapper(componentName)}>}
-        */
-       findAll${componentNamePlural}(selector?: string): MultiElementWrapper<${toWrapper(componentName)}>;`,
-  },
-};
-
-function generateFindersInterfaces({ testUtilMetaData, testUtilType, configs }) {
-  const { buildFinderInterface } = configs[testUtilType];
-  const findersInterfaces = testUtilMetaData.map(buildFinderInterface);
-
-  // we need to redeclare the interface in its original definition, extending a re-export will not work
-  // https://github.com/microsoft/TypeScript/issues/12607
-  const interfaces = `declare module '@cloudscape-design/test-utils-core/dist/${testUtilType}' {
-      interface ElementWrapper {
-        ${findersInterfaces.join('\n')}
-      }
-  }`;
-
-  return interfaces;
-}
-
-function generateFindersImplementations({ testUtilMetaData, configs }) {
-  const { buildFinder } = configs.common;
-  const findersImplementations = testUtilMetaData.map(buildFinder);
-
-  return findersImplementations.join('\n');
-}
-
-function generateIndexFileContent(testUtilType, testUtilMetaData) {
-  const config = configs[testUtilType];
-  if (config === undefined) {
-    throw new Error('Unknown test util type');
-  }
-
-  return [
-    // language=TypeScript
-    `import { ElementWrapper } from '@cloudscape-design/test-utils-core/${testUtilType}';`,
-    `import { appendSelector } from '@cloudscape-design/test-utils-core/utils';`,
-    `export { ElementWrapper };`,
-    ...testUtilMetaData.map(metaData => {
-      const { componentName, relPathtestUtilFile } = metaData;
-
-      return `
-        import ${toWrapper(componentName)} from '${relPathtestUtilFile}';
-        export { ${componentName}Wrapper };
-      `;
-    }),
-    generateFindersInterfaces({ testUtilMetaData, testUtilType, configs }),
-    generateFindersImplementations({ testUtilMetaData, configs }),
-    config.defaultExport,
-  ].join('\n');
-}
-
-function generateTestUtilMetaData(testUtilType) {
-  const components = listPublicItems(path.join(testUtilsSrcDir, testUtilType));
-
-  const metaData = components.reduce((allMetaData, componentFolderName) => {
-    const absPathComponentFolder = path.resolve(testUtilsSrcDir, componentFolderName);
-    const relPathtestUtilFile = `./${path.relative(testUtilsSrcDir, absPathComponentFolder)}`;
-
-    const componentNameKebab = componentFolderName;
-    const componentName = pascalCase(componentNameKebab);
-    const componentNamePlural = pluralizeComponentName(componentName);
-
-    const componentMetaData = {
-      componentName,
-      componentNamePlural,
-      relPathtestUtilFile,
-    };
-
-    return allMetaData.concat(componentMetaData);
-  }, []);
-
-  return metaData;
-}
-
-function writeContentToIndexTsFile(content, testUtilType) {
-  const filepath = path.join(testUtilsSrcDir, testUtilType, 'index.ts');
-  writeFile(filepath, content);
-}
-
-function generateIndexTsFile(signalCompletion, testUtilType) {
-  const testUtilMetaData = generateTestUtilMetaData(testUtilType);
-  const content = generateIndexFileContent(testUtilType, testUtilMetaData);
-  writeContentToIndexTsFile(content, testUtilType);
-
-  signalCompletion();
-}
 
 function compileTypescript(theme) {
   return task(`typescript:test-utils:${theme.name}`, async () => {
@@ -166,27 +20,25 @@ function compileTypescript(theme) {
   });
 }
 
-function generateIndexFiles(signalCompletion) {
-  generateIndexTsFile(signalCompletion, 'dom');
-  generateIndexTsFile(signalCompletion, 'selectors');
+function generateTestUtilsForComponents(signalCompletion) {
+  const componentNamesKebabCase = listPublicItems(path.join(testUtilsSrcDir, 'dom'));
+
+  const components = componentNamesKebabCase.map(testUtilsFolderName => {
+    const name = pascalCase(testUtilsFolderName);
+    const pluralName = pluralizeComponentName(name);
+    return {
+      name,
+      pluralName,
+      testUtilsFolderName,
+    };
+  });
+
+  generateTestUtils({
+    components,
+    testUtilsPath: testUtilsSrcDir,
+  });
 
   signalCompletion();
 }
 
-function generateSelectorUtils() {
-  return src(['**/*.ts', '!index.ts'], { cwd: path.join(testUtilsSrcDir, 'dom') })
-    .pipe(
-      through(file => {
-        const converted = convertToSelectorUtil(file.contents.toString());
-        file.contents = Buffer.from(converted);
-        return file;
-      })
-    )
-    .pipe(dest(path.join(testUtilsSrcDir, 'selectors')));
-}
-
-module.exports = series(
-  generateSelectorUtils,
-  generateIndexFiles,
-  parallel(themes.map(theme => compileTypescript(theme)))
-);
+module.exports = series(generateTestUtilsForComponents, parallel(themes.map(theme => compileTypescript(theme))));

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-wrappers.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-wrappers.test.tsx.snap
@@ -1,5395 +1,4798 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Generate test utils ElementWrapper dom ElementWrapper matches the snapshot 1`] = `
-"import { ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+"
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 import { appendSelector } from '@cloudscape-design/test-utils-core/utils';
+
 export { ElementWrapper };
 
-        import AlertWrapper from './alert';
-        export { AlertWrapper };
-      
+import AlertWrapper from './alert';
+import AnchorNavigationWrapper from './anchor-navigation';
+import AnnotationWrapper from './annotation';
+import AppLayoutWrapper from './app-layout';
+import AreaChartWrapper from './area-chart';
+import AttributeEditorWrapper from './attribute-editor';
+import AutosuggestWrapper from './autosuggest';
+import BadgeWrapper from './badge';
+import BarChartWrapper from './bar-chart';
+import BoxWrapper from './box';
+import BreadcrumbGroupWrapper from './breadcrumb-group';
+import ButtonWrapper from './button';
+import ButtonDropdownWrapper from './button-dropdown';
+import ButtonGroupWrapper from './button-group';
+import CalendarWrapper from './calendar';
+import CardsWrapper from './cards';
+import CheckboxWrapper from './checkbox';
+import CodeEditorWrapper from './code-editor';
+import CollectionPreferencesWrapper from './collection-preferences';
+import ColumnLayoutWrapper from './column-layout';
+import ContainerWrapper from './container';
+import ContentLayoutWrapper from './content-layout';
+import CopyToClipboardWrapper from './copy-to-clipboard';
+import DateInputWrapper from './date-input';
+import DatePickerWrapper from './date-picker';
+import DateRangePickerWrapper from './date-range-picker';
+import DrawerWrapper from './drawer';
+import ExpandableSectionWrapper from './expandable-section';
+import FileDropzoneWrapper from './file-dropzone';
+import FileInputWrapper from './file-input';
+import FileTokenGroupWrapper from './file-token-group';
+import FileUploadWrapper from './file-upload';
+import FlashbarWrapper from './flashbar';
+import FormWrapper from './form';
+import FormFieldWrapper from './form-field';
+import GridWrapper from './grid';
+import HeaderWrapper from './header';
+import HelpPanelWrapper from './help-panel';
+import HotspotWrapper from './hotspot';
+import IconWrapper from './icon';
+import InputWrapper from './input';
+import KeyValuePairsWrapper from './key-value-pairs';
+import LineChartWrapper from './line-chart';
+import LinkWrapper from './link';
+import LiveRegionWrapper from './live-region';
+import MixedLineBarChartWrapper from './mixed-line-bar-chart';
+import ModalWrapper from './modal';
+import MultiselectWrapper from './multiselect';
+import PaginationWrapper from './pagination';
+import PieChartWrapper from './pie-chart';
+import PopoverWrapper from './popover';
+import ProgressBarWrapper from './progress-bar';
+import PromptInputWrapper from './prompt-input';
+import PropertyFilterWrapper from './property-filter';
+import RadioGroupWrapper from './radio-group';
+import S3ResourceSelectorWrapper from './s3-resource-selector';
+import SegmentedControlWrapper from './segmented-control';
+import SelectWrapper from './select';
+import SideNavigationWrapper from './side-navigation';
+import SliderWrapper from './slider';
+import SpaceBetweenWrapper from './space-between';
+import SpinnerWrapper from './spinner';
+import SplitPanelWrapper from './split-panel';
+import StatusIndicatorWrapper from './status-indicator';
+import StepsWrapper from './steps';
+import TableWrapper from './table';
+import TabsWrapper from './tabs';
+import TagEditorWrapper from './tag-editor';
+import TextContentWrapper from './text-content';
+import TextFilterWrapper from './text-filter';
+import TextareaWrapper from './textarea';
+import TilesWrapper from './tiles';
+import TimeInputWrapper from './time-input';
+import ToggleWrapper from './toggle';
+import ToggleButtonWrapper from './toggle-button';
+import TokenGroupWrapper from './token-group';
+import TopNavigationWrapper from './top-navigation';
+import TutorialPanelWrapper from './tutorial-panel';
+import WizardWrapper from './wizard';
+
+
+export { AlertWrapper };
+export { AnchorNavigationWrapper };
+export { AnnotationWrapper };
+export { AppLayoutWrapper };
+export { AreaChartWrapper };
+export { AttributeEditorWrapper };
+export { AutosuggestWrapper };
+export { BadgeWrapper };
+export { BarChartWrapper };
+export { BoxWrapper };
+export { BreadcrumbGroupWrapper };
+export { ButtonWrapper };
+export { ButtonDropdownWrapper };
+export { ButtonGroupWrapper };
+export { CalendarWrapper };
+export { CardsWrapper };
+export { CheckboxWrapper };
+export { CodeEditorWrapper };
+export { CollectionPreferencesWrapper };
+export { ColumnLayoutWrapper };
+export { ContainerWrapper };
+export { ContentLayoutWrapper };
+export { CopyToClipboardWrapper };
+export { DateInputWrapper };
+export { DatePickerWrapper };
+export { DateRangePickerWrapper };
+export { DrawerWrapper };
+export { ExpandableSectionWrapper };
+export { FileDropzoneWrapper };
+export { FileInputWrapper };
+export { FileTokenGroupWrapper };
+export { FileUploadWrapper };
+export { FlashbarWrapper };
+export { FormWrapper };
+export { FormFieldWrapper };
+export { GridWrapper };
+export { HeaderWrapper };
+export { HelpPanelWrapper };
+export { HotspotWrapper };
+export { IconWrapper };
+export { InputWrapper };
+export { KeyValuePairsWrapper };
+export { LineChartWrapper };
+export { LinkWrapper };
+export { LiveRegionWrapper };
+export { MixedLineBarChartWrapper };
+export { ModalWrapper };
+export { MultiselectWrapper };
+export { PaginationWrapper };
+export { PieChartWrapper };
+export { PopoverWrapper };
+export { ProgressBarWrapper };
+export { PromptInputWrapper };
+export { PropertyFilterWrapper };
+export { RadioGroupWrapper };
+export { S3ResourceSelectorWrapper };
+export { SegmentedControlWrapper };
+export { SelectWrapper };
+export { SideNavigationWrapper };
+export { SliderWrapper };
+export { SpaceBetweenWrapper };
+export { SpinnerWrapper };
+export { SplitPanelWrapper };
+export { StatusIndicatorWrapper };
+export { StepsWrapper };
+export { TableWrapper };
+export { TabsWrapper };
+export { TagEditorWrapper };
+export { TextContentWrapper };
+export { TextFilterWrapper };
+export { TextareaWrapper };
+export { TilesWrapper };
+export { TimeInputWrapper };
+export { ToggleWrapper };
+export { ToggleButtonWrapper };
+export { TokenGroupWrapper };
+export { TopNavigationWrapper };
+export { TutorialPanelWrapper };
+export { WizardWrapper };
 
-        import AnchorNavigationWrapper from './anchor-navigation';
-        export { AnchorNavigationWrapper };
-      
-
-        import AnnotationWrapper from './annotation';
-        export { AnnotationWrapper };
-      
-
-        import AppLayoutWrapper from './app-layout';
-        export { AppLayoutWrapper };
-      
-
-        import AreaChartWrapper from './area-chart';
-        export { AreaChartWrapper };
-      
-
-        import AttributeEditorWrapper from './attribute-editor';
-        export { AttributeEditorWrapper };
-      
-
-        import AutosuggestWrapper from './autosuggest';
-        export { AutosuggestWrapper };
-      
-
-        import BadgeWrapper from './badge';
-        export { BadgeWrapper };
-      
-
-        import BarChartWrapper from './bar-chart';
-        export { BarChartWrapper };
-      
-
-        import BoxWrapper from './box';
-        export { BoxWrapper };
-      
-
-        import BreadcrumbGroupWrapper from './breadcrumb-group';
-        export { BreadcrumbGroupWrapper };
-      
-
-        import ButtonWrapper from './button';
-        export { ButtonWrapper };
-      
-
-        import ButtonDropdownWrapper from './button-dropdown';
-        export { ButtonDropdownWrapper };
-      
-
-        import ButtonGroupWrapper from './button-group';
-        export { ButtonGroupWrapper };
-      
-
-        import CalendarWrapper from './calendar';
-        export { CalendarWrapper };
-      
-
-        import CardsWrapper from './cards';
-        export { CardsWrapper };
-      
-
-        import CheckboxWrapper from './checkbox';
-        export { CheckboxWrapper };
-      
-
-        import CodeEditorWrapper from './code-editor';
-        export { CodeEditorWrapper };
-      
-
-        import CollectionPreferencesWrapper from './collection-preferences';
-        export { CollectionPreferencesWrapper };
-      
-
-        import ColumnLayoutWrapper from './column-layout';
-        export { ColumnLayoutWrapper };
-      
-
-        import ContainerWrapper from './container';
-        export { ContainerWrapper };
-      
-
-        import ContentLayoutWrapper from './content-layout';
-        export { ContentLayoutWrapper };
-      
-
-        import CopyToClipboardWrapper from './copy-to-clipboard';
-        export { CopyToClipboardWrapper };
-      
-
-        import DateInputWrapper from './date-input';
-        export { DateInputWrapper };
-      
-
-        import DatePickerWrapper from './date-picker';
-        export { DatePickerWrapper };
-      
-
-        import DateRangePickerWrapper from './date-range-picker';
-        export { DateRangePickerWrapper };
-      
-
-        import DrawerWrapper from './drawer';
-        export { DrawerWrapper };
-      
-
-        import ExpandableSectionWrapper from './expandable-section';
-        export { ExpandableSectionWrapper };
-      
-
-        import FileDropzoneWrapper from './file-dropzone';
-        export { FileDropzoneWrapper };
-      
-
-        import FileInputWrapper from './file-input';
-        export { FileInputWrapper };
-      
-
-        import FileTokenGroupWrapper from './file-token-group';
-        export { FileTokenGroupWrapper };
-      
-
-        import FileUploadWrapper from './file-upload';
-        export { FileUploadWrapper };
-      
-
-        import FlashbarWrapper from './flashbar';
-        export { FlashbarWrapper };
-      
-
-        import FormWrapper from './form';
-        export { FormWrapper };
-      
-
-        import FormFieldWrapper from './form-field';
-        export { FormFieldWrapper };
-      
-
-        import GridWrapper from './grid';
-        export { GridWrapper };
-      
-
-        import HeaderWrapper from './header';
-        export { HeaderWrapper };
-      
-
-        import HelpPanelWrapper from './help-panel';
-        export { HelpPanelWrapper };
-      
-
-        import HotspotWrapper from './hotspot';
-        export { HotspotWrapper };
-      
-
-        import IconWrapper from './icon';
-        export { IconWrapper };
-      
-
-        import InputWrapper from './input';
-        export { InputWrapper };
-      
-
-        import KeyValuePairsWrapper from './key-value-pairs';
-        export { KeyValuePairsWrapper };
-      
-
-        import LineChartWrapper from './line-chart';
-        export { LineChartWrapper };
-      
-
-        import LinkWrapper from './link';
-        export { LinkWrapper };
-      
-
-        import LiveRegionWrapper from './live-region';
-        export { LiveRegionWrapper };
-      
-
-        import MixedLineBarChartWrapper from './mixed-line-bar-chart';
-        export { MixedLineBarChartWrapper };
-      
-
-        import ModalWrapper from './modal';
-        export { ModalWrapper };
-      
-
-        import MultiselectWrapper from './multiselect';
-        export { MultiselectWrapper };
-      
-
-        import PaginationWrapper from './pagination';
-        export { PaginationWrapper };
-      
-
-        import PieChartWrapper from './pie-chart';
-        export { PieChartWrapper };
-      
-
-        import PopoverWrapper from './popover';
-        export { PopoverWrapper };
-      
-
-        import ProgressBarWrapper from './progress-bar';
-        export { ProgressBarWrapper };
-      
-
-        import PromptInputWrapper from './prompt-input';
-        export { PromptInputWrapper };
-      
-
-        import PropertyFilterWrapper from './property-filter';
-        export { PropertyFilterWrapper };
-      
-
-        import RadioGroupWrapper from './radio-group';
-        export { RadioGroupWrapper };
-      
-
-        import S3ResourceSelectorWrapper from './s3-resource-selector';
-        export { S3ResourceSelectorWrapper };
-      
-
-        import SegmentedControlWrapper from './segmented-control';
-        export { SegmentedControlWrapper };
-      
-
-        import SelectWrapper from './select';
-        export { SelectWrapper };
-      
-
-        import SideNavigationWrapper from './side-navigation';
-        export { SideNavigationWrapper };
-      
-
-        import SliderWrapper from './slider';
-        export { SliderWrapper };
-      
-
-        import SpaceBetweenWrapper from './space-between';
-        export { SpaceBetweenWrapper };
-      
-
-        import SpinnerWrapper from './spinner';
-        export { SpinnerWrapper };
-      
-
-        import SplitPanelWrapper from './split-panel';
-        export { SplitPanelWrapper };
-      
-
-        import StatusIndicatorWrapper from './status-indicator';
-        export { StatusIndicatorWrapper };
-      
-
-        import StepsWrapper from './steps';
-        export { StepsWrapper };
-      
-
-        import TableWrapper from './table';
-        export { TableWrapper };
-      
-
-        import TabsWrapper from './tabs';
-        export { TabsWrapper };
-      
-
-        import TagEditorWrapper from './tag-editor';
-        export { TagEditorWrapper };
-      
-
-        import TextContentWrapper from './text-content';
-        export { TextContentWrapper };
-      
-
-        import TextFilterWrapper from './text-filter';
-        export { TextFilterWrapper };
-      
-
-        import TextareaWrapper from './textarea';
-        export { TextareaWrapper };
-      
-
-        import TilesWrapper from './tiles';
-        export { TilesWrapper };
-      
-
-        import TimeInputWrapper from './time-input';
-        export { TimeInputWrapper };
-      
-
-        import ToggleWrapper from './toggle';
-        export { ToggleWrapper };
-      
-
-        import ToggleButtonWrapper from './toggle-button';
-        export { ToggleButtonWrapper };
-      
-
-        import TokenGroupWrapper from './token-group';
-        export { TokenGroupWrapper };
-      
-
-        import TopNavigationWrapper from './top-navigation';
-        export { TopNavigationWrapper };
-      
-
-        import TutorialPanelWrapper from './tutorial-panel';
-        export { TutorialPanelWrapper };
-      
-
-        import WizardWrapper from './wizard';
-        export { WizardWrapper };
-      
 declare module '@cloudscape-design/test-utils-core/dist/dom' {
-      interface ElementWrapper {
-        
-       /**
-        * Returns the wrapper of the first Alert that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Alert.
-        * If no matching Alert is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {AlertWrapper | null}
-        */
-       findAlert(selector?: string): AlertWrapper | null;
-
-       /**
-        * Returns an array of Alert wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Alerts inside the current wrapper.
-        * If no matching Alert is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<AlertWrapper>}
-        */
-       findAllAlerts(selector?: string): Array<AlertWrapper>;
-
-       /**
-        * Returns the wrapper of the first AnchorNavigation that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first AnchorNavigation.
-        * If no matching AnchorNavigation is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {AnchorNavigationWrapper | null}
-        */
-       findAnchorNavigation(selector?: string): AnchorNavigationWrapper | null;
-
-       /**
-        * Returns an array of AnchorNavigation wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the AnchorNavigations inside the current wrapper.
-        * If no matching AnchorNavigation is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<AnchorNavigationWrapper>}
-        */
-       findAllAnchorNavigations(selector?: string): Array<AnchorNavigationWrapper>;
-
-       /**
-        * Returns the wrapper of the first Annotation that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Annotation.
-        * If no matching Annotation is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {AnnotationWrapper | null}
-        */
-       findAnnotation(selector?: string): AnnotationWrapper | null;
-
-       /**
-        * Returns an array of Annotation wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Annotations inside the current wrapper.
-        * If no matching Annotation is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<AnnotationWrapper>}
-        */
-       findAllAnnotations(selector?: string): Array<AnnotationWrapper>;
-
-       /**
-        * Returns the wrapper of the first AppLayout that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first AppLayout.
-        * If no matching AppLayout is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {AppLayoutWrapper | null}
-        */
-       findAppLayout(selector?: string): AppLayoutWrapper | null;
-
-       /**
-        * Returns an array of AppLayout wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the AppLayouts inside the current wrapper.
-        * If no matching AppLayout is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<AppLayoutWrapper>}
-        */
-       findAllAppLayouts(selector?: string): Array<AppLayoutWrapper>;
-
-       /**
-        * Returns the wrapper of the first AreaChart that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first AreaChart.
-        * If no matching AreaChart is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {AreaChartWrapper | null}
-        */
-       findAreaChart(selector?: string): AreaChartWrapper | null;
-
-       /**
-        * Returns an array of AreaChart wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the AreaCharts inside the current wrapper.
-        * If no matching AreaChart is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<AreaChartWrapper>}
-        */
-       findAllAreaCharts(selector?: string): Array<AreaChartWrapper>;
-
-       /**
-        * Returns the wrapper of the first AttributeEditor that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first AttributeEditor.
-        * If no matching AttributeEditor is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {AttributeEditorWrapper | null}
-        */
-       findAttributeEditor(selector?: string): AttributeEditorWrapper | null;
-
-       /**
-        * Returns an array of AttributeEditor wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the AttributeEditors inside the current wrapper.
-        * If no matching AttributeEditor is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<AttributeEditorWrapper>}
-        */
-       findAllAttributeEditors(selector?: string): Array<AttributeEditorWrapper>;
-
-       /**
-        * Returns the wrapper of the first Autosuggest that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Autosuggest.
-        * If no matching Autosuggest is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {AutosuggestWrapper | null}
-        */
-       findAutosuggest(selector?: string): AutosuggestWrapper | null;
-
-       /**
-        * Returns an array of Autosuggest wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Autosuggests inside the current wrapper.
-        * If no matching Autosuggest is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<AutosuggestWrapper>}
-        */
-       findAllAutosuggests(selector?: string): Array<AutosuggestWrapper>;
-
-       /**
-        * Returns the wrapper of the first Badge that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Badge.
-        * If no matching Badge is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {BadgeWrapper | null}
-        */
-       findBadge(selector?: string): BadgeWrapper | null;
-
-       /**
-        * Returns an array of Badge wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Badges inside the current wrapper.
-        * If no matching Badge is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<BadgeWrapper>}
-        */
-       findAllBadges(selector?: string): Array<BadgeWrapper>;
-
-       /**
-        * Returns the wrapper of the first BarChart that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first BarChart.
-        * If no matching BarChart is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {BarChartWrapper | null}
-        */
-       findBarChart(selector?: string): BarChartWrapper | null;
-
-       /**
-        * Returns an array of BarChart wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the BarCharts inside the current wrapper.
-        * If no matching BarChart is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<BarChartWrapper>}
-        */
-       findAllBarCharts(selector?: string): Array<BarChartWrapper>;
-
-       /**
-        * Returns the wrapper of the first Box that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Box.
-        * If no matching Box is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {BoxWrapper | null}
-        */
-       findBox(selector?: string): BoxWrapper | null;
-
-       /**
-        * Returns an array of Box wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Boxes inside the current wrapper.
-        * If no matching Box is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<BoxWrapper>}
-        */
-       findAllBoxes(selector?: string): Array<BoxWrapper>;
-
-       /**
-        * Returns the wrapper of the first BreadcrumbGroup that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first BreadcrumbGroup.
-        * If no matching BreadcrumbGroup is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {BreadcrumbGroupWrapper | null}
-        */
-       findBreadcrumbGroup(selector?: string): BreadcrumbGroupWrapper | null;
-
-       /**
-        * Returns an array of BreadcrumbGroup wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the BreadcrumbGroups inside the current wrapper.
-        * If no matching BreadcrumbGroup is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<BreadcrumbGroupWrapper>}
-        */
-       findAllBreadcrumbGroups(selector?: string): Array<BreadcrumbGroupWrapper>;
-
-       /**
-        * Returns the wrapper of the first Button that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Button.
-        * If no matching Button is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ButtonWrapper | null}
-        */
-       findButton(selector?: string): ButtonWrapper | null;
-
-       /**
-        * Returns an array of Button wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Buttons inside the current wrapper.
-        * If no matching Button is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<ButtonWrapper>}
-        */
-       findAllButtons(selector?: string): Array<ButtonWrapper>;
-
-       /**
-        * Returns the wrapper of the first ButtonDropdown that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first ButtonDropdown.
-        * If no matching ButtonDropdown is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ButtonDropdownWrapper | null}
-        */
-       findButtonDropdown(selector?: string): ButtonDropdownWrapper | null;
-
-       /**
-        * Returns an array of ButtonDropdown wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the ButtonDropdowns inside the current wrapper.
-        * If no matching ButtonDropdown is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<ButtonDropdownWrapper>}
-        */
-       findAllButtonDropdowns(selector?: string): Array<ButtonDropdownWrapper>;
-
-       /**
-        * Returns the wrapper of the first ButtonGroup that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first ButtonGroup.
-        * If no matching ButtonGroup is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ButtonGroupWrapper | null}
-        */
-       findButtonGroup(selector?: string): ButtonGroupWrapper | null;
-
-       /**
-        * Returns an array of ButtonGroup wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the ButtonGroups inside the current wrapper.
-        * If no matching ButtonGroup is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<ButtonGroupWrapper>}
-        */
-       findAllButtonGroups(selector?: string): Array<ButtonGroupWrapper>;
-
-       /**
-        * Returns the wrapper of the first Calendar that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Calendar.
-        * If no matching Calendar is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {CalendarWrapper | null}
-        */
-       findCalendar(selector?: string): CalendarWrapper | null;
-
-       /**
-        * Returns an array of Calendar wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Calendars inside the current wrapper.
-        * If no matching Calendar is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<CalendarWrapper>}
-        */
-       findAllCalendars(selector?: string): Array<CalendarWrapper>;
-
-       /**
-        * Returns the wrapper of the first Cards that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Cards.
-        * If no matching Cards is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {CardsWrapper | null}
-        */
-       findCards(selector?: string): CardsWrapper | null;
-
-       /**
-        * Returns an array of Cards wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Cards inside the current wrapper.
-        * If no matching Cards is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<CardsWrapper>}
-        */
-       findAllCards(selector?: string): Array<CardsWrapper>;
-
-       /**
-        * Returns the wrapper of the first Checkbox that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Checkbox.
-        * If no matching Checkbox is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {CheckboxWrapper | null}
-        */
-       findCheckbox(selector?: string): CheckboxWrapper | null;
-
-       /**
-        * Returns an array of Checkbox wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Checkboxes inside the current wrapper.
-        * If no matching Checkbox is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<CheckboxWrapper>}
-        */
-       findAllCheckboxes(selector?: string): Array<CheckboxWrapper>;
-
-       /**
-        * Returns the wrapper of the first CodeEditor that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first CodeEditor.
-        * If no matching CodeEditor is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {CodeEditorWrapper | null}
-        */
-       findCodeEditor(selector?: string): CodeEditorWrapper | null;
-
-       /**
-        * Returns an array of CodeEditor wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the CodeEditors inside the current wrapper.
-        * If no matching CodeEditor is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<CodeEditorWrapper>}
-        */
-       findAllCodeEditors(selector?: string): Array<CodeEditorWrapper>;
-
-       /**
-        * Returns the wrapper of the first CollectionPreferences that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first CollectionPreferences.
-        * If no matching CollectionPreferences is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {CollectionPreferencesWrapper | null}
-        */
-       findCollectionPreferences(selector?: string): CollectionPreferencesWrapper | null;
-
-       /**
-        * Returns an array of CollectionPreferences wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the CollectionPreferences inside the current wrapper.
-        * If no matching CollectionPreferences is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<CollectionPreferencesWrapper>}
-        */
-       findAllCollectionPreferences(selector?: string): Array<CollectionPreferencesWrapper>;
-
-       /**
-        * Returns the wrapper of the first ColumnLayout that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first ColumnLayout.
-        * If no matching ColumnLayout is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ColumnLayoutWrapper | null}
-        */
-       findColumnLayout(selector?: string): ColumnLayoutWrapper | null;
-
-       /**
-        * Returns an array of ColumnLayout wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the ColumnLayouts inside the current wrapper.
-        * If no matching ColumnLayout is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<ColumnLayoutWrapper>}
-        */
-       findAllColumnLayouts(selector?: string): Array<ColumnLayoutWrapper>;
-
-       /**
-        * Returns the wrapper of the first Container that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Container.
-        * If no matching Container is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ContainerWrapper | null}
-        */
-       findContainer(selector?: string): ContainerWrapper | null;
-
-       /**
-        * Returns an array of Container wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Containers inside the current wrapper.
-        * If no matching Container is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<ContainerWrapper>}
-        */
-       findAllContainers(selector?: string): Array<ContainerWrapper>;
-
-       /**
-        * Returns the wrapper of the first ContentLayout that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first ContentLayout.
-        * If no matching ContentLayout is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ContentLayoutWrapper | null}
-        */
-       findContentLayout(selector?: string): ContentLayoutWrapper | null;
-
-       /**
-        * Returns an array of ContentLayout wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the ContentLayouts inside the current wrapper.
-        * If no matching ContentLayout is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<ContentLayoutWrapper>}
-        */
-       findAllContentLayouts(selector?: string): Array<ContentLayoutWrapper>;
-
-       /**
-        * Returns the wrapper of the first CopyToClipboard that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first CopyToClipboard.
-        * If no matching CopyToClipboard is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {CopyToClipboardWrapper | null}
-        */
-       findCopyToClipboard(selector?: string): CopyToClipboardWrapper | null;
-
-       /**
-        * Returns an array of CopyToClipboard wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the CopyToClipboards inside the current wrapper.
-        * If no matching CopyToClipboard is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<CopyToClipboardWrapper>}
-        */
-       findAllCopyToClipboards(selector?: string): Array<CopyToClipboardWrapper>;
-
-       /**
-        * Returns the wrapper of the first DateInput that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first DateInput.
-        * If no matching DateInput is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {DateInputWrapper | null}
-        */
-       findDateInput(selector?: string): DateInputWrapper | null;
-
-       /**
-        * Returns an array of DateInput wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the DateInputs inside the current wrapper.
-        * If no matching DateInput is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<DateInputWrapper>}
-        */
-       findAllDateInputs(selector?: string): Array<DateInputWrapper>;
-
-       /**
-        * Returns the wrapper of the first DatePicker that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first DatePicker.
-        * If no matching DatePicker is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {DatePickerWrapper | null}
-        */
-       findDatePicker(selector?: string): DatePickerWrapper | null;
-
-       /**
-        * Returns an array of DatePicker wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the DatePickers inside the current wrapper.
-        * If no matching DatePicker is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<DatePickerWrapper>}
-        */
-       findAllDatePickers(selector?: string): Array<DatePickerWrapper>;
-
-       /**
-        * Returns the wrapper of the first DateRangePicker that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first DateRangePicker.
-        * If no matching DateRangePicker is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {DateRangePickerWrapper | null}
-        */
-       findDateRangePicker(selector?: string): DateRangePickerWrapper | null;
-
-       /**
-        * Returns an array of DateRangePicker wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the DateRangePickers inside the current wrapper.
-        * If no matching DateRangePicker is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<DateRangePickerWrapper>}
-        */
-       findAllDateRangePickers(selector?: string): Array<DateRangePickerWrapper>;
-
-       /**
-        * Returns the wrapper of the first Drawer that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Drawer.
-        * If no matching Drawer is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {DrawerWrapper | null}
-        */
-       findDrawer(selector?: string): DrawerWrapper | null;
-
-       /**
-        * Returns an array of Drawer wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Drawers inside the current wrapper.
-        * If no matching Drawer is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<DrawerWrapper>}
-        */
-       findAllDrawers(selector?: string): Array<DrawerWrapper>;
-
-       /**
-        * Returns the wrapper of the first ExpandableSection that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first ExpandableSection.
-        * If no matching ExpandableSection is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ExpandableSectionWrapper | null}
-        */
-       findExpandableSection(selector?: string): ExpandableSectionWrapper | null;
-
-       /**
-        * Returns an array of ExpandableSection wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the ExpandableSections inside the current wrapper.
-        * If no matching ExpandableSection is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<ExpandableSectionWrapper>}
-        */
-       findAllExpandableSections(selector?: string): Array<ExpandableSectionWrapper>;
-
-       /**
-        * Returns the wrapper of the first FileDropzone that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first FileDropzone.
-        * If no matching FileDropzone is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {FileDropzoneWrapper | null}
-        */
-       findFileDropzone(selector?: string): FileDropzoneWrapper | null;
-
-       /**
-        * Returns an array of FileDropzone wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the FileDropzones inside the current wrapper.
-        * If no matching FileDropzone is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<FileDropzoneWrapper>}
-        */
-       findAllFileDropzones(selector?: string): Array<FileDropzoneWrapper>;
-
-       /**
-        * Returns the wrapper of the first FileInput that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first FileInput.
-        * If no matching FileInput is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {FileInputWrapper | null}
-        */
-       findFileInput(selector?: string): FileInputWrapper | null;
-
-       /**
-        * Returns an array of FileInput wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the FileInputs inside the current wrapper.
-        * If no matching FileInput is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<FileInputWrapper>}
-        */
-       findAllFileInputs(selector?: string): Array<FileInputWrapper>;
-
-       /**
-        * Returns the wrapper of the first FileTokenGroup that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first FileTokenGroup.
-        * If no matching FileTokenGroup is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {FileTokenGroupWrapper | null}
-        */
-       findFileTokenGroup(selector?: string): FileTokenGroupWrapper | null;
-
-       /**
-        * Returns an array of FileTokenGroup wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the FileTokenGroups inside the current wrapper.
-        * If no matching FileTokenGroup is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<FileTokenGroupWrapper>}
-        */
-       findAllFileTokenGroups(selector?: string): Array<FileTokenGroupWrapper>;
-
-       /**
-        * Returns the wrapper of the first FileUpload that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first FileUpload.
-        * If no matching FileUpload is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {FileUploadWrapper | null}
-        */
-       findFileUpload(selector?: string): FileUploadWrapper | null;
-
-       /**
-        * Returns an array of FileUpload wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the FileUploads inside the current wrapper.
-        * If no matching FileUpload is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<FileUploadWrapper>}
-        */
-       findAllFileUploads(selector?: string): Array<FileUploadWrapper>;
-
-       /**
-        * Returns the wrapper of the first Flashbar that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Flashbar.
-        * If no matching Flashbar is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {FlashbarWrapper | null}
-        */
-       findFlashbar(selector?: string): FlashbarWrapper | null;
-
-       /**
-        * Returns an array of Flashbar wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Flashbars inside the current wrapper.
-        * If no matching Flashbar is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<FlashbarWrapper>}
-        */
-       findAllFlashbars(selector?: string): Array<FlashbarWrapper>;
-
-       /**
-        * Returns the wrapper of the first Form that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Form.
-        * If no matching Form is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {FormWrapper | null}
-        */
-       findForm(selector?: string): FormWrapper | null;
-
-       /**
-        * Returns an array of Form wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Forms inside the current wrapper.
-        * If no matching Form is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<FormWrapper>}
-        */
-       findAllForms(selector?: string): Array<FormWrapper>;
-
-       /**
-        * Returns the wrapper of the first FormField that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first FormField.
-        * If no matching FormField is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {FormFieldWrapper | null}
-        */
-       findFormField(selector?: string): FormFieldWrapper | null;
-
-       /**
-        * Returns an array of FormField wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the FormFields inside the current wrapper.
-        * If no matching FormField is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<FormFieldWrapper>}
-        */
-       findAllFormFields(selector?: string): Array<FormFieldWrapper>;
-
-       /**
-        * Returns the wrapper of the first Grid that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Grid.
-        * If no matching Grid is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {GridWrapper | null}
-        */
-       findGrid(selector?: string): GridWrapper | null;
-
-       /**
-        * Returns an array of Grid wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Grids inside the current wrapper.
-        * If no matching Grid is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<GridWrapper>}
-        */
-       findAllGrids(selector?: string): Array<GridWrapper>;
-
-       /**
-        * Returns the wrapper of the first Header that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Header.
-        * If no matching Header is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {HeaderWrapper | null}
-        */
-       findHeader(selector?: string): HeaderWrapper | null;
-
-       /**
-        * Returns an array of Header wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Headers inside the current wrapper.
-        * If no matching Header is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<HeaderWrapper>}
-        */
-       findAllHeaders(selector?: string): Array<HeaderWrapper>;
-
-       /**
-        * Returns the wrapper of the first HelpPanel that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first HelpPanel.
-        * If no matching HelpPanel is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {HelpPanelWrapper | null}
-        */
-       findHelpPanel(selector?: string): HelpPanelWrapper | null;
-
-       /**
-        * Returns an array of HelpPanel wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the HelpPanels inside the current wrapper.
-        * If no matching HelpPanel is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<HelpPanelWrapper>}
-        */
-       findAllHelpPanels(selector?: string): Array<HelpPanelWrapper>;
-
-       /**
-        * Returns the wrapper of the first Hotspot that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Hotspot.
-        * If no matching Hotspot is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {HotspotWrapper | null}
-        */
-       findHotspot(selector?: string): HotspotWrapper | null;
-
-       /**
-        * Returns an array of Hotspot wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Hotspots inside the current wrapper.
-        * If no matching Hotspot is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<HotspotWrapper>}
-        */
-       findAllHotspots(selector?: string): Array<HotspotWrapper>;
-
-       /**
-        * Returns the wrapper of the first Icon that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Icon.
-        * If no matching Icon is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {IconWrapper | null}
-        */
-       findIcon(selector?: string): IconWrapper | null;
-
-       /**
-        * Returns an array of Icon wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Icons inside the current wrapper.
-        * If no matching Icon is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<IconWrapper>}
-        */
-       findAllIcons(selector?: string): Array<IconWrapper>;
-
-       /**
-        * Returns the wrapper of the first Input that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Input.
-        * If no matching Input is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {InputWrapper | null}
-        */
-       findInput(selector?: string): InputWrapper | null;
-
-       /**
-        * Returns an array of Input wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Inputs inside the current wrapper.
-        * If no matching Input is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<InputWrapper>}
-        */
-       findAllInputs(selector?: string): Array<InputWrapper>;
-
-       /**
-        * Returns the wrapper of the first KeyValuePairs that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first KeyValuePairs.
-        * If no matching KeyValuePairs is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {KeyValuePairsWrapper | null}
-        */
-       findKeyValuePairs(selector?: string): KeyValuePairsWrapper | null;
-
-       /**
-        * Returns an array of KeyValuePairs wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the KeyValuePairs inside the current wrapper.
-        * If no matching KeyValuePairs is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<KeyValuePairsWrapper>}
-        */
-       findAllKeyValuePairs(selector?: string): Array<KeyValuePairsWrapper>;
-
-       /**
-        * Returns the wrapper of the first LineChart that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first LineChart.
-        * If no matching LineChart is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {LineChartWrapper | null}
-        */
-       findLineChart(selector?: string): LineChartWrapper | null;
-
-       /**
-        * Returns an array of LineChart wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the LineCharts inside the current wrapper.
-        * If no matching LineChart is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<LineChartWrapper>}
-        */
-       findAllLineCharts(selector?: string): Array<LineChartWrapper>;
-
-       /**
-        * Returns the wrapper of the first Link that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Link.
-        * If no matching Link is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {LinkWrapper | null}
-        */
-       findLink(selector?: string): LinkWrapper | null;
-
-       /**
-        * Returns an array of Link wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Links inside the current wrapper.
-        * If no matching Link is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<LinkWrapper>}
-        */
-       findAllLinks(selector?: string): Array<LinkWrapper>;
-
-       /**
-        * Returns the wrapper of the first LiveRegion that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first LiveRegion.
-        * If no matching LiveRegion is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {LiveRegionWrapper | null}
-        */
-       findLiveRegion(selector?: string): LiveRegionWrapper | null;
-
-       /**
-        * Returns an array of LiveRegion wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the LiveRegions inside the current wrapper.
-        * If no matching LiveRegion is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<LiveRegionWrapper>}
-        */
-       findAllLiveRegions(selector?: string): Array<LiveRegionWrapper>;
-
-       /**
-        * Returns the wrapper of the first MixedLineBarChart that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first MixedLineBarChart.
-        * If no matching MixedLineBarChart is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MixedLineBarChartWrapper | null}
-        */
-       findMixedLineBarChart(selector?: string): MixedLineBarChartWrapper | null;
-
-       /**
-        * Returns an array of MixedLineBarChart wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the MixedLineBarCharts inside the current wrapper.
-        * If no matching MixedLineBarChart is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<MixedLineBarChartWrapper>}
-        */
-       findAllMixedLineBarCharts(selector?: string): Array<MixedLineBarChartWrapper>;
-
-       /**
-        * Returns the wrapper of the first Modal that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Modal.
-        * If no matching Modal is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ModalWrapper | null}
-        */
-       findModal(selector?: string): ModalWrapper | null;
-
-       /**
-        * Returns an array of Modal wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Modals inside the current wrapper.
-        * If no matching Modal is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<ModalWrapper>}
-        */
-       findAllModals(selector?: string): Array<ModalWrapper>;
-
-       /**
-        * Returns the wrapper of the first Multiselect that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Multiselect.
-        * If no matching Multiselect is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiselectWrapper | null}
-        */
-       findMultiselect(selector?: string): MultiselectWrapper | null;
-
-       /**
-        * Returns an array of Multiselect wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Multiselects inside the current wrapper.
-        * If no matching Multiselect is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<MultiselectWrapper>}
-        */
-       findAllMultiselects(selector?: string): Array<MultiselectWrapper>;
-
-       /**
-        * Returns the wrapper of the first Pagination that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Pagination.
-        * If no matching Pagination is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {PaginationWrapper | null}
-        */
-       findPagination(selector?: string): PaginationWrapper | null;
-
-       /**
-        * Returns an array of Pagination wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Paginations inside the current wrapper.
-        * If no matching Pagination is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<PaginationWrapper>}
-        */
-       findAllPaginations(selector?: string): Array<PaginationWrapper>;
-
-       /**
-        * Returns the wrapper of the first PieChart that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first PieChart.
-        * If no matching PieChart is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {PieChartWrapper | null}
-        */
-       findPieChart(selector?: string): PieChartWrapper | null;
-
-       /**
-        * Returns an array of PieChart wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the PieCharts inside the current wrapper.
-        * If no matching PieChart is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<PieChartWrapper>}
-        */
-       findAllPieCharts(selector?: string): Array<PieChartWrapper>;
-
-       /**
-        * Returns the wrapper of the first Popover that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Popover.
-        * If no matching Popover is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {PopoverWrapper | null}
-        */
-       findPopover(selector?: string): PopoverWrapper | null;
-
-       /**
-        * Returns an array of Popover wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Popovers inside the current wrapper.
-        * If no matching Popover is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<PopoverWrapper>}
-        */
-       findAllPopovers(selector?: string): Array<PopoverWrapper>;
-
-       /**
-        * Returns the wrapper of the first ProgressBar that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first ProgressBar.
-        * If no matching ProgressBar is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ProgressBarWrapper | null}
-        */
-       findProgressBar(selector?: string): ProgressBarWrapper | null;
-
-       /**
-        * Returns an array of ProgressBar wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the ProgressBars inside the current wrapper.
-        * If no matching ProgressBar is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<ProgressBarWrapper>}
-        */
-       findAllProgressBars(selector?: string): Array<ProgressBarWrapper>;
-
-       /**
-        * Returns the wrapper of the first PromptInput that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first PromptInput.
-        * If no matching PromptInput is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {PromptInputWrapper | null}
-        */
-       findPromptInput(selector?: string): PromptInputWrapper | null;
-
-       /**
-        * Returns an array of PromptInput wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the PromptInputs inside the current wrapper.
-        * If no matching PromptInput is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<PromptInputWrapper>}
-        */
-       findAllPromptInputs(selector?: string): Array<PromptInputWrapper>;
-
-       /**
-        * Returns the wrapper of the first PropertyFilter that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first PropertyFilter.
-        * If no matching PropertyFilter is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {PropertyFilterWrapper | null}
-        */
-       findPropertyFilter(selector?: string): PropertyFilterWrapper | null;
-
-       /**
-        * Returns an array of PropertyFilter wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the PropertyFilters inside the current wrapper.
-        * If no matching PropertyFilter is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<PropertyFilterWrapper>}
-        */
-       findAllPropertyFilters(selector?: string): Array<PropertyFilterWrapper>;
-
-       /**
-        * Returns the wrapper of the first RadioGroup that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first RadioGroup.
-        * If no matching RadioGroup is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {RadioGroupWrapper | null}
-        */
-       findRadioGroup(selector?: string): RadioGroupWrapper | null;
-
-       /**
-        * Returns an array of RadioGroup wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the RadioGroups inside the current wrapper.
-        * If no matching RadioGroup is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<RadioGroupWrapper>}
-        */
-       findAllRadioGroups(selector?: string): Array<RadioGroupWrapper>;
-
-       /**
-        * Returns the wrapper of the first S3ResourceSelector that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first S3ResourceSelector.
-        * If no matching S3ResourceSelector is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {S3ResourceSelectorWrapper | null}
-        */
-       findS3ResourceSelector(selector?: string): S3ResourceSelectorWrapper | null;
-
-       /**
-        * Returns an array of S3ResourceSelector wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the S3ResourceSelectors inside the current wrapper.
-        * If no matching S3ResourceSelector is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<S3ResourceSelectorWrapper>}
-        */
-       findAllS3ResourceSelectors(selector?: string): Array<S3ResourceSelectorWrapper>;
-
-       /**
-        * Returns the wrapper of the first SegmentedControl that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first SegmentedControl.
-        * If no matching SegmentedControl is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {SegmentedControlWrapper | null}
-        */
-       findSegmentedControl(selector?: string): SegmentedControlWrapper | null;
-
-       /**
-        * Returns an array of SegmentedControl wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the SegmentedControls inside the current wrapper.
-        * If no matching SegmentedControl is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<SegmentedControlWrapper>}
-        */
-       findAllSegmentedControls(selector?: string): Array<SegmentedControlWrapper>;
-
-       /**
-        * Returns the wrapper of the first Select that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Select.
-        * If no matching Select is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {SelectWrapper | null}
-        */
-       findSelect(selector?: string): SelectWrapper | null;
-
-       /**
-        * Returns an array of Select wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Selects inside the current wrapper.
-        * If no matching Select is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<SelectWrapper>}
-        */
-       findAllSelects(selector?: string): Array<SelectWrapper>;
-
-       /**
-        * Returns the wrapper of the first SideNavigation that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first SideNavigation.
-        * If no matching SideNavigation is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {SideNavigationWrapper | null}
-        */
-       findSideNavigation(selector?: string): SideNavigationWrapper | null;
-
-       /**
-        * Returns an array of SideNavigation wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the SideNavigations inside the current wrapper.
-        * If no matching SideNavigation is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<SideNavigationWrapper>}
-        */
-       findAllSideNavigations(selector?: string): Array<SideNavigationWrapper>;
-
-       /**
-        * Returns the wrapper of the first Slider that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Slider.
-        * If no matching Slider is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {SliderWrapper | null}
-        */
-       findSlider(selector?: string): SliderWrapper | null;
-
-       /**
-        * Returns an array of Slider wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Sliders inside the current wrapper.
-        * If no matching Slider is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<SliderWrapper>}
-        */
-       findAllSliders(selector?: string): Array<SliderWrapper>;
-
-       /**
-        * Returns the wrapper of the first SpaceBetween that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first SpaceBetween.
-        * If no matching SpaceBetween is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {SpaceBetweenWrapper | null}
-        */
-       findSpaceBetween(selector?: string): SpaceBetweenWrapper | null;
-
-       /**
-        * Returns an array of SpaceBetween wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the SpaceBetweens inside the current wrapper.
-        * If no matching SpaceBetween is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<SpaceBetweenWrapper>}
-        */
-       findAllSpaceBetweens(selector?: string): Array<SpaceBetweenWrapper>;
-
-       /**
-        * Returns the wrapper of the first Spinner that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Spinner.
-        * If no matching Spinner is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {SpinnerWrapper | null}
-        */
-       findSpinner(selector?: string): SpinnerWrapper | null;
-
-       /**
-        * Returns an array of Spinner wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Spinners inside the current wrapper.
-        * If no matching Spinner is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<SpinnerWrapper>}
-        */
-       findAllSpinners(selector?: string): Array<SpinnerWrapper>;
-
-       /**
-        * Returns the wrapper of the first SplitPanel that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first SplitPanel.
-        * If no matching SplitPanel is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {SplitPanelWrapper | null}
-        */
-       findSplitPanel(selector?: string): SplitPanelWrapper | null;
-
-       /**
-        * Returns an array of SplitPanel wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the SplitPanels inside the current wrapper.
-        * If no matching SplitPanel is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<SplitPanelWrapper>}
-        */
-       findAllSplitPanels(selector?: string): Array<SplitPanelWrapper>;
-
-       /**
-        * Returns the wrapper of the first StatusIndicator that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first StatusIndicator.
-        * If no matching StatusIndicator is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {StatusIndicatorWrapper | null}
-        */
-       findStatusIndicator(selector?: string): StatusIndicatorWrapper | null;
-
-       /**
-        * Returns an array of StatusIndicator wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the StatusIndicators inside the current wrapper.
-        * If no matching StatusIndicator is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<StatusIndicatorWrapper>}
-        */
-       findAllStatusIndicators(selector?: string): Array<StatusIndicatorWrapper>;
-
-       /**
-        * Returns the wrapper of the first Steps that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Steps.
-        * If no matching Steps is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {StepsWrapper | null}
-        */
-       findSteps(selector?: string): StepsWrapper | null;
-
-       /**
-        * Returns an array of Steps wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Steps inside the current wrapper.
-        * If no matching Steps is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<StepsWrapper>}
-        */
-       findAllSteps(selector?: string): Array<StepsWrapper>;
-
-       /**
-        * Returns the wrapper of the first Table that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Table.
-        * If no matching Table is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TableWrapper | null}
-        */
-       findTable(selector?: string): TableWrapper | null;
-
-       /**
-        * Returns an array of Table wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Tables inside the current wrapper.
-        * If no matching Table is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<TableWrapper>}
-        */
-       findAllTables(selector?: string): Array<TableWrapper>;
-
-       /**
-        * Returns the wrapper of the first Tabs that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Tabs.
-        * If no matching Tabs is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TabsWrapper | null}
-        */
-       findTabs(selector?: string): TabsWrapper | null;
-
-       /**
-        * Returns an array of Tabs wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Tabs inside the current wrapper.
-        * If no matching Tabs is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<TabsWrapper>}
-        */
-       findAllTabs(selector?: string): Array<TabsWrapper>;
-
-       /**
-        * Returns the wrapper of the first TagEditor that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first TagEditor.
-        * If no matching TagEditor is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TagEditorWrapper | null}
-        */
-       findTagEditor(selector?: string): TagEditorWrapper | null;
-
-       /**
-        * Returns an array of TagEditor wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the TagEditors inside the current wrapper.
-        * If no matching TagEditor is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<TagEditorWrapper>}
-        */
-       findAllTagEditors(selector?: string): Array<TagEditorWrapper>;
-
-       /**
-        * Returns the wrapper of the first TextContent that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first TextContent.
-        * If no matching TextContent is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TextContentWrapper | null}
-        */
-       findTextContent(selector?: string): TextContentWrapper | null;
-
-       /**
-        * Returns an array of TextContent wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the TextContents inside the current wrapper.
-        * If no matching TextContent is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<TextContentWrapper>}
-        */
-       findAllTextContents(selector?: string): Array<TextContentWrapper>;
-
-       /**
-        * Returns the wrapper of the first TextFilter that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first TextFilter.
-        * If no matching TextFilter is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TextFilterWrapper | null}
-        */
-       findTextFilter(selector?: string): TextFilterWrapper | null;
-
-       /**
-        * Returns an array of TextFilter wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the TextFilters inside the current wrapper.
-        * If no matching TextFilter is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<TextFilterWrapper>}
-        */
-       findAllTextFilters(selector?: string): Array<TextFilterWrapper>;
-
-       /**
-        * Returns the wrapper of the first Textarea that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Textarea.
-        * If no matching Textarea is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TextareaWrapper | null}
-        */
-       findTextarea(selector?: string): TextareaWrapper | null;
-
-       /**
-        * Returns an array of Textarea wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Textareas inside the current wrapper.
-        * If no matching Textarea is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<TextareaWrapper>}
-        */
-       findAllTextareas(selector?: string): Array<TextareaWrapper>;
-
-       /**
-        * Returns the wrapper of the first Tiles that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Tiles.
-        * If no matching Tiles is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TilesWrapper | null}
-        */
-       findTiles(selector?: string): TilesWrapper | null;
-
-       /**
-        * Returns an array of Tiles wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Tiles inside the current wrapper.
-        * If no matching Tiles is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<TilesWrapper>}
-        */
-       findAllTiles(selector?: string): Array<TilesWrapper>;
-
-       /**
-        * Returns the wrapper of the first TimeInput that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first TimeInput.
-        * If no matching TimeInput is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TimeInputWrapper | null}
-        */
-       findTimeInput(selector?: string): TimeInputWrapper | null;
-
-       /**
-        * Returns an array of TimeInput wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the TimeInputs inside the current wrapper.
-        * If no matching TimeInput is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<TimeInputWrapper>}
-        */
-       findAllTimeInputs(selector?: string): Array<TimeInputWrapper>;
-
-       /**
-        * Returns the wrapper of the first Toggle that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Toggle.
-        * If no matching Toggle is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ToggleWrapper | null}
-        */
-       findToggle(selector?: string): ToggleWrapper | null;
-
-       /**
-        * Returns an array of Toggle wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Toggles inside the current wrapper.
-        * If no matching Toggle is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<ToggleWrapper>}
-        */
-       findAllToggles(selector?: string): Array<ToggleWrapper>;
-
-       /**
-        * Returns the wrapper of the first ToggleButton that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first ToggleButton.
-        * If no matching ToggleButton is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ToggleButtonWrapper | null}
-        */
-       findToggleButton(selector?: string): ToggleButtonWrapper | null;
-
-       /**
-        * Returns an array of ToggleButton wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the ToggleButtons inside the current wrapper.
-        * If no matching ToggleButton is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<ToggleButtonWrapper>}
-        */
-       findAllToggleButtons(selector?: string): Array<ToggleButtonWrapper>;
-
-       /**
-        * Returns the wrapper of the first TokenGroup that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first TokenGroup.
-        * If no matching TokenGroup is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TokenGroupWrapper | null}
-        */
-       findTokenGroup(selector?: string): TokenGroupWrapper | null;
-
-       /**
-        * Returns an array of TokenGroup wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the TokenGroups inside the current wrapper.
-        * If no matching TokenGroup is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<TokenGroupWrapper>}
-        */
-       findAllTokenGroups(selector?: string): Array<TokenGroupWrapper>;
-
-       /**
-        * Returns the wrapper of the first TopNavigation that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first TopNavigation.
-        * If no matching TopNavigation is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TopNavigationWrapper | null}
-        */
-       findTopNavigation(selector?: string): TopNavigationWrapper | null;
-
-       /**
-        * Returns an array of TopNavigation wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the TopNavigations inside the current wrapper.
-        * If no matching TopNavigation is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<TopNavigationWrapper>}
-        */
-       findAllTopNavigations(selector?: string): Array<TopNavigationWrapper>;
-
-       /**
-        * Returns the wrapper of the first TutorialPanel that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first TutorialPanel.
-        * If no matching TutorialPanel is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TutorialPanelWrapper | null}
-        */
-       findTutorialPanel(selector?: string): TutorialPanelWrapper | null;
-
-       /**
-        * Returns an array of TutorialPanel wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the TutorialPanels inside the current wrapper.
-        * If no matching TutorialPanel is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<TutorialPanelWrapper>}
-        */
-       findAllTutorialPanels(selector?: string): Array<TutorialPanelWrapper>;
-
-       /**
-        * Returns the wrapper of the first Wizard that matches the specified CSS selector.
-        * If no CSS selector is specified, returns the wrapper of the first Wizard.
-        * If no matching Wizard is found, returns \`null\`.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {WizardWrapper | null}
-        */
-       findWizard(selector?: string): WizardWrapper | null;
-
-       /**
-        * Returns an array of Wizard wrapper that matches the specified CSS selector.
-        * If no CSS selector is specified, returns all of the Wizards inside the current wrapper.
-        * If no matching Wizard is found, returns an empty array.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {Array<WizardWrapper>}
-        */
-       findAllWizards(selector?: string): Array<WizardWrapper>;
-      }
-  }
-
-      ElementWrapper.prototype.findAlert = function(selector) {
-        const rootSelector = \`.\${AlertWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AlertWrapper);
-      };
-
-      ElementWrapper.prototype.findAllAlerts = function(selector) {
-        return this.findAllComponents(AlertWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findAnchorNavigation = function(selector) {
-        const rootSelector = \`.\${AnchorNavigationWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AnchorNavigationWrapper);
-      };
-
-      ElementWrapper.prototype.findAllAnchorNavigations = function(selector) {
-        return this.findAllComponents(AnchorNavigationWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findAnnotation = function(selector) {
-        const rootSelector = \`.\${AnnotationWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AnnotationWrapper);
-      };
-
-      ElementWrapper.prototype.findAllAnnotations = function(selector) {
-        return this.findAllComponents(AnnotationWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findAppLayout = function(selector) {
-        const rootSelector = \`.\${AppLayoutWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AppLayoutWrapper);
-      };
-
-      ElementWrapper.prototype.findAllAppLayouts = function(selector) {
-        return this.findAllComponents(AppLayoutWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findAreaChart = function(selector) {
-        const rootSelector = \`.\${AreaChartWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AreaChartWrapper);
-      };
-
-      ElementWrapper.prototype.findAllAreaCharts = function(selector) {
-        return this.findAllComponents(AreaChartWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findAttributeEditor = function(selector) {
-        const rootSelector = \`.\${AttributeEditorWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AttributeEditorWrapper);
-      };
-
-      ElementWrapper.prototype.findAllAttributeEditors = function(selector) {
-        return this.findAllComponents(AttributeEditorWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findAutosuggest = function(selector) {
-        const rootSelector = \`.\${AutosuggestWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AutosuggestWrapper);
-      };
-
-      ElementWrapper.prototype.findAllAutosuggests = function(selector) {
-        return this.findAllComponents(AutosuggestWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findBadge = function(selector) {
-        const rootSelector = \`.\${BadgeWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BadgeWrapper);
-      };
-
-      ElementWrapper.prototype.findAllBadges = function(selector) {
-        return this.findAllComponents(BadgeWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findBarChart = function(selector) {
-        const rootSelector = \`.\${BarChartWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BarChartWrapper);
-      };
-
-      ElementWrapper.prototype.findAllBarCharts = function(selector) {
-        return this.findAllComponents(BarChartWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findBox = function(selector) {
-        const rootSelector = \`.\${BoxWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BoxWrapper);
-      };
-
-      ElementWrapper.prototype.findAllBoxes = function(selector) {
-        return this.findAllComponents(BoxWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findBreadcrumbGroup = function(selector) {
-        const rootSelector = \`.\${BreadcrumbGroupWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BreadcrumbGroupWrapper);
-      };
-
-      ElementWrapper.prototype.findAllBreadcrumbGroups = function(selector) {
-        return this.findAllComponents(BreadcrumbGroupWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findButton = function(selector) {
-        const rootSelector = \`.\${ButtonWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ButtonWrapper);
-      };
-
-      ElementWrapper.prototype.findAllButtons = function(selector) {
-        return this.findAllComponents(ButtonWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findButtonDropdown = function(selector) {
-        const rootSelector = \`.\${ButtonDropdownWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ButtonDropdownWrapper);
-      };
-
-      ElementWrapper.prototype.findAllButtonDropdowns = function(selector) {
-        return this.findAllComponents(ButtonDropdownWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findButtonGroup = function(selector) {
-        const rootSelector = \`.\${ButtonGroupWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ButtonGroupWrapper);
-      };
-
-      ElementWrapper.prototype.findAllButtonGroups = function(selector) {
-        return this.findAllComponents(ButtonGroupWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findCalendar = function(selector) {
-        const rootSelector = \`.\${CalendarWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CalendarWrapper);
-      };
-
-      ElementWrapper.prototype.findAllCalendars = function(selector) {
-        return this.findAllComponents(CalendarWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findCards = function(selector) {
-        const rootSelector = \`.\${CardsWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CardsWrapper);
-      };
-
-      ElementWrapper.prototype.findAllCards = function(selector) {
-        return this.findAllComponents(CardsWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findCheckbox = function(selector) {
-        const rootSelector = \`.\${CheckboxWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CheckboxWrapper);
-      };
-
-      ElementWrapper.prototype.findAllCheckboxes = function(selector) {
-        return this.findAllComponents(CheckboxWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findCodeEditor = function(selector) {
-        const rootSelector = \`.\${CodeEditorWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CodeEditorWrapper);
-      };
-
-      ElementWrapper.prototype.findAllCodeEditors = function(selector) {
-        return this.findAllComponents(CodeEditorWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findCollectionPreferences = function(selector) {
-        const rootSelector = \`.\${CollectionPreferencesWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CollectionPreferencesWrapper);
-      };
-
-      ElementWrapper.prototype.findAllCollectionPreferences = function(selector) {
-        return this.findAllComponents(CollectionPreferencesWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findColumnLayout = function(selector) {
-        const rootSelector = \`.\${ColumnLayoutWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ColumnLayoutWrapper);
-      };
-
-      ElementWrapper.prototype.findAllColumnLayouts = function(selector) {
-        return this.findAllComponents(ColumnLayoutWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findContainer = function(selector) {
-        const rootSelector = \`.\${ContainerWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ContainerWrapper);
-      };
-
-      ElementWrapper.prototype.findAllContainers = function(selector) {
-        return this.findAllComponents(ContainerWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findContentLayout = function(selector) {
-        const rootSelector = \`.\${ContentLayoutWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ContentLayoutWrapper);
-      };
-
-      ElementWrapper.prototype.findAllContentLayouts = function(selector) {
-        return this.findAllComponents(ContentLayoutWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findCopyToClipboard = function(selector) {
-        const rootSelector = \`.\${CopyToClipboardWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CopyToClipboardWrapper);
-      };
-
-      ElementWrapper.prototype.findAllCopyToClipboards = function(selector) {
-        return this.findAllComponents(CopyToClipboardWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findDateInput = function(selector) {
-        const rootSelector = \`.\${DateInputWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DateInputWrapper);
-      };
-
-      ElementWrapper.prototype.findAllDateInputs = function(selector) {
-        return this.findAllComponents(DateInputWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findDatePicker = function(selector) {
-        const rootSelector = \`.\${DatePickerWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DatePickerWrapper);
-      };
-
-      ElementWrapper.prototype.findAllDatePickers = function(selector) {
-        return this.findAllComponents(DatePickerWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findDateRangePicker = function(selector) {
-        const rootSelector = \`.\${DateRangePickerWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DateRangePickerWrapper);
-      };
-
-      ElementWrapper.prototype.findAllDateRangePickers = function(selector) {
-        return this.findAllComponents(DateRangePickerWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findDrawer = function(selector) {
-        const rootSelector = \`.\${DrawerWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DrawerWrapper);
-      };
-
-      ElementWrapper.prototype.findAllDrawers = function(selector) {
-        return this.findAllComponents(DrawerWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findExpandableSection = function(selector) {
-        const rootSelector = \`.\${ExpandableSectionWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ExpandableSectionWrapper);
-      };
-
-      ElementWrapper.prototype.findAllExpandableSections = function(selector) {
-        return this.findAllComponents(ExpandableSectionWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findFileDropzone = function(selector) {
-        const rootSelector = \`.\${FileDropzoneWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileDropzoneWrapper);
-      };
-
-      ElementWrapper.prototype.findAllFileDropzones = function(selector) {
-        return this.findAllComponents(FileDropzoneWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findFileInput = function(selector) {
-        const rootSelector = \`.\${FileInputWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileInputWrapper);
-      };
-
-      ElementWrapper.prototype.findAllFileInputs = function(selector) {
-        return this.findAllComponents(FileInputWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findFileTokenGroup = function(selector) {
-        const rootSelector = \`.\${FileTokenGroupWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileTokenGroupWrapper);
-      };
-
-      ElementWrapper.prototype.findAllFileTokenGroups = function(selector) {
-        return this.findAllComponents(FileTokenGroupWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findFileUpload = function(selector) {
-        const rootSelector = \`.\${FileUploadWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileUploadWrapper);
-      };
-
-      ElementWrapper.prototype.findAllFileUploads = function(selector) {
-        return this.findAllComponents(FileUploadWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findFlashbar = function(selector) {
-        const rootSelector = \`.\${FlashbarWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FlashbarWrapper);
-      };
-
-      ElementWrapper.prototype.findAllFlashbars = function(selector) {
-        return this.findAllComponents(FlashbarWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findForm = function(selector) {
-        const rootSelector = \`.\${FormWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FormWrapper);
-      };
-
-      ElementWrapper.prototype.findAllForms = function(selector) {
-        return this.findAllComponents(FormWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findFormField = function(selector) {
-        const rootSelector = \`.\${FormFieldWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FormFieldWrapper);
-      };
-
-      ElementWrapper.prototype.findAllFormFields = function(selector) {
-        return this.findAllComponents(FormFieldWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findGrid = function(selector) {
-        const rootSelector = \`.\${GridWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, GridWrapper);
-      };
-
-      ElementWrapper.prototype.findAllGrids = function(selector) {
-        return this.findAllComponents(GridWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findHeader = function(selector) {
-        const rootSelector = \`.\${HeaderWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, HeaderWrapper);
-      };
-
-      ElementWrapper.prototype.findAllHeaders = function(selector) {
-        return this.findAllComponents(HeaderWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findHelpPanel = function(selector) {
-        const rootSelector = \`.\${HelpPanelWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, HelpPanelWrapper);
-      };
-
-      ElementWrapper.prototype.findAllHelpPanels = function(selector) {
-        return this.findAllComponents(HelpPanelWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findHotspot = function(selector) {
-        const rootSelector = \`.\${HotspotWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, HotspotWrapper);
-      };
-
-      ElementWrapper.prototype.findAllHotspots = function(selector) {
-        return this.findAllComponents(HotspotWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findIcon = function(selector) {
-        const rootSelector = \`.\${IconWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, IconWrapper);
-      };
-
-      ElementWrapper.prototype.findAllIcons = function(selector) {
-        return this.findAllComponents(IconWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findInput = function(selector) {
-        const rootSelector = \`.\${InputWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, InputWrapper);
-      };
-
-      ElementWrapper.prototype.findAllInputs = function(selector) {
-        return this.findAllComponents(InputWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findKeyValuePairs = function(selector) {
-        const rootSelector = \`.\${KeyValuePairsWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, KeyValuePairsWrapper);
-      };
-
-      ElementWrapper.prototype.findAllKeyValuePairs = function(selector) {
-        return this.findAllComponents(KeyValuePairsWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findLineChart = function(selector) {
-        const rootSelector = \`.\${LineChartWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, LineChartWrapper);
-      };
-
-      ElementWrapper.prototype.findAllLineCharts = function(selector) {
-        return this.findAllComponents(LineChartWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findLink = function(selector) {
-        const rootSelector = \`.\${LinkWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, LinkWrapper);
-      };
-
-      ElementWrapper.prototype.findAllLinks = function(selector) {
-        return this.findAllComponents(LinkWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findLiveRegion = function(selector) {
-        const rootSelector = \`.\${LiveRegionWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, LiveRegionWrapper);
-      };
-
-      ElementWrapper.prototype.findAllLiveRegions = function(selector) {
-        return this.findAllComponents(LiveRegionWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findMixedLineBarChart = function(selector) {
-        const rootSelector = \`.\${MixedLineBarChartWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, MixedLineBarChartWrapper);
-      };
-
-      ElementWrapper.prototype.findAllMixedLineBarCharts = function(selector) {
-        return this.findAllComponents(MixedLineBarChartWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findModal = function(selector) {
-        const rootSelector = \`.\${ModalWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ModalWrapper);
-      };
-
-      ElementWrapper.prototype.findAllModals = function(selector) {
-        return this.findAllComponents(ModalWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findMultiselect = function(selector) {
-        const rootSelector = \`.\${MultiselectWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, MultiselectWrapper);
-      };
-
-      ElementWrapper.prototype.findAllMultiselects = function(selector) {
-        return this.findAllComponents(MultiselectWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findPagination = function(selector) {
-        const rootSelector = \`.\${PaginationWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PaginationWrapper);
-      };
-
-      ElementWrapper.prototype.findAllPaginations = function(selector) {
-        return this.findAllComponents(PaginationWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findPieChart = function(selector) {
-        const rootSelector = \`.\${PieChartWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PieChartWrapper);
-      };
-
-      ElementWrapper.prototype.findAllPieCharts = function(selector) {
-        return this.findAllComponents(PieChartWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findPopover = function(selector) {
-        const rootSelector = \`.\${PopoverWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PopoverWrapper);
-      };
-
-      ElementWrapper.prototype.findAllPopovers = function(selector) {
-        return this.findAllComponents(PopoverWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findProgressBar = function(selector) {
-        const rootSelector = \`.\${ProgressBarWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ProgressBarWrapper);
-      };
-
-      ElementWrapper.prototype.findAllProgressBars = function(selector) {
-        return this.findAllComponents(ProgressBarWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findPromptInput = function(selector) {
-        const rootSelector = \`.\${PromptInputWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PromptInputWrapper);
-      };
-
-      ElementWrapper.prototype.findAllPromptInputs = function(selector) {
-        return this.findAllComponents(PromptInputWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findPropertyFilter = function(selector) {
-        const rootSelector = \`.\${PropertyFilterWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PropertyFilterWrapper);
-      };
-
-      ElementWrapper.prototype.findAllPropertyFilters = function(selector) {
-        return this.findAllComponents(PropertyFilterWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findRadioGroup = function(selector) {
-        const rootSelector = \`.\${RadioGroupWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, RadioGroupWrapper);
-      };
-
-      ElementWrapper.prototype.findAllRadioGroups = function(selector) {
-        return this.findAllComponents(RadioGroupWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findS3ResourceSelector = function(selector) {
-        const rootSelector = \`.\${S3ResourceSelectorWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, S3ResourceSelectorWrapper);
-      };
-
-      ElementWrapper.prototype.findAllS3ResourceSelectors = function(selector) {
-        return this.findAllComponents(S3ResourceSelectorWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSegmentedControl = function(selector) {
-        const rootSelector = \`.\${SegmentedControlWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SegmentedControlWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSegmentedControls = function(selector) {
-        return this.findAllComponents(SegmentedControlWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSelect = function(selector) {
-        const rootSelector = \`.\${SelectWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SelectWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSelects = function(selector) {
-        return this.findAllComponents(SelectWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSideNavigation = function(selector) {
-        const rootSelector = \`.\${SideNavigationWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SideNavigationWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSideNavigations = function(selector) {
-        return this.findAllComponents(SideNavigationWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSlider = function(selector) {
-        const rootSelector = \`.\${SliderWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SliderWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSliders = function(selector) {
-        return this.findAllComponents(SliderWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSpaceBetween = function(selector) {
-        const rootSelector = \`.\${SpaceBetweenWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SpaceBetweenWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSpaceBetweens = function(selector) {
-        return this.findAllComponents(SpaceBetweenWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSpinner = function(selector) {
-        const rootSelector = \`.\${SpinnerWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SpinnerWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSpinners = function(selector) {
-        return this.findAllComponents(SpinnerWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSplitPanel = function(selector) {
-        const rootSelector = \`.\${SplitPanelWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SplitPanelWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSplitPanels = function(selector) {
-        return this.findAllComponents(SplitPanelWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findStatusIndicator = function(selector) {
-        const rootSelector = \`.\${StatusIndicatorWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, StatusIndicatorWrapper);
-      };
-
-      ElementWrapper.prototype.findAllStatusIndicators = function(selector) {
-        return this.findAllComponents(StatusIndicatorWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSteps = function(selector) {
-        const rootSelector = \`.\${StepsWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, StepsWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSteps = function(selector) {
-        return this.findAllComponents(StepsWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTable = function(selector) {
-        const rootSelector = \`.\${TableWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TableWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTables = function(selector) {
-        return this.findAllComponents(TableWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTabs = function(selector) {
-        const rootSelector = \`.\${TabsWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TabsWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTabs = function(selector) {
-        return this.findAllComponents(TabsWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTagEditor = function(selector) {
-        const rootSelector = \`.\${TagEditorWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TagEditorWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTagEditors = function(selector) {
-        return this.findAllComponents(TagEditorWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTextContent = function(selector) {
-        const rootSelector = \`.\${TextContentWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TextContentWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTextContents = function(selector) {
-        return this.findAllComponents(TextContentWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTextFilter = function(selector) {
-        const rootSelector = \`.\${TextFilterWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TextFilterWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTextFilters = function(selector) {
-        return this.findAllComponents(TextFilterWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTextarea = function(selector) {
-        const rootSelector = \`.\${TextareaWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TextareaWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTextareas = function(selector) {
-        return this.findAllComponents(TextareaWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTiles = function(selector) {
-        const rootSelector = \`.\${TilesWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TilesWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTiles = function(selector) {
-        return this.findAllComponents(TilesWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTimeInput = function(selector) {
-        const rootSelector = \`.\${TimeInputWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TimeInputWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTimeInputs = function(selector) {
-        return this.findAllComponents(TimeInputWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findToggle = function(selector) {
-        const rootSelector = \`.\${ToggleWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ToggleWrapper);
-      };
-
-      ElementWrapper.prototype.findAllToggles = function(selector) {
-        return this.findAllComponents(ToggleWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findToggleButton = function(selector) {
-        const rootSelector = \`.\${ToggleButtonWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ToggleButtonWrapper);
-      };
-
-      ElementWrapper.prototype.findAllToggleButtons = function(selector) {
-        return this.findAllComponents(ToggleButtonWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTokenGroup = function(selector) {
-        const rootSelector = \`.\${TokenGroupWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TokenGroupWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTokenGroups = function(selector) {
-        return this.findAllComponents(TokenGroupWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTopNavigation = function(selector) {
-        const rootSelector = \`.\${TopNavigationWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TopNavigationWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTopNavigations = function(selector) {
-        return this.findAllComponents(TopNavigationWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTutorialPanel = function(selector) {
-        const rootSelector = \`.\${TutorialPanelWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TutorialPanelWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTutorialPanels = function(selector) {
-        return this.findAllComponents(TutorialPanelWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findWizard = function(selector) {
-        const rootSelector = \`.\${WizardWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, WizardWrapper);
-      };
-
-      ElementWrapper.prototype.findAllWizards = function(selector) {
-        return this.findAllComponents(WizardWrapper, selector);
-      };
-export default function wrapper(root: Element = document.body) { if (document && document.body && !document.body.contains(root)) { console.warn('[AwsUi] [test-utils] provided element is not part of the document body, interactions may work incorrectly')}; return new ElementWrapper(root); }"
+   interface ElementWrapper {
+    
+/**
+ * Returns the wrapper of the first Alert that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Alert.
+ * If no matching Alert is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {AlertWrapper | null}
+ */
+findAlert(selector?: string): AlertWrapper | null;
+
+/**
+ * Returns an array of Alert wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Alerts inside the current wrapper.
+ * If no matching Alert is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<AlertWrapper>}
+ */
+findAllAlerts(selector?: string): Array<AlertWrapper>;
+/**
+ * Returns the wrapper of the first AnchorNavigation that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first AnchorNavigation.
+ * If no matching AnchorNavigation is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {AnchorNavigationWrapper | null}
+ */
+findAnchorNavigation(selector?: string): AnchorNavigationWrapper | null;
+
+/**
+ * Returns an array of AnchorNavigation wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the AnchorNavigations inside the current wrapper.
+ * If no matching AnchorNavigation is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<AnchorNavigationWrapper>}
+ */
+findAllAnchorNavigations(selector?: string): Array<AnchorNavigationWrapper>;
+/**
+ * Returns the wrapper of the first Annotation that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Annotation.
+ * If no matching Annotation is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {AnnotationWrapper | null}
+ */
+findAnnotation(selector?: string): AnnotationWrapper | null;
+
+/**
+ * Returns an array of Annotation wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Annotations inside the current wrapper.
+ * If no matching Annotation is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<AnnotationWrapper>}
+ */
+findAllAnnotations(selector?: string): Array<AnnotationWrapper>;
+/**
+ * Returns the wrapper of the first AppLayout that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first AppLayout.
+ * If no matching AppLayout is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {AppLayoutWrapper | null}
+ */
+findAppLayout(selector?: string): AppLayoutWrapper | null;
+
+/**
+ * Returns an array of AppLayout wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the AppLayouts inside the current wrapper.
+ * If no matching AppLayout is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<AppLayoutWrapper>}
+ */
+findAllAppLayouts(selector?: string): Array<AppLayoutWrapper>;
+/**
+ * Returns the wrapper of the first AreaChart that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first AreaChart.
+ * If no matching AreaChart is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {AreaChartWrapper | null}
+ */
+findAreaChart(selector?: string): AreaChartWrapper | null;
+
+/**
+ * Returns an array of AreaChart wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the AreaCharts inside the current wrapper.
+ * If no matching AreaChart is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<AreaChartWrapper>}
+ */
+findAllAreaCharts(selector?: string): Array<AreaChartWrapper>;
+/**
+ * Returns the wrapper of the first AttributeEditor that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first AttributeEditor.
+ * If no matching AttributeEditor is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {AttributeEditorWrapper | null}
+ */
+findAttributeEditor(selector?: string): AttributeEditorWrapper | null;
+
+/**
+ * Returns an array of AttributeEditor wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the AttributeEditors inside the current wrapper.
+ * If no matching AttributeEditor is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<AttributeEditorWrapper>}
+ */
+findAllAttributeEditors(selector?: string): Array<AttributeEditorWrapper>;
+/**
+ * Returns the wrapper of the first Autosuggest that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Autosuggest.
+ * If no matching Autosuggest is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {AutosuggestWrapper | null}
+ */
+findAutosuggest(selector?: string): AutosuggestWrapper | null;
+
+/**
+ * Returns an array of Autosuggest wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Autosuggests inside the current wrapper.
+ * If no matching Autosuggest is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<AutosuggestWrapper>}
+ */
+findAllAutosuggests(selector?: string): Array<AutosuggestWrapper>;
+/**
+ * Returns the wrapper of the first Badge that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Badge.
+ * If no matching Badge is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {BadgeWrapper | null}
+ */
+findBadge(selector?: string): BadgeWrapper | null;
+
+/**
+ * Returns an array of Badge wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Badges inside the current wrapper.
+ * If no matching Badge is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<BadgeWrapper>}
+ */
+findAllBadges(selector?: string): Array<BadgeWrapper>;
+/**
+ * Returns the wrapper of the first BarChart that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first BarChart.
+ * If no matching BarChart is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {BarChartWrapper | null}
+ */
+findBarChart(selector?: string): BarChartWrapper | null;
+
+/**
+ * Returns an array of BarChart wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the BarCharts inside the current wrapper.
+ * If no matching BarChart is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<BarChartWrapper>}
+ */
+findAllBarCharts(selector?: string): Array<BarChartWrapper>;
+/**
+ * Returns the wrapper of the first Box that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Box.
+ * If no matching Box is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {BoxWrapper | null}
+ */
+findBox(selector?: string): BoxWrapper | null;
+
+/**
+ * Returns an array of Box wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Boxes inside the current wrapper.
+ * If no matching Box is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<BoxWrapper>}
+ */
+findAllBoxes(selector?: string): Array<BoxWrapper>;
+/**
+ * Returns the wrapper of the first BreadcrumbGroup that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first BreadcrumbGroup.
+ * If no matching BreadcrumbGroup is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {BreadcrumbGroupWrapper | null}
+ */
+findBreadcrumbGroup(selector?: string): BreadcrumbGroupWrapper | null;
+
+/**
+ * Returns an array of BreadcrumbGroup wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the BreadcrumbGroups inside the current wrapper.
+ * If no matching BreadcrumbGroup is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<BreadcrumbGroupWrapper>}
+ */
+findAllBreadcrumbGroups(selector?: string): Array<BreadcrumbGroupWrapper>;
+/**
+ * Returns the wrapper of the first Button that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Button.
+ * If no matching Button is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ButtonWrapper | null}
+ */
+findButton(selector?: string): ButtonWrapper | null;
+
+/**
+ * Returns an array of Button wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Buttons inside the current wrapper.
+ * If no matching Button is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<ButtonWrapper>}
+ */
+findAllButtons(selector?: string): Array<ButtonWrapper>;
+/**
+ * Returns the wrapper of the first ButtonDropdown that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first ButtonDropdown.
+ * If no matching ButtonDropdown is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ButtonDropdownWrapper | null}
+ */
+findButtonDropdown(selector?: string): ButtonDropdownWrapper | null;
+
+/**
+ * Returns an array of ButtonDropdown wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the ButtonDropdowns inside the current wrapper.
+ * If no matching ButtonDropdown is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<ButtonDropdownWrapper>}
+ */
+findAllButtonDropdowns(selector?: string): Array<ButtonDropdownWrapper>;
+/**
+ * Returns the wrapper of the first ButtonGroup that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first ButtonGroup.
+ * If no matching ButtonGroup is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ButtonGroupWrapper | null}
+ */
+findButtonGroup(selector?: string): ButtonGroupWrapper | null;
+
+/**
+ * Returns an array of ButtonGroup wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the ButtonGroups inside the current wrapper.
+ * If no matching ButtonGroup is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<ButtonGroupWrapper>}
+ */
+findAllButtonGroups(selector?: string): Array<ButtonGroupWrapper>;
+/**
+ * Returns the wrapper of the first Calendar that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Calendar.
+ * If no matching Calendar is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {CalendarWrapper | null}
+ */
+findCalendar(selector?: string): CalendarWrapper | null;
+
+/**
+ * Returns an array of Calendar wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Calendars inside the current wrapper.
+ * If no matching Calendar is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<CalendarWrapper>}
+ */
+findAllCalendars(selector?: string): Array<CalendarWrapper>;
+/**
+ * Returns the wrapper of the first Cards that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Cards.
+ * If no matching Cards is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {CardsWrapper | null}
+ */
+findCards(selector?: string): CardsWrapper | null;
+
+/**
+ * Returns an array of Cards wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Cards inside the current wrapper.
+ * If no matching Cards is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<CardsWrapper>}
+ */
+findAllCards(selector?: string): Array<CardsWrapper>;
+/**
+ * Returns the wrapper of the first Checkbox that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Checkbox.
+ * If no matching Checkbox is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {CheckboxWrapper | null}
+ */
+findCheckbox(selector?: string): CheckboxWrapper | null;
+
+/**
+ * Returns an array of Checkbox wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Checkboxes inside the current wrapper.
+ * If no matching Checkbox is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<CheckboxWrapper>}
+ */
+findAllCheckboxes(selector?: string): Array<CheckboxWrapper>;
+/**
+ * Returns the wrapper of the first CodeEditor that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first CodeEditor.
+ * If no matching CodeEditor is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {CodeEditorWrapper | null}
+ */
+findCodeEditor(selector?: string): CodeEditorWrapper | null;
+
+/**
+ * Returns an array of CodeEditor wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the CodeEditors inside the current wrapper.
+ * If no matching CodeEditor is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<CodeEditorWrapper>}
+ */
+findAllCodeEditors(selector?: string): Array<CodeEditorWrapper>;
+/**
+ * Returns the wrapper of the first CollectionPreferences that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first CollectionPreferences.
+ * If no matching CollectionPreferences is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {CollectionPreferencesWrapper | null}
+ */
+findCollectionPreferences(selector?: string): CollectionPreferencesWrapper | null;
+
+/**
+ * Returns an array of CollectionPreferences wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the CollectionPreferences inside the current wrapper.
+ * If no matching CollectionPreferences is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<CollectionPreferencesWrapper>}
+ */
+findAllCollectionPreferences(selector?: string): Array<CollectionPreferencesWrapper>;
+/**
+ * Returns the wrapper of the first ColumnLayout that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first ColumnLayout.
+ * If no matching ColumnLayout is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ColumnLayoutWrapper | null}
+ */
+findColumnLayout(selector?: string): ColumnLayoutWrapper | null;
+
+/**
+ * Returns an array of ColumnLayout wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the ColumnLayouts inside the current wrapper.
+ * If no matching ColumnLayout is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<ColumnLayoutWrapper>}
+ */
+findAllColumnLayouts(selector?: string): Array<ColumnLayoutWrapper>;
+/**
+ * Returns the wrapper of the first Container that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Container.
+ * If no matching Container is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ContainerWrapper | null}
+ */
+findContainer(selector?: string): ContainerWrapper | null;
+
+/**
+ * Returns an array of Container wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Containers inside the current wrapper.
+ * If no matching Container is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<ContainerWrapper>}
+ */
+findAllContainers(selector?: string): Array<ContainerWrapper>;
+/**
+ * Returns the wrapper of the first ContentLayout that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first ContentLayout.
+ * If no matching ContentLayout is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ContentLayoutWrapper | null}
+ */
+findContentLayout(selector?: string): ContentLayoutWrapper | null;
+
+/**
+ * Returns an array of ContentLayout wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the ContentLayouts inside the current wrapper.
+ * If no matching ContentLayout is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<ContentLayoutWrapper>}
+ */
+findAllContentLayouts(selector?: string): Array<ContentLayoutWrapper>;
+/**
+ * Returns the wrapper of the first CopyToClipboard that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first CopyToClipboard.
+ * If no matching CopyToClipboard is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {CopyToClipboardWrapper | null}
+ */
+findCopyToClipboard(selector?: string): CopyToClipboardWrapper | null;
+
+/**
+ * Returns an array of CopyToClipboard wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the CopyToClipboards inside the current wrapper.
+ * If no matching CopyToClipboard is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<CopyToClipboardWrapper>}
+ */
+findAllCopyToClipboards(selector?: string): Array<CopyToClipboardWrapper>;
+/**
+ * Returns the wrapper of the first DateInput that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first DateInput.
+ * If no matching DateInput is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {DateInputWrapper | null}
+ */
+findDateInput(selector?: string): DateInputWrapper | null;
+
+/**
+ * Returns an array of DateInput wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the DateInputs inside the current wrapper.
+ * If no matching DateInput is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<DateInputWrapper>}
+ */
+findAllDateInputs(selector?: string): Array<DateInputWrapper>;
+/**
+ * Returns the wrapper of the first DatePicker that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first DatePicker.
+ * If no matching DatePicker is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {DatePickerWrapper | null}
+ */
+findDatePicker(selector?: string): DatePickerWrapper | null;
+
+/**
+ * Returns an array of DatePicker wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the DatePickers inside the current wrapper.
+ * If no matching DatePicker is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<DatePickerWrapper>}
+ */
+findAllDatePickers(selector?: string): Array<DatePickerWrapper>;
+/**
+ * Returns the wrapper of the first DateRangePicker that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first DateRangePicker.
+ * If no matching DateRangePicker is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {DateRangePickerWrapper | null}
+ */
+findDateRangePicker(selector?: string): DateRangePickerWrapper | null;
+
+/**
+ * Returns an array of DateRangePicker wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the DateRangePickers inside the current wrapper.
+ * If no matching DateRangePicker is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<DateRangePickerWrapper>}
+ */
+findAllDateRangePickers(selector?: string): Array<DateRangePickerWrapper>;
+/**
+ * Returns the wrapper of the first Drawer that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Drawer.
+ * If no matching Drawer is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {DrawerWrapper | null}
+ */
+findDrawer(selector?: string): DrawerWrapper | null;
+
+/**
+ * Returns an array of Drawer wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Drawers inside the current wrapper.
+ * If no matching Drawer is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<DrawerWrapper>}
+ */
+findAllDrawers(selector?: string): Array<DrawerWrapper>;
+/**
+ * Returns the wrapper of the first ExpandableSection that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first ExpandableSection.
+ * If no matching ExpandableSection is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ExpandableSectionWrapper | null}
+ */
+findExpandableSection(selector?: string): ExpandableSectionWrapper | null;
+
+/**
+ * Returns an array of ExpandableSection wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the ExpandableSections inside the current wrapper.
+ * If no matching ExpandableSection is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<ExpandableSectionWrapper>}
+ */
+findAllExpandableSections(selector?: string): Array<ExpandableSectionWrapper>;
+/**
+ * Returns the wrapper of the first FileDropzone that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first FileDropzone.
+ * If no matching FileDropzone is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {FileDropzoneWrapper | null}
+ */
+findFileDropzone(selector?: string): FileDropzoneWrapper | null;
+
+/**
+ * Returns an array of FileDropzone wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the FileDropzones inside the current wrapper.
+ * If no matching FileDropzone is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<FileDropzoneWrapper>}
+ */
+findAllFileDropzones(selector?: string): Array<FileDropzoneWrapper>;
+/**
+ * Returns the wrapper of the first FileInput that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first FileInput.
+ * If no matching FileInput is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {FileInputWrapper | null}
+ */
+findFileInput(selector?: string): FileInputWrapper | null;
+
+/**
+ * Returns an array of FileInput wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the FileInputs inside the current wrapper.
+ * If no matching FileInput is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<FileInputWrapper>}
+ */
+findAllFileInputs(selector?: string): Array<FileInputWrapper>;
+/**
+ * Returns the wrapper of the first FileTokenGroup that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first FileTokenGroup.
+ * If no matching FileTokenGroup is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {FileTokenGroupWrapper | null}
+ */
+findFileTokenGroup(selector?: string): FileTokenGroupWrapper | null;
+
+/**
+ * Returns an array of FileTokenGroup wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the FileTokenGroups inside the current wrapper.
+ * If no matching FileTokenGroup is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<FileTokenGroupWrapper>}
+ */
+findAllFileTokenGroups(selector?: string): Array<FileTokenGroupWrapper>;
+/**
+ * Returns the wrapper of the first FileUpload that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first FileUpload.
+ * If no matching FileUpload is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {FileUploadWrapper | null}
+ */
+findFileUpload(selector?: string): FileUploadWrapper | null;
+
+/**
+ * Returns an array of FileUpload wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the FileUploads inside the current wrapper.
+ * If no matching FileUpload is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<FileUploadWrapper>}
+ */
+findAllFileUploads(selector?: string): Array<FileUploadWrapper>;
+/**
+ * Returns the wrapper of the first Flashbar that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Flashbar.
+ * If no matching Flashbar is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {FlashbarWrapper | null}
+ */
+findFlashbar(selector?: string): FlashbarWrapper | null;
+
+/**
+ * Returns an array of Flashbar wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Flashbars inside the current wrapper.
+ * If no matching Flashbar is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<FlashbarWrapper>}
+ */
+findAllFlashbars(selector?: string): Array<FlashbarWrapper>;
+/**
+ * Returns the wrapper of the first Form that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Form.
+ * If no matching Form is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {FormWrapper | null}
+ */
+findForm(selector?: string): FormWrapper | null;
+
+/**
+ * Returns an array of Form wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Forms inside the current wrapper.
+ * If no matching Form is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<FormWrapper>}
+ */
+findAllForms(selector?: string): Array<FormWrapper>;
+/**
+ * Returns the wrapper of the first FormField that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first FormField.
+ * If no matching FormField is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {FormFieldWrapper | null}
+ */
+findFormField(selector?: string): FormFieldWrapper | null;
+
+/**
+ * Returns an array of FormField wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the FormFields inside the current wrapper.
+ * If no matching FormField is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<FormFieldWrapper>}
+ */
+findAllFormFields(selector?: string): Array<FormFieldWrapper>;
+/**
+ * Returns the wrapper of the first Grid that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Grid.
+ * If no matching Grid is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {GridWrapper | null}
+ */
+findGrid(selector?: string): GridWrapper | null;
+
+/**
+ * Returns an array of Grid wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Grids inside the current wrapper.
+ * If no matching Grid is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<GridWrapper>}
+ */
+findAllGrids(selector?: string): Array<GridWrapper>;
+/**
+ * Returns the wrapper of the first Header that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Header.
+ * If no matching Header is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {HeaderWrapper | null}
+ */
+findHeader(selector?: string): HeaderWrapper | null;
+
+/**
+ * Returns an array of Header wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Headers inside the current wrapper.
+ * If no matching Header is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<HeaderWrapper>}
+ */
+findAllHeaders(selector?: string): Array<HeaderWrapper>;
+/**
+ * Returns the wrapper of the first HelpPanel that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first HelpPanel.
+ * If no matching HelpPanel is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {HelpPanelWrapper | null}
+ */
+findHelpPanel(selector?: string): HelpPanelWrapper | null;
+
+/**
+ * Returns an array of HelpPanel wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the HelpPanels inside the current wrapper.
+ * If no matching HelpPanel is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<HelpPanelWrapper>}
+ */
+findAllHelpPanels(selector?: string): Array<HelpPanelWrapper>;
+/**
+ * Returns the wrapper of the first Hotspot that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Hotspot.
+ * If no matching Hotspot is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {HotspotWrapper | null}
+ */
+findHotspot(selector?: string): HotspotWrapper | null;
+
+/**
+ * Returns an array of Hotspot wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Hotspots inside the current wrapper.
+ * If no matching Hotspot is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<HotspotWrapper>}
+ */
+findAllHotspots(selector?: string): Array<HotspotWrapper>;
+/**
+ * Returns the wrapper of the first Icon that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Icon.
+ * If no matching Icon is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {IconWrapper | null}
+ */
+findIcon(selector?: string): IconWrapper | null;
+
+/**
+ * Returns an array of Icon wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Icons inside the current wrapper.
+ * If no matching Icon is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<IconWrapper>}
+ */
+findAllIcons(selector?: string): Array<IconWrapper>;
+/**
+ * Returns the wrapper of the first Input that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Input.
+ * If no matching Input is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {InputWrapper | null}
+ */
+findInput(selector?: string): InputWrapper | null;
+
+/**
+ * Returns an array of Input wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Inputs inside the current wrapper.
+ * If no matching Input is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<InputWrapper>}
+ */
+findAllInputs(selector?: string): Array<InputWrapper>;
+/**
+ * Returns the wrapper of the first KeyValuePairs that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first KeyValuePairs.
+ * If no matching KeyValuePairs is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {KeyValuePairsWrapper | null}
+ */
+findKeyValuePairs(selector?: string): KeyValuePairsWrapper | null;
+
+/**
+ * Returns an array of KeyValuePairs wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the KeyValuePairs inside the current wrapper.
+ * If no matching KeyValuePairs is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<KeyValuePairsWrapper>}
+ */
+findAllKeyValuePairs(selector?: string): Array<KeyValuePairsWrapper>;
+/**
+ * Returns the wrapper of the first LineChart that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first LineChart.
+ * If no matching LineChart is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {LineChartWrapper | null}
+ */
+findLineChart(selector?: string): LineChartWrapper | null;
+
+/**
+ * Returns an array of LineChart wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the LineCharts inside the current wrapper.
+ * If no matching LineChart is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<LineChartWrapper>}
+ */
+findAllLineCharts(selector?: string): Array<LineChartWrapper>;
+/**
+ * Returns the wrapper of the first Link that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Link.
+ * If no matching Link is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {LinkWrapper | null}
+ */
+findLink(selector?: string): LinkWrapper | null;
+
+/**
+ * Returns an array of Link wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Links inside the current wrapper.
+ * If no matching Link is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<LinkWrapper>}
+ */
+findAllLinks(selector?: string): Array<LinkWrapper>;
+/**
+ * Returns the wrapper of the first LiveRegion that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first LiveRegion.
+ * If no matching LiveRegion is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {LiveRegionWrapper | null}
+ */
+findLiveRegion(selector?: string): LiveRegionWrapper | null;
+
+/**
+ * Returns an array of LiveRegion wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the LiveRegions inside the current wrapper.
+ * If no matching LiveRegion is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<LiveRegionWrapper>}
+ */
+findAllLiveRegions(selector?: string): Array<LiveRegionWrapper>;
+/**
+ * Returns the wrapper of the first MixedLineBarChart that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first MixedLineBarChart.
+ * If no matching MixedLineBarChart is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MixedLineBarChartWrapper | null}
+ */
+findMixedLineBarChart(selector?: string): MixedLineBarChartWrapper | null;
+
+/**
+ * Returns an array of MixedLineBarChart wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the MixedLineBarCharts inside the current wrapper.
+ * If no matching MixedLineBarChart is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<MixedLineBarChartWrapper>}
+ */
+findAllMixedLineBarCharts(selector?: string): Array<MixedLineBarChartWrapper>;
+/**
+ * Returns the wrapper of the first Modal that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Modal.
+ * If no matching Modal is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ModalWrapper | null}
+ */
+findModal(selector?: string): ModalWrapper | null;
+
+/**
+ * Returns an array of Modal wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Modals inside the current wrapper.
+ * If no matching Modal is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<ModalWrapper>}
+ */
+findAllModals(selector?: string): Array<ModalWrapper>;
+/**
+ * Returns the wrapper of the first Multiselect that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Multiselect.
+ * If no matching Multiselect is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiselectWrapper | null}
+ */
+findMultiselect(selector?: string): MultiselectWrapper | null;
+
+/**
+ * Returns an array of Multiselect wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Multiselects inside the current wrapper.
+ * If no matching Multiselect is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<MultiselectWrapper>}
+ */
+findAllMultiselects(selector?: string): Array<MultiselectWrapper>;
+/**
+ * Returns the wrapper of the first Pagination that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Pagination.
+ * If no matching Pagination is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {PaginationWrapper | null}
+ */
+findPagination(selector?: string): PaginationWrapper | null;
+
+/**
+ * Returns an array of Pagination wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Paginations inside the current wrapper.
+ * If no matching Pagination is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<PaginationWrapper>}
+ */
+findAllPaginations(selector?: string): Array<PaginationWrapper>;
+/**
+ * Returns the wrapper of the first PieChart that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first PieChart.
+ * If no matching PieChart is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {PieChartWrapper | null}
+ */
+findPieChart(selector?: string): PieChartWrapper | null;
+
+/**
+ * Returns an array of PieChart wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the PieCharts inside the current wrapper.
+ * If no matching PieChart is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<PieChartWrapper>}
+ */
+findAllPieCharts(selector?: string): Array<PieChartWrapper>;
+/**
+ * Returns the wrapper of the first Popover that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Popover.
+ * If no matching Popover is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {PopoverWrapper | null}
+ */
+findPopover(selector?: string): PopoverWrapper | null;
+
+/**
+ * Returns an array of Popover wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Popovers inside the current wrapper.
+ * If no matching Popover is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<PopoverWrapper>}
+ */
+findAllPopovers(selector?: string): Array<PopoverWrapper>;
+/**
+ * Returns the wrapper of the first ProgressBar that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first ProgressBar.
+ * If no matching ProgressBar is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ProgressBarWrapper | null}
+ */
+findProgressBar(selector?: string): ProgressBarWrapper | null;
+
+/**
+ * Returns an array of ProgressBar wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the ProgressBars inside the current wrapper.
+ * If no matching ProgressBar is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<ProgressBarWrapper>}
+ */
+findAllProgressBars(selector?: string): Array<ProgressBarWrapper>;
+/**
+ * Returns the wrapper of the first PromptInput that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first PromptInput.
+ * If no matching PromptInput is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {PromptInputWrapper | null}
+ */
+findPromptInput(selector?: string): PromptInputWrapper | null;
+
+/**
+ * Returns an array of PromptInput wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the PromptInputs inside the current wrapper.
+ * If no matching PromptInput is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<PromptInputWrapper>}
+ */
+findAllPromptInputs(selector?: string): Array<PromptInputWrapper>;
+/**
+ * Returns the wrapper of the first PropertyFilter that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first PropertyFilter.
+ * If no matching PropertyFilter is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {PropertyFilterWrapper | null}
+ */
+findPropertyFilter(selector?: string): PropertyFilterWrapper | null;
+
+/**
+ * Returns an array of PropertyFilter wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the PropertyFilters inside the current wrapper.
+ * If no matching PropertyFilter is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<PropertyFilterWrapper>}
+ */
+findAllPropertyFilters(selector?: string): Array<PropertyFilterWrapper>;
+/**
+ * Returns the wrapper of the first RadioGroup that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first RadioGroup.
+ * If no matching RadioGroup is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {RadioGroupWrapper | null}
+ */
+findRadioGroup(selector?: string): RadioGroupWrapper | null;
+
+/**
+ * Returns an array of RadioGroup wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the RadioGroups inside the current wrapper.
+ * If no matching RadioGroup is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<RadioGroupWrapper>}
+ */
+findAllRadioGroups(selector?: string): Array<RadioGroupWrapper>;
+/**
+ * Returns the wrapper of the first S3ResourceSelector that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first S3ResourceSelector.
+ * If no matching S3ResourceSelector is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {S3ResourceSelectorWrapper | null}
+ */
+findS3ResourceSelector(selector?: string): S3ResourceSelectorWrapper | null;
+
+/**
+ * Returns an array of S3ResourceSelector wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the S3ResourceSelectors inside the current wrapper.
+ * If no matching S3ResourceSelector is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<S3ResourceSelectorWrapper>}
+ */
+findAllS3ResourceSelectors(selector?: string): Array<S3ResourceSelectorWrapper>;
+/**
+ * Returns the wrapper of the first SegmentedControl that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first SegmentedControl.
+ * If no matching SegmentedControl is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {SegmentedControlWrapper | null}
+ */
+findSegmentedControl(selector?: string): SegmentedControlWrapper | null;
+
+/**
+ * Returns an array of SegmentedControl wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the SegmentedControls inside the current wrapper.
+ * If no matching SegmentedControl is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<SegmentedControlWrapper>}
+ */
+findAllSegmentedControls(selector?: string): Array<SegmentedControlWrapper>;
+/**
+ * Returns the wrapper of the first Select that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Select.
+ * If no matching Select is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {SelectWrapper | null}
+ */
+findSelect(selector?: string): SelectWrapper | null;
+
+/**
+ * Returns an array of Select wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Selects inside the current wrapper.
+ * If no matching Select is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<SelectWrapper>}
+ */
+findAllSelects(selector?: string): Array<SelectWrapper>;
+/**
+ * Returns the wrapper of the first SideNavigation that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first SideNavigation.
+ * If no matching SideNavigation is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {SideNavigationWrapper | null}
+ */
+findSideNavigation(selector?: string): SideNavigationWrapper | null;
+
+/**
+ * Returns an array of SideNavigation wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the SideNavigations inside the current wrapper.
+ * If no matching SideNavigation is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<SideNavigationWrapper>}
+ */
+findAllSideNavigations(selector?: string): Array<SideNavigationWrapper>;
+/**
+ * Returns the wrapper of the first Slider that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Slider.
+ * If no matching Slider is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {SliderWrapper | null}
+ */
+findSlider(selector?: string): SliderWrapper | null;
+
+/**
+ * Returns an array of Slider wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Sliders inside the current wrapper.
+ * If no matching Slider is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<SliderWrapper>}
+ */
+findAllSliders(selector?: string): Array<SliderWrapper>;
+/**
+ * Returns the wrapper of the first SpaceBetween that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first SpaceBetween.
+ * If no matching SpaceBetween is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {SpaceBetweenWrapper | null}
+ */
+findSpaceBetween(selector?: string): SpaceBetweenWrapper | null;
+
+/**
+ * Returns an array of SpaceBetween wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the SpaceBetweens inside the current wrapper.
+ * If no matching SpaceBetween is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<SpaceBetweenWrapper>}
+ */
+findAllSpaceBetweens(selector?: string): Array<SpaceBetweenWrapper>;
+/**
+ * Returns the wrapper of the first Spinner that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Spinner.
+ * If no matching Spinner is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {SpinnerWrapper | null}
+ */
+findSpinner(selector?: string): SpinnerWrapper | null;
+
+/**
+ * Returns an array of Spinner wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Spinners inside the current wrapper.
+ * If no matching Spinner is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<SpinnerWrapper>}
+ */
+findAllSpinners(selector?: string): Array<SpinnerWrapper>;
+/**
+ * Returns the wrapper of the first SplitPanel that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first SplitPanel.
+ * If no matching SplitPanel is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {SplitPanelWrapper | null}
+ */
+findSplitPanel(selector?: string): SplitPanelWrapper | null;
+
+/**
+ * Returns an array of SplitPanel wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the SplitPanels inside the current wrapper.
+ * If no matching SplitPanel is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<SplitPanelWrapper>}
+ */
+findAllSplitPanels(selector?: string): Array<SplitPanelWrapper>;
+/**
+ * Returns the wrapper of the first StatusIndicator that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first StatusIndicator.
+ * If no matching StatusIndicator is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {StatusIndicatorWrapper | null}
+ */
+findStatusIndicator(selector?: string): StatusIndicatorWrapper | null;
+
+/**
+ * Returns an array of StatusIndicator wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the StatusIndicators inside the current wrapper.
+ * If no matching StatusIndicator is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<StatusIndicatorWrapper>}
+ */
+findAllStatusIndicators(selector?: string): Array<StatusIndicatorWrapper>;
+/**
+ * Returns the wrapper of the first Steps that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Steps.
+ * If no matching Steps is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {StepsWrapper | null}
+ */
+findSteps(selector?: string): StepsWrapper | null;
+
+/**
+ * Returns an array of Steps wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Steps inside the current wrapper.
+ * If no matching Steps is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<StepsWrapper>}
+ */
+findAllSteps(selector?: string): Array<StepsWrapper>;
+/**
+ * Returns the wrapper of the first Table that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Table.
+ * If no matching Table is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TableWrapper | null}
+ */
+findTable(selector?: string): TableWrapper | null;
+
+/**
+ * Returns an array of Table wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Tables inside the current wrapper.
+ * If no matching Table is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<TableWrapper>}
+ */
+findAllTables(selector?: string): Array<TableWrapper>;
+/**
+ * Returns the wrapper of the first Tabs that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Tabs.
+ * If no matching Tabs is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TabsWrapper | null}
+ */
+findTabs(selector?: string): TabsWrapper | null;
+
+/**
+ * Returns an array of Tabs wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Tabs inside the current wrapper.
+ * If no matching Tabs is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<TabsWrapper>}
+ */
+findAllTabs(selector?: string): Array<TabsWrapper>;
+/**
+ * Returns the wrapper of the first TagEditor that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first TagEditor.
+ * If no matching TagEditor is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TagEditorWrapper | null}
+ */
+findTagEditor(selector?: string): TagEditorWrapper | null;
+
+/**
+ * Returns an array of TagEditor wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the TagEditors inside the current wrapper.
+ * If no matching TagEditor is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<TagEditorWrapper>}
+ */
+findAllTagEditors(selector?: string): Array<TagEditorWrapper>;
+/**
+ * Returns the wrapper of the first TextContent that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first TextContent.
+ * If no matching TextContent is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TextContentWrapper | null}
+ */
+findTextContent(selector?: string): TextContentWrapper | null;
+
+/**
+ * Returns an array of TextContent wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the TextContents inside the current wrapper.
+ * If no matching TextContent is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<TextContentWrapper>}
+ */
+findAllTextContents(selector?: string): Array<TextContentWrapper>;
+/**
+ * Returns the wrapper of the first TextFilter that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first TextFilter.
+ * If no matching TextFilter is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TextFilterWrapper | null}
+ */
+findTextFilter(selector?: string): TextFilterWrapper | null;
+
+/**
+ * Returns an array of TextFilter wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the TextFilters inside the current wrapper.
+ * If no matching TextFilter is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<TextFilterWrapper>}
+ */
+findAllTextFilters(selector?: string): Array<TextFilterWrapper>;
+/**
+ * Returns the wrapper of the first Textarea that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Textarea.
+ * If no matching Textarea is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TextareaWrapper | null}
+ */
+findTextarea(selector?: string): TextareaWrapper | null;
+
+/**
+ * Returns an array of Textarea wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Textareas inside the current wrapper.
+ * If no matching Textarea is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<TextareaWrapper>}
+ */
+findAllTextareas(selector?: string): Array<TextareaWrapper>;
+/**
+ * Returns the wrapper of the first Tiles that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Tiles.
+ * If no matching Tiles is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TilesWrapper | null}
+ */
+findTiles(selector?: string): TilesWrapper | null;
+
+/**
+ * Returns an array of Tiles wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Tiles inside the current wrapper.
+ * If no matching Tiles is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<TilesWrapper>}
+ */
+findAllTiles(selector?: string): Array<TilesWrapper>;
+/**
+ * Returns the wrapper of the first TimeInput that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first TimeInput.
+ * If no matching TimeInput is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TimeInputWrapper | null}
+ */
+findTimeInput(selector?: string): TimeInputWrapper | null;
+
+/**
+ * Returns an array of TimeInput wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the TimeInputs inside the current wrapper.
+ * If no matching TimeInput is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<TimeInputWrapper>}
+ */
+findAllTimeInputs(selector?: string): Array<TimeInputWrapper>;
+/**
+ * Returns the wrapper of the first Toggle that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Toggle.
+ * If no matching Toggle is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ToggleWrapper | null}
+ */
+findToggle(selector?: string): ToggleWrapper | null;
+
+/**
+ * Returns an array of Toggle wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Toggles inside the current wrapper.
+ * If no matching Toggle is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<ToggleWrapper>}
+ */
+findAllToggles(selector?: string): Array<ToggleWrapper>;
+/**
+ * Returns the wrapper of the first ToggleButton that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first ToggleButton.
+ * If no matching ToggleButton is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ToggleButtonWrapper | null}
+ */
+findToggleButton(selector?: string): ToggleButtonWrapper | null;
+
+/**
+ * Returns an array of ToggleButton wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the ToggleButtons inside the current wrapper.
+ * If no matching ToggleButton is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<ToggleButtonWrapper>}
+ */
+findAllToggleButtons(selector?: string): Array<ToggleButtonWrapper>;
+/**
+ * Returns the wrapper of the first TokenGroup that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first TokenGroup.
+ * If no matching TokenGroup is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TokenGroupWrapper | null}
+ */
+findTokenGroup(selector?: string): TokenGroupWrapper | null;
+
+/**
+ * Returns an array of TokenGroup wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the TokenGroups inside the current wrapper.
+ * If no matching TokenGroup is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<TokenGroupWrapper>}
+ */
+findAllTokenGroups(selector?: string): Array<TokenGroupWrapper>;
+/**
+ * Returns the wrapper of the first TopNavigation that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first TopNavigation.
+ * If no matching TopNavigation is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TopNavigationWrapper | null}
+ */
+findTopNavigation(selector?: string): TopNavigationWrapper | null;
+
+/**
+ * Returns an array of TopNavigation wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the TopNavigations inside the current wrapper.
+ * If no matching TopNavigation is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<TopNavigationWrapper>}
+ */
+findAllTopNavigations(selector?: string): Array<TopNavigationWrapper>;
+/**
+ * Returns the wrapper of the first TutorialPanel that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first TutorialPanel.
+ * If no matching TutorialPanel is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TutorialPanelWrapper | null}
+ */
+findTutorialPanel(selector?: string): TutorialPanelWrapper | null;
+
+/**
+ * Returns an array of TutorialPanel wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the TutorialPanels inside the current wrapper.
+ * If no matching TutorialPanel is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<TutorialPanelWrapper>}
+ */
+findAllTutorialPanels(selector?: string): Array<TutorialPanelWrapper>;
+/**
+ * Returns the wrapper of the first Wizard that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first Wizard.
+ * If no matching Wizard is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {WizardWrapper | null}
+ */
+findWizard(selector?: string): WizardWrapper | null;
+
+/**
+ * Returns an array of Wizard wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the Wizards inside the current wrapper.
+ * If no matching Wizard is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<WizardWrapper>}
+ */
+findAllWizards(selector?: string): Array<WizardWrapper>;
+   }
+}
+
+
+ElementWrapper.prototype.findAlert = function(selector) {
+  const rootSelector = \`.\${AlertWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AlertWrapper);
+};
+
+ElementWrapper.prototype.findAllAlerts = function(selector) {
+  return this.findAllComponents(AlertWrapper, selector);
+};
+ElementWrapper.prototype.findAnchorNavigation = function(selector) {
+  const rootSelector = \`.\${AnchorNavigationWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AnchorNavigationWrapper);
+};
+
+ElementWrapper.prototype.findAllAnchorNavigations = function(selector) {
+  return this.findAllComponents(AnchorNavigationWrapper, selector);
+};
+ElementWrapper.prototype.findAnnotation = function(selector) {
+  const rootSelector = \`.\${AnnotationWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AnnotationWrapper);
+};
+
+ElementWrapper.prototype.findAllAnnotations = function(selector) {
+  return this.findAllComponents(AnnotationWrapper, selector);
+};
+ElementWrapper.prototype.findAppLayout = function(selector) {
+  const rootSelector = \`.\${AppLayoutWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AppLayoutWrapper);
+};
+
+ElementWrapper.prototype.findAllAppLayouts = function(selector) {
+  return this.findAllComponents(AppLayoutWrapper, selector);
+};
+ElementWrapper.prototype.findAreaChart = function(selector) {
+  const rootSelector = \`.\${AreaChartWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AreaChartWrapper);
+};
+
+ElementWrapper.prototype.findAllAreaCharts = function(selector) {
+  return this.findAllComponents(AreaChartWrapper, selector);
+};
+ElementWrapper.prototype.findAttributeEditor = function(selector) {
+  const rootSelector = \`.\${AttributeEditorWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AttributeEditorWrapper);
+};
+
+ElementWrapper.prototype.findAllAttributeEditors = function(selector) {
+  return this.findAllComponents(AttributeEditorWrapper, selector);
+};
+ElementWrapper.prototype.findAutosuggest = function(selector) {
+  const rootSelector = \`.\${AutosuggestWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AutosuggestWrapper);
+};
+
+ElementWrapper.prototype.findAllAutosuggests = function(selector) {
+  return this.findAllComponents(AutosuggestWrapper, selector);
+};
+ElementWrapper.prototype.findBadge = function(selector) {
+  const rootSelector = \`.\${BadgeWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BadgeWrapper);
+};
+
+ElementWrapper.prototype.findAllBadges = function(selector) {
+  return this.findAllComponents(BadgeWrapper, selector);
+};
+ElementWrapper.prototype.findBarChart = function(selector) {
+  const rootSelector = \`.\${BarChartWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BarChartWrapper);
+};
+
+ElementWrapper.prototype.findAllBarCharts = function(selector) {
+  return this.findAllComponents(BarChartWrapper, selector);
+};
+ElementWrapper.prototype.findBox = function(selector) {
+  const rootSelector = \`.\${BoxWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BoxWrapper);
+};
+
+ElementWrapper.prototype.findAllBoxes = function(selector) {
+  return this.findAllComponents(BoxWrapper, selector);
+};
+ElementWrapper.prototype.findBreadcrumbGroup = function(selector) {
+  const rootSelector = \`.\${BreadcrumbGroupWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BreadcrumbGroupWrapper);
+};
+
+ElementWrapper.prototype.findAllBreadcrumbGroups = function(selector) {
+  return this.findAllComponents(BreadcrumbGroupWrapper, selector);
+};
+ElementWrapper.prototype.findButton = function(selector) {
+  const rootSelector = \`.\${ButtonWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ButtonWrapper);
+};
+
+ElementWrapper.prototype.findAllButtons = function(selector) {
+  return this.findAllComponents(ButtonWrapper, selector);
+};
+ElementWrapper.prototype.findButtonDropdown = function(selector) {
+  const rootSelector = \`.\${ButtonDropdownWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ButtonDropdownWrapper);
+};
+
+ElementWrapper.prototype.findAllButtonDropdowns = function(selector) {
+  return this.findAllComponents(ButtonDropdownWrapper, selector);
+};
+ElementWrapper.prototype.findButtonGroup = function(selector) {
+  const rootSelector = \`.\${ButtonGroupWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ButtonGroupWrapper);
+};
+
+ElementWrapper.prototype.findAllButtonGroups = function(selector) {
+  return this.findAllComponents(ButtonGroupWrapper, selector);
+};
+ElementWrapper.prototype.findCalendar = function(selector) {
+  const rootSelector = \`.\${CalendarWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CalendarWrapper);
+};
+
+ElementWrapper.prototype.findAllCalendars = function(selector) {
+  return this.findAllComponents(CalendarWrapper, selector);
+};
+ElementWrapper.prototype.findCards = function(selector) {
+  const rootSelector = \`.\${CardsWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CardsWrapper);
+};
+
+ElementWrapper.prototype.findAllCards = function(selector) {
+  return this.findAllComponents(CardsWrapper, selector);
+};
+ElementWrapper.prototype.findCheckbox = function(selector) {
+  const rootSelector = \`.\${CheckboxWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CheckboxWrapper);
+};
+
+ElementWrapper.prototype.findAllCheckboxes = function(selector) {
+  return this.findAllComponents(CheckboxWrapper, selector);
+};
+ElementWrapper.prototype.findCodeEditor = function(selector) {
+  const rootSelector = \`.\${CodeEditorWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CodeEditorWrapper);
+};
+
+ElementWrapper.prototype.findAllCodeEditors = function(selector) {
+  return this.findAllComponents(CodeEditorWrapper, selector);
+};
+ElementWrapper.prototype.findCollectionPreferences = function(selector) {
+  const rootSelector = \`.\${CollectionPreferencesWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CollectionPreferencesWrapper);
+};
+
+ElementWrapper.prototype.findAllCollectionPreferences = function(selector) {
+  return this.findAllComponents(CollectionPreferencesWrapper, selector);
+};
+ElementWrapper.prototype.findColumnLayout = function(selector) {
+  const rootSelector = \`.\${ColumnLayoutWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ColumnLayoutWrapper);
+};
+
+ElementWrapper.prototype.findAllColumnLayouts = function(selector) {
+  return this.findAllComponents(ColumnLayoutWrapper, selector);
+};
+ElementWrapper.prototype.findContainer = function(selector) {
+  const rootSelector = \`.\${ContainerWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ContainerWrapper);
+};
+
+ElementWrapper.prototype.findAllContainers = function(selector) {
+  return this.findAllComponents(ContainerWrapper, selector);
+};
+ElementWrapper.prototype.findContentLayout = function(selector) {
+  const rootSelector = \`.\${ContentLayoutWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ContentLayoutWrapper);
+};
+
+ElementWrapper.prototype.findAllContentLayouts = function(selector) {
+  return this.findAllComponents(ContentLayoutWrapper, selector);
+};
+ElementWrapper.prototype.findCopyToClipboard = function(selector) {
+  const rootSelector = \`.\${CopyToClipboardWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CopyToClipboardWrapper);
+};
+
+ElementWrapper.prototype.findAllCopyToClipboards = function(selector) {
+  return this.findAllComponents(CopyToClipboardWrapper, selector);
+};
+ElementWrapper.prototype.findDateInput = function(selector) {
+  const rootSelector = \`.\${DateInputWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DateInputWrapper);
+};
+
+ElementWrapper.prototype.findAllDateInputs = function(selector) {
+  return this.findAllComponents(DateInputWrapper, selector);
+};
+ElementWrapper.prototype.findDatePicker = function(selector) {
+  const rootSelector = \`.\${DatePickerWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DatePickerWrapper);
+};
+
+ElementWrapper.prototype.findAllDatePickers = function(selector) {
+  return this.findAllComponents(DatePickerWrapper, selector);
+};
+ElementWrapper.prototype.findDateRangePicker = function(selector) {
+  const rootSelector = \`.\${DateRangePickerWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DateRangePickerWrapper);
+};
+
+ElementWrapper.prototype.findAllDateRangePickers = function(selector) {
+  return this.findAllComponents(DateRangePickerWrapper, selector);
+};
+ElementWrapper.prototype.findDrawer = function(selector) {
+  const rootSelector = \`.\${DrawerWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DrawerWrapper);
+};
+
+ElementWrapper.prototype.findAllDrawers = function(selector) {
+  return this.findAllComponents(DrawerWrapper, selector);
+};
+ElementWrapper.prototype.findExpandableSection = function(selector) {
+  const rootSelector = \`.\${ExpandableSectionWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ExpandableSectionWrapper);
+};
+
+ElementWrapper.prototype.findAllExpandableSections = function(selector) {
+  return this.findAllComponents(ExpandableSectionWrapper, selector);
+};
+ElementWrapper.prototype.findFileDropzone = function(selector) {
+  const rootSelector = \`.\${FileDropzoneWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileDropzoneWrapper);
+};
+
+ElementWrapper.prototype.findAllFileDropzones = function(selector) {
+  return this.findAllComponents(FileDropzoneWrapper, selector);
+};
+ElementWrapper.prototype.findFileInput = function(selector) {
+  const rootSelector = \`.\${FileInputWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileInputWrapper);
+};
+
+ElementWrapper.prototype.findAllFileInputs = function(selector) {
+  return this.findAllComponents(FileInputWrapper, selector);
+};
+ElementWrapper.prototype.findFileTokenGroup = function(selector) {
+  const rootSelector = \`.\${FileTokenGroupWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileTokenGroupWrapper);
+};
+
+ElementWrapper.prototype.findAllFileTokenGroups = function(selector) {
+  return this.findAllComponents(FileTokenGroupWrapper, selector);
+};
+ElementWrapper.prototype.findFileUpload = function(selector) {
+  const rootSelector = \`.\${FileUploadWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileUploadWrapper);
+};
+
+ElementWrapper.prototype.findAllFileUploads = function(selector) {
+  return this.findAllComponents(FileUploadWrapper, selector);
+};
+ElementWrapper.prototype.findFlashbar = function(selector) {
+  const rootSelector = \`.\${FlashbarWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FlashbarWrapper);
+};
+
+ElementWrapper.prototype.findAllFlashbars = function(selector) {
+  return this.findAllComponents(FlashbarWrapper, selector);
+};
+ElementWrapper.prototype.findForm = function(selector) {
+  const rootSelector = \`.\${FormWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FormWrapper);
+};
+
+ElementWrapper.prototype.findAllForms = function(selector) {
+  return this.findAllComponents(FormWrapper, selector);
+};
+ElementWrapper.prototype.findFormField = function(selector) {
+  const rootSelector = \`.\${FormFieldWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FormFieldWrapper);
+};
+
+ElementWrapper.prototype.findAllFormFields = function(selector) {
+  return this.findAllComponents(FormFieldWrapper, selector);
+};
+ElementWrapper.prototype.findGrid = function(selector) {
+  const rootSelector = \`.\${GridWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, GridWrapper);
+};
+
+ElementWrapper.prototype.findAllGrids = function(selector) {
+  return this.findAllComponents(GridWrapper, selector);
+};
+ElementWrapper.prototype.findHeader = function(selector) {
+  const rootSelector = \`.\${HeaderWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, HeaderWrapper);
+};
+
+ElementWrapper.prototype.findAllHeaders = function(selector) {
+  return this.findAllComponents(HeaderWrapper, selector);
+};
+ElementWrapper.prototype.findHelpPanel = function(selector) {
+  const rootSelector = \`.\${HelpPanelWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, HelpPanelWrapper);
+};
+
+ElementWrapper.prototype.findAllHelpPanels = function(selector) {
+  return this.findAllComponents(HelpPanelWrapper, selector);
+};
+ElementWrapper.prototype.findHotspot = function(selector) {
+  const rootSelector = \`.\${HotspotWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, HotspotWrapper);
+};
+
+ElementWrapper.prototype.findAllHotspots = function(selector) {
+  return this.findAllComponents(HotspotWrapper, selector);
+};
+ElementWrapper.prototype.findIcon = function(selector) {
+  const rootSelector = \`.\${IconWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, IconWrapper);
+};
+
+ElementWrapper.prototype.findAllIcons = function(selector) {
+  return this.findAllComponents(IconWrapper, selector);
+};
+ElementWrapper.prototype.findInput = function(selector) {
+  const rootSelector = \`.\${InputWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, InputWrapper);
+};
+
+ElementWrapper.prototype.findAllInputs = function(selector) {
+  return this.findAllComponents(InputWrapper, selector);
+};
+ElementWrapper.prototype.findKeyValuePairs = function(selector) {
+  const rootSelector = \`.\${KeyValuePairsWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, KeyValuePairsWrapper);
+};
+
+ElementWrapper.prototype.findAllKeyValuePairs = function(selector) {
+  return this.findAllComponents(KeyValuePairsWrapper, selector);
+};
+ElementWrapper.prototype.findLineChart = function(selector) {
+  const rootSelector = \`.\${LineChartWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, LineChartWrapper);
+};
+
+ElementWrapper.prototype.findAllLineCharts = function(selector) {
+  return this.findAllComponents(LineChartWrapper, selector);
+};
+ElementWrapper.prototype.findLink = function(selector) {
+  const rootSelector = \`.\${LinkWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, LinkWrapper);
+};
+
+ElementWrapper.prototype.findAllLinks = function(selector) {
+  return this.findAllComponents(LinkWrapper, selector);
+};
+ElementWrapper.prototype.findLiveRegion = function(selector) {
+  const rootSelector = \`.\${LiveRegionWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, LiveRegionWrapper);
+};
+
+ElementWrapper.prototype.findAllLiveRegions = function(selector) {
+  return this.findAllComponents(LiveRegionWrapper, selector);
+};
+ElementWrapper.prototype.findMixedLineBarChart = function(selector) {
+  const rootSelector = \`.\${MixedLineBarChartWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, MixedLineBarChartWrapper);
+};
+
+ElementWrapper.prototype.findAllMixedLineBarCharts = function(selector) {
+  return this.findAllComponents(MixedLineBarChartWrapper, selector);
+};
+ElementWrapper.prototype.findModal = function(selector) {
+  const rootSelector = \`.\${ModalWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ModalWrapper);
+};
+
+ElementWrapper.prototype.findAllModals = function(selector) {
+  return this.findAllComponents(ModalWrapper, selector);
+};
+ElementWrapper.prototype.findMultiselect = function(selector) {
+  const rootSelector = \`.\${MultiselectWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, MultiselectWrapper);
+};
+
+ElementWrapper.prototype.findAllMultiselects = function(selector) {
+  return this.findAllComponents(MultiselectWrapper, selector);
+};
+ElementWrapper.prototype.findPagination = function(selector) {
+  const rootSelector = \`.\${PaginationWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PaginationWrapper);
+};
+
+ElementWrapper.prototype.findAllPaginations = function(selector) {
+  return this.findAllComponents(PaginationWrapper, selector);
+};
+ElementWrapper.prototype.findPieChart = function(selector) {
+  const rootSelector = \`.\${PieChartWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PieChartWrapper);
+};
+
+ElementWrapper.prototype.findAllPieCharts = function(selector) {
+  return this.findAllComponents(PieChartWrapper, selector);
+};
+ElementWrapper.prototype.findPopover = function(selector) {
+  const rootSelector = \`.\${PopoverWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PopoverWrapper);
+};
+
+ElementWrapper.prototype.findAllPopovers = function(selector) {
+  return this.findAllComponents(PopoverWrapper, selector);
+};
+ElementWrapper.prototype.findProgressBar = function(selector) {
+  const rootSelector = \`.\${ProgressBarWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ProgressBarWrapper);
+};
+
+ElementWrapper.prototype.findAllProgressBars = function(selector) {
+  return this.findAllComponents(ProgressBarWrapper, selector);
+};
+ElementWrapper.prototype.findPromptInput = function(selector) {
+  const rootSelector = \`.\${PromptInputWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PromptInputWrapper);
+};
+
+ElementWrapper.prototype.findAllPromptInputs = function(selector) {
+  return this.findAllComponents(PromptInputWrapper, selector);
+};
+ElementWrapper.prototype.findPropertyFilter = function(selector) {
+  const rootSelector = \`.\${PropertyFilterWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PropertyFilterWrapper);
+};
+
+ElementWrapper.prototype.findAllPropertyFilters = function(selector) {
+  return this.findAllComponents(PropertyFilterWrapper, selector);
+};
+ElementWrapper.prototype.findRadioGroup = function(selector) {
+  const rootSelector = \`.\${RadioGroupWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, RadioGroupWrapper);
+};
+
+ElementWrapper.prototype.findAllRadioGroups = function(selector) {
+  return this.findAllComponents(RadioGroupWrapper, selector);
+};
+ElementWrapper.prototype.findS3ResourceSelector = function(selector) {
+  const rootSelector = \`.\${S3ResourceSelectorWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, S3ResourceSelectorWrapper);
+};
+
+ElementWrapper.prototype.findAllS3ResourceSelectors = function(selector) {
+  return this.findAllComponents(S3ResourceSelectorWrapper, selector);
+};
+ElementWrapper.prototype.findSegmentedControl = function(selector) {
+  const rootSelector = \`.\${SegmentedControlWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SegmentedControlWrapper);
+};
+
+ElementWrapper.prototype.findAllSegmentedControls = function(selector) {
+  return this.findAllComponents(SegmentedControlWrapper, selector);
+};
+ElementWrapper.prototype.findSelect = function(selector) {
+  const rootSelector = \`.\${SelectWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SelectWrapper);
+};
+
+ElementWrapper.prototype.findAllSelects = function(selector) {
+  return this.findAllComponents(SelectWrapper, selector);
+};
+ElementWrapper.prototype.findSideNavigation = function(selector) {
+  const rootSelector = \`.\${SideNavigationWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SideNavigationWrapper);
+};
+
+ElementWrapper.prototype.findAllSideNavigations = function(selector) {
+  return this.findAllComponents(SideNavigationWrapper, selector);
+};
+ElementWrapper.prototype.findSlider = function(selector) {
+  const rootSelector = \`.\${SliderWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SliderWrapper);
+};
+
+ElementWrapper.prototype.findAllSliders = function(selector) {
+  return this.findAllComponents(SliderWrapper, selector);
+};
+ElementWrapper.prototype.findSpaceBetween = function(selector) {
+  const rootSelector = \`.\${SpaceBetweenWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SpaceBetweenWrapper);
+};
+
+ElementWrapper.prototype.findAllSpaceBetweens = function(selector) {
+  return this.findAllComponents(SpaceBetweenWrapper, selector);
+};
+ElementWrapper.prototype.findSpinner = function(selector) {
+  const rootSelector = \`.\${SpinnerWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SpinnerWrapper);
+};
+
+ElementWrapper.prototype.findAllSpinners = function(selector) {
+  return this.findAllComponents(SpinnerWrapper, selector);
+};
+ElementWrapper.prototype.findSplitPanel = function(selector) {
+  const rootSelector = \`.\${SplitPanelWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SplitPanelWrapper);
+};
+
+ElementWrapper.prototype.findAllSplitPanels = function(selector) {
+  return this.findAllComponents(SplitPanelWrapper, selector);
+};
+ElementWrapper.prototype.findStatusIndicator = function(selector) {
+  const rootSelector = \`.\${StatusIndicatorWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, StatusIndicatorWrapper);
+};
+
+ElementWrapper.prototype.findAllStatusIndicators = function(selector) {
+  return this.findAllComponents(StatusIndicatorWrapper, selector);
+};
+ElementWrapper.prototype.findSteps = function(selector) {
+  const rootSelector = \`.\${StepsWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, StepsWrapper);
+};
+
+ElementWrapper.prototype.findAllSteps = function(selector) {
+  return this.findAllComponents(StepsWrapper, selector);
+};
+ElementWrapper.prototype.findTable = function(selector) {
+  const rootSelector = \`.\${TableWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TableWrapper);
+};
+
+ElementWrapper.prototype.findAllTables = function(selector) {
+  return this.findAllComponents(TableWrapper, selector);
+};
+ElementWrapper.prototype.findTabs = function(selector) {
+  const rootSelector = \`.\${TabsWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TabsWrapper);
+};
+
+ElementWrapper.prototype.findAllTabs = function(selector) {
+  return this.findAllComponents(TabsWrapper, selector);
+};
+ElementWrapper.prototype.findTagEditor = function(selector) {
+  const rootSelector = \`.\${TagEditorWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TagEditorWrapper);
+};
+
+ElementWrapper.prototype.findAllTagEditors = function(selector) {
+  return this.findAllComponents(TagEditorWrapper, selector);
+};
+ElementWrapper.prototype.findTextContent = function(selector) {
+  const rootSelector = \`.\${TextContentWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TextContentWrapper);
+};
+
+ElementWrapper.prototype.findAllTextContents = function(selector) {
+  return this.findAllComponents(TextContentWrapper, selector);
+};
+ElementWrapper.prototype.findTextFilter = function(selector) {
+  const rootSelector = \`.\${TextFilterWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TextFilterWrapper);
+};
+
+ElementWrapper.prototype.findAllTextFilters = function(selector) {
+  return this.findAllComponents(TextFilterWrapper, selector);
+};
+ElementWrapper.prototype.findTextarea = function(selector) {
+  const rootSelector = \`.\${TextareaWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TextareaWrapper);
+};
+
+ElementWrapper.prototype.findAllTextareas = function(selector) {
+  return this.findAllComponents(TextareaWrapper, selector);
+};
+ElementWrapper.prototype.findTiles = function(selector) {
+  const rootSelector = \`.\${TilesWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TilesWrapper);
+};
+
+ElementWrapper.prototype.findAllTiles = function(selector) {
+  return this.findAllComponents(TilesWrapper, selector);
+};
+ElementWrapper.prototype.findTimeInput = function(selector) {
+  const rootSelector = \`.\${TimeInputWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TimeInputWrapper);
+};
+
+ElementWrapper.prototype.findAllTimeInputs = function(selector) {
+  return this.findAllComponents(TimeInputWrapper, selector);
+};
+ElementWrapper.prototype.findToggle = function(selector) {
+  const rootSelector = \`.\${ToggleWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ToggleWrapper);
+};
+
+ElementWrapper.prototype.findAllToggles = function(selector) {
+  return this.findAllComponents(ToggleWrapper, selector);
+};
+ElementWrapper.prototype.findToggleButton = function(selector) {
+  const rootSelector = \`.\${ToggleButtonWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ToggleButtonWrapper);
+};
+
+ElementWrapper.prototype.findAllToggleButtons = function(selector) {
+  return this.findAllComponents(ToggleButtonWrapper, selector);
+};
+ElementWrapper.prototype.findTokenGroup = function(selector) {
+  const rootSelector = \`.\${TokenGroupWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TokenGroupWrapper);
+};
+
+ElementWrapper.prototype.findAllTokenGroups = function(selector) {
+  return this.findAllComponents(TokenGroupWrapper, selector);
+};
+ElementWrapper.prototype.findTopNavigation = function(selector) {
+  const rootSelector = \`.\${TopNavigationWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TopNavigationWrapper);
+};
+
+ElementWrapper.prototype.findAllTopNavigations = function(selector) {
+  return this.findAllComponents(TopNavigationWrapper, selector);
+};
+ElementWrapper.prototype.findTutorialPanel = function(selector) {
+  const rootSelector = \`.\${TutorialPanelWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TutorialPanelWrapper);
+};
+
+ElementWrapper.prototype.findAllTutorialPanels = function(selector) {
+  return this.findAllComponents(TutorialPanelWrapper, selector);
+};
+ElementWrapper.prototype.findWizard = function(selector) {
+  const rootSelector = \`.\${WizardWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, WizardWrapper);
+};
+
+ElementWrapper.prototype.findAllWizards = function(selector) {
+  return this.findAllComponents(WizardWrapper, selector);
+};
+
+
+export default function wrapper(root: Element = document.body) {
+  if (document && document.body && !document.body.contains(root)) {
+    console.warn('[AwsUi] [test-utils] provided element is not part of the document body, interactions may work incorrectly')
+  };
+  return new ElementWrapper(root);
+}
+"
 `;
 
 exports[`Generate test utils ElementWrapper selectors ElementWrapper matches the snapshot 1`] = `
-"import { ElementWrapper } from '@cloudscape-design/test-utils-core/selectors';
+"
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ElementWrapper } from '@cloudscape-design/test-utils-core/selectors';
 import { appendSelector } from '@cloudscape-design/test-utils-core/utils';
+
 export { ElementWrapper };
 
-        import AlertWrapper from './alert';
-        export { AlertWrapper };
-      
+import AlertWrapper from './alert';
+import AnchorNavigationWrapper from './anchor-navigation';
+import AnnotationWrapper from './annotation';
+import AppLayoutWrapper from './app-layout';
+import AreaChartWrapper from './area-chart';
+import AttributeEditorWrapper from './attribute-editor';
+import AutosuggestWrapper from './autosuggest';
+import BadgeWrapper from './badge';
+import BarChartWrapper from './bar-chart';
+import BoxWrapper from './box';
+import BreadcrumbGroupWrapper from './breadcrumb-group';
+import ButtonWrapper from './button';
+import ButtonDropdownWrapper from './button-dropdown';
+import ButtonGroupWrapper from './button-group';
+import CalendarWrapper from './calendar';
+import CardsWrapper from './cards';
+import CheckboxWrapper from './checkbox';
+import CodeEditorWrapper from './code-editor';
+import CollectionPreferencesWrapper from './collection-preferences';
+import ColumnLayoutWrapper from './column-layout';
+import ContainerWrapper from './container';
+import ContentLayoutWrapper from './content-layout';
+import CopyToClipboardWrapper from './copy-to-clipboard';
+import DateInputWrapper from './date-input';
+import DatePickerWrapper from './date-picker';
+import DateRangePickerWrapper from './date-range-picker';
+import DrawerWrapper from './drawer';
+import ExpandableSectionWrapper from './expandable-section';
+import FileDropzoneWrapper from './file-dropzone';
+import FileInputWrapper from './file-input';
+import FileTokenGroupWrapper from './file-token-group';
+import FileUploadWrapper from './file-upload';
+import FlashbarWrapper from './flashbar';
+import FormWrapper from './form';
+import FormFieldWrapper from './form-field';
+import GridWrapper from './grid';
+import HeaderWrapper from './header';
+import HelpPanelWrapper from './help-panel';
+import HotspotWrapper from './hotspot';
+import IconWrapper from './icon';
+import InputWrapper from './input';
+import KeyValuePairsWrapper from './key-value-pairs';
+import LineChartWrapper from './line-chart';
+import LinkWrapper from './link';
+import LiveRegionWrapper from './live-region';
+import MixedLineBarChartWrapper from './mixed-line-bar-chart';
+import ModalWrapper from './modal';
+import MultiselectWrapper from './multiselect';
+import PaginationWrapper from './pagination';
+import PieChartWrapper from './pie-chart';
+import PopoverWrapper from './popover';
+import ProgressBarWrapper from './progress-bar';
+import PromptInputWrapper from './prompt-input';
+import PropertyFilterWrapper from './property-filter';
+import RadioGroupWrapper from './radio-group';
+import S3ResourceSelectorWrapper from './s3-resource-selector';
+import SegmentedControlWrapper from './segmented-control';
+import SelectWrapper from './select';
+import SideNavigationWrapper from './side-navigation';
+import SliderWrapper from './slider';
+import SpaceBetweenWrapper from './space-between';
+import SpinnerWrapper from './spinner';
+import SplitPanelWrapper from './split-panel';
+import StatusIndicatorWrapper from './status-indicator';
+import StepsWrapper from './steps';
+import TableWrapper from './table';
+import TabsWrapper from './tabs';
+import TagEditorWrapper from './tag-editor';
+import TextContentWrapper from './text-content';
+import TextFilterWrapper from './text-filter';
+import TextareaWrapper from './textarea';
+import TilesWrapper from './tiles';
+import TimeInputWrapper from './time-input';
+import ToggleWrapper from './toggle';
+import ToggleButtonWrapper from './toggle-button';
+import TokenGroupWrapper from './token-group';
+import TopNavigationWrapper from './top-navigation';
+import TutorialPanelWrapper from './tutorial-panel';
+import WizardWrapper from './wizard';
+
+
+export { AlertWrapper };
+export { AnchorNavigationWrapper };
+export { AnnotationWrapper };
+export { AppLayoutWrapper };
+export { AreaChartWrapper };
+export { AttributeEditorWrapper };
+export { AutosuggestWrapper };
+export { BadgeWrapper };
+export { BarChartWrapper };
+export { BoxWrapper };
+export { BreadcrumbGroupWrapper };
+export { ButtonWrapper };
+export { ButtonDropdownWrapper };
+export { ButtonGroupWrapper };
+export { CalendarWrapper };
+export { CardsWrapper };
+export { CheckboxWrapper };
+export { CodeEditorWrapper };
+export { CollectionPreferencesWrapper };
+export { ColumnLayoutWrapper };
+export { ContainerWrapper };
+export { ContentLayoutWrapper };
+export { CopyToClipboardWrapper };
+export { DateInputWrapper };
+export { DatePickerWrapper };
+export { DateRangePickerWrapper };
+export { DrawerWrapper };
+export { ExpandableSectionWrapper };
+export { FileDropzoneWrapper };
+export { FileInputWrapper };
+export { FileTokenGroupWrapper };
+export { FileUploadWrapper };
+export { FlashbarWrapper };
+export { FormWrapper };
+export { FormFieldWrapper };
+export { GridWrapper };
+export { HeaderWrapper };
+export { HelpPanelWrapper };
+export { HotspotWrapper };
+export { IconWrapper };
+export { InputWrapper };
+export { KeyValuePairsWrapper };
+export { LineChartWrapper };
+export { LinkWrapper };
+export { LiveRegionWrapper };
+export { MixedLineBarChartWrapper };
+export { ModalWrapper };
+export { MultiselectWrapper };
+export { PaginationWrapper };
+export { PieChartWrapper };
+export { PopoverWrapper };
+export { ProgressBarWrapper };
+export { PromptInputWrapper };
+export { PropertyFilterWrapper };
+export { RadioGroupWrapper };
+export { S3ResourceSelectorWrapper };
+export { SegmentedControlWrapper };
+export { SelectWrapper };
+export { SideNavigationWrapper };
+export { SliderWrapper };
+export { SpaceBetweenWrapper };
+export { SpinnerWrapper };
+export { SplitPanelWrapper };
+export { StatusIndicatorWrapper };
+export { StepsWrapper };
+export { TableWrapper };
+export { TabsWrapper };
+export { TagEditorWrapper };
+export { TextContentWrapper };
+export { TextFilterWrapper };
+export { TextareaWrapper };
+export { TilesWrapper };
+export { TimeInputWrapper };
+export { ToggleWrapper };
+export { ToggleButtonWrapper };
+export { TokenGroupWrapper };
+export { TopNavigationWrapper };
+export { TutorialPanelWrapper };
+export { WizardWrapper };
 
-        import AnchorNavigationWrapper from './anchor-navigation';
-        export { AnchorNavigationWrapper };
-      
-
-        import AnnotationWrapper from './annotation';
-        export { AnnotationWrapper };
-      
-
-        import AppLayoutWrapper from './app-layout';
-        export { AppLayoutWrapper };
-      
-
-        import AreaChartWrapper from './area-chart';
-        export { AreaChartWrapper };
-      
-
-        import AttributeEditorWrapper from './attribute-editor';
-        export { AttributeEditorWrapper };
-      
-
-        import AutosuggestWrapper from './autosuggest';
-        export { AutosuggestWrapper };
-      
-
-        import BadgeWrapper from './badge';
-        export { BadgeWrapper };
-      
-
-        import BarChartWrapper from './bar-chart';
-        export { BarChartWrapper };
-      
-
-        import BoxWrapper from './box';
-        export { BoxWrapper };
-      
-
-        import BreadcrumbGroupWrapper from './breadcrumb-group';
-        export { BreadcrumbGroupWrapper };
-      
-
-        import ButtonWrapper from './button';
-        export { ButtonWrapper };
-      
-
-        import ButtonDropdownWrapper from './button-dropdown';
-        export { ButtonDropdownWrapper };
-      
-
-        import ButtonGroupWrapper from './button-group';
-        export { ButtonGroupWrapper };
-      
-
-        import CalendarWrapper from './calendar';
-        export { CalendarWrapper };
-      
-
-        import CardsWrapper from './cards';
-        export { CardsWrapper };
-      
-
-        import CheckboxWrapper from './checkbox';
-        export { CheckboxWrapper };
-      
-
-        import CodeEditorWrapper from './code-editor';
-        export { CodeEditorWrapper };
-      
-
-        import CollectionPreferencesWrapper from './collection-preferences';
-        export { CollectionPreferencesWrapper };
-      
-
-        import ColumnLayoutWrapper from './column-layout';
-        export { ColumnLayoutWrapper };
-      
-
-        import ContainerWrapper from './container';
-        export { ContainerWrapper };
-      
-
-        import ContentLayoutWrapper from './content-layout';
-        export { ContentLayoutWrapper };
-      
-
-        import CopyToClipboardWrapper from './copy-to-clipboard';
-        export { CopyToClipboardWrapper };
-      
-
-        import DateInputWrapper from './date-input';
-        export { DateInputWrapper };
-      
-
-        import DatePickerWrapper from './date-picker';
-        export { DatePickerWrapper };
-      
-
-        import DateRangePickerWrapper from './date-range-picker';
-        export { DateRangePickerWrapper };
-      
-
-        import DrawerWrapper from './drawer';
-        export { DrawerWrapper };
-      
-
-        import ExpandableSectionWrapper from './expandable-section';
-        export { ExpandableSectionWrapper };
-      
-
-        import FileDropzoneWrapper from './file-dropzone';
-        export { FileDropzoneWrapper };
-      
-
-        import FileInputWrapper from './file-input';
-        export { FileInputWrapper };
-      
-
-        import FileTokenGroupWrapper from './file-token-group';
-        export { FileTokenGroupWrapper };
-      
-
-        import FileUploadWrapper from './file-upload';
-        export { FileUploadWrapper };
-      
-
-        import FlashbarWrapper from './flashbar';
-        export { FlashbarWrapper };
-      
-
-        import FormWrapper from './form';
-        export { FormWrapper };
-      
-
-        import FormFieldWrapper from './form-field';
-        export { FormFieldWrapper };
-      
-
-        import GridWrapper from './grid';
-        export { GridWrapper };
-      
-
-        import HeaderWrapper from './header';
-        export { HeaderWrapper };
-      
-
-        import HelpPanelWrapper from './help-panel';
-        export { HelpPanelWrapper };
-      
-
-        import HotspotWrapper from './hotspot';
-        export { HotspotWrapper };
-      
-
-        import IconWrapper from './icon';
-        export { IconWrapper };
-      
-
-        import InputWrapper from './input';
-        export { InputWrapper };
-      
-
-        import KeyValuePairsWrapper from './key-value-pairs';
-        export { KeyValuePairsWrapper };
-      
-
-        import LineChartWrapper from './line-chart';
-        export { LineChartWrapper };
-      
-
-        import LinkWrapper from './link';
-        export { LinkWrapper };
-      
-
-        import LiveRegionWrapper from './live-region';
-        export { LiveRegionWrapper };
-      
-
-        import MixedLineBarChartWrapper from './mixed-line-bar-chart';
-        export { MixedLineBarChartWrapper };
-      
-
-        import ModalWrapper from './modal';
-        export { ModalWrapper };
-      
-
-        import MultiselectWrapper from './multiselect';
-        export { MultiselectWrapper };
-      
-
-        import PaginationWrapper from './pagination';
-        export { PaginationWrapper };
-      
-
-        import PieChartWrapper from './pie-chart';
-        export { PieChartWrapper };
-      
-
-        import PopoverWrapper from './popover';
-        export { PopoverWrapper };
-      
-
-        import ProgressBarWrapper from './progress-bar';
-        export { ProgressBarWrapper };
-      
-
-        import PromptInputWrapper from './prompt-input';
-        export { PromptInputWrapper };
-      
-
-        import PropertyFilterWrapper from './property-filter';
-        export { PropertyFilterWrapper };
-      
-
-        import RadioGroupWrapper from './radio-group';
-        export { RadioGroupWrapper };
-      
-
-        import S3ResourceSelectorWrapper from './s3-resource-selector';
-        export { S3ResourceSelectorWrapper };
-      
-
-        import SegmentedControlWrapper from './segmented-control';
-        export { SegmentedControlWrapper };
-      
-
-        import SelectWrapper from './select';
-        export { SelectWrapper };
-      
-
-        import SideNavigationWrapper from './side-navigation';
-        export { SideNavigationWrapper };
-      
-
-        import SliderWrapper from './slider';
-        export { SliderWrapper };
-      
-
-        import SpaceBetweenWrapper from './space-between';
-        export { SpaceBetweenWrapper };
-      
-
-        import SpinnerWrapper from './spinner';
-        export { SpinnerWrapper };
-      
-
-        import SplitPanelWrapper from './split-panel';
-        export { SplitPanelWrapper };
-      
-
-        import StatusIndicatorWrapper from './status-indicator';
-        export { StatusIndicatorWrapper };
-      
-
-        import StepsWrapper from './steps';
-        export { StepsWrapper };
-      
-
-        import TableWrapper from './table';
-        export { TableWrapper };
-      
-
-        import TabsWrapper from './tabs';
-        export { TabsWrapper };
-      
-
-        import TagEditorWrapper from './tag-editor';
-        export { TagEditorWrapper };
-      
-
-        import TextContentWrapper from './text-content';
-        export { TextContentWrapper };
-      
-
-        import TextFilterWrapper from './text-filter';
-        export { TextFilterWrapper };
-      
-
-        import TextareaWrapper from './textarea';
-        export { TextareaWrapper };
-      
-
-        import TilesWrapper from './tiles';
-        export { TilesWrapper };
-      
-
-        import TimeInputWrapper from './time-input';
-        export { TimeInputWrapper };
-      
-
-        import ToggleWrapper from './toggle';
-        export { ToggleWrapper };
-      
-
-        import ToggleButtonWrapper from './toggle-button';
-        export { ToggleButtonWrapper };
-      
-
-        import TokenGroupWrapper from './token-group';
-        export { TokenGroupWrapper };
-      
-
-        import TopNavigationWrapper from './top-navigation';
-        export { TopNavigationWrapper };
-      
-
-        import TutorialPanelWrapper from './tutorial-panel';
-        export { TutorialPanelWrapper };
-      
-
-        import WizardWrapper from './wizard';
-        export { WizardWrapper };
-      
 declare module '@cloudscape-design/test-utils-core/dist/selectors' {
-      interface ElementWrapper {
-        
-       /**
-        * Returns a wrapper that matches the Alerts with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Alerts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {AlertWrapper}
-        */
-       findAlert(selector?: string): AlertWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Alerts with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Alerts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<AlertWrapper>}
-        */
-       findAllAlerts(selector?: string): MultiElementWrapper<AlertWrapper>;
-
-       /**
-        * Returns a wrapper that matches the AnchorNavigations with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches AnchorNavigations.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {AnchorNavigationWrapper}
-        */
-       findAnchorNavigation(selector?: string): AnchorNavigationWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches AnchorNavigations with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches AnchorNavigations.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<AnchorNavigationWrapper>}
-        */
-       findAllAnchorNavigations(selector?: string): MultiElementWrapper<AnchorNavigationWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Annotations with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Annotations.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {AnnotationWrapper}
-        */
-       findAnnotation(selector?: string): AnnotationWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Annotations with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Annotations.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<AnnotationWrapper>}
-        */
-       findAllAnnotations(selector?: string): MultiElementWrapper<AnnotationWrapper>;
-
-       /**
-        * Returns a wrapper that matches the AppLayouts with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches AppLayouts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {AppLayoutWrapper}
-        */
-       findAppLayout(selector?: string): AppLayoutWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches AppLayouts with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches AppLayouts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<AppLayoutWrapper>}
-        */
-       findAllAppLayouts(selector?: string): MultiElementWrapper<AppLayoutWrapper>;
-
-       /**
-        * Returns a wrapper that matches the AreaCharts with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches AreaCharts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {AreaChartWrapper}
-        */
-       findAreaChart(selector?: string): AreaChartWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches AreaCharts with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches AreaCharts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<AreaChartWrapper>}
-        */
-       findAllAreaCharts(selector?: string): MultiElementWrapper<AreaChartWrapper>;
-
-       /**
-        * Returns a wrapper that matches the AttributeEditors with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches AttributeEditors.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {AttributeEditorWrapper}
-        */
-       findAttributeEditor(selector?: string): AttributeEditorWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches AttributeEditors with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches AttributeEditors.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<AttributeEditorWrapper>}
-        */
-       findAllAttributeEditors(selector?: string): MultiElementWrapper<AttributeEditorWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Autosuggests with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Autosuggests.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {AutosuggestWrapper}
-        */
-       findAutosuggest(selector?: string): AutosuggestWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Autosuggests with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Autosuggests.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<AutosuggestWrapper>}
-        */
-       findAllAutosuggests(selector?: string): MultiElementWrapper<AutosuggestWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Badges with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Badges.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {BadgeWrapper}
-        */
-       findBadge(selector?: string): BadgeWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Badges with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Badges.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<BadgeWrapper>}
-        */
-       findAllBadges(selector?: string): MultiElementWrapper<BadgeWrapper>;
-
-       /**
-        * Returns a wrapper that matches the BarCharts with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches BarCharts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {BarChartWrapper}
-        */
-       findBarChart(selector?: string): BarChartWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches BarCharts with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches BarCharts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<BarChartWrapper>}
-        */
-       findAllBarCharts(selector?: string): MultiElementWrapper<BarChartWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Boxes with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Boxes.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {BoxWrapper}
-        */
-       findBox(selector?: string): BoxWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Boxes with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Boxes.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<BoxWrapper>}
-        */
-       findAllBoxes(selector?: string): MultiElementWrapper<BoxWrapper>;
-
-       /**
-        * Returns a wrapper that matches the BreadcrumbGroups with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches BreadcrumbGroups.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {BreadcrumbGroupWrapper}
-        */
-       findBreadcrumbGroup(selector?: string): BreadcrumbGroupWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches BreadcrumbGroups with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches BreadcrumbGroups.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<BreadcrumbGroupWrapper>}
-        */
-       findAllBreadcrumbGroups(selector?: string): MultiElementWrapper<BreadcrumbGroupWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Buttons with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Buttons.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ButtonWrapper}
-        */
-       findButton(selector?: string): ButtonWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Buttons with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Buttons.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<ButtonWrapper>}
-        */
-       findAllButtons(selector?: string): MultiElementWrapper<ButtonWrapper>;
-
-       /**
-        * Returns a wrapper that matches the ButtonDropdowns with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches ButtonDropdowns.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ButtonDropdownWrapper}
-        */
-       findButtonDropdown(selector?: string): ButtonDropdownWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches ButtonDropdowns with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches ButtonDropdowns.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<ButtonDropdownWrapper>}
-        */
-       findAllButtonDropdowns(selector?: string): MultiElementWrapper<ButtonDropdownWrapper>;
-
-       /**
-        * Returns a wrapper that matches the ButtonGroups with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches ButtonGroups.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ButtonGroupWrapper}
-        */
-       findButtonGroup(selector?: string): ButtonGroupWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches ButtonGroups with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches ButtonGroups.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<ButtonGroupWrapper>}
-        */
-       findAllButtonGroups(selector?: string): MultiElementWrapper<ButtonGroupWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Calendars with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Calendars.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {CalendarWrapper}
-        */
-       findCalendar(selector?: string): CalendarWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Calendars with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Calendars.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<CalendarWrapper>}
-        */
-       findAllCalendars(selector?: string): MultiElementWrapper<CalendarWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Cards with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Cards.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {CardsWrapper}
-        */
-       findCards(selector?: string): CardsWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Cards with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Cards.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<CardsWrapper>}
-        */
-       findAllCards(selector?: string): MultiElementWrapper<CardsWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Checkboxes with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Checkboxes.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {CheckboxWrapper}
-        */
-       findCheckbox(selector?: string): CheckboxWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Checkboxes with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Checkboxes.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<CheckboxWrapper>}
-        */
-       findAllCheckboxes(selector?: string): MultiElementWrapper<CheckboxWrapper>;
-
-       /**
-        * Returns a wrapper that matches the CodeEditors with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches CodeEditors.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {CodeEditorWrapper}
-        */
-       findCodeEditor(selector?: string): CodeEditorWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches CodeEditors with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches CodeEditors.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<CodeEditorWrapper>}
-        */
-       findAllCodeEditors(selector?: string): MultiElementWrapper<CodeEditorWrapper>;
-
-       /**
-        * Returns a wrapper that matches the CollectionPreferences with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches CollectionPreferences.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {CollectionPreferencesWrapper}
-        */
-       findCollectionPreferences(selector?: string): CollectionPreferencesWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches CollectionPreferences with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches CollectionPreferences.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<CollectionPreferencesWrapper>}
-        */
-       findAllCollectionPreferences(selector?: string): MultiElementWrapper<CollectionPreferencesWrapper>;
-
-       /**
-        * Returns a wrapper that matches the ColumnLayouts with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches ColumnLayouts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ColumnLayoutWrapper}
-        */
-       findColumnLayout(selector?: string): ColumnLayoutWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches ColumnLayouts with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches ColumnLayouts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<ColumnLayoutWrapper>}
-        */
-       findAllColumnLayouts(selector?: string): MultiElementWrapper<ColumnLayoutWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Containers with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Containers.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ContainerWrapper}
-        */
-       findContainer(selector?: string): ContainerWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Containers with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Containers.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<ContainerWrapper>}
-        */
-       findAllContainers(selector?: string): MultiElementWrapper<ContainerWrapper>;
-
-       /**
-        * Returns a wrapper that matches the ContentLayouts with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches ContentLayouts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ContentLayoutWrapper}
-        */
-       findContentLayout(selector?: string): ContentLayoutWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches ContentLayouts with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches ContentLayouts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<ContentLayoutWrapper>}
-        */
-       findAllContentLayouts(selector?: string): MultiElementWrapper<ContentLayoutWrapper>;
-
-       /**
-        * Returns a wrapper that matches the CopyToClipboards with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches CopyToClipboards.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {CopyToClipboardWrapper}
-        */
-       findCopyToClipboard(selector?: string): CopyToClipboardWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches CopyToClipboards with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches CopyToClipboards.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<CopyToClipboardWrapper>}
-        */
-       findAllCopyToClipboards(selector?: string): MultiElementWrapper<CopyToClipboardWrapper>;
-
-       /**
-        * Returns a wrapper that matches the DateInputs with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches DateInputs.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {DateInputWrapper}
-        */
-       findDateInput(selector?: string): DateInputWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches DateInputs with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches DateInputs.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<DateInputWrapper>}
-        */
-       findAllDateInputs(selector?: string): MultiElementWrapper<DateInputWrapper>;
-
-       /**
-        * Returns a wrapper that matches the DatePickers with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches DatePickers.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {DatePickerWrapper}
-        */
-       findDatePicker(selector?: string): DatePickerWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches DatePickers with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches DatePickers.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<DatePickerWrapper>}
-        */
-       findAllDatePickers(selector?: string): MultiElementWrapper<DatePickerWrapper>;
-
-       /**
-        * Returns a wrapper that matches the DateRangePickers with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches DateRangePickers.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {DateRangePickerWrapper}
-        */
-       findDateRangePicker(selector?: string): DateRangePickerWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches DateRangePickers with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches DateRangePickers.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<DateRangePickerWrapper>}
-        */
-       findAllDateRangePickers(selector?: string): MultiElementWrapper<DateRangePickerWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Drawers with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Drawers.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {DrawerWrapper}
-        */
-       findDrawer(selector?: string): DrawerWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Drawers with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Drawers.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<DrawerWrapper>}
-        */
-       findAllDrawers(selector?: string): MultiElementWrapper<DrawerWrapper>;
-
-       /**
-        * Returns a wrapper that matches the ExpandableSections with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches ExpandableSections.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ExpandableSectionWrapper}
-        */
-       findExpandableSection(selector?: string): ExpandableSectionWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches ExpandableSections with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches ExpandableSections.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<ExpandableSectionWrapper>}
-        */
-       findAllExpandableSections(selector?: string): MultiElementWrapper<ExpandableSectionWrapper>;
-
-       /**
-        * Returns a wrapper that matches the FileDropzones with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches FileDropzones.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {FileDropzoneWrapper}
-        */
-       findFileDropzone(selector?: string): FileDropzoneWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches FileDropzones with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches FileDropzones.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<FileDropzoneWrapper>}
-        */
-       findAllFileDropzones(selector?: string): MultiElementWrapper<FileDropzoneWrapper>;
-
-       /**
-        * Returns a wrapper that matches the FileInputs with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches FileInputs.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {FileInputWrapper}
-        */
-       findFileInput(selector?: string): FileInputWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches FileInputs with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches FileInputs.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<FileInputWrapper>}
-        */
-       findAllFileInputs(selector?: string): MultiElementWrapper<FileInputWrapper>;
-
-       /**
-        * Returns a wrapper that matches the FileTokenGroups with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches FileTokenGroups.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {FileTokenGroupWrapper}
-        */
-       findFileTokenGroup(selector?: string): FileTokenGroupWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches FileTokenGroups with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches FileTokenGroups.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<FileTokenGroupWrapper>}
-        */
-       findAllFileTokenGroups(selector?: string): MultiElementWrapper<FileTokenGroupWrapper>;
-
-       /**
-        * Returns a wrapper that matches the FileUploads with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches FileUploads.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {FileUploadWrapper}
-        */
-       findFileUpload(selector?: string): FileUploadWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches FileUploads with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches FileUploads.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<FileUploadWrapper>}
-        */
-       findAllFileUploads(selector?: string): MultiElementWrapper<FileUploadWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Flashbars with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Flashbars.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {FlashbarWrapper}
-        */
-       findFlashbar(selector?: string): FlashbarWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Flashbars with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Flashbars.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<FlashbarWrapper>}
-        */
-       findAllFlashbars(selector?: string): MultiElementWrapper<FlashbarWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Forms with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Forms.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {FormWrapper}
-        */
-       findForm(selector?: string): FormWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Forms with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Forms.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<FormWrapper>}
-        */
-       findAllForms(selector?: string): MultiElementWrapper<FormWrapper>;
-
-       /**
-        * Returns a wrapper that matches the FormFields with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches FormFields.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {FormFieldWrapper}
-        */
-       findFormField(selector?: string): FormFieldWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches FormFields with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches FormFields.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<FormFieldWrapper>}
-        */
-       findAllFormFields(selector?: string): MultiElementWrapper<FormFieldWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Grids with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Grids.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {GridWrapper}
-        */
-       findGrid(selector?: string): GridWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Grids with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Grids.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<GridWrapper>}
-        */
-       findAllGrids(selector?: string): MultiElementWrapper<GridWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Headers with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Headers.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {HeaderWrapper}
-        */
-       findHeader(selector?: string): HeaderWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Headers with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Headers.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<HeaderWrapper>}
-        */
-       findAllHeaders(selector?: string): MultiElementWrapper<HeaderWrapper>;
-
-       /**
-        * Returns a wrapper that matches the HelpPanels with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches HelpPanels.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {HelpPanelWrapper}
-        */
-       findHelpPanel(selector?: string): HelpPanelWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches HelpPanels with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches HelpPanels.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<HelpPanelWrapper>}
-        */
-       findAllHelpPanels(selector?: string): MultiElementWrapper<HelpPanelWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Hotspots with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Hotspots.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {HotspotWrapper}
-        */
-       findHotspot(selector?: string): HotspotWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Hotspots with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Hotspots.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<HotspotWrapper>}
-        */
-       findAllHotspots(selector?: string): MultiElementWrapper<HotspotWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Icons with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Icons.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {IconWrapper}
-        */
-       findIcon(selector?: string): IconWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Icons with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Icons.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<IconWrapper>}
-        */
-       findAllIcons(selector?: string): MultiElementWrapper<IconWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Inputs with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Inputs.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {InputWrapper}
-        */
-       findInput(selector?: string): InputWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Inputs with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Inputs.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<InputWrapper>}
-        */
-       findAllInputs(selector?: string): MultiElementWrapper<InputWrapper>;
-
-       /**
-        * Returns a wrapper that matches the KeyValuePairs with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches KeyValuePairs.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {KeyValuePairsWrapper}
-        */
-       findKeyValuePairs(selector?: string): KeyValuePairsWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches KeyValuePairs with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches KeyValuePairs.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<KeyValuePairsWrapper>}
-        */
-       findAllKeyValuePairs(selector?: string): MultiElementWrapper<KeyValuePairsWrapper>;
-
-       /**
-        * Returns a wrapper that matches the LineCharts with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches LineCharts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {LineChartWrapper}
-        */
-       findLineChart(selector?: string): LineChartWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches LineCharts with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches LineCharts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<LineChartWrapper>}
-        */
-       findAllLineCharts(selector?: string): MultiElementWrapper<LineChartWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Links with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Links.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {LinkWrapper}
-        */
-       findLink(selector?: string): LinkWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Links with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Links.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<LinkWrapper>}
-        */
-       findAllLinks(selector?: string): MultiElementWrapper<LinkWrapper>;
-
-       /**
-        * Returns a wrapper that matches the LiveRegions with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches LiveRegions.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {LiveRegionWrapper}
-        */
-       findLiveRegion(selector?: string): LiveRegionWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches LiveRegions with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches LiveRegions.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<LiveRegionWrapper>}
-        */
-       findAllLiveRegions(selector?: string): MultiElementWrapper<LiveRegionWrapper>;
-
-       /**
-        * Returns a wrapper that matches the MixedLineBarCharts with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches MixedLineBarCharts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MixedLineBarChartWrapper}
-        */
-       findMixedLineBarChart(selector?: string): MixedLineBarChartWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches MixedLineBarCharts with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches MixedLineBarCharts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<MixedLineBarChartWrapper>}
-        */
-       findAllMixedLineBarCharts(selector?: string): MultiElementWrapper<MixedLineBarChartWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Modals with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Modals.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ModalWrapper}
-        */
-       findModal(selector?: string): ModalWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Modals with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Modals.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<ModalWrapper>}
-        */
-       findAllModals(selector?: string): MultiElementWrapper<ModalWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Multiselects with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Multiselects.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiselectWrapper}
-        */
-       findMultiselect(selector?: string): MultiselectWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Multiselects with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Multiselects.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<MultiselectWrapper>}
-        */
-       findAllMultiselects(selector?: string): MultiElementWrapper<MultiselectWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Paginations with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Paginations.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {PaginationWrapper}
-        */
-       findPagination(selector?: string): PaginationWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Paginations with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Paginations.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<PaginationWrapper>}
-        */
-       findAllPaginations(selector?: string): MultiElementWrapper<PaginationWrapper>;
-
-       /**
-        * Returns a wrapper that matches the PieCharts with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches PieCharts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {PieChartWrapper}
-        */
-       findPieChart(selector?: string): PieChartWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches PieCharts with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches PieCharts.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<PieChartWrapper>}
-        */
-       findAllPieCharts(selector?: string): MultiElementWrapper<PieChartWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Popovers with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Popovers.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {PopoverWrapper}
-        */
-       findPopover(selector?: string): PopoverWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Popovers with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Popovers.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<PopoverWrapper>}
-        */
-       findAllPopovers(selector?: string): MultiElementWrapper<PopoverWrapper>;
-
-       /**
-        * Returns a wrapper that matches the ProgressBars with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches ProgressBars.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ProgressBarWrapper}
-        */
-       findProgressBar(selector?: string): ProgressBarWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches ProgressBars with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches ProgressBars.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<ProgressBarWrapper>}
-        */
-       findAllProgressBars(selector?: string): MultiElementWrapper<ProgressBarWrapper>;
-
-       /**
-        * Returns a wrapper that matches the PromptInputs with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches PromptInputs.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {PromptInputWrapper}
-        */
-       findPromptInput(selector?: string): PromptInputWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches PromptInputs with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches PromptInputs.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<PromptInputWrapper>}
-        */
-       findAllPromptInputs(selector?: string): MultiElementWrapper<PromptInputWrapper>;
-
-       /**
-        * Returns a wrapper that matches the PropertyFilters with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches PropertyFilters.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {PropertyFilterWrapper}
-        */
-       findPropertyFilter(selector?: string): PropertyFilterWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches PropertyFilters with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches PropertyFilters.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<PropertyFilterWrapper>}
-        */
-       findAllPropertyFilters(selector?: string): MultiElementWrapper<PropertyFilterWrapper>;
-
-       /**
-        * Returns a wrapper that matches the RadioGroups with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches RadioGroups.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {RadioGroupWrapper}
-        */
-       findRadioGroup(selector?: string): RadioGroupWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches RadioGroups with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches RadioGroups.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<RadioGroupWrapper>}
-        */
-       findAllRadioGroups(selector?: string): MultiElementWrapper<RadioGroupWrapper>;
-
-       /**
-        * Returns a wrapper that matches the S3ResourceSelectors with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches S3ResourceSelectors.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {S3ResourceSelectorWrapper}
-        */
-       findS3ResourceSelector(selector?: string): S3ResourceSelectorWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches S3ResourceSelectors with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches S3ResourceSelectors.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<S3ResourceSelectorWrapper>}
-        */
-       findAllS3ResourceSelectors(selector?: string): MultiElementWrapper<S3ResourceSelectorWrapper>;
-
-       /**
-        * Returns a wrapper that matches the SegmentedControls with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches SegmentedControls.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {SegmentedControlWrapper}
-        */
-       findSegmentedControl(selector?: string): SegmentedControlWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches SegmentedControls with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches SegmentedControls.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<SegmentedControlWrapper>}
-        */
-       findAllSegmentedControls(selector?: string): MultiElementWrapper<SegmentedControlWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Selects with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Selects.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {SelectWrapper}
-        */
-       findSelect(selector?: string): SelectWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Selects with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Selects.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<SelectWrapper>}
-        */
-       findAllSelects(selector?: string): MultiElementWrapper<SelectWrapper>;
-
-       /**
-        * Returns a wrapper that matches the SideNavigations with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches SideNavigations.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {SideNavigationWrapper}
-        */
-       findSideNavigation(selector?: string): SideNavigationWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches SideNavigations with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches SideNavigations.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<SideNavigationWrapper>}
-        */
-       findAllSideNavigations(selector?: string): MultiElementWrapper<SideNavigationWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Sliders with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Sliders.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {SliderWrapper}
-        */
-       findSlider(selector?: string): SliderWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Sliders with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Sliders.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<SliderWrapper>}
-        */
-       findAllSliders(selector?: string): MultiElementWrapper<SliderWrapper>;
-
-       /**
-        * Returns a wrapper that matches the SpaceBetweens with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches SpaceBetweens.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {SpaceBetweenWrapper}
-        */
-       findSpaceBetween(selector?: string): SpaceBetweenWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches SpaceBetweens with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches SpaceBetweens.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<SpaceBetweenWrapper>}
-        */
-       findAllSpaceBetweens(selector?: string): MultiElementWrapper<SpaceBetweenWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Spinners with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Spinners.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {SpinnerWrapper}
-        */
-       findSpinner(selector?: string): SpinnerWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Spinners with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Spinners.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<SpinnerWrapper>}
-        */
-       findAllSpinners(selector?: string): MultiElementWrapper<SpinnerWrapper>;
-
-       /**
-        * Returns a wrapper that matches the SplitPanels with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches SplitPanels.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {SplitPanelWrapper}
-        */
-       findSplitPanel(selector?: string): SplitPanelWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches SplitPanels with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches SplitPanels.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<SplitPanelWrapper>}
-        */
-       findAllSplitPanels(selector?: string): MultiElementWrapper<SplitPanelWrapper>;
-
-       /**
-        * Returns a wrapper that matches the StatusIndicators with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches StatusIndicators.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {StatusIndicatorWrapper}
-        */
-       findStatusIndicator(selector?: string): StatusIndicatorWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches StatusIndicators with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches StatusIndicators.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<StatusIndicatorWrapper>}
-        */
-       findAllStatusIndicators(selector?: string): MultiElementWrapper<StatusIndicatorWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Steps with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Steps.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {StepsWrapper}
-        */
-       findSteps(selector?: string): StepsWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Steps with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Steps.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<StepsWrapper>}
-        */
-       findAllSteps(selector?: string): MultiElementWrapper<StepsWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Tables with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Tables.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TableWrapper}
-        */
-       findTable(selector?: string): TableWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Tables with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Tables.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<TableWrapper>}
-        */
-       findAllTables(selector?: string): MultiElementWrapper<TableWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Tabs with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Tabs.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TabsWrapper}
-        */
-       findTabs(selector?: string): TabsWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Tabs with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Tabs.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<TabsWrapper>}
-        */
-       findAllTabs(selector?: string): MultiElementWrapper<TabsWrapper>;
-
-       /**
-        * Returns a wrapper that matches the TagEditors with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches TagEditors.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TagEditorWrapper}
-        */
-       findTagEditor(selector?: string): TagEditorWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches TagEditors with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches TagEditors.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<TagEditorWrapper>}
-        */
-       findAllTagEditors(selector?: string): MultiElementWrapper<TagEditorWrapper>;
-
-       /**
-        * Returns a wrapper that matches the TextContents with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches TextContents.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TextContentWrapper}
-        */
-       findTextContent(selector?: string): TextContentWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches TextContents with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches TextContents.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<TextContentWrapper>}
-        */
-       findAllTextContents(selector?: string): MultiElementWrapper<TextContentWrapper>;
-
-       /**
-        * Returns a wrapper that matches the TextFilters with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches TextFilters.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TextFilterWrapper}
-        */
-       findTextFilter(selector?: string): TextFilterWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches TextFilters with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches TextFilters.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<TextFilterWrapper>}
-        */
-       findAllTextFilters(selector?: string): MultiElementWrapper<TextFilterWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Textareas with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Textareas.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TextareaWrapper}
-        */
-       findTextarea(selector?: string): TextareaWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Textareas with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Textareas.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<TextareaWrapper>}
-        */
-       findAllTextareas(selector?: string): MultiElementWrapper<TextareaWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Tiles with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Tiles.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TilesWrapper}
-        */
-       findTiles(selector?: string): TilesWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Tiles with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Tiles.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<TilesWrapper>}
-        */
-       findAllTiles(selector?: string): MultiElementWrapper<TilesWrapper>;
-
-       /**
-        * Returns a wrapper that matches the TimeInputs with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches TimeInputs.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TimeInputWrapper}
-        */
-       findTimeInput(selector?: string): TimeInputWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches TimeInputs with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches TimeInputs.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<TimeInputWrapper>}
-        */
-       findAllTimeInputs(selector?: string): MultiElementWrapper<TimeInputWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Toggles with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Toggles.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ToggleWrapper}
-        */
-       findToggle(selector?: string): ToggleWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Toggles with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Toggles.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<ToggleWrapper>}
-        */
-       findAllToggles(selector?: string): MultiElementWrapper<ToggleWrapper>;
-
-       /**
-        * Returns a wrapper that matches the ToggleButtons with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches ToggleButtons.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {ToggleButtonWrapper}
-        */
-       findToggleButton(selector?: string): ToggleButtonWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches ToggleButtons with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches ToggleButtons.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<ToggleButtonWrapper>}
-        */
-       findAllToggleButtons(selector?: string): MultiElementWrapper<ToggleButtonWrapper>;
-
-       /**
-        * Returns a wrapper that matches the TokenGroups with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches TokenGroups.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TokenGroupWrapper}
-        */
-       findTokenGroup(selector?: string): TokenGroupWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches TokenGroups with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches TokenGroups.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<TokenGroupWrapper>}
-        */
-       findAllTokenGroups(selector?: string): MultiElementWrapper<TokenGroupWrapper>;
-
-       /**
-        * Returns a wrapper that matches the TopNavigations with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches TopNavigations.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TopNavigationWrapper}
-        */
-       findTopNavigation(selector?: string): TopNavigationWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches TopNavigations with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches TopNavigations.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<TopNavigationWrapper>}
-        */
-       findAllTopNavigations(selector?: string): MultiElementWrapper<TopNavigationWrapper>;
-
-       /**
-        * Returns a wrapper that matches the TutorialPanels with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches TutorialPanels.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {TutorialPanelWrapper}
-        */
-       findTutorialPanel(selector?: string): TutorialPanelWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches TutorialPanels with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches TutorialPanels.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<TutorialPanelWrapper>}
-        */
-       findAllTutorialPanels(selector?: string): MultiElementWrapper<TutorialPanelWrapper>;
-
-       /**
-        * Returns a wrapper that matches the Wizards with the specified CSS selector.
-        * If no CSS selector is specified, returns a wrapper that matches Wizards.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {WizardWrapper}
-        */
-       findWizard(selector?: string): WizardWrapper;
-
-       /**
-        * Returns a multi-element wrapper that matches Wizards with the specified CSS selector.
-        * If no CSS selector is specified, returns a multi-element wrapper that matches Wizards.
-        *
-        * @param {string} [selector] CSS Selector
-        * @returns {MultiElementWrapper<WizardWrapper>}
-        */
-       findAllWizards(selector?: string): MultiElementWrapper<WizardWrapper>;
-      }
-  }
-
-      ElementWrapper.prototype.findAlert = function(selector) {
-        const rootSelector = \`.\${AlertWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AlertWrapper);
-      };
-
-      ElementWrapper.prototype.findAllAlerts = function(selector) {
-        return this.findAllComponents(AlertWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findAnchorNavigation = function(selector) {
-        const rootSelector = \`.\${AnchorNavigationWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AnchorNavigationWrapper);
-      };
-
-      ElementWrapper.prototype.findAllAnchorNavigations = function(selector) {
-        return this.findAllComponents(AnchorNavigationWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findAnnotation = function(selector) {
-        const rootSelector = \`.\${AnnotationWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AnnotationWrapper);
-      };
-
-      ElementWrapper.prototype.findAllAnnotations = function(selector) {
-        return this.findAllComponents(AnnotationWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findAppLayout = function(selector) {
-        const rootSelector = \`.\${AppLayoutWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AppLayoutWrapper);
-      };
-
-      ElementWrapper.prototype.findAllAppLayouts = function(selector) {
-        return this.findAllComponents(AppLayoutWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findAreaChart = function(selector) {
-        const rootSelector = \`.\${AreaChartWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AreaChartWrapper);
-      };
-
-      ElementWrapper.prototype.findAllAreaCharts = function(selector) {
-        return this.findAllComponents(AreaChartWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findAttributeEditor = function(selector) {
-        const rootSelector = \`.\${AttributeEditorWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AttributeEditorWrapper);
-      };
-
-      ElementWrapper.prototype.findAllAttributeEditors = function(selector) {
-        return this.findAllComponents(AttributeEditorWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findAutosuggest = function(selector) {
-        const rootSelector = \`.\${AutosuggestWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AutosuggestWrapper);
-      };
-
-      ElementWrapper.prototype.findAllAutosuggests = function(selector) {
-        return this.findAllComponents(AutosuggestWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findBadge = function(selector) {
-        const rootSelector = \`.\${BadgeWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BadgeWrapper);
-      };
-
-      ElementWrapper.prototype.findAllBadges = function(selector) {
-        return this.findAllComponents(BadgeWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findBarChart = function(selector) {
-        const rootSelector = \`.\${BarChartWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BarChartWrapper);
-      };
-
-      ElementWrapper.prototype.findAllBarCharts = function(selector) {
-        return this.findAllComponents(BarChartWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findBox = function(selector) {
-        const rootSelector = \`.\${BoxWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BoxWrapper);
-      };
-
-      ElementWrapper.prototype.findAllBoxes = function(selector) {
-        return this.findAllComponents(BoxWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findBreadcrumbGroup = function(selector) {
-        const rootSelector = \`.\${BreadcrumbGroupWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BreadcrumbGroupWrapper);
-      };
-
-      ElementWrapper.prototype.findAllBreadcrumbGroups = function(selector) {
-        return this.findAllComponents(BreadcrumbGroupWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findButton = function(selector) {
-        const rootSelector = \`.\${ButtonWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ButtonWrapper);
-      };
-
-      ElementWrapper.prototype.findAllButtons = function(selector) {
-        return this.findAllComponents(ButtonWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findButtonDropdown = function(selector) {
-        const rootSelector = \`.\${ButtonDropdownWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ButtonDropdownWrapper);
-      };
-
-      ElementWrapper.prototype.findAllButtonDropdowns = function(selector) {
-        return this.findAllComponents(ButtonDropdownWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findButtonGroup = function(selector) {
-        const rootSelector = \`.\${ButtonGroupWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ButtonGroupWrapper);
-      };
-
-      ElementWrapper.prototype.findAllButtonGroups = function(selector) {
-        return this.findAllComponents(ButtonGroupWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findCalendar = function(selector) {
-        const rootSelector = \`.\${CalendarWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CalendarWrapper);
-      };
-
-      ElementWrapper.prototype.findAllCalendars = function(selector) {
-        return this.findAllComponents(CalendarWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findCards = function(selector) {
-        const rootSelector = \`.\${CardsWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CardsWrapper);
-      };
-
-      ElementWrapper.prototype.findAllCards = function(selector) {
-        return this.findAllComponents(CardsWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findCheckbox = function(selector) {
-        const rootSelector = \`.\${CheckboxWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CheckboxWrapper);
-      };
-
-      ElementWrapper.prototype.findAllCheckboxes = function(selector) {
-        return this.findAllComponents(CheckboxWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findCodeEditor = function(selector) {
-        const rootSelector = \`.\${CodeEditorWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CodeEditorWrapper);
-      };
-
-      ElementWrapper.prototype.findAllCodeEditors = function(selector) {
-        return this.findAllComponents(CodeEditorWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findCollectionPreferences = function(selector) {
-        const rootSelector = \`.\${CollectionPreferencesWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CollectionPreferencesWrapper);
-      };
-
-      ElementWrapper.prototype.findAllCollectionPreferences = function(selector) {
-        return this.findAllComponents(CollectionPreferencesWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findColumnLayout = function(selector) {
-        const rootSelector = \`.\${ColumnLayoutWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ColumnLayoutWrapper);
-      };
-
-      ElementWrapper.prototype.findAllColumnLayouts = function(selector) {
-        return this.findAllComponents(ColumnLayoutWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findContainer = function(selector) {
-        const rootSelector = \`.\${ContainerWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ContainerWrapper);
-      };
-
-      ElementWrapper.prototype.findAllContainers = function(selector) {
-        return this.findAllComponents(ContainerWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findContentLayout = function(selector) {
-        const rootSelector = \`.\${ContentLayoutWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ContentLayoutWrapper);
-      };
-
-      ElementWrapper.prototype.findAllContentLayouts = function(selector) {
-        return this.findAllComponents(ContentLayoutWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findCopyToClipboard = function(selector) {
-        const rootSelector = \`.\${CopyToClipboardWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CopyToClipboardWrapper);
-      };
-
-      ElementWrapper.prototype.findAllCopyToClipboards = function(selector) {
-        return this.findAllComponents(CopyToClipboardWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findDateInput = function(selector) {
-        const rootSelector = \`.\${DateInputWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DateInputWrapper);
-      };
-
-      ElementWrapper.prototype.findAllDateInputs = function(selector) {
-        return this.findAllComponents(DateInputWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findDatePicker = function(selector) {
-        const rootSelector = \`.\${DatePickerWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DatePickerWrapper);
-      };
-
-      ElementWrapper.prototype.findAllDatePickers = function(selector) {
-        return this.findAllComponents(DatePickerWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findDateRangePicker = function(selector) {
-        const rootSelector = \`.\${DateRangePickerWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DateRangePickerWrapper);
-      };
-
-      ElementWrapper.prototype.findAllDateRangePickers = function(selector) {
-        return this.findAllComponents(DateRangePickerWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findDrawer = function(selector) {
-        const rootSelector = \`.\${DrawerWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DrawerWrapper);
-      };
-
-      ElementWrapper.prototype.findAllDrawers = function(selector) {
-        return this.findAllComponents(DrawerWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findExpandableSection = function(selector) {
-        const rootSelector = \`.\${ExpandableSectionWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ExpandableSectionWrapper);
-      };
-
-      ElementWrapper.prototype.findAllExpandableSections = function(selector) {
-        return this.findAllComponents(ExpandableSectionWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findFileDropzone = function(selector) {
-        const rootSelector = \`.\${FileDropzoneWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileDropzoneWrapper);
-      };
-
-      ElementWrapper.prototype.findAllFileDropzones = function(selector) {
-        return this.findAllComponents(FileDropzoneWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findFileInput = function(selector) {
-        const rootSelector = \`.\${FileInputWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileInputWrapper);
-      };
-
-      ElementWrapper.prototype.findAllFileInputs = function(selector) {
-        return this.findAllComponents(FileInputWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findFileTokenGroup = function(selector) {
-        const rootSelector = \`.\${FileTokenGroupWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileTokenGroupWrapper);
-      };
-
-      ElementWrapper.prototype.findAllFileTokenGroups = function(selector) {
-        return this.findAllComponents(FileTokenGroupWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findFileUpload = function(selector) {
-        const rootSelector = \`.\${FileUploadWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileUploadWrapper);
-      };
-
-      ElementWrapper.prototype.findAllFileUploads = function(selector) {
-        return this.findAllComponents(FileUploadWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findFlashbar = function(selector) {
-        const rootSelector = \`.\${FlashbarWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FlashbarWrapper);
-      };
-
-      ElementWrapper.prototype.findAllFlashbars = function(selector) {
-        return this.findAllComponents(FlashbarWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findForm = function(selector) {
-        const rootSelector = \`.\${FormWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FormWrapper);
-      };
-
-      ElementWrapper.prototype.findAllForms = function(selector) {
-        return this.findAllComponents(FormWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findFormField = function(selector) {
-        const rootSelector = \`.\${FormFieldWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FormFieldWrapper);
-      };
-
-      ElementWrapper.prototype.findAllFormFields = function(selector) {
-        return this.findAllComponents(FormFieldWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findGrid = function(selector) {
-        const rootSelector = \`.\${GridWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, GridWrapper);
-      };
-
-      ElementWrapper.prototype.findAllGrids = function(selector) {
-        return this.findAllComponents(GridWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findHeader = function(selector) {
-        const rootSelector = \`.\${HeaderWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, HeaderWrapper);
-      };
-
-      ElementWrapper.prototype.findAllHeaders = function(selector) {
-        return this.findAllComponents(HeaderWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findHelpPanel = function(selector) {
-        const rootSelector = \`.\${HelpPanelWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, HelpPanelWrapper);
-      };
-
-      ElementWrapper.prototype.findAllHelpPanels = function(selector) {
-        return this.findAllComponents(HelpPanelWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findHotspot = function(selector) {
-        const rootSelector = \`.\${HotspotWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, HotspotWrapper);
-      };
-
-      ElementWrapper.prototype.findAllHotspots = function(selector) {
-        return this.findAllComponents(HotspotWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findIcon = function(selector) {
-        const rootSelector = \`.\${IconWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, IconWrapper);
-      };
-
-      ElementWrapper.prototype.findAllIcons = function(selector) {
-        return this.findAllComponents(IconWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findInput = function(selector) {
-        const rootSelector = \`.\${InputWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, InputWrapper);
-      };
-
-      ElementWrapper.prototype.findAllInputs = function(selector) {
-        return this.findAllComponents(InputWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findKeyValuePairs = function(selector) {
-        const rootSelector = \`.\${KeyValuePairsWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, KeyValuePairsWrapper);
-      };
-
-      ElementWrapper.prototype.findAllKeyValuePairs = function(selector) {
-        return this.findAllComponents(KeyValuePairsWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findLineChart = function(selector) {
-        const rootSelector = \`.\${LineChartWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, LineChartWrapper);
-      };
-
-      ElementWrapper.prototype.findAllLineCharts = function(selector) {
-        return this.findAllComponents(LineChartWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findLink = function(selector) {
-        const rootSelector = \`.\${LinkWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, LinkWrapper);
-      };
-
-      ElementWrapper.prototype.findAllLinks = function(selector) {
-        return this.findAllComponents(LinkWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findLiveRegion = function(selector) {
-        const rootSelector = \`.\${LiveRegionWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, LiveRegionWrapper);
-      };
-
-      ElementWrapper.prototype.findAllLiveRegions = function(selector) {
-        return this.findAllComponents(LiveRegionWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findMixedLineBarChart = function(selector) {
-        const rootSelector = \`.\${MixedLineBarChartWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, MixedLineBarChartWrapper);
-      };
-
-      ElementWrapper.prototype.findAllMixedLineBarCharts = function(selector) {
-        return this.findAllComponents(MixedLineBarChartWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findModal = function(selector) {
-        const rootSelector = \`.\${ModalWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ModalWrapper);
-      };
-
-      ElementWrapper.prototype.findAllModals = function(selector) {
-        return this.findAllComponents(ModalWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findMultiselect = function(selector) {
-        const rootSelector = \`.\${MultiselectWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, MultiselectWrapper);
-      };
-
-      ElementWrapper.prototype.findAllMultiselects = function(selector) {
-        return this.findAllComponents(MultiselectWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findPagination = function(selector) {
-        const rootSelector = \`.\${PaginationWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PaginationWrapper);
-      };
-
-      ElementWrapper.prototype.findAllPaginations = function(selector) {
-        return this.findAllComponents(PaginationWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findPieChart = function(selector) {
-        const rootSelector = \`.\${PieChartWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PieChartWrapper);
-      };
-
-      ElementWrapper.prototype.findAllPieCharts = function(selector) {
-        return this.findAllComponents(PieChartWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findPopover = function(selector) {
-        const rootSelector = \`.\${PopoverWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PopoverWrapper);
-      };
-
-      ElementWrapper.prototype.findAllPopovers = function(selector) {
-        return this.findAllComponents(PopoverWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findProgressBar = function(selector) {
-        const rootSelector = \`.\${ProgressBarWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ProgressBarWrapper);
-      };
-
-      ElementWrapper.prototype.findAllProgressBars = function(selector) {
-        return this.findAllComponents(ProgressBarWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findPromptInput = function(selector) {
-        const rootSelector = \`.\${PromptInputWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PromptInputWrapper);
-      };
-
-      ElementWrapper.prototype.findAllPromptInputs = function(selector) {
-        return this.findAllComponents(PromptInputWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findPropertyFilter = function(selector) {
-        const rootSelector = \`.\${PropertyFilterWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PropertyFilterWrapper);
-      };
-
-      ElementWrapper.prototype.findAllPropertyFilters = function(selector) {
-        return this.findAllComponents(PropertyFilterWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findRadioGroup = function(selector) {
-        const rootSelector = \`.\${RadioGroupWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, RadioGroupWrapper);
-      };
-
-      ElementWrapper.prototype.findAllRadioGroups = function(selector) {
-        return this.findAllComponents(RadioGroupWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findS3ResourceSelector = function(selector) {
-        const rootSelector = \`.\${S3ResourceSelectorWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, S3ResourceSelectorWrapper);
-      };
-
-      ElementWrapper.prototype.findAllS3ResourceSelectors = function(selector) {
-        return this.findAllComponents(S3ResourceSelectorWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSegmentedControl = function(selector) {
-        const rootSelector = \`.\${SegmentedControlWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SegmentedControlWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSegmentedControls = function(selector) {
-        return this.findAllComponents(SegmentedControlWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSelect = function(selector) {
-        const rootSelector = \`.\${SelectWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SelectWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSelects = function(selector) {
-        return this.findAllComponents(SelectWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSideNavigation = function(selector) {
-        const rootSelector = \`.\${SideNavigationWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SideNavigationWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSideNavigations = function(selector) {
-        return this.findAllComponents(SideNavigationWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSlider = function(selector) {
-        const rootSelector = \`.\${SliderWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SliderWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSliders = function(selector) {
-        return this.findAllComponents(SliderWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSpaceBetween = function(selector) {
-        const rootSelector = \`.\${SpaceBetweenWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SpaceBetweenWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSpaceBetweens = function(selector) {
-        return this.findAllComponents(SpaceBetweenWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSpinner = function(selector) {
-        const rootSelector = \`.\${SpinnerWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SpinnerWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSpinners = function(selector) {
-        return this.findAllComponents(SpinnerWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSplitPanel = function(selector) {
-        const rootSelector = \`.\${SplitPanelWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SplitPanelWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSplitPanels = function(selector) {
-        return this.findAllComponents(SplitPanelWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findStatusIndicator = function(selector) {
-        const rootSelector = \`.\${StatusIndicatorWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, StatusIndicatorWrapper);
-      };
-
-      ElementWrapper.prototype.findAllStatusIndicators = function(selector) {
-        return this.findAllComponents(StatusIndicatorWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findSteps = function(selector) {
-        const rootSelector = \`.\${StepsWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, StepsWrapper);
-      };
-
-      ElementWrapper.prototype.findAllSteps = function(selector) {
-        return this.findAllComponents(StepsWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTable = function(selector) {
-        const rootSelector = \`.\${TableWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TableWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTables = function(selector) {
-        return this.findAllComponents(TableWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTabs = function(selector) {
-        const rootSelector = \`.\${TabsWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TabsWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTabs = function(selector) {
-        return this.findAllComponents(TabsWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTagEditor = function(selector) {
-        const rootSelector = \`.\${TagEditorWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TagEditorWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTagEditors = function(selector) {
-        return this.findAllComponents(TagEditorWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTextContent = function(selector) {
-        const rootSelector = \`.\${TextContentWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TextContentWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTextContents = function(selector) {
-        return this.findAllComponents(TextContentWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTextFilter = function(selector) {
-        const rootSelector = \`.\${TextFilterWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TextFilterWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTextFilters = function(selector) {
-        return this.findAllComponents(TextFilterWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTextarea = function(selector) {
-        const rootSelector = \`.\${TextareaWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TextareaWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTextareas = function(selector) {
-        return this.findAllComponents(TextareaWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTiles = function(selector) {
-        const rootSelector = \`.\${TilesWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TilesWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTiles = function(selector) {
-        return this.findAllComponents(TilesWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTimeInput = function(selector) {
-        const rootSelector = \`.\${TimeInputWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TimeInputWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTimeInputs = function(selector) {
-        return this.findAllComponents(TimeInputWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findToggle = function(selector) {
-        const rootSelector = \`.\${ToggleWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ToggleWrapper);
-      };
-
-      ElementWrapper.prototype.findAllToggles = function(selector) {
-        return this.findAllComponents(ToggleWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findToggleButton = function(selector) {
-        const rootSelector = \`.\${ToggleButtonWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ToggleButtonWrapper);
-      };
-
-      ElementWrapper.prototype.findAllToggleButtons = function(selector) {
-        return this.findAllComponents(ToggleButtonWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTokenGroup = function(selector) {
-        const rootSelector = \`.\${TokenGroupWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TokenGroupWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTokenGroups = function(selector) {
-        return this.findAllComponents(TokenGroupWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTopNavigation = function(selector) {
-        const rootSelector = \`.\${TopNavigationWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TopNavigationWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTopNavigations = function(selector) {
-        return this.findAllComponents(TopNavigationWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findTutorialPanel = function(selector) {
-        const rootSelector = \`.\${TutorialPanelWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TutorialPanelWrapper);
-      };
-
-      ElementWrapper.prototype.findAllTutorialPanels = function(selector) {
-        return this.findAllComponents(TutorialPanelWrapper, selector);
-      };
-
-      ElementWrapper.prototype.findWizard = function(selector) {
-        const rootSelector = \`.\${WizardWrapper.rootSelector}\`;
-        // casting to 'any' is needed to avoid this issue with generics
-        // https://github.com/microsoft/TypeScript/issues/29132
-        return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, WizardWrapper);
-      };
-
-      ElementWrapper.prototype.findAllWizards = function(selector) {
-        return this.findAllComponents(WizardWrapper, selector);
-      };
-export default function wrapper(root: string = 'body') { return new ElementWrapper(root); }"
+   interface ElementWrapper {
+    
+/**
+ * Returns a wrapper that matches the Alerts with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Alerts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {AlertWrapper}
+ */
+findAlert(selector?: string): AlertWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Alerts with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Alerts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<AlertWrapper>}
+ */
+findAllAlerts(selector?: string): MultiElementWrapper<AlertWrapper>;
+/**
+ * Returns a wrapper that matches the AnchorNavigations with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches AnchorNavigations.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {AnchorNavigationWrapper}
+ */
+findAnchorNavigation(selector?: string): AnchorNavigationWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches AnchorNavigations with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches AnchorNavigations.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<AnchorNavigationWrapper>}
+ */
+findAllAnchorNavigations(selector?: string): MultiElementWrapper<AnchorNavigationWrapper>;
+/**
+ * Returns a wrapper that matches the Annotations with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Annotations.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {AnnotationWrapper}
+ */
+findAnnotation(selector?: string): AnnotationWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Annotations with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Annotations.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<AnnotationWrapper>}
+ */
+findAllAnnotations(selector?: string): MultiElementWrapper<AnnotationWrapper>;
+/**
+ * Returns a wrapper that matches the AppLayouts with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches AppLayouts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {AppLayoutWrapper}
+ */
+findAppLayout(selector?: string): AppLayoutWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches AppLayouts with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches AppLayouts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<AppLayoutWrapper>}
+ */
+findAllAppLayouts(selector?: string): MultiElementWrapper<AppLayoutWrapper>;
+/**
+ * Returns a wrapper that matches the AreaCharts with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches AreaCharts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {AreaChartWrapper}
+ */
+findAreaChart(selector?: string): AreaChartWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches AreaCharts with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches AreaCharts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<AreaChartWrapper>}
+ */
+findAllAreaCharts(selector?: string): MultiElementWrapper<AreaChartWrapper>;
+/**
+ * Returns a wrapper that matches the AttributeEditors with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches AttributeEditors.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {AttributeEditorWrapper}
+ */
+findAttributeEditor(selector?: string): AttributeEditorWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches AttributeEditors with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches AttributeEditors.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<AttributeEditorWrapper>}
+ */
+findAllAttributeEditors(selector?: string): MultiElementWrapper<AttributeEditorWrapper>;
+/**
+ * Returns a wrapper that matches the Autosuggests with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Autosuggests.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {AutosuggestWrapper}
+ */
+findAutosuggest(selector?: string): AutosuggestWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Autosuggests with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Autosuggests.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<AutosuggestWrapper>}
+ */
+findAllAutosuggests(selector?: string): MultiElementWrapper<AutosuggestWrapper>;
+/**
+ * Returns a wrapper that matches the Badges with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Badges.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {BadgeWrapper}
+ */
+findBadge(selector?: string): BadgeWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Badges with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Badges.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<BadgeWrapper>}
+ */
+findAllBadges(selector?: string): MultiElementWrapper<BadgeWrapper>;
+/**
+ * Returns a wrapper that matches the BarCharts with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches BarCharts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {BarChartWrapper}
+ */
+findBarChart(selector?: string): BarChartWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches BarCharts with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches BarCharts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<BarChartWrapper>}
+ */
+findAllBarCharts(selector?: string): MultiElementWrapper<BarChartWrapper>;
+/**
+ * Returns a wrapper that matches the Boxes with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Boxes.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {BoxWrapper}
+ */
+findBox(selector?: string): BoxWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Boxes with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Boxes.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<BoxWrapper>}
+ */
+findAllBoxes(selector?: string): MultiElementWrapper<BoxWrapper>;
+/**
+ * Returns a wrapper that matches the BreadcrumbGroups with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches BreadcrumbGroups.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {BreadcrumbGroupWrapper}
+ */
+findBreadcrumbGroup(selector?: string): BreadcrumbGroupWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches BreadcrumbGroups with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches BreadcrumbGroups.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<BreadcrumbGroupWrapper>}
+ */
+findAllBreadcrumbGroups(selector?: string): MultiElementWrapper<BreadcrumbGroupWrapper>;
+/**
+ * Returns a wrapper that matches the Buttons with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Buttons.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ButtonWrapper}
+ */
+findButton(selector?: string): ButtonWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Buttons with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Buttons.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<ButtonWrapper>}
+ */
+findAllButtons(selector?: string): MultiElementWrapper<ButtonWrapper>;
+/**
+ * Returns a wrapper that matches the ButtonDropdowns with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches ButtonDropdowns.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ButtonDropdownWrapper}
+ */
+findButtonDropdown(selector?: string): ButtonDropdownWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches ButtonDropdowns with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches ButtonDropdowns.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<ButtonDropdownWrapper>}
+ */
+findAllButtonDropdowns(selector?: string): MultiElementWrapper<ButtonDropdownWrapper>;
+/**
+ * Returns a wrapper that matches the ButtonGroups with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches ButtonGroups.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ButtonGroupWrapper}
+ */
+findButtonGroup(selector?: string): ButtonGroupWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches ButtonGroups with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches ButtonGroups.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<ButtonGroupWrapper>}
+ */
+findAllButtonGroups(selector?: string): MultiElementWrapper<ButtonGroupWrapper>;
+/**
+ * Returns a wrapper that matches the Calendars with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Calendars.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {CalendarWrapper}
+ */
+findCalendar(selector?: string): CalendarWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Calendars with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Calendars.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<CalendarWrapper>}
+ */
+findAllCalendars(selector?: string): MultiElementWrapper<CalendarWrapper>;
+/**
+ * Returns a wrapper that matches the Cards with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Cards.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {CardsWrapper}
+ */
+findCards(selector?: string): CardsWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Cards with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Cards.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<CardsWrapper>}
+ */
+findAllCards(selector?: string): MultiElementWrapper<CardsWrapper>;
+/**
+ * Returns a wrapper that matches the Checkboxes with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Checkboxes.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {CheckboxWrapper}
+ */
+findCheckbox(selector?: string): CheckboxWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Checkboxes with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Checkboxes.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<CheckboxWrapper>}
+ */
+findAllCheckboxes(selector?: string): MultiElementWrapper<CheckboxWrapper>;
+/**
+ * Returns a wrapper that matches the CodeEditors with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches CodeEditors.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {CodeEditorWrapper}
+ */
+findCodeEditor(selector?: string): CodeEditorWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches CodeEditors with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches CodeEditors.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<CodeEditorWrapper>}
+ */
+findAllCodeEditors(selector?: string): MultiElementWrapper<CodeEditorWrapper>;
+/**
+ * Returns a wrapper that matches the CollectionPreferences with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches CollectionPreferences.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {CollectionPreferencesWrapper}
+ */
+findCollectionPreferences(selector?: string): CollectionPreferencesWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches CollectionPreferences with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches CollectionPreferences.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<CollectionPreferencesWrapper>}
+ */
+findAllCollectionPreferences(selector?: string): MultiElementWrapper<CollectionPreferencesWrapper>;
+/**
+ * Returns a wrapper that matches the ColumnLayouts with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches ColumnLayouts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ColumnLayoutWrapper}
+ */
+findColumnLayout(selector?: string): ColumnLayoutWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches ColumnLayouts with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches ColumnLayouts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<ColumnLayoutWrapper>}
+ */
+findAllColumnLayouts(selector?: string): MultiElementWrapper<ColumnLayoutWrapper>;
+/**
+ * Returns a wrapper that matches the Containers with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Containers.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ContainerWrapper}
+ */
+findContainer(selector?: string): ContainerWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Containers with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Containers.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<ContainerWrapper>}
+ */
+findAllContainers(selector?: string): MultiElementWrapper<ContainerWrapper>;
+/**
+ * Returns a wrapper that matches the ContentLayouts with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches ContentLayouts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ContentLayoutWrapper}
+ */
+findContentLayout(selector?: string): ContentLayoutWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches ContentLayouts with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches ContentLayouts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<ContentLayoutWrapper>}
+ */
+findAllContentLayouts(selector?: string): MultiElementWrapper<ContentLayoutWrapper>;
+/**
+ * Returns a wrapper that matches the CopyToClipboards with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches CopyToClipboards.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {CopyToClipboardWrapper}
+ */
+findCopyToClipboard(selector?: string): CopyToClipboardWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches CopyToClipboards with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches CopyToClipboards.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<CopyToClipboardWrapper>}
+ */
+findAllCopyToClipboards(selector?: string): MultiElementWrapper<CopyToClipboardWrapper>;
+/**
+ * Returns a wrapper that matches the DateInputs with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches DateInputs.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {DateInputWrapper}
+ */
+findDateInput(selector?: string): DateInputWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches DateInputs with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches DateInputs.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<DateInputWrapper>}
+ */
+findAllDateInputs(selector?: string): MultiElementWrapper<DateInputWrapper>;
+/**
+ * Returns a wrapper that matches the DatePickers with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches DatePickers.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {DatePickerWrapper}
+ */
+findDatePicker(selector?: string): DatePickerWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches DatePickers with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches DatePickers.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<DatePickerWrapper>}
+ */
+findAllDatePickers(selector?: string): MultiElementWrapper<DatePickerWrapper>;
+/**
+ * Returns a wrapper that matches the DateRangePickers with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches DateRangePickers.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {DateRangePickerWrapper}
+ */
+findDateRangePicker(selector?: string): DateRangePickerWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches DateRangePickers with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches DateRangePickers.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<DateRangePickerWrapper>}
+ */
+findAllDateRangePickers(selector?: string): MultiElementWrapper<DateRangePickerWrapper>;
+/**
+ * Returns a wrapper that matches the Drawers with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Drawers.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {DrawerWrapper}
+ */
+findDrawer(selector?: string): DrawerWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Drawers with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Drawers.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<DrawerWrapper>}
+ */
+findAllDrawers(selector?: string): MultiElementWrapper<DrawerWrapper>;
+/**
+ * Returns a wrapper that matches the ExpandableSections with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches ExpandableSections.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ExpandableSectionWrapper}
+ */
+findExpandableSection(selector?: string): ExpandableSectionWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches ExpandableSections with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches ExpandableSections.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<ExpandableSectionWrapper>}
+ */
+findAllExpandableSections(selector?: string): MultiElementWrapper<ExpandableSectionWrapper>;
+/**
+ * Returns a wrapper that matches the FileDropzones with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches FileDropzones.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {FileDropzoneWrapper}
+ */
+findFileDropzone(selector?: string): FileDropzoneWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches FileDropzones with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches FileDropzones.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<FileDropzoneWrapper>}
+ */
+findAllFileDropzones(selector?: string): MultiElementWrapper<FileDropzoneWrapper>;
+/**
+ * Returns a wrapper that matches the FileInputs with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches FileInputs.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {FileInputWrapper}
+ */
+findFileInput(selector?: string): FileInputWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches FileInputs with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches FileInputs.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<FileInputWrapper>}
+ */
+findAllFileInputs(selector?: string): MultiElementWrapper<FileInputWrapper>;
+/**
+ * Returns a wrapper that matches the FileTokenGroups with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches FileTokenGroups.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {FileTokenGroupWrapper}
+ */
+findFileTokenGroup(selector?: string): FileTokenGroupWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches FileTokenGroups with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches FileTokenGroups.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<FileTokenGroupWrapper>}
+ */
+findAllFileTokenGroups(selector?: string): MultiElementWrapper<FileTokenGroupWrapper>;
+/**
+ * Returns a wrapper that matches the FileUploads with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches FileUploads.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {FileUploadWrapper}
+ */
+findFileUpload(selector?: string): FileUploadWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches FileUploads with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches FileUploads.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<FileUploadWrapper>}
+ */
+findAllFileUploads(selector?: string): MultiElementWrapper<FileUploadWrapper>;
+/**
+ * Returns a wrapper that matches the Flashbars with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Flashbars.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {FlashbarWrapper}
+ */
+findFlashbar(selector?: string): FlashbarWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Flashbars with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Flashbars.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<FlashbarWrapper>}
+ */
+findAllFlashbars(selector?: string): MultiElementWrapper<FlashbarWrapper>;
+/**
+ * Returns a wrapper that matches the Forms with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Forms.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {FormWrapper}
+ */
+findForm(selector?: string): FormWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Forms with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Forms.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<FormWrapper>}
+ */
+findAllForms(selector?: string): MultiElementWrapper<FormWrapper>;
+/**
+ * Returns a wrapper that matches the FormFields with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches FormFields.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {FormFieldWrapper}
+ */
+findFormField(selector?: string): FormFieldWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches FormFields with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches FormFields.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<FormFieldWrapper>}
+ */
+findAllFormFields(selector?: string): MultiElementWrapper<FormFieldWrapper>;
+/**
+ * Returns a wrapper that matches the Grids with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Grids.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {GridWrapper}
+ */
+findGrid(selector?: string): GridWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Grids with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Grids.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<GridWrapper>}
+ */
+findAllGrids(selector?: string): MultiElementWrapper<GridWrapper>;
+/**
+ * Returns a wrapper that matches the Headers with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Headers.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {HeaderWrapper}
+ */
+findHeader(selector?: string): HeaderWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Headers with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Headers.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<HeaderWrapper>}
+ */
+findAllHeaders(selector?: string): MultiElementWrapper<HeaderWrapper>;
+/**
+ * Returns a wrapper that matches the HelpPanels with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches HelpPanels.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {HelpPanelWrapper}
+ */
+findHelpPanel(selector?: string): HelpPanelWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches HelpPanels with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches HelpPanels.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<HelpPanelWrapper>}
+ */
+findAllHelpPanels(selector?: string): MultiElementWrapper<HelpPanelWrapper>;
+/**
+ * Returns a wrapper that matches the Hotspots with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Hotspots.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {HotspotWrapper}
+ */
+findHotspot(selector?: string): HotspotWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Hotspots with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Hotspots.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<HotspotWrapper>}
+ */
+findAllHotspots(selector?: string): MultiElementWrapper<HotspotWrapper>;
+/**
+ * Returns a wrapper that matches the Icons with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Icons.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {IconWrapper}
+ */
+findIcon(selector?: string): IconWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Icons with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Icons.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<IconWrapper>}
+ */
+findAllIcons(selector?: string): MultiElementWrapper<IconWrapper>;
+/**
+ * Returns a wrapper that matches the Inputs with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Inputs.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {InputWrapper}
+ */
+findInput(selector?: string): InputWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Inputs with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Inputs.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<InputWrapper>}
+ */
+findAllInputs(selector?: string): MultiElementWrapper<InputWrapper>;
+/**
+ * Returns a wrapper that matches the KeyValuePairs with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches KeyValuePairs.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {KeyValuePairsWrapper}
+ */
+findKeyValuePairs(selector?: string): KeyValuePairsWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches KeyValuePairs with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches KeyValuePairs.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<KeyValuePairsWrapper>}
+ */
+findAllKeyValuePairs(selector?: string): MultiElementWrapper<KeyValuePairsWrapper>;
+/**
+ * Returns a wrapper that matches the LineCharts with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches LineCharts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {LineChartWrapper}
+ */
+findLineChart(selector?: string): LineChartWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches LineCharts with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches LineCharts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<LineChartWrapper>}
+ */
+findAllLineCharts(selector?: string): MultiElementWrapper<LineChartWrapper>;
+/**
+ * Returns a wrapper that matches the Links with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Links.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {LinkWrapper}
+ */
+findLink(selector?: string): LinkWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Links with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Links.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<LinkWrapper>}
+ */
+findAllLinks(selector?: string): MultiElementWrapper<LinkWrapper>;
+/**
+ * Returns a wrapper that matches the LiveRegions with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches LiveRegions.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {LiveRegionWrapper}
+ */
+findLiveRegion(selector?: string): LiveRegionWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches LiveRegions with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches LiveRegions.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<LiveRegionWrapper>}
+ */
+findAllLiveRegions(selector?: string): MultiElementWrapper<LiveRegionWrapper>;
+/**
+ * Returns a wrapper that matches the MixedLineBarCharts with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches MixedLineBarCharts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MixedLineBarChartWrapper}
+ */
+findMixedLineBarChart(selector?: string): MixedLineBarChartWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches MixedLineBarCharts with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches MixedLineBarCharts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<MixedLineBarChartWrapper>}
+ */
+findAllMixedLineBarCharts(selector?: string): MultiElementWrapper<MixedLineBarChartWrapper>;
+/**
+ * Returns a wrapper that matches the Modals with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Modals.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ModalWrapper}
+ */
+findModal(selector?: string): ModalWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Modals with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Modals.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<ModalWrapper>}
+ */
+findAllModals(selector?: string): MultiElementWrapper<ModalWrapper>;
+/**
+ * Returns a wrapper that matches the Multiselects with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Multiselects.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiselectWrapper}
+ */
+findMultiselect(selector?: string): MultiselectWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Multiselects with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Multiselects.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<MultiselectWrapper>}
+ */
+findAllMultiselects(selector?: string): MultiElementWrapper<MultiselectWrapper>;
+/**
+ * Returns a wrapper that matches the Paginations with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Paginations.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {PaginationWrapper}
+ */
+findPagination(selector?: string): PaginationWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Paginations with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Paginations.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<PaginationWrapper>}
+ */
+findAllPaginations(selector?: string): MultiElementWrapper<PaginationWrapper>;
+/**
+ * Returns a wrapper that matches the PieCharts with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches PieCharts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {PieChartWrapper}
+ */
+findPieChart(selector?: string): PieChartWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches PieCharts with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches PieCharts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<PieChartWrapper>}
+ */
+findAllPieCharts(selector?: string): MultiElementWrapper<PieChartWrapper>;
+/**
+ * Returns a wrapper that matches the Popovers with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Popovers.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {PopoverWrapper}
+ */
+findPopover(selector?: string): PopoverWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Popovers with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Popovers.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<PopoverWrapper>}
+ */
+findAllPopovers(selector?: string): MultiElementWrapper<PopoverWrapper>;
+/**
+ * Returns a wrapper that matches the ProgressBars with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches ProgressBars.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ProgressBarWrapper}
+ */
+findProgressBar(selector?: string): ProgressBarWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches ProgressBars with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches ProgressBars.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<ProgressBarWrapper>}
+ */
+findAllProgressBars(selector?: string): MultiElementWrapper<ProgressBarWrapper>;
+/**
+ * Returns a wrapper that matches the PromptInputs with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches PromptInputs.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {PromptInputWrapper}
+ */
+findPromptInput(selector?: string): PromptInputWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches PromptInputs with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches PromptInputs.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<PromptInputWrapper>}
+ */
+findAllPromptInputs(selector?: string): MultiElementWrapper<PromptInputWrapper>;
+/**
+ * Returns a wrapper that matches the PropertyFilters with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches PropertyFilters.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {PropertyFilterWrapper}
+ */
+findPropertyFilter(selector?: string): PropertyFilterWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches PropertyFilters with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches PropertyFilters.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<PropertyFilterWrapper>}
+ */
+findAllPropertyFilters(selector?: string): MultiElementWrapper<PropertyFilterWrapper>;
+/**
+ * Returns a wrapper that matches the RadioGroups with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches RadioGroups.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {RadioGroupWrapper}
+ */
+findRadioGroup(selector?: string): RadioGroupWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches RadioGroups with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches RadioGroups.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<RadioGroupWrapper>}
+ */
+findAllRadioGroups(selector?: string): MultiElementWrapper<RadioGroupWrapper>;
+/**
+ * Returns a wrapper that matches the S3ResourceSelectors with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches S3ResourceSelectors.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {S3ResourceSelectorWrapper}
+ */
+findS3ResourceSelector(selector?: string): S3ResourceSelectorWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches S3ResourceSelectors with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches S3ResourceSelectors.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<S3ResourceSelectorWrapper>}
+ */
+findAllS3ResourceSelectors(selector?: string): MultiElementWrapper<S3ResourceSelectorWrapper>;
+/**
+ * Returns a wrapper that matches the SegmentedControls with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches SegmentedControls.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {SegmentedControlWrapper}
+ */
+findSegmentedControl(selector?: string): SegmentedControlWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches SegmentedControls with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches SegmentedControls.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<SegmentedControlWrapper>}
+ */
+findAllSegmentedControls(selector?: string): MultiElementWrapper<SegmentedControlWrapper>;
+/**
+ * Returns a wrapper that matches the Selects with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Selects.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {SelectWrapper}
+ */
+findSelect(selector?: string): SelectWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Selects with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Selects.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<SelectWrapper>}
+ */
+findAllSelects(selector?: string): MultiElementWrapper<SelectWrapper>;
+/**
+ * Returns a wrapper that matches the SideNavigations with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches SideNavigations.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {SideNavigationWrapper}
+ */
+findSideNavigation(selector?: string): SideNavigationWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches SideNavigations with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches SideNavigations.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<SideNavigationWrapper>}
+ */
+findAllSideNavigations(selector?: string): MultiElementWrapper<SideNavigationWrapper>;
+/**
+ * Returns a wrapper that matches the Sliders with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Sliders.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {SliderWrapper}
+ */
+findSlider(selector?: string): SliderWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Sliders with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Sliders.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<SliderWrapper>}
+ */
+findAllSliders(selector?: string): MultiElementWrapper<SliderWrapper>;
+/**
+ * Returns a wrapper that matches the SpaceBetweens with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches SpaceBetweens.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {SpaceBetweenWrapper}
+ */
+findSpaceBetween(selector?: string): SpaceBetweenWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches SpaceBetweens with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches SpaceBetweens.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<SpaceBetweenWrapper>}
+ */
+findAllSpaceBetweens(selector?: string): MultiElementWrapper<SpaceBetweenWrapper>;
+/**
+ * Returns a wrapper that matches the Spinners with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Spinners.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {SpinnerWrapper}
+ */
+findSpinner(selector?: string): SpinnerWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Spinners with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Spinners.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<SpinnerWrapper>}
+ */
+findAllSpinners(selector?: string): MultiElementWrapper<SpinnerWrapper>;
+/**
+ * Returns a wrapper that matches the SplitPanels with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches SplitPanels.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {SplitPanelWrapper}
+ */
+findSplitPanel(selector?: string): SplitPanelWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches SplitPanels with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches SplitPanels.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<SplitPanelWrapper>}
+ */
+findAllSplitPanels(selector?: string): MultiElementWrapper<SplitPanelWrapper>;
+/**
+ * Returns a wrapper that matches the StatusIndicators with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches StatusIndicators.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {StatusIndicatorWrapper}
+ */
+findStatusIndicator(selector?: string): StatusIndicatorWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches StatusIndicators with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches StatusIndicators.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<StatusIndicatorWrapper>}
+ */
+findAllStatusIndicators(selector?: string): MultiElementWrapper<StatusIndicatorWrapper>;
+/**
+ * Returns a wrapper that matches the Steps with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Steps.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {StepsWrapper}
+ */
+findSteps(selector?: string): StepsWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Steps with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Steps.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<StepsWrapper>}
+ */
+findAllSteps(selector?: string): MultiElementWrapper<StepsWrapper>;
+/**
+ * Returns a wrapper that matches the Tables with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Tables.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TableWrapper}
+ */
+findTable(selector?: string): TableWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Tables with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Tables.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<TableWrapper>}
+ */
+findAllTables(selector?: string): MultiElementWrapper<TableWrapper>;
+/**
+ * Returns a wrapper that matches the Tabs with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Tabs.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TabsWrapper}
+ */
+findTabs(selector?: string): TabsWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Tabs with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Tabs.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<TabsWrapper>}
+ */
+findAllTabs(selector?: string): MultiElementWrapper<TabsWrapper>;
+/**
+ * Returns a wrapper that matches the TagEditors with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches TagEditors.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TagEditorWrapper}
+ */
+findTagEditor(selector?: string): TagEditorWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches TagEditors with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches TagEditors.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<TagEditorWrapper>}
+ */
+findAllTagEditors(selector?: string): MultiElementWrapper<TagEditorWrapper>;
+/**
+ * Returns a wrapper that matches the TextContents with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches TextContents.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TextContentWrapper}
+ */
+findTextContent(selector?: string): TextContentWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches TextContents with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches TextContents.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<TextContentWrapper>}
+ */
+findAllTextContents(selector?: string): MultiElementWrapper<TextContentWrapper>;
+/**
+ * Returns a wrapper that matches the TextFilters with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches TextFilters.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TextFilterWrapper}
+ */
+findTextFilter(selector?: string): TextFilterWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches TextFilters with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches TextFilters.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<TextFilterWrapper>}
+ */
+findAllTextFilters(selector?: string): MultiElementWrapper<TextFilterWrapper>;
+/**
+ * Returns a wrapper that matches the Textareas with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Textareas.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TextareaWrapper}
+ */
+findTextarea(selector?: string): TextareaWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Textareas with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Textareas.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<TextareaWrapper>}
+ */
+findAllTextareas(selector?: string): MultiElementWrapper<TextareaWrapper>;
+/**
+ * Returns a wrapper that matches the Tiles with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Tiles.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TilesWrapper}
+ */
+findTiles(selector?: string): TilesWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Tiles with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Tiles.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<TilesWrapper>}
+ */
+findAllTiles(selector?: string): MultiElementWrapper<TilesWrapper>;
+/**
+ * Returns a wrapper that matches the TimeInputs with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches TimeInputs.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TimeInputWrapper}
+ */
+findTimeInput(selector?: string): TimeInputWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches TimeInputs with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches TimeInputs.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<TimeInputWrapper>}
+ */
+findAllTimeInputs(selector?: string): MultiElementWrapper<TimeInputWrapper>;
+/**
+ * Returns a wrapper that matches the Toggles with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Toggles.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ToggleWrapper}
+ */
+findToggle(selector?: string): ToggleWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Toggles with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Toggles.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<ToggleWrapper>}
+ */
+findAllToggles(selector?: string): MultiElementWrapper<ToggleWrapper>;
+/**
+ * Returns a wrapper that matches the ToggleButtons with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches ToggleButtons.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ToggleButtonWrapper}
+ */
+findToggleButton(selector?: string): ToggleButtonWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches ToggleButtons with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches ToggleButtons.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<ToggleButtonWrapper>}
+ */
+findAllToggleButtons(selector?: string): MultiElementWrapper<ToggleButtonWrapper>;
+/**
+ * Returns a wrapper that matches the TokenGroups with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches TokenGroups.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TokenGroupWrapper}
+ */
+findTokenGroup(selector?: string): TokenGroupWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches TokenGroups with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches TokenGroups.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<TokenGroupWrapper>}
+ */
+findAllTokenGroups(selector?: string): MultiElementWrapper<TokenGroupWrapper>;
+/**
+ * Returns a wrapper that matches the TopNavigations with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches TopNavigations.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TopNavigationWrapper}
+ */
+findTopNavigation(selector?: string): TopNavigationWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches TopNavigations with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches TopNavigations.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<TopNavigationWrapper>}
+ */
+findAllTopNavigations(selector?: string): MultiElementWrapper<TopNavigationWrapper>;
+/**
+ * Returns a wrapper that matches the TutorialPanels with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches TutorialPanels.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TutorialPanelWrapper}
+ */
+findTutorialPanel(selector?: string): TutorialPanelWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches TutorialPanels with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches TutorialPanels.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<TutorialPanelWrapper>}
+ */
+findAllTutorialPanels(selector?: string): MultiElementWrapper<TutorialPanelWrapper>;
+/**
+ * Returns a wrapper that matches the Wizards with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches Wizards.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {WizardWrapper}
+ */
+findWizard(selector?: string): WizardWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches Wizards with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches Wizards.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<WizardWrapper>}
+ */
+findAllWizards(selector?: string): MultiElementWrapper<WizardWrapper>;
+   }
+}
+
+
+ElementWrapper.prototype.findAlert = function(selector) {
+  const rootSelector = \`.\${AlertWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AlertWrapper);
+};
+
+ElementWrapper.prototype.findAllAlerts = function(selector) {
+  return this.findAllComponents(AlertWrapper, selector);
+};
+ElementWrapper.prototype.findAnchorNavigation = function(selector) {
+  const rootSelector = \`.\${AnchorNavigationWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AnchorNavigationWrapper);
+};
+
+ElementWrapper.prototype.findAllAnchorNavigations = function(selector) {
+  return this.findAllComponents(AnchorNavigationWrapper, selector);
+};
+ElementWrapper.prototype.findAnnotation = function(selector) {
+  const rootSelector = \`.\${AnnotationWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AnnotationWrapper);
+};
+
+ElementWrapper.prototype.findAllAnnotations = function(selector) {
+  return this.findAllComponents(AnnotationWrapper, selector);
+};
+ElementWrapper.prototype.findAppLayout = function(selector) {
+  const rootSelector = \`.\${AppLayoutWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AppLayoutWrapper);
+};
+
+ElementWrapper.prototype.findAllAppLayouts = function(selector) {
+  return this.findAllComponents(AppLayoutWrapper, selector);
+};
+ElementWrapper.prototype.findAreaChart = function(selector) {
+  const rootSelector = \`.\${AreaChartWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AreaChartWrapper);
+};
+
+ElementWrapper.prototype.findAllAreaCharts = function(selector) {
+  return this.findAllComponents(AreaChartWrapper, selector);
+};
+ElementWrapper.prototype.findAttributeEditor = function(selector) {
+  const rootSelector = \`.\${AttributeEditorWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AttributeEditorWrapper);
+};
+
+ElementWrapper.prototype.findAllAttributeEditors = function(selector) {
+  return this.findAllComponents(AttributeEditorWrapper, selector);
+};
+ElementWrapper.prototype.findAutosuggest = function(selector) {
+  const rootSelector = \`.\${AutosuggestWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, AutosuggestWrapper);
+};
+
+ElementWrapper.prototype.findAllAutosuggests = function(selector) {
+  return this.findAllComponents(AutosuggestWrapper, selector);
+};
+ElementWrapper.prototype.findBadge = function(selector) {
+  const rootSelector = \`.\${BadgeWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BadgeWrapper);
+};
+
+ElementWrapper.prototype.findAllBadges = function(selector) {
+  return this.findAllComponents(BadgeWrapper, selector);
+};
+ElementWrapper.prototype.findBarChart = function(selector) {
+  const rootSelector = \`.\${BarChartWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BarChartWrapper);
+};
+
+ElementWrapper.prototype.findAllBarCharts = function(selector) {
+  return this.findAllComponents(BarChartWrapper, selector);
+};
+ElementWrapper.prototype.findBox = function(selector) {
+  const rootSelector = \`.\${BoxWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BoxWrapper);
+};
+
+ElementWrapper.prototype.findAllBoxes = function(selector) {
+  return this.findAllComponents(BoxWrapper, selector);
+};
+ElementWrapper.prototype.findBreadcrumbGroup = function(selector) {
+  const rootSelector = \`.\${BreadcrumbGroupWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BreadcrumbGroupWrapper);
+};
+
+ElementWrapper.prototype.findAllBreadcrumbGroups = function(selector) {
+  return this.findAllComponents(BreadcrumbGroupWrapper, selector);
+};
+ElementWrapper.prototype.findButton = function(selector) {
+  const rootSelector = \`.\${ButtonWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ButtonWrapper);
+};
+
+ElementWrapper.prototype.findAllButtons = function(selector) {
+  return this.findAllComponents(ButtonWrapper, selector);
+};
+ElementWrapper.prototype.findButtonDropdown = function(selector) {
+  const rootSelector = \`.\${ButtonDropdownWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ButtonDropdownWrapper);
+};
+
+ElementWrapper.prototype.findAllButtonDropdowns = function(selector) {
+  return this.findAllComponents(ButtonDropdownWrapper, selector);
+};
+ElementWrapper.prototype.findButtonGroup = function(selector) {
+  const rootSelector = \`.\${ButtonGroupWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ButtonGroupWrapper);
+};
+
+ElementWrapper.prototype.findAllButtonGroups = function(selector) {
+  return this.findAllComponents(ButtonGroupWrapper, selector);
+};
+ElementWrapper.prototype.findCalendar = function(selector) {
+  const rootSelector = \`.\${CalendarWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CalendarWrapper);
+};
+
+ElementWrapper.prototype.findAllCalendars = function(selector) {
+  return this.findAllComponents(CalendarWrapper, selector);
+};
+ElementWrapper.prototype.findCards = function(selector) {
+  const rootSelector = \`.\${CardsWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CardsWrapper);
+};
+
+ElementWrapper.prototype.findAllCards = function(selector) {
+  return this.findAllComponents(CardsWrapper, selector);
+};
+ElementWrapper.prototype.findCheckbox = function(selector) {
+  const rootSelector = \`.\${CheckboxWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CheckboxWrapper);
+};
+
+ElementWrapper.prototype.findAllCheckboxes = function(selector) {
+  return this.findAllComponents(CheckboxWrapper, selector);
+};
+ElementWrapper.prototype.findCodeEditor = function(selector) {
+  const rootSelector = \`.\${CodeEditorWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CodeEditorWrapper);
+};
+
+ElementWrapper.prototype.findAllCodeEditors = function(selector) {
+  return this.findAllComponents(CodeEditorWrapper, selector);
+};
+ElementWrapper.prototype.findCollectionPreferences = function(selector) {
+  const rootSelector = \`.\${CollectionPreferencesWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CollectionPreferencesWrapper);
+};
+
+ElementWrapper.prototype.findAllCollectionPreferences = function(selector) {
+  return this.findAllComponents(CollectionPreferencesWrapper, selector);
+};
+ElementWrapper.prototype.findColumnLayout = function(selector) {
+  const rootSelector = \`.\${ColumnLayoutWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ColumnLayoutWrapper);
+};
+
+ElementWrapper.prototype.findAllColumnLayouts = function(selector) {
+  return this.findAllComponents(ColumnLayoutWrapper, selector);
+};
+ElementWrapper.prototype.findContainer = function(selector) {
+  const rootSelector = \`.\${ContainerWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ContainerWrapper);
+};
+
+ElementWrapper.prototype.findAllContainers = function(selector) {
+  return this.findAllComponents(ContainerWrapper, selector);
+};
+ElementWrapper.prototype.findContentLayout = function(selector) {
+  const rootSelector = \`.\${ContentLayoutWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ContentLayoutWrapper);
+};
+
+ElementWrapper.prototype.findAllContentLayouts = function(selector) {
+  return this.findAllComponents(ContentLayoutWrapper, selector);
+};
+ElementWrapper.prototype.findCopyToClipboard = function(selector) {
+  const rootSelector = \`.\${CopyToClipboardWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, CopyToClipboardWrapper);
+};
+
+ElementWrapper.prototype.findAllCopyToClipboards = function(selector) {
+  return this.findAllComponents(CopyToClipboardWrapper, selector);
+};
+ElementWrapper.prototype.findDateInput = function(selector) {
+  const rootSelector = \`.\${DateInputWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DateInputWrapper);
+};
+
+ElementWrapper.prototype.findAllDateInputs = function(selector) {
+  return this.findAllComponents(DateInputWrapper, selector);
+};
+ElementWrapper.prototype.findDatePicker = function(selector) {
+  const rootSelector = \`.\${DatePickerWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DatePickerWrapper);
+};
+
+ElementWrapper.prototype.findAllDatePickers = function(selector) {
+  return this.findAllComponents(DatePickerWrapper, selector);
+};
+ElementWrapper.prototype.findDateRangePicker = function(selector) {
+  const rootSelector = \`.\${DateRangePickerWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DateRangePickerWrapper);
+};
+
+ElementWrapper.prototype.findAllDateRangePickers = function(selector) {
+  return this.findAllComponents(DateRangePickerWrapper, selector);
+};
+ElementWrapper.prototype.findDrawer = function(selector) {
+  const rootSelector = \`.\${DrawerWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DrawerWrapper);
+};
+
+ElementWrapper.prototype.findAllDrawers = function(selector) {
+  return this.findAllComponents(DrawerWrapper, selector);
+};
+ElementWrapper.prototype.findExpandableSection = function(selector) {
+  const rootSelector = \`.\${ExpandableSectionWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ExpandableSectionWrapper);
+};
+
+ElementWrapper.prototype.findAllExpandableSections = function(selector) {
+  return this.findAllComponents(ExpandableSectionWrapper, selector);
+};
+ElementWrapper.prototype.findFileDropzone = function(selector) {
+  const rootSelector = \`.\${FileDropzoneWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileDropzoneWrapper);
+};
+
+ElementWrapper.prototype.findAllFileDropzones = function(selector) {
+  return this.findAllComponents(FileDropzoneWrapper, selector);
+};
+ElementWrapper.prototype.findFileInput = function(selector) {
+  const rootSelector = \`.\${FileInputWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileInputWrapper);
+};
+
+ElementWrapper.prototype.findAllFileInputs = function(selector) {
+  return this.findAllComponents(FileInputWrapper, selector);
+};
+ElementWrapper.prototype.findFileTokenGroup = function(selector) {
+  const rootSelector = \`.\${FileTokenGroupWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileTokenGroupWrapper);
+};
+
+ElementWrapper.prototype.findAllFileTokenGroups = function(selector) {
+  return this.findAllComponents(FileTokenGroupWrapper, selector);
+};
+ElementWrapper.prototype.findFileUpload = function(selector) {
+  const rootSelector = \`.\${FileUploadWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FileUploadWrapper);
+};
+
+ElementWrapper.prototype.findAllFileUploads = function(selector) {
+  return this.findAllComponents(FileUploadWrapper, selector);
+};
+ElementWrapper.prototype.findFlashbar = function(selector) {
+  const rootSelector = \`.\${FlashbarWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FlashbarWrapper);
+};
+
+ElementWrapper.prototype.findAllFlashbars = function(selector) {
+  return this.findAllComponents(FlashbarWrapper, selector);
+};
+ElementWrapper.prototype.findForm = function(selector) {
+  const rootSelector = \`.\${FormWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FormWrapper);
+};
+
+ElementWrapper.prototype.findAllForms = function(selector) {
+  return this.findAllComponents(FormWrapper, selector);
+};
+ElementWrapper.prototype.findFormField = function(selector) {
+  const rootSelector = \`.\${FormFieldWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, FormFieldWrapper);
+};
+
+ElementWrapper.prototype.findAllFormFields = function(selector) {
+  return this.findAllComponents(FormFieldWrapper, selector);
+};
+ElementWrapper.prototype.findGrid = function(selector) {
+  const rootSelector = \`.\${GridWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, GridWrapper);
+};
+
+ElementWrapper.prototype.findAllGrids = function(selector) {
+  return this.findAllComponents(GridWrapper, selector);
+};
+ElementWrapper.prototype.findHeader = function(selector) {
+  const rootSelector = \`.\${HeaderWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, HeaderWrapper);
+};
+
+ElementWrapper.prototype.findAllHeaders = function(selector) {
+  return this.findAllComponents(HeaderWrapper, selector);
+};
+ElementWrapper.prototype.findHelpPanel = function(selector) {
+  const rootSelector = \`.\${HelpPanelWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, HelpPanelWrapper);
+};
+
+ElementWrapper.prototype.findAllHelpPanels = function(selector) {
+  return this.findAllComponents(HelpPanelWrapper, selector);
+};
+ElementWrapper.prototype.findHotspot = function(selector) {
+  const rootSelector = \`.\${HotspotWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, HotspotWrapper);
+};
+
+ElementWrapper.prototype.findAllHotspots = function(selector) {
+  return this.findAllComponents(HotspotWrapper, selector);
+};
+ElementWrapper.prototype.findIcon = function(selector) {
+  const rootSelector = \`.\${IconWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, IconWrapper);
+};
+
+ElementWrapper.prototype.findAllIcons = function(selector) {
+  return this.findAllComponents(IconWrapper, selector);
+};
+ElementWrapper.prototype.findInput = function(selector) {
+  const rootSelector = \`.\${InputWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, InputWrapper);
+};
+
+ElementWrapper.prototype.findAllInputs = function(selector) {
+  return this.findAllComponents(InputWrapper, selector);
+};
+ElementWrapper.prototype.findKeyValuePairs = function(selector) {
+  const rootSelector = \`.\${KeyValuePairsWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, KeyValuePairsWrapper);
+};
+
+ElementWrapper.prototype.findAllKeyValuePairs = function(selector) {
+  return this.findAllComponents(KeyValuePairsWrapper, selector);
+};
+ElementWrapper.prototype.findLineChart = function(selector) {
+  const rootSelector = \`.\${LineChartWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, LineChartWrapper);
+};
+
+ElementWrapper.prototype.findAllLineCharts = function(selector) {
+  return this.findAllComponents(LineChartWrapper, selector);
+};
+ElementWrapper.prototype.findLink = function(selector) {
+  const rootSelector = \`.\${LinkWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, LinkWrapper);
+};
+
+ElementWrapper.prototype.findAllLinks = function(selector) {
+  return this.findAllComponents(LinkWrapper, selector);
+};
+ElementWrapper.prototype.findLiveRegion = function(selector) {
+  const rootSelector = \`.\${LiveRegionWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, LiveRegionWrapper);
+};
+
+ElementWrapper.prototype.findAllLiveRegions = function(selector) {
+  return this.findAllComponents(LiveRegionWrapper, selector);
+};
+ElementWrapper.prototype.findMixedLineBarChart = function(selector) {
+  const rootSelector = \`.\${MixedLineBarChartWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, MixedLineBarChartWrapper);
+};
+
+ElementWrapper.prototype.findAllMixedLineBarCharts = function(selector) {
+  return this.findAllComponents(MixedLineBarChartWrapper, selector);
+};
+ElementWrapper.prototype.findModal = function(selector) {
+  const rootSelector = \`.\${ModalWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ModalWrapper);
+};
+
+ElementWrapper.prototype.findAllModals = function(selector) {
+  return this.findAllComponents(ModalWrapper, selector);
+};
+ElementWrapper.prototype.findMultiselect = function(selector) {
+  const rootSelector = \`.\${MultiselectWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, MultiselectWrapper);
+};
+
+ElementWrapper.prototype.findAllMultiselects = function(selector) {
+  return this.findAllComponents(MultiselectWrapper, selector);
+};
+ElementWrapper.prototype.findPagination = function(selector) {
+  const rootSelector = \`.\${PaginationWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PaginationWrapper);
+};
+
+ElementWrapper.prototype.findAllPaginations = function(selector) {
+  return this.findAllComponents(PaginationWrapper, selector);
+};
+ElementWrapper.prototype.findPieChart = function(selector) {
+  const rootSelector = \`.\${PieChartWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PieChartWrapper);
+};
+
+ElementWrapper.prototype.findAllPieCharts = function(selector) {
+  return this.findAllComponents(PieChartWrapper, selector);
+};
+ElementWrapper.prototype.findPopover = function(selector) {
+  const rootSelector = \`.\${PopoverWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PopoverWrapper);
+};
+
+ElementWrapper.prototype.findAllPopovers = function(selector) {
+  return this.findAllComponents(PopoverWrapper, selector);
+};
+ElementWrapper.prototype.findProgressBar = function(selector) {
+  const rootSelector = \`.\${ProgressBarWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ProgressBarWrapper);
+};
+
+ElementWrapper.prototype.findAllProgressBars = function(selector) {
+  return this.findAllComponents(ProgressBarWrapper, selector);
+};
+ElementWrapper.prototype.findPromptInput = function(selector) {
+  const rootSelector = \`.\${PromptInputWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PromptInputWrapper);
+};
+
+ElementWrapper.prototype.findAllPromptInputs = function(selector) {
+  return this.findAllComponents(PromptInputWrapper, selector);
+};
+ElementWrapper.prototype.findPropertyFilter = function(selector) {
+  const rootSelector = \`.\${PropertyFilterWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, PropertyFilterWrapper);
+};
+
+ElementWrapper.prototype.findAllPropertyFilters = function(selector) {
+  return this.findAllComponents(PropertyFilterWrapper, selector);
+};
+ElementWrapper.prototype.findRadioGroup = function(selector) {
+  const rootSelector = \`.\${RadioGroupWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, RadioGroupWrapper);
+};
+
+ElementWrapper.prototype.findAllRadioGroups = function(selector) {
+  return this.findAllComponents(RadioGroupWrapper, selector);
+};
+ElementWrapper.prototype.findS3ResourceSelector = function(selector) {
+  const rootSelector = \`.\${S3ResourceSelectorWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, S3ResourceSelectorWrapper);
+};
+
+ElementWrapper.prototype.findAllS3ResourceSelectors = function(selector) {
+  return this.findAllComponents(S3ResourceSelectorWrapper, selector);
+};
+ElementWrapper.prototype.findSegmentedControl = function(selector) {
+  const rootSelector = \`.\${SegmentedControlWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SegmentedControlWrapper);
+};
+
+ElementWrapper.prototype.findAllSegmentedControls = function(selector) {
+  return this.findAllComponents(SegmentedControlWrapper, selector);
+};
+ElementWrapper.prototype.findSelect = function(selector) {
+  const rootSelector = \`.\${SelectWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SelectWrapper);
+};
+
+ElementWrapper.prototype.findAllSelects = function(selector) {
+  return this.findAllComponents(SelectWrapper, selector);
+};
+ElementWrapper.prototype.findSideNavigation = function(selector) {
+  const rootSelector = \`.\${SideNavigationWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SideNavigationWrapper);
+};
+
+ElementWrapper.prototype.findAllSideNavigations = function(selector) {
+  return this.findAllComponents(SideNavigationWrapper, selector);
+};
+ElementWrapper.prototype.findSlider = function(selector) {
+  const rootSelector = \`.\${SliderWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SliderWrapper);
+};
+
+ElementWrapper.prototype.findAllSliders = function(selector) {
+  return this.findAllComponents(SliderWrapper, selector);
+};
+ElementWrapper.prototype.findSpaceBetween = function(selector) {
+  const rootSelector = \`.\${SpaceBetweenWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SpaceBetweenWrapper);
+};
+
+ElementWrapper.prototype.findAllSpaceBetweens = function(selector) {
+  return this.findAllComponents(SpaceBetweenWrapper, selector);
+};
+ElementWrapper.prototype.findSpinner = function(selector) {
+  const rootSelector = \`.\${SpinnerWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SpinnerWrapper);
+};
+
+ElementWrapper.prototype.findAllSpinners = function(selector) {
+  return this.findAllComponents(SpinnerWrapper, selector);
+};
+ElementWrapper.prototype.findSplitPanel = function(selector) {
+  const rootSelector = \`.\${SplitPanelWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, SplitPanelWrapper);
+};
+
+ElementWrapper.prototype.findAllSplitPanels = function(selector) {
+  return this.findAllComponents(SplitPanelWrapper, selector);
+};
+ElementWrapper.prototype.findStatusIndicator = function(selector) {
+  const rootSelector = \`.\${StatusIndicatorWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, StatusIndicatorWrapper);
+};
+
+ElementWrapper.prototype.findAllStatusIndicators = function(selector) {
+  return this.findAllComponents(StatusIndicatorWrapper, selector);
+};
+ElementWrapper.prototype.findSteps = function(selector) {
+  const rootSelector = \`.\${StepsWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, StepsWrapper);
+};
+
+ElementWrapper.prototype.findAllSteps = function(selector) {
+  return this.findAllComponents(StepsWrapper, selector);
+};
+ElementWrapper.prototype.findTable = function(selector) {
+  const rootSelector = \`.\${TableWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TableWrapper);
+};
+
+ElementWrapper.prototype.findAllTables = function(selector) {
+  return this.findAllComponents(TableWrapper, selector);
+};
+ElementWrapper.prototype.findTabs = function(selector) {
+  const rootSelector = \`.\${TabsWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TabsWrapper);
+};
+
+ElementWrapper.prototype.findAllTabs = function(selector) {
+  return this.findAllComponents(TabsWrapper, selector);
+};
+ElementWrapper.prototype.findTagEditor = function(selector) {
+  const rootSelector = \`.\${TagEditorWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TagEditorWrapper);
+};
+
+ElementWrapper.prototype.findAllTagEditors = function(selector) {
+  return this.findAllComponents(TagEditorWrapper, selector);
+};
+ElementWrapper.prototype.findTextContent = function(selector) {
+  const rootSelector = \`.\${TextContentWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TextContentWrapper);
+};
+
+ElementWrapper.prototype.findAllTextContents = function(selector) {
+  return this.findAllComponents(TextContentWrapper, selector);
+};
+ElementWrapper.prototype.findTextFilter = function(selector) {
+  const rootSelector = \`.\${TextFilterWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TextFilterWrapper);
+};
+
+ElementWrapper.prototype.findAllTextFilters = function(selector) {
+  return this.findAllComponents(TextFilterWrapper, selector);
+};
+ElementWrapper.prototype.findTextarea = function(selector) {
+  const rootSelector = \`.\${TextareaWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TextareaWrapper);
+};
+
+ElementWrapper.prototype.findAllTextareas = function(selector) {
+  return this.findAllComponents(TextareaWrapper, selector);
+};
+ElementWrapper.prototype.findTiles = function(selector) {
+  const rootSelector = \`.\${TilesWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TilesWrapper);
+};
+
+ElementWrapper.prototype.findAllTiles = function(selector) {
+  return this.findAllComponents(TilesWrapper, selector);
+};
+ElementWrapper.prototype.findTimeInput = function(selector) {
+  const rootSelector = \`.\${TimeInputWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TimeInputWrapper);
+};
+
+ElementWrapper.prototype.findAllTimeInputs = function(selector) {
+  return this.findAllComponents(TimeInputWrapper, selector);
+};
+ElementWrapper.prototype.findToggle = function(selector) {
+  const rootSelector = \`.\${ToggleWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ToggleWrapper);
+};
+
+ElementWrapper.prototype.findAllToggles = function(selector) {
+  return this.findAllComponents(ToggleWrapper, selector);
+};
+ElementWrapper.prototype.findToggleButton = function(selector) {
+  const rootSelector = \`.\${ToggleButtonWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ToggleButtonWrapper);
+};
+
+ElementWrapper.prototype.findAllToggleButtons = function(selector) {
+  return this.findAllComponents(ToggleButtonWrapper, selector);
+};
+ElementWrapper.prototype.findTokenGroup = function(selector) {
+  const rootSelector = \`.\${TokenGroupWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TokenGroupWrapper);
+};
+
+ElementWrapper.prototype.findAllTokenGroups = function(selector) {
+  return this.findAllComponents(TokenGroupWrapper, selector);
+};
+ElementWrapper.prototype.findTopNavigation = function(selector) {
+  const rootSelector = \`.\${TopNavigationWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TopNavigationWrapper);
+};
+
+ElementWrapper.prototype.findAllTopNavigations = function(selector) {
+  return this.findAllComponents(TopNavigationWrapper, selector);
+};
+ElementWrapper.prototype.findTutorialPanel = function(selector) {
+  const rootSelector = \`.\${TutorialPanelWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TutorialPanelWrapper);
+};
+
+ElementWrapper.prototype.findAllTutorialPanels = function(selector) {
+  return this.findAllComponents(TutorialPanelWrapper, selector);
+};
+ElementWrapper.prototype.findWizard = function(selector) {
+  const rootSelector = \`.\${WizardWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, WizardWrapper);
+};
+
+ElementWrapper.prototype.findAllWizards = function(selector) {
+  return this.findAllComponents(WizardWrapper, selector);
+};
+
+
+export default function wrapper(root: string = 'body') {
+  return new ElementWrapper(root);
+}
+"
 `;


### PR DESCRIPTION
### Description

We moved the test utils generation code to the `test-utils` repo [here](https://github.com/cloudscape-design/test-utils/pull/77). This PR removes the redundant code and reuses the utils exported from the `test-utils` repo.

No functional changes are expected. The snapshot diffs must be only spacings/ordering. 

Similar to: https://github.com/cloudscape-design/code-view/pull/54, https://github.com/cloudscape-design/board-components/pull/332, https://github.com/cloudscape-design/chat-components/pull/35

### How has this been tested?

We have already implemented functional tests both in the `test-utils` repo and `components` repo which generates actual test utils and tries to query dom with the generated test utils.

- Unit tests for test utils.
- Unit tests for components.

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
