### PR TITLE
fix: Remove aria-expanded from date range picker trigger

### DIFF
--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -176,6 +176,13 @@ describe('Date range picker', () => {
           i18nStrings.modeSelectionLabel
         );
       });
+
+      test('does not have aria-expanded', () => {
+        const { wrapper } = renderDateRangePicker();
+        expect(wrapper.findTrigger().getElement()).not.toHaveAttribute('aria-expanded');
+        wrapper.openDropdown();
+        expect(wrapper.findDropdown()!.getElement()).not.toHaveAttribute('aria-expanded');
+      });
     });
 
     test('opens relative range mode by default', () => {

--- a/src/internal/components/button-trigger/index.tsx
+++ b/src/internal/components/button-trigger/index.tsx
@@ -40,7 +40,7 @@ export interface ButtonTriggerProps extends BaseComponentProps {
 const ButtonTrigger = (
   {
     children,
-    pressed = false,
+    pressed,
     hideCaret = false,
     disabled = false,
     readOnly = false,

--- a/src/select/parts/trigger.tsx
+++ b/src/select/parts/trigger.tsx
@@ -112,7 +112,7 @@ const Trigger = React.forwardRef(
         {...triggerProps}
         id={id}
         ref={mergedRef}
-        pressed={isOpen}
+        pressed={!!isOpen}
         disabled={disabled}
         readOnly={readOnly}
         invalid={invalid}


### PR DESCRIPTION
### Description

`aria-expanded` is always false for the date range picker, because it opens a dialog. There's no open/close state to the trigger like there is for select or multiselect. So the attribute is incorrect and misleading here.

Related links, issue #, if available: AWSUI-60204

### How has this been tested?

Added a unit test for the date range picker. The select already has one.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
