### PR TITLE
chore: Do not load testing-library and jest-dom helpers in SSR enviroment

### DIFF
--- a/build-tools/jest/setup.js
+++ b/build-tools/jest/setup.js
@@ -1,5 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-require('@testing-library/jest-dom/extend-expect');
-const { cleanup } = require('@testing-library/react');
-afterEach(cleanup);
+
+if (typeof window !== 'undefined') {
+  require('@testing-library/jest-dom/extend-expect');
+  const { cleanup } = require('@testing-library/react');
+  afterEach(cleanup);
+}

--- a/build-tools/jest/setup.js
+++ b/build-tools/jest/setup.js
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// we load this file in both SSR and DOM environment, but these utilities are only needed in DOM
 if (typeof window !== 'undefined') {
   require('@testing-library/jest-dom/extend-expect');
   const { cleanup } = require('@testing-library/react');

--- a/src/__tests__/functional-tests/ssr.test.ts
+++ b/src/__tests__/functional-tests/ssr.test.ts
@@ -17,6 +17,7 @@ const allComponents = getAllComponents().filter(component => !skipComponents.inc
 
 test('ensure is it not DOM', () => {
   expect(typeof window).toBe('undefined');
+  expect(typeof CSS).toBe('undefined');
 });
 
 for (const componentName of allComponents) {


### PR DESCRIPTION
### Description

These imports have side-effects which we do not want when running SSR compatibility tests

Related links, issue #, if available: n/a

### How has this been tested?

Updated an SSR test to ensure the CSS.escape polyfill is not loaded

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
