### PR TITLE
chore: add close-stale-issues workflow

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,31 @@
+
+
+name: "Close Stale Issues"
+
+on:
+  # allow to run manually when needed
+  workflow_dispatch:
+  # at 7:15 and 19:15 every day
+  schedule:
+    - cron: "15 7,19 * * *"
+
+jobs:
+  cleanup:
+    permissions:
+      issues: write
+      contents: read
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+      - uses: aws-actions/stale-issue-cleanup@v6
+        with:
+          issue-types: issues
+
+          stale-issue-message: This issue will automatically resolve if we don't hear back from you soon.
+          response-requested-label: response-requested
+          stale-issue-label: closing-soon
+
+          days-before-stale: 6
+          days-before-close: 3
+
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

After testing in https://github.com/cloudscape-design/demos/pull/184, apply the same workflow to the main repo (other repos with issues support will follow)

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
