### PR TITLE
chore: Re-order s3 resource selector bucket Regions column

### DIFF
--- a/src/s3-resource-selector/s3-modal/buckets-table.tsx
+++ b/src/s3-resource-selector/s3-modal/buckets-table.tsx
@@ -94,17 +94,6 @@ export function BucketsTable({
           minWidth: '250px',
         },
         {
-          id: 'CreationDate',
-          header: i18n('i18nStrings.columnBucketCreationDate', i18nStrings?.columnBucketCreationDate),
-          ariaLabel: getColumnAriaLabel(
-            i18n,
-            i18nStrings,
-            i18n('i18nStrings.columnBucketCreationDate', i18nStrings?.columnBucketCreationDate)
-          ),
-          sortingComparator: (a, b) => compareDates(a.CreationDate, b.CreationDate),
-          cell: item => formatDefault(item.CreationDate),
-        },
-        {
           id: 'Region',
           header: i18n('i18nStrings.columnBucketRegion', i18nStrings?.columnBucketRegion),
           ariaLabel: getColumnAriaLabel(
@@ -115,6 +104,17 @@ export function BucketsTable({
           sortingField: 'Region',
           cell: item => formatDefault(item.Region),
           minWidth: '150px',
+        },
+        {
+          id: 'CreationDate',
+          header: i18n('i18nStrings.columnBucketCreationDate', i18nStrings?.columnBucketCreationDate),
+          ariaLabel: getColumnAriaLabel(
+            i18n,
+            i18nStrings,
+            i18n('i18nStrings.columnBucketCreationDate', i18nStrings?.columnBucketCreationDate)
+          ),
+          sortingComparator: (a, b) => compareDates(a.CreationDate, b.CreationDate),
+          cell: item => formatDefault(item.CreationDate),
         },
       ]}
       onSelect={item => onSelect(item?.Name ?? '')}


### PR DESCRIPTION
### Description

Reorder columns in table so Region comes before the date. This is in preparation for a new article about Region formatting in the console. This also matches more closely what is displayed in s3 and in the s3 selector widget.

Related links, issue #, if available: n/a

### How has this been tested?

Ran through dev pipeline.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
