### PR TITLE
fix: Correctly overlap sticky columns over static columns in borderless tables

### DIFF
--- a/pages/table/sticky-columns.page.tsx
+++ b/pages/table/sticky-columns.page.tsx
@@ -16,6 +16,8 @@ import ScreenshotArea from '../utils/screenshot-area';
 import { generateItems, Instance } from './generate-data';
 import { columnsConfig } from './shared-configs';
 
+import styles from './styles.scss';
+
 type DemoContext = React.Context<
   AppContextType<{
     loading: boolean;
@@ -340,7 +342,7 @@ export default () => {
           ariaLabels={{ ...ariaLabels, tableLabel: 'Inline editing table' }}
           header={<Header>Large table with inline editing</Header>}
         />
-        <div style={{ backgroundColor: 'orange' }}>
+        <div className={styles['borderless-wrapper']}>
           <Table
             {...collectionProps}
             variant="borderless"

--- a/pages/table/sticky-columns.page.tsx
+++ b/pages/table/sticky-columns.page.tsx
@@ -125,7 +125,7 @@ const COLUMN_DEFINITIONS: TableProps.ColumnDefinition<ExtendedInstance>[] = [
   {
     id: 'description-10',
     header: 'Description',
-    cell: item => <Link href="#">Link: {item.description}</Link> || '-',
+    cell: item => <Link href="#">Link: {item.description || '-'}</Link>,
     sortingField: 'description',
   },
   {
@@ -340,6 +340,23 @@ export default () => {
           ariaLabels={{ ...ariaLabels, tableLabel: 'Inline editing table' }}
           header={<Header>Large table with inline editing</Header>}
         />
+        <div style={{ backgroundColor: 'orange' }}>
+          <Table
+            {...collectionProps}
+            variant="borderless"
+            data-test-id="borderless-table"
+            stickyColumns={{
+              first: parseInt(urlParams.stickyColumnsFirst || '0'),
+              last: parseInt(urlParams.stickyColumnsLast || '0'),
+            }}
+            {...urlParams}
+            ariaLabels={{ ...ariaLabels, tableLabel: 'Borderless table' }}
+            columnDefinitions={COLUMN_DEFINITIONS}
+            selectedItems={selectedItems}
+            onSelectionChange={({ detail: { selectedItems } }) => setSelectedItems(selectedItems)}
+            items={items}
+          />
+        </div>
       </SpaceBetween>
     </ScreenshotArea>
   );

--- a/pages/table/styles.scss
+++ b/pages/table/styles.scss
@@ -1,0 +1,9 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+@use '~design-tokens' as tokens;
+
+.borderless-wrapper {
+  background-color: tokens.$color-background-status-warning;
+}

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -75,8 +75,8 @@ $cell-horizontal-padding: awsui.$space-scaled-l;
   &-variant-full-page.header-cell-hidden {
     border-block-end-color: transparent;
   }
-  &-variant-embedded.is-visual-refresh:not(.header-cell-sticky),
-  &-variant-borderless.is-visual-refresh:not(.header-cell-sticky) {
+  &-variant-embedded.is-visual-refresh:not(:is(.header-cell-sticky, .sticky-cell)),
+  &-variant-borderless.is-visual-refresh:not(:is(.header-cell-sticky, .sticky-cell)) {
     background: none;
   }
   &:last-child,


### PR DESCRIPTION
### Description

Spotted twice in Slack, looks like it was caused by #3198. The PR specifically skipped removing the background on the sticky header row, but missed the case of the sticky columns. I don't think there's any real fix besides restoring the background color to those sticky columns - and just not properly "supporting" sticky columns in transparent embedded tables.

Related links, issue #, if available: n/a

### How has this been tested?

Created a dev page addition for this.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
