### PR TITLE
chore: Adds the z-index-constraint rule to stylelint

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -42,6 +42,7 @@
       }
     ],
     "@cloudscape-design/no-motion-outside-of-mixin": [true],
+    "@cloudscape-design/z-index-value-constraint": [true],
     "plugin/no-unsupported-browser-features": [
       true,
       {


### PR DESCRIPTION
### Description

Adds the `z-index-value-constraint` stylelint rule to this repo.
The rule itself was added in [this PR](https://github.com/cloudscape-design/build-tools/pull/4).

Related links, issue #, if available: AWSUI-55594

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
