### PR TITLE
chore: Fix multi modal funnel support

### DIFF
--- a/pages/funnel-analytics/modal.page.tsx
+++ b/pages/funnel-analytics/modal.page.tsx
@@ -35,6 +35,7 @@ export default function ModalFunnelPage() {
     <>
       <h1>Modal Funnel</h1>
       <Button onClick={() => setVisible(true)}>Open Modal</Button>
+      <Modal visible={false} header="Wrong modal title" />
       {visible && (
         <Modal
           analyticsMetadata={{

--- a/src/form/__tests__/analytics.test.tsx
+++ b/src/form/__tests__/analytics.test.tsx
@@ -13,8 +13,6 @@ import Modal from '../../../lib/components/modal';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { mockFunnelMetrics, mockInnerText } from '../../internal/analytics/__tests__/mocks';
 
-import modalStyles from '../../../lib/components/modal/styles.selectors.js';
-
 mockInnerText();
 
 describe('Form Analytics', () => {
@@ -367,7 +365,7 @@ describe('Form Analytics', () => {
     expect(FunnelMetrics.funnelStart).toHaveBeenCalledTimes(1);
     expect(FunnelMetrics.funnelStart).toHaveBeenCalledWith(
       expect.objectContaining({
-        funnelNameSelector: `.${modalStyles['header--text']}`,
+        funnelName: 'My Modal Funnel',
         stepConfiguration: [{ isOptional: false, name: 'My Modal Funnel', number: 1 }],
       })
     );

--- a/src/internal/analytics/selectors.ts
+++ b/src/internal/analytics/selectors.ts
@@ -7,6 +7,7 @@ export const DATA_ATTR_FUNNEL_VALUE = `${DATA_ATTR_FUNNEL}-value`;
 export const DATA_ATTR_FUNNEL_STEP = `${DATA_ATTR_FUNNEL}-step`;
 export const DATA_ATTR_FUNNEL_SUBSTEP = `${DATA_ATTR_FUNNEL}-substep`;
 export const DATA_ATTR_RESOURCE_TYPE = `${DATA_ATTR_FUNNEL}-resource-type`;
+export const DATA_ATTR_MODAL_ID = 'data-analytics-modal-id';
 
 export const DATA_ATTR_FIELD_LABEL = 'data-analytics-field-label';
 export const DATA_ATTR_FIELD_ERROR = 'data-analytics-field-error';

--- a/src/modal/__tests__/analytics.test.tsx
+++ b/src/modal/__tests__/analytics.test.tsx
@@ -83,6 +83,22 @@ describe('Modal Analytics', () => {
     );
   });
 
+  test('send funnelStart with the correct modal when multiple modals are present', () => {
+    render(
+      <>
+        <Modal header="Wrong Modal title" visible={false} />
+        <Modal header="Modal title" visible={true} />
+      </>
+    );
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelStart).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        funnelName: 'Modal title',
+      })
+    );
+  });
+
   test('sends funnelCancelled when modal is dismissed', () => {
     const { rerender } = render(<Modal header="Modal title" visible={true} />);
     act(() => void jest.runAllTimers());

--- a/src/modal/index.tsx
+++ b/src/modal/index.tsx
@@ -41,7 +41,7 @@ function ModalWithAnalyticsFunnel({
       funnelType="modal"
       optionalStepNumbers={[]}
       totalFunnelSteps={1}
-      funnelNameSelectors={[`[${DATA_ATTR_MODAL_ID}="${modalId}"] .${styles['header--text']}`]}
+      funnelNameSelectors={[`[${DATA_ATTR_MODAL_ID}="${CSS.escape(modalId)}"] .${styles['header--text']}`]}
     >
       <AnalyticsFunnelStep
         mounted={props.visible}

--- a/src/modal/index.tsx
+++ b/src/modal/index.tsx
@@ -8,8 +8,10 @@ import {
   AnalyticsFunnelSubStep,
 } from '../internal/analytics/components/analytics-funnel';
 import { useFunnel } from '../internal/analytics/hooks/use-funnel';
+import { DATA_ATTR_MODAL_ID } from '../internal/analytics/selectors';
 import { BasePropsWithAnalyticsMetadata, getAnalyticsMetadataProps } from '../internal/base-component';
 import useBaseComponent from '../internal/hooks/use-base-component';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { ModalProps } from './interfaces';
 import InternalModal, { InternalModalAsFunnel } from './internal';
@@ -24,6 +26,11 @@ function ModalWithAnalyticsFunnel({
   size = 'medium',
   ...props
 }: ModalProps & { analyticsMetadata: any; baseComponentProps: ReturnType<typeof useBaseComponent> }) {
+  const modalId = useUniqueId();
+  const dataAttributes = {
+    [DATA_ATTR_MODAL_ID]: modalId,
+  };
+
   return (
     <AnalyticsFunnel
       mounted={props.visible}
@@ -34,7 +41,7 @@ function ModalWithAnalyticsFunnel({
       funnelType="modal"
       optionalStepNumbers={[]}
       totalFunnelSteps={1}
-      funnelNameSelectors={[`.${styles['header--text']}`]}
+      funnelNameSelectors={[`[${DATA_ATTR_MODAL_ID}="${modalId}"] .${styles['header--text']}`]}
     >
       <AnalyticsFunnelStep
         mounted={props.visible}
@@ -50,6 +57,7 @@ function ModalWithAnalyticsFunnel({
             size={size}
             {...props}
             {...baseComponentProps}
+            {...dataAttributes}
             __injectAnalyticsComponentMetadata={true}
           />
         </AnalyticsFunnelSubStep>


### PR DESCRIPTION
### Description

Currently the funnel name selector was resolving to the first modal header it could find. If there are multiple modals on the page, even if the modal is not visible its header could still be found in the dom. This change adds a unique id for each modal associated with a funnel for the selector to resolve correctly.

### How has this been tested?

Added unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
