### PR TITLE
fix: Add more css specificity to center text in full width button dropdown main action

### DIFF
--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -222,6 +222,7 @@ const InternalButtonDropdown = React.forwardRef(
           ref={mainActionRef}
           {...mainActionProps}
           {...mainActionIconProps}
+          fullWidth={canBeFullWidth}
           className={clsx(
             styles['trigger-button'],
             hasNoText && styles['has-no-text'],

--- a/src/button-dropdown/styles.scss
+++ b/src/button-dropdown/styles.scss
@@ -120,7 +120,6 @@ $dropdown-trigger-icon-offset: 2px;
 
 .main-action-full-width {
   flex: 1 1 0;
-  text-align: center;
 }
 
 .main-action-trigger-full-width {


### PR DESCRIPTION
### Description

In ButtonDropdown component with main action and full width props, the css style to align text to the center gets overriden sometimes by `Button` component default styles due to not having enough specificity.

in this commit, passing `fullWidth` prop to internal button ensures that the `text-align` style is applied with a specificity that doesn't get overriden by default styles.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
