### PR TITLE
chore: Adds group role and aria label to flash focus

### DIFF
--- a/src/flashbar/__tests__/collapsible.test.tsx
+++ b/src/flashbar/__tests__/collapsible.test.tsx
@@ -12,7 +12,7 @@ jest.mock('../../../lib/components/internal/utils/scrollable-containers', () => 
 });
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 
 import { disableMotion } from '@cloudscape-design/global-styles';
 
@@ -20,6 +20,8 @@ import Flashbar from '../../../lib/components/flashbar';
 import createWrapper, { FlashbarWrapper } from '../../../lib/components/test-utils/dom';
 import { FlashbarProps } from '../interfaces';
 import { createFlashbarWrapper, findList, testFlashDismissal } from './common';
+
+import stylesCss from '../../../lib/components/flashbar/styles.css.js';
 
 const sampleItems: Record<FlashbarProps.Type, FlashbarProps.MessageDefinition> = {
   error: { type: 'error', header: 'Error', content: 'There was an error' },
@@ -206,6 +208,41 @@ describe('Collapsible Flashbar', () => {
         const list = findList(flashbar)!;
         expect(list).toBeTruthy();
         expect(list.getElement().getAttribute('aria-label')).toEqual(customAriaLabel);
+      });
+
+      it('applies ARIA role "group" to the flash messages and labels them by their icon and content', () => {
+        const flashbar = renderFlashbar({
+          items: [sampleItems.success, sampleItems.warning, sampleItems.error],
+        });
+
+        findNotificationBar(flashbar)!.click();
+
+        const [successItem, warningItem, errorItem] = flashbar.findItems()!;
+        const flashItemsWithExpectedLabels = [
+          {
+            item: successItem,
+            // Label is computed by: Icon Header Content
+            expectedLabel: 'Success Success Everything went fine',
+          },
+          {
+            item: warningItem,
+            // Label is computed by: Icon Header Content
+            expectedLabel: 'Warning Warning',
+          },
+          {
+            item: errorItem,
+            // Label is computed by: Icon Header Content
+            expectedLabel: 'Error Error There was an error',
+          },
+        ];
+
+        for (const { item, expectedLabel } of flashItemsWithExpectedLabels) {
+          const focusContainer = within(item.getElement()!).getByRole('group', {
+            name: expectedLabel,
+          });
+          expect(focusContainer).toBeInTheDocument();
+          expect(focusContainer).toHaveClass(stylesCss['flash-focus-container']);
+        }
       });
 
       it('hides collapsed items from the accessibility tree', () => {

--- a/src/flashbar/flash.tsx
+++ b/src/flashbar/flash.tsx
@@ -17,6 +17,7 @@ import { BasePropsWithAnalyticsMetadata, getAnalyticsMetadataProps } from '../in
 import { getVisualContextClassname } from '../internal/components/visual-context';
 import { PACKAGE_VERSION } from '../internal/environment';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { isDevelopment } from '../internal/is-development';
 import { awsuiPluginsInternal } from '../internal/plugins/api';
 import { createUseDiscoveredAction, createUseDiscoveredContent } from '../internal/plugins/helpers';
@@ -122,6 +123,8 @@ export const Flash = React.forwardRef(
     );
     const elementRef = useComponentMetadata('Flash', PACKAGE_VERSION, { ...analyticsMetadata });
     const mergedRef = useMergeRefs(ref, elementRef);
+    const flashIconId = useUniqueId('flash-icon');
+    const flashMessageId = useUniqueId('flash-message');
 
     const headerRefObject = useRef<HTMLDivElement>(null);
     const contentRefObject = useRef<HTMLDivElement>(null);
@@ -188,9 +191,16 @@ export const Flash = React.forwardRef(
         {...analyticsAttributes}
       >
         <div className={styles['flash-body']}>
-          <div className={styles['flash-focus-container']} tabIndex={-1}>
-            <div className={clsx(styles['flash-icon'], styles['flash-text'])}>{icon}</div>
-            <div className={clsx(styles['flash-message'], styles['flash-text'])}>
+          <div
+            className={styles['flash-focus-container']}
+            tabIndex={-1}
+            role="group"
+            aria-labelledby={`${flashIconId} ${flashMessageId}`}
+          >
+            <div className={clsx(styles['flash-icon'], styles['flash-text'])} id={flashIconId}>
+              {icon}
+            </div>
+            <div className={clsx(styles['flash-message'], styles['flash-text'])} id={flashMessageId}>
               <div
                 className={clsx(
                   styles['flash-header'],


### PR DESCRIPTION
Re-opens the https://github.com/cloudscape-design/components/pull/3263, after the second revert. Blocking issue was resolved on the customer side.

This reverts commit d67161a67bafa89823f17a75ba8f0fe9f3bb5fa0.

### Description

Related links, issue #, if available: AWSUI-60238

### How has this been tested?

* Newly added unit test
* Manual check with voice over

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
