### PR TITLE
chore: Merges the resize observers

### DIFF
--- a/pages/app-layout/with-sticky-notifications-and-header.page.tsx
+++ b/pages/app-layout/with-sticky-notifications-and-header.page.tsx
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useState } from 'react';
 
 import AppLayout from '~components/app-layout';
-import Flashbar from '~components/flashbar';
+import Flashbar, { FlashbarProps } from '~components/flashbar';
 import Header from '~components/header';
 import Table from '~components/table';
 
@@ -12,28 +12,38 @@ import { Breadcrumbs } from './utils/content-blocks';
 import labels from './utils/labels';
 
 export default function () {
+  const [flashItems, setFlashItems] = useState<FlashbarProps['items']>([
+    {
+      id: 'item-1',
+      type: 'success',
+      header: 'Success message',
+      statusIconAriaLabel: 'success',
+      dismissible: true,
+      dismissLabel: 'Dismiss item-1',
+      onDismiss: () => dismissFlashItem('item-1'),
+    },
+    {
+      id: 'item-2',
+      type: 'info',
+      header: 'Info message',
+      statusIconAriaLabel: 'info',
+      dismissible: true,
+      dismissLabel: 'Dismiss item-2',
+      onDismiss: () => dismissFlashItem('item-2'),
+    },
+  ]);
+
+  const dismissFlashItem = (itemId: string) => {
+    setFlashItems(items => items.filter(item => item.id !== itemId));
+  };
+
   return (
     <ScreenshotArea gutters={false}>
       <AppLayout
         ariaLabels={labels}
         stickyNotifications={true}
         breadcrumbs={<Breadcrumbs />}
-        notifications={
-          <Flashbar
-            items={[
-              {
-                type: 'success',
-                header: 'Success message',
-                statusIconAriaLabel: 'success',
-              },
-              {
-                type: 'info',
-                header: 'Info message',
-                statusIconAriaLabel: 'info',
-              },
-            ]}
-          />
-        }
+        notifications={<Flashbar items={flashItems} />}
         content={
           <>
             <h1>Sticky Notifications + Table Header</h1>

--- a/src/app-layout/visual-refresh-toolbar/notifications/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/notifications/index.tsx
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
-import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
 import { highContrastHeaderClassName } from '../../../internal/utils/content-header-utils';
@@ -25,9 +24,14 @@ export function AppLayoutNotificationsImplementation({
   children,
 }: AppLayoutNotificationsImplementationProps) {
   const { ariaLabels, stickyNotifications, setNotificationsHeight, verticalOffsets } = appLayoutInternals;
-  const [hasNotificationsContent, contentRef] = useContainerQuery(rect => rect.borderBoxHeight > 0);
+  const [hasNotificationsContent, setHasNotificationsContent] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
-  useResizeObserver(rootRef, entry => setNotificationsHeight(entry.borderBoxHeight));
+
+  useResizeObserver(rootRef, entry => {
+    const hasContent = entry.contentBoxHeight > 0;
+    setNotificationsHeight(hasContent ? entry.borderBoxHeight : 0);
+    setHasNotificationsContent(hasContent);
+  });
   useEffect(() => {
     return () => {
       setNotificationsHeight(0);
@@ -48,12 +52,7 @@ export function AppLayoutNotificationsImplementation({
         insetBlockStart: stickyNotifications ? verticalOffsets.notifications : undefined,
       }}
     >
-      <div
-        ref={contentRef}
-        className={testutilStyles.notifications}
-        role="region"
-        aria-label={ariaLabels?.notifications}
-      >
+      <div className={testutilStyles.notifications} role="region" aria-label={ariaLabels?.notifications}>
         {children}
       </div>
     </NotificationsSlot>


### PR DESCRIPTION
### Description

Fixes the race condition in `ResizeObserver` listeners.

Related links, issue #, if available: AWSUI-60457

### Context

A few facts about the sticky headers:

1. We use `ResizeObserver` to recalculate `--awsui-sticky-vertical-top-offset` which determines the offset of the table's sticky header.
2. When there is a sticky notification in the page and it is dimissed, the recalculation takes place.
3. We rely on `ResizeObserver` to do the recalculation.
4. `ResizeObserver` listens to the `content-box` changes by default ([Ref](https://developer.mozilla.org/de/docs/Web/API/ResizeObserver/observe#options)). **Important!**
5. Sticky notification adds `8px` of padding when it has a content.

Now with the above points, this is what is happening when a sticky notification is dismissed:

1. `useContainerQuery` callback is called and sets `hasNotificationContent: false`
2. `useResizeObserver` callback is called with `borderBoxHeight: 8px`, remember the `8px` padding is still there.
3. In the next render cycle the `8px` padding is removed because `hasNotificationContent` has been set to `false`.
4. `useResizeObserver` will be not called because the `content-box` is unchanged, removing `8px` changes only the `border-box`.

### Why this is a race condition?

If the `useResizeObserver` is called just a little bit later, the value will be `0` instead of `8px`. You can reproduce this by adding your own resize observer to the same dom node.

### How has this been tested?

1. Dev pipeline
7. Manually on the major browsers.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
