### PR TITLE
chore: Set limit to number of permutations

### DIFF
--- a/pages/utils/permutations-view.tsx
+++ b/pages/utils/permutations-view.tsx
@@ -21,11 +21,11 @@ function formatValue(key: string, value: any) {
   return value;
 }
 
-const limit = 276;
+const maximumPermutations = 276;
 
 export default function PermutationsView<T>({ permutations, render }: PermutationsViewProps<T>) {
-  if (permutations.length > limit) {
-    throw new Error(`Too many permutations (${permutations.length}), limit is ${limit}`);
+  if (permutations.length > maximumPermutations) {
+    throw new Error(`Too many permutations (${permutations.length}), maximum is ${maximumPermutations}`);
   }
 
   return (

--- a/pages/utils/permutations-view.tsx
+++ b/pages/utils/permutations-view.tsx
@@ -21,7 +21,13 @@ function formatValue(key: string, value: any) {
   return value;
 }
 
+const limit = 200;
+
 export default function PermutationsView<T>({ permutations, render }: PermutationsViewProps<T>) {
+  if (permutations.length > limit) {
+    throw new Error(`Too many permutations (${permutations.length}), limit is ${limit}`);
+  }
+
   return (
     <SpaceBetween size="m">
       {permutations.map((permutation, index) => {

--- a/pages/utils/permutations-view.tsx
+++ b/pages/utils/permutations-view.tsx
@@ -21,7 +21,7 @@ function formatValue(key: string, value: any) {
   return value;
 }
 
-const limit = 200;
+const limit = 276;
 
 export default function PermutationsView<T>({ permutations, render }: PermutationsViewProps<T>) {
   if (permutations.length > limit) {


### PR DESCRIPTION
### Description

Issue: `AWSUI-60140`

When the number of permutations exceeds the established maximum, an error will be thrown, which will be shown instead of the page content:
![Screenshot 2024-12-10 at 21 51 35](https://github.com/user-attachments/assets/b562f60a-24d0-4d47-bf34-6e7974904107)

### How has this been tested?

In the first commit of this PR, the maximum was tentatively set to 200 and a few views showed the error which caused existing tests to fail: https://github.com/cloudscape-design/components/actions/runs/12263978366

[Example dev page](https://d21d5uik3ws71m.cloudfront.net/components/ff71362d9ed7554551cfa01fcf0c5318d707c384/dev-pages/index.html#/light/slider/permutations) from the first deployment.

The highest number of permutations we currently have in a dev page is 276, so using that as the maximum.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
