### PR TITLE
feat: Add setSelectionRange to PromptInput

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -12604,6 +12604,25 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "parameters": [],
       "returnType": "void",
     },
+    {
+      "description": "Selects a range of text in the textarea control.",
+      "name": "setSelectionRange",
+      "parameters": [
+        {
+          "name": "start",
+          "type": "null | number",
+        },
+        {
+          "name": "end",
+          "type": "null | number",
+        },
+        {
+          "name": "direction",
+          "type": ""backward" | "forward" | "none"",
+        },
+      ],
+      "returnType": "void",
+    },
   ],
   "name": "PromptInput",
   "properties": [

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -12605,7 +12605,10 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "returnType": "void",
     },
     {
-      "description": "Selects a range of text in the textarea control.",
+      "description": "Selects a range of text in the textarea control.
+See https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/setSelectionRange
+for more details on this method.
+",
       "name": "setSelectionRange",
       "parameters": [
         {

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -12607,7 +12607,8 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
     {
       "description": "Selects a range of text in the textarea control.
 See https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/setSelectionRange
-for more details on this method.
+for more details on this method. Be aware that using this method in React has some
+common pitfalls: https://stackoverflow.com/questions/60129605/is-javascripts-setselectionrange-incompatible-with-react-hooks
 ",
       "name": "setSelectionRange",
       "parameters": [

--- a/src/prompt-input/__tests__/prompt-input.test.tsx
+++ b/src/prompt-input/__tests__/prompt-input.test.tsx
@@ -55,6 +55,23 @@ describe('ref', () => {
     expect(textarea.selectionStart).toBe(0);
     expect(textarea.selectionEnd).toBe(4);
   });
+
+  test('can be used to select a range', () => {
+    const ref = React.createRef<HTMLTextAreaElement>();
+    const { wrapper } = renderPromptInput({ value: 'Test', ref });
+    const textarea = wrapper.findNativeTextarea().getElement();
+
+    // Make sure no text is selected
+    textarea.selectionStart = textarea.selectionEnd = 0;
+    textarea.blur();
+    expect(textarea.selectionStart).toBe(0);
+    expect(textarea.selectionEnd).toBe(0);
+
+    // Select all text
+    ref.current!.setSelectionRange(1, 3);
+    expect(textarea.selectionStart).toBe(1);
+    expect(textarea.selectionEnd).toBe(3);
+  });
 });
 
 describe('disableBrowserAutocorrect', () => {

--- a/src/prompt-input/interfaces.ts
+++ b/src/prompt-input/interfaces.ts
@@ -124,7 +124,8 @@ export namespace PromptInputProps {
      * Selects a range of text in the textarea control.
      *
      * See https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/setSelectionRange
-     * for more details on this method.
+     * for more details on this method. Be aware that using this method in React has some
+     * common pitfalls: https://stackoverflow.com/questions/60129605/is-javascripts-setselectionrange-incompatible-with-react-hooks
      */
     setSelectionRange(start: number | null, end: number | null, direction?: 'forward' | 'backward' | 'none'): void;
   }

--- a/src/prompt-input/interfaces.ts
+++ b/src/prompt-input/interfaces.ts
@@ -119,5 +119,10 @@ export namespace PromptInputProps {
      * Selects all text in the textarea control.
      */
     select(): void;
+
+    /**
+     * Selects a range of text in the textarea control.
+     */
+    setSelectionRange(start: number | null, end: number | null, direction?: 'forward' | 'backward' | 'none'): void;
   }
 }

--- a/src/prompt-input/interfaces.ts
+++ b/src/prompt-input/interfaces.ts
@@ -122,6 +122,9 @@ export namespace PromptInputProps {
 
     /**
      * Selects a range of text in the textarea control.
+     *
+     * See https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/setSelectionRange
+     * for more details on this method.
      */
     setSelectionRange(start: number | null, end: number | null, direction?: 'forward' | 'backward' | 'none'): void;
   }

--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -77,6 +77,9 @@ const InternalPromptInput = React.forwardRef(
         select() {
           textareaRef.current?.select();
         },
+        setSelectionRange(...args: Parameters<HTMLTextAreaElement['setSelectionRange']>) {
+          textareaRef.current?.setSelectionRange(...args);
+        },
       }),
       [textareaRef]
     );


### PR DESCRIPTION
### Description

Add setSelectionRange to PromptInput

Related links, issue #, if available: AWSUI-60374

### How has this been tested?

New unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
