### PR TITLE
fix: Performance bug fix to emit marks for only first tab

### DIFF
--- a/src/internal/context/tab-context.ts
+++ b/src/internal/context/tab-context.ts
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { createContext, useContext } from 'react';
+export interface TabContextProps {
+  isInFirstTab: boolean | null;
+}
+export const TabContext = createContext<TabContextProps>({
+  isInFirstTab: null,
+});
+export const useTabContext = () => {
+  return useContext(TabContext);
+};

--- a/src/internal/hooks/use-performance-marks/index.ts
+++ b/src/internal/hooks/use-performance-marks/index.ts
@@ -4,6 +4,7 @@
 import { useEffect, useState } from 'react';
 
 import { useModalContext } from '../../context/modal-context';
+import { useTabContext } from '../../context/tab-context';
 import { useDOMAttribute } from '../use-dom-attribute';
 import { useEffectOnUpdate } from '../use-effect-on-update';
 import { useRandomId } from '../use-unique-id';
@@ -48,10 +49,11 @@ export function usePerformanceMarks(
 ) {
   const id = useRandomId();
   const { isInModal } = useModalContext();
+  const { isInFirstTab } = useTabContext();
   const attributes = useDOMAttribute(elementRef, 'data-analytics-performance-mark', id);
   const evaluateComponentVisibility = useEvaluateComponentVisibility();
   useEffect(() => {
-    if (!enabled() || !elementRef.current || isInModal) {
+    if (!enabled || !elementRef.current || isInModal || isInFirstTab === false) {
       return;
     }
     const elementVisible =
@@ -64,6 +66,7 @@ export function usePerformanceMarks(
     }
 
     const renderedMarkName = `${name}Rendered`;
+    console.log('mark');
     performance.mark(renderedMarkName, {
       detail: {
         source: 'awsui',
@@ -75,7 +78,7 @@ export function usePerformanceMarks(
   }, []);
 
   useEffectOnUpdate(() => {
-    if (!enabled() || !elementRef.current || isInModal) {
+    if (!enabled || !elementRef.current || isInModal || isInFirstTab === false) {
       return;
     }
     const elementVisible =

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -7,6 +7,7 @@ import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-tool
 
 import InternalContainer from '../container/internal';
 import { getBaseProps } from '../internal/base-component';
+import { TabContext } from '../internal/context/tab-context';
 import { fireNonCancelableEvent } from '../internal/events';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { useControllable } from '../internal/hooks/use-controllable';
@@ -96,7 +97,17 @@ export default function Tabs({
       };
 
       const isContentShown = isTabSelected && !selectedTab.disabled;
-      return <div {...contentAttributes}>{isContentShown && selectedTab.content}</div>;
+      const firstTab = firstEnabledTab(tabs);
+
+      return (
+        <TabContext.Provider
+          value={{
+            isInFirstTab: firstTab !== null && firstTab.id === tab.id,
+          }}
+        >
+          <div {...contentAttributes}>{isContentShown && selectedTab.content}</div>
+        </TabContext.Provider>
+      );
     };
 
     return (


### PR DESCRIPTION
### Description

Bug - {component}Rendered and {component}Updated marks are emitted even if current component is adding to the second tab component. We don't want to publish metrics for the sections which are not visible on page load. 
Fix - Updated the usePerformanceMarks logic to emit markers only if the primary button or table is added to the first tab. 

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->
Locally tested the change
TODO - Updated unit and integration tests

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_ existing tests
- _Changes are covered with new/existing integration tests?_ existing tests
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
