### PR TITLE
feat: Add flexible layout for attribute editor

### DIFF
--- a/pages/attribute-editor/buttons.page.tsx
+++ b/pages/attribute-editor/buttons.page.tsx
@@ -1,0 +1,156 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+import { Box, ButtonDropdown, ButtonDropdownProps, Input, InputProps, Link } from '~components';
+import AttributeEditor, { AttributeEditorProps } from '~components/attribute-editor';
+
+interface Tag {
+  key?: string;
+  value?: string;
+}
+
+interface ControlProps extends InputProps {
+  index: number;
+  setItems: React.Dispatch<React.SetStateAction<Tag[]>>;
+  prop: keyof Tag;
+}
+
+const labelProps = {
+  addButtonText: 'Add new item',
+  removeButtonText: 'Remove',
+  empty: 'No tags associated to the resource',
+  i18nStrings: { itemRemovedAriaLive: 'An item was removed.' },
+} as AttributeEditorProps<unknown>;
+
+const tagLimit = 50;
+
+const Control = React.memo(
+  React.forwardRef<HTMLInputElement, ControlProps>(({ value, index, setItems, prop }, ref) => {
+    return (
+      <Input
+        ref={ref}
+        value={value}
+        onChange={({ detail }) => {
+          setItems(items => {
+            const updatedItems = [...items];
+            updatedItems[index] = { ...updatedItems[index], [prop]: detail.value };
+            return updatedItems;
+          });
+        }}
+      />
+    );
+  })
+);
+
+export default function AttributeEditorPage() {
+  const [items, setItems] = useState<Tag[]>([
+    { key: 'bla', value: 'foo' },
+    { key: 'bar', value: 'yam' },
+  ]);
+  const ref = useRef<AttributeEditorProps.Ref>(null);
+
+  const definition: AttributeEditorProps.FieldDefinition<Tag>[] = useMemo(
+    () => [
+      {
+        label: 'Key label',
+        info: <Link variant="info">Info</Link>,
+        control: ({ key = '' }, itemIndex) => (
+          <Control
+            prop="key"
+            value={key}
+            index={itemIndex}
+            setItems={setItems}
+            ref={ref => (keyInputRefs.current[itemIndex] = ref)}
+          />
+        ),
+      },
+      {
+        label: 'Value label',
+        info: <Link variant="info">Info</Link>,
+        control: ({ value = '' }, itemIndex) => (
+          <Control prop="value" value={value} index={itemIndex} setItems={setItems} />
+        ),
+      },
+    ],
+    []
+  );
+
+  const buttonRefs = useRef<Array<ButtonDropdownProps.Ref | null>>([]);
+  const keyInputRefs = useRef<Array<InputProps.Ref | null>>([]);
+  const focusEventRef = useRef<() => void>();
+
+  useLayoutEffect(() => {
+    focusEventRef.current?.apply(undefined);
+    focusEventRef.current = undefined;
+  });
+
+  const onAddButtonClick = useCallback(() => {
+    setItems(items => {
+      const newItems = [...items, {}];
+      focusEventRef.current = () => {
+        keyInputRefs.current[newItems.length - 1]?.focus();
+      };
+      return newItems;
+    });
+  }, []);
+
+  const onRemoveButtonClick = useCallback((itemIndex: number) => {
+    setItems(items => {
+      const newItems = items.slice();
+      newItems.splice(itemIndex, 1);
+
+      if (newItems.length === 0) {
+        ref.current?.focusAddButton();
+      }
+      if (itemIndex === items.length - 1) {
+        buttonRefs.current[items.length - 2]?.focus();
+      }
+
+      return newItems;
+    });
+  }, []);
+  const moveRow = useCallback((itemIndex: number, direction: string) => {
+    const newIndex = direction === 'up' ? itemIndex - 1 : itemIndex + 1;
+    setItems(items => {
+      const newItems = items.slice();
+      newItems.splice(newIndex, 0, newItems.splice(itemIndex, 1)[0]);
+      buttonRefs.current[newIndex]?.focusDropdownTrigger();
+      return newItems;
+    });
+  }, []);
+
+  const additionalInfo = useMemo(() => `You can add ${tagLimit - items.length} more tags.`, [items.length]);
+
+  return (
+    <Box margin="xl">
+      <h1>Attribute Editor - Custom row actions</h1>
+      <AttributeEditor<Tag>
+        ref={ref}
+        {...labelProps}
+        additionalInfo={additionalInfo}
+        items={items}
+        definition={definition}
+        onAddButtonClick={onAddButtonClick}
+        customRowActions={({ itemIndex }) => (
+          <ButtonDropdown
+            ref={ref => {
+              buttonRefs.current[itemIndex] = ref;
+            }}
+            items={[
+              { text: 'Move up', id: 'up', disabled: itemIndex === 0 },
+              { text: 'Move down', id: 'down', disabled: itemIndex === items.length - 1 },
+            ]}
+            ariaLabel={`More actions for row ${itemIndex + 1}`}
+            mainAction={{
+              text: 'Delete row',
+              ariaLabel: `Delete row ${itemIndex + 1}`,
+              onClick: () => onRemoveButtonClick(itemIndex),
+            }}
+            onItemClick={e => moveRow(itemIndex, e.detail.id)}
+          />
+        )}
+      />
+    </Box>
+  );
+}

--- a/pages/attribute-editor/form-field-label.page.tsx
+++ b/pages/attribute-editor/form-field-label.page.tsx
@@ -12,7 +12,7 @@ interface Tag {
 
 interface ControlProps extends InputProps {
   index: number;
-  setItems?: any;
+  setItems: React.Dispatch<React.SetStateAction<Tag[]>>;
   prop: keyof Tag;
 }
 
@@ -29,7 +29,7 @@ const Control = React.memo(({ value, index, setItems, prop }: ControlProps) => {
       ariaLabel="Secondary owner username"
       ariaLabelledby=""
       onChange={({ detail }) => {
-        setItems((items: any) => {
+        setItems(items => {
           const updatedItems = [...items];
           updatedItems[index] = { ...updatedItems[index], [prop]: detail.value };
           return updatedItems;

--- a/pages/attribute-editor/permutations.page.tsx
+++ b/pages/attribute-editor/permutations.page.tsx
@@ -119,6 +119,25 @@ export const permutations = createPermutations<AttributeEditorProps<Item>>([
     removeButtonText: ['Remove item'],
   },
   {
+    definition: [definition4],
+    gridLayout: [
+      [
+        { rows: [[2, 1, 3, 1]], breakpoint: 'l' },
+        {
+          rows: [
+            [2, 1],
+            [3, 1],
+          ],
+        },
+      ],
+      [{ rows: [[2, 1, 3, 1]], removeButton: { width: 'auto' } }],
+      [{ rows: [[2, 1, 3, 1]], removeButton: { ownRow: true } }],
+    ],
+    items: [defaultItems],
+    addButtonText: ['Add item (grid)'],
+    removeButtonText: ['Remove item (grid)'],
+  },
+  {
     definition: [validationDefinitions],
     i18nStrings: [{ errorIconAriaLabel: 'Error', warningIconAriaLabel: 'Warning' }],
     items: [defaultItems],

--- a/pages/attribute-editor/simple-grid.page.tsx
+++ b/pages/attribute-editor/simple-grid.page.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useCallback, useMemo, useState } from 'react';
 
-import { Box, Input, InputProps, Link, NonCancelableCustomEvent } from '~components';
+import { Box, Button, Input, InputProps, Link } from '~components';
 import AttributeEditor, { AttributeEditorProps } from '~components/attribute-editor';
 
 interface Tag {
@@ -30,7 +30,7 @@ const Control = React.memo(({ value, index, setItems, prop }: ControlProps) => {
     <Input
       value={value}
       onChange={({ detail }) => {
-        setItems(items => {
+        setItems((items: Tag[]) => {
           const updatedItems = [...items];
           updatedItems[index] = { ...updatedItems[index], [prop]: detail.value };
           return updatedItems;
@@ -82,22 +82,20 @@ export default function AttributeEditorPage() {
     setItems(items => [...items, {}]);
   }, []);
 
-  const onRemoveButtonClick = useCallback(
-    ({ detail: { itemIndex } }: NonCancelableCustomEvent<AttributeEditorProps.RemoveButtonClickDetail>) => {
-      setItems(items => {
-        const newItems = items.slice();
-        newItems.splice(itemIndex, 1);
-        return newItems;
-      });
-    },
-    []
-  );
+  const onRemoveButtonClick = useCallback(({ detail: { itemIndex } }: { detail: { itemIndex: number } }) => {
+    setItems(items => {
+      const newItems = items.slice();
+      newItems.splice(itemIndex, 1);
+      return newItems;
+    });
+  }, []);
 
   const additionalInfo = useMemo(() => `You can add ${tagLimit - items.length} more tags.`, [items.length]);
 
   return (
     <Box margin="xl">
-      <h1>Attribute Editor - Functional</h1>
+      <h1>Attribute Editor - Grid</h1>
+      <h2>Non-responsive 2:3:auto layout</h2>
       <AttributeEditor<Tag>
         {...labelProps}
         additionalInfo={additionalInfo}
@@ -105,6 +103,73 @@ export default function AttributeEditorPage() {
         definition={definition}
         onAddButtonClick={onAddButtonClick}
         onRemoveButtonClick={onRemoveButtonClick}
+        gridLayout={[{ rows: [[2, 3]], removeButton: { width: 'auto' } }]}
+      />
+      <h2>Non-responsive 4:1 - 2:2 layout</h2>
+      <AttributeEditor<Tag>
+        {...labelProps}
+        additionalInfo={additionalInfo}
+        items={items}
+        definition={[...definition, ...definition]}
+        onAddButtonClick={onAddButtonClick}
+        onRemoveButtonClick={onRemoveButtonClick}
+        gridLayout={[
+          {
+            rows: [
+              [4, 1],
+              [2, 2],
+            ],
+          },
+        ]}
+      />
+      <h2>Responsive layout</h2>
+      <AttributeEditor<Tag>
+        {...labelProps}
+        additionalInfo={additionalInfo}
+        items={items}
+        definition={[...definition, ...definition]}
+        customRowActions={({ breakpoint, item, itemIndex }) => {
+          const clickHandler = () => {
+            onRemoveButtonClick({ detail: { itemIndex } });
+          };
+          const ariaLabel = `Remove ${item.key}`;
+          if (breakpoint === 'xl') {
+            return <Button iconName="remove" variant="icon" ariaLabel={ariaLabel} onClick={clickHandler} />;
+          }
+          return (
+            <Button ariaLabel={ariaLabel} onClick={clickHandler}>
+              Remove
+            </Button>
+          );
+        }}
+        onAddButtonClick={onAddButtonClick}
+        onRemoveButtonClick={onRemoveButtonClick}
+        gridLayout={[
+          {
+            breakpoint: 'xl',
+            rows: [[4, 1, 2, 2]],
+            removeButton: {
+              width: 'auto',
+            },
+          },
+          {
+            breakpoint: 'l',
+            rows: [[4, 1, 2, 2]],
+            removeButton: {
+              ownRow: true,
+            },
+          },
+          {
+            breakpoint: 's',
+            rows: [
+              [3, 1],
+              [2, 2],
+            ],
+          },
+          {
+            rows: [[1], [1], [1], [1]],
+          },
+        ]}
       />
     </Box>
   );

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -1468,7 +1468,25 @@ with expandable sections.",
       "type": "string",
     },
     {
+      "description": "Specifies a custom action trigger for each row, in place of the remove button.
+Only button and button dropdown components are supported.
+If you provide this, \`removeButtonText\`, \`removeButtonAriaLabel\`,
+and \`onRemoveButtonClick\` will be ignored.
+The trigger must be given the provided \`ref\` in order for \`focusRemoveButton\`
+to work.
+The function receives the following properties:
+- \`item\`: The item being rendered in the current row.
+- \`itemIndex\` (\`number\`): The index of the item.
+- \`ref\` (\`ReactRef\`): A React ref that should be passed to the rendered button.
+- \`breakpoint\` (\`Breakpoint\`): The current breakpoint, for responsive behavior.
+- \`ownRow\` (\`boolean\`): Whether the button is rendered on its own row.",
+      "name": "customRowActions",
+      "optional": true,
+      "type": "(props: AttributeEditorProps.RowActionsProps<T>) => React.ReactNode",
+    },
+    {
       "description": "Defines the editor configuration. Each object in the array represents one form field in the row.
+If more than 6 attributes are specified, a \`gridLayout\` must be provided.
 * \`label\` (ReactNode) - Text label for the form field.
 * \`info\` (ReactNode) - Info link for the form field.
 * \`errorText\` ((item, itemIndex) => ReactNode) - Error message text to display as a control validation message.
@@ -1477,8 +1495,6 @@ with expandable sections.",
    It renders the form field in a warning state if the returned value is not \`null\` or \`undefined\`.
 * \`constraintText\` ((item, itemIndex) => ReactNode) - Text to display as a constraint message below the field.
 * \`control\` ((item, itemIndex) => ReactNode) - A control to use as the input for the field.
-
-A maximum of four fields are supported.
 ",
       "name": "definition",
       "optional": false,
@@ -1489,6 +1505,23 @@ A maximum of four fields are supported.
       "name": "disableAddButton",
       "optional": true,
       "type": "boolean",
+    },
+    {
+      "description": "Optionally specifies the layout of the attributes. By default, all attributes will be
+equally spaced and wrapped into multiple rows on smaller viewports.
+A \`gridLayout\` is an array of breakpoint definitions. Each definition consists of:
+- \`rows\` (\`number[][]\`): the rows in which to display the attributes. Each row consists of a list of numbers indicating
+  the relative width of each attribute. For example, \`[[1, 1, 1, 1]]\` is a single row of four evenly-spaced attributes,
+  or \`[[1, 2], [1, 1, 1]]\` splits five attributes onto two rows.
+- \`breakpoint\` (\`string\`): optionally specifies that the given entry should only be used when at least that much width is available.
+- \`removeButton\`: optionally configures the remove (or row action) button placement. If this is not provided, the button will be
+  placed at the end of a single row, or below if multiple rows are present. The \`removeButton\` property supports contains two properties:
+  - \`ownRow\` (\`boolean\`): forces the remove button onto its own row.
+  - \`width\` (\`number | 'auto'\`): a number indicating the relative width (equivalent to a \`rows\` entry), or 'auto' to fit to the button width.
+",
+      "name": "gridLayout",
+      "optional": true,
+      "type": "ReadonlyArray<AttributeEditorProps.GridLayout>",
     },
     {
       "description": "An object containing all the necessary localized strings required by the component.",
@@ -3633,9 +3666,25 @@ modifier keys (that is, CTRL, ALT, SHIFT, META), and the item has an \`href\` se
   ],
   "functions": [
     {
-      "description": "Focuses the underlying native button.",
+      "description": "Focuses the underlying native button. If a main action is defined this will focus that button.",
       "name": "focus",
-      "parameters": [],
+      "parameters": [
+        {
+          "name": "options",
+          "type": "FocusOptions",
+        },
+      ],
+      "returnType": "void",
+    },
+    {
+      "description": "Focuses the underlying native button for the dropdown.",
+      "name": "focusDropdownTrigger",
+      "parameters": [
+        {
+          "name": "options",
+          "type": "FocusOptions",
+        },
+      ],
       "returnType": "void",
     },
   ],

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -60,9 +60,9 @@ exports[`test-utils selectors 1`] = `
     "awsui_additional-info_n4qlp",
     "awsui_empty_n4qlp",
     "awsui_field_n4qlp",
+    "awsui_remove-button-container_n4qlp",
     "awsui_remove-button_n4qlp",
     "awsui_root_n4qlp",
-    "awsui_row-control_n4qlp",
     "awsui_row_n4qlp",
   ],
   "autosuggest": [

--- a/src/attribute-editor/__tests__/grid-defaults.test.ts
+++ b/src/attribute-editor/__tests__/grid-defaults.test.ts
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { gridDefaults } from '../grid-defaults';
+
+describe('grid-defaults', () => {
+  describe.each(Object.entries(gridDefaults))('Has right number of entries for %i items', (attributes, layouts) => {
+    test.each(layouts)('breakpoint: $breakpoint', layout => {
+      const totalItems = layout.rows.reduce((acc, row) => acc + row.length, 0);
+      expect(totalItems).toEqual(parseInt(attributes, 10));
+    });
+  });
+});

--- a/src/attribute-editor/__tests__/utils.test.ts
+++ b/src/attribute-editor/__tests__/utils.test.ts
@@ -1,0 +1,111 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { AttributeEditorProps } from '../interfaces';
+import {
+  getGridTemplateColumns,
+  getItemGridColumns,
+  getRemoveButtonGridColumns,
+  isRemoveButtonOnSameLine,
+} from '../utils';
+
+describe('utils', () => {
+  const sampleLayout: AttributeEditorProps.GridLayout = {
+    rows: [
+      [1, 2],
+      [2, 1],
+    ],
+    removeButton: {
+      width: 1,
+      ownRow: false,
+    },
+  };
+
+  describe('getItemGridColumns', () => {
+    it('should return correct grid columns for first item', () => {
+      const result = getItemGridColumns(sampleLayout, 0);
+      expect(result).toEqual({ gridColumnStart: 1, gridColumnEnd: 2 });
+    });
+
+    it('should return correct grid columns for second item', () => {
+      const result = getItemGridColumns(sampleLayout, 1);
+      expect(result).toEqual({ gridColumnStart: 2, gridColumnEnd: 4 });
+    });
+
+    it('should return correct grid columns for third item (second row)', () => {
+      const result = getItemGridColumns(sampleLayout, 2);
+      expect(result).toEqual({ gridColumnStart: 1, gridColumnEnd: 3 });
+    });
+  });
+
+  describe('getRemoveButtonGridColumns', () => {
+    it('should return correct columns when button is on single line', () => {
+      const singleLineLayout: AttributeEditorProps.GridLayout = {
+        rows: [[1]],
+        removeButton: { width: 1 },
+      };
+      const result = getRemoveButtonGridColumns(singleLineLayout, 2);
+      expect(result).toEqual({ gridColumnStart: 2, gridColumnEnd: 3 });
+    });
+
+    it('should return full width when button is on own row', () => {
+      const multiLineLayout: AttributeEditorProps.GridLayout = {
+        rows: [[1, 2]],
+        removeButton: { width: 1, ownRow: true },
+      };
+      const result = getRemoveButtonGridColumns(multiLineLayout, 2);
+      expect(result).toEqual({ gridColumnStart: 1, gridColumnEnd: 4 });
+    });
+  });
+
+  describe('isRemoveButtonOnSameLine', () => {
+    it('should return true for single row layout without ownRow', () => {
+      const layout: AttributeEditorProps.GridLayout = {
+        rows: [[1]],
+        removeButton: { width: 1 },
+      };
+      expect(isRemoveButtonOnSameLine(layout)).toBe(true);
+    });
+
+    it('should return false for single row layout with ownRow', () => {
+      const layout: AttributeEditorProps.GridLayout = {
+        rows: [[1]],
+        removeButton: { width: 1, ownRow: true },
+      };
+      expect(isRemoveButtonOnSameLine(layout)).toBe(false);
+    });
+
+    it('should return false for multi-row layout', () => {
+      const layout: AttributeEditorProps.GridLayout = {
+        rows: [[1], [1]],
+        removeButton: { width: 1 },
+      };
+      expect(isRemoveButtonOnSameLine(layout)).toBe(false);
+    });
+  });
+
+  describe('getGridTemplateColumns', () => {
+    it('should generate correct template for single row with remove button', () => {
+      const layout: AttributeEditorProps.GridLayout = {
+        rows: [[1, 1]],
+        removeButton: { width: 1 },
+      };
+      expect(getGridTemplateColumns(layout)).toBe('repeat(2, 1fr) 1fr');
+    });
+
+    it('should handle auto width remove button', () => {
+      const layout: AttributeEditorProps.GridLayout = {
+        rows: [[1]],
+        removeButton: { width: 'auto' },
+      };
+      expect(getGridTemplateColumns(layout)).toBe('repeat(1, 1fr) max-content');
+    });
+
+    it('should not add remove button column when button is on own row', () => {
+      const layout: AttributeEditorProps.GridLayout = {
+        rows: [[1, 1]],
+        removeButton: { width: 1, ownRow: true },
+      };
+      expect(getGridTemplateColumns(layout)).toBe('repeat(2, 1fr) ');
+    });
+  });
+});

--- a/src/attribute-editor/grid-defaults.ts
+++ b/src/attribute-editor/grid-defaults.ts
@@ -1,0 +1,125 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { AttributeEditorProps } from './interfaces';
+
+export const gridDefaults: Record<number, AttributeEditorProps.GridLayout[]> = {
+  1: [
+    {
+      breakpoint: 'xxs',
+      rows: [[3]],
+    },
+    {
+      rows: [[1]],
+      removeButton: {
+        ownRow: true,
+      },
+    },
+  ],
+  2: [
+    {
+      breakpoint: 'xs',
+      rows: [[3, 3]],
+      removeButton: {
+        width: 2,
+      },
+    },
+    {
+      breakpoint: 'xxs',
+      rows: [[1, 1]],
+      removeButton: {
+        ownRow: true,
+      },
+    },
+    {
+      rows: [[1], [1]],
+    },
+  ],
+  3: [
+    {
+      breakpoint: 'xs',
+      rows: [[3, 3, 3]],
+      removeButton: {
+        width: 3,
+      },
+    },
+    {
+      breakpoint: 'xxs',
+      rows: [[1, 1], [1]],
+      removeButton: {
+        ownRow: true,
+      },
+    },
+    {
+      rows: [[1], [1], [1]],
+    },
+  ],
+  4: [
+    {
+      breakpoint: 'xs',
+      rows: [[3, 3, 3, 3]],
+      removeButton: {
+        width: 4,
+      },
+    },
+    {
+      breakpoint: 'xxs',
+      rows: [
+        [1, 1],
+        [1, 1],
+      ],
+    },
+    {
+      rows: [[1], [1], [1], [1]],
+    },
+  ],
+  5: [
+    {
+      breakpoint: 's',
+      rows: [[3, 3, 3, 3, 3]],
+      removeButton: {
+        width: 5,
+      },
+    },
+    {
+      breakpoint: 'xs',
+      rows: [
+        [1, 1, 1],
+        [1, 1],
+      ],
+    },
+    {
+      breakpoint: 'xxs',
+      rows: [[1, 1], [1, 1], [1]],
+    },
+    {
+      rows: [[1], [1], [1], [1], [1]],
+    },
+  ],
+  6: [
+    {
+      breakpoint: 's',
+      rows: [[3, 3, 3, 3, 3, 3]],
+      removeButton: {
+        width: 6,
+      },
+    },
+    {
+      breakpoint: 'xs',
+      rows: [
+        [1, 1, 1],
+        [1, 1, 1],
+      ],
+    },
+    {
+      breakpoint: 'xxs',
+      rows: [
+        [1, 1],
+        [1, 1],
+        [1, 1],
+      ],
+    },
+    {
+      rows: [[1], [1], [1], [1], [1], [1]],
+    },
+  ],
+};

--- a/src/attribute-editor/interfaces.ts
+++ b/src/attribute-editor/interfaces.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import { ButtonDropdownProps } from '../button-dropdown/interfaces';
 import { BaseComponentProps } from '../internal/base-component';
+import { Breakpoint as InternalBreakpoint } from '../internal/breakpoints';
 import { NonCancelableEventHandler } from '../internal/events';
 
 /*
@@ -51,6 +53,14 @@ export namespace AttributeEditorProps {
     focusAddButton(): void;
   }
 
+  export interface RowActionsProps<T> {
+    item: T;
+    itemIndex: number;
+    ref: React.Ref<ButtonDropdownProps.Ref>;
+    breakpoint: Breakpoint | null;
+    ownRow: boolean;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export interface I18nStrings<T = any> {
     errorIconAriaLabel?: string;
@@ -61,6 +71,17 @@ export namespace AttributeEditorProps {
      * @deprecated Use `removeButtonAriaLabel` on the component instead.
      */
     removeButtonAriaLabel?: (item: T) => string;
+  }
+
+  export type Breakpoint = InternalBreakpoint;
+
+  export interface GridLayout {
+    breakpoint?: Breakpoint;
+    rows: ReadonlyArray<ReadonlyArray<number>>;
+    removeButton?: {
+      ownRow?: boolean;
+      width?: number | 'auto';
+    };
   }
 }
 
@@ -118,6 +139,7 @@ export interface AttributeEditorProps<T> extends BaseComponentProps {
 
   /**
    * Defines the editor configuration. Each object in the array represents one form field in the row.
+   * If more than 6 attributes are specified, a `gridLayout` must be provided.
    *
    * * `label` (ReactNode) - Text label for the form field.
    * * `info` (ReactNode) - Info link for the form field.
@@ -127,10 +149,40 @@ export interface AttributeEditorProps<T> extends BaseComponentProps {
    *    It renders the form field in a warning state if the returned value is not `null` or `undefined`.
    * * `constraintText` ((item, itemIndex) => ReactNode) - Text to display as a constraint message below the field.
    * * `control` ((item, itemIndex) => ReactNode) - A control to use as the input for the field.
-   *
-   * A maximum of four fields are supported.
    */
   definition: ReadonlyArray<AttributeEditorProps.FieldDefinition<T>>;
+
+  /**
+   * Optionally specifies the layout of the attributes. By default, all attributes will be
+   * equally spaced and wrapped into multiple rows on smaller viewports.
+   *
+   * A `gridLayout` is an array of breakpoint definitions. Each definition consists of:
+   * - `rows` (`number[][]`): the rows in which to display the attributes. Each row consists of a list of numbers indicating
+   *   the relative width of each attribute. For example, `[[1, 1, 1, 1]]` is a single row of four evenly-spaced attributes,
+   *   or `[[1, 2], [1, 1, 1]]` splits five attributes onto two rows.
+   * - `breakpoint` (`string`): optionally specifies that the given entry should only be used when at least that much width is available.
+   * - `removeButton`: optionally configures the remove (or row action) button placement. If this is not provided, the button will be
+   *   placed at the end of a single row, or below if multiple rows are present. The `removeButton` property supports contains two properties:
+   *   - `ownRow` (`boolean`): forces the remove button onto its own row.
+   *   - `width` (`number | 'auto'`): a number indicating the relative width (equivalent to a `rows` entry), or 'auto' to fit to the button width.
+   */
+  gridLayout?: ReadonlyArray<AttributeEditorProps.GridLayout>;
+
+  /**
+   * Specifies a custom action trigger for each row, in place of the remove button.
+   * Only button and button dropdown components are supported.
+   * If you provide this, `removeButtonText`, `removeButtonAriaLabel`,
+   * and `onRemoveButtonClick` will be ignored.
+   * The trigger must be given the provided `ref` in order for `focusRemoveButton`
+   * to work.
+   * The function receives the following properties:
+   * - `item`: The item being rendered in the current row.
+   * - `itemIndex` (`number`): The index of the item.
+   * - `ref` (`ReactRef`): A React ref that should be passed to the rendered button.
+   * - `breakpoint` (`Breakpoint`): The current breakpoint, for responsive behavior.
+   * - `ownRow` (`boolean`): Whether the button is rendered on its own row.
+   */
+  customRowActions?: (props: AttributeEditorProps.RowActionsProps<T>) => React.ReactNode;
 
   /**
    * Called when add button is clicked.

--- a/src/attribute-editor/internal.tsx
+++ b/src/attribute-editor/internal.tsx
@@ -3,10 +3,10 @@
 import React, { useImperativeHandle, useRef, useState } from 'react';
 import clsx from 'clsx';
 
-import InternalBox from '../box/internal';
 import { ButtonProps } from '../button/interfaces';
 import { InternalButton } from '../button/internal';
 import { getBaseProps } from '../internal/base-component';
+import { matchBreakpointMapping } from '../internal/breakpoints';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
@@ -15,8 +15,10 @@ import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { SomeRequired } from '../internal/types';
 import InternalLiveRegion from '../live-region/internal';
 import { AdditionalInfo } from './additional-info';
+import { gridDefaults } from './grid-defaults';
 import { AttributeEditorForwardRefType, AttributeEditorProps } from './interfaces';
 import { Row } from './row';
+import { getGridTemplateColumns } from './utils';
 
 import styles from './styles.css.js';
 
@@ -27,7 +29,8 @@ const InternalAttributeEditor = React.forwardRef(
     {
       additionalInfo,
       disableAddButton,
-      definition,
+      definition = [{}],
+      gridLayout,
       items,
       isItemRemovable = () => true,
       empty,
@@ -35,6 +38,7 @@ const InternalAttributeEditor = React.forwardRef(
       addButtonVariant = 'normal',
       removeButtonText,
       removeButtonAriaLabel,
+      customRowActions,
       i18nStrings,
       onAddButtonClick,
       onRemoveButtonClick,
@@ -43,7 +47,6 @@ const InternalAttributeEditor = React.forwardRef(
     }: InternalAttributeEditorProps<T>,
     ref: React.Ref<AttributeEditorProps.Ref>
   ) => {
-    const [breakpoint, breakpointRef] = useContainerBreakpoints(['default', 'xxs', 'xs']);
     const removeButtonRefs = useRef<Array<ButtonProps.Ref | undefined>>([]);
     const addButtonRef = useRef<ButtonProps.Ref>(null);
     const wasNonEmpty = useRef<boolean>(false);
@@ -63,8 +66,6 @@ const InternalAttributeEditor = React.forwardRef(
       },
     }));
 
-    const mergedRef = useMergeRefs(breakpointRef, __internalRootRef);
-
     const additionalInfoId = useUniqueId('attribute-editor-info');
     const infoAriaDescribedBy = additionalInfo ? additionalInfoId : undefined;
 
@@ -80,54 +81,98 @@ const InternalAttributeEditor = React.forwardRef(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [items, i18nStrings?.itemRemovedAriaLive]);
 
-    return (
-      <div {...baseProps} ref={mergedRef} className={clsx(baseProps.className, styles.root)}>
-        <InternalBox margin={{ bottom: 'l' }}>
-          {isEmpty && <div className={clsx(styles.empty, wasNonEmpty.current && styles['empty-appear'])}>{empty}</div>}
-          {items.map((item, index) => (
-            <Row<T>
-              key={index}
-              index={index}
-              breakpoint={breakpoint}
-              item={item}
-              definition={definition}
-              i18nStrings={i18nStrings}
-              removable={isItemRemovable(item)}
-              removeButtonText={removeButtonText}
-              removeButtonRefs={removeButtonRefs.current}
-              onRemoveButtonClick={onRemoveButtonClick}
-              removeButtonAriaLabel={removeButtonAriaLabel}
-            />
-          ))}
-        </InternalBox>
+    if (!gridLayout) {
+      gridLayout = gridDefaults[definition.length];
+      if (!gridLayout) {
+        console.warn('AttributeEditor', '`gridLayout` is required for more than 6 attributes. Cannot render.');
+        gridLayout = [];
+      }
+    }
 
-        <InternalButton
-          className={styles['add-button']}
-          disabled={disableAddButton}
-          // Using aria-disabled="true" and tabindex="-1" instead of "disabled"
-          // because focus can be dynamically moved to this button by calling
-          // `focusAddButton()` on the ref.
-          __nativeAttributes={disableAddButton ? { tabIndex: -1 } : {}}
-          __focusable={true}
-          onClick={onAddButtonClick}
-          formAction="none"
-          ref={addButtonRef}
-          ariaDescribedby={infoAriaDescribedBy}
-          variant={addButtonVariant}
-          iconName={addButtonVariant === 'inline-link' ? 'add-plus' : undefined}
-        >
-          {addButtonText}
-        </InternalButton>
-        <InternalLiveRegion
-          data-testid="removal-announcement"
-          tagName="span"
-          hidden={true}
-          delay={5}
-          key={items.length}
-        >
-          {removalAnnouncement}
-        </InternalLiveRegion>
-        {!!additionalInfo && <AdditionalInfo id={infoAriaDescribedBy}>{additionalInfo}</AdditionalInfo>}
+    const gridLayoutBreakpoints = gridLayout.reduce(
+      (acc, layout) => ({
+        ...acc,
+        [layout.breakpoint || 'default']: layout,
+      }),
+      {} as Record<AttributeEditorProps.Breakpoint, AttributeEditorProps.GridLayout>
+    );
+
+    const [breakpoint, breakpointRef] = useContainerBreakpoints(
+      Object.keys(gridLayoutBreakpoints) as AttributeEditorProps.Breakpoint[]
+    );
+    const mergedRef = useMergeRefs(breakpointRef, __internalRootRef);
+
+    const gridLayoutForBreakpoint = matchBreakpointMapping(gridLayoutBreakpoints, breakpoint || 'default');
+
+    if (!gridLayoutForBreakpoint) {
+      console.warn('AttributeEditor', `No \`gridLayout\` entry found for breakpoint ${breakpoint}. Cannot render.`);
+      return <div />;
+    }
+
+    const totalColumnsInLayout = gridLayoutForBreakpoint.rows.reduce((total, columns) => total + columns.length, 0);
+    if (totalColumnsInLayout !== definition.length) {
+      console.warn(
+        'AttributeEditor',
+        `Incorrect number of columns in layout (${totalColumnsInLayout}) for definition (${definition.length}). Cannot render.`
+      );
+      return <div />;
+    }
+
+    return (
+      <div
+        {...baseProps}
+        ref={mergedRef}
+        className={clsx(baseProps.className, styles.root)}
+        style={{ gridTemplateColumns: getGridTemplateColumns(gridLayoutForBreakpoint) }}
+      >
+        {isEmpty && <div className={clsx(styles.empty, wasNonEmpty.current && styles['empty-appear'])}>{empty}</div>}
+        {items.map((item, index) => (
+          <Row<T>
+            key={index}
+            index={index}
+            breakpoint={breakpoint}
+            layout={gridLayoutForBreakpoint}
+            item={item}
+            definition={definition}
+            i18nStrings={i18nStrings}
+            removable={isItemRemovable(item)}
+            removeButtonText={removeButtonText}
+            removeButtonRefs={removeButtonRefs.current}
+            customRowActions={customRowActions}
+            onRemoveButtonClick={onRemoveButtonClick}
+            removeButtonAriaLabel={removeButtonAriaLabel}
+          />
+        ))}
+
+        <div className={styles['add-row']}>
+          <InternalButton
+            className={styles['add-button']}
+            disabled={disableAddButton}
+            // Using aria-disabled="true" and tabindex="-1" instead of "disabled"
+            // because focus can be dynamically moved to this button by calling
+            // `focusAddButton()` on the ref.
+            __nativeAttributes={disableAddButton ? { tabIndex: -1 } : {}}
+            __focusable={true}
+            onClick={onAddButtonClick}
+            formAction="none"
+            ref={addButtonRef}
+            ariaDescribedby={infoAriaDescribedBy}
+            variant={addButtonVariant}
+            iconName={addButtonVariant === 'inline-link' ? 'add-plus' : undefined}
+          >
+            {addButtonText}
+          </InternalButton>
+          <InternalLiveRegion
+            data-testid="removal-announcement"
+            tagName="span"
+            hidden={true}
+            delay={5}
+            key={items.length}
+          >
+            {removalAnnouncement}
+          </InternalLiveRegion>
+          {!!additionalInfo && <AdditionalInfo id={infoAriaDescribedBy}>{additionalInfo}</AdditionalInfo>}
+        </div>
       </div>
     );
   }

--- a/src/attribute-editor/row.tsx
+++ b/src/attribute-editor/row.tsx
@@ -3,23 +3,21 @@
 import React, { useCallback } from 'react';
 import clsx from 'clsx';
 
-import InternalBox from '../box/internal';
 import { ButtonProps } from '../button/interfaces';
 import { InternalButton } from '../button/internal';
-import InternalColumnLayout, { ColumnLayoutBreakpoint } from '../column-layout/internal';
 import InternalFormField from '../form-field/internal';
-import InternalGrid from '../grid/internal';
 import { useInternalI18n } from '../i18n/context';
+import { Breakpoint } from '../internal/breakpoints';
 import { fireNonCancelableEvent, NonCancelableEventHandler } from '../internal/events';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { AttributeEditorProps } from './interfaces';
+import { getItemGridColumns, getRemoveButtonGridColumns, isRemoveButtonOnSameLine } from './utils';
 
 import styles from './styles.css.js';
 
-const Divider = () => <InternalBox className={styles.divider} padding={{ top: 'l' }} />;
-
 interface RowProps<T> {
-  breakpoint: ColumnLayoutBreakpoint | null;
+  breakpoint: Breakpoint | null;
+  layout: AttributeEditorProps.GridLayout;
   item: T;
   definition: ReadonlyArray<AttributeEditorProps.FieldDefinition<T>>;
   i18nStrings: AttributeEditorProps.I18nStrings | undefined;
@@ -27,6 +25,7 @@ interface RowProps<T> {
   removable: boolean;
   removeButtonText?: string;
   removeButtonRefs: Array<ButtonProps.Ref | undefined>;
+  customRowActions?: (props: AttributeEditorProps.RowActionsProps<T>) => React.ReactNode;
   onRemoveButtonClick?: NonCancelableEventHandler<AttributeEditorProps.RemoveButtonClickDetail>;
   removeButtonAriaLabel?: (item: T) => string;
 }
@@ -46,24 +45,22 @@ function render<T>(
   }
 }
 
-const GRID_DEFINITION = [{ colspan: { default: 12, xs: 9 } }];
-const REMOVABLE_GRID_DEFINITION = [{ colspan: { default: 12, xs: 9 } }, { colspan: { default: 12, xs: 3 } }];
 export const Row = React.memo(
   <T,>({
     breakpoint,
     item,
     definition,
+    layout,
     i18nStrings = {},
     index,
     removable,
     removeButtonText,
     removeButtonRefs,
+    customRowActions,
     onRemoveButtonClick,
     removeButtonAriaLabel,
   }: RowProps<T>) => {
     const i18n = useInternalI18n('attribute-editor');
-    const isNarrowViewport = breakpoint === 'default' || breakpoint === 'xxs';
-    const isWideViewport = !isNarrowViewport;
 
     const handleRemoveClick = useCallback(() => {
       fireNonCancelableEvent(onRemoveButtonClick, { itemIndex: index });
@@ -71,81 +68,76 @@ export const Row = React.memo(
 
     const firstControlId = useUniqueId('first-control-id-');
 
+    const buttonRef = (ref: ButtonProps.Ref | null) => {
+      removeButtonRefs[index] = ref ?? undefined;
+    };
+
+    let gridColumnStart = 1;
+    let gridColumnEnd = 1;
+    const removeButtonOnSameLine = isRemoveButtonOnSameLine(layout);
+
+    const customActions = customRowActions?.({
+      item,
+      itemIndex: index,
+      ref: buttonRef,
+      breakpoint,
+      ownRow: !removeButtonOnSameLine,
+    });
+
     return (
-      <InternalBox className={styles.row} margin={{ bottom: 's' }}>
-        <div role="group" aria-labelledby={`${firstControlId}-label ${firstControlId}`}>
-          <InternalGrid
-            __breakpoint={breakpoint}
-            gridDefinition={removable ? REMOVABLE_GRID_DEFINITION : GRID_DEFINITION}
-          >
-            <InternalColumnLayout
-              className={styles['row-control']}
-              columns={definition.length}
-              __breakpoint={breakpoint}
+      <div
+        className={clsx(styles.row, layout.rows.length === 1 && styles['single-row'])}
+        role="group"
+        aria-labelledby={`${firstControlId}-label ${firstControlId}`}
+      >
+        {definition.map(({ info, label, constraintText, errorText, warningText, control }, defIndex) => {
+          ({ gridColumnStart, gridColumnEnd } = getItemGridColumns(layout, defIndex));
+          return (
+            <InternalFormField
+              key={defIndex}
+              className={styles.field}
+              __style={{ gridColumnStart, gridColumnEnd }}
+              label={label}
+              info={info}
+              constraintText={render(item, index, constraintText)}
+              errorText={render(item, index, errorText)}
+              warningText={render(item, index, warningText)}
+              stretch={true}
+              i18nStrings={{
+                errorIconAriaLabel: i18nStrings.errorIconAriaLabel,
+                warningIconAriaLabel: i18nStrings.warningIconAriaLabel,
+              }}
+              __hideLabel={index !== 0 && removeButtonOnSameLine}
+              controlId={defIndex === 0 ? firstControlId : undefined}
             >
-              {definition.map(({ info, label, constraintText, errorText, warningText, control }, defIndex) => (
-                <InternalFormField
-                  key={defIndex}
-                  className={styles.field}
-                  label={label}
-                  info={info}
-                  constraintText={render(item, index, constraintText)}
-                  errorText={render(item, index, errorText)}
-                  warningText={render(item, index, warningText)}
-                  stretch={true}
-                  i18nStrings={{
-                    errorIconAriaLabel: i18nStrings.errorIconAriaLabel,
-                    warningIconAriaLabel: i18nStrings.warningIconAriaLabel,
-                  }}
-                  __hideLabel={isWideViewport && index > 0}
-                  controlId={defIndex === 0 ? firstControlId : undefined}
-                >
-                  {render(item, index, control)}
-                </InternalFormField>
-              ))}
-            </InternalColumnLayout>
-            {removable && (
-              <ButtonContainer
-                index={index}
-                isNarrowViewport={isNarrowViewport}
-                hasLabel={definition.some(row => row.label)}
+              {render(item, index, control)}
+            </InternalFormField>
+          );
+        })}
+        <div
+          className={clsx(styles['remove-button-container'], {
+            [styles['remove-button-field-padding']]: removeButtonOnSameLine && index === 0,
+            [styles['remove-button-own-row']]: !removeButtonOnSameLine,
+          })}
+          style={{ ...getRemoveButtonGridColumns(layout, gridColumnEnd) }}
+        >
+          {removable &&
+            (customActions !== undefined ? (
+              customActions
+            ) : (
+              <InternalButton
+                className={styles['remove-button']}
+                formAction="none"
+                ref={buttonRef}
+                ariaLabel={(removeButtonAriaLabel ?? i18nStrings.removeButtonAriaLabel)?.(item)}
+                onClick={handleRemoveClick}
               >
-                <InternalButton
-                  className={styles['remove-button']}
-                  formAction="none"
-                  ref={ref => {
-                    removeButtonRefs[index] = ref ?? undefined;
-                  }}
-                  ariaLabel={(removeButtonAriaLabel ?? i18nStrings.removeButtonAriaLabel)?.(item)}
-                  onClick={handleRemoveClick}
-                >
-                  {i18n('removeButtonText', removeButtonText)}
-                </InternalButton>
-              </ButtonContainer>
-            )}
-          </InternalGrid>
+                {i18n('removeButtonText', removeButtonText)}
+              </InternalButton>
+            ))}
         </div>
-        {isNarrowViewport && <Divider />}
-      </InternalBox>
+        {!removeButtonOnSameLine && <div className={styles.divider} />}
+      </div>
     );
   }
 ) as <T>(props: RowProps<T>) => JSX.Element;
-
-interface ButtonContainer {
-  index: number;
-  children: React.ReactNode;
-  isNarrowViewport: boolean;
-  hasLabel: boolean;
-}
-
-const ButtonContainer = ({ index, children, isNarrowViewport, hasLabel }: ButtonContainer) => (
-  <div
-    className={clsx({
-      [styles['button-container-haslabel']]: !isNarrowViewport && index === 0 && hasLabel,
-      [styles['button-container-nolabel']]: !isNarrowViewport && index === 0 && !hasLabel,
-      [styles['right-align']]: isNarrowViewport,
-    })}
-  >
-    {children}
-  </div>
-);

--- a/src/attribute-editor/styles.scss
+++ b/src/attribute-editor/styles.scss
@@ -9,16 +9,25 @@
 
 .root {
   @include styles.styles-reset;
-  display: block;
+  display: grid;
+  grid-template-rows: min-content;
+  gap: awsui.$space-grid-gutter;
+  align-items: start;
 }
 
 .empty {
   @include styles.font-body-m;
   color: awsui.$color-text-empty;
+  grid-column: 1 / -1;
 }
 
 .row {
-  /* used in test-utils */
+  display: contents;
+}
+
+.divider {
+  grid-column: 1 / -1;
+  border-block-start: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
 }
 
 .row-control {
@@ -27,30 +36,6 @@
 
 .field {
   /* used in test-utils */
-}
-
-.add-button {
-  /* used in test-utils */
-}
-
-.remove-button {
-  /* used in test-utils */
-}
-
-.button-container-haslabel {
-  // We only support vertical alignment of the remove button for labels with exactly one line.
-  // The value is calculated as follows:
-  // padding-top = awsui-form-field-controls: 4px +
-  // line height (also applies to icon size) awsui-form-field-label: 22px
-  padding-block-start: calc(#{awsui.$space-xxs} + #{awsui.$line-height-body-m});
-}
-
-.button-container-nolabel {
-  padding-block-start: #{awsui.$space-xxs};
-}
-
-.divider {
-  border-block-end: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
 }
 
 .additional-info {
@@ -65,7 +50,24 @@
   }
 }
 
-.right-align {
-  display: flex;
-  justify-content: flex-end;
+.add-row {
+  grid-column: 1 / -1;
+}
+
+.add-button {
+  /* used in test-utils */
+}
+
+.remove-button-container {
+  display: inline-block;
+}
+.remove-button-field-padding {
+  padding-block-start: calc(#{awsui.$space-xxs} + #{awsui.$line-height-body-m});
+}
+.remove-button-own-row {
+  justify-self: end;
+}
+
+.remove-button {
+  /* used in test-utils */
 }

--- a/src/attribute-editor/utils.ts
+++ b/src/attribute-editor/utils.ts
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { AttributeEditorProps } from './interfaces';
+
+interface GridColumns {
+  gridColumnStart: number;
+  gridColumnEnd: number;
+}
+
+export function getItemGridColumns(layout: AttributeEditorProps.GridLayout, itemIndex: number): GridColumns {
+  let i = 0;
+  for (const row of layout.rows) {
+    let gridColumnStart = 1;
+    for (const columnWidth of row) {
+      if (i === itemIndex) {
+        return { gridColumnStart, gridColumnEnd: gridColumnStart + columnWidth };
+      } else {
+        gridColumnStart += columnWidth;
+      }
+      i++;
+    }
+  }
+  return { gridColumnStart: 1, gridColumnEnd: 1 };
+}
+
+export function getRemoveButtonGridColumns(
+  layout: AttributeEditorProps.GridLayout,
+  previousGridColumnEnd: number
+): GridColumns {
+  const maxColumns = layout.rows.reduce(
+    (max, columns) =>
+      Math.max(
+        max,
+        columns.reduce((sum, col) => sum + col, 0)
+      ),
+    0
+  );
+  if (isRemoveButtonOnSameLine(layout)) {
+    const removeButtonWidth = typeof layout.removeButton?.width === 'number' ? layout.removeButton?.width : 1;
+    return {
+      gridColumnStart: previousGridColumnEnd,
+      gridColumnEnd: previousGridColumnEnd + removeButtonWidth,
+    };
+  }
+  return { gridColumnStart: 1, gridColumnEnd: maxColumns + 1 };
+}
+
+export function isRemoveButtonOnSameLine(layout: AttributeEditorProps.GridLayout) {
+  return layout.rows.length === 1 && !layout.removeButton?.ownRow;
+}
+
+export function getGridTemplateColumns(layout: AttributeEditorProps.GridLayout) {
+  const totalColumnUnits = layout.rows.reduce(
+    (maxCols, row) =>
+      Math.max(
+        maxCols,
+        row.reduce((cols, col) => cols + col, 0)
+      ),
+    0
+  );
+
+  const removeButtonColumn = isRemoveButtonOnSameLine(layout)
+    ? layout.removeButton?.width === 'auto'
+      ? 'max-content'
+      : `${layout.removeButton?.width ?? 1}fr`
+    : '';
+
+  return `repeat(${totalColumnUnits}, 1fr) ${removeButtonColumn}`;
+}

--- a/src/button-dropdown/__tests__/button-dropdown-item-click.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-item-click.test.tsx
@@ -217,8 +217,8 @@ describe('default href navigation', () => {
     expect(onClickSpy).toHaveBeenCalled();
   });
 
-  [true, false].forEach(mobile => {
-    test(`toggles category on click when mobile=${mobile}`, () => {
+  describe.each([true, false])('mobile=%b', mobile => {
+    test('toggles category on click', () => {
       (useMobile as jest.Mock).mockReturnValue(mobile);
       const categoryId = 'category';
       const itemId = 'nested-item';
@@ -231,6 +231,40 @@ describe('default href navigation', () => {
       act(() => wrapper.findExpandableCategoryById(categoryId)!.click());
 
       expect(wrapper.findItemById(itemId)).not.toBeNull();
+    });
+    test('returns focus acter clicking item', () => {
+      const { container } = render(
+        <div>
+          <ButtonDropdown
+            items={[
+              { id: '1', text: '1' },
+              { id: '2', text: '2' },
+            ]}
+          />
+        </div>
+      );
+      const wrapper = createWrapper(container).findButtonDropdown()!;
+      wrapper.openDropdown();
+      wrapper.findItemById('1')?.click();
+      expect(wrapper.findNativeButton().getElement()).toHaveFocus();
+    });
+    test('allows focus to be moved in the onItemClick function', () => {
+      const { container } = render(
+        <div>
+          <ButtonDropdown
+            items={[
+              { id: '1', text: '1' },
+              { id: '2', text: '2' },
+            ]}
+            onItemClick={e => e.detail.id === '1' && container.querySelector('input')?.focus()}
+          />
+          <input />
+        </div>
+      );
+      const wrapper = createWrapper(container).findButtonDropdown()!;
+      wrapper.openDropdown();
+      wrapper.findItemById('1')?.click();
+      expect(container.querySelector('input')).toHaveFocus();
     });
   });
 });

--- a/src/button-dropdown/__tests__/button-dropdown.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown.test.tsx
@@ -435,6 +435,15 @@ describe('with main action', () => {
 
     expect(wrapper.findMainAction()!.getElement()).toHaveFocus();
   });
+
+  test('ref.focusDropdownTrigger focuses the dropdown', () => {
+    const ref = React.createRef<ButtonDropdownProps.Ref>();
+    const wrapper = renderSplitButtonDropdown({ mainAction: { text: 'Main' } }, ref);
+
+    ref.current!.focusDropdownTrigger();
+
+    expect(wrapper.findNativeButton()!.getElement()).toHaveFocus();
+  });
 });
 
 test('should work in controlled context', () => {

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -188,9 +188,13 @@ export namespace ButtonDropdownProps {
 
   export interface Ref {
     /**
-     * Focuses the underlying native button.
+     * Focuses the underlying native button. If a main action is defined this will focus that button.
      */
-    focus(): void;
+    focus(options?: FocusOptions): void;
+    /**
+     * Focuses the underlying native button for the dropdown.
+     */
+    focusDropdownTrigger(options?: FocusOptions): void;
   }
 }
 

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useImperativeHandle, useRef } from 'react';
 import clsx from 'clsx';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
@@ -13,7 +13,6 @@ import { useFunnel } from '../internal/analytics/hooks/use-funnel.js';
 import { getBaseProps } from '../internal/base-component';
 import Dropdown from '../internal/components/dropdown';
 import OptionsList from '../internal/components/options-list';
-import useForwardFocus from '../internal/hooks/forward-focus';
 import { useMobile } from '../internal/hooks/use-mobile';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode/index.js';
@@ -111,7 +110,18 @@ const InternalButtonDropdown = React.forwardRef(
     const mainActionRef = useRef<HTMLElement>(null);
     const triggerRef = useRef<HTMLElement>(null);
 
-    useForwardFocus(ref, isMainAction ? mainActionRef : triggerRef);
+    useImperativeHandle(
+      ref,
+      () => ({
+        focus(...args) {
+          (isMainAction ? mainActionRef : triggerRef).current?.focus(...args);
+        },
+        focusDropdownTrigger(...args) {
+          triggerRef.current?.focus(...args);
+        },
+      }),
+      [mainActionRef, triggerRef, isMainAction]
+    );
 
     const clickHandler = () => {
       if (!loading && !disabled) {

--- a/src/button-dropdown/utils/use-button-dropdown.ts
+++ b/src/button-dropdown/utils/use-button-dropdown.ts
@@ -75,13 +75,13 @@ export function useButtonDropdown({
       target: isLink ? getItemTarget(item) : undefined,
       checked: isCheckbox ? !item.checked : undefined,
     };
+    onReturnFocus();
     if (onItemFollow && isLink && isPlainLeftClick(event)) {
       fireCancelableEvent(onItemFollow, details, event);
     }
     if (onItemClick) {
       fireCancelableEvent(onItemClick, details, event);
     }
-    onReturnFocus();
     closeDropdown();
   };
 

--- a/src/button-group/item-element.tsx
+++ b/src/button-group/item-element.tsx
@@ -3,6 +3,8 @@
 import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 
 import { ButtonProps } from '../button/interfaces.js';
+import { ButtonDropdownProps } from '../button-dropdown/interfaces.js';
+import { FileInputProps } from '../file-input/interfaces';
 import { fireCancelableEvent, NonCancelableEventHandler } from '../internal/events';
 import { nodeBelongs } from '../internal/utils/node-belongs';
 import FileInputItem from './file-input-item';
@@ -28,11 +30,15 @@ const ItemElement = forwardRef(
     ref: React.Ref<ButtonProps.Ref>
   ) => {
     const containerRef = useRef<HTMLDivElement>(null);
-    const itemRef = useRef<HTMLButtonElement | HTMLInputElement>(null);
+    const buttonRef = useRef<ButtonProps.Ref>(null);
+    const fileInputRef = useRef<FileInputProps.Ref>(null);
+    const buttonDropdownRef = useRef<ButtonDropdownProps.Ref>(null);
 
     useImperativeHandle(ref, () => ({
       focus: () => {
-        itemRef.current?.focus();
+        buttonRef.current?.focus();
+        fileInputRef.current?.focus();
+        buttonDropdownRef.current?.focus();
       },
     }));
 
@@ -117,7 +123,7 @@ const ItemElement = forwardRef(
       >
         {item.type === 'icon-button' && (
           <IconButtonItem
-            ref={itemRef}
+            ref={buttonRef}
             item={item}
             onItemClick={onClickHandler}
             showTooltip={tooltip?.item === item.id}
@@ -126,7 +132,7 @@ const ItemElement = forwardRef(
         )}
         {item.type === 'icon-toggle-button' && (
           <IconToggleButtonItem
-            ref={itemRef}
+            ref={buttonRef}
             item={item}
             onItemClick={onClickHandler}
             showTooltip={tooltip?.item === item.id}
@@ -135,7 +141,7 @@ const ItemElement = forwardRef(
         )}
         {item.type === 'icon-file-input' && (
           <FileInputItem
-            ref={itemRef}
+            ref={fileInputRef}
             item={item}
             onFilesChange={onFilesChangeHandler}
             showTooltip={tooltip?.item === item.id}
@@ -143,7 +149,7 @@ const ItemElement = forwardRef(
         )}
         {item.type === 'menu-dropdown' && (
           <MenuDropdownItem
-            ref={itemRef}
+            ref={buttonDropdownRef}
             item={item}
             showTooltip={tooltip?.item === item.id}
             onItemClick={onClickHandler}

--- a/src/form-field/interfaces.ts
+++ b/src/form-field/interfaces.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { CSSProperties } from 'react';
 
 import { AnalyticsMetadata } from '../internal/analytics/interfaces';
 import { BaseComponentProps } from '../internal/base-component';
@@ -106,4 +106,5 @@ export interface InternalFormFieldProps extends FormFieldProps, InternalBaseComp
    */
   __disableGutters?: boolean;
   __analyticsMetadata?: AnalyticsMetadata;
+  __style?: CSSProperties;
 }

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -121,6 +121,7 @@ export default function InternalFormField({
   __internalRootRef = null,
   __disableGutters = false,
   __analyticsMetadata = undefined,
+  __style = {},
   ...rest
 }: InternalFormFieldProps) {
   const baseProps = getBaseProps(rest);
@@ -216,6 +217,7 @@ export default function InternalFormField({
     <div
       {...baseProps}
       className={clsx(baseProps.className, styles.root)}
+      style={__style}
       ref={__internalRootRef}
       {...analyticsAttributes}
       {...copyAnalyticsMetadataAttribute(rest)}

--- a/src/test-utils/dom/attribute-editor/index.ts
+++ b/src/test-utils/dom/attribute-editor/index.ts
@@ -6,7 +6,6 @@ import ButtonWrapper from '../button';
 import FormFieldWrapper from '../form-field';
 
 import styles from '../../../attribute-editor/styles.selectors.js';
-import gridstyles from '../../../grid/styles.selectors.js';
 
 export class AttributeEditorRowWrapper extends ElementWrapper {
   /**
@@ -22,14 +21,15 @@ export class AttributeEditorRowWrapper extends ElementWrapper {
    * @param column 1-based column index
    */
   findField(column: number): FormFieldWrapper | null {
-    return this.findComponent(
-      `.${styles['row-control']} > .${gridstyles.grid} > .${gridstyles['grid-column']}:nth-child(${column}) > div > .${styles.field}`,
-      FormFieldWrapper
-    );
+    return this.findComponent(`.${styles.field}:nth-child(${column})`, FormFieldWrapper);
   }
 
   findRemoveButton(): ButtonWrapper | null {
     return this.findComponent(`.${styles['remove-button']}`, ButtonWrapper);
+  }
+
+  findCustomAction(): ElementWrapper | null {
+    return this.findComponent(`.${styles['remove-button-container']}`, ElementWrapper);
   }
 }
 


### PR DESCRIPTION
### Description

Re-run of #3123 with an additional fix for a regression found in visual tests (missing individual row labels in certain layouts)

Related links, issue #, if available: n/a

### How has this been tested?

Tested locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
