### PR TITLE
revert: chore: Adds pseudo element around the annotation trigger

### DIFF
--- a/src/annotation-context/annotation/styles.scss
+++ b/src/annotation-context/annotation/styles.scss
@@ -49,18 +49,10 @@
   padding-inline: 0;
   cursor: pointer;
   scroll-margin: var(#{custom-props.$contentScrollMargin}, 40px 0 0 0);
-  position: relative;
 
   // These dimensions match the dimensions of the contained SVG icon.
   inline-size: 16px;
   block-size: 16px;
-
-  // Extends the clickable area beyond the actual size of the button
-  &:before {
-    content: '';
-    position: absolute;
-    inset: calc(-1 * #{awsui.$space-xxs});
-  }
 
   &:focus {
     outline: none;


### PR DESCRIPTION
Reverts cloudscape-design/components#3246

Seems that this is causing the hotspot to disappear in some circumstances in Firefox.