### PR TITLE
chore: Move dev pages build artifacts outside of lib

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -23,7 +23,7 @@ jobs:
     uses: cloudscape-design/actions/.github/workflows/build-lint-test.yml@main
     secrets: inherit
     with:
-      artifact-path: lib/static-default
+      artifact-path: pages/lib/static-default
       artifact-name: dev-pages
   deploy:
     needs: build
@@ -31,4 +31,4 @@ jobs:
     secrets: inherit
     with:
       artifact-name: dev-pages
-      deployment-path: lib/static-default
+      deployment-path: pages/lib/static-default

--- a/pages/webpack.config.base.js
+++ b/pages/webpack.config.base.js
@@ -16,7 +16,7 @@ const replaceModule = (from, to) =>
   new NormalModuleReplacementPlugin(from, resource => (resource.request = resource.request.replace(from, to)));
 
 module.exports = ({
-  outputPath = 'lib/static/',
+  outputPath = 'pages/lib/static/',
   componentsPath,
   designTokensPath,
   globalStylesPath,

--- a/pages/webpack.config.js
+++ b/pages/webpack.config.js
@@ -17,6 +17,6 @@ module.exports = () => {
       themeDefinition.designTokensOutput
     ),
     globalStylesPath: themeDefinition.globalStylesPath,
-    outputPath: `lib/static-${theme}`,
+    outputPath: `pages/lib/static-${theme}`,
   });
 };


### PR DESCRIPTION
### Description

Moves the build artifacts of the pages outside of the root lib and into the `/pages/lib`.  Everything inside the root lib is considered a releasable artifact but we do not need to release the dev pages and so they can be removed.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
