### PR TITLE
fix: Prevents table keyboard nav from stealing focus when element re-register

### DIFF
--- a/src/table/table-role/__tests__/grid-navigation.test.tsx
+++ b/src/table/table-role/__tests__/grid-navigation.test.tsx
@@ -364,3 +364,36 @@ test.each(['td', 'th'] as const)('focuses on the element registered inside focus
   rerender(<TestTable contentType="button" />);
   expect(readActiveElement()).toEqual('BUTTON[action]');
 });
+
+test('does not focus re-registered element if the focus is not within the table anymore', () => {
+  const { container, rerender } = render(
+    <div>
+      <TestTable columns={[idColumn, valueColumn]} items={items} />
+      <button data-testid="outside-focus-target">outside</button>
+    </div>
+  );
+  const firstCell = container.querySelector('td')!;
+  const outsideButton = container.querySelector('[data-testid="outside-focus-target"]') as HTMLButtonElement;
+
+  firstCell.focus();
+  expect(firstCell).toHaveFocus();
+
+  rerender(
+    <div>
+      <TestTable columns={[idColumn, valueColumn]} items={items} />
+      <button data-testid="outside-focus-target">outside</button>
+    </div>
+  );
+  expect(firstCell).toHaveFocus();
+
+  outsideButton.focus();
+  expect(outsideButton).toHaveFocus();
+
+  rerender(
+    <div>
+      <TestTable columns={[idColumn, valueColumn]} items={items} />
+      <button data-testid="outside-focus-target">outside</button>
+    </div>
+  );
+  expect(outsideButton).toHaveFocus();
+});

--- a/src/table/table-role/grid-navigation.tsx
+++ b/src/table/table-role/grid-navigation.tsx
@@ -84,6 +84,7 @@ class GridNavigationProcessor {
 
   // State
   private focusedCell: null | FocusedCell = null;
+  private focusInside = false;
   private keepUserIndex = false;
 
   constructor(navigationAPI: { current: null | SingleTabStopNavigationAPI }) {
@@ -94,10 +95,12 @@ class GridNavigationProcessor {
     this._table = table;
 
     this.table.addEventListener('focusin', this.onFocusin);
+    this.table.addEventListener('focusout', this.onFocusout);
     this.table.addEventListener('keydown', this.onKeydown);
 
     this.cleanup = () => {
       this.table.removeEventListener('focusin', this.onFocusin);
+      this.table.removeEventListener('focusout', this.onFocusout);
       this.table.removeEventListener('keydown', this.onKeydown);
     };
   }
@@ -122,6 +125,9 @@ class GridNavigationProcessor {
   }
 
   public onRegisterFocusable = (focusableElement: HTMLElement) => {
+    if (!this.focusInside) {
+      return;
+    }
     // When newly registered element belongs to the focused cell the focus must transition to it.
     const focusedElement = this.focusedCell?.element;
     if (focusedElement && isTableCell(focusedElement) && focusedElement.contains(focusableElement)) {
@@ -175,6 +181,8 @@ class GridNavigationProcessor {
   }
 
   private onFocusin = (event: FocusEvent) => {
+    this.focusInside = true;
+
     if (!(event.target instanceof HTMLElement)) {
       return;
     }
@@ -196,6 +204,10 @@ class GridNavigationProcessor {
     } else {
       this.keepUserIndex = false;
     }
+  };
+
+  private onFocusout = () => {
+    this.focusInside = false;
   };
 
   private onKeydown = (event: KeyboardEvent) => {


### PR DESCRIPTION
### Description

The table keyboard nav ensures the focus is correctly assigned if the element under the focused cell is re-mounted. However, this should only happen if the focus was within the table to prevent focus stealing.

### How has this been tested?

* New unit test
* Tested on the demo test page where the issue was noticed

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
