### PR TITLE
fix: Live announce resultState in ProgressBar

### DIFF
--- a/src/progress-bar/__tests__/progress-bar.test.tsx
+++ b/src/progress-bar/__tests__/progress-bar.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 
 import ProgressBar, { ProgressBarProps } from '../../../lib/components/progress-bar';
 import createWrapper from '../../../lib/components/test-utils/dom';
@@ -80,14 +80,22 @@ allVariants.forEach(variant => {
     });
 
     describe('ARIA live region', () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
+      });
+
+      afterEach(() => {
+        jest.clearAllTimers();
+      });
+
       test('is present in the DOM while in-progress', () => {
-        renderProgressBar({ variant, value: 0 });
-        expect(createWrapper().find('[aria-live]')).not.toBeNull();
+        renderProgressBar({ variant, value: 22 });
+        expect(createWrapper().findLiveRegion()!.getElement()).toHaveTextContent('22%');
       });
 
       test('contains result text', () => {
-        const wrapper = renderProgressBar({ variant, value: 100, status: 'success', resultText: 'Result!' });
-        expect(wrapper.find('[aria-live]')!.getElement()).toHaveTextContent('Result!');
+        renderProgressBar({ variant, value: 100, status: 'success', resultText: 'Result!' });
+        expect(createWrapper().findLiveRegion()!.getElement()).toHaveTextContent('Result!');
       });
     });
 
@@ -253,8 +261,10 @@ describe('Progress updates', () => {
     expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(`${label}: 0%`);
     rerender(<ProgressBar label={label} value={2} />);
 
-    // 6 seconds passed, live region has a new value
-    jest.advanceTimersByTime(6000);
+    act(() => {
+      // 6 seconds passed, live region has a new value
+      jest.advanceTimersByTime(6000);
+    });
     expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(`${label}: 2%`);
   });
 

--- a/src/progress-bar/index.tsx
+++ b/src/progress-bar/index.tsx
@@ -104,15 +104,17 @@ export default function ProgressBar({
               </InternalLiveRegion>
             </>
           ) : (
-            <ResultState
-              resultText={resultText}
-              isInFlash={isInFlash}
-              resultButtonText={resultButtonText}
-              status={status}
-              onClick={() => {
-                fireNonCancelableEvent(onResultButtonClick);
-              }}
-            />
+            <InternalLiveRegion hidden={false} tagName="span" delay={0}>
+              <ResultState
+                resultText={resultText}
+                isInFlash={isInFlash}
+                resultButtonText={resultButtonText}
+                status={status}
+                onClick={() => {
+                  fireNonCancelableEvent(onResultButtonClick);
+                }}
+              />
+            </InternalLiveRegion>
           )}
         </div>
       </div>

--- a/src/progress-bar/internal.tsx
+++ b/src/progress-bar/internal.tsx
@@ -91,14 +91,14 @@ export const ResultState = ({ isInFlash, resultText, resultButtonText, status, o
 
   if (isInFlash) {
     return (
-      <div className={styles[`result-container-${status}`]} aria-live="polite" aria-atomic="true">
+      <div className={styles[`result-container-${status}`]}>
         <span className={styles['result-text']}>{resultText}</span>
       </div>
     );
   }
 
   return (
-    <div className={styles[`result-container-${status}`]} aria-live="polite" aria-atomic="true">
+    <div className={styles[`result-container-${status}`]}>
       <span className={clsx(hasResultButton && styles['with-result-button'])}>
         <InternalStatusIndicator type={status === 'success' ? 'success' : 'error'}>
           <span className={styles['result-text']}>{resultText}</span>


### PR DESCRIPTION
### Description

Before this change, the `resultState` was not live-announced when displayed becaue the content of the `aria-live` container did not change.

With this change, the `InternalLiveRegion` componnt takes care about the live announcement, once the `resultState` is rendered.

Related links, issue #, if available: AWSUI-60207

### How has this been tested?

- tested manually using Voice Over on Mac.
- How can reviewers test these changes efficiently?
  - Open the `with-updates` demo page, enable VO and click the "Start" button. Live announcement is happening once the loading is done.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
