### PR TITLE
fix: Makes autosuggest input use aria-expanded every time the dropdown is shown

### DIFF
--- a/pages/autosuggest/simple.page.tsx
+++ b/pages/autosuggest/simple.page.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useRef, useState } from 'react';
 
-import Autosuggest, { AutosuggestProps } from '~components/autosuggest';
+import { Autosuggest, AutosuggestProps, Box, SpaceBetween } from '~components';
 
 const empty = <span>Nothing found</span>;
 const options = [
@@ -18,27 +18,32 @@ export default function AutosuggestPage() {
   const [hasOptions, setHasOptions] = useState(true);
   const ref = useRef<AutosuggestProps.Ref>(null);
   return (
-    <div style={{ padding: 10 }}>
+    <Box margin="m">
       <h1>Simple autosuggest</h1>
-      <Autosuggest
-        ref={ref}
-        value={value}
-        readOnly={readOnly}
-        options={hasOptions ? options : []}
-        onChange={event => setValue(event.detail.value)}
-        enteredTextLabel={enteredTextLabel}
-        ariaLabel={'simple autosuggest'}
-        selectedAriaLabel="Selected"
-        empty={empty}
-        filteringResultsText={matchesCount => `${matchesCount} items`}
-      />
-      <button id="remove-options" onClick={() => setHasOptions(false)}>
-        set empty options
-      </button>
-      <button id="set-read-only" onClick={() => setReadOnly(true)}>
-        set read only
-      </button>
-      <button onClick={() => ref.current?.focus()}>focus</button>
-    </div>
+      <SpaceBetween size="l">
+        <Autosuggest
+          ref={ref}
+          value={value}
+          readOnly={readOnly}
+          options={hasOptions ? options : []}
+          onChange={event => setValue(event.detail.value)}
+          enteredTextLabel={enteredTextLabel}
+          ariaLabel={'simple autosuggest'}
+          selectedAriaLabel="Selected"
+          empty={empty}
+          filteringResultsText={matchesCount => `${matchesCount} items`}
+        />
+
+        <Box>
+          <button id="remove-options" onClick={() => setHasOptions(false)}>
+            set empty options
+          </button>
+          <button id="set-read-only" onClick={() => setReadOnly(true)}>
+            set read only
+          </button>
+          <button onClick={() => ref.current?.focus()}>focus</button>
+        </Box>
+      </SpaceBetween>
+    </Box>
   );
 }

--- a/src/autosuggest/__tests__/autosuggest-dropdown-states.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest-dropdown-states.test.tsx
@@ -1,0 +1,212 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import '../../__a11y__/to-validate-a11y';
+import Autosuggest, { AutosuggestProps } from '../../../lib/components/autosuggest';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+import styles from '../../../lib/components/autosuggest/styles.css.js';
+
+const defaultOptions: AutosuggestProps.Options = [
+  { value: '1', label: 'One' },
+  { value: '2', lang: 'Two' },
+];
+const defaultProps: AutosuggestProps = {
+  ariaLabel: 'search',
+  enteredTextLabel: text => `Use value: ${text}`,
+  value: '',
+  onChange: () => {},
+  options: defaultOptions,
+  empty: 'No options',
+  loadingText: 'loading...',
+  finishedText: 'finished!',
+  errorText: 'error!',
+  errorIconAriaLabel: 'error icon',
+  clearAriaLabel: 'clear input',
+};
+
+function renderAutosuggest(props: Partial<AutosuggestProps>) {
+  const { container } = render(<Autosuggest {...defaultProps} {...props} />);
+  const wrapper = createWrapper(container).findAutosuggest()!;
+  return { container, wrapper };
+}
+
+function focusInput() {
+  createWrapper().findAutosuggest()!.focus();
+}
+
+function expectDropdown() {
+  const wrapper = createWrapper().findAutosuggest()!;
+  expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+  expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'true');
+}
+
+function expectNoFooter() {
+  expect(createWrapper().findAutosuggest()!.findDropdown().findFooterRegion()).toBe(null);
+}
+
+function expectFooterSticky(isSticky: boolean) {
+  const dropdown = createWrapper().findAutosuggest()!.findDropdown()!.findOpenDropdown()!;
+  expect(Boolean(dropdown.findByClassName(styles['list-bottom']))).toBe(!isSticky);
+}
+
+function expectFooterContent(expectedText: string) {
+  const wrapper = createWrapper().findAutosuggest()!;
+  expect(wrapper.findDropdown().findFooterRegion()!).not.toBe(null);
+  expect(wrapper.findDropdown().findFooterRegion()!.getElement()).toHaveTextContent(expectedText);
+  expect(wrapper.findDropdown().find('ul')!.getElement()).toHaveAccessibleDescription(expectedText);
+}
+
+function expectFooterImage(expectedText: string) {
+  const footer = createWrapper().findAutosuggest()!.findDropdown().findFooterRegion()!;
+  expect(footer).not.toBe(null);
+  expect(footer.find('[role="img"]')!.getElement()).toHaveAccessibleName(expectedText);
+}
+
+async function expectA11y() {
+  const wrapper = createWrapper().findAutosuggest()!;
+  await expect(wrapper.getElement()).toValidateA11y();
+}
+
+describe('footer types', () => {
+  test('empty', async () => {
+    renderAutosuggest({ options: [] });
+    focusInput();
+    expectDropdown();
+    expectFooterSticky(true);
+    expectFooterContent('No options');
+    await expectA11y();
+  });
+
+  test('pending', async () => {
+    renderAutosuggest({ statusType: 'pending' });
+    focusInput();
+    expectDropdown();
+    expectNoFooter();
+    await expectA11y();
+  });
+
+  test('loading', async () => {
+    renderAutosuggest({ statusType: 'loading' });
+    focusInput();
+    expectDropdown();
+    expectFooterSticky(true);
+    expectFooterContent('loading...');
+    await expectA11y();
+  });
+
+  test('error', async () => {
+    renderAutosuggest({ statusType: 'error' });
+    focusInput();
+    expectDropdown();
+    expectFooterSticky(true);
+    expectFooterContent('error!');
+    expectFooterImage('error icon');
+    await expectA11y();
+  });
+
+  test('finished', async () => {
+    renderAutosuggest({ statusType: 'finished' });
+    focusInput();
+    expectDropdown();
+    expectFooterSticky(false);
+    expectFooterContent('finished!');
+    await expectA11y();
+  });
+
+  test('results', async () => {
+    renderAutosuggest({ value: 'x', filteringResultsText: () => '3 items' });
+    focusInput();
+    expectDropdown();
+    expectFooterSticky(true);
+    expectFooterContent('3 items');
+    await expectA11y();
+  });
+});
+
+describe('filtering results', () => {
+  describe('with empty state', () => {
+    test('displays empty state footer when value is empty', () => {
+      renderAutosuggest({ options: [], filteringResultsText: () => '0 items' });
+      focusInput();
+      expectFooterContent('No options');
+    });
+
+    test('displays results footer when value is not empty', () => {
+      renderAutosuggest({ value: ' ', options: [], filteringResultsText: () => '0 items' });
+      focusInput();
+      expectFooterContent('0 items');
+    });
+  });
+
+  describe('with pending state', () => {
+    test('displays no footer when value is empty', () => {
+      renderAutosuggest({ statusType: 'pending', filteringResultsText: () => '3 items' });
+      focusInput();
+      expectNoFooter();
+    });
+
+    test('displays results footer when value is not empty', () => {
+      renderAutosuggest({ value: ' ', statusType: 'pending', filteringResultsText: () => '3 items' });
+      focusInput();
+      expectFooterContent('3 items');
+    });
+  });
+
+  describe('with loading state', () => {
+    test('displays loading footer when value is empty', () => {
+      renderAutosuggest({ statusType: 'loading', filteringResultsText: () => '3 items' });
+      focusInput();
+      expectFooterContent('loading...');
+    });
+
+    test('displays loading footer when value is not empty', () => {
+      renderAutosuggest({ value: ' ', statusType: 'loading', filteringResultsText: () => '3 items' });
+      focusInput();
+      expectFooterContent('loading...');
+    });
+  });
+
+  describe('with error state', () => {
+    test('displays error footer when value is empty', () => {
+      renderAutosuggest({ statusType: 'error', filteringResultsText: () => '3 items' });
+      focusInput();
+      expectFooterContent('error!');
+    });
+
+    test('displays error footer when value is not empty', () => {
+      renderAutosuggest({ value: ' ', statusType: 'error', filteringResultsText: () => '3 items' });
+      focusInput();
+      expectFooterContent('error!');
+    });
+  });
+
+  describe('with finished state', () => {
+    test('displays no footer when finished w/o finished text and value is empty', () => {
+      renderAutosuggest({ finishedText: undefined, filteringResultsText: () => '3 items' });
+      focusInput();
+      expectNoFooter();
+    });
+
+    test('displays finished footer when finished w/ finished text and value is empty', () => {
+      renderAutosuggest({ filteringResultsText: () => '3 items' });
+      focusInput();
+      expectFooterContent('finished!');
+    });
+
+    test('displays results footer when finished w/o finished text and value is not empty', () => {
+      renderAutosuggest({ value: ' ', finishedText: undefined, filteringResultsText: () => '3 items' });
+      focusInput();
+      expectFooterContent('3 items');
+    });
+
+    test('displays results footer when finished w/ finished text and value is not empty', () => {
+      renderAutosuggest({ value: ' ', filteringResultsText: () => '3 items' });
+      focusInput();
+      expectFooterContent('3 items');
+    });
+  });
+});

--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -10,9 +10,7 @@ import '../../__a11y__/to-validate-a11y';
 import Autosuggest, { AutosuggestProps } from '../../../lib/components/autosuggest';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
-import styles from '../../../lib/components/autosuggest/styles.css.js';
 import itemStyles from '../../../lib/components/internal/components/selectable-item/styles.css.js';
-import statusIconStyles from '../../../lib/components/status-indicator/styles.selectors.js';
 
 const defaultOptions: AutosuggestProps.Options = [
   { value: '1', label: 'One' },
@@ -140,6 +138,17 @@ test('should not close dropdown when no realted target in blur', () => {
   expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
 });
 
+it('should warn if recoveryText is provided without associated handler', () => {
+  renderAutosuggest(
+    <Autosuggest {...defaultProps} statusType="error" errorText="Test error text" recoveryText="Retry" />
+  );
+  expect(warnOnce).toHaveBeenCalledTimes(1);
+  expect(warnOnce).toHaveBeenCalledWith(
+    'Autosuggest',
+    '`onLoadItems` must be provided for `recoveryText` to be displayed.'
+  );
+});
+
 describe('onSelect', () => {
   test('should select normal value', () => {
     const onChange = jest.fn();
@@ -173,89 +182,6 @@ describe('onSelect', () => {
     expect(onChange).toHaveBeenCalledWith({ value: 'test' });
     expect(onSelect).toHaveBeenCalledWith({ value: 'test', selectedOption: undefined });
     expect(wrapper.findDropdown().findOpenDropdown()).toBeFalsy();
-  });
-});
-
-describe('Dropdown states', () => {
-  (
-    [
-      ['loading', true],
-      ['error', true],
-      ['finished', false],
-    ] as const
-  ).forEach(([statusType, isSticky]) => {
-    test(`should display ${statusType} status text as ${isSticky ? 'sticky' : 'non-sticky'} footer`, () => {
-      const statusText = {
-        [`${statusType}Text`]: `Test ${statusType} text`,
-      };
-      const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} statusType={statusType} {...statusText} />);
-      wrapper.focus();
-      expect(wrapper.findStatusIndicator()!.getElement()).toHaveTextContent(`Test ${statusType} text`);
-
-      const dropdown = wrapper.findDropdown()!.findOpenDropdown()!;
-      expect(Boolean(dropdown.findByClassName(styles['list-bottom']))).toBe(!isSticky);
-    });
-
-    test(`check a11y for ${statusType} and ${isSticky ? 'sticky' : 'non-sticky'} footer`, async () => {
-      const statusText = {
-        [`${statusType}Text`]: `Test ${statusType} text`,
-      };
-      const { container, wrapper } = renderAutosuggest(
-        <Autosuggest {...defaultProps} statusType={statusType} {...statusText} ariaLabel="input" />
-      );
-      wrapper.focus();
-
-      await expect(container).toValidateA11y();
-    });
-  });
-
-  test('should display error status icon with provided aria label', () => {
-    const { wrapper } = renderAutosuggest(
-      <Autosuggest
-        {...defaultProps}
-        statusType="error"
-        errorText="Test error text"
-        errorIconAriaLabel="Test error text"
-      />
-    );
-    wrapper.focus();
-    const statusIcon = wrapper.findStatusIndicator()!.findByClassName(statusIconStyles.icon)!.getElement();
-    expect(statusIcon).toHaveAttribute('aria-label', 'Test error text');
-    expect(statusIcon).toHaveAttribute('role', 'img');
-  });
-
-  test('should associate the error status footer with the dropdown', () => {
-    const { wrapper } = renderAutosuggest(
-      <Autosuggest {...defaultProps} statusType="error" errorText="Test error text" />
-    );
-    wrapper.focus();
-    expect(wrapper.findDropdown().find('ul')!.getElement()).toHaveAccessibleDescription('Test error text');
-  });
-
-  test('should associate the finished status footer with the dropdown', () => {
-    const { wrapper } = renderAutosuggest(
-      <Autosuggest {...defaultProps} statusType="finished" finishedText="Finished text" />
-    );
-    wrapper.focus();
-    expect(wrapper.findDropdown().find('ul')!.getElement()).toHaveAccessibleDescription('Finished text');
-  });
-
-  it('when no options is matched the dropdown is shown but aria-expanded is false', () => {
-    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} statusType="finished" value="free-text" />);
-    wrapper.setInputValue('free-text');
-    expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'false');
-    expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
-  });
-
-  it('should warn if recoveryText is provided without associated handler', () => {
-    renderAutosuggest(
-      <Autosuggest {...defaultProps} statusType="error" errorText="Test error text" recoveryText="Retry" />
-    );
-    expect(warnOnce).toHaveBeenCalledTimes(1);
-    expect(warnOnce).toHaveBeenCalledWith(
-      'Autosuggest',
-      '`onLoadItems` must be provided for `recoveryText` to be displayed.'
-    );
   });
 });
 

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -195,7 +195,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     hasRecoveryCallback: !!onLoadItems,
   });
 
-  const shouldRenderDropdownContent = !isEmpty || dropdownStatus.content;
+  const shouldRenderDropdownContent = !isEmpty || !!dropdownStatus.content;
 
   return (
     <AutosuggestInput
@@ -222,7 +222,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
       expandToViewport={expandToViewport}
       ariaControls={listId}
       ariaActivedescendant={highlightedOptionId}
-      dropdownExpanded={autosuggestItemsState.items.length > 1 || dropdownStatus.content !== null}
+      dropdownExpanded={shouldRenderDropdownContent}
       dropdownContent={
         shouldRenderDropdownContent && (
           <AutosuggestOptionsList


### PR DESCRIPTION
### Description

Currently, the aria-expanded on autosuggest input is set to false when the dropdown has only entered text value option. That is inconsistent to states when the dropdown only shows a status like "finished" or "loading". The PR makes it so the ARIA expanded is added whenever the dropdown is visible.

Additionally, the PR refactors autosuggest dropdown states tests mainly to include the filtering results text feature that does not have a single in the main.

Rel: [A2f2AlIalxx9]

### How has this been tested?

* Updated unit tests to secure the aria-expanded is set to true for all dropdown states.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
