### PR TITLE
chore: Reduce duplicated styles on button component

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     {
       "path": "lib/components/internal/widget-exports.js",
       "brotli": false,
-      "limit": "800 kB"
+      "limit": "750 kB"
     }
   ],
   "browserslist": [

--- a/src/button/styles.scss
+++ b/src/button/styles.scss
@@ -34,32 +34,6 @@
     border-color: map.get($variant, 'active-border-color');
   }
 
-  &:focus {
-    outline: none;
-    text-decoration: none;
-  }
-
-  @include focus-visible.when-visible {
-    @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
-  }
-  &.variant-icon,
-  &.variant-modal-dismiss,
-  &.variant-flashbar-icon {
-    @include focus-visible.when-visible {
-      @include styles.focus-highlight(
-        (
-          'vertical': awsui.$space-button-icon-focus-outline-gutter-vertical,
-          'horizontal': awsui.$space-button-focus-outline-gutter,
-        )
-      );
-    }
-  }
-  &.variant-inline-icon {
-    @include focus-visible.when-visible {
-      @include styles.focus-highlight(awsui.$space-button-inline-icon-focus-outline-gutter);
-    }
-  }
-
   &.disabled {
     background: map.get($variant, 'disabled-background');
     border-color: map.get($variant, 'disabled-border-color');
@@ -96,6 +70,29 @@
     }
   }
 
+  &:focus {
+    outline: none;
+    text-decoration: none;
+  }
+
+  @include focus-visible.when-visible {
+    @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
+
+    &.variant-icon,
+    &.variant-flashbar-icon {
+      @include styles.focus-highlight(
+        (
+          'vertical': awsui.$space-button-icon-focus-outline-gutter-vertical,
+          'horizontal': awsui.$space-button-focus-outline-gutter,
+        )
+      );
+    }
+
+    &.variant-inline-icon {
+      @include styles.focus-highlight(awsui.$space-button-inline-icon-focus-outline-gutter);
+    }
+  }
+
   &.button-no-text {
     padding-inline-start: awsui.$space-button-icon-only-horizontal;
     padding-inline-end: awsui.$space-button-icon-only-horizontal;
@@ -111,7 +108,6 @@
   }
 
   &.variant-icon,
-  &.variant-inline-icon,
   &.variant-flashbar-icon {
     // Icon has vertical padding, but no horizontal, we need to conpensate this
     // in order to have equal height and width

--- a/src/button/styles.scss
+++ b/src/button/styles.scss
@@ -79,6 +79,7 @@
     @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
 
     &.variant-icon,
+    &.variant-modal-dismiss,
     &.variant-flashbar-icon {
       @include styles.focus-highlight(
         (
@@ -108,6 +109,7 @@
   }
 
   &.variant-icon,
+  &.variant-inline-icon,
   &.variant-flashbar-icon {
     // Icon has vertical padding, but no horizontal, we need to conpensate this
     // in order to have equal height and width


### PR DESCRIPTION
### Description

Created to "unblock" #3253. We're at the edge of a couple of the bundle size checks, and adding a new button variant pushed it over the edge. Taking a look at the CSS, I realized we were looping through and generating a chunk of CSS for each button variant, but a lot of it wasn't variant-dependent, so it didn't really belong in that for loop.

Just like that! A lot of pointless CSS removed (though with no particular user impact since I imagine it could easily be gzipped away)

```diff
  lib/components/internal/plugins/index.js
  Size limit: 14 kB
  Size:       13.79 kB with all dependencies and minified
  
  lib/components/internal/widget-exports.js
- Size limit: 800 kB
- Size:       796.35 kB with all dependencies and minified
+ Size limit: 750 kB
+ Size:       745 kB with all dependencies and minified
```

### How has this been tested?

Will run it in my pipeline to make sure the selector order changes didn't mess anything up visually. But it seems reasonable enough to have a reviewer assigned in the meantime.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
