### PR TITLE
chore: Removes dependencies on React <19 in test utils

### DIFF
--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import * as React from 'react';
+import React, { useState } from 'react';
 import { render } from '@testing-library/react';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
@@ -27,6 +27,20 @@ const defaultProps: AutosuggestProps = {
   onChange: () => {},
   options: defaultOptions,
 };
+
+function StatefulAutosuggest(props: AutosuggestProps) {
+  const [value, setValue] = useState(props.value);
+  return (
+    <Autosuggest
+      {...props}
+      value={value}
+      onChange={event => {
+        props.onChange?.(event);
+        setValue(event.detail.value);
+      }}
+    />
+  );
+}
 
 function renderAutosuggest(jsx: React.ReactElement) {
   const { container, rerender } = render(jsx);
@@ -114,7 +128,7 @@ test('option with special characters can be selected by value', () => {
 test('should display entered text option/label', () => {
   const enteredTextLabel = jest.fn(value => `Custom function with ${value} placeholder`);
   const { wrapper } = renderAutosuggest(
-    <Autosuggest enteredTextLabel={enteredTextLabel} value="1" options={defaultOptions} />
+    <StatefulAutosuggest enteredTextLabel={enteredTextLabel} value="" options={defaultOptions} />
   );
   wrapper.setInputValue('1');
   expect(enteredTextLabel).toHaveBeenCalledWith('1');

--- a/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
+++ b/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
@@ -163,7 +163,7 @@ describe('extended operators', () => {
     expect(wrapper.findDropdown()?.findOpenDropdown()).toBeFalsy();
 
     // Reopen dropdown
-    wrapper.setInputValue('index >');
+    wrapper.setInputValue('index > ');
     expect(wrapper.find('[data-testid="change+"]')!.getElement()).toHaveTextContent('0');
   });
 

--- a/src/test-utils/dom/input/base-input.ts
+++ b/src/test-utils/dom/input/base-input.ts
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Simulate } from 'react-dom/test-utils';
 
 import { ComponentWrapper, ElementWrapper, usesDom } from '@cloudscape-design/test-utils-core/dom';
-import { act } from '@cloudscape-design/test-utils-core/utils-dom';
+import { act, setNativeValue } from '@cloudscape-design/test-utils-core/utils-dom';
 
 import inputSelectors from '../../../input/styles.selectors.js';
 
@@ -45,7 +44,9 @@ export default abstract class BaseInputWrapper extends ComponentWrapper {
   @usesDom setInputValue(value: string): void {
     const element = this.findNativeInput().getElement();
     act(() => {
-      Simulate.change(element, { target: { value } as unknown as EventTarget });
+      const event = new Event('change', { bubbles: true, cancelable: false });
+      setNativeValue(element, value);
+      element.dispatchEvent(event);
     });
   }
 

--- a/src/test-utils/dom/prompt-input/index.ts
+++ b/src/test-utils/dom/prompt-input/index.ts
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Simulate } from 'react-dom/test-utils';
 
 import { ComponentWrapper, ElementWrapper, usesDom } from '@cloudscape-design/test-utils-core/dom';
-import { act } from '@cloudscape-design/test-utils-core/utils-dom';
+import { act, setNativeValue } from '@cloudscape-design/test-utils-core/utils-dom';
 
 import testutilStyles from '../../../prompt-input/test-classes/styles.selectors.js';
 
@@ -41,9 +40,11 @@ export default class PromptInputWrapper extends ComponentWrapper {
    * @param value value to set the textarea to.
    */
   @usesDom setTextareaValue(value: string): void {
-    const element: HTMLTextAreaElement = this.findNativeTextarea().getElement();
+    const element = this.findNativeTextarea().getElement();
     act(() => {
-      Simulate.change(element, { target: { value } as unknown as EventTarget });
+      const event = new Event('change', { bubbles: true, cancelable: false });
+      setNativeValue(element, value);
+      element.dispatchEvent(event);
     });
   }
 }

--- a/src/test-utils/dom/textarea/index.ts
+++ b/src/test-utils/dom/textarea/index.ts
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Simulate } from 'react-dom/test-utils';
 
 import { ComponentWrapper, ElementWrapper, usesDom } from '@cloudscape-design/test-utils-core/dom';
-import { act } from '@cloudscape-design/test-utils-core/utils-dom';
+import { act, setNativeValue } from '@cloudscape-design/test-utils-core/utils-dom';
 
 import selectors from '../../../textarea/styles.selectors.js';
 
@@ -29,9 +28,11 @@ export default class TextareaWrapper extends ComponentWrapper<HTMLTextAreaElemen
    * @param value value to set the textarea to.
    */
   @usesDom setTextareaValue(value: string): void {
-    const element: HTMLTextAreaElement = this.findNativeTextarea().getElement();
+    const element = this.findNativeTextarea().getElement();
     act(() => {
-      Simulate.change(element, { target: { value } as unknown as EventTarget });
+      const event = new Event('change', { bubbles: true, cancelable: false });
+      setNativeValue(element, value);
+      element.dispatchEvent(event);
     });
   }
 }


### PR DESCRIPTION
### Description

The PR updates the uses of Simulate test-util from React with a custom event dispatcher.

Depends on: https://github.com/cloudscape-design/components/pull/3252

Rel: AWSUI-60345

### How has this been tested?

* Existing unit tests pass with minor adjustments (calling change when the value remains the same now has no effect)
* Dry-run

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
