### PR TITLE
chore: Add data attribute to flashbar to suppress metrics events

### DIFF
--- a/src/flashbar/__tests__/analytics-metadata.test.tsx
+++ b/src/flashbar/__tests__/analytics-metadata.test.tsx
@@ -11,7 +11,10 @@ import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-tool
 
 import Button from '../../../lib/components/button';
 import Flashbar, { FlashbarProps } from '../../../lib/components/flashbar';
-import { DATA_ATTR_ANALYTICS_FLASHBAR } from '../../../lib/components/internal/analytics/selectors';
+import {
+  DATA_ATTR_ANALYTICS_FLASHBAR,
+  DATA_ATTR_ANALYTICS_SUPPRESS_FLOW_EVENTS,
+} from '../../../lib/components/internal/analytics/selectors';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { validateComponentNameAndLabels } from '../../internal/__tests__/analytics-metadata-test-utils';
 
@@ -217,11 +220,11 @@ describe('Flashbar renders correct analytics metadata', () => {
       expect(wrapper.find(`[${DATA_ATTR_ANALYTICS_FLASHBAR}="info"]`)!.getElement()).toBeInTheDocument();
     });
 
-    test('adds no attribute if suppressFlowMetricEvents is set', () => {
+    test('adds a data suppress attribute if suppressFlowMetricEvents is set', () => {
       const wrapper = renderFlashbar({
         items: [{ id: '0', type: 'success', analyticsMetadata: { suppressFlowMetricEvents: true } }],
       });
-      expect(wrapper.find(`[${DATA_ATTR_ANALYTICS_FLASHBAR}]`)).toBeNull();
+      expect(wrapper.find(`[${DATA_ATTR_ANALYTICS_SUPPRESS_FLOW_EVENTS}]`)).not.toBeNull();
     });
   });
 });

--- a/src/flashbar/flash.tsx
+++ b/src/flashbar/flash.tsx
@@ -9,7 +9,10 @@ import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-tool
 import { ActionsWrapper } from '../alert/actions-wrapper';
 import { InternalButton } from '../button/internal';
 import InternalIcon from '../icon/internal';
-import { DATA_ATTR_ANALYTICS_FLASHBAR } from '../internal/analytics/selectors';
+import {
+  DATA_ATTR_ANALYTICS_FLASHBAR,
+  DATA_ATTR_ANALYTICS_SUPPRESS_FLOW_EVENTS,
+} from '../internal/analytics/selectors';
 import { BasePropsWithAnalyticsMetadata, getAnalyticsMetadataProps } from '../internal/base-component';
 import { getVisualContextClassname } from '../internal/components/visual-context';
 import { PACKAGE_VERSION } from '../internal/environment';
@@ -151,9 +154,13 @@ export const Flash = React.forwardRef(
 
     const effectiveType = loading ? 'info' : type;
 
-    const analyticsAttributes = {
+    const analyticsAttributes: Record<string, string> = {
       [DATA_ATTR_ANALYTICS_FLASHBAR]: effectiveType,
     };
+
+    if (analyticsMetadata.suppressFlowMetricEvents) {
+      analyticsAttributes[DATA_ATTR_ANALYTICS_SUPPRESS_FLOW_EVENTS] = 'true';
+    }
 
     return (
       // We're not using "polite" or "assertive" here, just turning default behavior off.
@@ -178,7 +185,7 @@ export const Flash = React.forwardRef(
           getVisualContextClassname(type === 'warning' && !loading ? 'flashbar-warning' : 'flashbar'),
           initialHidden && styles['initial-hidden']
         )}
-        {...(analyticsMetadata.suppressFlowMetricEvents ? undefined : analyticsAttributes)}
+        {...analyticsAttributes}
       >
         <div className={styles['flash-body']}>
           <div className={styles['flash-focus-container']} tabIndex={-1}>

--- a/src/internal/analytics/selectors.ts
+++ b/src/internal/analytics/selectors.ts
@@ -14,6 +14,7 @@ export const DATA_ATTR_FIELD_ERROR = 'data-analytics-field-error';
 
 export const DATA_ATTR_ANALYTICS_ALERT = 'data-analytics-alert';
 export const DATA_ATTR_ANALYTICS_FLASHBAR = 'data-analytics-flashbar';
+export const DATA_ATTR_ANALYTICS_SUPPRESS_FLOW_EVENTS = 'data-analytics-suppress-flow-events';
 
 export const FUNNEL_KEY_FUNNEL_NAME = 'funnel-name';
 export const FUNNEL_KEY_STEP_NAME = 'step-name';


### PR DESCRIPTION
### Description

- Adds back the `data-analytics-flashbar` attribute to Flashbar
- When suppressFlowMetricEvents is set, adds a `data-analytics-suppress-flow-events` attribute instead

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

- Updated existing unit test

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
