### PR TITLE
fix: Rigorizing the isStuck logic in container use-sticky-header

### DIFF
--- a/src/container/__tests__/sticky-header.test.tsx
+++ b/src/container/__tests__/sticky-header.test.tsx
@@ -25,7 +25,64 @@ beforeEach(() => {
 describe.each(['embedded', 'full-page', 'cards', 'default', 'stacked'] as Array<
   ContainerProps['variant'] | 'embedded' | 'full-page' | 'cards'
 >)('useStickyHeader with variant %s', variant => {
-  test('should set isStuck to true when rootTop is less than headerTop', () => {
+  test('should set isStuck to false when rootTop headerTop are equal and headerTop is not 0', () => {
+    const rootRef = {
+      current: document.createElement('div'),
+    };
+    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+
+    const headerRef = {
+      current: document.createElement('div'),
+    };
+    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+
+    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current.isStuck).toBe(false);
+  });
+
+  test('should set isStuck to true when rootTop less than a headerTop at 0', () => {
+    const rootRef = {
+      current: document.createElement('div'),
+    };
+    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: -100 });
+
+    const headerRef = {
+      current: document.createElement('div'),
+    };
+    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 0 });
+
+    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current.isStuck).toBe(true);
+  });
+
+  test('should set isStuck to false when rootTop and headerTop are equal at 0', () => {
+    const rootRef = {
+      current: document.createElement('div'),
+    };
+    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 0 });
+
+    const headerRef = {
+      current: document.createElement('div'),
+    };
+    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 0 });
+
+    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current.isStuck).toBe(false);
+  });
+
+  test('should set isStuck correctly when rootTop is less than headerTop', () => {
     const rootRef = {
       current: document.createElement('div'),
     };
@@ -41,10 +98,10 @@ describe.each(['embedded', 'full-page', 'cards', 'default', 'stacked'] as Array<
       window.dispatchEvent(new Event('scroll'));
     });
 
-    expect(result.current.isStuck).toBe(true);
+    expect(result.current.isStuck).toBe(variant === 'full-page');
   });
 
-  test('should set isStuck to false when rootTop is larger than than headerTop', () => {
+  test('should set isStuck to false when rootTop is larger than than nonZero headerTop', () => {
     const rootRef = {
       current: document.createElement('div'),
     };
@@ -54,6 +111,25 @@ describe.each(['embedded', 'full-page', 'cards', 'default', 'stacked'] as Array<
       current: document.createElement('div'),
     };
     headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+
+    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current.isStuck).toBe(false);
+  });
+
+  test('should set isStuck to false when rootTop is larger than than zero headerTop', () => {
+    const rootRef = {
+      current: document.createElement('div'),
+    };
+    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
+
+    const headerRef = {
+      current: document.createElement('div'),
+    };
+    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 0 });
 
     const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
     act(() => {

--- a/src/container/__tests__/sticky-header.test.tsx
+++ b/src/container/__tests__/sticky-header.test.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { act, renderHook } from '../../__tests__/render-hook';
-import { ContainerProps } from '../interfaces';
 import { useStickyHeader } from '../use-sticky-header';
+
 jest.mock('../../../lib/components/container/use-sticky-header', () => ({
   useStickyHeader: () => ({ isSticky: true }),
 }));
@@ -22,215 +22,211 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-describe.each(['embedded', 'full-page', 'cards', 'default', 'stacked', 'borderless'] as Array<
-  ContainerProps['variant'] | 'embedded' | 'full-page' | 'borderless' | 'cards'
->)('useStickyHeader with variant of %s', variant => {
-  test('should set isStuck to false when __stickyHeader is false', () => {
-    const rootRef = {
-      current: document.createElement('div'),
-    };
-    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+test('should set isStuck to false when __stickyHeader is false', () => {
+  const rootRef = {
+    current: document.createElement('div'),
+  };
+  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
 
-    const headerRef = {
-      current: document.createElement('div'),
-    };
-    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: -200 });
+  const headerRef = {
+    current: document.createElement('div'),
+  };
+  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: -200 });
 
-    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, false, 0, 0, false));
-    act(() => {
-      window.dispatchEvent(new Event('scroll'));
-    });
-
-    expect(result.current.isStuck).toBe(false);
+  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, false, 0, 0, false));
+  act(() => {
+    window.dispatchEvent(new Event('scroll'));
   });
 
-  test('should set isStuck to false when __disableMobile is false', () => {
-    const rootRef = {
-      current: document.createElement('div'),
-    };
-    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+  expect(result.current.isStuck).toBe(false);
+});
 
-    const headerRef = {
-      current: document.createElement('div'),
-    };
-    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: -200 });
+test('should set isStuck to false when __disableMobile is false', () => {
+  const rootRef = {
+    current: document.createElement('div'),
+  };
+  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
 
-    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, true));
-    act(() => {
-      window.dispatchEvent(new Event('scroll'));
-    });
+  const headerRef = {
+    current: document.createElement('div'),
+  };
+  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: -200 });
 
-    expect(result.current.isStuck).toBe(false);
+  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, true));
+  act(() => {
+    window.dispatchEvent(new Event('scroll'));
   });
 
-  test('should set isStuck to false when rootTop headerTop are equal and headerTop is not 0', () => {
-    const rootRef = {
-      current: document.createElement('div'),
-    };
-    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+  expect(result.current.isStuck).toBe(false);
+});
 
-    const headerRef = {
-      current: document.createElement('div'),
-    };
-    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+test('should set isStuck to false when rootTop headerTop are equal and headerTop is not 0', () => {
+  const rootRef = {
+    current: document.createElement('div'),
+  };
+  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
 
-    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
-    act(() => {
-      window.dispatchEvent(new Event('scroll'));
-    });
+  const headerRef = {
+    current: document.createElement('div'),
+  };
+  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
 
-    expect(result.current.isStuck).toBe(false);
+  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
+  act(() => {
+    window.dispatchEvent(new Event('scroll'));
   });
 
-  test('should set isStuck to true when rootTop less than a headerTop at 0', () => {
-    const rootRef = {
-      current: document.createElement('div'),
-    };
-    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: -100 });
+  expect(result.current.isStuck).toBe(false);
+});
 
-    const headerRef = {
-      current: document.createElement('div'),
-    };
-    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 0 });
+test('should set isStuck to true when rootTop less than a headerTop at 0', () => {
+  const rootRef = {
+    current: document.createElement('div'),
+  };
+  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: -100 });
 
-    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
-    act(() => {
-      window.dispatchEvent(new Event('scroll'));
-    });
+  const headerRef = {
+    current: document.createElement('div'),
+  };
+  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 0 });
 
-    expect(result.current.isStuck).toBe(true);
+  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
+  act(() => {
+    window.dispatchEvent(new Event('scroll'));
   });
 
-  test('should set isStuck to false when rootTop and headerTop are equal at 0', () => {
-    const rootRef = {
-      current: document.createElement('div'),
-    };
-    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 0 });
+  expect(result.current.isStuck).toBe(true);
+});
 
-    const headerRef = {
-      current: document.createElement('div'),
-    };
-    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 0 });
+test('should set isStuck to false when rootTop and headerTop are equal at 0', () => {
+  const rootRef = {
+    current: document.createElement('div'),
+  };
+  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 0 });
 
-    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
-    act(() => {
-      window.dispatchEvent(new Event('scroll'));
-    });
+  const headerRef = {
+    current: document.createElement('div'),
+  };
+  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 0 });
 
-    expect(result.current.isStuck).toBe(false);
+  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
+  act(() => {
+    window.dispatchEvent(new Event('scroll'));
   });
 
-  test('should set isStuck correctly when rootTop is less than headerTop', () => {
-    const rootRef = {
-      current: document.createElement('div'),
-    };
-    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+  expect(result.current.isStuck).toBe(false);
+});
 
-    const headerRef = {
-      current: document.createElement('div'),
-    };
-    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
+test('should set isStuck to true when rootTop is less than headerTop', () => {
+  const rootRef = {
+    current: document.createElement('div'),
+  };
+  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
 
-    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
-    act(() => {
-      window.dispatchEvent(new Event('scroll'));
-    });
+  const headerRef = {
+    current: document.createElement('div'),
+  };
+  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
 
-    expect(result.current.isStuck).toBe(variant === 'full-page');
+  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
+  act(() => {
+    window.dispatchEvent(new Event('scroll'));
   });
 
-  test('should set isStuck to false when rootTop is larger than than nonZero headerTop', () => {
-    const rootRef = {
-      current: document.createElement('div'),
-    };
-    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
+  expect(result.current.isStuck).toBe(true);
+});
 
-    const headerRef = {
-      current: document.createElement('div'),
-    };
-    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+test('should set isStuck to false when rootTop is larger than than nonZero headerTop', () => {
+  const rootRef = {
+    current: document.createElement('div'),
+  };
+  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
 
-    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
-    act(() => {
-      window.dispatchEvent(new Event('scroll'));
-    });
+  const headerRef = {
+    current: document.createElement('div'),
+  };
+  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
 
-    expect(result.current.isStuck).toBe(false);
+  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
+  act(() => {
+    window.dispatchEvent(new Event('scroll'));
   });
 
-  test('should set isStuck to false when rootTop is larger than than zero headerTop', () => {
-    const rootRef = {
-      current: document.createElement('div'),
-    };
-    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
+  expect(result.current.isStuck).toBe(false);
+});
 
-    const headerRef = {
-      current: document.createElement('div'),
-    };
-    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 0 });
+test('should set isStuck to false when rootTop is larger than than zero headerTop', () => {
+  const rootRef = {
+    current: document.createElement('div'),
+  };
+  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
 
-    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
-    act(() => {
-      window.dispatchEvent(new Event('scroll'));
-    });
+  const headerRef = {
+    current: document.createElement('div'),
+  };
+  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 0 });
 
-    expect(result.current.isStuck).toBe(false);
+  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
+  act(() => {
+    window.dispatchEvent(new Event('scroll'));
   });
 
-  test('should not set isStuck to true when rootTop has a border and is larger than than headerTop', () => {
-    const rootRef = {
-      current: document.createElement('div'),
-    };
-    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 199 });
-    rootRef.current.style.borderTopWidth = '1px';
+  expect(result.current.isStuck).toBe(false);
+});
 
-    const headerRef = {
-      current: document.createElement('div'),
-    };
-    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
+test('should not set isStuck to true when rootTop has a border and is larger than than headerTop', () => {
+  const rootRef = {
+    current: document.createElement('div'),
+  };
+  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 199 });
+  rootRef.current.style.borderTopWidth = '1px';
 
-    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
-    act(() => {
-      window.dispatchEvent(new Event('scroll'));
-    });
+  const headerRef = {
+    current: document.createElement('div'),
+  };
+  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
 
-    expect(result.current.isStuck).toBe(false);
+  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
+  act(() => {
+    window.dispatchEvent(new Event('scroll'));
   });
 
-  test('should set isStuck to false when headerRef is null', () => {
-    const rootRef = {
-      current: document.createElement('div'),
-    };
-    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
+  expect(result.current.isStuck).toBe(false);
+});
 
-    const headerRef = {
-      current: null,
-    };
+test('should set isStuck to false when headerRef is null', () => {
+  const rootRef = {
+    current: document.createElement('div'),
+  };
+  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
 
-    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
-    act(() => {
-      window.dispatchEvent(new Event('scroll'));
-    });
+  const headerRef = {
+    current: null,
+  };
 
-    expect(result.current.isStuck).toBe(false);
+  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
+  act(() => {
+    window.dispatchEvent(new Event('scroll'));
   });
 
-  test('should not react to synthetic window resize events', () => {
-    const rootRef = {
-      current: document.createElement('div'),
-    };
-    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+  expect(result.current.isStuck).toBe(false);
+});
 
-    const headerRef = {
-      current: document.createElement('div'),
-    };
-    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
+test('should not react to synthetic window resize events', () => {
+  const rootRef = {
+    current: document.createElement('div'),
+  };
+  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
 
-    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
-    act(() => {
-      window.dispatchEvent(new Event('resize'));
-    });
+  const headerRef = {
+    current: document.createElement('div'),
+  };
+  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
 
-    expect(result.current.isStuck).toBe(false);
+  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
+  act(() => {
+    window.dispatchEvent(new Event('resize'));
   });
+
+  expect(result.current.isStuck).toBe(false);
 });

--- a/src/container/__tests__/sticky-header.test.tsx
+++ b/src/container/__tests__/sticky-header.test.tsx
@@ -25,7 +25,7 @@ beforeEach(() => {
 describe.each(['embedded', 'full-page', 'cards', 'default', 'stacked'] as Array<
   ContainerProps['variant'] | 'embedded' | 'full-page' | 'cards'
 >)('useStickyHeader with variant %s', variant => {
-  test('should set isStuck properly when rootTop is less than headerTop', () => {
+  test('should set isStuck to true when rootTop is less than headerTop', () => {
     const rootRef = {
       current: document.createElement('div'),
     };
@@ -41,7 +41,7 @@ describe.each(['embedded', 'full-page', 'cards', 'default', 'stacked'] as Array<
       window.dispatchEvent(new Event('scroll'));
     });
 
-    expect(result.current.isStuck).toBe(variant === 'full-page');
+    expect(result.current.isStuck).toBe(true);
   });
 
   test('should set isStuck to false when rootTop is larger than than headerTop', () => {

--- a/src/container/__tests__/sticky-header.test.tsx
+++ b/src/container/__tests__/sticky-header.test.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { act, renderHook } from '../../__tests__/render-hook';
+import { ContainerProps } from '../interfaces';
 import { useStickyHeader } from '../use-sticky-header';
 jest.mock('../../../lib/components/container/use-sticky-header', () => ({
   useStickyHeader: () => ({ isSticky: true }),
@@ -21,97 +22,101 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-test('should set isStuck to true when rootTop is less than headerTop', () => {
-  const rootRef = {
-    current: document.createElement('div'),
-  };
-  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+describe.each(['embedded', 'full-page', 'cards', 'default', 'stacked'] as Array<
+  ContainerProps['variant'] | 'embedded' | 'full-page' | 'cards'
+>)('useStickyHeader with variant %s', variant => {
+  test('should set isStuck properly when rootTop is less than headerTop', () => {
+    const rootRef = {
+      current: document.createElement('div'),
+    };
+    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
 
-  const headerRef = {
-    current: document.createElement('div'),
-  };
-  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
+    const headerRef = {
+      current: document.createElement('div'),
+    };
+    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
 
-  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
-  act(() => {
-    window.dispatchEvent(new Event('scroll'));
+    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current.isStuck).toBe(variant === 'full-page');
   });
 
-  expect(result.current.isStuck).toBe(true);
-});
+  test('should set isStuck to false when rootTop is larger than than headerTop', () => {
+    const rootRef = {
+      current: document.createElement('div'),
+    };
+    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
 
-test('should set isStuck to false when rootTop is larger than than headerTop', () => {
-  const rootRef = {
-    current: document.createElement('div'),
-  };
-  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
+    const headerRef = {
+      current: document.createElement('div'),
+    };
+    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
 
-  const headerRef = {
-    current: document.createElement('div'),
-  };
-  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
 
-  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
-  act(() => {
-    window.dispatchEvent(new Event('scroll'));
+    expect(result.current.isStuck).toBe(false);
   });
 
-  expect(result.current.isStuck).toBe(false);
-});
+  test('should not set isStuck to true when rootTop has a border and is larger than than headerTop', () => {
+    const rootRef = {
+      current: document.createElement('div'),
+    };
+    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 199 });
+    rootRef.current.style.borderTopWidth = '1px';
 
-test('should not set isStuck to true when rootTop has a border and is larger than than headerTop', () => {
-  const rootRef = {
-    current: document.createElement('div'),
-  };
-  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 199 });
-  rootRef.current.style.borderTopWidth = '1px';
+    const headerRef = {
+      current: document.createElement('div'),
+    };
+    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
 
-  const headerRef = {
-    current: document.createElement('div'),
-  };
-  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
+    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
 
-  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
-  act(() => {
-    window.dispatchEvent(new Event('scroll'));
+    expect(result.current.isStuck).toBe(false);
   });
 
-  expect(result.current.isStuck).toBe(false);
-});
+  test('should set isStuck to false when headerRef is null', () => {
+    const rootRef = {
+      current: document.createElement('div'),
+    };
+    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
 
-test('should set isStuck to false when headerRef is null', () => {
-  const rootRef = {
-    current: document.createElement('div'),
-  };
-  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
+    const headerRef = {
+      current: null,
+    };
 
-  const headerRef = {
-    current: null,
-  };
+    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
 
-  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
-  act(() => {
-    window.dispatchEvent(new Event('scroll'));
+    expect(result.current.isStuck).toBe(false);
   });
 
-  expect(result.current.isStuck).toBe(false);
-});
+  test('should not react to synthetic window resize events', () => {
+    const rootRef = {
+      current: document.createElement('div'),
+    };
+    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
 
-test('should not react to synthetic window resize events', () => {
-  const rootRef = {
-    current: document.createElement('div'),
-  };
-  rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+    const headerRef = {
+      current: document.createElement('div'),
+    };
+    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
 
-  const headerRef = {
-    current: document.createElement('div'),
-  };
-  headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 200 });
+    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, false));
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
 
-  const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, true, 0, 0, false));
-  act(() => {
-    window.dispatchEvent(new Event('resize'));
+    expect(result.current.isStuck).toBe(false);
   });
-
-  expect(result.current.isStuck).toBe(false);
 });

--- a/src/container/__tests__/sticky-header.test.tsx
+++ b/src/container/__tests__/sticky-header.test.tsx
@@ -22,9 +22,47 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-describe.each(['embedded', 'full-page', 'cards', 'default', 'stacked'] as Array<
-  ContainerProps['variant'] | 'embedded' | 'full-page' | 'cards'
->)('useStickyHeader with variant %s', variant => {
+describe.each(['embedded', 'full-page', 'cards', 'default', 'stacked', 'borderless'] as Array<
+  ContainerProps['variant'] | 'embedded' | 'full-page' | 'borderless' | 'cards'
+>)('useStickyHeader with variant of %s', variant => {
+  test('should set isStuck to false when __stickyHeader is false', () => {
+    const rootRef = {
+      current: document.createElement('div'),
+    };
+    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+
+    const headerRef = {
+      current: document.createElement('div'),
+    };
+    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: -200 });
+
+    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, false, 0, 0, false));
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current.isStuck).toBe(false);
+  });
+
+  test('should set isStuck to false when __disableMobile is false', () => {
+    const rootRef = {
+      current: document.createElement('div'),
+    };
+    rootRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: 100 });
+
+    const headerRef = {
+      current: document.createElement('div'),
+    };
+    headerRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ top: -200 });
+
+    const { result } = renderHook(() => useStickyHeader(rootRef, headerRef, variant, true, 0, 0, true));
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current.isStuck).toBe(false);
+  });
+
   test('should set isStuck to false when rootTop headerTop are equal and headerTop is not 0', () => {
     const rootRef = {
       current: document.createElement('div'),

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -87,7 +87,6 @@ export default function InternalContainer({
   const { isSticky, isStuck, stickyStyles } = useStickyHeader(
     rootRef,
     headerRef,
-    variant,
     __stickyHeader,
     __stickyOffset,
     __mobileStickyOffset,

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -87,6 +87,7 @@ export default function InternalContainer({
   const { isSticky, isStuck, stickyStyles } = useStickyHeader(
     rootRef,
     headerRef,
+    variant,
     __stickyHeader,
     __stickyOffset,
     __mobileStickyOffset,

--- a/src/container/use-sticky-header.ts
+++ b/src/container/use-sticky-header.ts
@@ -8,7 +8,6 @@ import * as tokens from '../internal/generated/styles/tokens';
 import { useMobile } from '../internal/hooks/use-mobile';
 import globalVars from '../internal/styles/global-vars';
 import { getOverflowParents } from '../internal/utils/scrollable-containers';
-import { ContainerProps } from './interfaces';
 
 interface StickyHeaderContextProps {
   isStuck: boolean;
@@ -45,10 +44,6 @@ export const StickyHeaderContext = createContext<StickyHeaderContextProps>({
 export const useStickyHeader = (
   rootRef: RefObject<HTMLDivElement>,
   headerRef: RefObject<HTMLDivElement>,
-  /**
-   * variant extends those from the ContainerProps to also include those from table
-   */
-  variant: ContainerProps['variant'] | 'embedded' | 'full-page' | 'cards' | 'borderless' = 'default',
   __stickyHeader?: boolean,
   __stickyOffset?: number,
   __mobileStickyOffset?: number,
@@ -105,15 +100,14 @@ export const useStickyHeader = (
         //using Math.round to adjust for rounding errors in floating-point arithmetic and timing issues
         const rootTop = Math.round((rootRef.current.getBoundingClientRect().top + rootTopBorderWidth) * 10000) / 10000;
         const headerTop = Math.round(headerRef.current.getBoundingClientRect().top * 10000) / 10000;
-
-        if (rootTop < headerTop && (variant === 'full-page' || headerTop === 0)) {
+        if (rootTop < headerTop) {
           setIsStuck(true);
         } else {
           setIsStuck(false);
         }
       }
     },
-    [rootRef, headerRef, variant]
+    [rootRef, headerRef]
   );
 
   useEffect(() => {

--- a/src/container/use-sticky-header.ts
+++ b/src/container/use-sticky-header.ts
@@ -45,7 +45,10 @@ export const StickyHeaderContext = createContext<StickyHeaderContextProps>({
 export const useStickyHeader = (
   rootRef: RefObject<HTMLDivElement>,
   headerRef: RefObject<HTMLDivElement>,
-  variant: ContainerProps['variant'] | 'embedded' | 'full-page' | 'cards' = 'default',
+  /**
+   * variant extends those from the ContainerProps to also include those from table
+   */
+  variant: ContainerProps['variant'] | 'embedded' | 'full-page' | 'cards' | 'borderless' = 'default',
   __stickyHeader?: boolean,
   __stickyOffset?: number,
   __mobileStickyOffset?: number,
@@ -112,6 +115,7 @@ export const useStickyHeader = (
     },
     [rootRef, headerRef, variant]
   );
+
   useEffect(() => {
     if (isSticky) {
       const controller = new AbortController();

--- a/src/container/use-sticky-header.ts
+++ b/src/container/use-sticky-header.ts
@@ -97,9 +97,9 @@ export const useStickyHeader = (
       }
       if (rootRef.current && headerRef.current) {
         const rootTopBorderWidth = parseFloat(getComputedStyle(rootRef.current).borderTopWidth) || 0;
-        //using Math.round to adjust for rounding errors in floating-point arithmetic and timing issues
-        const rootTop = Math.round((rootRef.current.getBoundingClientRect().top + rootTopBorderWidth) * 10000) / 10000;
-        const headerTop = Math.round(headerRef.current.getBoundingClientRect().top * 10000) / 10000;
+        // Using Math.round to adjust for rounding errors in floating-point arithmetic and timing issues
+        const rootTop = Math.round(rootRef.current.getBoundingClientRect().top + rootTopBorderWidth);
+        const headerTop = Math.round(headerRef.current.getBoundingClientRect().top);
         if (rootTop < headerTop) {
           setIsStuck(true);
         } else {

--- a/src/container/use-sticky-header.ts
+++ b/src/container/use-sticky-header.ts
@@ -98,20 +98,12 @@ export const useStickyHeader = (
         return;
       }
       if (rootRef.current && headerRef.current) {
-        // const overflowParents = getOverflowParents(rootRef.current);
-        // const mainElement = findUpUntil(rootRef.current, elem => elem.tagName === 'MAIN');
         const rootTopBorderWidth = parseFloat(getComputedStyle(rootRef.current).borderTopWidth) || 0;
-        //using math.Round to adjust for rounding errors in floating-point arithmetic and timing issues
+        //using Math.round to adjust for rounding errors in floating-point arithmetic and timing issues
         const rootTop = Math.round((rootRef.current.getBoundingClientRect().top + rootTopBorderWidth) * 10000) / 10000;
         const headerTop = Math.round(headerRef.current.getBoundingClientRect().top * 10000) / 10000;
 
-        // console.log({ headerTopDistance, currentHTD: rootTop - headerTop, overflowParents, mainElement, rootTopBorderWidth, rootTop, headerTop, variant, isStuck: (variant === 'full-page' || headerTop === 0 || hasInnerOverflowParents) && rootTop < headerTop})
-        if (
-          (variant === 'full-page' ||
-            headerTop === 0 || //when the header is at the top of the page
-            headerTop !== rootTop) &&
-          rootTop < headerTop
-        ) {
+        if (rootTop < headerTop && (variant === 'full-page' || headerTop === 0)) {
           setIsStuck(true);
         } else {
           setIsStuck(false);


### PR DESCRIPTION
### Description

The previous isStuck logic was causing some unintended visual issues. When the isStuck condition was falsey set to true, it was removing the border radius on an internal element. This caused that element to overlay on top of its parent container, hiding the curved borders on the corners. This problem became more noticeable when the screen was viewed at different zoom levels.

The isStuck was being falsely set to true because why the top pixel values from sequentially calling `.getBoundingClientRect()` on a parent and nested child element might not return the same values, even if they are in the same position. Here are some reasons as to why:

- Timing issues: The `.getBoundingClientRect()` method returns the size and position of the element relative to the viewport, and this can change slightly between the two calls if the element is being scrolled or resized during that time. This is especially true if the function is being called on scroll, as the element's position may have shifted slightly between the two calls.
- Pixel differences and rounding: The values returned by `.getBoundingClientRect() `are in pixels, but there can be small differences in the decimal places due to browser rounding and the way floating-point numbers are represented in JavaScript. This can result in slight discrepancies, even if the elements are in the same position.
- Subpixel rendering: Modern browsers use subpixel rendering to improve the appearance of text and graphics on high-resolution displays. This can result in slightly different bounding rectangle values, even for elements that appear to be in the same position.

To mitigate the issue, I wrap the returned values in a `Math.round()` function as I noticed the differences were often in the .00001's of pixels. This seems to resolve the issue.

<img width="162" alt="broken-corner" src="https://github.com/user-attachments/assets/ae7278bf-f9b7-471d-ac24-7ff60cef4883" />




<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-60267

### How has this been tested?

- unit test cases have been added for more conditionals
- integ passes test
- visual regression tests pass in dev pipeline

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
