### PR TITLE
fix: Adds position relative to the actions container

### DIFF
--- a/src/tabs/tab-header-bar.scss
+++ b/src/tabs/tab-header-bar.scss
@@ -106,6 +106,7 @@ $label-horizontal-spacing: awsui.$space-xs;
 
   & > .tabs-tab-dismiss,
   & > .tabs-tab-action {
+    position: relative;
     display: flex;
     align-items: center;
   }


### PR DESCRIPTION
### Description

When popover is placed inside the tab component's header action slot, it becomes unclickable.

#### Root cause

Inside the tab action, the tab separator is pseudo element with `position: absolute` property. This covers the whole space of the element and if a child element is not positioned, it will end up behind this transparent pseudo element, hence becomes unclickable.

#### Solution

The adjacent element (`tabs-tab-link`) already has `position: relative` which brings it on top of the mentioned pseudo-element. This PR adds the same `position: relative` to the `tabs-tab-actions` to fix the issue.

Related links, issue #, if available: AWSUI-60197

### How has this been tested?

Unit / Integ and dev screenshot tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
