### PR TITLE
fix: setting update offset to handle date-only format

### DIFF
--- a/src/date-range-picker/__tests__/time-offset.test.ts
+++ b/src/date-range-picker/__tests__/time-offset.test.ts
@@ -9,6 +9,30 @@ describe('Date range picker', () => {
     describe('setTimeOffset', () => {
       test.each([
         [
+          'absolute date-only dates with no offset',
+          { type: 'absolute', startDate: '2020-10-12', endDate: '2020-10-12' },
+          { startDate: undefined, endDate: undefined },
+          { type: 'absolute', startDate: '2020-10-12+00:00', endDate: '2020-10-12+00:00' },
+        ],
+        [
+          'absolute date-only dates with positive offset',
+          { type: 'absolute', startDate: '2020-10-12', endDate: '2020-10-12' },
+          { startDate: -240, endDate: -240 },
+          { type: 'absolute', startDate: '2020-10-12-04:00', endDate: '2020-10-12-04:00' },
+        ],
+        [
+          'absolute date-only dates with positive offset',
+          { type: 'absolute', startDate: '2020-10-12', endDate: '2020-10-12' },
+          { startDate: 120, endDate: 120 },
+          { type: 'absolute', startDate: '2020-10-12+02:00', endDate: '2020-10-12+02:00' },
+        ],
+        [
+          'absolute dates with no offsets',
+          { type: 'absolute', startDate: '2020-10-12T01:23:45', endDate: '2020-10-12T01:23:45' },
+          { startDate: undefined, endDate: undefined },
+          { type: 'absolute', startDate: '2020-10-12T01:23:45+00:00', endDate: '2020-10-12T01:23:45+00:00' },
+        ],
+        [
           'absolute dates with positive offset',
           { type: 'absolute', startDate: '2020-10-12T01:23:45', endDate: '2020-10-12T01:23:45' },
           { startDate: 120, endDate: 120 },

--- a/src/date-range-picker/time-offset.ts
+++ b/src/date-range-picker/time-offset.ts
@@ -39,11 +39,12 @@ export function shiftTimeOffset(
 
   /*
     This regex matches an ISO date-time with
+    - optionally matches date-only format
     - optional seconds;
     - optional milliseconds;
     - optional time offset or 'Z'.
   */
-  const dateTimeRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d{1,3})?(((\+|-)\d{2}(:\d{2})?)|Z)?$/;
+  const dateTimeRegex = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2})?(\.\d{1,3})?(((\+|-)\d{2}(:\d{2})?)|Z)?)?$/;
 
   if (!dateTimeRegex.test(value.startDate) || !dateTimeRegex.test(value.endDate)) {
     warnOnce(


### PR DESCRIPTION
### Description

Currently the regex check within the setTimeOffset function in the date-range-picker returns false for date only dates despit them being considered a valid ISO 8601 representation. It represents a calendar date without any time information. This format will be used when only the date is relevant, and the time doesn't need to be specified


<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
