### PR TITLE
chore: Ensure aria-disabled is placed correctly in disabled groups

### DIFF
--- a/src/button-dropdown/__tests__/button-dropdown-items.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-items.test.tsx
@@ -24,8 +24,7 @@ const renderButtonDropdown = (props: ButtonDropdownProps) => {
 const checkRenderedGroup = (
   renderedItem: ElementWrapper,
   group: ButtonDropdownProps.ItemGroup,
-  parentIsDisabled: boolean,
-  renderedCategoryGroup: ElementWrapper
+  parentIsDisabled: boolean
 ) => {
   const element = renderedItem.getElement();
 
@@ -40,7 +39,10 @@ const checkRenderedGroup = (
   if (parentIsDisabled || group.disabled) {
     expect(element).toHaveClass(`${categoryStyles.disabled}`);
     if (group.disabled) {
-      expect(renderedCategoryGroup?.getElement()).toHaveAttribute('aria-disabled', 'true');
+      expect(element.querySelector(`.${categoryItemStyles['items-list-container']}`)).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
     }
   }
 };
@@ -92,15 +94,11 @@ const checkRenderedItems = (
 
   expect(renderedItems.length).toBe(items.length);
 
-  const categoryGroups = wrapper.findAllByClassName(`${categoryItemStyles['items-list-container']}`);
-
-  let categoryGroup = 0;
   renderedItems.forEach((renderedItem: ElementWrapper, index: number) => {
     const item = items[index];
 
     if (isItemGroup(item)) {
-      checkRenderedGroup(renderedItem, item, parentIsDisabled, categoryGroups[categoryGroup]!);
-      categoryGroup++;
+      checkRenderedGroup(renderedItem, item, parentIsDisabled);
     } else {
       checkElementItem(renderedItem, item, parentIsDisabled);
     }

--- a/src/button-dropdown/__tests__/button-dropdown-items.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-items.test.tsx
@@ -95,7 +95,7 @@ const checkRenderedItems = (
   const categoryGroups = wrapper.findAllByClassName(`${categoryItemStyles['items-list-container']}`);
 
   let categoryGroup = 0;
-  Array.prototype.forEach.call(renderedItems, (renderedItem: ElementWrapper, index: number) => {
+  renderedItems.forEach((renderedItem: ElementWrapper, index: number) => {
     const item = items[index];
 
     if (isItemGroup(item)) {

--- a/src/button-dropdown/__tests__/button-dropdown-items.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-items.test.tsx
@@ -11,6 +11,7 @@ import createWrapper from '../../../lib/components/test-utils/dom';
 import { isItemGroup, isLinkItem } from '../utils/utils';
 
 import categoryStyles from '../../../lib/components/button-dropdown/category-elements/styles.css.js';
+import categoryItemStyles from '../../../lib/components/button-dropdown/category-elements/styles.css.js';
 import itemStyles from '../../../lib/components/button-dropdown/item-element/styles.css.js';
 import iconStyles from '../../../lib/components/icon/styles.css.js';
 import optionsListStyles from '../../../lib/components/internal/components/options-list/styles.css.js';
@@ -23,7 +24,8 @@ const renderButtonDropdown = (props: ButtonDropdownProps) => {
 const checkRenderedGroup = (
   renderedItem: ElementWrapper,
   group: ButtonDropdownProps.ItemGroup,
-  parentIsDisabled = false
+  parentIsDisabled: boolean,
+  renderedCategoryGroup: ElementWrapper
 ) => {
   const element = renderedItem.getElement();
 
@@ -37,7 +39,9 @@ const checkRenderedGroup = (
 
   if (parentIsDisabled || group.disabled) {
     expect(element).toHaveClass(`${categoryStyles.disabled}`);
-    expect(element).toHaveAttribute('aria-disabled', 'true');
+    if (group.disabled) {
+      expect(renderedCategoryGroup?.getElement()).toHaveAttribute('aria-disabled', 'true');
+    }
   }
 };
 
@@ -88,11 +92,15 @@ const checkRenderedItems = (
 
   expect(renderedItems.length).toBe(items.length);
 
-  Array.prototype.forEach.call(renderedItems, (renderedItem, index) => {
+  const categoryGroups = wrapper.findAllByClassName(`${categoryItemStyles['items-list-container']}`);
+
+  let categoryGroup = 0;
+  Array.prototype.forEach.call(renderedItems, (renderedItem: ElementWrapper, index: number) => {
     const item = items[index];
 
     if (isItemGroup(item)) {
-      checkRenderedGroup(renderedItem, item, parentIsDisabled);
+      checkRenderedGroup(renderedItem, item, parentIsDisabled, categoryGroups[categoryGroup]!);
+      categoryGroup++;
     } else {
       checkElementItem(renderedItem, item, parentIsDisabled);
     }

--- a/src/button-dropdown/category-elements/category-element.tsx
+++ b/src/button-dropdown/category-elements/category-element.tsx
@@ -34,12 +34,7 @@ const CategoryElement = ({
           {item.text}
         </p>
       )}
-      <ul
-        className={styles['items-list-container']}
-        role="group"
-        aria-label={item.text}
-        aria-disabled={disabled ? 'true' : undefined}
-      >
+      <ul className={styles['items-list-container']} role="group" aria-label={item.text} aria-disabled={disabled}>
         {item.items && (
           <ItemsList
             items={item.items}

--- a/src/button-dropdown/category-elements/category-element.tsx
+++ b/src/button-dropdown/category-elements/category-element.tsx
@@ -28,14 +28,18 @@ const CategoryElement = ({
     <li
       className={clsx(styles.category, styles[`variant-${variant}`], disabled && styles.disabled)}
       role="presentation"
-      aria-disabled={disabled ? 'true' : undefined}
     >
       {item.text && (
         <p className={clsx(styles.header, { [styles.disabled]: disabled })} aria-hidden="true">
           {item.text}
         </p>
       )}
-      <ul className={styles['items-list-container']} role="group" aria-label={item.text}>
+      <ul
+        className={styles['items-list-container']}
+        role="group"
+        aria-label={item.text}
+        aria-disabled={disabled ? 'true' : undefined}
+      >
         {item.items && (
           <ItemsList
             items={item.items}


### PR DESCRIPTION
### Description

Related a11y ticket: AWSUI-60215

A simple edit that makes disabled groups correctly have the `aria-disabled` over the `ul` instead of the `li` because it has a role of presentation. Screen readers may not announce this content as disabled.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
