### PR TITLE
fix: Fixes collection preferences active item style

### DIFF
--- a/src/collection-preferences/content-display/index.tsx
+++ b/src/collection-preferences/content-display/index.tsx
@@ -134,11 +134,14 @@ export default function ContentDisplayPreference({
           itemDefinition={{ id: item => item.id, label: item => item.label }}
           onItemsChange={({ detail }) => onChange(detail.items)}
           disableReorder={columnFilteringText.trim().length > 0}
-          renderItem={({ ref, item, style, className, dragHandleProps }) => {
+          renderItem={({ ref, item, style, className, dragHandleProps, isDragGhost }) => {
             className = clsx(className, getOptionClassName());
             const content = (
               <ContentDisplayOption ref={ref} option={item} onToggle={onToggle} dragHandleProps={dragHandleProps} />
             );
+            if (isDragGhost) {
+              return content;
+            }
             return (
               <li className={className} style={style}>
                 {content}


### PR DESCRIPTION
### Description

Fixing a small visual regression introduced in: https://github.com/cloudscape-design/components/pull/3195

The `<li>` styles include borders that overlay the focus outline added when the item is active.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
