### PR TITLE
chore: Add aria-expanded to Hotspot trigger buttons

### DIFF
--- a/pages/onboarding/i18n.ts
+++ b/pages/onboarding/i18n.ts
@@ -29,10 +29,7 @@ export const tutorialPanelStrings: TutorialPanelProps.I18nStrings = {
 export const annotationContextStrings: AnnotationContextProps.I18nStrings = {
   stepCounterText: (stepIndex, totalStepCount) => `Step ${stepIndex + 1}/${totalStepCount}`,
   taskTitle: (taskIndex, taskTitle) => `Task ${taskIndex + 1}: ${taskTitle}`,
-  labelHotspot: (openState, stepIndex, totalStepCount) =>
-    openState
-      ? `close annotation for step ${stepIndex + 1}/${totalStepCount}`
-      : `open annotation for step ${stepIndex + 1}/${totalStepCount}`,
+  labelHotspot: (openState, stepIndex, totalStepCount) => `Annotation for step ${stepIndex + 1}/${totalStepCount}`,
   nextButtonText: 'Next',
   previousButtonText: 'Previous',
   finishButtonText: 'Finish',

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -380,8 +380,15 @@ in the \`detail\` property of the \`onStartTutorial\` event.",
       "type": "AnnotationContextProps.Tutorial | null",
     },
     {
-      "description": "An object containing all the necessary localized strings required by
-the component.",
+      "description": "An object containing all the necessary localized strings required by the component. The object should contain:
+* \`finishButtonText\` - Specifies the text that's displayed in the finish button.
+* \`labelDismissAnnotation\` - Specifies the aria-label for the dismiss button.
+* \`labelHotspot\` - Specifies the aria-label for the hotspot button. The \`openState\` argument is deprecated, it's handled by the hotspot button aria-expanded attribute.
+* \`nextButtonText\` - Specifies the text that's displayed in the next button.
+* \`previousButtonText\` - Specifies the text that's displayed in the previous button.
+* \`stepCounterText\` - Specifies the step counter text that's displayed in the annotation popover.
+* \`taskTitle\` - Specifies the title text that's displayed in the annotation popover.
+",
       "inlineType": {
         "name": "AnnotationContextProps.I18nStrings",
         "properties": [

--- a/src/annotation-context/__tests__/annotation-context.test.tsx
+++ b/src/annotation-context/__tests__/annotation-context.test.tsx
@@ -244,6 +244,22 @@ test('trigger should have aria-label with steps information', () => {
   expect(hotspot.findTrigger().getElement().getAttribute('aria-label')).toBe('CLOSE_HOTSPOT_TEST_FOR_STEP_1_OF_2_TEST');
 });
 
+test('trigger should have aria-expanded depending on open state', () => {
+  const { wrapper } = renderAnnotationContext(
+    <>
+      <Hotspot hotspotId="first-hotspot" data-testid="first-hotspot" />
+      <Hotspot hotspotId="second-hotspot" data-testid="second-hotspot" />
+    </>
+  );
+
+  // First hotspot is open by default.
+  const hotspot = wrapper.findHotspot('[data-testid="first-hotspot"]')!;
+  expect(hotspot.findTrigger().getElement().getAttribute('aria-expanded')).toBe('true');
+  // Switching to the second hotspot which closes the first one.
+  hotspot.findTrigger().click();
+  expect(hotspot.findTrigger().getElement().getAttribute('aria-expanded')).toBe('false');
+});
+
 test('annotation should have be labeled by header and step counter', () => {
   const { wrapper } = renderAnnotationContext(
     <>

--- a/src/annotation-context/annotation/annotation-trigger.tsx
+++ b/src/annotation-context/annotation/annotation-trigger.tsx
@@ -34,6 +34,7 @@ export default React.forwardRef<HTMLButtonElement, AnnotationTriggerProps>(funct
       ref={ref}
       className={styles.hotspot}
       aria-haspopup="dialog"
+      aria-expanded={open ? 'true' : 'false'}
       aria-label={i18nStrings.labelHotspot(open, taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)}
       onClick={onClick}
     >

--- a/src/annotation-context/annotation/annotation-trigger.tsx
+++ b/src/annotation-context/annotation/annotation-trigger.tsx
@@ -34,7 +34,7 @@ export default React.forwardRef<HTMLButtonElement, AnnotationTriggerProps>(funct
       ref={ref}
       className={styles.hotspot}
       aria-haspopup="dialog"
-      aria-expanded={open ? 'true' : 'false'}
+      aria-expanded={open}
       aria-label={i18nStrings.labelHotspot(open, taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)}
       onClick={onClick}
     >

--- a/src/annotation-context/interfaces.ts
+++ b/src/annotation-context/interfaces.ts
@@ -46,8 +46,15 @@ export interface AnnotationContextProps {
   children: React.ReactNode;
 
   /**
-   * An object containing all the necessary localized strings required by
-   * the component.
+   * An object containing all the necessary localized strings required by the component. The object should contain:
+   *
+   * * `finishButtonText` - Specifies the text that's displayed in the finish button.
+   * * `labelDismissAnnotation` - Specifies the aria-label for the dismiss button.
+   * * `labelHotspot` - Specifies the aria-label for the hotspot button. The `openState` argument is deprecated, it's handled by the hotspot button aria-expanded attribute.
+   * * `nextButtonText` - Specifies the text that's displayed in the next button.
+   * * `previousButtonText` - Specifies the text that's displayed in the previous button.
+   * * `stepCounterText` - Specifies the step counter text that's displayed in the annotation popover.
+   * * `taskTitle` - Specifies the title text that's displayed in the annotation popover.
    */
   i18nStrings: AnnotationContextProps.I18nStrings;
 }


### PR DESCRIPTION
### Description

The label should not consider the open/closed state anymore.
This is handled via the `aria-expanded` attribute on the button which informs screen reader users about it. 

Related links, issue #, if available: AWSUI-60206, CR-180686961

### How has this been tested?

- verified manually on test pages.
- add additional unit test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
