### PR TITLE
fix: Unclickable actions in tabs

### DIFF
--- a/pages/tabs/actions.page.tsx
+++ b/pages/tabs/actions.page.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 
-import { Button, Container, Header } from '~components';
+import { Button, Container, Header, Popover } from '~components';
 import ButtonDropdown from '~components/button-dropdown';
 import SpaceBetween from '~components/space-between';
 import Tabs, { TabsProps } from '~components/tabs';
@@ -135,6 +135,39 @@ export default function TabsDemoPage() {
     },
   ]);
 
+  const tabsPopoverActions = [
+    {
+      id: 'first',
+      label: 'First tab label',
+      action: (
+        <Popover header="Header" content="Description">
+          <span data-testid="popover1">Popover 1</span>
+        </Popover>
+      ),
+      content: <p>First tab content</p>,
+    },
+    {
+      id: 'second',
+      label: 'Second tab label',
+      action: (
+        <Popover header="Header" content="Description">
+          <span data-testid="popover2">Popover 2</span>
+        </Popover>
+      ),
+      content: <p>Second tab content</p>,
+    },
+    {
+      id: 'third',
+      label: 'Third tab label',
+      action: (
+        <Popover header="Header" content="Description">
+          <span data-testid="popover3">Popover 3</span>
+        </Popover>
+      ),
+      content: <p>Third tab content</p>,
+    },
+  ];
+
   return (
     <>
       <h1>Tabs</h1>
@@ -165,6 +198,13 @@ export default function TabsDemoPage() {
           <h2>Tabs with actions and dismissibles</h2>
           <Tabs
             tabs={tabsBoth}
+            i18nStrings={{ scrollLeftAriaLabel: 'Scroll left', scrollRightAriaLabel: 'Scroll right' }}
+          />
+        </div>
+        <div>
+          <h2>Tabs with popover actions</h2>
+          <Tabs
+            tabs={tabsPopoverActions}
             i18nStrings={{ scrollLeftAriaLabel: 'Scroll left', scrollRightAriaLabel: 'Scroll right' }}
           />
         </div>

--- a/src/tabs/__integ__/tabs-actions.test.ts
+++ b/src/tabs/__integ__/tabs-actions.test.ts
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+import createWrapper from '../../../lib/components/test-utils/selectors';
+
+const wrapper = createWrapper();
+
+const setupTest = (testFn: (page: BasePageObject) => Promise<void>) => {
+  return useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/tabs/actions');
+    await page.waitForVisible(wrapper.findTabs().findTabContent().toSelector());
+    await testFn(page);
+  });
+};
+
+test(
+  'tabs actions with popovers should be clickable',
+  setupTest(async page => {
+    for (let i = 1; i <= 3; i++) {
+      await page.click(`[data-testid="popover${i}"]`);
+      await expect(page.isDisplayed(wrapper.findPopover().toSelector())).resolves.toBe(true);
+    }
+  })
+);

--- a/src/tabs/tab-header-bar.scss
+++ b/src/tabs/tab-header-bar.scss
@@ -106,6 +106,7 @@ $label-horizontal-spacing: awsui.$space-xs;
 
   & > .tabs-tab-dismiss,
   & > .tabs-tab-action {
+    position: relative;
     display: flex;
     align-items: center;
   }


### PR DESCRIPTION
### Description

This PR addressed the bug https://github.com/cloudscape-design/components/issues/3159

The root cause is that the tab element has a `:before` element to represent the left border, which is absolutely positioned, so it overlaps the `action` within the tab. Setting `position: relative` for tabs' actions solves the problem. 

<img width="1398" alt="Screenshot 2025-01-13 at 17 32 24" src="https://github.com/user-attachments/assets/a3d67dec-d1ef-4fbd-ba39-dea26ab14b58" />


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
