### PR TITLE
fix: Breadcrumb dropdown items have same color on mouse or keyboard interaction

### DIFF
--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -114,6 +114,7 @@ function MenuItem({ item, disabled, highlighted, linkStyle }: MenuItemProps) {
       styles['menu-item'],
       analyticsLabels['menu-item'],
       linkStyle && styles['link-style'],
+      linkStyle && highlighted && styles['link-style-highlighted'],
       isCurrentBreadcrumb && styles['current-breadcrumb']
     ),
     'aria-current': isCurrentBreadcrumb,

--- a/src/button-dropdown/item-element/styles.scss
+++ b/src/button-dropdown/item-element/styles.scss
@@ -70,6 +70,10 @@
       font-weight: styles.$font-weight-bold;
       text-decoration: none;
     }
+
+    &.link-style-highlighted {
+      color: awsui.$color-text-link-hover;
+    }
   }
 
   &:focus {


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
