### PR TITLE
chore: Add workflow dispatch to release workflow to allow e2e tests to trigger action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,16 @@
 name: Release
 
 on:
+  workflow_dispatch:
+    inputs:
+      role-to-assume:
+        type: string
+        description: Use to override the AWS role used during release
+        required: false
+      project-name:
+        type: string
+        description: Use to override the CodeBuild project called
+        required: false
   push:
     branches:
       - main
@@ -18,3 +28,5 @@ jobs:
     secrets: inherit
     with:
       skip-test: true
+      role-to-assume: ${{ inputs.role-to-assume }}
+      project-name: ${{ inputs.project-name }}      


### PR DESCRIPTION
### Description
Allows ability to trigger this workflow either through the UI or programmatically through the Octokit sdk. Additionally passes in some additional configuration to change the AWS role and the CodeBuild project used to perform the release.

Depends on: https://github.com/cloudscape-design/actions/pull/69

### How has this been tested?

Tested in my personal fork: 
https://github.com/michaeldowseza/actions/blob/main/.github/workflows/release.yml
https://github.com/michaeldowseza/components/actions/runs/13006036611/job/36273066928

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
