### PR TITLE
revert: Reusable internal drag handle (#3152)

### DIFF
--- a/src/app-layout/__tests__/split-panel-provider.test.tsx
+++ b/src/app-layout/__tests__/split-panel-provider.test.tsx
@@ -41,7 +41,6 @@ describe.each(['bottom', 'side'] as const)('position=%s', position => {
     onToggle: () => {},
     refs: {
       slider: { current: null },
-      handle: { current: null },
       toggle: { current: null },
       preferences: { current: null },
     },

--- a/src/app-layout/drawer/resizable-drawer.tsx
+++ b/src/app-layout/drawer/resizable-drawer.tsx
@@ -43,7 +43,7 @@ export const ResizableDrawer = ({
   const sizeControlProps: SizeControlProps = {
     position: 'side',
     panelRef: drawerRefObject,
-    handleRef: refs.handle,
+    handleRef: refs.slider,
     onResize: setSidePanelWidth,
   };
 
@@ -60,17 +60,15 @@ export const ResizableDrawer = ({
       resizeHandle={
         !isMobile &&
         activeDrawer?.resizable && (
-          <div ref={refs.handle}>
-            <PanelResizeHandle
-              ref={refs.slider}
-              position="side"
-              className={testutilStyles['drawers-slider']}
-              ariaLabel={activeDrawer?.ariaLabels?.resizeHandle}
-              ariaValuenow={relativeSize}
-              onKeyDown={onKeyDown}
-              onPointerDown={onSliderPointerDown}
-            />
-          </div>
+          <PanelResizeHandle
+            ref={refs.slider}
+            position="side"
+            className={testutilStyles['drawers-slider']}
+            ariaLabel={activeDrawer?.ariaLabels?.resizeHandle}
+            ariaValuenow={relativeSize}
+            onKeyDown={onKeyDown}
+            onPointerDown={onSliderPointerDown}
+          />
         )
       }
       ariaLabels={{

--- a/src/app-layout/utils/use-focus-control.ts
+++ b/src/app-layout/utils/use-focus-control.ts
@@ -9,8 +9,7 @@ export interface Focusable {
 export interface FocusControlRefs {
   toggle: RefObject<Focusable>;
   close: RefObject<Focusable>;
-  slider: RefObject<Focusable>;
-  handle: RefObject<HTMLDivElement>;
+  slider: RefObject<HTMLDivElement>;
 }
 
 export interface FocusControlState {
@@ -36,8 +35,7 @@ export function useMultipleFocusControl(
       refs.current[drawerId] = {
         toggle: createRef<Focusable>(),
         close: createRef<Focusable>(),
-        slider: createRef<Focusable>(),
-        handle: createRef<HTMLDivElement>(),
+        slider: createRef<HTMLDivElement>(),
       };
     }
   });
@@ -103,8 +101,7 @@ export function useFocusControl(
   const refs = {
     toggle: useRef<Focusable>(null),
     close: useRef<Focusable>(null),
-    slider: useRef<Focusable>(null),
-    handle: useRef<HTMLDivElement>(null),
+    slider: useRef<HTMLDivElement>(null),
   };
   const previousFocusedElement = useRef<HTMLElement>();
   const shouldFocus = useRef(false);

--- a/src/app-layout/utils/use-resize.tsx
+++ b/src/app-layout/utils/use-resize.tsx
@@ -61,7 +61,7 @@ function useResize(
   const sizeControlProps: SizeControlProps = {
     position: 'side',
     panelRef: drawerRefObject,
-    handleRef: drawersRefs.handle,
+    handleRef: drawersRefs.slider,
     onResize: setSidePanelWidth,
   };
 
@@ -69,17 +69,15 @@ function useResize(
   const onKeyDown = useKeyboardEvents(sizeControlProps);
 
   const resizeHandle = (
-    <div ref={drawersRefs.handle}>
-      <PanelResizeHandle
-        ref={drawersRefs.slider}
-        position="side"
-        ariaLabel={activeDrawer?.ariaLabels?.resizeHandle}
-        ariaValuenow={relativeSize}
-        className={testutilStyles['drawers-slider']}
-        onKeyDown={onKeyDown}
-        onPointerDown={onSliderPointerDown}
-      />
-    </div>
+    <PanelResizeHandle
+      ref={drawersRefs.slider}
+      position="side"
+      ariaLabel={activeDrawer?.ariaLabels?.resizeHandle}
+      ariaValuenow={relativeSize}
+      className={testutilStyles['drawers-slider']}
+      onKeyDown={onKeyDown}
+      onPointerDown={onSliderPointerDown}
+    />
   );
 
   return { resizeHandle, drawerSize };

--- a/src/app-layout/utils/use-split-panel-focus-control.ts
+++ b/src/app-layout/utils/use-split-panel-focus-control.ts
@@ -8,8 +8,7 @@ type SplitPanelLastInteraction = { type: 'open' } | { type: 'close' } | { type: 
 
 export interface SplitPanelFocusControlRefs {
   toggle: RefObject<Focusable>;
-  slider: RefObject<Focusable>;
-  handle: RefObject<HTMLDivElement>;
+  slider: RefObject<HTMLDivElement>;
   preferences: RefObject<Focusable>;
 }
 export interface SplitPanelFocusControlState {
@@ -20,8 +19,7 @@ export interface SplitPanelFocusControlState {
 export function useSplitPanelFocusControl(dependencies: DependencyList): SplitPanelFocusControlState {
   const refs = {
     toggle: useRef<Focusable>(null),
-    slider: useRef<Focusable>(null),
-    handle: useRef<HTMLDivElement>(null),
+    slider: useRef<HTMLDivElement>(null),
     preferences: useRef<Focusable>(null),
   };
   const lastInteraction = useRef<SplitPanelLastInteraction | null>(null);

--- a/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
@@ -58,7 +58,7 @@ function AppLayoutGlobalDrawerImplementation({
     minWidth: minDrawerSize,
     maxWidth: maxDrawerSize,
     panelRef: drawerRef,
-    handleRef: refs?.handle,
+    handleRef: refs?.slider,
     onResize: size => onActiveDrawerResize({ id: activeDrawerId!, size }),
   });
   const size = getLimitedValue(minDrawerSize, activeDrawerSize, maxDrawerSize);
@@ -111,17 +111,15 @@ function AppLayoutGlobalDrawerImplementation({
           >
             {!isMobile && activeGlobalDrawer?.resizable && (
               <div className={styles['drawer-slider']}>
-                <div ref={refs.handle}>
-                  <PanelResizeHandle
-                    ref={refs?.slider}
-                    position="side"
-                    className={testutilStyles['drawers-slider']}
-                    ariaLabel={activeGlobalDrawer?.ariaLabels?.resizeHandle}
-                    ariaValuenow={resizeProps.relativeSize}
-                    onKeyDown={resizeProps.onKeyDown}
-                    onPointerDown={resizeProps.onPointerDown}
-                  />
-                </div>
+                <PanelResizeHandle
+                  ref={refs?.slider}
+                  position="side"
+                  className={testutilStyles['drawers-slider']}
+                  ariaLabel={activeGlobalDrawer?.ariaLabels?.resizeHandle}
+                  ariaValuenow={resizeProps.relativeSize}
+                  onKeyDown={resizeProps.onKeyDown}
+                  onPointerDown={resizeProps.onPointerDown}
+                />
               </div>
             )}
             <div

--- a/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
@@ -55,7 +55,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
     minWidth: minDrawerSize,
     maxWidth: maxDrawerSize,
     panelRef: drawerRef,
-    handleRef: drawersFocusControl.refs.handle,
+    handleRef: drawersFocusControl.refs.slider,
     onResize: size => onActiveDrawerResize({ id: activeDrawerId!, size }),
   });
   // temporary handle a situation when app-layout is old, but this component come as a widget
@@ -98,17 +98,15 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
         >
           {!isMobile && activeDrawer?.resizable && (
             <div className={styles['drawer-slider']}>
-              <div ref={drawersFocusControl.refs.handle}>
-                <PanelResizeHandle
-                  ref={drawersFocusControl.refs.slider}
-                  position="side"
-                  className={testutilStyles['drawers-slider']}
-                  ariaLabel={activeDrawer?.ariaLabels?.resizeHandle}
-                  ariaValuenow={resizeProps.relativeSize}
-                  onKeyDown={resizeProps.onKeyDown}
-                  onPointerDown={resizeProps.onPointerDown}
-                />
-              </div>
+              <PanelResizeHandle
+                ref={drawersFocusControl.refs.slider}
+                position="side"
+                className={testutilStyles['drawers-slider']}
+                ariaLabel={activeDrawer?.ariaLabels?.resizeHandle}
+                ariaValuenow={resizeProps.relativeSize}
+                onKeyDown={resizeProps.onKeyDown}
+                onPointerDown={resizeProps.onPointerDown}
+              />
             </div>
           )}
           <div className={clsx(styles['drawer-content-container'], sharedStyles['with-motion-horizontal'])}>

--- a/src/internal/components/panel-resize-handle/icon.tsx
+++ b/src/internal/components/panel-resize-handle/icon.tsx
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+export default function ResizeHandleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      focusable={false}
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      aria-hidden={true}
+    >
+      <line strokeWidth="2" x1="2" y1="5" x2="14" y2="5" />
+      <line strokeWidth="2" x1="14" y1="10" x2="2" y2="10" />
+    </svg>
+  );
+}

--- a/src/internal/components/panel-resize-handle/index.tsx
+++ b/src/internal/components/panel-resize-handle/index.tsx
@@ -1,41 +1,39 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
+import clsx from 'clsx';
 
-import DragHandle from '../drag-handle';
+import ResizeHandleIcon from './icon';
 
 import styles from './styles.css.js';
 
 interface ResizeHandleProps {
+  className?: string;
   ariaLabel: string | undefined;
   position: 'side' | 'bottom';
   ariaValuenow: number;
   onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
   onPointerDown: (event: React.PointerEvent<HTMLElement>) => void;
-  className?: string;
 }
 
-export default React.forwardRef(function PanelResizeHandle(
-  { ariaLabel, ariaValuenow, position, onKeyDown, onPointerDown, className }: ResizeHandleProps,
-  ref: React.Ref<{ focus: () => void }>
+export default React.forwardRef<HTMLDivElement, ResizeHandleProps>(function PanelResizeHandle(
+  { className, ariaLabel, ariaValuenow, position, onKeyDown, onPointerDown },
+  ref
 ) {
   return (
-    <div className={styles[`handle-wrapper-${position}`]}>
-      <DragHandle
-        variant={position === 'bottom' ? 'resize-vertical' : 'resize-horizontal'}
-        size="small"
-        ref={ref}
-        ariaLabel={ariaLabel ?? ''}
-        ariaValue={{
-          valueMin: 0,
-          valueMax: 100,
-          valueNow: ariaValuenow,
-        }}
-        onPointerDown={onPointerDown}
-        onKeyDown={onKeyDown}
-        className={className}
-      />
+    <div
+      ref={ref}
+      className={clsx(className, styles.slider, styles[`slider-${position}`])}
+      role="slider"
+      tabIndex={0}
+      aria-label={ariaLabel}
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={ariaValuenow}
+      onKeyDown={onKeyDown}
+      onPointerDown={onPointerDown}
+    >
+      <ResizeHandleIcon className={clsx(styles['slider-icon'], styles[`slider-icon-${position}`])} />
     </div>
   );
 });

--- a/src/internal/components/panel-resize-handle/styles.scss
+++ b/src/internal/components/panel-resize-handle/styles.scss
@@ -3,9 +3,48 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
-.handle-wrapper-side {
-  margin-inline-start: 2px;
-}
-.handle-wrapper-bottom {
+@use '../../styles' as styles;
+@use '../../styles/tokens' as awsui;
+@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
+
+.slider {
+  padding-block: 0;
+  padding-inline: 0;
+  cursor: ns-resize;
   margin-block-start: 2px;
+  margin-block-end: 0;
+  margin-inline: 0;
+  block-size: 16px;
+  // Desktop Safari doesn't support touch events, but Safari on iOS does.
+  // stylelint-disable-next-line plugin/no-unsupported-browser-features
+  touch-action: none;
+
+  &:focus {
+    outline: none;
+  }
+
+  @include focus-visible.when-visible {
+    @include styles.focus-highlight(0px);
+  }
+}
+
+.slider-side {
+  cursor: ew-resize;
+  margin-block: 0;
+  margin-inline-start: 2px;
+  margin-inline-end: 0;
+}
+
+.slider-icon {
+  stroke: awsui.$color-text-interactive-default;
+  &:hover {
+    stroke: awsui.$color-text-interactive-hover;
+  }
+  &-bottom {
+    margin-block: auto;
+    margin-inline: auto;
+  }
+  &-side {
+    transform: rotate(90deg);
+  }
 }

--- a/src/split-panel/__tests__/helpers.ts
+++ b/src/split-panel/__tests__/helpers.ts
@@ -20,7 +20,6 @@ export const defaultSplitPanelContextProps: SplitPanelContextProps = {
   refs: {
     preferences: { current: null },
     slider: { current: null },
-    handle: { current: null },
     toggle: { current: null },
   },
 };

--- a/src/split-panel/implementation.tsx
+++ b/src/split-panel/implementation.tsx
@@ -76,7 +76,7 @@ export function SplitPanelImplementation({
   const sizeControlProps: SizeControlProps = {
     position,
     panelRef: splitPanelRefObject,
-    handleRef: refs.handle,
+    handleRef: refs.slider,
     onResize,
   };
   const onSliderPointerDown = usePointerEvents(sizeControlProps);
@@ -138,20 +138,18 @@ export function SplitPanelImplementation({
   );
 
   const resizeHandle = (
-    <div ref={refs.handle}>
-      <PanelResizeHandle
-        ref={refs.slider}
-        className={testUtilStyles.slider}
-        ariaLabel={i18nStrings.resizeHandleAriaLabel}
-        // Allows us to use the logical left/right keys to move the slider left/right,
-        // but match aria keyboard behavior of using left/right to decrease/increase
-        // the slider value.
-        ariaValuenow={position === 'bottom' ? relativeSize : 100 - relativeSize}
-        position={position}
-        onKeyDown={onKeyDown}
-        onPointerDown={onSliderPointerDown}
-      />
-    </div>
+    <PanelResizeHandle
+      ref={refs.slider}
+      className={testUtilStyles.slider}
+      ariaLabel={i18nStrings.resizeHandleAriaLabel}
+      // Allows us to use the logical left/right keys to move the slider left/right,
+      // but match aria keyboard behavior of using left/right to decrease/increase
+      // the slider value.
+      ariaValuenow={position === 'bottom' ? relativeSize : 100 - relativeSize}
+      position={position}
+      onKeyDown={onKeyDown}
+      onPointerDown={onSliderPointerDown}
+    />
   );
 
   /*


### PR DESCRIPTION
This reverts commit cf9b42c79e0fdbde2adfbc6744949c2892cdfa01.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
