### PR TITLE
chore: Pin ace-builds version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
         "@juggle/resize-observer": "^3.3.1",
-        "ace-builds": "^1.34.0",
+        "ace-builds": "1.36.0",
         "balanced-match": "^1.0.2",
         "clsx": "^1.1.0",
         "d3-shape": "^1.3.7",
@@ -4737,9 +4737,9 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.34.0.tgz",
-      "integrity": "sha512-ZQqoV76wl4guDE5zvEnxCDrvy9gzLAwu7eD4ikYj/Gdlb4+qRLbb+aOFVnweZZRsHh089V0WVaw2NMNuiiEdTw=="
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.36.0.tgz",
+      "integrity": "sha512-7to4F86V5N13EY4M9LWaGo2Wmr9iWe5CrYpc28F+/OyYCf7yd+xBV5x9v/GB73EBGGoYd89m6JjeIUjkL6Yw+w=="
     },
     "node_modules/acorn": {
       "version": "8.12.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.1",
     "@juggle/resize-observer": "^3.3.1",
-    "ace-builds": "^1.34.0",
+    "ace-builds": "1.36.0",
     "balanced-match": "^1.0.2",
     "clsx": "^1.1.0",
     "d3-shape": "^1.3.7",


### PR DESCRIPTION
### Description
In v 1.37 of `ace-builds` there are breaking changes. Pinning this for now to unblock the pipeline
Related links, issue #, if available: -

### How has this been tested?

- dry-run build 7167165402 to live is green
- dev pipeline successfully merged from live

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
