### PR TITLE
chore: un-pin ace-builds version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
         "@juggle/resize-observer": "^3.3.1",
-        "ace-builds": "1.36.0",
+        "ace-builds": "^1.34.0",
         "balanced-match": "^1.0.2",
         "clsx": "^1.1.0",
         "d3-shape": "^1.3.7",
@@ -4737,9 +4737,9 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.36.0.tgz",
-      "integrity": "sha512-7to4F86V5N13EY4M9LWaGo2Wmr9iWe5CrYpc28F+/OyYCf7yd+xBV5x9v/GB73EBGGoYd89m6JjeIUjkL6Yw+w=="
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.34.0.tgz",
+      "integrity": "sha512-ZQqoV76wl4guDE5zvEnxCDrvy9gzLAwu7eD4ikYj/Gdlb4+qRLbb+aOFVnweZZRsHh089V0WVaw2NMNuiiEdTw=="
     },
     "node_modules/acorn": {
       "version": "8.12.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.1",
     "@juggle/resize-observer": "^3.3.1",
-    "ace-builds": "1.36.0",
+    "ace-builds": "^1.34.0",
     "balanced-match": "^1.0.2",
     "clsx": "^1.1.0",
     "d3-shape": "^1.3.7",


### PR DESCRIPTION
This reverts commit 1e11f46fcfed3aa1c0bf67e74dad8f8cd6977eda.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Un-pin ace-builds after the breaking changes in the type definitions of version 1.37.1 were fixed in 1.37.4.

I will merge this only once ace-builds 1.37.4 is available internally.

Issue: `AWSUI-60195`

### How has this been tested?

Locally:

```
rm -f node_modules
npm i
npm run build
```

With the changes in this PR, the commands above were failing before ace-builds 1.37.4 was published and they succeed now.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
