### PR TITLE
fix: Make table column announcements less verbose for screen readers

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -15805,8 +15805,6 @@ add a meaningful description to the whole selection.
 * \`ariaLabel\` (LabelData => string) - An optional function that's called to provide an \`aria-label\` for the cell header.
   It receives the current sorting state of this column, the direction it's sorted in, and an indication of
   whether the sorting is disabled, as three Boolean values: \`sorted\`, \`descending\` and \`disabled\`.
-  We recommend that you use this for sortable columns to provide more meaningful labels based on the
-  current sorting direction.
 * \`sortingField\` (string) - Enables default column sorting. The value is used in [collection hooks](/get-started/dev-guides/collection-hooks/)
   to reorder the items. Provide the name of the property within each item that should be used for sorting by this column.
   For more complex sorting use \`sortingComparator\` instead.

--- a/src/table/__tests__/header-cell.test.tsx
+++ b/src/table/__tests__/header-cell.test.tsx
@@ -110,6 +110,17 @@ it('updates based on resize observer if dynamic flag is set', () => {
   expect(updateColumn).toHaveBeenCalledWith('id', 234);
 });
 
+it('is labelled using the header cell content', () => {
+  const { container } = render(
+    <TableWrapper>
+      <TestComponent column={{ cell: () => null, header: () => 'Test' }} />
+    </TableWrapper>
+  );
+  const ariaLabelledBy = container.querySelector('th')!.getAttribute('aria-labelledby');
+  expect(ariaLabelledBy).toBeTruthy();
+  expect(container.querySelector(`.${styles['header-cell-text']}`)).toHaveAttribute('id', ariaLabelledBy);
+});
+
 describe('i18n', () => {
   it('supports using editIconAriaLabel from i18n provider', () => {
     const { container } = render(

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -135,6 +135,7 @@ export function TableHeaderCell<ItemType>({
       stickyState={stickyState}
       tableRole={tableRole}
       variant={variant}
+      ariaLabelledby={headerId}
       {...(sortingDisabled
         ? {}
         : getAnalyticsMetadataAttribute({
@@ -154,21 +155,19 @@ export function TableHeaderCell<ItemType>({
           [styles['header-cell-fake-focus']]: focusedComponent === `sorting-control-${String(columnId)}`,
           [styles['header-cell-content-expandable']]: isExpandable,
         })}
-        aria-label={
-          column.ariaLabel
-            ? column.ariaLabel({
-                sorted: sorted,
-                descending: sorted && !!sortingDescending,
-                disabled: !!sortingDisabled,
-              })
-            : undefined
-        }
         {...(sortingStatus && !sortingDisabled
           ? {
               onKeyPress: handleKeyPress,
               tabIndex: clickableHeaderTabIndex,
               role: 'button',
               onClick: handleClick,
+              'aria-label': column.ariaLabel
+                ? column.ariaLabel({
+                    sorted: sorted,
+                    descending: sorted && !!sortingDescending,
+                    disabled: !!sortingDisabled,
+                  })
+                : undefined,
             }
           : {})}
       >

--- a/src/table/header-cell/th-element.tsx
+++ b/src/table/header-cell/th-element.tsx
@@ -36,6 +36,7 @@ export interface TableThElementProps {
   children: React.ReactNode;
   variant: TableProps.Variant;
   ariaLabel?: string;
+  ariaLabelledby?: string;
 }
 
 export function TableThElement({
@@ -56,6 +57,7 @@ export function TableThElement({
   children,
   variant,
   ariaLabel,
+  ariaLabelledby,
   ...props
 }: TableThElementProps) {
   const isVisualRefresh = useVisualRefresh();
@@ -98,6 +100,7 @@ export function TableThElement({
       tabIndex={cellTabIndex === -1 ? undefined : cellTabIndex}
       {...copyAnalyticsMetadataAttribute(props)}
       {...(ariaLabel ? { 'aria-label': ariaLabel } : {})}
+      aria-labelledby={ariaLabelledby}
     >
       {children}
     </th>

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -88,8 +88,6 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * * `ariaLabel` (LabelData => string) - An optional function that's called to provide an `aria-label` for the cell header.
    *   It receives the current sorting state of this column, the direction it's sorted in, and an indication of
    *   whether the sorting is disabled, as three Boolean values: `sorted`, `descending` and `disabled`.
-   *   We recommend that you use this for sortable columns to provide more meaningful labels based on the
-   *   current sorting direction.
    * * `sortingField` (string) - Enables default column sorting. The value is used in [collection hooks](/get-started/dev-guides/collection-hooks/)
    *   to reorder the items. Provide the name of the property within each item that should be used for sorting by this column.
    *   For more complex sorting use `sortingComparator` instead.


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
