### PR TITLE
fix: Reannounce validation error in date range picker on apply

### DIFF
--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -10,7 +10,7 @@ import { ButtonProps } from '../button/interfaces';
 import { InternalButton } from '../button/internal';
 import { useInternalI18n } from '../i18n/context';
 import FocusLock from '../internal/components/focus-lock';
-import InternalLiveRegion from '../live-region/internal';
+import InternalLiveRegion, { InternalLiveRegionRef } from '../live-region/internal';
 import InternalSpaceBetween from '../space-between/internal';
 import Calendar from './calendar';
 import { DateRangePickerProps } from './interfaces';
@@ -84,6 +84,7 @@ export function DateRangePickerDropdown({
   const i18n = useInternalI18n('date-range-picker');
   const isMonthPicker = granularity === 'month';
   const hideTime = dateOnly || isMonthPicker;
+  const liveRegionRef = useRef<InternalLiveRegionRef>(null);
 
   const [rangeSelectionMode, setRangeSelectionMode] = useState<'absolute' | 'relative'>(
     getDefaultMode(value, relativeOptions, rangeSelectorMode)
@@ -123,6 +124,7 @@ export function DateRangePickerDropdown({
     if (newValidationResult.valid === false) {
       setApplyClicked(true);
       setValidationResult(newValidationResult);
+      liveRegionRef.current?.reannounce();
     } else {
       setApplyClicked(false);
       closeDropdown();
@@ -230,7 +232,7 @@ export function DateRangePickerDropdown({
                       >
                         <span className={testutilStyles['validation-error']}>{validationResult.errorMessage}</span>
                       </InternalAlert>
-                      <InternalLiveRegion hidden={true} tagName="span">
+                      <InternalLiveRegion hidden={true} tagName="span" ref={liveRegionRef}>
                         {validationResult.errorMessage}
                       </InternalLiveRegion>
                     </>


### PR DESCRIPTION
### Description

When a user clicks on "Apply" in DateRangePicker, the error text should be reannounced 

Related links, issue #, if available: AWSUI-60295

### How has this been tested?

with voice over on, following the recording in the ticket

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
