### PR TITLE
fix: Add I18nProvider support for code editor theme filtering input

### DIFF
--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -661,6 +661,8 @@ describe('Code editor component', () => {
             'i18nStrings.preferencesModalTheme': 'Custom theme',
             'i18nStrings.preferencesModalLightThemes': 'Custom light themes',
             'i18nStrings.preferencesModalDarkThemes': 'Custom dark themes',
+            'i18nStrings.preferencesModalThemeFilteringAriaLabel': 'Custom theme filter',
+            'i18nStrings.preferencesModalThemeFilteringPlaceholder': 'Custom theme filter placeholder',
           },
         }}
       >
@@ -680,6 +682,9 @@ describe('Code editor component', () => {
     expect(modal.findContent()!.findCheckbox()!.findLabel().getElement()).toHaveTextContent('Custom wrap lines');
     expect(modal.findContent()!.findFormField()!.findLabel()!.getElement()).toHaveTextContent('Custom theme');
     modal.findContent()!.findSelect()!.openDropdown();
+    const filteringInput = modal.findContent()!.findSelect()!.findFilteringInput()!.findNativeInput().getElement();
+    expect(filteringInput).toHaveAccessibleName('Custom theme filter');
+    expect(filteringInput).toHaveAttribute('placeholder', 'Custom theme filter placeholder');
     expect(modal.findContent()!.findSelect()!.findDropdown().find('li:nth-child(1)')!.getElement()).toHaveTextContent(
       'Custom light themes'
     );

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -291,9 +291,15 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
                 theme: i18n('i18nStrings.preferencesModalTheme', i18nStrings?.preferencesModalTheme),
                 lightThemes: i18n('i18nStrings.preferencesModalLightThemes', i18nStrings?.preferencesModalLightThemes),
                 darkThemes: i18n('i18nStrings.preferencesModalDarkThemes', i18nStrings?.preferencesModalDarkThemes),
-                themeFilteringAriaLabel: i18nStrings?.preferencesModalThemeFilteringAriaLabel,
+                themeFilteringAriaLabel: i18n(
+                  'i18nStrings.preferencesModalThemeFilteringAriaLabel',
+                  i18nStrings?.preferencesModalThemeFilteringAriaLabel
+                ),
+                themeFilteringPlaceholder: i18n(
+                  'i18nStrings.preferencesModalThemeFilteringPlaceholder',
+                  i18nStrings?.preferencesModalThemeFilteringPlaceholder
+                ),
                 themeFilteringClearAriaLabel: i18nStrings?.preferencesModalThemeFilteringClearAriaLabel,
-                themeFilteringPlaceholder: i18nStrings?.preferencesModalThemeFilteringPlaceholder,
               }}
             />
           )}

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -104,6 +104,8 @@ export interface I18nFormatArgTypes {
     "i18nStrings.preferencesModalConfirm": never;
     "i18nStrings.preferencesModalWrapLines": never;
     "i18nStrings.preferencesModalTheme": never;
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": never;
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": never;
     "i18nStrings.preferencesModalLightThemes": never;
     "i18nStrings.preferencesModalDarkThemes": never;
     "i18nStrings.cursorPositionAriaLabel": {

--- a/src/i18n/messages/all.ar.json
+++ b/src/i18n/messages/all.ar.json
@@ -84,6 +84,8 @@
     "i18nStrings.preferencesModalConfirm": "تأكيد",
     "i18nStrings.preferencesModalWrapLines": "ترحيل الكلمات من نهاية السطر",
     "i18nStrings.preferencesModalTheme": "الشكل",
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": "تصفية الموضوعات",
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": "تصفية الموضوعات",
     "i18nStrings.preferencesModalLightThemes": "الأشكال فاتحة اللون",
     "i18nStrings.preferencesModalDarkThemes": "الأشكال قاتمة اللون",
     "i18nStrings.cursorPositionAriaLabel": "المؤشر على السطر رقم {row}"

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -84,6 +84,8 @@
     "i18nStrings.preferencesModalConfirm": "Bestätigen",
     "i18nStrings.preferencesModalWrapLines": "Zeilenumbruch",
     "i18nStrings.preferencesModalTheme": "Themen",
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": "Themen filtern",
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": "Themen filtern",
     "i18nStrings.preferencesModalLightThemes": "Hellere Themen",
     "i18nStrings.preferencesModalDarkThemes": "Dunkles Design",
     "i18nStrings.cursorPositionAriaLabel": "Cursor in Zeile {row}"

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -84,6 +84,8 @@
     "i18nStrings.preferencesModalConfirm": "Confirm",
     "i18nStrings.preferencesModalWrapLines": "Wrap lines",
     "i18nStrings.preferencesModalTheme": "Theme",
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": "Filter themes",
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": "Filter themes",
     "i18nStrings.preferencesModalLightThemes": "Light themes",
     "i18nStrings.preferencesModalDarkThemes": "Dark themes",
     "i18nStrings.cursorPositionAriaLabel": "Cursor on row {row}"

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -84,6 +84,8 @@
     "i18nStrings.preferencesModalConfirm": "Confirm",
     "i18nStrings.preferencesModalWrapLines": "Wrap lines",
     "i18nStrings.preferencesModalTheme": "Theme",
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": "Filter themes",
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": "Filter themes",
     "i18nStrings.preferencesModalLightThemes": "Light themes",
     "i18nStrings.preferencesModalDarkThemes": "Dark themes",
     "i18nStrings.cursorPositionAriaLabel": "Cursor on row {row}"

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -84,6 +84,8 @@
     "i18nStrings.preferencesModalConfirm": "Confirmar",
     "i18nStrings.preferencesModalWrapLines": "Ajustar líneas",
     "i18nStrings.preferencesModalTheme": "Tema",
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": "Filtrar temas",
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": "Filtrar temas",
     "i18nStrings.preferencesModalLightThemes": "Temas claros",
     "i18nStrings.preferencesModalDarkThemes": "Temas oscuros",
     "i18nStrings.cursorPositionAriaLabel": "Cursor en fila {row}"

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -84,6 +84,8 @@
     "i18nStrings.preferencesModalConfirm": "Confirmer",
     "i18nStrings.preferencesModalWrapLines": "Retour à la ligne",
     "i18nStrings.preferencesModalTheme": "Thème",
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": "Filtrer les thèmes",
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": "Filtrer les thèmes",
     "i18nStrings.preferencesModalLightThemes": "Thèmes clairs",
     "i18nStrings.preferencesModalDarkThemes": "Thèmes sombres",
     "i18nStrings.cursorPositionAriaLabel": "Curseur sur la ligne {row}"

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -84,6 +84,8 @@
     "i18nStrings.preferencesModalConfirm": "Konfirmasikan",
     "i18nStrings.preferencesModalWrapLines": "Bungkus baris",
     "i18nStrings.preferencesModalTheme": "Tema",
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": "Filter tema",
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": "Filter tema",
     "i18nStrings.preferencesModalLightThemes": "Tema terang",
     "i18nStrings.preferencesModalDarkThemes": "Tema gelap",
     "i18nStrings.cursorPositionAriaLabel": "Kursor pada baris {row}"

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -84,6 +84,8 @@
     "i18nStrings.preferencesModalConfirm": "Conferma",
     "i18nStrings.preferencesModalWrapLines": "Righe a capo",
     "i18nStrings.preferencesModalTheme": "Tema",
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": "Filtra i temi",
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": "Filtra i temi",
     "i18nStrings.preferencesModalLightThemes": "Temi chiari",
     "i18nStrings.preferencesModalDarkThemes": "Temi scuri",
     "i18nStrings.cursorPositionAriaLabel": "Cursore sulla riga {row}"

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -84,6 +84,8 @@
     "i18nStrings.preferencesModalConfirm": "確認",
     "i18nStrings.preferencesModalWrapLines": "折り返す",
     "i18nStrings.preferencesModalTheme": "テーマ",
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": "テーマをフィルタリング",
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": "テーマをフィルタリング",
     "i18nStrings.preferencesModalLightThemes": "明るいテーマ",
     "i18nStrings.preferencesModalDarkThemes": "暗いテーマ",
     "i18nStrings.cursorPositionAriaLabel": "カーソルは行 {row}"

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -84,6 +84,8 @@
     "i18nStrings.preferencesModalConfirm": "확인",
     "i18nStrings.preferencesModalWrapLines": "줄 바꿈",
     "i18nStrings.preferencesModalTheme": "테마",
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": "테마 필터링",
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": "테마 필터링",
     "i18nStrings.preferencesModalLightThemes": "밝은 테마",
     "i18nStrings.preferencesModalDarkThemes": "다크 테마",
     "i18nStrings.cursorPositionAriaLabel": "{row}행 위의 커서"

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -84,6 +84,8 @@
     "i18nStrings.preferencesModalConfirm": "Confirmar",
     "i18nStrings.preferencesModalWrapLines": "Quebrar linhas",
     "i18nStrings.preferencesModalTheme": "Tema",
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": "Filtrar temas",
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": "Filtrar temas",
     "i18nStrings.preferencesModalLightThemes": "Temas claros",
     "i18nStrings.preferencesModalDarkThemes": "Temas escuros",
     "i18nStrings.cursorPositionAriaLabel": "Cursor na linha {row}"

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -84,6 +84,8 @@
     "i18nStrings.preferencesModalConfirm": "Onayla",
     "i18nStrings.preferencesModalWrapLines": "Satırları kaydır",
     "i18nStrings.preferencesModalTheme": "Tema",
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": "Temaları filtrele",
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": "Temaları filtrele",
     "i18nStrings.preferencesModalLightThemes": "Açık temalar",
     "i18nStrings.preferencesModalDarkThemes": "Koyu temalar",
     "i18nStrings.cursorPositionAriaLabel": "İmleç {row}. satırda"

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -84,6 +84,8 @@
     "i18nStrings.preferencesModalConfirm": "确认",
     "i18nStrings.preferencesModalWrapLines": "换行",
     "i18nStrings.preferencesModalTheme": "主题",
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": "筛选主题",
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": "筛选主题",
     "i18nStrings.preferencesModalLightThemes": "浅色主题",
     "i18nStrings.preferencesModalDarkThemes": "深色主题",
     "i18nStrings.cursorPositionAriaLabel": "光标位于第 {row} 行"

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -84,6 +84,8 @@
     "i18nStrings.preferencesModalConfirm": "確認",
     "i18nStrings.preferencesModalWrapLines": "換行",
     "i18nStrings.preferencesModalTheme": "佈景主題",
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": "篩選主題",
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": "篩選主題",
     "i18nStrings.preferencesModalLightThemes": "淺色佈景主題",
     "i18nStrings.preferencesModalDarkThemes": "深色佈景主題",
     "i18nStrings.cursorPositionAriaLabel": "列 {row} 上的游標"


### PR DESCRIPTION
### Description

What it says on the tin. We missed those strings earlier, adding support for them now.

Related links, issue #, if available: AWSUI-60202

### How has this been tested?

Updated unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
