### PR TITLE
revert: "chore: Underline styles for popover text trigger (#3060)"

### DIFF
--- a/pages/popover/text-wrap.page.tsx
+++ b/pages/popover/text-wrap.page.tsx
@@ -26,7 +26,6 @@ const triggerPermutations = createPermutations<PopoverProps & { size: PopoverPro
       'Reallylongpopovercontentwithalotoftextbutnospacesthatwillprobablyoverflowthepopovertrigger',
     ],
     wrapTriggerText: [true, false],
-    triggerType: ['text', 'text-inline'],
   },
 ]);
 

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -12178,15 +12178,13 @@ that don't have visible text, and to distinguish between multiple triggers with 
     {
       "defaultValue": "'text'",
       "description": "Specifies the type of content inside the trigger region. The following types are available:
-- \`text\` - Use for triggers containing inline components, like status indicator.
-- \`text-inline\` - Use for triggers containing plain text only.
+- \`text\` - Use for inline text triggers.
 - \`custom\` - Use for the [button](/components/button/) component.",
       "inlineType": {
         "name": "PopoverProps.TriggerType",
         "type": "union",
         "values": [
           "text",
-          "text-inline",
           "custom",
         ],
       },

--- a/src/popover/interfaces.ts
+++ b/src/popover/interfaces.ts
@@ -23,8 +23,7 @@ export interface PopoverProps extends BaseComponentProps {
 
   /**
    * Specifies the type of content inside the trigger region. The following types are available:
-   * - `text` - Use for triggers containing inline components, like status indicator.
-   * - `text-inline` - Use for triggers containing plain text only.
+   * - `text` - Use for inline text triggers.
    * - `custom` - Use for the [button](/components/button/) component.
    */
   triggerType?: PopoverProps.TriggerType;
@@ -115,7 +114,7 @@ export type Rect = BoundingBox & {
 export namespace PopoverProps {
   export type Position = 'top' | 'right' | 'bottom' | 'left';
   export type Size = 'small' | 'medium' | 'large';
-  export type TriggerType = 'text' | 'text-inline' | 'custom';
+  export type TriggerType = 'text' | 'custom';
 
   export interface Ref {
     /**

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -74,7 +74,7 @@ function InternalPopover(
   const [visible, setVisible] = useState(false);
 
   const focusTrigger = useCallback(() => {
-    if (['text', 'text-inline'].includes(triggerType)) {
+    if (triggerType === 'text') {
       triggerRef.current?.focus();
     } else {
       triggerRef.current && getFirstFocusable(triggerRef.current)?.focus();
@@ -198,7 +198,7 @@ function InternalPopover(
         });
       }}
     >
-      {['text', 'text-inline'].includes(triggerType) ? (
+      {triggerType === 'text' ? (
         <button
           {...triggerProps}
           className={clsx(triggerProps.className, wrapTriggerText === false && styles['overflow-ellipsis'])}

--- a/src/popover/styles.scss
+++ b/src/popover/styles.scss
@@ -12,8 +12,6 @@
 @import './container';
 @import './motion';
 
-$trigger-underline-offset: 0.25em;
-
 .root {
   @include styles.styles-reset;
   color: inherit;
@@ -38,31 +36,8 @@ $trigger-underline-offset: 0.25em;
   @include styles.text-wrapping;
 }
 
-.trigger-type-text-inline {
-  border-block: 0;
-  /*
-    This transparent border is necessary to maintain space between the trigger and the bottom-positioned popover.
-  */
-  border-block-end: awsui.$border-divider-list-width dashed transparent;
-  text-decoration: underline dashed currentColor;
-  text-decoration-thickness: awsui.$border-divider-list-width;
-  text-underline-offset: $trigger-underline-offset;
-
-  &.overflow-ellipsis {
-    /*
-      This line-height needs to be overridden because the overflow: hidden would otherwise conceal the underline styles.
-    */
-    line-height: calc(1 + #{$trigger-underline-offset} + #{awsui.$border-divider-list-width});
-  }
-}
-
 .trigger-type-text {
   border-block: 0;
-  border-block-end: awsui.$border-divider-list-width dashed currentColor;
-}
-
-.trigger-type-text-inline,
-.trigger-type-text {
   border-inline: 0;
   margin-block: 0;
   margin-inline: 0;
@@ -71,6 +46,7 @@ $trigger-underline-offset: 0.25em;
   background-color: transparent;
 
   cursor: pointer;
+  border-block-end: awsui.$border-divider-list-width dashed currentColor;
 
   &:focus {
     outline: none;


### PR DESCRIPTION
This reverts commit e1c488b01396999a4609573bece9dcf830311632.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
