### PR TITLE
chore: Remove theme dropdown from dev pages

### DIFF
--- a/pages/app/components/theme-switcher.tsx
+++ b/pages/app/components/theme-switcher.tsx
@@ -4,7 +4,7 @@ import React, { useContext } from 'react';
 
 import { Density, Mode } from '@cloudscape-design/global-styles';
 
-import { ALWAYS_VISUAL_REFRESH, THEME } from '~components/internal/environment';
+import { ALWAYS_VISUAL_REFRESH } from '~components/internal/environment';
 import SpaceBetween from '~components/space-between';
 
 import AppContext from '../app-context';
@@ -30,12 +30,6 @@ export default function ThemeSwitcher() {
 
   return (
     <SpaceBetween direction="horizontal" size="xs">
-      <label>
-        Theme
-        <select defaultValue={THEME}>
-          <option value={THEME}>{THEME}</option>
-        </select>
-      </label>
       <label>
         <input {...vrSwitchProps} />
         Visual refresh


### PR DESCRIPTION
### Description

Removes this dropdown from the dev pages. It is not used anywhere.

<img width="577" alt="image" src="https://github.com/user-attachments/assets/9141210e-f855-4de0-95f9-812debcb3fbd" />

### How has this been tested?

Locally. Reviewer can see result in preview deployment

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
