### PR TITLE
chore: Assert that our components do not generate styles in SSR

### DIFF
--- a/src/__tests__/functional-tests/ssr.test.ts
+++ b/src/__tests__/functional-tests/ssr.test.ts
@@ -25,6 +25,7 @@ for (const componentName of getAllComponents()) {
       expect(content.length).toEqual(0);
     } else {
       expect(content.length).toBeGreaterThan(0);
+      expect(content).not.toContain('style="');
     }
   });
 }


### PR DESCRIPTION
### Description

When these styles are emitted during SSR, they break CSP `style-src`

Related links, issue #, if available: n/a

### How has this been tested?

This is a test only

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
