### PR TITLE
fix: Top navigation icon direction

### DIFF
--- a/src/top-navigation/parts/overflow-menu/menu-item.tsx
+++ b/src/top-navigation/parts/overflow-menu/menu-item.tsx
@@ -142,7 +142,7 @@ const ExpandableItem: React.FC<
         <ListItem
           endIcon={
             <span className={spinWhenOpen(styles, 'icon', expanded)}>
-              <InternalIcon name="caret-up-filled" />
+              <InternalIcon name="caret-down-filled" />
             </span>
           }
         >


### PR DESCRIPTION
### Description

Recent refactoring (#3025) caused top nav button to be reversed, this fixes that regression.

Related links, issue #, if available: n/a

### How has this been tested?

Local testing.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
