### PR TITLE
chore: Changes hotspot click area to 24 pxs

### DIFF
--- a/pages/annotation-context/annotation-scroll.page.tsx
+++ b/pages/annotation-context/annotation-scroll.page.tsx
@@ -25,7 +25,7 @@ export default function AnnotationScroll() {
     document.documentElement.style.setProperty(
       properties.contentScrollMargin,
       // Add 4px to scroll-margin to avoid edge on edge
-      `calc(var(${fixedHeightVar}) + 4px) 0 calc(var(${fixedHeightVar}) + 4px) 0`
+      `calc(var(${fixedHeightVar}) + 6px) 0 calc(var(${fixedHeightVar}) + 6px) 0`
     );
   }, []);
 

--- a/src/annotation-context/annotation/annotation-icon.tsx
+++ b/src/annotation-context/annotation/annotation-icon.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import styles from './styles.css.js';
 
@@ -8,43 +8,43 @@ interface AnnotationIconProps {
   open?: boolean;
 }
 
-export const AnnotationIcon = ({ open }: AnnotationIconProps) => {
-  if (open) {
-    return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
-        viewBox="0 0 16 16"
-        focusable="false"
-        aria-hidden="true"
-        className={styles.icon}
-      >
-        <g fill="none" fillRule="evenodd" transform="translate(1 1)">
-          <circle cx="7" cy="7" r="7" strokeWidth="2" />
-          <path strokeLinecap="square" strokeWidth="2.2" d="M2.5,-1 L2.5,3" transform="rotate(90 1.75 6.25)" />
-        </g>
-      </svg>
-    );
-  } else {
-    return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
-        viewBox="0 0 16 16"
-        focusable="false"
-        aria-hidden="true"
-        className={styles.icon}
-      >
-        <g fill="none" fillRule="evenodd" transform="translate(1 1)">
-          <circle cx="7" cy="7" r="7" strokeWidth="2" />
-          <g strokeLinecap="square" strokeWidth="2.2" transform="translate(4.5 5)">
-            <path d="M2.5,0 L2.5,4" transform="rotate(90 2.5 2)" />
-            <path d="M2.5,0 L2.5,4" />
+export const AnnotationIcon = forwardRef<HTMLDivElement, AnnotationIconProps>(({ open }, ref) => {
+  return (
+    <div className={styles['icon-wrapper']} ref={ref}>
+      {open ? (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          focusable="false"
+          aria-hidden="true"
+          className={styles.icon}
+        >
+          <g fill="none" fillRule="evenodd" transform="translate(1 1)">
+            <circle cx="7" cy="7" r="7" strokeWidth="2" />
+            <path strokeLinecap="square" strokeWidth="2.2" d="M2.5,-1 L2.5,3" transform="rotate(90 1.75 6.25)" />
           </g>
-        </g>
-      </svg>
-    );
-  }
-};
+        </svg>
+      ) : (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          focusable="false"
+          aria-hidden="true"
+          className={styles.icon}
+        >
+          <g fill="none" fillRule="evenodd" transform="translate(1 1)">
+            <circle cx="7" cy="7" r="7" strokeWidth="2" />
+            <g strokeLinecap="square" strokeWidth="2.2" transform="translate(4.5 5)">
+              <path d="M2.5,0 L2.5,4" transform="rotate(90 2.5 2)" />
+              <path d="M2.5,0 L2.5,4" />
+            </g>
+          </g>
+        </svg>
+      )}
+    </div>
+  );
+});

--- a/src/annotation-context/annotation/annotation-trigger.tsx
+++ b/src/annotation-context/annotation/annotation-trigger.tsx
@@ -15,10 +15,11 @@ interface AnnotationTriggerProps {
   i18nStrings: AnnotationContextProps['i18nStrings'];
   taskLocalStepIndex: number;
   totalLocalSteps: number;
+  iconRef?: React.Ref<HTMLDivElement>;
 }
 
 export default React.forwardRef<HTMLButtonElement, AnnotationTriggerProps>(function AnnotationTrigger(
-  { open, onClick: onClickHandler, i18nStrings, taskLocalStepIndex, totalLocalSteps }: AnnotationTriggerProps,
+  { open, onClick: onClickHandler, i18nStrings, taskLocalStepIndex, totalLocalSteps, iconRef }: AnnotationTriggerProps,
   ref
 ) {
   const onClick = useCallback(
@@ -37,7 +38,7 @@ export default React.forwardRef<HTMLButtonElement, AnnotationTriggerProps>(funct
       aria-label={i18nStrings.labelHotspot(open, taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)}
       onClick={onClick}
     >
-      <AnnotationIcon open={open} />
+      <AnnotationIcon open={open} ref={iconRef} />
     </button>
   );
 });

--- a/src/annotation-context/annotation/open-annotation.tsx
+++ b/src/annotation-context/annotation/open-annotation.tsx
@@ -58,7 +58,7 @@ export function OpenAnnotation({
   onPreviousButtonClick,
   i18nStrings,
 }: AnnotationProps) {
-  const trackRef = useRef<HTMLButtonElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
 
   return (
     <>
@@ -66,7 +66,7 @@ export function OpenAnnotation({
         open={true}
         onClick={onDismiss}
         i18nStrings={i18nStrings}
-        ref={trackRef}
+        iconRef={trackRef}
         totalLocalSteps={totalLocalSteps}
         taskLocalStepIndex={taskLocalStepIndex}
       />

--- a/src/annotation-context/annotation/styles.scss
+++ b/src/annotation-context/annotation/styles.scss
@@ -48,12 +48,6 @@
   padding-inline: awsui.$space-xxs;
   padding-block: awsui.$space-xxs;
   cursor: pointer;
-  scroll-margin: var(#{custom-props.$contentScrollMargin}, 40px 0 0 0);
-  box-sizing: content-box;
-
-  // These dimensions match the dimensions of the contained SVG icon.
-  inline-size: 16px;
-  block-size: 16px;
 
   &:focus {
     outline: none;
@@ -63,9 +57,17 @@
     @include styles.focus-highlight(2px, awsui.$border-radius-control-circular-focus-ring);
   }
 
-  > .icon {
+  > .icon-wrapper {
     position: relative;
-    stroke: awsui.$color-text-link-default;
+    scroll-margin: var(#{custom-props.$contentScrollMargin}, 40px 0 0 0);
+
+    // These dimensions match the dimensions of the contained SVG icon.
+    inline-size: 16px;
+    block-size: 16px;
+
+    > .icon {
+      stroke: awsui.$color-text-link-default;
+    }
   }
 
   &:hover {

--- a/src/annotation-context/annotation/styles.scss
+++ b/src/annotation-context/annotation/styles.scss
@@ -45,10 +45,11 @@
   background: transparent;
   border-block: none;
   border-inline: none;
-  padding-block: 0;
-  padding-inline: 0;
+  padding-inline: awsui.$space-xxs;
+  padding-block: awsui.$space-xxs;
   cursor: pointer;
   scroll-margin: var(#{custom-props.$contentScrollMargin}, 40px 0 0 0);
+  box-sizing: content-box;
 
   // These dimensions match the dimensions of the contained SVG icon.
   inline-size: 16px;

--- a/src/hotspot/index.tsx
+++ b/src/hotspot/index.tsx
@@ -51,9 +51,10 @@ export default function Hotspot({
       {...baseProps}
       className={clsx(baseProps.className, styles.root, styles.inlineWrapper)}
       ref={__internalRootRef}
-      onClick={e => e.stopPropagation()}
     >
-      {content}
+      <div className={styles.markerWrapper} onClick={e => e.stopPropagation()}>
+        {content}
+      </div>
     </span>
   );
 }

--- a/src/hotspot/styles.scss
+++ b/src/hotspot/styles.scss
@@ -36,9 +36,9 @@
   position: relative;
   vertical-align: text-top;
   inline-size: awsui.$space-scaled-m;
-  background: red;
+  min-block-size: 1em;
 
-  & > .markerWrapper {
+  > .markerWrapper {
     inset-block-start: calc(-1 * (#{awsui.$space-xxxs} + #{awsui.$space-xxs}));
   }
 }

--- a/src/hotspot/styles.scss
+++ b/src/hotspot/styles.scss
@@ -20,20 +20,25 @@
 
 .markerWrapper {
   position: absolute;
-
-  inset-block-start: 0;
+  inset-block-start: calc(-1 * #{awsui.$space-xxs});
 }
 
 .placement-right {
   inset-inline-start: 100%;
-  margin-inline-start: awsui.$space-xxs;
 }
 
 .placement-left {
   inset-inline-end: 100%;
-  margin-inline-end: awsui.$space-xxs;
 }
 
 .inlineWrapper {
-  margin-inline-start: awsui.$space-xxs;
+  display: inline-block;
+  position: relative;
+  vertical-align: text-top;
+  inline-size: awsui.$space-scaled-m;
+  background: red;
+
+  & > .markerWrapper {
+    inset-block-start: calc(-1 * (#{awsui.$space-xxxs} + #{awsui.$space-xxs}));
+  }
 }


### PR DESCRIPTION
### Description

Increases the hotspot button size to 24x24 according to WCAG2.2 guidelines.

### Reviewer notes

Increasing the button size would change the occupying space the button. Also it increases the space between the icon (16x16) and the popover that appears next to it. To avoid visual change:

* The popover tracking `ref` moved to the icon. Previously it was on the button.
* Icon is now wrapper into a `<div />` whose `ref` we use for the popover positioning.
* We changed the positioning in the use case (`<Hotspot />`) rather than the button itself (`<AnnotationTrigger />`) to match the previous visuals.

Related links, issue #, if available: AWSUI-60217

### How has this been tested?

Dev pipeline visual tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
