### PR TITLE
fix: Bottom padding in stacked table

### DIFF
--- a/pages/table/stacked-and-container-variant.page.tsx
+++ b/pages/table/stacked-and-container-variant.page.tsx
@@ -44,6 +44,11 @@ const ExampleTable = ({ variant }: { variant: TableProps.Variant }) => {
       items={tableItems}
       selectionType="multi"
       header={<Header>Table with variant {variant}</Header>}
+      ariaLabels={{
+        selectionGroupLabel: 'Items selection',
+        allItemsSelectionLabel: () => 'select all',
+        itemSelectionLabel: (selection, item) => item.id,
+      }}
     />
   );
 };

--- a/pages/table/stacked-and-container-variant.page.tsx
+++ b/pages/table/stacked-and-container-variant.page.tsx
@@ -11,6 +11,8 @@ import ScreenshotArea from '../utils/screenshot-area';
 export default () => {
   return (
     <ScreenshotArea>
+      <h1>Stacked and container variants</h1>
+
       {/* These two should look identical */}
       <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
         <ExampleTable variant="container" />

--- a/pages/table/stacked-and-container-variant.page.tsx
+++ b/pages/table/stacked-and-container-variant.page.tsx
@@ -34,6 +34,11 @@ const ExampleTable = ({ variant }: { variant: 'container' | 'embedded' | 'border
       variant={variant}
       onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
       selectedItems={selectedItems}
+      ariaLabels={{
+        selectionGroupLabel: 'Items selection',
+        allItemsSelectionLabel: () => 'select all',
+        itemSelectionLabel: (selection, item) => item.name,
+      }}
       columnDefinitions={[
         {
           id: 'variable',

--- a/pages/table/stacked-and-container-variant.page.tsx
+++ b/pages/table/stacked-and-container-variant.page.tsx
@@ -1,0 +1,89 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Grid from '~components/grid';
+import Header from '~components/header';
+import Table from '~components/table';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+export default () => {
+  return (
+    <ScreenshotArea>
+      {/* These two should look identical */}
+      <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+        <ExampleTable variant="container" />
+
+        <ExampleTable variant="stacked" />
+      </Grid>
+
+      <br />
+
+      <ExampleTable variant="stacked" />
+      <ExampleTable variant="stacked" />
+    </ScreenshotArea>
+  );
+};
+
+const ExampleTable = ({ variant }: { variant: 'container' | 'embedded' | 'borderless' | 'stacked' | 'full-page' }) => {
+  const [selectedItems, setSelectedItems] = useState<any>([{ name: 'Item 6' }]);
+
+  return (
+    <Table
+      variant={variant}
+      onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+      selectedItems={selectedItems}
+      columnDefinitions={[
+        {
+          id: 'variable',
+          header: 'Name',
+          cell: item => item.name,
+          sortingField: 'name',
+          isRowHeader: true,
+        },
+        {
+          id: 'value',
+          header: 'Value',
+          cell: item => item.value,
+          sortingField: 'value',
+        },
+      ]}
+      items={[
+        {
+          name: 'Item 1',
+          value: 'First',
+          size: 'Small',
+        },
+        {
+          name: 'Item 2',
+          value: 'Second',
+          size: 'Large',
+        },
+        {
+          name: 'Item 3',
+          value: 'Third',
+          size: 'Large',
+        },
+        {
+          name: 'Item 4',
+          value: 'Fourth',
+          size: 'Small',
+        },
+        {
+          name: 'Item 5',
+          value: '-',
+          size: 'Large',
+        },
+        {
+          name: 'Item 6',
+          value: 'Sixth',
+          size: 'Small',
+        },
+      ]}
+      selectionType="multi"
+      trackBy="name"
+      header={<Header>Table with variant {variant}</Header>}
+    />
+  );
+};

--- a/pages/table/stacked-and-container-variant.page.tsx
+++ b/pages/table/stacked-and-container-variant.page.tsx
@@ -4,9 +4,13 @@ import React, { useState } from 'react';
 
 import Grid from '~components/grid';
 import Header from '~components/header';
-import Table from '~components/table';
+import Table, { TableProps } from '~components/table';
 
 import ScreenshotArea from '../utils/screenshot-area';
+import { generateItems } from './generate-data';
+import { columnsConfig } from './shared-configs';
+
+const tableItems = generateItems(6);
 
 export default () => {
   return (
@@ -28,68 +32,17 @@ export default () => {
   );
 };
 
-const ExampleTable = ({ variant }: { variant: 'container' | 'embedded' | 'borderless' | 'stacked' | 'full-page' }) => {
-  const [selectedItems, setSelectedItems] = useState<any>([{ name: 'Item 6' }]);
+const ExampleTable = ({ variant }: { variant: TableProps.Variant }) => {
+  const [selectedItems, setSelectedItems] = useState<any>([tableItems[tableItems.length - 1]]);
 
   return (
     <Table
       variant={variant}
       onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
       selectedItems={selectedItems}
-      ariaLabels={{
-        selectionGroupLabel: 'Items selection',
-        allItemsSelectionLabel: () => 'select all',
-        itemSelectionLabel: (selection, item) => item.name,
-      }}
-      columnDefinitions={[
-        {
-          id: 'variable',
-          header: 'Name',
-          cell: item => item.name,
-          sortingField: 'name',
-          isRowHeader: true,
-        },
-        {
-          id: 'value',
-          header: 'Value',
-          cell: item => item.value,
-          sortingField: 'value',
-        },
-      ]}
-      items={[
-        {
-          name: 'Item 1',
-          value: 'First',
-          size: 'Small',
-        },
-        {
-          name: 'Item 2',
-          value: 'Second',
-          size: 'Large',
-        },
-        {
-          name: 'Item 3',
-          value: 'Third',
-          size: 'Large',
-        },
-        {
-          name: 'Item 4',
-          value: 'Fourth',
-          size: 'Small',
-        },
-        {
-          name: 'Item 5',
-          value: '-',
-          size: 'Large',
-        },
-        {
-          name: 'Item 6',
-          value: 'Sixth',
-          size: 'Small',
-        },
-      ]}
+      columnDefinitions={columnsConfig}
+      items={tableItems}
       selectionType="multi"
-      trackBy="name"
       header={<Header>Table with variant {variant}</Header>}
     />
   );

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -76,6 +76,7 @@
       padding-inline: awsui.$space-table-horizontal;
     }
   }
+  &.variant-stacked:not(.has-footer),
   &.variant-container:not(.has-footer) {
     padding-block-end: awsui.$space-table-content-bottom;
   }


### PR DESCRIPTION
### Description
Added bottom padding to stacked table. Previously when the last item was selected, there would be no space between the selected item and table border whereas container variant table had space.

Related links, issue #, if available: AWSUI-60100

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
