### PR TITLE
feat: Add `external` property to button

### DIFF
--- a/pages/button/permutations.page.tsx
+++ b/pages/button/permutations.page.tsx
@@ -15,6 +15,7 @@ const permutations = createPermutations<ButtonProps>([
     loading: [false, true],
     iconName: [undefined, 'settings'],
     iconAlign: ['left', 'right'],
+    external: [false, true],
     children: [
       'Button',
       <>
@@ -85,6 +86,7 @@ const permutations = createPermutations<ButtonProps>([
   },
   {
     variant: ['inline-link'],
+    external: [false, true],
     iconName: [undefined, 'download'],
     iconAlign: ['left', 'right'],
     children: ['Inline link'],
@@ -98,7 +100,12 @@ export default function ButtonPermutations() {
     <>
       <h1>Button permutations</h1>
       <ScreenshotArea disableAnimations={true}>
-        <PermutationsView permutations={permutations} render={permutation => <Button {...permutation} />} />
+        <PermutationsView
+          permutations={permutations}
+          render={permutation => (
+            <Button {...permutation} i18nStrings={{ externalIconAriaLabel: '(opens in a new tab)' }} />
+          )}
+        />
       </ScreenshotArea>
     </>
   );

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -3162,7 +3162,7 @@ This property only applies when an \`href\` is provided.",
     },
     {
       "defaultValue": "false",
-      "description": "Adds an external icon after the button text.
+      "description": "Adds an external icon after the button label text.
 If an href is provided, it opens the link in a new tab.",
       "name": "external",
       "optional": true,
@@ -17806,7 +17806,7 @@ Applicable only for the normal variant.",
       "type": "string",
     },
     {
-      "description": "Adds an external icon after the button text.
+      "description": "Adds an external icon after the button label text.
 If an href is provided, it opens the link in a new tab.",
       "name": "external",
       "optional": true,

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -3161,6 +3161,14 @@ This property only applies when an \`href\` is provided.",
       "type": "boolean | string",
     },
     {
+      "defaultValue": "false",
+      "description": "Adds an external icon after the button text.
+If an href is provided, it opens the link in a new tab.",
+      "name": "external",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
       "description": "The id of the <form> element to associate with the button. The value of this attribute must be the id of a <form> in the same document.
  Use when a button is not the ancestor of a form element, such as when used in a modal.",
       "name": "form",
@@ -3194,6 +3202,25 @@ For example, if you have a 'help' button that links to a documentation page.",
       "name": "href",
       "optional": true,
       "type": "string",
+    },
+    {
+      "description": "An object containing all the necessary localized strings required by the component. The object should contain:
+* \`externalIconAriaLabel\` - (optional) Specifies the aria-label for the external icon when \`external\` is set to \`true\`.",
+      "i18nTag": true,
+      "inlineType": {
+        "name": "ButtonProps.I18nStrings",
+        "properties": [
+          {
+            "name": "externalIconAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "i18nStrings",
+      "optional": true,
+      "type": "ButtonProps.I18nStrings",
     },
     {
       "defaultValue": "'left'",
@@ -17777,6 +17804,32 @@ Applicable only for the normal variant.",
       "name": "disabledReason",
       "optional": true,
       "type": "string",
+    },
+    {
+      "description": "Adds an external icon after the button text.
+If an href is provided, it opens the link in a new tab.",
+      "name": "external",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
+      "description": "An object containing all the necessary localized strings required by the component. The object should contain:
+* \`externalIconAriaLabel\` - (optional) Specifies the aria-label for the external icon when \`external\` is set to \`true\`.",
+      "i18nTag": true,
+      "inlineType": {
+        "name": "ButtonProps.I18nStrings",
+        "properties": [
+          {
+            "name": "externalIconAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "i18nStrings",
+      "optional": true,
+      "type": "ButtonProps.I18nStrings",
     },
     {
       "description": "Displays an icon next to the text.",

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 
-import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+import { clearMessageCache } from '@cloudscape-design/component-toolkit/internal';
 
 import Button, { ButtonProps } from '../../../lib/components/button';
 import InternalButton from '../../../lib/components/button/internal';
@@ -14,15 +14,6 @@ import { renderWithSingleTabStopNavigation } from '../../internal/context/__test
 
 import styles from '../../../lib/components/button/styles.css.js';
 import testUtilStyles from '../../../lib/components/button/test-classes/styles.css.js';
-
-jest.mock('@cloudscape-design/component-toolkit/internal', () => {
-  const originalModule = jest.requireActual('@cloudscape-design/component-toolkit/internal');
-  return { ...originalModule, warnOnce: jest.fn(originalModule.warnOnce) };
-});
-
-afterEach(() => {
-  jest.mocked(warnOnce).mockClear();
-});
 
 function renderWrappedButton(props: ButtonProps = {}) {
   const onClickSpy = jest.fn();
@@ -174,11 +165,16 @@ describe('Button Component', () => {
     });
 
     test('warns when used with a right aligned icon', () => {
-      renderButton({ external: true, children: 'Button', iconName: 'angle-right', iconAlign: 'right' });
-      expect(warnOnce).toHaveBeenCalledWith(
-        'Button',
-        'A right-aligned icon should not be combined with an external icon.'
-      );
+      const consoleWarnSpy = jest.spyOn(console, 'warn');
+      try {
+        clearMessageCache();
+        renderButton({ external: true, children: 'Button', iconName: 'angle-right', iconAlign: 'right' });
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          '[AwsUi] [Button] A right-aligned icon should not be combined with an external icon.'
+        );
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
     });
   });
 

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -3,6 +3,8 @@
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+
 import Button, { ButtonProps } from '../../../lib/components/button';
 import InternalButton from '../../../lib/components/button/internal';
 import TestI18nProvider from '../../../lib/components/i18n/testing';
@@ -12,6 +14,15 @@ import { renderWithSingleTabStopNavigation } from '../../internal/context/__test
 
 import styles from '../../../lib/components/button/styles.css.js';
 import testUtilStyles from '../../../lib/components/button/test-classes/styles.css.js';
+
+jest.mock('@cloudscape-design/component-toolkit/internal', () => {
+  const originalModule = jest.requireActual('@cloudscape-design/component-toolkit/internal');
+  return { ...originalModule, warnOnce: jest.fn(originalModule.warnOnce) };
+});
+
+afterEach(() => {
+  jest.mocked(warnOnce).mockClear();
+});
 
 function renderWrappedButton(props: ButtonProps = {}) {
   const onClickSpy = jest.fn();
@@ -160,6 +171,14 @@ describe('Button Component', () => {
         i18nStrings: { externalIconAriaLabel: 'external' },
       });
       expect(wrapper.find('[role=img]')!.getElement()).toHaveAccessibleName('external');
+    });
+
+    test('warns when used with a right aligned icon', () => {
+      renderButton({ external: true, children: 'Button', iconName: 'angle-right', iconAlign: 'right' });
+      expect(warnOnce).toHaveBeenCalledWith(
+        'Button',
+        'A right-aligned icon should not be combined with an external icon.'
+      );
     });
   });
 

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -5,6 +5,7 @@ import { act, fireEvent, render } from '@testing-library/react';
 
 import Button, { ButtonProps } from '../../../lib/components/button';
 import InternalButton from '../../../lib/components/button/internal';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 import createWrapper, { ButtonWrapper } from '../../../lib/components/test-utils/dom';
 import { buttonRelExpectations, buttonTargetExpectations } from '../../__tests__/target-rel-test-helper';
 import { renderWithSingleTabStopNavigation } from '../../internal/context/__tests__/utils';
@@ -63,6 +64,18 @@ describe('Button Component', () => {
     const wrapper = createWrapper(renderResult.container);
     button!.focus();
     expect(document.activeElement).toBe(wrapper.findButton()!.getElement());
+  });
+
+  describe('i18n', () => {
+    test('supports providing externalIconAriaLabel from i18n provider', () => {
+      const { container } = render(
+        <TestI18nProvider messages={{ button: { 'i18nStrings.externalIconAriaLabel': 'External test' } }}>
+          <Button external={true}>External</Button>
+        </TestI18nProvider>
+      );
+      const externalIcon = createWrapper(container).findButton()!.find('[role=img]')!.getElement();
+      expect(externalIcon).toHaveAccessibleName('External test');
+    });
   });
 
   describe.each([true, false])('loadingText property, with href: %s', withHref => {

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -10,6 +10,7 @@ import { buttonRelExpectations, buttonTargetExpectations } from '../../__tests__
 import { renderWithSingleTabStopNavigation } from '../../internal/context/__tests__/utils';
 
 import styles from '../../../lib/components/button/styles.css.js';
+import testUtilStyles from '../../../lib/components/button/test-classes/styles.css.js';
 
 function renderWrappedButton(props: ButtonProps = {}) {
   const onClickSpy = jest.fn();
@@ -29,6 +30,10 @@ function renderButton(props: ButtonProps = {}) {
 
 function findIcons(wrapper: ButtonWrapper) {
   return wrapper.findAll(`.${styles.icon}`);
+}
+
+function findExternalIcon(wrapper: ButtonWrapper) {
+  return wrapper.find(`.${testUtilStyles['external-icon']}`);
 }
 
 function expectToHaveClasses(element: HTMLElement, classesMap: Record<string, boolean>) {
@@ -101,6 +106,47 @@ describe('Button Component', () => {
     test('adds a tab index -1 when button with link is disabled', () => {
       const wrapper = renderButton({ disabled: true, href: 'https://amazon.com' });
       expect(wrapper.getElement()).toHaveAttribute('tabIndex', '-1');
+    });
+  });
+
+  describe('external property', () => {
+    test('renders an external icon when set', () => {
+      const wrapper = renderButton({ external: true, children: 'Button' });
+      expect(findExternalIcon(wrapper)).toBeTruthy();
+    });
+
+    test('renders an external icon even when an icon is provided', () => {
+      const wrapper = renderButton({ external: true, children: 'Button', iconName: 'add-plus' });
+      expect(findExternalIcon(wrapper)).toBeTruthy();
+    });
+
+    test('renders an external icon even when an icon is provided on the right', () => {
+      const wrapper = renderButton({ external: true, children: 'Button', iconName: 'angle-right', iconAlign: 'right' });
+      expect(findExternalIcon(wrapper)).toBeTruthy();
+    });
+
+    test('does not render an external icon when variant is icon', () => {
+      const wrapper = renderButton({ external: true, iconName: 'add-plus', variant: 'icon' });
+      expect(findExternalIcon(wrapper)).not.toBeTruthy();
+    });
+
+    test('sets target=_blank implicitly', () => {
+      const wrapper = renderButton({ external: true, href: 'https://amazon.com', children: 'Button' });
+      expect(wrapper.getElement()).toHaveAttribute('target', '_blank');
+    });
+
+    test('allows target to be overridden', () => {
+      const wrapper = renderButton({ external: true, href: 'https://amazon.com', target: '_top', children: 'Button' });
+      expect(wrapper.getElement()).toHaveAttribute('target', '_top');
+    });
+
+    test('labels the icon using i18nStrings.externalIconAriaLabel', () => {
+      const wrapper = renderButton({
+        external: true,
+        children: 'Button',
+        i18nStrings: { externalIconAriaLabel: 'external' },
+      });
+      expect(wrapper.find('[role=img]')!.getElement()).toHaveAccessibleName('external');
     });
   });
 

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -28,6 +28,7 @@ const Button = React.forwardRef(
       href,
       target,
       rel,
+      external = false,
       download,
       formAction = 'submit',
       ariaLabel,
@@ -38,12 +39,13 @@ const Button = React.forwardRef(
       ariaControls,
       fullWidth,
       form,
+      i18nStrings,
       ...props
     }: ButtonProps,
     ref: React.Ref<ButtonProps.Ref>
   ) => {
     const baseComponentProps = useBaseComponent('Button', {
-      props: { formAction, fullWidth, iconAlign, iconName, rel, target, variant, wrapText },
+      props: { formAction, fullWidth, iconAlign, iconName, rel, target, external, variant, wrapText },
       metadata: { hasDisabledReason: Boolean(disabledReason) },
     });
     const baseProps = getBaseProps(props);
@@ -66,6 +68,7 @@ const Button = React.forwardRef(
         href={href}
         target={target}
         rel={rel}
+        external={external}
         download={download}
         formAction={formAction}
         ariaLabel={ariaLabel}
@@ -76,6 +79,7 @@ const Button = React.forwardRef(
         ariaControls={ariaControls}
         fullWidth={fullWidth}
         form={form}
+        i18nStrings={i18nStrings}
         __injectAnalyticsComponentMetadata={true}
       >
         {children}

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -86,6 +86,20 @@ export interface BaseButtonProps {
    * Adds `aria-controls` to the button. Use when the button controls the contents or presence of an element.
    */
   ariaControls?: string;
+
+  /**
+   * Adds an external icon after the button text.
+   * If an href is provided, it opens the link in a new tab.
+   */
+  external?: boolean;
+
+  /**
+   * An object containing all the necessary localized strings required by the component. The object should contain:
+   *
+   * * `externalIconAriaLabel` - (optional) Specifies the aria-label for the external icon when `external` is set to `true`.
+   * @i18n
+   */
+  i18nStrings?: ButtonProps.I18nStrings;
 }
 
 export interface ButtonProps extends BaseComponentProps, BaseButtonProps {
@@ -175,6 +189,13 @@ export namespace ButtonProps {
   export type FormAction = 'submit' | 'none';
 
   export type IconAlign = 'left' | 'right';
+
+  export interface I18nStrings {
+    /**
+     * Specifies the aria-label for the external icon when `external` is set to `true`.
+     */
+    externalIconAriaLabel?: string;
+  }
 
   export interface Ref {
     /**

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -88,7 +88,7 @@ export interface BaseButtonProps {
   ariaControls?: string;
 
   /**
-   * Adds an external icon after the button text.
+   * Adds an external icon after the button label text.
    * If an href is provided, it opens the link in a new tab.
    */
   external?: boolean;

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -8,6 +8,7 @@ import {
   getAnalyticsMetadataAttribute,
 } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
+import Icon from '../icon/internal';
 import { FunnelMetrics } from '../internal/analytics';
 import { useFunnel, useFunnelStep, useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
 import {
@@ -70,7 +71,8 @@ export const InternalButton = React.forwardRef(
       disabledReason,
       wrapText = true,
       href,
-      target,
+      external,
+      target: targetOverride,
       rel,
       download,
       formAction = 'submit',
@@ -80,6 +82,7 @@ export const InternalButton = React.forwardRef(
       ariaControls,
       fullWidth,
       badge,
+      i18nStrings,
       __nativeAttributes,
       __internalRootRef = null,
       __focusable = false,
@@ -95,6 +98,7 @@ export const InternalButton = React.forwardRef(
 
     checkSafeUrl('Button', href);
     const isAnchor = Boolean(href);
+    const target = targetOverride ?? (external ? '_blank' : undefined);
     const isNotInteractive = loading || disabled;
     const isDisabledWithReason = (variant === 'normal' || variant === 'primary') && !!disabledReason && disabled;
     const hasAriaDisabled = (loading && !disabled) || (disabled && __focusable) || isDisabledWithReason;
@@ -221,7 +225,19 @@ export const InternalButton = React.forwardRef(
     const buttonContent = (
       <>
         <LeftIcon {...iconProps} />
-        {shouldHaveContent && <span className={clsx(styles.content, analyticsSelectors.label)}>{children}</span>}
+        {shouldHaveContent && (
+          <>
+            <span className={clsx(styles.content, analyticsSelectors.label)}>{children}</span>
+            {external && (
+              <>
+                &nbsp;
+                <span role="img" aria-label={i18nStrings?.externalIconAriaLabel}>
+                  <Icon name="external" className={testUtilStyles['external-icon']} />
+                </span>
+              </>
+            )}
+          </>
+        )}
         <RightIcon {...iconProps} />
       </>
     );

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -8,6 +8,7 @@ import {
   getAnalyticsMetadataAttribute,
 } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
+import { useInternalI18n } from '../i18n/context';
 import Icon from '../icon/internal';
 import { FunnelMetrics } from '../internal/analytics';
 import { useFunnel, useFunnelStep, useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
@@ -109,6 +110,7 @@ export const InternalButton = React.forwardRef(
     useForwardFocus(ref, buttonRef);
 
     const buttonContext = useButtonContext();
+    const i18n = useInternalI18n('button');
 
     const uniqueId = useUniqueId('button');
     const { funnelInteractionId } = useFunnel();
@@ -231,7 +233,10 @@ export const InternalButton = React.forwardRef(
             {external && (
               <>
                 &nbsp;
-                <span role="img" aria-label={i18nStrings?.externalIconAriaLabel}>
+                <span
+                  role="img"
+                  aria-label={i18n('i18nStrings.externalIconAriaLabel', i18nStrings?.externalIconAriaLabel)}
+                >
                   <Icon name="external" className={testUtilStyles['external-icon']} />
                 </span>
               </>

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import {
   getAnalyticsLabelAttribute,
   getAnalyticsMetadataAttribute,
@@ -105,6 +106,10 @@ export const InternalButton = React.forwardRef(
     const hasAriaDisabled = (loading && !disabled) || (disabled && __focusable) || isDisabledWithReason;
     const shouldHaveContent =
       children && ['icon', 'inline-icon', 'flashbar-icon', 'modal-dismiss'].indexOf(variant) === -1;
+
+    if ((iconName || iconUrl || iconSvg) && iconAlign === 'right' && external) {
+      warnOnce('Button', 'A right-aligned icon should not be combined with an external icon.');
+    }
 
     const buttonRef = useRef<HTMLElement>(null);
     useForwardFocus(ref, buttonRef);

--- a/src/button/test-classes/styles.scss
+++ b/src/button/test-classes/styles.scss
@@ -6,3 +6,7 @@
 .disabled-reason-tooltip {
   /* used in test-utils or tests */
 }
+
+.external-icon {
+  /* used in test-utils or tests */
+}

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -66,6 +66,9 @@ export interface I18nFormatArgTypes {
   "breadcrumb-group": {
     "expandAriaLabel": never;
   }
+  "button": {
+    "i18nStrings.externalIconAriaLabel": never;
+  }
   "calendar": {
     "nextMonthAriaLabel": never;
     "previousMonthAriaLabel": never;

--- a/src/i18n/messages/all.ar.json
+++ b/src/i18n/messages/all.ar.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "عرض المسار"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "تفتح الصفحة في علامة تبويب جديدة"
+  },
   "calendar": {
     "nextMonthAriaLabel": "الشهر التالي",
     "previousMonthAriaLabel": "الشهر السابق",

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Pfad anzeigen"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "Wird in einem neuen Fenster geöffnet"
+  },
   "calendar": {
     "nextMonthAriaLabel": "Nächster Monat",
     "previousMonthAriaLabel": "Vorheriger Monat",

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Show path"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "Opens in a new tab"
+  },
   "calendar": {
     "nextMonthAriaLabel": "Next month",
     "previousMonthAriaLabel": "Previous month",

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Show path"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "Opens in a new tab"
+  },
   "calendar": {
     "nextMonthAriaLabel": "Next month",
     "previousMonthAriaLabel": "Previous month",

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Mostrar ruta"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "Se abre en una pestaña nueva."
+  },
   "calendar": {
     "nextMonthAriaLabel": "Próximo mes",
     "previousMonthAriaLabel": "Mes anterior",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Afficher le chemin"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "S’ouvre dans un nouvel onglet"
+  },
   "calendar": {
     "nextMonthAriaLabel": "Mois suivant",
     "previousMonthAriaLabel": "Mois précédent",

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Tampilkan jalur"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "Buka di tab baru"
+  },
   "calendar": {
     "nextMonthAriaLabel": "Bulan berikutnya",
     "previousMonthAriaLabel": "Bulan sebelumnya",

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Mostra percorso"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "Si apre in una nuova scheda"
+  },
   "calendar": {
     "nextMonthAriaLabel": "Mese successivo",
     "previousMonthAriaLabel": "Mese precedente",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "パスの表示"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "新しいタブで開く"
+  },
   "calendar": {
     "nextMonthAriaLabel": "来月",
     "previousMonthAriaLabel": "前月",

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "경로 표시"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "새 탭에서 열림"
+  },
   "calendar": {
     "nextMonthAriaLabel": "다음 달",
     "previousMonthAriaLabel": "이전 달",

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Mostrar caminho"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "Abre em uma nova guia"
+  },
   "calendar": {
     "nextMonthAriaLabel": "Próximo mês",
     "previousMonthAriaLabel": "Mês anterior",

--- a/src/i18n/messages/all.th.json
+++ b/src/i18n/messages/all.th.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "แสดงเส้นทาง"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "เปิดในแท็บใหม่"
+  },
   "calendar": {
     "nextMonthAriaLabel": "เดือนถัดไป",
     "previousMonthAriaLabel": "เดือนก่อนหน้า",

--- a/src/i18n/messages/all.th.json
+++ b/src/i18n/messages/all.th.json
@@ -49,9 +49,6 @@
   "breadcrumb-group": {
     "expandAriaLabel": "แสดงเส้นทาง"
   },
-  "button": {
-    "i18nStrings.externalIconAriaLabel": "เปิดในแท็บใหม่"
-  },
   "calendar": {
     "nextMonthAriaLabel": "เดือนถัดไป",
     "previousMonthAriaLabel": "เดือนก่อนหน้า",

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Yolu göster"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "Yeni bir sekmede açılır"
+  },
   "calendar": {
     "nextMonthAriaLabel": "Gelecek ay",
     "previousMonthAriaLabel": "Önceki ay",

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "显示路径"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "在新标签页中打开"
+  },
   "calendar": {
     "nextMonthAriaLabel": "下个月",
     "previousMonthAriaLabel": "上个月",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -49,6 +49,9 @@
   "breadcrumb-group": {
     "expandAriaLabel": "顯示路徑"
   },
+  "button": {
+    "i18nStrings.externalIconAriaLabel": "在新索引標籤中開啟"
+  },
   "calendar": {
     "nextMonthAriaLabel": "下個月",
     "previousMonthAriaLabel": "上個月",


### PR DESCRIPTION
### Description

Added an external icon so that the icon label itself can be more easily provided by us through the I18nProvider.

~~The strings aren't included in this PR yet, waiting for a handover from the translators. Should take a few days, but with re:Invent, who knows.~~ In the meantime, I've included the strings we expect to get back (based on the link external icon strings) for review purposes.

Related links, issue #, if available: AWSUI-22607, [OdqSAkZmdBS7]

### How has this been tested?

Updated the permutations page and added unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
