### PR TITLE
chore: Re-export metadata folder to work with updated style-dictionary ESM changes

### DIFF
--- a/style-dictionary/visual-refresh/metadata.ts
+++ b/style-dictionary/visual-refresh/metadata.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import metadata from './metadata/index.js';
+
+export default metadata;


### PR DESCRIPTION
### Description

Previously cjs would handle whether it was a folder of file. Now we expect a file there.

Also important to note that this theme isn't actually used anywhere in our build so there's no impact here.

### How has this been tested?

Before the change I could not built visual refresh as the primary theme, now I can.

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
