### PR TITLE
chore: Flip arrow-right icon in RTL

### DIFF
--- a/src/icon/styles.scss
+++ b/src/icon/styles.scss
@@ -34,6 +34,7 @@
       .name-angle-right-double,
       .name-angle-right,
       .name-arrow-left,
+      .name-arrow-right,
       .name-caret-left-filled,
       .name-caret-right-filled,
       .name-audio-full,


### PR DESCRIPTION
### Description

Noticed while working on drag and drop. The left icon is flipped automatically, but the right arrow isn't. Seems like an oversight, since the other right pointing icons were flipped.

Related links, issue #, if available: n/a

### How has this been tested?

Will be caught on RTL permutation tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
