### PR TITLE
fix: Fix code editor becoming hidden when the group is focused

### DIFF
--- a/src/code-editor/styles.scss
+++ b/src/code-editor/styles.scss
@@ -27,9 +27,13 @@
   inset: 0;
 
   &:focus {
-    position: absolute;
-    overflow: visible;
     @include styles.focus-highlight(3px);
+    // Required to avoid SASS mixed declarations warning (https://sass-lang.com/d/mixed-decls)
+    // stylelint-disable-next-line no-duplicate-selectors
+    & {
+      position: absolute;
+      overflow: visible;
+    }
   }
 }
 


### PR DESCRIPTION
### Description

I don't think it's supposed to do that:

<img width="660" alt="Screenshot 2025-01-08 at 16 27 55" src="https://github.com/user-attachments/assets/79209686-4aab-4e42-a267-12fc9470cdb6" />

Not sure when it happened, but we are colliding with ace's wrapper div for styling here. I assume the intent was always to have `position: absolute`, but I don't know if it ever worked with the mixin's `position: relative` overriding that anyway. So I moved those declarations to after the mixin.

Related links, issue #, if available: AWSUI-60262

### How has this been tested?

Local testing, but I suppose a screenshot test is in order.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
