### PR TITLE
fix: Allow text selection in date picker and date range picker

### DIFF
--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -168,11 +168,6 @@ const DatePicker = React.forwardRef(
 
     baseProps.className = clsx(baseProps.className, styles.root, styles['date-picker-container']);
 
-    const handleMouseDown = (event: React.MouseEvent) => {
-      // prevent currently focused element from losing it
-      event.preventDefault();
-    };
-
     return (
       <div {...baseProps} ref={mergedRef} onKeyDown={!disabled && !readOnly ? onWrapperKeyDownHandler : undefined}>
         {disabled || readOnly ? (
@@ -183,7 +178,6 @@ const DatePicker = React.forwardRef(
             stretchHeight={true}
             open={isDropDownOpen}
             onDropdownClose={onDropdownCloseHandler}
-            onMouseDown={handleMouseDown}
             trigger={trigger}
             expandToViewport={expandToViewport}
             scrollable={false}

--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -131,7 +131,6 @@ $calendar-header-color: awsui.$color-text-body-default;
 }
 
 .label {
-  user-select: text;
   cursor: default;
 }
 
@@ -173,7 +172,6 @@ $calendar-header-color: awsui.$color-text-body-default;
 }
 
 .dropdown-content {
-  user-select: text;
   background-color: awsui.$color-background-container-content;
   inline-size: calc(2 * #{$calendar-grid-width} + #{awsui.$space-xs} + 2 * #{awsui.$space-l});
 

--- a/src/internal/components/dropdown/styles.scss
+++ b/src/internal/components/dropdown/styles.scss
@@ -23,7 +23,6 @@
   display: none;
   // Needs to be higher than a global navigation element
   z-index: 2000;
-  user-select: none;
   transform-origin: top;
 
   // When used in portal we need z-index to be higher than modal's

--- a/src/internal/components/options-list/styles.scss
+++ b/src/internal/components/options-list/styles.scss
@@ -23,6 +23,7 @@
   border-start-end-radius: awsui.$border-radius-dropdown;
   border-end-start-radius: awsui.$border-radius-dropdown;
   border-end-end-radius: awsui.$border-radius-dropdown;
+  user-select: none;
 
   &-embedded {
     border-start-start-radius: 0px;


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Issue: `AWSUI-60182`

In the case of dropdowns that contain only a list of selectable options (autosuggest, button dropdown, multiselect, select) it makes sense to disable text selection, but not necessarily for anything that the dropdown may contain, and in particular not for date pickers and date range pickers, where this is having undesired side effects. Therefore moving `user-select: none` from the dropdown component down to the options list component.

### How has this been tested?

- Preparing visual regression tests
- Manually tested:
  - Text is selectable in date picker and date ranger picker
  - Double-clicking previous and next buttons in date picker or date range picker does not have unexpected side effects
  - Text is _not_ selectable in autosuggest, button dropdown, multiselect, select

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
