### PR TITLE
fix: Allow hover tooltips to be dismissed using Esc

### DIFF
--- a/pages/modal/with-tooltip.page.tsx
+++ b/pages/modal/with-tooltip.page.tsx
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import { Button, FormField, Modal, Slider } from '~components';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+export default function () {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <article>
+      <h1>Simple modal with tooltip-based component (slider)</h1>
+      <Button onClick={() => setVisible(true)}>Show modal</Button>
+      <ScreenshotArea>
+        <Modal header="Slider" visible={visible} onDismiss={() => setVisible(false)} closeAriaLabel="Close modal">
+          <FormField label="Slider">
+            <Slider onChange={() => {}} value={50} max={100} min={0} />
+          </FormField>
+        </Modal>
+      </ScreenshotArea>
+    </article>
+  );
+}

--- a/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/index.tsx
@@ -234,7 +234,12 @@ function TriggerButton(
       </button>
       {badge && <div className={styles.dot} />}
       {tooltipVisible && (
-        <Tooltip trackRef={containerRef} value={tooltipValue} className={testutilStyles['trigger-tooltip']} />
+        <Tooltip
+          trackRef={containerRef}
+          value={tooltipValue}
+          className={testutilStyles['trigger-tooltip']}
+          onDismiss={() => setShowTooltip(false)}
+        />
       )}
     </div>
   );

--- a/src/breadcrumb-group/item/item.tsx
+++ b/src/breadcrumb-group/item/item.tsx
@@ -28,7 +28,9 @@ const BreadcrumbItemWithPopover = <T extends BreadcrumbGroupProps.Item>({
 }: BreadcrumbItemWithPopoverProps<T>) => {
   const [showPopover, setShowPopover] = useState(false);
   const textRef = useRef<HTMLElement>(null);
-  const popoverContent = <Tooltip trackRef={textRef} value={item.text} size="medium" />;
+  const popoverContent = (
+    <Tooltip trackRef={textRef} value={item.text} size="medium" onDismiss={() => setShowPopover(false)} />
+  );
 
   useEffect(() => {
     if (showPopover) {

--- a/src/button-group/__tests__/button-group-tooltips.test.tsx
+++ b/src/button-group/__tests__/button-group-tooltips.test.tsx
@@ -58,6 +58,20 @@ test.each([copyButton, likeButton, menuButton, fileInput])(
   }
 );
 
+test.each([copyButton, likeButton, menuButton, fileInput])(
+  'shows the tooltip on pointer enter and hides on Esc key, item id=$id',
+  item => {
+    const { wrapper } = renderButtonGroup({ items: [likeButton, copyButton, menuButton, fileInput] });
+    const button = item.id === 'file' ? wrapper.findFileInputById(item.id)! : wrapper.findButtonById(item.id)!;
+
+    fireEvent.pointerEnter(button.getElement());
+    expect(wrapper.findTooltip()!.getElement()).toHaveTextContent(item.text);
+
+    fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
+    expect(wrapper.findTooltip()).toBeNull();
+  }
+);
+
 test.each([copyButton, likeButton, menuButton])('shows no tooltip in loading state, item id=$id', item => {
   const { wrapper } = renderButtonGroup({
     items: [likeButton, copyButton, menuButton].map(item => ({ ...item, loading: true })),

--- a/src/button-group/file-input-item.tsx
+++ b/src/button-group/file-input-item.tsx
@@ -11,19 +11,15 @@ import { ButtonGroupProps } from './interfaces.js';
 
 import testUtilStyles from './test-classes/styles.css.js';
 
+interface FileInputItemProps {
+  item: ButtonGroupProps.IconFileInput;
+  showTooltip: boolean;
+  onTooltipDismiss: () => void;
+  onFilesChange?: CancelableEventHandler<ButtonGroupProps.FilesChangeDetails>;
+}
+
 const FileInputItem = forwardRef(
-  (
-    {
-      item,
-      showTooltip,
-      onFilesChange,
-    }: {
-      item: ButtonGroupProps.IconFileInput;
-      showTooltip: boolean;
-      onFilesChange?: CancelableEventHandler<ButtonGroupProps.FilesChangeDetails>;
-    },
-    ref: React.Ref<FileInputProps.Ref>
-  ) => {
+  ({ item, showTooltip, onTooltipDismiss, onFilesChange }: FileInputItemProps, ref: React.Ref<FileInputProps.Ref>) => {
     const [files, setFiles] = useState<File[]>([]);
     const containerRef = React.useRef<HTMLDivElement>(null);
 
@@ -55,6 +51,7 @@ const FileInputItem = forwardRef(
             trackKey={item.id}
             value={item.text}
             className={clsx(testUtilStyles.tooltip, testUtilStyles['button-group-tooltip'])}
+            onDismiss={onTooltipDismiss}
           />
         )}
       </div>

--- a/src/button-group/icon-button-item.tsx
+++ b/src/button-group/icon-button-item.tsx
@@ -14,19 +14,17 @@ import { ButtonGroupProps } from './interfaces.js';
 
 import testUtilStyles from './test-classes/styles.css.js';
 
+interface IconButtonItemProps {
+  item: ButtonGroupProps.IconButton;
+  showTooltip: boolean;
+  showFeedback: boolean;
+  onTooltipDismiss: () => void;
+  onItemClick?: CancelableEventHandler<ButtonGroupProps.ItemClickDetails>;
+}
+
 const IconButtonItem = forwardRef(
   (
-    {
-      item,
-      showTooltip,
-      showFeedback,
-      onItemClick,
-    }: {
-      item: ButtonGroupProps.IconButton;
-      showTooltip: boolean;
-      showFeedback: boolean;
-      onItemClick?: CancelableEventHandler<ButtonGroupProps.ItemClickDetails>;
-    },
+    { item, showTooltip, showFeedback, onTooltipDismiss, onItemClick }: IconButtonItemProps,
     ref: React.Ref<ButtonProps.Ref>
   ) => {
     const containerRef = React.useRef<HTMLDivElement>(null);
@@ -69,6 +67,7 @@ const IconButtonItem = forwardRef(
               item.text
             }
             className={clsx(testUtilStyles.tooltip, testUtilStyles['button-group-tooltip'])}
+            onDismiss={onTooltipDismiss}
           />
         )}
       </div>

--- a/src/button-group/icon-toggle-button-item.tsx
+++ b/src/button-group/icon-toggle-button-item.tsx
@@ -14,19 +14,17 @@ import { ButtonGroupProps } from './interfaces.js';
 
 import testUtilStyles from './test-classes/styles.css.js';
 
+interface IconToggleButtonItemProps {
+  item: ButtonGroupProps.IconToggleButton;
+  showTooltip: boolean;
+  showFeedback: boolean;
+  onTooltipDismiss: () => void;
+  onItemClick?: CancelableEventHandler<ButtonGroupProps.ItemClickDetails>;
+}
+
 const IconToggleButtonItem = forwardRef(
   (
-    {
-      item,
-      showTooltip,
-      showFeedback,
-      onItemClick,
-    }: {
-      item: ButtonGroupProps.IconToggleButton;
-      showTooltip: boolean;
-      showFeedback: boolean;
-      onItemClick?: CancelableEventHandler<ButtonGroupProps.ItemClickDetails>;
-    },
+    { item, showTooltip, showFeedback, onTooltipDismiss, onItemClick }: IconToggleButtonItemProps,
     ref: React.Ref<ButtonProps.Ref>
   ) => {
     const containerRef = React.useRef<HTMLDivElement>(null);
@@ -75,6 +73,7 @@ const IconToggleButtonItem = forwardRef(
               (showFeedback && <InternalLiveRegion tagName="span">{feedbackContent}</InternalLiveRegion>) || item.text
             }
             className={clsx(testUtilStyles.tooltip, testUtilStyles['button-group-tooltip'])}
+            onDismiss={onTooltipDismiss}
           />
         )}
       </div>

--- a/src/button-group/item-element.tsx
+++ b/src/button-group/item-element.tsx
@@ -128,6 +128,7 @@ const ItemElement = forwardRef(
             onItemClick={onClickHandler}
             showTooltip={tooltip?.item === item.id}
             showFeedback={!!tooltip?.feedback}
+            onTooltipDismiss={() => setTooltip(null)}
           />
         )}
         {item.type === 'icon-toggle-button' && (
@@ -137,6 +138,7 @@ const ItemElement = forwardRef(
             onItemClick={onClickHandler}
             showTooltip={tooltip?.item === item.id}
             showFeedback={!!tooltip?.feedback}
+            onTooltipDismiss={() => setTooltip(null)}
           />
         )}
         {item.type === 'icon-file-input' && (
@@ -145,6 +147,7 @@ const ItemElement = forwardRef(
             item={item}
             onFilesChange={onFilesChangeHandler}
             showTooltip={tooltip?.item === item.id}
+            onTooltipDismiss={() => setTooltip(null)}
           />
         )}
         {item.type === 'menu-dropdown' && (
@@ -154,6 +157,7 @@ const ItemElement = forwardRef(
             showTooltip={tooltip?.item === item.id}
             onItemClick={onClickHandler}
             expandToViewport={dropdownExpandToViewport}
+            onTooltipDismiss={() => setTooltip(null)}
           />
         )}
       </div>

--- a/src/button-group/menu-dropdown-item.tsx
+++ b/src/button-group/menu-dropdown-item.tsx
@@ -15,13 +15,14 @@ import testUtilStyles from './test-classes/styles.css.js';
 interface MenuDropdownItemProps {
   item: ButtonGroupProps.MenuDropdown;
   showTooltip: boolean;
+  onTooltipDismiss: () => void;
   onItemClick?: CancelableEventHandler<ButtonGroupProps.ItemClickDetails>;
   expandToViewport?: boolean;
 }
 
 const MenuDropdownItem = React.forwardRef(
   (
-    { item, showTooltip, onItemClick, expandToViewport }: MenuDropdownItemProps,
+    { item, showTooltip, onItemClick, onTooltipDismiss, expandToViewport }: MenuDropdownItemProps,
     ref: React.Ref<ButtonDropdownProps.Ref>
   ) => {
     const containerRef = React.useRef<HTMLDivElement>(null);
@@ -47,6 +48,7 @@ const MenuDropdownItem = React.forwardRef(
                 trackKey={item.id}
                 value={item.text}
                 className={clsx(testUtilStyles.tooltip, testUtilStyles['button-group-tooltip'])}
+                onDismiss={onTooltipDismiss}
               />
             )}
             <InternalButton

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -256,6 +256,18 @@ describe('Button Component', () => {
         expect(wrapper.findDisabledReason()).toBeNull();
       });
 
+      test('close tooltip on Esc keydown', () => {
+        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+        fireEvent.mouseEnter(wrapper.getElement());
+
+        expect(wrapper.findDisabledReason()).not.toBeNull();
+        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+
+        fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
+        expect(wrapper.findDisabledReason()).toBeNull();
+      });
+
       test('has no aria-describedby by default', () => {
         const wrapper = renderButton({ ...defaultProps });
 

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -274,7 +274,12 @@ export const InternalButton = React.forwardRef(
       <>
         {descriptionEl}
         {showTooltip && (
-          <Tooltip className={testUtilStyles['disabled-reason-tooltip']} trackRef={buttonRef} value={disabledReason!} />
+          <Tooltip
+            className={testUtilStyles['disabled-reason-tooltip']}
+            trackRef={buttonRef}
+            value={disabledReason!}
+            onDismiss={() => setShowTooltip(false)}
+          />
         )}
       </>
     );

--- a/src/calendar/__tests__/calendar.test.tsx
+++ b/src/calendar/__tests__/calendar.test.tsx
@@ -371,6 +371,29 @@ describe('disabled date', () => {
       expect(wrapper.findDateAt(1, 6).findDisabledReason()).toBe(null);
     });
 
+    test('closes tooltip on Esc', () => {
+      const { container } = render(
+        <Calendar
+          {...defaultProps}
+          value="2022-01-03"
+          isDateEnabled={(date: Date) => date.getDay() !== 6 && date.getDay() !== 0}
+          dateDisabledReason={(date: Date) => {
+            if (date.getDay() === 6) {
+              return 'Disabled on Saturdays';
+            } else if (date.getDay() === 0) {
+              return 'Disabled on Sundays';
+            }
+            return '';
+          }}
+        />
+      );
+      const wrapper = createWrapper(container).findCalendar()!;
+      wrapper.findDateAt(1, 6).focus();
+      expect(wrapper.findDateAt(1, 6).findDisabledReason()!.getElement()).toHaveTextContent('Disabled on Saturdays');
+      fireEvent.keyDown(wrapper.findDateAt(1, 6).getElement(), { key: 'Escape', code: 'Escape' });
+      expect(wrapper.findDateAt(1, 6).findDisabledReason()).toBe(null);
+    });
+
     test('open tooltip on mouseenter', () => {
       const { container } = render(
         <Calendar

--- a/src/calendar/grid/index.tsx
+++ b/src/calendar/grid/index.tsx
@@ -74,7 +74,12 @@ const GridCell = forwardRef((props: GridCellProps, focusedDateRef: React.Ref<HTM
         <>
           {descriptionEl}
           {showTooltip && (
-            <Tooltip className={styles['disabled-reason-tooltip']} trackRef={ref} value={disabledReason!} />
+            <Tooltip
+              className={styles['disabled-reason-tooltip']}
+              trackRef={ref}
+              value={disabledReason!}
+              onDismiss={() => setShowTooltip(false)}
+            />
           )}
         </>
       )}

--- a/src/date-range-picker/calendar/__tests__/calendar.test.tsx
+++ b/src/date-range-picker/calendar/__tests__/calendar.test.tsx
@@ -496,6 +496,26 @@ describe('Date range picker calendar', () => {
         expect(wrapper.findDropdown()!.findDateAt('left', 4, 1).findDisabledReason()).toBe(null);
       });
 
+      test('close tooltip on Esc but leaves the dialog open', () => {
+        const { wrapper } = renderDateRangePicker({
+          ...defaultProps,
+          value: { type: 'absolute', startDate: '2018-03-01T00:00:00', endDate: '2018-03-01T00:00:00' },
+          isDateEnabled,
+          dateDisabledReason,
+        });
+        changeMode(wrapper, 'absolute');
+
+        fireEvent.mouseEnter(wrapper.findDropdown()!.findDateAt('left', 4, 1).getElement());
+
+        expect(wrapper.findDropdown()!.findDateAt('left', 4, 1).findDisabledReason()!.getElement()).toHaveTextContent(
+          'Disabled with a reason'
+        );
+
+        fireEvent.keyDown(window, { key: 'Escape' });
+        expect(wrapper.findDropdown()).not.toBeNull();
+        expect(wrapper.findDropdown()!.findDateAt('left', 4, 1).findDisabledReason()).toBe(null);
+      });
+
       test('has no aria-describedby by default', () => {
         const { wrapper } = renderDateRangePicker({
           ...defaultProps,

--- a/src/date-range-picker/calendar/__tests__/grid-cell.test.tsx
+++ b/src/date-range-picker/calendar/__tests__/grid-cell.test.tsx
@@ -6,6 +6,8 @@ import { fireEvent, render } from '@testing-library/react';
 import { GridCell } from '../../../../lib/components/date-range-picker/calendar/grids/grid-cell';
 import createWrapper from '../../../../lib/components/test-utils/dom';
 
+import styles from '../../../../lib/components/date-range-picker/calendar/grids/styles.selectors.js';
+
 describe('Date range picker grid cell', () => {
   const mockOnFocus = jest.fn();
   const mockOnBlur = jest.fn();
@@ -77,6 +79,21 @@ describe('Date range picker grid cell', () => {
       expect(wrapper).not.toBeNull();
       fireEvent.mouseLeave(getByTestId('testitem'));
       expect(mockOnMouseLeave).toHaveBeenCalledTimes(1);
+    });
+
+    test('shows disabledReason tooltip on mouse enter', () => {
+      const { container, getByTestId } = render(
+        <GridCell {...mockProps}>
+          <div data-testid="testitem">Test</div>
+        </GridCell>
+      );
+      const wrapper = createWrapper(container);
+
+      expect(wrapper).not.toBeNull();
+      fireEvent.mouseEnter(getByTestId('testitem'));
+      expect(document.querySelector(`.${styles['disabled-reason-tooltip']}`)).toHaveTextContent(mockDisabledReason);
+      fireEvent.keyDown(window, { key: 'Escape' });
+      expect(document.querySelector(`.${styles['disabled-reason-tooltip']}`)).toBeNull();
     });
   });
 });

--- a/src/date-range-picker/calendar/grids/grid-cell.tsx
+++ b/src/date-range-picker/calendar/grids/grid-cell.tsx
@@ -67,7 +67,12 @@ export const GridCell = forwardRef((props: GridCellProps, focusedDateRef: React.
         <>
           {descriptionEl}
           {showTooltip && (
-            <Tooltip className={styles['disabled-reason-tooltip']} trackRef={ref} value={disabledReason!} />
+            <Tooltip
+              className={styles['disabled-reason-tooltip']}
+              trackRef={ref}
+              value={disabledReason!}
+              onDismiss={() => setShowTooltip(false)}
+            />
           )}
         </>
       )}

--- a/src/file-token-group/__tests__/file-token-group.test.tsx
+++ b/src/file-token-group/__tests__/file-token-group.test.tsx
@@ -242,6 +242,20 @@ describe('Tooltip', () => {
 
     expect(document.querySelector(`.${tooltipStyles.root}`)).toBeNull();
   });
+
+  test('Should hide tooltip on Escape', () => {
+    const wrapper = render({ items: [{ file: file3 }], alignment: 'horizontal' });
+
+    act(() => {
+      fireEvent.mouseEnter(wrapper.findFileToken(1)!.findFileName().getElement());
+    });
+    expect(document.querySelector(`.${tooltipStyles.root}`)).not.toBeNull();
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
+    });
+    expect(document.querySelector(`.${tooltipStyles.root}`)).toBeNull();
+  });
 });
 
 describe('Focusing behavior', () => {

--- a/src/file-token-group/__tests__/file-token-group.test.tsx
+++ b/src/file-token-group/__tests__/file-token-group.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
-import { act, fireEvent, render as testingLibraryRender, screen } from '@testing-library/react';
+import { fireEvent, render as testingLibraryRender, screen } from '@testing-library/react';
 
 import '../../__a11y__/to-validate-a11y';
 import FileTokenGroup, { FileTokenGroupProps } from '../../../lib/components/file-token-group';
@@ -220,40 +220,27 @@ describe('File loading', () => {
 describe('Tooltip', () => {
   test('Should show ellipsis on long file names', () => {
     const wrapper = render({ items: [{ file: file3 }] });
-    act(() => {
-      fireEvent.mouseEnter(wrapper.findFileToken(1)!.findFileName().getElement());
-    });
-
+    fireEvent.mouseEnter(wrapper.findFileToken(1)!.findFileName().getElement());
     expect(wrapper.findFileToken(1)!.findFileName().getElement()).toHaveClass(testStyles['ellipsis-active']);
   });
 
   test('Should show tooltip on mouse enter', () => {
     const wrapper = render({ items: [{ file: file3 }], alignment: 'horizontal' });
 
-    act(() => {
-      fireEvent.mouseEnter(wrapper.findFileToken(1)!.findFileName().getElement());
-    });
-
+    fireEvent.mouseEnter(wrapper.findFileToken(1)!.findFileName().getElement());
     expect(document.querySelector(`.${tooltipStyles.root}`)).not.toBeNull();
 
-    act(() => {
-      fireEvent.mouseLeave(wrapper.findFileToken(1)!.findFileName().getElement());
-    });
-
+    fireEvent.mouseLeave(wrapper.findFileToken(1)!.findFileName().getElement());
     expect(document.querySelector(`.${tooltipStyles.root}`)).toBeNull();
   });
 
   test('Should hide tooltip on Escape', () => {
     const wrapper = render({ items: [{ file: file3 }], alignment: 'horizontal' });
 
-    act(() => {
-      fireEvent.mouseEnter(wrapper.findFileToken(1)!.findFileName().getElement());
-    });
+    fireEvent.mouseEnter(wrapper.findFileToken(1)!.findFileName().getElement());
     expect(document.querySelector(`.${tooltipStyles.root}`)).not.toBeNull();
 
-    act(() => {
-      fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
-    });
+    fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
     expect(document.querySelector(`.${tooltipStyles.root}`)).toBeNull();
   });
 });

--- a/src/file-token-group/file-token.tsx
+++ b/src/file-token-group/file-token.tsx
@@ -187,6 +187,7 @@ function InternalFileToken({
           trackRef={containerRef}
           trackKey={file.name}
           value={<InternalBox fontWeight="normal">{file.name}</InternalBox>}
+          onDismiss={() => setShowTooltip(false)}
         />
       )}
     </div>

--- a/src/internal/components/tooltip/__integ__/tooltip.test.ts
+++ b/src/internal/components/tooltip/__integ__/tooltip.test.ts
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+import createWrapper from '../../../../../lib/components/test-utils/selectors';
+
+import tooltipStyles from '../../../../../lib/components/internal/components/tooltip/styles.selectors.js';
+
+test(
+  'should not close any wrapping modals when the tooltip detects an Escape keypress',
+  useBrowser(async browser => {
+    await browser.url('/#/light/modal/with-tooltip');
+    const page = new BasePageObject(browser);
+
+    const openButtonSelector = createWrapper().findButton().toSelector();
+    await page.waitForVisible(openButtonSelector);
+    await page.click(openButtonSelector);
+
+    const modal = createWrapper().findModal();
+    const slider = modal.findContent().findSlider();
+    await page.waitForVisible(slider.toSelector());
+
+    // Slider on the page is set at 50% on purpose. `hoverElement` will move the
+    // mouse to the center of the track where the "thumb" is.
+    await page.hoverElement(slider.findNativeInput().toSelector());
+    await page.waitForVisible(`.${tooltipStyles.root}`);
+
+    // Press once to close the tooltip
+    await page.keys(['Escape']);
+    await expect(page.isDisplayed(`.${tooltipStyles.root}`)).resolves.toBe(false);
+    await expect(page.isDisplayed(modal.toSelector())).resolves.toBe(true);
+
+    // Press again to close the modal
+    await page.keys(['Escape']);
+    await expect(page.isDisplayed(modal.toSelector())).resolves.toBe(false);
+  })
+);

--- a/src/internal/components/tooltip/__tests__/tooltip.test.tsx
+++ b/src/internal/components/tooltip/__tests__/tooltip.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 import Tooltip, { TooltipProps } from '../../../../../lib/components/internal/components/tooltip';
 import StatusIndicator from '../../../../../lib/components/status-indicator';
@@ -33,6 +33,7 @@ function renderTooltip(props: Partial<TooltipProps>) {
       trackKey={props.trackKey}
       value={props.value ?? ''}
       contentAttributes={props.contentAttributes}
+      onDismiss={props.onDismiss ?? (() => {})}
     />
   );
   return new TooltipInternalWrapper(container);
@@ -81,5 +82,20 @@ describe('Tooltip', () => {
     const wrapper = renderTooltip({ value: 'Value', trackKey });
 
     expect(wrapper.findTooltip()?.getElement()).toHaveAttribute('data-testid', trackKey);
+  });
+
+  it('calls onDismiss when an Escape keypress is detected anywhere', () => {
+    const onDismiss = jest.fn();
+    const keydownEvent = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+    jest.spyOn(keydownEvent, 'stopPropagation');
+
+    renderTooltip({ value: 'Value', onDismiss });
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    act(() => {
+      document.body.dispatchEvent(keydownEvent);
+    });
+    expect(keydownEvent.stopPropagation).toHaveBeenCalled();
+    expect(onDismiss).toHaveBeenCalled();
   });
 });

--- a/src/internal/components/tooltip/__tests__/tooltip.test.tsx
+++ b/src/internal/components/tooltip/__tests__/tooltip.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { act, render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 import Tooltip, { TooltipProps } from '../../../../../lib/components/internal/components/tooltip';
 import StatusIndicator from '../../../../../lib/components/status-indicator';
@@ -92,9 +92,7 @@ describe('Tooltip', () => {
     renderTooltip({ value: 'Value', onDismiss });
     expect(onDismiss).not.toHaveBeenCalled();
 
-    act(() => {
-      document.body.dispatchEvent(keydownEvent);
-    });
+    fireEvent.keyDown(window, keydownEvent);
     expect(keydownEvent.stopPropagation).toHaveBeenCalled();
     expect(onDismiss).toHaveBeenCalled();
   });

--- a/src/internal/components/tooltip/__tests__/tooltip.test.tsx
+++ b/src/internal/components/tooltip/__tests__/tooltip.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 import Tooltip, { TooltipProps } from '../../../../../lib/components/internal/components/tooltip';
 import StatusIndicator from '../../../../../lib/components/status-indicator';
@@ -92,7 +92,10 @@ describe('Tooltip', () => {
     renderTooltip({ value: 'Value', onDismiss });
     expect(onDismiss).not.toHaveBeenCalled();
 
-    fireEvent.keyDown(window, keydownEvent);
+    act(() => {
+      // Dispatch the exect event instance so that we can spy stopPropagation on it.
+      document.body.dispatchEvent(keydownEvent);
+    });
     expect(keydownEvent.stopPropagation).toHaveBeenCalled();
     expect(onDismiss).toHaveBeenCalled();
   });

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
@@ -774,6 +774,25 @@ describe('Disabled item with reason', () => {
     wrapper.openDropdown();
     wrapper.selectOptionByValue('1');
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('closes tooltip when Esc is pressed but leaves dropdown open', () => {
+    const { wrapper } = renderMultiselect(
+      <Multiselect
+        options={[{ label: 'First', value: '1', disabled: true, disabledReason: 'disabled reason' }]}
+        selectedOptions={[]}
+      />
+    );
+    wrapper.openDropdown();
+    wrapper.findTrigger().keydown(KeyCode.down);
+    expect(wrapper.findDropdown().findOption(1)!.findDisabledReason()!.getElement()).toHaveTextContent(
+      'disabled reason'
+    );
+    fireEvent.keyDown(wrapper.findDropdown().findOptionsContainer()!.getElement(), {
+      key: 'Escape',
+    });
+    expect(wrapper.findDropdown().findOpenDropdown()).not.toBeNull();
+    expect(wrapper.findDropdown().findOption(1)!.findDisabledReason()).toBeNull();
   });
 });
 

--- a/src/segmented-control/__tests__/desktop.test.tsx
+++ b/src/segmented-control/__tests__/desktop.test.tsx
@@ -344,6 +344,35 @@ describe('Segment disabled property', () => {
       expect(segmentedControlWrapper.findSegmentById('seg-2')!.findDisabledReason()).toBe(null);
     });
 
+    test('close tooltip on Escape keydown', () => {
+      const { segmentedControlWrapper } = renderSegmentedControl(
+        <SegmentedControl
+          selectedId="seg-1"
+          options={defaultOptions.map(option => {
+            if (option.id === 'seg-2') {
+              return {
+                ...option,
+                disabled: true,
+                disabledReason: 'disabled reason',
+              };
+            }
+
+            return option;
+          })}
+        />
+      );
+
+      fireEvent.mouseEnter(segmentedControlWrapper.findSegmentById('seg-2')!.getElement());
+
+      expect(segmentedControlWrapper.findSegmentById('seg-2')!.findDisabledReason()!.getElement()).toHaveTextContent(
+        'disabled reason'
+      );
+
+      fireEvent.keyDown(window, { key: 'Escape' });
+
+      expect(segmentedControlWrapper.findSegmentById('seg-2')!.findDisabledReason()).toBe(null);
+    });
+
     test('has no aria-describedby by default', () => {
       const { segmentedControlWrapper } = renderSegmentedControl(
         <SegmentedControl selectedId="seg-1" options={defaultOptions} />

--- a/src/segmented-control/segment.tsx
+++ b/src/segmented-control/segment.tsx
@@ -77,7 +77,12 @@ export const Segment = React.forwardRef(
           <>
             {descriptionEl}
             {showTooltip && (
-              <Tooltip className={styles['disabled-reason-tooltip']} trackRef={buttonRef} value={disabledReason!} />
+              <Tooltip
+                className={styles['disabled-reason-tooltip']}
+                trackRef={buttonRef}
+                value={disabledReason!}
+                onDismiss={() => setShowTooltip(false)}
+              />
             )}
           </>
         )}

--- a/src/select/__tests__/disabled.test.tsx
+++ b/src/select/__tests__/disabled.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 
 import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
@@ -127,6 +127,22 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
         wrapper.openDropdown();
         wrapper.selectOptionByValue('1', { expandToViewport });
         expect(wrapper.findDropdown({ expandToViewport })?.findOpenDropdown()).toBeTruthy();
+      });
+
+      test('closes tooltip when Esc is pressed but leaves dropdown open', () => {
+        const { wrapper } = renderSelect({
+          options: [{ label: 'First', value: '1', disabled: true, disabledReason: 'disabled reason' }],
+        });
+        wrapper.openDropdown();
+        wrapper.findTrigger().keydown(KeyCode.down);
+        expect(
+          wrapper.findDropdown({ expandToViewport }).findOption(1)!.findDisabledReason()!.getElement()
+        ).toHaveTextContent('disabled reason');
+        fireEvent.keyDown(wrapper.findDropdown({ expandToViewport }).findOptionsContainer()!.getElement(), {
+          key: 'Escape',
+        });
+        expect(wrapper.findDropdown().findOpenDropdown()).not.toBeNull();
+        expect(wrapper.findDropdown({ expandToViewport }).findOption(1)!.findDisabledReason()).toBeNull();
       });
 
       test('hides disabled reason when the option is scrolled away', async () => {

--- a/src/select/parts/item.tsx
+++ b/src/select/parts/item.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 import InternalIcon from '../../icon/internal.js';
@@ -61,6 +61,9 @@ const Item = (
 
   const { descriptionEl, descriptionId } = useHiddenDescription(disabledReason);
 
+  const [canShowTooltip, setCanShowTooltip] = useState(true);
+  useEffect(() => setCanShowTooltip(true), [highlighted]);
+
   return (
     <SelectableItem
       ariaSelected={Boolean(selected)}
@@ -102,13 +105,14 @@ const Item = (
         {isDisabledWithReason && (
           <>
             {descriptionEl}
-            {highlighted && (
+            {highlighted && canShowTooltip && (
               <Tooltip
                 className={styles['disabled-reason-tooltip']}
                 trackRef={internalRef}
                 value={disabledReason!}
                 position="right"
                 hideOnOverscroll={true}
+                onDismiss={() => setCanShowTooltip(false)}
               />
             )}
           </>

--- a/src/select/parts/multiselect-item.tsx
+++ b/src/select/parts/multiselect-item.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { getBaseProps } from '../../internal/base-component';
 import CheckboxIcon from '../../internal/components/checkbox-icon';
@@ -52,6 +52,9 @@ const MultiSelectItem = (
 
   const { descriptionId, descriptionEl } = useHiddenDescription(disabledReason);
 
+  const [canShowTooltip, setCanShowTooltip] = useState(true);
+  useEffect(() => setCanShowTooltip(true), [highlighted]);
+
   return (
     <SelectableItem
       ariaChecked={isParent && indeterminate ? 'mixed' : Boolean(selected)}
@@ -90,13 +93,14 @@ const MultiSelectItem = (
       {isDisabledWithReason && (
         <>
           {descriptionEl}
-          {highlighted && (
+          {highlighted && canShowTooltip && (
             <Tooltip
               className={styles['disabled-reason-tooltip']}
               trackRef={internalRef}
               value={disabledReason!}
               position="right"
               hideOnOverscroll={true}
+              onDismiss={() => setCanShowTooltip(false)}
             />
           )}
         </>

--- a/src/slider/__tests__/slider.test.tsx
+++ b/src/slider/__tests__/slider.test.tsx
@@ -289,6 +289,23 @@ describe('Slider events', () => {
 
     expect(screen.queryByText('50')).not.toBeInTheDocument();
   });
+
+  test('close tooltip on Esc keydown', () => {
+    const wrapper = renderSlider({
+      min: 0,
+      max: 100,
+      value: 50,
+    });
+    act(() => {
+      fireEvent.mouseEnter(wrapper.findNativeInput()!.getElement());
+    });
+    expect(screen.queryByText('50')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Escape' });
+    });
+    expect(screen.queryByText('50')).not.toBeInTheDocument();
+  });
 });
 
 describe('Slider i18n', () => {

--- a/src/slider/__tests__/slider.test.tsx
+++ b/src/slider/__tests__/slider.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
@@ -278,15 +278,10 @@ describe('Slider events', () => {
       max: 100,
       value: 50,
     });
-    act(() => {
-      fireEvent.mouseEnter(wrapper.findNativeInput()!.getElement());
-    });
+    fireEvent.mouseEnter(wrapper.findNativeInput()!.getElement());
     expect(screen.queryByText('50')).toBeInTheDocument();
 
-    act(() => {
-      fireEvent.mouseLeave(wrapper.findNativeInput()!.getElement());
-    });
-
+    fireEvent.mouseLeave(wrapper.findNativeInput()!.getElement());
     expect(screen.queryByText('50')).not.toBeInTheDocument();
   });
 
@@ -296,14 +291,10 @@ describe('Slider events', () => {
       max: 100,
       value: 50,
     });
-    act(() => {
-      fireEvent.mouseEnter(wrapper.findNativeInput()!.getElement());
-    });
+    fireEvent.mouseEnter(wrapper.findNativeInput()!.getElement());
     expect(screen.queryByText('50')).toBeInTheDocument();
 
-    act(() => {
-      fireEvent.keyDown(window, { key: 'Escape' });
-    });
+    fireEvent.keyDown(window, { key: 'Escape' });
     expect(screen.queryByText('50')).not.toBeInTheDocument();
   });
 });

--- a/src/slider/internal.tsx
+++ b/src/slider/internal.tsx
@@ -128,7 +128,11 @@ export default function InternalSlider({
   return (
     <div {...baseProps} ref={__internalRootRef} className={clsx(baseProps.className, styles.root)}>
       {showTooltip && (
-        <Tooltip value={valueFormatter ? valueFormatter(sliderValue) : sliderValue} trackRef={handleRef} />
+        <Tooltip
+          value={valueFormatter ? valueFormatter(sliderValue) : sliderValue}
+          trackRef={handleRef}
+          onDismiss={() => setShowTooltip(false)}
+        />
       )}
       <div
         ref={handleRef}

--- a/src/tabs/__tests__/tabs.test.tsx
+++ b/src/tabs/__tests__/tabs.test.tsx
@@ -1100,6 +1100,37 @@ describe('Tabs', () => {
         expect(wrapper.findTabLinkById('second')!.findDisabledReason()).toBe(null);
       });
 
+      test('close tooltip on Esc keydown', () => {
+        const firstTabId = defaultTabs[0].id;
+        const { wrapper } = renderTabs(
+          <Tabs
+            tabs={defaultTabs.map(item => {
+              if (item.id === 'second') {
+                return {
+                  ...item,
+                  disabled: true,
+                  disabledReason: 'disabled reason',
+                };
+              }
+
+              return item;
+            })}
+            activeTabId={firstTabId}
+            onChange={() => void 0}
+          />
+        );
+
+        fireEvent.mouseEnter(wrapper.findTabLinkById('second')!.getElement());
+
+        expect(wrapper.findTabLinkById('second')!.findDisabledReason()!.getElement()).toHaveTextContent(
+          'disabled reason'
+        );
+
+        fireEvent.keyDown(window, { key: 'Escape' });
+
+        expect(wrapper.findTabLinkById('second')!.findDisabledReason()).toBe(null);
+      });
+
       test('has no aria-describedby by default', () => {
         const firstTabId = defaultTabs[0].id;
         const { wrapper } = renderTabs(<Tabs tabs={defaultTabs} activeTabId={firstTabId} onChange={() => void 0} />);

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -528,6 +528,7 @@ const TabTrigger = forwardRef(
                 className={styles['disabled-reason-tooltip']}
                 trackRef={tabLabelRefObject}
                 value={tab.disabledReason!}
+                onDismiss={() => setShowTooltip(false)}
               />
             )}
           </>


### PR DESCRIPTION
### Description

Does what it says on the tin - tooltips should be dismissible by hitting the Escape key. I know the visibility logic for the tooltips is handled outside them, but it still seemed sensible to put the dismiss handler inside the tooltip in one shared place.

Not as complicated as it looks! A lot of it is just unit testing or just implementing the new `onDismiss` handler, which is super simple. Check my comments to see the areas of interest first.

Related links, issue #, if available: AWSUI-60227, AWSUI-60225, AWSUI-60230, AWSUI-60226, AWSUI-60228, AWSUI-60231, AWSUI-60229

### How has this been tested?

Added a unit test to the tooltip component itself, and all other components that use it.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
