### PR TITLE
fix: Table does not use instanceIdentifier for the reported task name in metrics

### DIFF
--- a/src/table/__tests__/analytics-events.test.tsx
+++ b/src/table/__tests__/analytics-events.test.tsx
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Header from '../../../lib/components/header';
+import { ComponentMetrics, setComponentMetrics } from '../../../lib/components/internal/analytics';
+import Table from '../../../lib/components/table';
+
+const componentMounted = jest.fn();
+const componentUpdated = jest.fn();
+
+setComponentMetrics({ componentMounted, componentUpdated });
+
+describe('Task name', () => {
+  test('instanceIdentifier overrides the automatically determined task name', () => {
+    render(
+      <Table
+        analyticsMetadata={{ instanceIdentifier: 'My custom task name override' }}
+        items={[]}
+        columnDefinitions={[]}
+        header={<Header>This is the table header</Header>}
+      />
+    );
+
+    expect(ComponentMetrics.componentMounted).toHaveBeenCalledTimes(1);
+    expect(ComponentMetrics.componentMounted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        componentConfiguration: expect.objectContaining({ taskName: 'My custom task name override' }),
+      })
+    );
+  });
+});

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -229,7 +229,7 @@ const InternalTable = React.forwardRef(
         variant,
         flowType: rest.analyticsMetadata?.flowType,
         instanceIdentifier: analyticsMetadata?.instanceIdentifier,
-        taskName: getHeaderText(),
+        taskName: analyticsMetadata?.instanceIdentifier ?? getHeaderText(),
         patternIdentifier: getPatternIdentifier(),
         sortedBy: {
           columnId: sortingColumn?.sortingField,


### PR DESCRIPTION
### Description

When an `instanceIdentifier` is provided on a Table, it should be used as the reported funnel name (to match the behaviour of the various `funnel*` events).

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-60419

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
