### PR TITLE
fix: Remove background color of embedded table only in VR

### DIFF
--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -128,7 +128,7 @@
   }
 
   // "embedded" variant is passed to container only from table variants "borderless" and "embedded"
-  &-variant-embedded:not(.header-sticky-enabled) {
+  &-variant-embedded.refresh:not(.header-sticky-enabled) {
     background-color: transparent;
   }
 

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -75,8 +75,8 @@ $cell-horizontal-padding: awsui.$space-scaled-l;
   &-variant-full-page.header-cell-hidden {
     border-block-end-color: transparent;
   }
-  &-variant-embedded:not(.header-cell-sticky),
-  &-variant-borderless:not(.header-cell-sticky) {
+  &-variant-embedded.is-visual-refresh:not(.header-cell-sticky),
+  &-variant-borderless.is-visual-refresh:not(.header-cell-sticky) {
     background: none;
   }
   &:last-child,


### PR DESCRIPTION
### Description
Removing background color of embedded table only in VR.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
