### PR TITLE
fix: Extend clickable area of Prompt Input

### DIFF
--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -215,6 +215,7 @@ const InternalPromptInput = React.forwardRef(
             })}
           >
             {secondaryActions}
+            <div className={styles.buffer} onClick={() => textareaRef.current?.focus()} />
             {hasActionButton && action}
           </div>
         )}

--- a/src/prompt-input/styles.scss
+++ b/src/prompt-input/styles.scss
@@ -199,3 +199,9 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
     padding-block-end: awsui.$space-scaled-xxs;
   }
 }
+
+.buffer {
+  flex: 1;
+  align-self: stretch;
+  cursor: text;
+}


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

![image](https://github.com/user-attachments/assets/caf437e5-9316-4397-bd8b-9029b2d53200)


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
