### PR TITLE
chore: Sync i18n messages, apply grammar fix

### DIFF
--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -111,7 +111,7 @@
     "stickyColumnsPreference.lastColumns.options[0].label": "None",
     "stickyColumnsPreference.lastColumns.options[1].label": "Last column",
     "contentDisplayPreference.title": "Column preferences",
-    "contentDisplayPreference.description": "Customise the columns visibility and order.",
+    "contentDisplayPreference.description": "Customise the visibility and order of the columns.",
     "contentDisplayPreference.dragHandleAriaLabel": "Drag handle",
     "contentDisplayPreference.dragHandleAriaDescription": "Use Space or Enter to activate drag for an item, then use the arrow keys to move the item's position. To complete the position move, use Space or Enter, or to discard the move, use Escape.",
     "contentDisplayPreference.liveAnnouncementDndStarted": "Picked up item at position {position} of {total}",

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -111,7 +111,7 @@
     "stickyColumnsPreference.lastColumns.options[0].label": "None",
     "stickyColumnsPreference.lastColumns.options[1].label": "Last column",
     "contentDisplayPreference.title": "Column preferences",
-    "contentDisplayPreference.description": "Customize the columns visibility and order.",
+    "contentDisplayPreference.description": "Customize the visibility and order of the columns.",
     "contentDisplayPreference.dragHandleAriaLabel": "Drag handle",
     "contentDisplayPreference.dragHandleAriaDescription": "Use Space or Enter to activate drag for an item, then use the arrow keys to move the item's position. To complete the position move, use Space or Enter, or to discard the move, use Escape.",
     "contentDisplayPreference.liveAnnouncementDndStarted": "Picked up item at position {position} of {total}",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -111,7 +111,7 @@
     "stickyColumnsPreference.lastColumns.options[0].label": "Aucun",
     "stickyColumnsPreference.lastColumns.options[1].label": "Dernière colonne",
     "contentDisplayPreference.title": "Préférences de colonne",
-    "contentDisplayPreference.description": "Personnalisez la visibilité et l'ordre des colonnes.",
+    "contentDisplayPreference.description": "Personnalisez la visibilité et l’ordre des colonnes.",
     "contentDisplayPreference.dragHandleAriaLabel": "Faire glisser",
     "contentDisplayPreference.dragHandleAriaDescription": "Utilisez Espace ou Entrée pour activer le glissement pour un élément, puis utilisez les touches fléchées pour déplacer la position de l'élément. Pour terminer le déplacement de la position, utilisez Espace ou Entrée. Pour ignorer le déplacement, utilisez Échap.",
     "contentDisplayPreference.liveAnnouncementDndStarted": "Élément sélectionné à la position {position} de {total}",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -111,7 +111,7 @@
     "stickyColumnsPreference.lastColumns.options[0].label": "なし",
     "stickyColumnsPreference.lastColumns.options[1].label": "最後の列",
     "contentDisplayPreference.title": "列の詳細設定",
-    "contentDisplayPreference.description": "列の可視性と順序をカスタマイズします。",
+    "contentDisplayPreference.description": "列の表示設定と順序をカスタマイズします。",
     "contentDisplayPreference.dragHandleAriaLabel": "ドラッグハンドル",
     "contentDisplayPreference.dragHandleAriaDescription": "Space または Enter を使用して項目のドラッグをアクティブ化し、矢印キーを使用して項目の位置を移動します。位置の移動を完了するには、Space または Enter を使用します。移動を取り消すには、Escape を使用します。",
     "contentDisplayPreference.liveAnnouncementDndStarted": "{position}/{total} の位置で項目をピックアップしました",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -111,7 +111,7 @@
     "stickyColumnsPreference.lastColumns.options[0].label": "無",
     "stickyColumnsPreference.lastColumns.options[1].label": "最後一欄",
     "contentDisplayPreference.title": "欄偏好設定",
-    "contentDisplayPreference.description": "自訂欄的可見性和順序。",
+    "contentDisplayPreference.description": "自訂欄位的可見性和順序。",
     "contentDisplayPreference.dragHandleAriaLabel": "拖曳控點",
     "contentDisplayPreference.dragHandleAriaDescription": "使用空白鍵或 ENTER 鍵啟用項目拖曳功能，然後使用方向鍵移動項目的位置。若要完成位置移動，請使用空白鍵或 ENTER 鍵，或者若要捨棄移動，請使用 ESC 鍵。",
     "contentDisplayPreference.liveAnnouncementDndStarted": "在第 {position} 位置 (共 {total} 個位置) 拾取了項目",


### PR DESCRIPTION
### Description

Fix a grammatical error in the text of the Collection preferences component under Column preferences.

Related links, issue #, if available: AWSUI-60354

### How has this been tested?

- verified manually in dev pages
- 
<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
