### PR TITLE
fix: Prevent filtering highlighting from crashing when match is >10000 chars

### DIFF
--- a/src/internal/components/option/__tests__/option.test.tsx
+++ b/src/internal/components/option/__tests__/option.test.tsx
@@ -305,10 +305,10 @@ describe('Option component', () => {
     test('skips highlighting if the label text is too long', () => {
       const optionWrapper = renderOption({
         option: {
-          label: 'a'.repeat(1000000),
+          label: 'a'.repeat(100000),
           value: '1',
         },
-        highlightText: 'a'.repeat(500000),
+        highlightText: 'a'.repeat(50000),
       });
       checkMatches(optionWrapper, 0, '');
     });

--- a/src/internal/components/option/highlight-match.tsx
+++ b/src/internal/components/option/highlight-match.tsx
@@ -7,7 +7,7 @@ import styles from './styles.css.js';
 const splitOnFiltering = (str: string, highlightText: string) => {
   // We match by creating a regex using user-provided strings, so we skip
   // highlighting if the generated regex would be too memory intensive.
-  if (highlightText.length > 100000) {
+  if (highlightText.length > 10_000) {
     return { noMatches: [str], matches: null };
   }
 


### PR DESCRIPTION
### Description

Reported by a user on Slack. This is just #1885 but the limit is set even lower. Based on empirical testing, the regex limit seems to be set at 32768 characters now.

We initially set it to 100,000 characters last time to avoid breaking any legitimate workflows and it worked in previous Chrome versions. But in retrospect, autosuggest matches with over 10,000 characters are probably well past most reasonable uses of the component anyway, so this should be fine.

Related links, issue #, if available: n/a

### How has this been tested?

Updated the tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
