### PR TITLE
fix: Allows table cells be expandable and editable at the same time

### DIFF
--- a/src/table/__integ__/inline-editing.test.ts
+++ b/src/table/__integ__/inline-editing.test.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 import range from 'lodash/range';
 
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
@@ -9,203 +10,217 @@ import createWrapper from '../../../lib/components/test-utils/selectors';
 
 import styles from '../../../lib/components/table/body-cell/styles.selectors.js';
 
-const DOMAIN_ERROR = 'Must be a valid domain name';
-const tableWrapper = createWrapper().findTable()!;
-
 // $ = selector
 
-const bodyCell = tableWrapper.findBodyCell(2, 2)!;
-const cellRoot$ = bodyCell.toSelector();
-const cellInputField$ = bodyCell.findFormField().find('input').toSelector();
-const cellEditButton$ = tableWrapper.findEditCellButton(2, 2).toSelector();
-const cellSaveButton = tableWrapper.findEditingCellSaveButton();
-const successIcon$ = bodyCell.findByClassName(styles['body-cell-success']).toSelector();
-const ariaLiveAnnouncement$ = bodyCell.find(`[aria-live="polite"]`).toSelector();
+const distributionIdRow1 = [1, 1] as const;
+const distributionIdRow2 = [2, 1] as const; // Disabled
+const domainNameRow1 = [1, 2] as const;
+const domainNameRow2 = [2, 2] as const;
+const tslVersionRow4 = [4, 5] as const;
 
-// for arrow key navigation
-const mainCell = tableWrapper.findBodyCell(4, 5);
-const mainCell$ = mainCell.toSelector();
-const leftCell$ = tableWrapper.findEditCellButton(4, 4).toSelector();
-const rightCell$ = tableWrapper.findEditCellButton(4, 6).toSelector();
-const cellAbove$ = tableWrapper.findEditCellButton(3, 5).toSelector();
-const cellBelow$ = tableWrapper.findEditCellButton(5, 5).toSelector();
+const tableWrapper = createWrapper().findTable();
+const cellSaveButton$ = tableWrapper.findEditingCellSaveButton().toSelector();
+const liveRegion$ = createWrapper().findLiveRegion().toSelector();
 
-const bodyCellError = bodyCell.findFormField().findError().toSelector();
-
-const disabledCell = tableWrapper.findBodyCell(4, 4);
-const disabledCell$ = disabledCell.toSelector();
-const disabledCellLiveRegion$ = createWrapper().findLiveRegion().toSelector();
+function cell$(rowIndex: number, columnIndex: number) {
+  return tableWrapper.findBodyCell(rowIndex, columnIndex).toSelector();
+}
+function cellEditButton$(rowIndex: number, columnIndex: number) {
+  return tableWrapper.findEditCellButton(rowIndex, columnIndex).toSelector();
+}
+function cellExpandToggle$(rowIndex: number) {
+  return tableWrapper.findExpandToggle(rowIndex).toSelector();
+}
+function cellError$(rowIndex: number, columnIndex: number) {
+  return tableWrapper.findBodyCell(rowIndex, columnIndex).findFormField().findError().toSelector();
+}
+function cellInput$(rowIndex: number, columnIndex: number) {
+  return tableWrapper.findBodyCell(rowIndex, columnIndex).findFormField().find('input').toSelector();
+}
+function cellSuccessIcon$(rowIndex: number, columnIndex: number) {
+  return tableWrapper.findBodyCell(rowIndex, columnIndex).findByClassName(styles['body-cell-success']).toSelector();
+}
 
 interface TestOptions {
   enableKeyboardNavigation?: boolean;
+  expandableRows?: boolean;
 }
 
 const setupTest = (
-  { enableKeyboardNavigation = false }: TestOptions,
+  { enableKeyboardNavigation = false, expandableRows = false }: TestOptions,
   testFn: (page: BasePageObject) => Promise<void>
 ) => {
   return useBrowser(async browser => {
     const page = new BasePageObject(browser);
     await page.setWindowSize({ width: 1200, height: 800 });
-    const query = new URLSearchParams({ enableKeyboardNavigation: String(enableKeyboardNavigation) });
+    const query = new URLSearchParams({
+      enableKeyboardNavigation: String(enableKeyboardNavigation),
+      expandableRows: String(expandableRows),
+    });
     await browser.url(`#/light/table/editable?${query.toString()}`);
     await testFn(page);
   });
 };
 
 test(
-  'input field is displayed when editable cell is clicked',
-  setupTest({}, async page => {
-    const value = await page.getText(cellRoot$);
-    await page.click(cellRoot$);
-    await expect(page.getValue(cellInputField$)).resolves.toBe(value);
+  'input field is displayed when click on editable cell',
+  setupTest({ expandableRows: false }, async page => {
+    const value = await page.getText(cell$(...distributionIdRow1));
+    await expect(page.isDisplayed(cellExpandToggle$(distributionIdRow1[0]))).resolves.toBe(false);
+    await page.click(cell$(...distributionIdRow1));
+    await expect(page.getValue(cellInput$(...distributionIdRow1))).resolves.toBe(value);
+    await expect(page.isDisplayed(cellSaveButton$)).resolves.toBe(true);
+  })
+);
+
+test(
+  'input field is displayed when click on cell edit button inside expandable column',
+  setupTest({ expandableRows: true }, async page => {
+    const value = await page.getText(cell$(...distributionIdRow1));
+    await expect(page.isDisplayed(cellExpandToggle$(distributionIdRow1[0]))).resolves.toBe(true);
+    await page.click(cellEditButton$(...distributionIdRow1));
+    await expect(page.getValue(cellInput$(...distributionIdRow1))).resolves.toBe(value);
+    await expect(page.isDisplayed(cellSaveButton$)).resolves.toBe(true);
+  })
+);
+
+test(
+  'disabled reason is displayed when click on disabled editable cell',
+  setupTest({ expandableRows: false }, async page => {
+    await expect(page.isDisplayed(cellExpandToggle$(distributionIdRow1[0]))).resolves.toBe(false);
+
+    // Click on cell with disabled inline edit
+    await page.click(cell$(...distributionIdRow2));
+    await expect(page.getText(liveRegion$)).resolves.toContain("You don't have the necessary permissions");
+
+    // Dismiss with click outside
+    await page.click('[data-testid="focus"]');
+    await expect(page.getElementsCount(liveRegion$)).resolves.toBe(0);
+  })
+);
+
+test(
+  'disabled reason is displayed when click on disabled edit button inside expandable column',
+  setupTest({ expandableRows: true }, async page => {
+    await expect(page.isDisplayed(cellExpandToggle$(distributionIdRow1[0]))).resolves.toBe(true);
+
+    // Click on cell with disabled inline edit
+    await page.click(cellEditButton$(...distributionIdRow2));
+    await expect(page.getText(liveRegion$)).resolves.toContain("You don't have the necessary permissions");
+
+    // Dismiss with click outside
+    await page.click('[data-testid="focus"]');
+    await expect(page.getElementsCount(liveRegion$)).resolves.toBe(0);
   })
 );
 
 test(
   'errorText is displayed when input field is invalid',
   setupTest({}, async page => {
-    await page.click(cellRoot$);
-    await page.setValue(cellInputField$, 'xyz .com'); // space is not allowed
-    await expect(page.getText(bodyCellError)).resolves.toBe(DOMAIN_ERROR);
+    await page.click(cell$(...domainNameRow2));
+    await page.setValue(cellInput$(...domainNameRow2), 'xyz .com'); // space is not allowed
+    await expect(page.getText(cellError$(...domainNameRow2))).resolves.toBe('Must be a valid domain name');
+    await expect(page.isDisplayed(cellSaveButton$)).resolves.toBe(true);
   })
-);
-
-test.each([false, true])(
-  'after edit is submitted, cell is focused, success icon is displayed and aria live region is rendered [enableKeyboardNavigation=%s]',
-  enableKeyboardNavigation => {
-    setupTest({ enableKeyboardNavigation }, async page => {
-      await page.click(cellRoot$);
-      await page.click(cellSaveButton.toSelector());
-
-      await expect(page.isFocused(cellEditButton$)).resolves.toBe(true);
-      await expect(page.isDisplayed(successIcon$)).resolves.toBe(true);
-      await expect(page.getElementProperty(ariaLiveAnnouncement$, 'textContent')).resolves.toBe('Edit successful');
-    });
-  }
 );
 
 test(
-  'can start editing with mouse',
+  'click focusable element outside when editing cancels editing and focuses clicked element',
   setupTest({}, async page => {
-    await page.click(cellEditButton$);
-    await expect(page.isDisplayed(cellSaveButton.toSelector())).resolves.toBe(true);
+    // Edit a cell
+    await page.click(cellEditButton$(...domainNameRow2));
+    await expect(page.isFocused(cellInput$(...domainNameRow2))).resolves.toBe(true);
+
+    // Click on the input element outside, it should get focused.
+    await page.click('[data-testid="focus"]');
+    await expect(page.isFocused('[data-testid="focus"]')).resolves.toBe(true);
   })
 );
 
-test.each(['Enter', 'Space'])('can start editing with %s key', key => {
-  setupTest({}, async page => {
-    // Focus element before the table
-    await page.click('[data-testid="focus"]');
-
-    // Tab to the first editable column
-    await page.keys(range(11).map(() => 'Tab'));
-    await expect(page.isFocused(tableWrapper.findEditCellButton(1, 2).toSelector())).resolves.toBe(true);
-
-    // Activate with given key
-    await page.keys([key]);
-    await expect(page.isDisplayed(cellSaveButton.toSelector())).resolves.toBe(true);
-  });
-});
-
-test.each(['Enter', 'Space'])('can start editing with %s key with keyboard navigation', key => {
-  setupTest({}, async page => {
-    // Focus element before the table
-    await page.click('[data-testid="focus"]');
-
-    // Tab to the first cell
-    await page.keys(['Tab', 'Tab']);
-
-    // Navigate to the first editable column
-    await page.keys(['ArrowDown', 'ArrowRight']);
-    await expect(page.isFocused(tableWrapper.findEditCellButton(1, 2).toSelector())).resolves.toBe(true);
-
-    // Activate with given key
-    await page.keys([key]);
-    await expect(page.isDisplayed(cellSaveButton.toSelector())).resolves.toBe(true);
-  });
-});
-
-test.each([false, true])(
-  'cell focus is moved when arrow keys are pressed [enableKeyboardNavigation=%s]',
-  enableKeyboardNavigation => {
+describe.each([false, true])('enableKeyboardNavigation=%s', enableKeyboardNavigation => {
+  test(
+    'after edit is submitted, cell is focused, success icon is displayed and aria live region is rendered [enableKeyboardNavigation=%s]',
     setupTest({ enableKeyboardNavigation }, async page => {
-      await page.click(mainCell$);
-      await page.click(cellSaveButton.toSelector());
+      await page.click(cell$(...domainNameRow2));
+      await page.click(cellSaveButton$);
+
+      await expect(page.isFocused(cellEditButton$(...domainNameRow2))).resolves.toBe(true);
+      await expect(page.isDisplayed(cellSuccessIcon$(...domainNameRow2))).resolves.toBe(true);
+      await expect(page.getElementProperty(liveRegion$, 'textContent')).resolves.toBe('Edit successful');
+    })
+  );
+
+  test.each([
+    { expandableRows: false, key: 'Enter' },
+    { expandableRows: false, key: 'Space' },
+    { expandableRows: true, key: 'Enter' },
+    { expandableRows: true, key: 'Space' },
+  ])('can start editing with $key key, expandableRows=$expandableRows', async ({ expandableRows, key }) => {
+    await setupTest({ enableKeyboardNavigation, expandableRows }, async page => {
+      // Focus element before the table
+      await page.click('[data-testid="focus"]');
+
+      // Navigate to the target cell
+      if (enableKeyboardNavigation) {
+        await page.keys(['Tab', 'Tab']);
+        await page.keys(['ArrowDown', 'ArrowRight']);
+      } else {
+        await page.keys(range(11).map(() => 'Tab'));
+      }
+      const targetRow = (expandableRows ? distributionIdRow1 : domainNameRow1) as [number, number];
+      await expect(page.isFocused(cellEditButton$(...targetRow))).resolves.toBe(true);
+
+      // Activate with given key
+      await page.keys([key]);
+      await expect(page.isDisplayed(cellSaveButton$)).resolves.toBe(true);
+    })();
+  });
+
+  test(
+    'cell focus is moved when arrow keys are pressed',
+    setupTest({ enableKeyboardNavigation }, async page => {
+      await page.click(cell$(...tslVersionRow4));
+      await page.click(cellSaveButton$);
       await page.keys(['ArrowRight']);
-      await expect(page.isFocused(rightCell$)).resolves.toBe(true);
+      await expect(page.isFocused(cellEditButton$(tslVersionRow4[0], tslVersionRow4[1] + 1))).resolves.toBe(true);
       await page.keys(['ArrowLeft', 'ArrowLeft']);
-      await expect(page.isFocused(leftCell$)).resolves.toBe(true);
+      await expect(page.isFocused(cellEditButton$(tslVersionRow4[0], tslVersionRow4[1] - 1))).resolves.toBe(true);
       await page.keys(['ArrowRight', 'ArrowUp']);
-      await expect(page.isFocused(cellAbove$)).resolves.toBe(true);
+      await expect(page.isFocused(cellEditButton$(tslVersionRow4[0] - 1, tslVersionRow4[1]))).resolves.toBe(true);
       await page.keys(['ArrowDown', 'ArrowDown']);
-      await expect(page.isFocused(cellBelow$)).resolves.toBe(true);
-    });
-  }
-);
+      await expect(page.isFocused(cellEditButton$(tslVersionRow4[0] + 1, tslVersionRow4[1]))).resolves.toBe(true);
+    })
+  );
 
-test.each([false, true])(
-  'input is focused when the edit operation failed [enableKeyboardNavigation=%s]',
-  enableKeyboardNavigation => {
+  test(
+    'input is focused when the edit operation failed',
     setupTest({ enableKeyboardNavigation }, async page => {
-      await page.click(cellRoot$);
+      await page.click(cell$(...domainNameRow2));
 
       // "inline" is a special keyword that causes a server-side error
-      await page.setValue(cellInputField$, 'inline');
+      await page.setValue(cellInput$(...domainNameRow2), 'inline');
       await page.keys('Enter');
 
       // after loading, the focus should be back on the input
-      await page.waitForAssertion(() => expect(page.isFocused(cellInputField$)).resolves.toBe(true));
-    });
-  }
-);
+      await page.waitForAssertion(() => expect(page.isFocused(cellInput$(...domainNameRow2))).resolves.toBe(true));
+    })
+  );
 
-test.each([false, true])(
-  'click focusable element outside when editing cancels editing and focuses clicked element [enableKeyboardNavigation=%s]',
-  enableKeyboardNavigation => {
-    setupTest({ enableKeyboardNavigation }, async page => {
-      // Edit a cell
-      await page.click(cellEditButton$);
-      await expect(page.isFocused(cellInputField$)).resolves.toBe(true);
-
-      // Click on the input element outside, it should get focused.
-      await page.click('[data-testid="focus"]');
-      await expect(page.isFocused('[data-testid="focus"]')).resolves.toBe(true);
-    });
-  }
-);
-
-test(
-  'can activate and dismiss disabled reason popover with mouse',
-  setupTest({}, async page => {
-    // Click on cell with disabled inline edit
-    await page.click(disabledCell$);
-
-    await expect(page.getText(disabledCellLiveRegion$)).resolves.toContain(
-      "You don't have the necessary permissions to change a BrowserStack origin."
-    );
-
-    // Dismiss with Escape
-    await page.keys(['Escape']);
-    await expect(page.getElementsCount(disabledCellLiveRegion$)).resolves.toBe(0);
-  })
-);
-
-test.each([false, true])(
-  'can activate disabled reason popover with keyboard [enableKeyboardNavigation=%s]',
-  enableKeyboardNavigation => {
+  test(
+    'can activate disabled reason popover with keyboard',
     setupTest({ enableKeyboardNavigation }, async page => {
       // Navigate to a disabled cell
-      await page.click(mainCell$);
-      await page.click(cellSaveButton.toSelector());
+      await page.click(cell$(...tslVersionRow4));
+      await page.click(cellSaveButton$);
       await page.keys(['ArrowLeft']);
 
       // Activate the popover with Enter
       await page.keys(['Enter']);
+      await expect(page.getText(liveRegion$)).resolves.toContain("You don't have the necessary permissions");
 
-      await expect(page.getText(disabledCellLiveRegion$)).resolves.toContain(
-        "You don't have the necessary permissions to change a BrowserStack origin."
-      );
-    });
-  }
-);
+      // Dismiss popover
+      await page.keys(['Escape']);
+      await expect(page.getElementsCount(liveRegion$)).resolves.toBe(0);
+    })
+  );
+});

--- a/src/table/__tests__/body-cell.test.tsx
+++ b/src/table/__tests__/body-cell.test.tsx
@@ -323,21 +323,6 @@ describe('TableBodyCell', () => {
       fireEvent.keyDown(disabledButton, { key: 'Escape' });
       expect(onEditEndMock).toBeCalledWith(true);
     });
-
-    test('show and hide lock icon based on hover when popover is not visible', () => {
-      const { container } = render(<TestComponent {...commonProps} column={disableInlineEditColumn} />);
-
-      // No icon by default
-      expect(wrapper(container).findIcon()).toBeNull();
-
-      // Hover over TD element
-      fireEvent.mouseEnter(container.querySelector('[data-inline-editing-active]')!);
-      expect(wrapper(container).findIcon()).not.toBeNull();
-
-      // Remove mouse
-      fireEvent.mouseLeave(container.querySelector('[data-inline-editing-active]')!);
-      expect(wrapper(container).findIcon()).toBeNull();
-    });
   });
 
   test('does not set tab index when negative', () => {

--- a/src/table/__tests__/expandable-rows.test.tsx
+++ b/src/table/__tests__/expandable-rows.test.tsx
@@ -283,7 +283,7 @@ describe('Expandable rows', () => {
     expect(table.findEditCellButton(1, 2)).not.toBe(null);
   });
 
-  test('first column of expandable table cannot be editable', () => {
+  test('columns can be both editable and expandable', () => {
     const { table } = renderTable({
       items: simpleItems,
       columnDefinitions: [
@@ -297,7 +297,6 @@ describe('Expandable rows', () => {
         onExpandableItemToggle: () => {},
       },
     });
-    expect(table.findEditCellButton(1, 1)).toBe(null);
-    expect(table.findEditCellButton(1, 2)).not.toBe(null);
+    expect(table.findEditCellButton(1, 1)).not.toBe(null);
   });
 });

--- a/src/table/body-cell/disabled-inline-editor.tsx
+++ b/src/table/body-cell/disabled-inline-editor.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import clsx from 'clsx';
 
 import Icon from '../../icon/internal';
@@ -32,16 +32,12 @@ export function DisabledInlineEditor<ItemType>({
   editDisabledReason,
   ...rest
 }: DisabledInlineEditorProps<ItemType>) {
+  const isExpandableColumn = rest.level !== undefined;
   const clickAwayRef = useClickAway(() => {
     if (isEditing) {
       onEditEnd(true);
     }
   });
-
-  const [hasHover, setHasHover] = useState(false);
-  const [hasFocus, setHasFocus] = useState(false);
-  // When a cell is both expandable and editable the icon is always shown.
-  const showIcon = hasHover || hasFocus || isEditing;
 
   const iconRef = useRef(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -71,29 +67,34 @@ export function DisabledInlineEditor<ItemType>({
       }
       isEditing={isEditing}
       isEditingDisabled={true}
-      onClick={!isEditing ? onClick : undefined}
-      onMouseEnter={() => setHasHover(true)}
-      onMouseLeave={() => setHasHover(false)}
-      ref={clickAwayRef}
+      onClick={!isEditing && !isExpandableColumn ? onClick : undefined}
+      ref={!isExpandableColumn ? clickAwayRef : undefined}
     >
       {column.cell(item)}
 
       <div className={styles['body-cell-editor-wrapper']}>
-        <button
-          ref={buttonRef}
-          tabIndex={tabIndex}
-          className={clsx(styles['body-cell-editor'], styles['body-cell-editor-disabled'])}
-          aria-label={ariaLabels?.activateEditLabel?.(column, item)}
-          aria-haspopup="dialog"
-          aria-disabled="true"
-          onFocus={() => setHasFocus(true)}
-          onBlur={() => setHasFocus(false)}
-          onKeyDown={handleEscape}
-          {...targetProps}
-        >
-          {showIcon && <Icon name="lock-private" variant="normal" __internalRootRef={iconRef} />}
-          {descriptionEl}
-        </button>
+        <div ref={isExpandableColumn ? clickAwayRef : undefined}>
+          <button
+            ref={buttonRef}
+            tabIndex={tabIndex}
+            className={clsx(
+              styles['body-cell-editor'],
+              styles['body-cell-editor-disabled'],
+              isExpandableColumn && styles['body-cell-editor-focusable']
+            )}
+            onClick={!isEditing && isExpandableColumn ? onClick : undefined}
+            aria-label={ariaLabels?.activateEditLabel?.(column, item)}
+            aria-haspopup="dialog"
+            aria-disabled="true"
+            onKeyDown={handleEscape}
+            {...targetProps}
+          >
+            <span className={styles['body-cell-editor-icon']}>
+              <Icon name="lock-private" variant="normal" __internalRootRef={iconRef} />
+            </span>
+            {descriptionEl}
+          </button>
+        </div>
       </div>
 
       {isEditing && (

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -117,7 +117,7 @@ $cell-negative-space-vertical: 2px;
   }
 }
 @mixin body-cell-active-hover-padding($padding-start) {
-  &:not(.body-cell-edit-active).body-cell-editable:hover {
+  &:not(.body-cell-edit-active):not(.body-cell-expandable).body-cell-editable:hover {
     @include cell-padding-inline-start(calc(#{$padding-start} + #{awsui.$border-divider-list-width}));
   }
 }
@@ -358,8 +358,8 @@ $cell-negative-space-vertical: 2px;
     background: 0;
     border-block: 0;
     border-inline: 0;
-    padding-block: 0;
-    padding-inline: 0;
+    padding-block: awsui.$space-scaled-xxs;
+    padding-inline: awsui.$space-scaled-xxs;
 
     // This gives the editor button a small area even when the icon is not rendered.
     // That is to allow programmatic interaction in tests.
@@ -394,6 +394,16 @@ $cell-negative-space-vertical: 2px;
       // 6 space-xxs: 2 * icon left padding + 2 * icon right padding + space between icons + space between icons and editor
       max-inline-size: calc(100% - 6 * #{awsui.$space-xxs} - 2 * #{awsui.$size-icon-normal});
     }
+
+    &-focusable {
+      @include focus-visible.when-visible {
+        // Making focus outline slightly smaller to not intersect with the success indicator.
+        @include styles.focus-highlight(-1px);
+      }
+    }
+  }
+  &-editor-icon {
+    display: none;
   }
 
   &.body-cell-expandable {
@@ -422,8 +432,6 @@ $cell-negative-space-vertical: 2px;
     }
 
     &:not(.body-cell-edit-active) {
-      cursor: pointer;
-
       // Include interactive padding even when a cell is not hovered to prevent jittering when resizableColumns=false.
       &:not(.resizable-columns) {
         @include cell-padding-inline-end($interactive-column-padding-inline-end);
@@ -444,17 +452,21 @@ $cell-negative-space-vertical: 2px;
         opacity: 0;
       }
 
-      // Showing focus outline for the cell.
-      // We don't use our focus-visible polyfill here because it doesn't work properly with screen readers.
-      // These edit buttons are special because they are visually hidden (opacity: 0), but exposed to assistive technology.
-      // It's therefore important to display the focus outline, even when a keyboard use wasn't detected.
-      // For example, when an edit button is selected from the VoiceOver rotor menu.
-      &:focus-within {
-        @include cell-focus-outline;
+      // The editable cells are interactive but the actual focus lands on the edit button which is decorative.
+      // That is why we use focus-within to detect if the focus is on the edit button to draw the outline around the cell.
+      // For expandable+editable cells the edit button works as a normal button because the cell itself is not interactive.
+      &:not(.body-cell-expandable) {
+        &:focus-within {
+          @include cell-focus-outline;
+        }
       }
 
       &:focus-within:focus-within,
       &.body-cell-edit-disabled-popover {
+        // stylelint-disable-next-line @cloudscape-design/no-implicit-descendant, no-descending-specificity
+        .body-cell-editor-icon {
+          display: unset;
+        }
         &.body-cell-has-success {
           // After a successful edit, we display the success icon next to the edit button and need additional padding to not let the text overflow the success icon.
           @include cell-padding-inline-end(
@@ -470,10 +482,19 @@ $cell-negative-space-vertical: 2px;
       &:hover:hover {
         position: relative;
 
-        background-color: awsui.$color-background-dropdown-item-hover;
-        border-block: awsui.$border-divider-list-width solid awsui.$color-border-editable-cell-hover;
-        border-inline: awsui.$border-divider-list-width solid awsui.$color-border-editable-cell-hover;
-        inset-inline: calc(-1 * #{awsui.$border-divider-list-width});
+        // stylelint-disable-next-line @cloudscape-design/no-implicit-descendant
+        .body-cell-editor-icon {
+          display: unset;
+        }
+
+        &:not(.body-cell-expandable) {
+          cursor: pointer;
+          background-color: awsui.$color-background-dropdown-item-hover;
+          border-block: awsui.$border-divider-list-width solid awsui.$color-border-editable-cell-hover;
+          border-inline: awsui.$border-divider-list-width solid awsui.$color-border-editable-cell-hover;
+          inset-inline: calc(-1 * #{awsui.$border-divider-list-width});
+        }
+
         &.sticky-cell {
           position: sticky;
         }
@@ -504,12 +525,12 @@ $cell-negative-space-vertical: 2px;
         &.body-cell-next-selected {
           @include cell-padding-block(calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width} / 2)));
         }
-        &.body-cell-last-row:not(.body-cell-selected) {
+        &.body-cell-last-row:not(.body-cell-expandable):not(.body-cell-selected) {
           @include cell-padding-block-start(
             calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}))
           );
         }
-        &.body-cell-first-row:not(.body-cell-selected) {
+        &.body-cell-first-row:not(.body-cell-expandable):not(.body-cell-selected) {
           @include cell-padding-block(calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width})));
         }
         @include focused-editor-styles;

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -31,8 +31,8 @@ export interface TableTdElementProps {
     'style' | 'className' | 'onClick'
   >;
   onClick?: () => void;
-  onMouseEnter?: () => void;
-  onMouseLeave?: () => void;
+  onFocus?: () => void;
+  onBlur?: () => void;
   children?: React.ReactNode;
   isEvenRow?: boolean;
   stripedRows?: boolean;
@@ -71,8 +71,8 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
       isPrevSelected,
       nativeAttributes,
       onClick,
-      onMouseEnter,
-      onMouseLeave,
+      onFocus,
+      onBlur,
       isEvenRow,
       stripedRows,
       isSelection,
@@ -115,6 +115,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
     const cellRefObject = useRef<HTMLTableCellElement>(null);
     const mergedRef = useMergeRefs(stickyStyles.ref, ref, cellRefObject);
     const { tabIndex: cellTabIndex } = useSingleTabStopNavigation(cellRefObject);
+    const isEditingActive = isEditing && !isEditingDisabled;
 
     return (
       <Element
@@ -137,19 +138,19 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
           isEditing && !isEditingDisabled && styles['body-cell-edit-active'],
           isEditing && isEditingDisabled && styles['body-cell-edit-disabled-popover'],
           hasSuccessIcon && styles['body-cell-has-success'],
-          level !== undefined && styles['body-cell-expandable'],
-          level !== undefined && styles[`expandable-level-${getLevelClassSuffix(level)}`],
+          level !== undefined && !isEditingActive && styles['body-cell-expandable'],
+          level !== undefined && !isEditingActive && styles[`expandable-level-${getLevelClassSuffix(level)}`],
           stickyStyles.className
         )}
         onClick={onClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
+        onFocus={onFocus}
+        onBlur={onBlur}
         ref={mergedRef}
         {...nativeAttributes}
         tabIndex={cellTabIndex === -1 ? undefined : cellTabIndex}
         {...copyAnalyticsMetadataAttribute(rest)}
       >
-        {level !== undefined && isExpandable && (
+        {level !== undefined && isExpandable && !isEditingActive && (
           <div className={styles['expandable-toggle-wrapper']}>
             <ExpandToggleButton
               isExpanded={isExpanded}

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -181,7 +181,7 @@ export function TableHeaderCell<ItemType>({
           id={headerId}
         >
           {column.header}
-          {isEditable && !isExpandable ? (
+          {isEditable ? (
             <span
               className={styles['edit-icon']}
               role="img"


### PR DESCRIPTION
### Description

The PR makes it possible to have cell editing in the first column of tables with expandable rows.

Rel: [tNAkA40KWyvj], AWSUI-43194.

### How has this been tested?

* New unit and integration test
* Screenshot tests
* Dry-run to live

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
