### PR TITLE
feat: Add tab header "actions"

### DIFF
--- a/pages/tabs/permutations.page.tsx
+++ b/pages/tabs/permutations.page.tsx
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 
+import Button from '~components/button';
 import ButtonDropdown from '~components/button-dropdown';
+import SpaceBetween from '~components/space-between';
 import Tabs, { TabsProps } from '~components/tabs';
 
 import createPermutations from '../utils/permutations';
@@ -106,6 +108,14 @@ const tabActionPermutations = createPermutations<TabsProps>([
   {
     activeTabId: ['first', 'second'],
     variant: ['default', 'container'],
+    actions: [
+      undefined,
+      <Button key="button">Add</Button>,
+      <SpaceBetween key="space-between" size="s" direction="horizontal">
+        <Button>Add</Button>
+        <Button>Add2</Button>
+      </SpaceBetween>,
+    ],
     tabs: [
       [
         {

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -16664,7 +16664,16 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "visualRefreshTag": "\`stacked\` variant",
     },
   ],
-  "regions": [],
+  "regions": [
+    {
+      "description": "Actions for the tabs header, displayed next to the list of tabs.
+Use this to add a button or button dropdown that performs actions on the
+entire tab list. We recommend a maximum of one interactive element to
+minimize the number of keyboard tab stops between the tab list and content.",
+      "isDefault": false,
+      "name": "actions",
+    },
+  ],
   "releaseStatus": "stable",
 }
 `;

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -584,6 +584,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_wrapper_wih1l",
   ],
   "tabs": [
+    "awsui_actions-container_14rmt",
     "awsui_disabled-reason-tooltip_14rmt",
     "awsui_root_14rmt",
     "awsui_tab-dismiss-button_1nq1i",

--- a/src/tabs/__tests__/tabs.test.tsx
+++ b/src/tabs/__tests__/tabs.test.tsx
@@ -1260,4 +1260,8 @@ describe('Tabs', () => {
       verifyTabContentLabelledBy(secondTabId);
     });
   });
+  test('renders actions', () => {
+    const wrapper = renderTabs(<Tabs tabs={defaultTabs} actions={<div>Actions content</div>} />).wrapper;
+    expect(wrapper.findActions()!.getElement()).toHaveTextContent('Actions content');
+  });
 });

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -50,6 +50,7 @@ export default function Tabs({
     props: { disableContentPaddings, variant, fitHeight },
     metadata: {
       hasActions: tabs.some(tab => !!tab.action),
+      hasHeaderActions: !!actions,
       hasDisabledReasons: tabs.some(tab => !!tab.disabledReason),
     },
   });

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -40,6 +40,7 @@ export default function Tabs({
   disableContentPaddings = false,
   i18nStrings,
   fitHeight,
+  actions,
   ...rest
 }: TabsProps) {
   for (const tab of tabs) {
@@ -123,6 +124,7 @@ export default function Tabs({
       ariaLabel={ariaLabel}
       ariaLabelledby={ariaLabelledby}
       tabs={tabs}
+      actions={actions}
       onChange={changeDetail => {
         setActiveTabId(changeDetail.activeTabId);
         fireNonCancelableEvent(onChange, changeDetail);

--- a/src/tabs/interfaces.ts
+++ b/src/tabs/interfaces.ts
@@ -29,6 +29,14 @@ export interface TabsProps extends BaseComponentProps {
   tabs: ReadonlyArray<TabsProps.Tab>;
 
   /**
+   * Actions for the tabs header, displayed next to the list of tabs.
+   * Use this to add a button or button dropdown that performs actions on the
+   * entire tab list. We recommend a maximum of one interactive element to
+   * minimize the number of keyboard tab stops between the tab list and content.
+   */
+  actions?: React.ReactNode;
+
+  /**
    * The possible visual variants of tabs are the following:
    * * `default` - Use in any context.
    * * `container` - Use this variant to have the tabs displayed within a container header.

--- a/src/tabs/tab-header-bar.scss
+++ b/src/tabs/tab-header-bar.scss
@@ -66,6 +66,12 @@ $label-horizontal-spacing: awsui.$space-xs;
   }
 }
 
+.actions-container {
+  flex-shrink: 0;
+  align-self: center;
+  padding-inline: awsui.$space-xxs;
+}
+
 .tabs-tab {
   // Clear list formatting that comes with list item
   list-style: none;

--- a/src/tabs/tab-header-bar.scss
+++ b/src/tabs/tab-header-bar.scss
@@ -17,6 +17,13 @@ $label-horizontal-spacing: awsui.$space-xs;
   padding-block: 0;
   padding-inline: 0;
   display: flex;
+  flex-wrap: wrap;
+}
+
+.tab-header-scroll-container {
+  display: flex;
+  flex-grow: 1;
+  max-inline-size: 100%;
 }
 
 .tabs-header-list {
@@ -69,7 +76,9 @@ $label-horizontal-spacing: awsui.$space-xs;
 .actions-container {
   flex-shrink: 0;
   align-self: center;
-  padding-inline: awsui.$space-xxs;
+  padding-block: awsui.$space-xs;
+  padding-inline: awsui.$space-xs;
+  margin-inline-start: auto;
 }
 
 .tabs-tab {

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -79,6 +79,7 @@ interface TabHeaderBarProps {
   ariaLabel?: string;
   ariaLabelledby?: string;
   i18nStrings?: TabsProps.I18nStrings;
+  actions?: TabsProps['actions'];
 }
 
 export function TabHeaderBar({
@@ -90,6 +91,7 @@ export function TabHeaderBar({
   ariaLabel,
   ariaLabelledby,
   i18nStrings,
+  actions,
 }: TabHeaderBarProps) {
   const headerBarRef = useRef<HTMLUListElement>(null);
   const activeTabHeaderRef = useRef<null | HTMLElement>(null);
@@ -337,6 +339,7 @@ export function TabHeaderBar({
           />
         </span>
       )}
+      {actions && <div className={styles['actions-container']}>{actions}</div>}
     </div>
   );
 

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -291,54 +291,55 @@ export function TabHeaderBar({
   const TabList = hasActionOrDismissible ? 'div' : 'ul';
 
   return (
-    //converted span to div as list should not be a child of span for HTML validation
-    <div className={classes} ref={containerRef}>
-      {horizontalOverflow && (
-        <span ref={inlineStartOverflowButton} className={leftButtonClasses}>
-          <InternalButton
-            formAction="none"
-            variant="icon"
-            iconName="angle-left"
-            disabled={!inlineStartOverflow}
-            __focusable={true}
-            onClick={() => onPaginationClick(headerBarRef, 'backward')}
-            ariaLabel={i18n('i18nStrings.scrollLeftAriaLabel', i18nStrings?.scrollLeftAriaLabel)}
-          />
-        </span>
-      )}
-      <SingleTabStopNavigationProvider
-        ref={navigationAPI}
-        navigationActive={true}
-        getNextFocusTarget={getNextFocusTarget}
-        onUnregisterActive={onUnregisterActive}
-      >
-        <TabList
-          {...tabActionAttributes}
-          className={clsx(styles['tabs-header-list'], analyticsSelectors['tabs-header-list'])}
-          aria-label={ariaLabel}
-          aria-labelledby={ariaLabelledby}
-          ref={headerBarRef as never}
-          onScroll={onScroll}
-          onKeyDown={onKeyDown}
-          onFocus={onFocus}
-          onBlur={onBlur}
+    <div className={classes}>
+      <div className={styles['tab-header-scroll-container']} ref={containerRef}>
+        {horizontalOverflow && (
+          <span ref={inlineStartOverflowButton} className={leftButtonClasses}>
+            <InternalButton
+              formAction="none"
+              variant="icon"
+              iconName="angle-left"
+              disabled={!inlineStartOverflow}
+              __focusable={true}
+              onClick={() => onPaginationClick(headerBarRef, 'backward')}
+              ariaLabel={i18n('i18nStrings.scrollLeftAriaLabel', i18nStrings?.scrollLeftAriaLabel)}
+            />
+          </span>
+        )}
+        <SingleTabStopNavigationProvider
+          ref={navigationAPI}
+          navigationActive={true}
+          getNextFocusTarget={getNextFocusTarget}
+          onUnregisterActive={onUnregisterActive}
         >
-          {tabs.map(renderTabHeader)}
-        </TabList>
-      </SingleTabStopNavigationProvider>
-      {horizontalOverflow && (
-        <span className={rightButtonClasses}>
-          <InternalButton
-            formAction="none"
-            variant="icon"
-            iconName="angle-right"
-            disabled={!inlineEndOverflow}
-            __focusable={true}
-            onClick={() => onPaginationClick(headerBarRef, 'forward')}
-            ariaLabel={i18n('i18nStrings.scrollRightAriaLabel', i18nStrings?.scrollRightAriaLabel)}
-          />
-        </span>
-      )}
+          <TabList
+            {...tabActionAttributes}
+            className={clsx(styles['tabs-header-list'], analyticsSelectors['tabs-header-list'])}
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledby}
+            ref={headerBarRef as never}
+            onScroll={onScroll}
+            onKeyDown={onKeyDown}
+            onFocus={onFocus}
+            onBlur={onBlur}
+          >
+            {tabs.map(renderTabHeader)}
+          </TabList>
+        </SingleTabStopNavigationProvider>
+        {horizontalOverflow && (
+          <span className={rightButtonClasses}>
+            <InternalButton
+              formAction="none"
+              variant="icon"
+              iconName="angle-right"
+              disabled={!inlineEndOverflow}
+              __focusable={true}
+              onClick={() => onPaginationClick(headerBarRef, 'forward')}
+              ariaLabel={i18n('i18nStrings.scrollRightAriaLabel', i18nStrings?.scrollRightAriaLabel)}
+            />
+          </span>
+        )}
+      </div>
       {actions && <div className={styles['actions-container']}>{actions}</div>}
     </div>
   );

--- a/src/test-utils/dom/tabs/index.ts
+++ b/src/test-utils/dom/tabs/index.ts
@@ -124,4 +124,8 @@ export default class TabsWrapper extends ComponentWrapper<HTMLButtonElement> {
   findActiveTabAction(): ElementWrapper | null {
     return this.find(`.${styles['tabs-tab-active']} .${styles['tabs-tab-action']}`);
   }
+
+  findActions(): ElementWrapper | null {
+    return this.find(`.${styles['actions-container']}`);
+  }
 }


### PR DESCRIPTION
### Description

Add a slot for "actions", placed within the tabs header

Related links, issue #, if available: 4aAdA16jV0dV

### How has this been tested?

New unit tests & permutations

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
