### PR TITLE
fix: Parent container scrolls when select opens

### DIFF
--- a/pages/select/select.test.page.tsx
+++ b/pages/select/select.test.page.tsx
@@ -76,6 +76,7 @@ export default function SelectPage() {
       <ScreenshotArea>
         <Box padding="l">
           <Box padding="s">
+            <div style={{ height: '300px' }}>300px space above the select</div>
             <Box variant="h1">Overflow test</Box>
             <Box variant="p">Dropdown should not be rendered beyond the container with overflow hidden</Box>
             <div id="smallest_container" style={{ overflow: 'hidden', blockSize: '500px', padding: 0 }}>

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -291,7 +291,7 @@ export const getDropdownPosition = ({
     availableSpace.blockEnd < dropdownElement.offsetHeight && availableSpace.blockStart > availableSpace.blockEnd;
   const availableHeight = dropBlockStart ? availableSpace.blockStart : availableSpace.blockEnd;
   // Try and crop the bottom item when all options can't be displayed, affordance for "there's more"
-  const croppedHeight = stretchHeight ? availableHeight : Math.floor(availableHeight / 31) * 31 + 16;
+  const croppedHeight = Math.max(stretchHeight ? availableHeight : Math.floor(availableHeight / 31) * 31 + 16, 15);
 
   return {
     dropBlockStart,

--- a/src/select/parts/plain-list.tsx
+++ b/src/select/parts/plain-list.tsx
@@ -49,7 +49,10 @@ const PlainList = (
     () => (index: number) => {
       const item = menuRef.current?.querySelector<HTMLElement>(`[data-mouse-target="${index}"]`);
       if (highlightType.moveFocus && item) {
-        scrollElementIntoView(item);
+        // In edge case dropdown can be very small, scrolling can cause side effect AWSUI-60318
+        if (menuRef.current?.clientHeight !== undefined && menuRef.current?.clientHeight > 15) {
+          scrollElementIntoView(item);
+        }
       }
     },
     [highlightType, menuRef]


### PR DESCRIPTION
### Description

Fix issue AWSUI-60318

**Issue**: 
When Select locates top inside of a `overflow:hidden` container and at the bottom of the window, the select can not open upwards because `overflow:hidden` and has little space downwards to display the dropdown. When open the dropdown with a **selected option**, the page scrolls up. See screen recording in the ticket. 

**Cause**:
1. When dropdown has very small space to display, the height is calculated to a negative number (because 50 padding we usually have for the dropdown) https://github.com/cloudscape-design/components/blob/main/src/internal/components/dropdown/dropdown-fit-handler.ts#L294. Negative value does not limit the height, so the dropdown overflows out of the view port.
2. When an option is pre-selected, the option scrolls into view https://github.com/cloudscape-design/components/blob/main/src/select/parts/plain-list.tsx#L52, so the container scrolls up. 

**Fix**:
1. Set a minimum height 15px to the dropdown. 
2. Stop scrolling the selected option if the dropdown height is <=15px. In this case, the dropdown content is not really readable, scrolling it does not give benefit but can cause page scroll (when the dropdown overflows the viewport). 

**Test**:
Tested manually and added integ tests in the PR. 


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
