### PR TITLE
feat: Add `suppressFlowMetricEvents` field to flashbars

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -8357,6 +8357,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
+      "analyticsTag": "",
       "description": "Specifies flash messages that appear in the same order that they are listed.
 The value is an array of flash message definition objects.
 A flash message object contains the following properties:
@@ -8382,7 +8383,8 @@ If the \`action\` property is set, this property is ignored. **Deprecated**, rep
 * \`id\` (string) - Specifies a unique flash message identifier. This property is used in two ways:
   1. As a [keys](https://reactjs.org/docs/lists-and-keys.html#keys) source for React rendering.
   2. To identify which flash message will be removed from the DOM when it is dismissed, to animate it out.
-",
+* \`analyticsMetadata\` (FlashbarProps.ItemAnalyticsMetadata) - (Optional) Specifies additional analytics-related metadata.
+  * \`suppressFlowMetricEvents\` - Prevent this item from generating events related to flow metrics.",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<FlashbarProps.MessageDefinition>",

--- a/src/flashbar/__tests__/analytics-metadata.test.tsx
+++ b/src/flashbar/__tests__/analytics-metadata.test.tsx
@@ -216,5 +216,12 @@ describe('Flashbar renders correct analytics metadata', () => {
       const wrapper = renderFlashbar({ items: [{ id: '0', type: 'success', loading: true }] });
       expect(wrapper.find(`[${DATA_ATTR_ANALYTICS_FLASHBAR}="info"]`)!.getElement()).toBeInTheDocument();
     });
+
+    test('adds no attribute if suppressFlowMetricEvents is set', () => {
+      const wrapper = renderFlashbar({
+        items: [{ id: '0', type: 'success', analyticsMetadata: { suppressFlowMetricEvents: true } }],
+      });
+      expect(wrapper.find(`[${DATA_ATTR_ANALYTICS_FLASHBAR}]`)).toBeNull();
+    });
   });
 });

--- a/src/flashbar/flash.tsx
+++ b/src/flashbar/flash.tsx
@@ -114,7 +114,9 @@ export const Flash = React.forwardRef(
       }
     }
 
-    const analyticsMetadata = getAnalyticsMetadataProps(props as BasePropsWithAnalyticsMetadata);
+    const analyticsMetadata = getAnalyticsMetadataProps(
+      props as BasePropsWithAnalyticsMetadata & FlashbarProps.MessageDefinition
+    );
     const elementRef = useComponentMetadata('Flash', PACKAGE_VERSION, { ...analyticsMetadata });
     const mergedRef = useMergeRefs(ref, elementRef);
 
@@ -176,7 +178,7 @@ export const Flash = React.forwardRef(
           getVisualContextClassname(type === 'warning' && !loading ? 'flashbar-warning' : 'flashbar'),
           initialHidden && styles['initial-hidden']
         )}
-        {...analyticsAttributes}
+        {...(analyticsMetadata.suppressFlowMetricEvents ? undefined : analyticsAttributes)}
       >
         <div className={styles['flash-body']}>
           <div className={styles['flash-focus-container']} tabIndex={-1}>

--- a/src/flashbar/interfaces.ts
+++ b/src/flashbar/interfaces.ts
@@ -20,6 +20,9 @@ export namespace FlashbarProps {
     buttonText?: ButtonProps['children'];
     onButtonClick?: ButtonProps['onClick'];
     onDismiss?: ButtonProps['onClick'];
+    analyticsMetadata?: {
+      suppressFlowMetricEvents?: boolean;
+    };
   }
 
   export interface I18nStrings {

--- a/src/flashbar/interfaces.ts
+++ b/src/flashbar/interfaces.ts
@@ -20,9 +20,11 @@ export namespace FlashbarProps {
     buttonText?: ButtonProps['children'];
     onButtonClick?: ButtonProps['onClick'];
     onDismiss?: ButtonProps['onClick'];
-    analyticsMetadata?: {
-      suppressFlowMetricEvents?: boolean;
-    };
+    analyticsMetadata?: FlashbarProps.ItemAnalyticsMetadata;
+  }
+
+  export interface ItemAnalyticsMetadata {
+    suppressFlowMetricEvents?: boolean;
   }
 
   export interface I18nStrings {
@@ -68,6 +70,9 @@ export interface FlashbarProps extends BaseComponentProps {
    * * `id` (string) - Specifies a unique flash message identifier. This property is used in two ways:
    *   1. As a [keys](https://reactjs.org/docs/lists-and-keys.html#keys) source for React rendering.
    *   2. To identify which flash message will be removed from the DOM when it is dismissed, to animate it out.
+   * * `analyticsMetadata` (FlashbarProps.ItemAnalyticsMetadata) - (Optional) Specifies additional analytics-related metadata.
+   *   * `suppressFlowMetricEvents` - Prevent this item from generating events related to flow metrics.
+   * @analytics
    */
   items: ReadonlyArray<FlashbarProps.MessageDefinition>;
 

--- a/src/internal/base-component/index.ts
+++ b/src/internal/base-component/index.ts
@@ -48,6 +48,8 @@ export interface BasePropsWithAnalyticsMetadata {
  * Helper function to merge beta analytics metadata with the public analytics metadata api.
  * Beta analytics metadata will override the public values to allow for safe migration.
  */
-export function getAnalyticsMetadataProps(props?: BasePropsWithAnalyticsMetadata) {
+export function getAnalyticsMetadataProps<T extends BasePropsWithAnalyticsMetadata>(
+  props?: T
+): NonNullable<T['analyticsMetadata'] & T['__analyticsMetadata']> {
   return { ...props?.analyticsMetadata, ...props?.__analyticsMetadata };
 }


### PR DESCRIPTION
### Description

This PR adds a new field to the analytics metadata field of individual flash items. The `analyticsMetadata` field can currently already be used (see [code](https://github.com/cloudscape-design/components/blob/e30984564d0899802df1265b4831228d46cea7bc/src/flashbar/flash.tsx#L117)), but it is not documented, since it was only intended for internal testing. 
When the `suppressFlowMetricEvents` field is set, the flashbar will no longer be marked with analytics-related attributes, which will exclude it from generating flow metric events.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: Document `cVyaAI57bL8k`

### How has this been tested?

Tested manually in the browser and added a unit test

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
