### PR TITLE
chore: Do not hide scrollbars in dev pages in Mac OS

### DIFF
--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -16,7 +16,7 @@ import StrictModeWrapper from './components/strict-mode-wrapper';
 // import font-size reset and Ember font
 import '@cloudscape-design/global-styles/index.css';
 // screenshot test overrides
-import styles from './styles.scss';
+import './styles.scss';
 
 interface GlobalFlags {
   appLayoutWidget?: boolean;
@@ -57,7 +57,6 @@ function App() {
   // Also, AppLayout pages should resemble the ConsoleNav 2.0 styles
   const isAppLayout = isAppLayoutPage(pageId);
   const ContentTag = isAppLayout ? 'div' : 'main';
-  const isMacOS = navigator.userAgent.toLowerCase().indexOf('macintosh') > -1;
 
   useEffect(() => {
     applyMode(mode ?? null);
@@ -70,14 +69,6 @@ function App() {
   useEffect(() => {
     disableMotion(motionDisabled);
   }, [motionDisabled]);
-
-  useEffect(() => {
-    if (isMacOS) {
-      document.body.classList.add(styles.macos);
-    } else {
-      document.body.classList.remove(styles.macos);
-    }
-  }, [isMacOS]);
 
   if (!mode) {
     return <Redirect to="/light/" />;

--- a/pages/app/styles.scss
+++ b/pages/app/styles.scss
@@ -20,15 +20,6 @@ body {
     caret-color: transparent !important;
   }
   // stylelint-enable @cloudscape-design/no-implicit-descendant, selector-max-type
-
-  &.macos {
-    // override scrollbars in macos for stable screenshot tests
-    // stylelint-disable-next-line @cloudscape-design/no-implicit-descendant
-    ::-webkit-scrollbar {
-      inline-size: 0;
-      block-size: 0;
-    }
-  }
 }
 
 /*


### PR DESCRIPTION
### Description

Removing unnecessary code as it is not really having any effect on visual regression tests, and it is confusing to manual inspection because:
- scrollbars being hidden might not be expected at all
- it hides some scrollbars (the ones in the body) but not others (the page-level ones)

### How has this been tested?

Ran in my pipeline. Specifically verified that visual regression tests are green for the Safari tests, both for components and demos. And as I expected, scrollbars are still not shown in the screenshots anyway even after this change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
