### PR TITLE
fix: Incorporate split panel height when rendering stickyVerticalBottomOffset value

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/compute-layout.ts
+++ b/src/app-layout/visual-refresh-toolbar/compute-layout.ts
@@ -113,6 +113,36 @@ export function computeVerticalLayout({
   return { toolbar, notifications, header, drawers };
 }
 
+interface SplitPanelOffsetInput {
+  hasSplitPanel: boolean;
+  placement: AppLayoutPropsWithDefaults['placement'];
+  splitPanelPosition: 'bottom' | 'side';
+  splitPanelOpen: boolean;
+  splitPanelHeaderHeight: number;
+  splitPanelFullHeight: number;
+}
+
+export function computeSplitPanelOffsets({
+  hasSplitPanel,
+  splitPanelPosition,
+  placement,
+  splitPanelOpen,
+  splitPanelFullHeight,
+  splitPanelHeaderHeight,
+}: SplitPanelOffsetInput) {
+  if (!hasSplitPanel || splitPanelPosition !== 'bottom') {
+    return {
+      stickyVerticalBottomOffset: placement.insetBlockEnd,
+      mainContentPaddingBlockEnd: undefined,
+    };
+  }
+  const mainContentBottomOffset = splitPanelOpen ? splitPanelFullHeight : splitPanelHeaderHeight;
+  return {
+    stickyVerticalBottomOffset: mainContentBottomOffset + placement.insetBlockEnd,
+    mainContentPaddingBlockEnd: mainContentBottomOffset,
+  };
+}
+
 export function getDrawerStyles(
   verticalOffsets: VerticalLayoutOutput,
   isMobile: boolean,

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -21,7 +21,12 @@ import { MIN_DRAWER_SIZE, OnChangeParams, useDrawers } from '../utils/use-drawer
 import { useFocusControl, useMultipleFocusControl } from '../utils/use-focus-control';
 import { useSplitPanelFocusControl } from '../utils/use-split-panel-focus-control';
 import { ActiveDrawersContext } from '../utils/visibility-context';
-import { computeHorizontalLayout, computeVerticalLayout, CONTENT_PADDING } from './compute-layout';
+import {
+  computeHorizontalLayout,
+  computeSplitPanelOffsets,
+  computeVerticalLayout,
+  CONTENT_PADDING,
+} from './compute-layout';
 import { AppLayoutVisibilityContext } from './contexts';
 import { AppLayoutInternals } from './interfaces';
 import {
@@ -461,6 +466,15 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       }
     }, [hasToolbar]);
 
+    const splitPanelOffsets = computeSplitPanelOffsets({
+      placement,
+      hasSplitPanel: !!splitPanel,
+      splitPanelOpen,
+      splitPanelPosition,
+      splitPanelFullHeight: splitPanelReportedSize,
+      splitPanelHeaderHeight: splitPanelHeaderBlockSize,
+    });
+
     return (
       <AppLayoutVisibilityContext.Provider value={isIntersecting}>
         {/* Rendering a hidden copy of breadcrumbs to trigger their deduplication */}
@@ -469,16 +483,11 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
           ref={useMergeRefs(intersectionObserverRef, rootRef)}
           isNested={isNested}
           style={{
-            paddingBlockEnd:
-              splitPanelPosition === 'bottom'
-                ? splitPanelOpen
-                  ? splitPanelReportedSize
-                  : splitPanelHeaderBlockSize
-                : '',
+            paddingBlockEnd: splitPanelOffsets.mainContentPaddingBlockEnd,
             ...(hasToolbar || !isNested
               ? {
                   [globalVars.stickyVerticalTopOffset]: `${verticalOffsets.header}px`,
-                  [globalVars.stickyVerticalBottomOffset]: `${placement.insetBlockEnd}px`,
+                  [globalVars.stickyVerticalBottomOffset]: `${splitPanelOffsets.stickyVerticalBottomOffset}px`,
                 }
               : {}),
             ...(!isMobile ? { minWidth: `${minContentWidth}px` } : {}),


### PR DESCRIPTION
### Description

Fixing a bug

Related links, issue #, if available: AWSUI-60293

### How has this been tested?

1. Added a test
2. Will be also visible on screenshot tests, since they render the scrollbars now

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
