### PR TITLE
chore: Adds pseudo element around the annotation trigger

### DIFF
--- a/src/annotation-context/annotation/styles.scss
+++ b/src/annotation-context/annotation/styles.scss
@@ -49,10 +49,18 @@
   padding-inline: 0;
   cursor: pointer;
   scroll-margin: var(#{custom-props.$contentScrollMargin}, 40px 0 0 0);
+  position: relative;
 
   // These dimensions match the dimensions of the contained SVG icon.
   inline-size: 16px;
   block-size: 16px;
+
+  // Extends the clickable area beyond the actual size of the button
+  &:before {
+    content: '';
+    position: absolute;
+    inset: calc(-1 * #{awsui.$space-xxs});
+  }
 
   &:focus {
     outline: none;


### PR DESCRIPTION
### Description

Extends the clickable area of the hotspot button to 24 pixels. This is to conform to WCAG 2.2 specs.

Related links, issue #, if available: AWSUI-60217

A more complicated solution with many more moving parts is also available in #3237. Feel free to compare the both solutions but we are leaning toward this solution which is simpler.

### How has this been tested?

Dev pipeline screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
