### PR TITLE
chore: Allow theme env to be passed into component metrics

### DIFF
--- a/src/internal/hooks/use-telemetry/index.ts
+++ b/src/internal/hooks/use-telemetry/index.ts
@@ -6,6 +6,7 @@ import { PACKAGE_SOURCE, PACKAGE_VERSION, THEME } from '../../environment';
 import { useVisualRefresh } from '../use-visual-mode';
 
 export function useTelemetry(componentName: string, config?: ComponentConfiguration) {
-  const theme = useVisualRefresh() ? 'vr' : THEME;
+  const isVisualRefresh = useVisualRefresh();
+  const theme = THEME === 'polaris' && isVisualRefresh ? 'vr' : THEME;
   useComponentMetrics(componentName, { packageSource: PACKAGE_SOURCE, packageVersion: PACKAGE_VERSION, theme }, config);
 }


### PR DESCRIPTION
### Description

Allows additional themes to pass in a theme to the metrics emitted. 

### How has this been tested?

Locally verified that each theme is set correctly for each theme.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
