### PR TITLE
chore: Add linter for no 'only' tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     'no-unsanitized',
     'header',
     'simple-import-sort',
+    'no-only-tests',
   ],
   rules: {
     '@typescript-eslint/no-empty-function': 'off',
@@ -89,6 +90,7 @@ module.exports = {
     ],
     'no-warning-comments': 'warn',
     'simple-import-sort/imports': 'error',
+    'no-only-tests/no-only-tests': 'error',
   },
   settings: {
     react: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "eslint": "^8.28.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-header": "^3.1.1",
+        "eslint-plugin-no-only-tests": "^3.3.0",
         "eslint-plugin-no-unsanitized": "^4.0.2",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react": "^7.31.11",
@@ -8128,6 +8129,16 @@
       "license": "MIT",
       "peerDependencies": {
         "eslint": ">=7.7.0"
+      }
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz",
+      "integrity": "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=5.0.0"
       }
     },
     "node_modules/eslint-plugin-no-unsanitized": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "eslint": "^8.28.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-header": "^3.1.1",
+    "eslint-plugin-no-only-tests": "^3.3.0",
     "eslint-plugin-no-unsanitized": "^4.0.2",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.31.11",


### PR DESCRIPTION
### Description

Self-explanatory: let's lint this rather than leaving it for humans to catch

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
