### PR TITLE
chore: Upgrade react-keyed-flatten-children to v2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "date-fns": "^2.25.0",
         "intl-messageformat": "^10.3.1",
         "mnth": "^2.0.0",
-        "react-keyed-flatten-children": "^3.0.2",
+        "react-keyed-flatten-children": "^2.2.1",
         "react-transition-group": "^4.4.2",
         "tslib": "^2.4.0",
         "weekstart": "^1.1.0"
@@ -15828,9 +15828,9 @@
       "license": "MIT"
     },
     "node_modules/react-keyed-flatten-children": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/react-keyed-flatten-children/-/react-keyed-flatten-children-3.0.2.tgz",
-      "integrity": "sha512-5oiw2x9QlCSOTeAerw72e3ij0P+kJ60A7mtHvpabbOc4j3mvVQB3YpXCy2Qt/0YOuDWvAq3w/cGRuO7G20KISQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-keyed-flatten-children/-/react-keyed-flatten-children-2.2.1.tgz",
+      "integrity": "sha512-6yBLVO6suN8c/OcJk1mzIrUHdeEzf5rtRVBhxEXAHO49D7SlJ70cG4xrSJrBIAG7MMeQ+H/T151mM2dRDNnFaA==",
       "license": "MIT",
       "dependencies": {
         "react-is": "^18.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "date-fns": "^2.25.0",
         "intl-messageformat": "^10.3.1",
         "mnth": "^2.0.0",
-        "react-keyed-flatten-children": "^1.3.0",
+        "react-keyed-flatten-children": "^3.0.2",
         "react-transition-group": "^4.4.2",
         "tslib": "^2.4.0",
         "weekstart": "^1.1.0"
@@ -15828,14 +15828,22 @@
       "license": "MIT"
     },
     "node_modules/react-keyed-flatten-children": {
-      "version": "1.3.0",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-keyed-flatten-children/-/react-keyed-flatten-children-3.0.2.tgz",
+      "integrity": "sha512-5oiw2x9QlCSOTeAerw72e3ij0P+kJ60A7mtHvpabbOc4j3mvVQB3YpXCy2Qt/0YOuDWvAq3w/cGRuO7G20KISQ==",
       "license": "MIT",
       "dependencies": {
-        "react-is": "^16.8.6"
+        "react-is": "^18.2.0"
       },
       "peerDependencies": {
         "react": ">=15.0.0"
       }
+    },
+    "node_modules/react-keyed-flatten-children/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/react-router": {
       "version": "5.3.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "date-fns": "^2.25.0",
     "intl-messageformat": "^10.3.1",
     "mnth": "^2.0.0",
-    "react-keyed-flatten-children": "^1.3.0",
+    "react-keyed-flatten-children": "^3.0.2",
     "react-transition-group": "^4.4.2",
     "tslib": "^2.4.0",
     "weekstart": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "date-fns": "^2.25.0",
     "intl-messageformat": "^10.3.1",
     "mnth": "^2.0.0",
-    "react-keyed-flatten-children": "^3.0.2",
+    "react-keyed-flatten-children": "^2.2.1",
     "react-transition-group": "^4.4.2",
     "tslib": "^2.4.0",
     "weekstart": "^1.1.0"


### PR DESCRIPTION
### Description

Issue: `AWSUI-60096`

Also see #3080

### How has this been tested?

- Dry run

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
