### PR TITLE
fix: Fixes editable table cell paddings for certain corner cases

### DIFF
--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -418,7 +418,8 @@ $cell-negative-space-vertical: 2px;
       }
       @include cell-padding-inline-start($editing-cell-padding-inline);
       @include cell-padding-inline-end($editing-cell-padding-inline);
-      @include cell-padding-block($editing-cell-padding-block);
+      @include cell-padding-block-start($editing-cell-padding-block);
+      @include cell-padding-block-end(calc($editing-cell-padding-block + 1px));
     }
 
     &:not(.body-cell-edit-active) {

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -116,6 +116,11 @@ $cell-negative-space-vertical: 2px;
     margin-block-end: calc(-1 * #{$cell-negative-space-vertical});
   }
 }
+@mixin body-cell-active-hover-padding($padding-start) {
+  &:not(.body-cell-edit-active).body-cell-editable:hover {
+    @include cell-padding-inline-start(calc(#{$padding-start} + #{awsui.$border-divider-list-width}));
+  }
+}
 
 .body-cell {
   box-sizing: border-box;
@@ -157,23 +162,24 @@ $cell-negative-space-vertical: 2px;
   // Using very small padding for 1st column cells in VR.
   &.is-visual-refresh:first-child {
     @include cell-padding-inline-start(awsui.$space-xxxs);
-    &.body-cell-editable:hover {
-      @include cell-padding-inline-start(calc(#{awsui.$space-xxxs} + #{awsui.$border-divider-list-width}));
-    }
+    @include body-cell-active-hover-padding(awsui.$space-xxxs);
 
     // Using slightly larger padding for tables with striped rows because the shaded background
     // makes the child content appear too close to the table edge.
     &:first-child.has-striped-rows {
       @include cell-padding-inline-start(awsui.$space-xxs);
+      @include body-cell-active-hover-padding(awsui.$space-xxs);
 
       &.sticky-cell-pad-inline-start {
         @include cell-padding-inline-start($cell-horizontal-padding);
+        @include body-cell-active-hover-padding($cell-horizontal-padding);
       }
     }
 
     // Using normal padding when 1st column is sticky.
     &.sticky-cell-pad-inline-start:not(.has-selection) {
       @include cell-padding-inline-start($cell-horizontal-padding);
+      @include body-cell-active-hover-padding($cell-horizontal-padding);
     }
 
     /*

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -126,9 +126,10 @@ $cell-negative-space-vertical: 2px;
   text-align: start;
 
   @include cell-padding-inline-start($cell-horizontal-padding);
+  @include cell-padding-inline-end($cell-horizontal-padding);
+
   @include cell-padding-block-start($cell-vertical-padding);
   @include cell-padding-block-end($cell-vertical-padding-w-border);
-  @include cell-padding-inline-end($cell-horizontal-padding);
 
   &-content {
     box-sizing: border-box;
@@ -147,34 +148,32 @@ $cell-negative-space-vertical: 2px;
   }
   &:first-child {
     border-inline-start: $border-placeholder;
+    @include cell-padding-inline-start($cell-edge-horizontal-padding);
   }
   &:last-child {
     border-inline-end: $border-placeholder;
     @include cell-padding-inline-end($cell-edge-horizontal-padding);
   }
+  // Using very small padding for 1st column cells in VR.
   &.is-visual-refresh:first-child {
-    &:not(.has-striped-rows) {
-      @include cell-padding-inline-start(awsui.$space-xxxs);
-      &:not(.body-cell-edit-active).body-cell-editable:hover {
-        @include cell-padding-inline-start(calc(#{awsui.$space-xxxs} + #{awsui.$border-divider-list-width}));
-      }
+    @include cell-padding-inline-start(awsui.$space-xxxs);
+    &.body-cell-editable:hover {
+      @include cell-padding-inline-start(calc(#{awsui.$space-xxxs} + #{awsui.$border-divider-list-width}));
     }
 
-    &.sticky-cell-pad-inline-start:not(.has-selection) {
-      @include cell-padding-inline-start($cell-horizontal-padding);
-    }
-
-    /*
-      Striped rows requires additional left padding because the
-      shaded background makes the child content appear too close
-      to the table edge.
-    */
+    // Using slightly larger padding for tables with striped rows because the shaded background
+    // makes the child content appear too close to the table edge.
     &:first-child.has-striped-rows {
       @include cell-padding-inline-start(awsui.$space-xxs);
 
       &.sticky-cell-pad-inline-start {
         @include cell-padding-inline-start($cell-horizontal-padding);
       }
+    }
+
+    // Using normal padding when 1st column is sticky.
+    &.sticky-cell-pad-inline-start:not(.has-selection) {
+      @include cell-padding-inline-start($cell-horizontal-padding);
     }
 
     /*
@@ -185,9 +184,6 @@ $cell-negative-space-vertical: 2px;
     &:not(.has-selection):not(.body-cell-editable) {
       border-inline-start: none;
     }
-  }
-  &:first-child:not(.is-visual-refresh) {
-    @include cell-padding-inline-start($cell-edge-horizontal-padding);
   }
   &-first-row {
     border-block-start: $border-placeholder;
@@ -245,9 +241,6 @@ $cell-negative-space-vertical: 2px;
       transition-property: padding;
       transition-duration: awsui.$motion-duration-transition-show-quick;
       transition-timing-function: awsui.$motion-easing-sticky;
-    }
-    &-pad-left:not(.has-selection):not(.is-visual-refresh.body-cell:first-child.has-striped-rows) {
-      @include cell-padding-inline-start(awsui.$space-table-horizontal);
     }
     &.body-cell-shaded {
       background: awsui.$color-background-cell-shaded;


### PR DESCRIPTION
### Description

The PR includes two small fixes and minor refactoring for editable table cell styles:
1. Improved editor vertical alignment;
2. Correct editable cell padding in sticky column.

Before:

<img width="1659" alt="Screenshot 2024-12-17 at 10 51 21" src="https://github.com/user-attachments/assets/c8ea6360-853a-408b-8fe2-e28a1c293f22" />

https://github.com/user-attachments/assets/cc480f20-3953-44e6-81c1-53d17d9cda01

After:

<img width="1659" alt="Screenshot 2024-12-17 at 10 52 00" src="https://github.com/user-attachments/assets/c43ea22c-0f99-4071-bf8c-23537e05a26f" />

https://github.com/user-attachments/assets/57ccf36c-2152-432e-be90-04ca496532bc

### How has this been tested?

* Manual testing on "cell-permutations" and "editable" test pages.
* Screenshot tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
