### PR TITLE
feat: Tabs scroll snapping

### DIFF
--- a/src/tabs/__integ__/tabs.test.ts
+++ b/src/tabs/__integ__/tabs.test.ts
@@ -223,10 +223,22 @@ test(
     await page.setWindowSize({ width: 500, height: 1000 });
     await page.click('#add-tab');
     await page.click(page.paginationButton('right', true));
+    await page.click(page.paginationButton('right', true));
     await page.click(wrapper.findTabLinkByIndex(7).toSelector());
     await page.waitForAssertion(async () =>
       expect(await page.isExisting(page.paginationButton('right', true))).toBe(false)
     );
+  })
+);
+
+test(
+  'tab selection does not cause vertical scroll',
+  setupTest(async page => {
+    await page.setWindowSize({ width: 600, height: 300 });
+    const { top: initialTopScrollPosition } = await page.getWindowScroll();
+    await page.click(wrapper.findTabLinkByIndex(3).toSelector());
+    const { top: currentTopScrollPosition } = await page.getWindowScroll();
+    expect(initialTopScrollPosition).toEqual(currentTopScrollPosition);
   })
 );
 

--- a/src/tabs/tab-header-bar.scss
+++ b/src/tabs/tab-header-bar.scss
@@ -29,6 +29,7 @@ $label-horizontal-spacing: awsui.$space-xs;
   overflow-y: hidden;
   position: relative;
   inline-size: 100%;
+  scroll-snap-type: inline proximity;
   // do not use pointer-events none because it disables scroll by sliding
 
   // Hide scrollbar in all browsers
@@ -74,6 +75,7 @@ $label-horizontal-spacing: awsui.$space-xs;
   flex-shrink: 0;
   display: flex;
   max-inline-size: calc(90% - awsui.$space-l);
+  scroll-snap-align: start;
 }
 
 .tabs-tab-label {
@@ -205,6 +207,7 @@ $label-horizontal-spacing: awsui.$space-xs;
 // Remediate focus shadow
 .tabs-tab:first-child {
   margin-inline-start: 1px;
+  scroll-margin-inline-start: 1px;
   & > .tabs-tab-header-container {
     padding-inline-start: calc(#{$label-horizontal-spacing} - 1px);
   }
@@ -213,6 +216,7 @@ $label-horizontal-spacing: awsui.$space-xs;
 // Remediate focus shadow
 .tabs-tab:last-child {
   margin-inline-end: 1px;
+  scroll-margin-inline-end: 1px;
   & > .tabs-tab-header-container {
     padding-inline-end: calc(#{$label-horizontal-spacing} - 1px);
   }


### PR DESCRIPTION
### Description

Reintroduced tabs scroll snapping reverted in [this commit](https://github.com/cloudscape-design/components/pull/3110)
The main problem with the previous implementation was related to `scrollIntoView` usage, that causes undesired side effects (vertical page scrolling). I left the custom scrolling implementation as is and covered this cause with an integration test.

To check if the new integ test actually covers this scenario, replace [this line](https://github.com/cloudscape-design/components/blob/main/src/tabs/tab-header-bar.tsx#L137) with the following code:
```javascript
activeTabRef?.scrollIntoView?.({ behavior: smooth ? 'smooth' : 'auto', inline: 'center' });
```
and then run:
```
npx jest -c jest.integ.config.js src/tabs/__integ__/tabs.test.ts;
```

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
