### PR TITLE
chore: Improve performance for repeated i18n format calls

### DIFF
--- a/pages/i18n/performance.page.tsx
+++ b/pages/i18n/performance.page.tsx
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useMemo, useState } from 'react';
+
+import Button from '~components/button';
+import Header from '~components/header';
+import I18nProvider from '~components/i18n';
+import enMessages from '~components/i18n/messages/all.en';
+import Table from '~components/table';
+
+export default function WrappedI18nPerformancePage() {
+  return (
+    <I18nProvider locale="en" messages={[enMessages]}>
+      <I18nPerformancePage />
+    </I18nProvider>
+  );
+}
+
+function I18nPerformancePage() {
+  const [itemCount, setItemCount] = useState(10_000);
+
+  const items = useMemo(
+    () =>
+      new Array(itemCount).fill(null).map((_value, i) => ({
+        id: `${i}`,
+        value: `Item ${i + 1}`,
+        children: [{ id: `${i}-0`, value: 'Child' }],
+      })),
+    [itemCount]
+  );
+
+  return (
+    <Table<{ id: string; value: string; children: { id: string; value: string }[] }>
+      header={
+        <Header
+          variant="h1"
+          counter={`(${itemCount})`}
+          description="Reproduction page for AWSUI-60323"
+          actions={<Button onClick={() => setItemCount(itemCount => itemCount + 1000)}>More items</Button>}
+        >
+          Performance test
+        </Header>
+      }
+      items={items}
+      trackBy="id"
+      expandableRows={{
+        getItemChildren: () => [],
+        isItemExpandable: item => item.children.length > 0,
+        onExpandableItemToggle: () => {},
+        expandedItems: [],
+      }}
+      columnDefinitions={[
+        {
+          id: 'value',
+          header: 'Text value',
+          cell: ({ value }) => value,
+        },
+      ]}
+      enableKeyboardNavigation={true}
+    />
+  );
+}

--- a/pages/i18n/performance.page.tsx
+++ b/pages/i18n/performance.page.tsx
@@ -17,7 +17,7 @@ export default function WrappedI18nPerformancePage() {
 }
 
 function I18nPerformancePage() {
-  const [itemCount, setItemCount] = useState(10_000);
+  const [itemCount, setItemCount] = useState(1000);
 
   const items = useMemo(
     () =>


### PR DESCRIPTION
### Description

After a bit of a deep dive, I can reduce the time taken by the format function by 10x (in my contrived dev page example).

Related links, issue #, if available: AWSUI-60323

### How has this been tested?

Tested manually using the included dev page. Used a table rather than some other component because I wanted to reproduce their use-case closely rather than just rendering an i18n provider supported component over and over again. No automated tests, but we do have perf tests in the pipeline, so a regression here would presumably be visible there.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
