### PR TITLE
chore: Un-skip modal in ssr tests

### DIFF
--- a/src/__tests__/functional-tests/ssr.test.ts
+++ b/src/__tests__/functional-tests/ssr.test.ts
@@ -10,21 +10,21 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { getRequiredPropsForComponent } from '../required-props-for-components';
 import { getAllComponents, requireComponent } from '../utils';
 
-const skipComponents = [
-  'modal', // it uses portal API which does not work on server
-];
-const allComponents = getAllComponents().filter(component => !skipComponents.includes(component));
-
 test('ensure is it not DOM', () => {
   expect(typeof window).toBe('undefined');
   expect(typeof CSS).toBe('undefined');
 });
 
-for (const componentName of allComponents) {
+for (const componentName of getAllComponents()) {
   test(`renders ${componentName} without crashing`, () => {
     const { default: Component } = requireComponent(componentName);
     const props = getRequiredPropsForComponent(componentName);
     const content = renderToStaticMarkup(React.createElement(Component, props, 'test content'));
-    expect(content.length).toBeGreaterThan(0);
+    if (componentName === 'modal') {
+      // modal uses portal API which does not work on server and returns an empty content
+      expect(content.length).toEqual(0);
+    } else {
+      expect(content.length).toBeGreaterThan(0);
+    }
   });
 }


### PR DESCRIPTION
### Description

Some people rely on modal not throwing in SSR, so we will include this into our SSR test suite, even if the expected result is an empty string

Related links, issue #, if available: n/a

### How has this been tested?

Test-only change

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
