### PR TITLE
fix: Sass incompatible units

### DIFF
--- a/src/popover/styles.scss
+++ b/src/popover/styles.scss
@@ -3,6 +3,7 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
+@use 'sass:string';
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
 @use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
@@ -52,7 +53,7 @@ $trigger-underline-offset: 0.25em;
     /*
       This line-height needs to be overridden because the overflow: hidden would otherwise conceal the underline styles.
     */
-    line-height: calc(1 + #{$trigger-underline-offset} + #{awsui.$border-divider-list-width});
+    line-height: string.unquote('calc(1 + #{$trigger-underline-offset} + #{awsui.$border-divider-list-width})');
   }
 }
 


### PR DESCRIPTION
### Description

Some packages in the build `7206966688` have failed because of the units incompatibility problem as shown below:

SassError: 1 and 0.25em are incompatible.
     ╷
1136 │   line-height: calc(1 + 0.25em + var(--border-divider-list-width-471u6a, 1px));
     │                     ^^^^^^^^^^

While this code works correctly in most packages, it fails in some packages, likely due to their Webpack configuration. To avoid this issue, wrap the problematic styles with string.unquote, which should resolve the problem.


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
