### PR TITLE
fix: Prevent collapsed bottom split panel from covering content

### DIFF
--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -258,6 +258,20 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
     })
   );
 
+  test(
+    'avoids covering the page content when collapsed at the bottom',
+    setupTest(async page => {
+      const splitPanel = wrapper.findSplitPanel();
+      const splitPanelSelector = wrapper.findSplitPanel().toSelector();
+      const contentSelector = wrapper.findContentRegion().findSpaceBetween().toSelector();
+      await expect(page.isExisting(splitPanel.findOpenButton().toSelector())).resolves.toBe(true);
+      await page.windowScrollTo({ top: 1000 });
+      const { top: splitPAnelTop } = await page.getBoundingBox(splitPanelSelector);
+      const { bottom: contentBottom } = await page.getBoundingBox(contentSelector);
+      expect(splitPAnelTop).toBeGreaterThanOrEqual(contentBottom);
+    })
+  );
+
   describe('interaction with table sticky header', () => {
     // bottom padding is included into the offset in VR but not in classic
     const splitPanelPadding = theme === 'refresh' ? 40 : 0;

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -204,6 +204,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
     );
 
     const [splitPanelReportedSize, setSplitPanelReportedSize] = useState(0);
+    const [splitPanelHeaderBockSize, setSplitPanelHeaderBlockSize] = useState(0);
 
     const onSplitPanelResizeHandler = (size: number) => {
       setSplitPanelSize(size);
@@ -362,9 +363,8 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       onToggle: onSplitPanelToggleHandler,
       position: splitPanelPosition,
       reportSize: size => setSplitPanelReportedSize(size),
-      reportHeaderHeight: () => {
-        /*unused in this design*/
-      },
+      reportHeaderHeight: size => setSplitPanelHeaderBlockSize(size),
+      headerHeight: splitPanelHeaderBockSize,
       rightOffset: 0,
       size: splitPanelSize,
       topOffset: 0,
@@ -467,7 +467,12 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
         <SkeletonLayout
           ref={useMergeRefs(intersectionObserverRef, rootRef)}
           style={{
-            paddingBlockEnd: splitPanelOpen && splitPanelPosition === 'bottom' ? splitPanelReportedSize : '',
+            paddingBlockEnd:
+              splitPanelPosition === 'bottom'
+                ? splitPanelOpen
+                  ? splitPanelReportedSize
+                  : splitPanelHeaderBockSize
+                : '',
             ...(hasToolbar || !isNested
               ? {
                   [globalVars.stickyVerticalTopOffset]: `${verticalOffsets.header}px`,

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -204,7 +204,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
     );
 
     const [splitPanelReportedSize, setSplitPanelReportedSize] = useState(0);
-    const [splitPanelHeaderBockSize, setSplitPanelHeaderBlockSize] = useState(0);
+    const [splitPanelHeaderBlockSize, setSplitPanelHeaderBlockSize] = useState(0);
 
     const onSplitPanelResizeHandler = (size: number) => {
       setSplitPanelSize(size);
@@ -364,7 +364,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       position: splitPanelPosition,
       reportSize: size => setSplitPanelReportedSize(size),
       reportHeaderHeight: size => setSplitPanelHeaderBlockSize(size),
-      headerHeight: splitPanelHeaderBockSize,
+      headerHeight: splitPanelHeaderBlockSize,
       rightOffset: 0,
       size: splitPanelSize,
       topOffset: 0,
@@ -471,7 +471,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
               splitPanelPosition === 'bottom'
                 ? splitPanelOpen
                   ? splitPanelReportedSize
-                  : splitPanelHeaderBockSize
+                  : splitPanelHeaderBlockSize
                 : '',
             ...(hasToolbar || !isNested
               ? {

--- a/src/internal/context/split-panel-context.ts
+++ b/src/internal/context/split-panel-context.ts
@@ -28,6 +28,7 @@ export interface SplitPanelContextBaseProps {
   onToggle: () => void;
   onPreferencesChange: (detail: { position: 'side' | 'bottom' }) => void;
   reportHeaderHeight: (pixels: number) => void;
+  headerHeight?: number;
   setSplitPanelToggle: (config: SplitPanelSideToggleProps) => void;
   refs: SplitPanelFocusControlRefs;
 }

--- a/src/split-panel/bottom.tsx
+++ b/src/split-panel/bottom.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import clsx from 'clsx';
 
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
@@ -41,16 +41,15 @@ export function SplitPanelContentBottom({
     disableContentPaddings,
     contentWrapperPaddings,
     reportHeaderHeight,
+    headerHeight: headerBlockSize,
     animationDisabled,
   } = useSplitPanelContext();
   const isMobile = useMobile();
 
   const headerRef = useRef<HTMLDivElement>(null);
-  const [headerBlockSize, setHeaderBlockSize] = useState<number>();
 
   useResizeObserver(headerRef, entry => {
     const { borderBoxHeight } = entry;
-    setHeaderBlockSize(borderBoxHeight);
     reportHeaderHeight(borderBoxHeight);
   });
 


### PR DESCRIPTION
### Description

When the split panel is collapsed, it should not cover the main content. We achieve this by adding extra padding to the main content, similar to the non-toolbar design: https://github.com/cloudscape-design/components/blob/468db9e5e4f940ceff4c1289f8800121ca1f9cc5/src/app-layout/visual-refresh/main.scss#L20-L22

### How has this been tested?

- Added integration test, which failed before the fix and passes after
- Manually tested. Compared result with non-toolbar design

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
