### PR TITLE
refactor: Reusable internal drag handle

### DIFF
--- a/pages/drag-handle/permutations.page.tsx
+++ b/pages/drag-handle/permutations.page.tsx
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+import DragHandle, { DragHandleProps } from '~components/internal/components/drag-handle';
+
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
+
+const permutations = createPermutations<DragHandleProps>([
+  {
+    variant: ['drag-indicator', 'resize-area', 'resize-horizontal', 'resize-vertical'],
+    ariaLabel: ['drag-handle'],
+  },
+  {
+    variant: ['drag-indicator', 'resize-area', 'resize-horizontal', 'resize-vertical'],
+    ariaLabel: ['drag-handle'],
+    size: ['small'],
+  },
+  {
+    variant: ['drag-indicator', 'resize-area', 'resize-horizontal', 'resize-vertical'],
+    ariaLabel: ['drag-handle'],
+    disabled: [true],
+  },
+]);
+
+export default function DragHandlePermutations() {
+  return (
+    <>
+      <h1>Drag handle permutations</h1>
+      <ScreenshotArea style={{ maxWidth: 600 }}>
+        <PermutationsView permutations={permutations} render={permutation => <DragHandle {...permutation} />} />
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/src/app-layout/__tests__/split-panel-provider.test.tsx
+++ b/src/app-layout/__tests__/split-panel-provider.test.tsx
@@ -41,6 +41,7 @@ describe.each(['bottom', 'side'] as const)('position=%s', position => {
     onToggle: () => {},
     refs: {
       slider: { current: null },
+      handle: { current: null },
       toggle: { current: null },
       preferences: { current: null },
     },

--- a/src/app-layout/drawer/resizable-drawer.tsx
+++ b/src/app-layout/drawer/resizable-drawer.tsx
@@ -43,7 +43,7 @@ export const ResizableDrawer = ({
   const sizeControlProps: SizeControlProps = {
     position: 'side',
     panelRef: drawerRefObject,
-    handleRef: refs.slider,
+    handleRef: refs.handle,
     onResize: setSidePanelWidth,
   };
 
@@ -60,15 +60,17 @@ export const ResizableDrawer = ({
       resizeHandle={
         !isMobile &&
         activeDrawer?.resizable && (
-          <PanelResizeHandle
-            ref={refs.slider}
-            position="side"
-            className={testutilStyles['drawers-slider']}
-            ariaLabel={activeDrawer?.ariaLabels?.resizeHandle}
-            ariaValuenow={relativeSize}
-            onKeyDown={onKeyDown}
-            onPointerDown={onSliderPointerDown}
-          />
+          <div ref={refs.handle}>
+            <PanelResizeHandle
+              ref={refs.slider}
+              position="side"
+              className={testutilStyles['drawers-slider']}
+              ariaLabel={activeDrawer?.ariaLabels?.resizeHandle}
+              ariaValuenow={relativeSize}
+              onKeyDown={onKeyDown}
+              onPointerDown={onSliderPointerDown}
+            />
+          </div>
         )
       }
       ariaLabels={{

--- a/src/app-layout/utils/use-focus-control.ts
+++ b/src/app-layout/utils/use-focus-control.ts
@@ -9,7 +9,8 @@ export interface Focusable {
 export interface FocusControlRefs {
   toggle: RefObject<Focusable>;
   close: RefObject<Focusable>;
-  slider: RefObject<HTMLDivElement>;
+  slider: RefObject<Focusable>;
+  handle: RefObject<HTMLDivElement>;
 }
 
 export interface FocusControlState {
@@ -35,7 +36,8 @@ export function useMultipleFocusControl(
       refs.current[drawerId] = {
         toggle: createRef<Focusable>(),
         close: createRef<Focusable>(),
-        slider: createRef<HTMLDivElement>(),
+        slider: createRef<Focusable>(),
+        handle: createRef<HTMLDivElement>(),
       };
     }
   });
@@ -101,7 +103,8 @@ export function useFocusControl(
   const refs = {
     toggle: useRef<Focusable>(null),
     close: useRef<Focusable>(null),
-    slider: useRef<HTMLDivElement>(null),
+    slider: useRef<Focusable>(null),
+    handle: useRef<HTMLDivElement>(null),
   };
   const previousFocusedElement = useRef<HTMLElement>();
   const shouldFocus = useRef(false);

--- a/src/app-layout/utils/use-resize.tsx
+++ b/src/app-layout/utils/use-resize.tsx
@@ -61,7 +61,7 @@ function useResize(
   const sizeControlProps: SizeControlProps = {
     position: 'side',
     panelRef: drawerRefObject,
-    handleRef: drawersRefs.slider,
+    handleRef: drawersRefs.handle,
     onResize: setSidePanelWidth,
   };
 
@@ -69,15 +69,17 @@ function useResize(
   const onKeyDown = useKeyboardEvents(sizeControlProps);
 
   const resizeHandle = (
-    <PanelResizeHandle
-      ref={drawersRefs.slider}
-      position="side"
-      ariaLabel={activeDrawer?.ariaLabels?.resizeHandle}
-      ariaValuenow={relativeSize}
-      className={testutilStyles['drawers-slider']}
-      onKeyDown={onKeyDown}
-      onPointerDown={onSliderPointerDown}
-    />
+    <div ref={drawersRefs.handle}>
+      <PanelResizeHandle
+        ref={drawersRefs.slider}
+        position="side"
+        ariaLabel={activeDrawer?.ariaLabels?.resizeHandle}
+        ariaValuenow={relativeSize}
+        className={testutilStyles['drawers-slider']}
+        onKeyDown={onKeyDown}
+        onPointerDown={onSliderPointerDown}
+      />
+    </div>
   );
 
   return { resizeHandle, drawerSize };

--- a/src/app-layout/utils/use-split-panel-focus-control.ts
+++ b/src/app-layout/utils/use-split-panel-focus-control.ts
@@ -8,7 +8,8 @@ type SplitPanelLastInteraction = { type: 'open' } | { type: 'close' } | { type: 
 
 export interface SplitPanelFocusControlRefs {
   toggle: RefObject<Focusable>;
-  slider: RefObject<HTMLDivElement>;
+  slider: RefObject<Focusable>;
+  handle: RefObject<HTMLDivElement>;
   preferences: RefObject<Focusable>;
 }
 export interface SplitPanelFocusControlState {
@@ -19,7 +20,8 @@ export interface SplitPanelFocusControlState {
 export function useSplitPanelFocusControl(dependencies: DependencyList): SplitPanelFocusControlState {
   const refs = {
     toggle: useRef<Focusable>(null),
-    slider: useRef<HTMLDivElement>(null),
+    slider: useRef<Focusable>(null),
+    handle: useRef<HTMLDivElement>(null),
     preferences: useRef<Focusable>(null),
   };
   const lastInteraction = useRef<SplitPanelLastInteraction | null>(null);

--- a/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
@@ -58,7 +58,7 @@ function AppLayoutGlobalDrawerImplementation({
     minWidth: minDrawerSize,
     maxWidth: maxDrawerSize,
     panelRef: drawerRef,
-    handleRef: refs?.slider,
+    handleRef: refs?.handle,
     onResize: size => onActiveDrawerResize({ id: activeDrawerId!, size }),
   });
   const size = getLimitedValue(minDrawerSize, activeDrawerSize, maxDrawerSize);
@@ -111,15 +111,17 @@ function AppLayoutGlobalDrawerImplementation({
           >
             {!isMobile && activeGlobalDrawer?.resizable && (
               <div className={styles['drawer-slider']}>
-                <PanelResizeHandle
-                  ref={refs?.slider}
-                  position="side"
-                  className={testutilStyles['drawers-slider']}
-                  ariaLabel={activeGlobalDrawer?.ariaLabels?.resizeHandle}
-                  ariaValuenow={resizeProps.relativeSize}
-                  onKeyDown={resizeProps.onKeyDown}
-                  onPointerDown={resizeProps.onPointerDown}
-                />
+                <div ref={refs.handle}>
+                  <PanelResizeHandle
+                    ref={refs?.slider}
+                    position="side"
+                    className={testutilStyles['drawers-slider']}
+                    ariaLabel={activeGlobalDrawer?.ariaLabels?.resizeHandle}
+                    ariaValuenow={resizeProps.relativeSize}
+                    onKeyDown={resizeProps.onKeyDown}
+                    onPointerDown={resizeProps.onPointerDown}
+                  />
+                </div>
               </div>
             )}
             <div

--- a/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
@@ -55,7 +55,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
     minWidth: minDrawerSize,
     maxWidth: maxDrawerSize,
     panelRef: drawerRef,
-    handleRef: drawersFocusControl.refs.slider,
+    handleRef: drawersFocusControl.refs.handle,
     onResize: size => onActiveDrawerResize({ id: activeDrawerId!, size }),
   });
   // temporary handle a situation when app-layout is old, but this component come as a widget
@@ -98,15 +98,17 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
         >
           {!isMobile && activeDrawer?.resizable && (
             <div className={styles['drawer-slider']}>
-              <PanelResizeHandle
-                ref={drawersFocusControl.refs.slider}
-                position="side"
-                className={testutilStyles['drawers-slider']}
-                ariaLabel={activeDrawer?.ariaLabels?.resizeHandle}
-                ariaValuenow={resizeProps.relativeSize}
-                onKeyDown={resizeProps.onKeyDown}
-                onPointerDown={resizeProps.onPointerDown}
-              />
+              <div ref={drawersFocusControl.refs.handle}>
+                <PanelResizeHandle
+                  ref={drawersFocusControl.refs.slider}
+                  position="side"
+                  className={testutilStyles['drawers-slider']}
+                  ariaLabel={activeDrawer?.ariaLabels?.resizeHandle}
+                  ariaValuenow={resizeProps.relativeSize}
+                  onKeyDown={resizeProps.onKeyDown}
+                  onPointerDown={resizeProps.onPointerDown}
+                />
+              </div>
             </div>
           )}
           <div className={clsx(styles['drawer-content-container'], sharedStyles['with-motion-horizontal'])}>

--- a/src/collection-preferences/content-display/content-display-option.scss
+++ b/src/collection-preferences/content-display/content-display-option.scss
@@ -35,3 +35,7 @@
   @include styles.text-wrapping;
   padding-inline-end: awsui.$space-l;
 }
+
+.drag-handle-wrapper {
+  margin-inline: awsui.$space-scaled-xxs;
+}

--- a/src/collection-preferences/content-display/content-display-option.tsx
+++ b/src/collection-preferences/content-display/content-display-option.tsx
@@ -24,7 +24,9 @@ const ContentDisplayOption = forwardRef(
     const controlId = `${idPrefix}-control-${option.id}`;
     return (
       <div ref={ref} className={getClassName('content')}>
-        <DragHandle {...dragHandleProps} />
+        <div className={styles['drag-handle-wrapper']}>
+          <DragHandle {...dragHandleProps} />
+        </div>
 
         <label className={getClassName('label')} htmlFor={controlId}>
           {option.label}

--- a/src/internal/components/drag-handle/__tests__/drag-handle.test.tsx
+++ b/src/internal/components/drag-handle/__tests__/drag-handle.test.tsx
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import DragHandle from '../../../../../lib/components/internal/components/drag-handle';
+
+import styles from '../../../../../lib/components/internal/components/drag-handle/styles.css.js';
+
+const allVariants = ['drag-indicator', 'resize-area', 'resize-horizontal', 'resize-vertical'] as const;
+const allSizes = ['small', 'normal'] as const;
+
+test('renders default variant and size', () => {
+  render(<DragHandle ariaLabel="drag handle" />);
+
+  expect(document.querySelector(`.${styles.handle}`)).toBeInTheDocument();
+  expect(document.querySelector(`.${styles['handle-drag-indicator']}`)).toBeInTheDocument();
+  expect(document.querySelector(`.${styles['handle-size-normal']}`)).toBeInTheDocument();
+});
+
+test('renders all variants and sizes', () => {
+  for (const variant of allVariants) {
+    for (const size of allSizes) {
+      render(<DragHandle ariaLabel="drag handle" variant={variant} size={size} />);
+
+      expect(document.querySelector(`.${styles.handle}`)).toBeInTheDocument();
+      expect(document.querySelector(`.${styles[`handle-${variant}`]}`)).toBeInTheDocument();
+      expect(document.querySelector(`.${styles[`handle-size-${size}`]}`)).toBeInTheDocument();
+    }
+  }
+});
+
+test('assigns aria label and aria description', () => {
+  render(
+    <div>
+      <DragHandle ariaLabel="drag" ariaDescribedby="description" />
+      <div id="description">handle</div>
+    </div>
+  );
+  expect(document.querySelector(`.${styles.handle}`)).toHaveAccessibleName('drag');
+  expect(document.querySelector(`.${styles.handle}`)).toHaveAccessibleDescription('handle');
+});
+
+test('has role="button" by default', () => {
+  render(<DragHandle ariaLabel="drag handle" />);
+
+  expect(screen.getByRole('button')).toHaveAccessibleName('drag handle');
+});
+
+test('has role="slider" and aria-value attributes when ariaValue is set', () => {
+  render(<DragHandle ariaLabel="drag handle" ariaValue={{ valueMin: -1, valueMax: 1, valueNow: 0 }} />);
+
+  const handle = screen.getByRole('slider');
+  expect(handle).toHaveAccessibleName('drag handle');
+  expect(handle).toHaveAttribute('aria-valuemin', '-1');
+  expect(handle).toHaveAttribute('aria-valuemax', '1');
+  expect(handle).toHaveAttribute('aria-valuenow', '0');
+});
+
+test('sets aria-disabled when disabled', () => {
+  const { rerender } = render(<DragHandle ariaLabel="drag handle" disabled={false} />);
+
+  expect(document.querySelector(`.${styles.handle}`)).toHaveAttribute('aria-disabled', 'false');
+  expect(document.querySelector(`.${styles['handle-disabled']}`)).not.toBeInTheDocument();
+
+  rerender(<DragHandle ariaLabel="drag handle" disabled={true} />);
+
+  expect(document.querySelector(`.${styles.handle}`)).toHaveAttribute('aria-disabled');
+  expect(document.querySelector(`.${styles['handle-disabled']}`)).toBeInTheDocument();
+});

--- a/src/internal/components/drag-handle/index.tsx
+++ b/src/internal/components/drag-handle/index.tsx
@@ -6,7 +6,6 @@ import clsx from 'clsx';
 import { IconProps } from '../../../icon/interfaces';
 import InternalIcon from '../../../icon/internal';
 import useForwardFocus from '../../hooks/forward-focus';
-import { useMergeRefs } from '../../hooks/use-merge-refs';
 import { DragHandleProps } from './interfaces';
 import { ResizeIcon } from './resize-icon';
 
@@ -29,8 +28,7 @@ const DragHandle = forwardRef(
     }: DragHandleProps,
     ref: React.Ref<DragHandleProps.Ref>
   ) => {
-    const dragHandleRefObject = useRef<HTMLElement>(null);
-    const dragHandleRef = useMergeRefs(dragHandleRefObject);
+    const dragHandleRefObject = useRef<HTMLDivElement>(null);
 
     useForwardFocus(ref, dragHandleRefObject);
 
@@ -55,7 +53,7 @@ const DragHandle = forwardRef(
       // Otherwise, we can't reliably catch keyboard events coming from the handle
       // when it is being dragged.
       <div
-        ref={dragHandleRef}
+        ref={dragHandleRefObject}
         role={ariaValue ? 'slider' : 'button'}
         tabIndex={0}
         className={clsx(

--- a/src/internal/components/drag-handle/index.tsx
+++ b/src/internal/components/drag-handle/index.tsx
@@ -1,44 +1,83 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { forwardRef, useRef } from 'react';
 import clsx from 'clsx';
 
+import { IconProps } from '../../../icon/interfaces';
 import InternalIcon from '../../../icon/internal';
+import useForwardFocus from '../../hooks/forward-focus';
+import { useMergeRefs } from '../../hooks/use-merge-refs';
+import { DragHandleProps } from './interfaces';
+import { ResizeIcon } from './resize-icon';
 
 import styles from './styles.css.js';
 
-export interface DragHandleProps {
-  ariaLabel: string;
-  ariaDescribedby?: string;
-  disabled?: boolean;
-  onPointerDown?: React.PointerEventHandler;
-  onKeyDown?: React.KeyboardEventHandler;
-}
+export { DragHandleProps };
 
-export default function DragHandle({
-  ariaLabel,
-  ariaDescribedby,
-  disabled,
-  onPointerDown,
-  onKeyDown,
-}: DragHandleProps) {
-  return (
-    // We need to use a div with button role instead of a button
-    // so that Safari will focus on it when clicking it.
-    // (See https://bugs.webkit.org/show_bug.cgi?id=22261)
-    // Otherwise, we can't reliably catch keyboard events coming from the handle
-    // when it is being dragged.
-    <div
-      role="button"
-      tabIndex={0}
-      className={clsx(styles.handle, disabled && styles['handle-disabled'])}
-      aria-label={ariaLabel}
-      aria-describedby={ariaDescribedby}
-      aria-disabled={disabled}
-      onPointerDown={onPointerDown}
-      onKeyDown={onKeyDown}
-    >
-      <InternalIcon variant={disabled ? 'disabled' : undefined} name="drag-indicator" />
-    </div>
-  );
-}
+const DragHandle = forwardRef(
+  (
+    {
+      variant = 'drag-indicator',
+      size = 'normal',
+      ariaLabel,
+      ariaDescribedby,
+      ariaValue,
+      disabled,
+      onPointerDown,
+      onKeyDown,
+      className,
+    }: DragHandleProps,
+    ref: React.Ref<DragHandleProps.Ref>
+  ) => {
+    const dragHandleRefObject = useRef<HTMLElement>(null);
+    const dragHandleRef = useMergeRefs(dragHandleRefObject);
+
+    useForwardFocus(ref, dragHandleRefObject);
+
+    const iconProps: IconProps = (() => {
+      const shared = { variant: disabled ? ('disabled' as const) : undefined, size };
+      switch (variant) {
+        case 'drag-indicator':
+          return { ...shared, name: 'drag-indicator' };
+        case 'resize-area':
+          return { ...shared, name: 'resize-area' };
+        case 'resize-horizontal':
+          return { ...shared, svg: <ResizeIcon variant="horizontal" /> };
+        case 'resize-vertical':
+          return { ...shared, svg: <ResizeIcon variant="vertical" /> };
+      }
+    })();
+
+    return (
+      // We need to use a div with button role instead of a button
+      // so that Safari will focus on it when clicking it.
+      // (See https://bugs.webkit.org/show_bug.cgi?id=22261)
+      // Otherwise, we can't reliably catch keyboard events coming from the handle
+      // when it is being dragged.
+      <div
+        ref={dragHandleRef}
+        role={ariaValue ? 'slider' : 'button'}
+        tabIndex={0}
+        className={clsx(
+          className,
+          styles.handle,
+          styles[`handle-${variant}`],
+          styles[`handle-size-${size}`],
+          disabled && styles['handle-disabled']
+        )}
+        aria-label={ariaLabel}
+        aria-describedby={ariaDescribedby}
+        aria-disabled={disabled}
+        aria-valuemax={ariaValue?.valueMax}
+        aria-valuemin={ariaValue?.valueMin}
+        aria-valuenow={ariaValue?.valueNow}
+        onPointerDown={onPointerDown}
+        onKeyDown={onKeyDown}
+      >
+        <InternalIcon {...iconProps} />
+      </div>
+    );
+  }
+);
+
+export default DragHandle;

--- a/src/internal/components/drag-handle/interfaces.ts
+++ b/src/internal/components/drag-handle/interfaces.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export interface DragHandleProps {
+  variant?: DragHandleProps.Variant;
+  size?: DragHandleProps.Size;
+  ariaLabel: string;
+  ariaDescribedby?: string;
+  ariaValue?: DragHandleProps.AriaValue;
+  disabled?: boolean;
+  onPointerDown?: React.PointerEventHandler;
+  onKeyDown?: React.KeyboardEventHandler;
+  className?: string;
+}
+
+export namespace DragHandleProps {
+  export type Variant = 'drag-indicator' | 'resize-area' | 'resize-horizontal' | 'resize-vertical';
+
+  export type Size = 'small' | 'normal';
+
+  export interface AriaValue {
+    valueMin: number;
+    valueMax: number;
+    valueNow: number;
+  }
+
+  export interface Ref {
+    focus(options?: FocusOptions): void;
+  }
+}

--- a/src/internal/components/drag-handle/resize-icon.tsx
+++ b/src/internal/components/drag-handle/resize-icon.tsx
@@ -1,12 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
 
-export default function ResizeHandleIcon({ className }: { className?: string }) {
+import React from 'react';
+import clsx from 'clsx';
+
+import styles from './styles.css.js';
+
+interface ResizeIconProps {
+  variant: 'horizontal' | 'vertical';
+}
+
+export function ResizeIcon({ variant }: ResizeIconProps) {
   return (
     <svg
       focusable={false}
-      className={className}
+      className={clsx(styles['resize-icon'], styles[`resize-icon-${variant}`])}
       xmlns="http://www.w3.org/2000/svg"
       width="16"
       height="16"

--- a/src/internal/components/drag-handle/styles.scss
+++ b/src/internal/components/drag-handle/styles.scss
@@ -9,23 +9,48 @@
 
 .handle {
   appearance: none;
-  background: transparent;
-  border-block: none;
-  border-inline: none;
-  padding-block: 0;
-  padding-inline: awsui.$space-scaled-xxxs;
-  margin-block: 0;
-  margin-inline: awsui.$space-scaled-xxs;
-
   color: awsui.$color-text-interactive-default;
+  background: transparent;
+  inline-size: fit-content;
 
-  cursor: grab;
   // Prevent the browser from scrolling on touch devices when the touch event comes from the drag handle,
   // because this would otherwise interfere with actually dragging the handle.
   // The `touch-action` CSS property is not supported in desktop Safari but it is in mobile Safari
   // (and all our supported mobile browsers, in all the supported versions), which is where it actually matters.
   /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
   touch-action: none;
+
+  &-size-normal {
+    block-size: awsui.$line-height-body-m;
+    padding-inline: awsui.$space-scaled-xxxs;
+  }
+  &-size-small {
+    block-size: awsui.$line-height-body-s;
+  }
+
+  &-drag-indicator {
+    cursor: grab;
+
+    &:active {
+      cursor: grabbing;
+    }
+  }
+  &-resize-area {
+    cursor: nwse-resize;
+
+    @include styles.with-direction('rtl') {
+      cursor: nesw-resize;
+    }
+  }
+  &-resize-horizontal {
+    cursor: ew-resize;
+  }
+  &-resize-vertical {
+    cursor: ns-resize;
+  }
+  &-disabled {
+    cursor: default;
+  }
 
   &:hover {
     color: awsui.$color-text-interactive-hover;
@@ -41,10 +66,16 @@
   }
 }
 
-.handle:active {
-  cursor: grabbing;
-}
-
-.handle-disabled {
-  cursor: default;
+.resize-icon {
+  stroke: awsui.$color-text-interactive-default;
+  &:hover {
+    stroke: awsui.$color-text-interactive-hover;
+  }
+  &-vertical {
+    margin-block: auto;
+    margin-inline: auto;
+  }
+  &-horizontal {
+    transform: rotate(90deg);
+  }
 }

--- a/src/internal/components/options-list/index.tsx
+++ b/src/internal/components/options-list/index.tsx
@@ -115,7 +115,7 @@ const OptionsList = (
       style={{ position }}
       role={role}
       onScroll={handleScroll}
-      onKeyDown={event => onKeyDown && fireKeyboardEvent(onKeyDown, event)}
+      onKeyDown={event => fireKeyboardEvent(onKeyDown, event)}
       onMouseMove={event => onMouseMove?.(getItemIndex(menuRef, event))}
       onMouseUp={event => onMouseUp?.(getItemIndex(menuRef, event))}
       onBlur={event => fireNonCancelableEvent(onBlur, { relatedTarget: event.relatedTarget })}

--- a/src/internal/components/panel-resize-handle/index.tsx
+++ b/src/internal/components/panel-resize-handle/index.tsx
@@ -1,39 +1,41 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
-import clsx from 'clsx';
 
-import ResizeHandleIcon from './icon';
+import React from 'react';
+
+import DragHandle from '../drag-handle';
 
 import styles from './styles.css.js';
 
 interface ResizeHandleProps {
-  className?: string;
   ariaLabel: string | undefined;
   position: 'side' | 'bottom';
   ariaValuenow: number;
   onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
   onPointerDown: (event: React.PointerEvent<HTMLElement>) => void;
+  className?: string;
 }
 
-export default React.forwardRef<HTMLDivElement, ResizeHandleProps>(function PanelResizeHandle(
-  { className, ariaLabel, ariaValuenow, position, onKeyDown, onPointerDown },
-  ref
+export default React.forwardRef(function PanelResizeHandle(
+  { ariaLabel, ariaValuenow, position, onKeyDown, onPointerDown, className }: ResizeHandleProps,
+  ref: React.Ref<{ focus: () => void }>
 ) {
   return (
-    <div
-      ref={ref}
-      className={clsx(className, styles.slider, styles[`slider-${position}`])}
-      role="slider"
-      tabIndex={0}
-      aria-label={ariaLabel}
-      aria-valuemax={100}
-      aria-valuemin={0}
-      aria-valuenow={ariaValuenow}
-      onKeyDown={onKeyDown}
-      onPointerDown={onPointerDown}
-    >
-      <ResizeHandleIcon className={clsx(styles['slider-icon'], styles[`slider-icon-${position}`])} />
+    <div className={styles[`handle-wrapper-${position}`]}>
+      <DragHandle
+        variant={position === 'bottom' ? 'resize-vertical' : 'resize-horizontal'}
+        size="small"
+        ref={ref}
+        ariaLabel={ariaLabel ?? ''}
+        ariaValue={{
+          valueMin: 0,
+          valueMax: 100,
+          valueNow: ariaValuenow,
+        }}
+        onPointerDown={onPointerDown}
+        onKeyDown={onKeyDown}
+        className={className}
+      />
     </div>
   );
 });

--- a/src/internal/components/panel-resize-handle/styles.scss
+++ b/src/internal/components/panel-resize-handle/styles.scss
@@ -3,48 +3,9 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
-@use '../../styles' as styles;
-@use '../../styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
-
-.slider {
-  padding-block: 0;
-  padding-inline: 0;
-  cursor: ns-resize;
-  margin-block-start: 2px;
-  margin-block-end: 0;
-  margin-inline: 0;
-  block-size: 16px;
-  // Desktop Safari doesn't support touch events, but Safari on iOS does.
-  // stylelint-disable-next-line plugin/no-unsupported-browser-features
-  touch-action: none;
-
-  &:focus {
-    outline: none;
-  }
-
-  @include focus-visible.when-visible {
-    @include styles.focus-highlight(0px);
-  }
-}
-
-.slider-side {
-  cursor: ew-resize;
-  margin-block: 0;
+.handle-wrapper-side {
   margin-inline-start: 2px;
-  margin-inline-end: 0;
 }
-
-.slider-icon {
-  stroke: awsui.$color-text-interactive-default;
-  &:hover {
-    stroke: awsui.$color-text-interactive-hover;
-  }
-  &-bottom {
-    margin-block: auto;
-    margin-inline: auto;
-  }
-  &-side {
-    transform: rotate(90deg);
-  }
+.handle-wrapper-bottom {
+  margin-block-start: 2px;
 }

--- a/src/internal/events/index.ts
+++ b/src/internal/events/index.ts
@@ -82,7 +82,13 @@ export function fireCancelableEvent<T>(
   return event.defaultPrevented;
 }
 
-export function fireKeyboardEvent(handler: CancelableEventHandler<BaseKeyDetail>, reactEvent: React.KeyboardEvent) {
+export function fireKeyboardEvent(
+  handler: CancelableEventHandler<BaseKeyDetail> | undefined,
+  reactEvent: React.KeyboardEvent
+) {
+  if (!handler) {
+    return;
+  }
   return fireCancelableEvent(
     handler,
     {

--- a/src/internal/events/index.ts
+++ b/src/internal/events/index.ts
@@ -86,9 +86,6 @@ export function fireKeyboardEvent(
   handler: CancelableEventHandler<BaseKeyDetail> | undefined,
   reactEvent: React.KeyboardEvent
 ) {
-  if (!handler) {
-    return;
-  }
   return fireCancelableEvent(
     handler,
     {

--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -82,9 +82,7 @@ const InternalPromptInput = React.forwardRef(
     );
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (onKeyDown) {
-        fireKeyboardEvent(onKeyDown, event);
-      }
+      fireKeyboardEvent(onKeyDown, event);
 
       if (event.key === 'Enter' && !event.shiftKey) {
         if ('form' in event.target && event.target.form !== null && !event.isDefaultPrevented()) {

--- a/src/split-panel/__tests__/helpers.ts
+++ b/src/split-panel/__tests__/helpers.ts
@@ -20,6 +20,7 @@ export const defaultSplitPanelContextProps: SplitPanelContextProps = {
   refs: {
     preferences: { current: null },
     slider: { current: null },
+    handle: { current: null },
     toggle: { current: null },
   },
 };

--- a/src/split-panel/implementation.tsx
+++ b/src/split-panel/implementation.tsx
@@ -76,7 +76,7 @@ export function SplitPanelImplementation({
   const sizeControlProps: SizeControlProps = {
     position,
     panelRef: splitPanelRefObject,
-    handleRef: refs.slider,
+    handleRef: refs.handle,
     onResize,
   };
   const onSliderPointerDown = usePointerEvents(sizeControlProps);
@@ -138,18 +138,20 @@ export function SplitPanelImplementation({
   );
 
   const resizeHandle = (
-    <PanelResizeHandle
-      ref={refs.slider}
-      className={testUtilStyles.slider}
-      ariaLabel={i18nStrings.resizeHandleAriaLabel}
-      // Allows us to use the logical left/right keys to move the slider left/right,
-      // but match aria keyboard behavior of using left/right to decrease/increase
-      // the slider value.
-      ariaValuenow={position === 'bottom' ? relativeSize : 100 - relativeSize}
-      position={position}
-      onKeyDown={onKeyDown}
-      onPointerDown={onSliderPointerDown}
-    />
+    <div ref={refs.handle}>
+      <PanelResizeHandle
+        ref={refs.slider}
+        className={testUtilStyles.slider}
+        ariaLabel={i18nStrings.resizeHandleAriaLabel}
+        // Allows us to use the logical left/right keys to move the slider left/right,
+        // but match aria keyboard behavior of using left/right to decrease/increase
+        // the slider value.
+        ariaValuenow={position === 'bottom' ? relativeSize : 100 - relativeSize}
+        position={position}
+        onKeyDown={onKeyDown}
+        onPointerDown={onSliderPointerDown}
+      />
+    </div>
   );
 
   /*


### PR DESCRIPTION
### Description

Reusing drag handle between collection prefs, split panel, and drawers with potential future extension to board components, see: [a3UOAhaNX7KH].

### How has this been tested?

* New unit tests for drag handle
* Screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
