### PR TITLE
feat: Allow custom row actions in AttributeEditor

### DIFF
--- a/pages/attribute-editor/buttons.page.tsx
+++ b/pages/attribute-editor/buttons.page.tsx
@@ -1,0 +1,130 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+
+import { Box, ButtonDropdown, ButtonDropdownProps, Input, InputProps, Link } from '~components';
+import AttributeEditor, { AttributeEditorProps } from '~components/attribute-editor';
+
+interface Tag {
+  key?: string;
+  value?: string;
+}
+
+interface ControlProps extends InputProps {
+  index: number;
+  setItems?: any;
+  prop: keyof Tag;
+}
+
+const labelProps = {
+  addButtonText: 'Add new item',
+  removeButtonText: 'Remove',
+  empty: 'No tags associated to the resource',
+  i18nStrings: { itemRemovedAriaLive: 'An item was removed.' },
+} as AttributeEditorProps<unknown>;
+
+const tagLimit = 50;
+
+const Control = React.memo(({ value, index, setItems, prop }: ControlProps) => {
+  return (
+    <Input
+      value={value}
+      onChange={({ detail }) => {
+        setItems((items: any) => {
+          const updatedItems = [...items];
+          updatedItems[index] = { ...updatedItems[index], [prop]: detail.value };
+          return updatedItems;
+        });
+      }}
+    />
+  );
+});
+
+export default function AttributeEditorPage() {
+  const [items, setItems] = useState<Tag[]>([
+    { key: 'bla', value: 'foo' },
+    { key: 'bar', value: 'yam' },
+  ]);
+  const ref = useRef<AttributeEditorProps.Ref>(null);
+
+  const definition: AttributeEditorProps.FieldDefinition<Tag>[] = useMemo(
+    () => [
+      {
+        label: 'Key label',
+        info: <Link variant="info">Info</Link>,
+        control: ({ key = '' }, itemIndex) => <Control prop="key" value={key} index={itemIndex} setItems={setItems} />,
+      },
+      {
+        label: 'Value label',
+        info: <Link variant="info">Info</Link>,
+        control: ({ value = '' }, itemIndex) => (
+          <Control prop="value" value={value} index={itemIndex} setItems={setItems} />
+        ),
+      },
+    ],
+    []
+  );
+
+  const buttonRefs = useRef<Array<ButtonDropdownProps.Ref | null>>([]);
+
+  const onAddButtonClick = useCallback(() => {
+    setItems(items => [...items, {}]);
+  }, []);
+
+  const onRemoveButtonClick = (itemIndex: number) => {
+    setItems(items => {
+      const newItems = items.slice();
+      newItems.splice(itemIndex, 1);
+      return newItems;
+    });
+    if (items.length === 1) {
+      ref.current?.focusAddButton();
+    }
+    if (itemIndex === items.length - 1) {
+      buttonRefs.current[items.length - 2]?.focus();
+    }
+  };
+  const moveRow = (itemIndex: number, direction: string) => {
+    const newIndex = direction === 'up' ? itemIndex - 1 : itemIndex + 1;
+    setItems(items => {
+      const newItems = items.slice();
+      newItems.splice(newIndex, 0, newItems.splice(itemIndex, 1)[0]);
+      buttonRefs.current[newIndex]?.focusDropdownTrigger();
+      return newItems;
+    });
+  };
+
+  const additionalInfo = useMemo(() => `You can add ${tagLimit - items.length} more tags.`, [items.length]);
+
+  return (
+    <Box margin="xl">
+      <h1>Attribute Editor - Functional</h1>
+      <AttributeEditor<Tag>
+        ref={ref}
+        {...labelProps}
+        additionalInfo={additionalInfo}
+        items={items}
+        definition={definition}
+        onAddButtonClick={onAddButtonClick}
+        customRowActions={({ itemIndex }) => (
+          <ButtonDropdown
+            ref={ref => {
+              buttonRefs.current[itemIndex] = ref;
+            }}
+            items={[
+              { text: 'Move up', id: 'up', disabled: itemIndex === 0 },
+              { text: 'Move down', id: 'down', disabled: itemIndex === items.length - 1 },
+            ]}
+            ariaLabel={`More actions for row ${itemIndex + 1}`}
+            mainAction={{
+              text: 'Delete row',
+              ariaLabel: `Delete row ${itemIndex + 1}`,
+              onClick: () => onRemoveButtonClick(itemIndex),
+            }}
+            onItemClick={e => moveRow(itemIndex, e.detail.id)}
+          />
+        )}
+      />
+    </Box>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -1410,6 +1410,17 @@ The event \`detail\` contains the index of the corresponding item.",
       "type": "string",
     },
     {
+      "description": "Specifies a custom action trigger for each row, in place of the remove button.
+Only button and button dropdown components are supported.
+If you provide this, \`removeButtonText\`, \`removeButtonAriaLabel\`,
+and \`onRemoveButtonClick\` will be ignored.
+The trigger must be given the provided \`ref\` in order for \`focusRemoveButton\`
+to work.",
+      "name": "customRowActions",
+      "optional": true,
+      "type": "(props: AttributeEditorProps.RowActionsProps<T>) => React.ReactNode",
+    },
+    {
       "description": "Defines the editor configuration. Each object in the array represents one form field in the row.
 * \`label\` (ReactNode) - Text label for the form field.
 * \`info\` (ReactNode) - Info link for the form field.
@@ -3575,9 +3586,25 @@ modifier keys (that is, CTRL, ALT, SHIFT, META), and the item has an \`href\` se
   ],
   "functions": [
     {
-      "description": "Focuses the underlying native button.",
+      "description": "Focuses the underlying native button. If a main action is defined this will focus that button.",
       "name": "focus",
-      "parameters": [],
+      "parameters": [
+        {
+          "name": "options",
+          "type": "FocusOptions",
+        },
+      ],
+      "returnType": "void",
+    },
+    {
+      "description": "Focuses the underlying native button for the dropdown.",
+      "name": "focusDropdownTrigger",
+      "parameters": [
+        {
+          "name": "options",
+          "type": "FocusOptions",
+        },
+      ],
       "returnType": "void",
     },
   ],

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`test-utils selectors 1`] = `
   "attribute-editor": [
     "awsui_add-button_n4qlp",
     "awsui_additional-info_n4qlp",
+    "awsui_button-container_n4qlp",
     "awsui_empty_n4qlp",
     "awsui_field_n4qlp",
     "awsui_remove-button_n4qlp",

--- a/src/attribute-editor/interfaces.ts
+++ b/src/attribute-editor/interfaces.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import { ButtonDropdownProps } from '../button-dropdown/interfaces';
 import { BaseComponentProps } from '../internal/base-component';
+import { Breakpoint } from '../internal/breakpoints';
 import { NonCancelableEventHandler } from '../internal/events';
 
 /*
@@ -47,6 +49,13 @@ export namespace AttributeEditorProps {
      * Focuses the 'add' button. Use this, for example, after a user removes the last row.
      */
     focusAddButton(): void;
+  }
+
+  export interface RowActionsProps<T> {
+    item: T;
+    itemIndex: number;
+    ref: React.Ref<ButtonDropdownProps.Ref>;
+    breakpoint: Breakpoint | null;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -122,6 +131,16 @@ export interface AttributeEditorProps<T> extends BaseComponentProps {
    * A maximum of four fields are supported.
    */
   definition: ReadonlyArray<AttributeEditorProps.FieldDefinition<T>>;
+
+  /**
+   * Specifies a custom action trigger for each row, in place of the remove button.
+   * Only button and button dropdown components are supported.
+   * If you provide this, `removeButtonText`, `removeButtonAriaLabel`,
+   * and `onRemoveButtonClick` will be ignored.
+   * The trigger must be given the provided `ref` in order for `focusRemoveButton`
+   * to work.
+   */
+  customRowActions?: (props: AttributeEditorProps.RowActionsProps<T>) => React.ReactNode;
 
   /**
    * Called when add button is clicked.

--- a/src/attribute-editor/internal.tsx
+++ b/src/attribute-editor/internal.tsx
@@ -34,6 +34,7 @@ const InternalAttributeEditor = React.forwardRef(
       addButtonText,
       removeButtonText,
       removeButtonAriaLabel,
+      customRowActions,
       i18nStrings,
       onAddButtonClick,
       onRemoveButtonClick,
@@ -94,6 +95,7 @@ const InternalAttributeEditor = React.forwardRef(
               removable={isItemRemovable(item)}
               removeButtonText={removeButtonText}
               removeButtonRefs={removeButtonRefs.current}
+              customRowActions={customRowActions}
               onRemoveButtonClick={onRemoveButtonClick}
               removeButtonAriaLabel={removeButtonAriaLabel}
             />

--- a/src/attribute-editor/row.tsx
+++ b/src/attribute-editor/row.tsx
@@ -27,6 +27,7 @@ interface RowProps<T> {
   removable: boolean;
   removeButtonText?: string;
   removeButtonRefs: Array<ButtonProps.Ref | undefined>;
+  customRowActions?: (props: AttributeEditorProps.RowActionsProps<T>) => React.ReactNode;
   onRemoveButtonClick?: NonCancelableEventHandler<AttributeEditorProps.RemoveButtonClickDetail>;
   removeButtonAriaLabel?: (item: T) => string;
 }
@@ -58,6 +59,7 @@ export const Row = React.memo(
     removable,
     removeButtonText,
     removeButtonRefs,
+    customRowActions,
     onRemoveButtonClick,
     removeButtonAriaLabel,
   }: RowProps<T>) => {
@@ -70,6 +72,12 @@ export const Row = React.memo(
     }, [onRemoveButtonClick, index]);
 
     const firstControlId = useUniqueId('first-control-id-');
+
+    const buttonRef = (ref: ButtonProps.Ref | null) => {
+      removeButtonRefs[index] = ref ?? undefined;
+    };
+
+    const customActions = customRowActions?.({ item, itemIndex: index, ref: buttonRef, breakpoint });
 
     return (
       <InternalBox className={styles.row} margin={{ bottom: 's' }}>
@@ -110,17 +118,19 @@ export const Row = React.memo(
                 isNarrowViewport={isNarrowViewport}
                 hasLabel={definition.some(row => row.label)}
               >
-                <InternalButton
-                  className={styles['remove-button']}
-                  formAction="none"
-                  ref={ref => {
-                    removeButtonRefs[index] = ref ?? undefined;
-                  }}
-                  ariaLabel={(removeButtonAriaLabel ?? i18nStrings.removeButtonAriaLabel)?.(item)}
-                  onClick={handleRemoveClick}
-                >
-                  {i18n('removeButtonText', removeButtonText)}
-                </InternalButton>
+                {customActions !== undefined ? (
+                  customActions
+                ) : (
+                  <InternalButton
+                    className={styles['remove-button']}
+                    formAction="none"
+                    ref={buttonRef}
+                    ariaLabel={(removeButtonAriaLabel ?? i18nStrings.removeButtonAriaLabel)?.(item)}
+                    onClick={handleRemoveClick}
+                  >
+                    {i18n('removeButtonText', removeButtonText)}
+                  </InternalButton>
+                )}
               </ButtonContainer>
             )}
           </InternalGrid>
@@ -140,7 +150,7 @@ interface ButtonContainer {
 
 const ButtonContainer = ({ index, children, isNarrowViewport, hasLabel }: ButtonContainer) => (
   <div
-    className={clsx({
+    className={clsx(styles['button-container'], {
       [styles['button-container-haslabel']]: !isNarrowViewport && index === 0 && hasLabel,
       [styles['button-container-nolabel']]: !isNarrowViewport && index === 0 && !hasLabel,
       [styles['right-align']]: isNarrowViewport,

--- a/src/attribute-editor/styles.scss
+++ b/src/attribute-editor/styles.scss
@@ -37,16 +37,19 @@
   /* used in test-utils */
 }
 
-.button-container-haslabel {
-  // We only support vertical alignment of the remove button for labels with exactly one line.
-  // The value is calculated as follows:
-  // padding-top = awsui-form-field-controls: 4px +
-  // line height (also applies to icon size) awsui-form-field-label: 22px
-  padding-block-start: calc(#{awsui.$space-xxs} + #{awsui.$line-height-body-m});
-}
+.button-container {
+  /* used in test-utils */
+  &-haslabel {
+    // We only support vertical alignment of the remove button for labels with exactly one line.
+    // The value is calculated as follows:
+    // padding-top = awsui-form-field-controls: 4px +
+    // line height (also applies to icon size) awsui-form-field-label: 22px
+    padding-block-start: calc(#{awsui.$space-xxs} + #{awsui.$line-height-body-m});
+  }
 
-.button-container-nolabel {
-  padding-block-start: #{awsui.$space-xxs};
+  &-nolabel {
+    padding-block-start: #{awsui.$space-xxs};
+  }
 }
 
 .divider {

--- a/src/button-dropdown/__tests__/button-dropdown-item-click.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-item-click.test.tsx
@@ -217,8 +217,8 @@ describe('default href navigation', () => {
     expect(onClickSpy).toHaveBeenCalled();
   });
 
-  [true, false].forEach(mobile => {
-    test(`toggles category on click when mobile=${mobile}`, () => {
+  describe.each([true, false])('mobile=%b', mobile => {
+    test('toggles category on click', () => {
       (useMobile as jest.Mock).mockReturnValue(mobile);
       const categoryId = 'category';
       const itemId = 'nested-item';
@@ -231,6 +231,40 @@ describe('default href navigation', () => {
       act(() => wrapper.findExpandableCategoryById(categoryId)!.click());
 
       expect(wrapper.findItemById(itemId)).not.toBeNull();
+    });
+    test('returns focus acter clicking item', () => {
+      const { container } = render(
+        <div>
+          <ButtonDropdown
+            items={[
+              { id: '1', text: '1' },
+              { id: '2', text: '2' },
+            ]}
+          />
+        </div>
+      );
+      const wrapper = createWrapper(container).findButtonDropdown()!;
+      wrapper.openDropdown();
+      wrapper.findItemById('1')?.click();
+      expect(wrapper.findNativeButton().getElement()).toHaveFocus();
+    });
+    test('allows focus to be moved in the onItemClick function', () => {
+      const { container } = render(
+        <div>
+          <ButtonDropdown
+            items={[
+              { id: '1', text: '1' },
+              { id: '2', text: '2' },
+            ]}
+            onItemClick={e => e.detail.id === '1' && container.querySelector('input')?.focus()}
+          />
+          <input />
+        </div>
+      );
+      const wrapper = createWrapper(container).findButtonDropdown()!;
+      wrapper.openDropdown();
+      wrapper.findItemById('1')?.click();
+      expect(container.querySelector('input')).toHaveFocus();
     });
   });
 });

--- a/src/button-dropdown/__tests__/button-dropdown.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown.test.tsx
@@ -435,6 +435,15 @@ describe('with main action', () => {
 
     expect(wrapper.findMainAction()!.getElement()).toHaveFocus();
   });
+
+  test('ref.focusDropdownTrigger focuses the dropdown', () => {
+    const ref = React.createRef<ButtonDropdownProps.Ref>();
+    const wrapper = renderSplitButtonDropdown({ mainAction: { text: 'Main' } }, ref);
+
+    ref.current!.focusDropdownTrigger();
+
+    expect(wrapper.findNativeButton()!.getElement()).toHaveFocus();
+  });
 });
 
 test('should work in controlled context', () => {

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -188,9 +188,13 @@ export namespace ButtonDropdownProps {
 
   export interface Ref {
     /**
-     * Focuses the underlying native button.
+     * Focuses the underlying native button. If a main action is defined this will focus that button.
      */
-    focus(): void;
+    focus(options?: FocusOptions): void;
+    /**
+     * Focuses the underlying native button for the dropdown.
+     */
+    focusDropdownTrigger(options?: FocusOptions): void;
   }
 }
 

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useImperativeHandle, useRef } from 'react';
 import clsx from 'clsx';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
@@ -13,7 +13,6 @@ import { useFunnel } from '../internal/analytics/hooks/use-funnel.js';
 import { getBaseProps } from '../internal/base-component';
 import Dropdown from '../internal/components/dropdown';
 import OptionsList from '../internal/components/options-list';
-import useForwardFocus from '../internal/hooks/forward-focus';
 import { useMobile } from '../internal/hooks/use-mobile';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode/index.js';
@@ -111,7 +110,18 @@ const InternalButtonDropdown = React.forwardRef(
     const mainActionRef = useRef<HTMLElement>(null);
     const triggerRef = useRef<HTMLElement>(null);
 
-    useForwardFocus(ref, isMainAction ? mainActionRef : triggerRef);
+    useImperativeHandle(
+      ref,
+      () => ({
+        focus(...args) {
+          (isMainAction ? mainActionRef : triggerRef).current?.focus(...args);
+        },
+        focusDropdownTrigger(...args) {
+          triggerRef.current?.focus(...args);
+        },
+      }),
+      [mainActionRef, triggerRef, isMainAction]
+    );
 
     const clickHandler = () => {
       if (!loading && !disabled) {

--- a/src/button-dropdown/utils/use-button-dropdown.ts
+++ b/src/button-dropdown/utils/use-button-dropdown.ts
@@ -75,13 +75,13 @@ export function useButtonDropdown({
       target: isLink ? getItemTarget(item) : undefined,
       checked: isCheckbox ? !item.checked : undefined,
     };
+    onReturnFocus();
     if (onItemFollow && isLink && isPlainLeftClick(event)) {
       fireCancelableEvent(onItemFollow, details, event);
     }
     if (onItemClick) {
       fireCancelableEvent(onItemClick, details, event);
     }
-    onReturnFocus();
     closeDropdown();
   };
 

--- a/src/button-group/item-element.tsx
+++ b/src/button-group/item-element.tsx
@@ -3,6 +3,8 @@
 import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 
 import { ButtonProps } from '../button/interfaces.js';
+import { ButtonDropdownProps } from '../button-dropdown/interfaces.js';
+import { FileInputProps } from '../file-input/interfaces';
 import { fireCancelableEvent, NonCancelableEventHandler } from '../internal/events';
 import { nodeBelongs } from '../internal/utils/node-belongs';
 import FileInputItem from './file-input-item';
@@ -28,11 +30,15 @@ const ItemElement = forwardRef(
     ref: React.Ref<ButtonProps.Ref>
   ) => {
     const containerRef = useRef<HTMLDivElement>(null);
-    const itemRef = useRef<HTMLButtonElement | HTMLInputElement>(null);
+    const buttonRef = useRef<ButtonProps.Ref>(null);
+    const fileInputRef = useRef<FileInputProps.Ref>(null);
+    const buttonDropdownRef = useRef<ButtonDropdownProps.Ref>(null);
 
     useImperativeHandle(ref, () => ({
       focus: () => {
-        itemRef.current?.focus();
+        buttonRef.current?.focus();
+        fileInputRef.current?.focus();
+        buttonDropdownRef.current?.focus();
       },
     }));
 
@@ -117,7 +123,7 @@ const ItemElement = forwardRef(
       >
         {item.type === 'icon-button' && (
           <IconButtonItem
-            ref={itemRef}
+            ref={buttonRef}
             item={item}
             onItemClick={onClickHandler}
             showTooltip={tooltip?.item === item.id}
@@ -126,7 +132,7 @@ const ItemElement = forwardRef(
         )}
         {item.type === 'icon-toggle-button' && (
           <IconToggleButtonItem
-            ref={itemRef}
+            ref={buttonRef}
             item={item}
             onItemClick={onClickHandler}
             showTooltip={tooltip?.item === item.id}
@@ -135,7 +141,7 @@ const ItemElement = forwardRef(
         )}
         {item.type === 'icon-file-input' && (
           <FileInputItem
-            ref={itemRef}
+            ref={fileInputRef}
             item={item}
             onFilesChange={onFilesChangeHandler}
             showTooltip={tooltip?.item === item.id}
@@ -143,7 +149,7 @@ const ItemElement = forwardRef(
         )}
         {item.type === 'menu-dropdown' && (
           <MenuDropdownItem
-            ref={itemRef}
+            ref={buttonDropdownRef}
             item={item}
             showTooltip={tooltip?.item === item.id}
             onItemClick={onClickHandler}

--- a/src/test-utils/dom/attribute-editor/index.ts
+++ b/src/test-utils/dom/attribute-editor/index.ts
@@ -31,6 +31,10 @@ export class AttributeEditorRowWrapper extends ElementWrapper {
   findRemoveButton(): ButtonWrapper | null {
     return this.findComponent(`.${styles['remove-button']}`, ButtonWrapper);
   }
+
+  findCustomAction(): ElementWrapper | null {
+    return this.findComponent(`.${styles['button-container']}`, ElementWrapper);
+  }
 }
 
 export default class AttributeEditorWrapper extends ComponentWrapper {


### PR DESCRIPTION
### Description

Allow custom row actions (in place of "Delete" button).

Related links, issue #, if available: 3chrAl7pqZdZ

### How has this been tested?

New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
