### PR TITLE
chore: Adds missing filtering-tags to the announcer string

### DIFF
--- a/pages/autosuggest/simple.page.tsx
+++ b/pages/autosuggest/simple.page.tsx
@@ -6,7 +6,7 @@ import { Autosuggest, AutosuggestProps, Box, SpaceBetween } from '~components';
 
 const empty = <span>Nothing found</span>;
 const options = [
-  { value: 'Option 0', tags: ['tag1', 'tag2'], filteringTags: ['bla', 'opt'], description: 'description1' },
+  { value: 'Option 0', tags: ['tag1', 'tag2'], filteringTags: ['bla', 'opt', 'blauer'], description: 'description1' },
   { value: 'Option 1', labelTag: 'This is a label tag' },
   { value: 'Option 2' },
   { value: 'Option', description: 'description2' },

--- a/src/autosuggest/options-list.tsx
+++ b/src/autosuggest/options-list.tsx
@@ -52,6 +52,7 @@ export default function AutosuggestOptionsList({
   const ListComponent = virtualScroll ? VirtualList : PlainList;
 
   const announcement = useAnnouncement({
+    highlightText,
     announceSelected: autosuggestItemsState.highlightedOption?.value === highlightText,
     highlightedOption: autosuggestItemsState.highlightedOption,
     getParent: option => autosuggestItemsState.getItemGroup(option),

--- a/src/internal/components/option/option-announcer.ts
+++ b/src/internal/components/option/option-announcer.ts
@@ -1,8 +1,23 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { OptionDefinition, OptionGroup } from './interfaces';
+import { matchesString } from './utils/filter-options';
 
-function defaultOptionDescription(option: OptionDefinition, parentGroup: OptionGroup | undefined) {
+interface DefaultOptionDescriptionProps {
+  option: OptionDefinition;
+  parentGroup?: OptionGroup;
+  highlightText?: string;
+}
+
+function getMatchingFilteringTags(filteringTags?: readonly string[], highlightText?: string): string[] {
+  if (!highlightText || !filteringTags) {
+    return [];
+  }
+
+  return filteringTags.filter(filteringTag => matchesString(filteringTag, highlightText, false));
+}
+
+function defaultOptionDescription({ option, parentGroup, highlightText }: DefaultOptionDescriptionProps) {
   return [
     parentGroup && parentGroup.label,
     option.__labelPrefix,
@@ -11,6 +26,7 @@ function defaultOptionDescription(option: OptionDefinition, parentGroup: OptionG
     option.labelTag,
   ]
     .concat(option.tags)
+    .concat(getMatchingFilteringTags(option.filteringTags, highlightText))
     .filter(el => !!el)
     .join(' ');
 }

--- a/src/select/__tests__/use-announcement.test.ts
+++ b/src/select/__tests__/use-announcement.test.ts
@@ -5,7 +5,7 @@ import { DropdownOption, OptionDefinition, OptionGroup } from '../../internal/co
 import { flattenOptions } from '../../internal/components/option/utils/flatten-options';
 import { useAnnouncement } from '../utils/use-announcement';
 
-const options = [
+const options: DropdownOption['option'][] = [
   {
     label: 'Group 1',
     options: [
@@ -37,6 +37,11 @@ const options = [
         disabled: true,
       },
     ],
+  },
+  {
+    label: 'Option 2',
+    tags: ['tag-1', 'tag-2'],
+    filteringTags: ['filtering-tag-1', 'filtering-tag-2'],
   },
 ];
 
@@ -79,6 +84,41 @@ describe('useAnnouncement', () => {
       initialProps: { getParent, highlightedOption: flatOptions[1], announceSelected: false },
     });
     expect(hook.result.current).toEqual('Group 1 Child 1');
+  });
+
+  test('should return announcement string with tags', () => {
+    const hook = renderHook(useAnnouncement, {
+      initialProps: {
+        getParent,
+        highlightedOption: flatOptions[7],
+        announceSelected: false,
+      },
+    });
+    expect(hook.result.current).toEqual('Option 2 tag-1 tag-2');
+  });
+
+  test('should return announcement string with all of the matching filtering tags', () => {
+    const hook = renderHook(useAnnouncement, {
+      initialProps: {
+        getParent,
+        highlightedOption: flatOptions[7],
+        announceSelected: false,
+        highlightText: 'filtering',
+      },
+    });
+    expect(hook.result.current).toEqual('Option 2 tag-1 tag-2 filtering-tag-1 filtering-tag-2');
+  });
+
+  test('should return announcement string without non-matching filtering tags', () => {
+    const hook = renderHook(useAnnouncement, {
+      initialProps: {
+        getParent,
+        highlightedOption: flatOptions[7],
+        announceSelected: false,
+        highlightText: 'filtering-tag-2',
+      },
+    });
+    expect(hook.result.current).toEqual('Option 2 tag-1 tag-2 filtering-tag-2');
   });
 
   test('announcement should be prepended with selected label, if highlighted item is selected', () => {

--- a/src/select/utils/use-announcement.ts
+++ b/src/select/utils/use-announcement.ts
@@ -17,12 +17,14 @@ interface OptionHolder {
  * If the testing reveals no issues with the native announcements the live-region can be removed.
  */
 export function useAnnouncement<Option extends OptionHolder>({
+  highlightText,
   announceSelected,
   highlightedOption,
   getParent,
   selectedAriaLabel,
   renderHighlightedAriaLive,
 }: {
+  highlightText?: string;
   announceSelected: boolean;
   highlightedOption?: Option;
   getParent: (option: Option) => undefined | OptionGroup;
@@ -57,6 +59,6 @@ export function useAnnouncement<Option extends OptionHolder>({
 
   // Use default renderer with selected ARIA label if defined and relevant.
   const selectedAnnouncement = announceSelected && selectedAriaLabel ? selectedAriaLabel : '';
-  const defaultDescription = defaultOptionDescription(option, group);
+  const defaultDescription = defaultOptionDescription({ option, parentGroup: group, highlightText });
   return [selectedAnnouncement, defaultDescription].filter(Boolean).join(' ');
 }


### PR DESCRIPTION
### Description

Adds option's `filteringText` to the announcement text. This follows the visual behavior and is added to the announcement text only when the text input matches the `filteringText`

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-60198

### How has this been tested?

Added unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
