### PR TITLE
Adjust prompt input height when minRows changes

### DIFF
--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -111,7 +111,7 @@ const InternalPromptInput = React.forwardRef(
         const minTextareaHeight = `calc(${LINE_HEIGHT} +  ${tokens.spaceScaledXxs} * 2)`; // the min height of Textarea with 1 row
         textareaRef.current.style.height = `min(max(${scrollHeight}, ${minTextareaHeight}), ${maxRowsHeight})`;
       }
-    }, [maxRows, LINE_HEIGHT, PADDING]);
+    }, [minRows, maxRows, LINE_HEIGHT, PADDING]);
 
     useEffect(() => {
       const handleResize = () => {


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

This PR fixes a bug that when `minRows` of `PromptInput` changes, it won't have effect until either `maxRows` or `value` changes. Changing `minRows` should also adjust height.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
