### PR TITLE
refactor: Use custom function to format month instead of date-fns function

### DIFF
--- a/src/internal/utils/date-time/format-date-iso.ts
+++ b/src/internal/utils/date-time/format-date-iso.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { format, parseISO } from 'date-fns';
+import { parseISO } from 'date-fns';
 
 import { formatTimeOffsetISO } from './format-time-offset';
 
@@ -19,7 +19,11 @@ export default function ({
 }) {
   const formattedOffset = hideTimeOffset || isDateOnly || isMonthOnly ? '' : formatTimeOffsetISO(isoDate, timeOffset);
   if (isMonthOnly) {
-    return format(parseISO(isoDate), 'yyyy-MM');
+    const date = parseISO(isoDate);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    return `${year}-${month}`;
   }
+
   return isoDate + formattedOffset;
 }


### PR DESCRIPTION
`format` function from `date-fns` added 5kb to our bundle, since this is the only usage of it in our codebase, removing it and formatting month manually saves the 5kb.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

there is already a unit test for it

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
