### PR TITLE
fix: Fixes table with keyboard nav losing focus at times

### DIFF
--- a/src/table/table-role/utils.ts
+++ b/src/table/table-role/utils.ts
@@ -96,12 +96,11 @@ export function isTableCell(element: Element) {
 
 export function focusNextElement(element: null | HTMLElement) {
   if (element) {
-    // Table cells are not focusable by default (tabIndex=undefined) and cell.focus() is ignored.
-    // To force focusing we have to imperatively set tabIndex to -1. When focused, the grid navigation
-    // will update the tabIndex to 0 if the cell gets focused or set it to undefined if the cell content
-    // gets focused instead.
+    // Table cells are not focusable by default (tabIndex=undefined) so cell.focus() is ignored.
+    // To force focusing we have to imperatively set tabIndex to -1. This tabIndex is then to be
+    // overridden by the single tab stop context to be 0 or undefined.
     // We cannot make cells have tabIndex=-1 by default due to an associated bug with text selection, see: PR 2158.
-    if (isTableCell(element)) {
+    if (isTableCell(element) && element.tabIndex !== 0) {
       element.tabIndex = -1;
     }
     element.focus();


### PR DESCRIPTION
### Description

Fixes a hard to reproduce issue causing the table to become non-focusable when keyboard nav is on. If moving focus using arrow keys quickly then after moving the focus outside the table it might not be possible to bring it back unless reloading the page. This can only happen on table cells and was caused by explicitly setting the tabIndex=-1 to cells that can sometimes override the tabIndex=0 set by the single tab stop navigation mechanism.

Rel: AWSUI-60269

### How has this been tested?

* Manual tests
* Dry run and screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
