### PR TITLE
chore: Ensure AnchorNavigation lists are marked up properly

### DIFF
--- a/src/anchor-navigation/__tests__/anchor-navigation.test.tsx
+++ b/src/anchor-navigation/__tests__/anchor-navigation.test.tsx
@@ -133,7 +133,7 @@ describe('AnchorNavigation', () => {
     });
   });
 
-  describe('nested items', () => {
+  describe('nested anchors', () => {
     const getParentTagChainUntilLastOL = (element: HTMLElement): string[] => {
       const parentChain: string[] = [];
       let currentElement = element;
@@ -162,11 +162,13 @@ describe('AnchorNavigation', () => {
           { text: 'Section 2', href: '#section2', level: 1 },
           { text: 'Section 3', href: '#section3', level: 1 },
           { text: 'Section 3.1', href: '#section3.1', level: 2 },
+          { text: 'Section 4', href: '#section4', level: 1 },
+          { text: 'Section 4.1.1.1', href: '#section4.1.1.1', level: 4 },
         ],
       });
 
       const olElements = wrapper.findAnchorNavigation()!.getElement().querySelectorAll('ol');
-      expect(olElements).toHaveLength(5);
+      expect(olElements).toHaveLength(6);
 
       const expectedNestings: { [key: number]: string[] } = {
         1: ['OL'],
@@ -177,6 +179,8 @@ describe('AnchorNavigation', () => {
         6: ['OL'],
         7: ['OL'],
         8: ['OL', 'LI', 'OL'],
+        9: ['OL'],
+        10: ['OL', 'LI', 'OL'],
       };
 
       Object.keys(expectedNestings).forEach(i => {

--- a/src/anchor-navigation/__tests__/anchor-navigation.test.tsx
+++ b/src/anchor-navigation/__tests__/anchor-navigation.test.tsx
@@ -132,4 +132,58 @@ describe('AnchorNavigation', () => {
       detail: { text: 'Section 2', href: '#section2', level: 1 },
     });
   });
+
+  describe('nested items', () => {
+    const getParentTagChainUntilLastOL = (element: HTMLElement): string[] => {
+      const parentChain: string[] = [];
+      let currentElement = element;
+
+      while (currentElement.parentElement) {
+        parentChain.push(currentElement.parentElement.tagName);
+        currentElement = currentElement.parentElement;
+
+        // Stop when reaching an element whose parent is not OL or LI
+        if (currentElement.parentElement && !['OL', 'LI'].includes(currentElement.parentElement.tagName)) {
+          break;
+        }
+      }
+
+      return parentChain;
+    };
+
+    it('renders nested levels in a sub-list', () => {
+      const wrapper = renderAnchorNavigation({
+        anchors: [
+          { text: 'Section 1', href: '#section1', level: 1 },
+          { text: 'Section 1.1', href: '#section1.1', level: 2 },
+          { text: 'Section 1.1.1', href: '#section1.1.1', level: 3 },
+          { text: 'Section 1.1.1.1', href: '#section1.1.1.1', level: 4 },
+          { text: 'Section 1.2', href: '#section1.2', level: 2 },
+          { text: 'Section 2', href: '#section2', level: 1 },
+          { text: 'Section 3', href: '#section3', level: 1 },
+          { text: 'Section 3.1', href: '#section3.1', level: 2 },
+        ],
+      });
+
+      const olElements = wrapper.findAnchorNavigation()!.getElement().querySelectorAll('ol');
+      expect(olElements).toHaveLength(5);
+
+      const expectedNestings: { [key: number]: string[] } = {
+        1: ['OL'],
+        2: ['OL', 'LI', 'OL'],
+        3: ['OL', 'LI', 'OL', 'LI', 'OL'],
+        4: ['OL', 'LI', 'OL', 'LI', 'OL', 'LI', 'OL'],
+        5: ['OL', 'LI', 'OL'],
+        6: ['OL'],
+        7: ['OL'],
+        8: ['OL', 'LI', 'OL'],
+      };
+
+      Object.keys(expectedNestings).forEach(i => {
+        const index = Number(i);
+        const tagChain = getParentTagChainUntilLastOL(wrapper.findAnchorByIndex(index)!.getElement()!);
+        expect(tagChain).toEqual(expectedNestings[index]);
+      });
+    });
+  });
 });

--- a/src/anchor-navigation/anchor-item/index.tsx
+++ b/src/anchor-navigation/anchor-item/index.tsx
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useCallback } from 'react';
+import clsx from 'clsx';
+
+import { isPlainLeftClick } from '../../internal/events';
+import { checkSafeUrl } from '../../internal/utils/check-safe-url';
+import { AnchorNavigationProps } from '../interfaces';
+
+import styles from '../styles.css.js';
+import testUtilsStyles from '../test-classes/styles.css.js';
+
+interface AnchorItemProps {
+  anchor: AnchorNavigationProps.Anchor;
+  onFollow: (anchor: AnchorNavigationProps.Anchor, event: React.SyntheticEvent | Event) => void;
+  isActive: boolean;
+  index: number;
+  children: React.ReactNode;
+}
+
+export const AnchorItem = ({ anchor, onFollow, isActive, index, children }: AnchorItemProps) => {
+  checkSafeUrl('AnchorNavigation', anchor.href);
+
+  const onClick = useCallback(
+    (event: React.MouseEvent) => {
+      if (isPlainLeftClick(event)) {
+        onFollow(anchor, event);
+      }
+    },
+    [onFollow, anchor]
+  );
+
+  const activeItemClasses = clsx(styles['anchor-item--active'], testUtilsStyles['anchor-item--active']);
+
+  return (
+    <li data-itemid={`anchor-item-${index + 1}`} className={clsx(styles['anchor-item'], isActive && activeItemClasses)}>
+      <a
+        onClick={onClick}
+        className={clsx(
+          styles['anchor-link'],
+          testUtilsStyles['anchor-link'],
+          isActive && styles['anchor-link--active']
+        )}
+        {...(isActive ? { 'aria-current': true } : {})}
+        href={anchor.href}
+      >
+        <span
+          className={clsx(styles['anchor-link-text'], testUtilsStyles['anchor-link-text'])}
+          style={{ paddingInlineStart: `${anchor.level * 16 + 2}px` }}
+        >
+          {anchor.text}
+        </span>
+        {anchor.info && (
+          <span className={clsx(styles['anchor-link-info'], testUtilsStyles['anchor-link-info'])}>{anchor.info}</span>
+        )}
+      </a>
+      {children}
+    </li>
+  );
+};

--- a/src/anchor-navigation/internal.tsx
+++ b/src/anchor-navigation/internal.tsx
@@ -4,9 +4,9 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import clsx from 'clsx';
 
 import { getBaseProps } from '../internal/base-component/index.js';
-import { fireCancelableEvent, fireNonCancelableEvent, isPlainLeftClick } from '../internal/events/index';
+import { fireCancelableEvent, fireNonCancelableEvent } from '../internal/events/index';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component/index.js';
-import { checkSafeUrl } from '../internal/utils/check-safe-url';
+import { AnchorItem } from './anchor-item';
 import { AnchorNavigationProps } from './interfaces';
 import useScrollSpy from './use-scroll-spy.js';
 
@@ -96,52 +96,3 @@ export default function InternalAnchorNavigation({
     </nav>
   );
 }
-
-interface AnchorItemProps {
-  anchor: AnchorNavigationProps.Anchor;
-  onFollow: (anchor: AnchorNavigationProps.Anchor, event: React.SyntheticEvent | Event) => void;
-  isActive: boolean;
-  index: number;
-  children: React.ReactNode;
-}
-
-const AnchorItem = ({ anchor, onFollow, isActive, index, children }: AnchorItemProps) => {
-  checkSafeUrl('AnchorNavigation', anchor.href);
-
-  const onClick = useCallback(
-    (event: React.MouseEvent) => {
-      if (isPlainLeftClick(event)) {
-        onFollow(anchor, event);
-      }
-    },
-    [onFollow, anchor]
-  );
-
-  const activeItemClasses = clsx(styles['anchor-item--active'], testUtilsStyles['anchor-item--active']);
-
-  return (
-    <li data-itemid={`anchor-item-${index + 1}`} className={clsx(styles['anchor-item'], isActive && activeItemClasses)}>
-      <a
-        onClick={onClick}
-        className={clsx(
-          styles['anchor-link'],
-          testUtilsStyles['anchor-link'],
-          isActive && styles['anchor-link--active']
-        )}
-        {...(isActive ? { 'aria-current': true } : {})}
-        href={anchor.href}
-      >
-        <span
-          className={clsx(styles['anchor-link-text'], testUtilsStyles['anchor-link-text'])}
-          style={{ paddingInlineStart: `${anchor.level * 16 + 2}px` }}
-        >
-          {anchor.text}
-        </span>
-        {anchor.info && (
-          <span className={clsx(styles['anchor-link-info'], testUtilsStyles['anchor-link-info'])}>{anchor.info}</span>
-        )}
-      </a>
-      {children}
-    </li>
-  );
-};

--- a/src/anchor-navigation/internal.tsx
+++ b/src/anchor-navigation/internal.tsx
@@ -6,9 +6,9 @@ import clsx from 'clsx';
 import { getBaseProps } from '../internal/base-component/index.js';
 import { fireCancelableEvent, fireNonCancelableEvent } from '../internal/events/index';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component/index.js';
-import { AnchorItem } from './anchor-item';
 import { AnchorNavigationProps } from './interfaces';
 import useScrollSpy from './use-scroll-spy.js';
+import { renderNestedAnchors } from './utils';
 
 import styles from './styles.css.js';
 import testUtilsStyles from './test-classes/styles.css.js';
@@ -47,44 +47,6 @@ export default function InternalAnchorNavigation({
     }
   }, [onActiveHrefChange, anchors, currentActiveHref]);
 
-  const renderNestedAnchors = (items: AnchorNavigationProps.Anchor[], startIndex: number = 0): React.ReactNode => {
-    if (items.length === 0) {
-      return null;
-    }
-
-    const result: React.ReactNode[] = [];
-    let currentIndex = 0;
-
-    while (currentIndex < items.length) {
-      const currentItem = items[currentIndex];
-      const childItems: AnchorNavigationProps.Anchor[] = [];
-
-      let nextIndex = currentIndex + 1;
-      while (nextIndex < items.length && items[nextIndex].level > currentItem.level) {
-        childItems.push(items[nextIndex]);
-        nextIndex++;
-      }
-
-      result.push(
-        <AnchorItem
-          onFollow={onFollowHandler}
-          isActive={currentItem.href === currentActiveHref}
-          key={startIndex + currentIndex}
-          index={startIndex + currentIndex}
-          anchor={currentItem}
-        >
-          {childItems.length > 0 && (
-            <ol className={styles['anchor-list']}>{renderNestedAnchors(childItems, startIndex + currentIndex + 1)}</ol>
-          )}
-        </AnchorItem>
-      );
-
-      currentIndex = nextIndex;
-    }
-
-    return result;
-  };
-
   return (
     <nav
       {...baseProps}
@@ -92,7 +54,12 @@ export default function InternalAnchorNavigation({
       aria-labelledby={ariaLabelledby}
       className={clsx(baseProps.className, styles.root, testUtilsStyles.root)}
     >
-      <ol className={clsx(styles['anchor-list'], testUtilsStyles['anchor-list'])}>{renderNestedAnchors(anchors)}</ol>
+      <ol className={clsx(styles['anchor-list'], testUtilsStyles['anchor-list'])}>
+        {renderNestedAnchors(anchors, {
+          onFollowHandler,
+          currentActiveHref,
+        })}
+      </ol>
     </nav>
   );
 }

--- a/src/anchor-navigation/utils.tsx
+++ b/src/anchor-navigation/utils.tsx
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+
+import { AnchorItem } from './anchor-item';
+import { AnchorNavigationProps } from './interfaces';
+
+import styles from './styles.css.js';
+import testUtilsStyles from './test-classes/styles.css.js';
+
+interface AnchorRenderQueueItem {
+  items: AnchorNavigationProps.Anchor[];
+  parentList: React.ReactNode[];
+  startIndex: number;
+}
+
+const collectChildItems = (
+  items: AnchorNavigationProps.Anchor[],
+  currentIndex: number,
+  currentLevel: number
+): AnchorNavigationProps.Anchor[] => {
+  const childItems: AnchorNavigationProps.Anchor[] = [];
+  let nextIndex = currentIndex + 1;
+
+  while (nextIndex < items.length && items[nextIndex].level > currentLevel) {
+    childItems.push(items[nextIndex]);
+    nextIndex++;
+  }
+
+  return childItems;
+};
+
+interface RenderContext {
+  onFollowHandler: (anchor: AnchorNavigationProps.Anchor, sourceEvent: React.SyntheticEvent | Event) => void;
+  currentActiveHref: string | undefined;
+}
+
+const createAnchorItem = (
+  currentItem: AnchorNavigationProps.Anchor,
+  index: number,
+  childItems: AnchorNavigationProps.Anchor[],
+  renderQueue: AnchorRenderQueueItem[],
+  context: RenderContext
+) => {
+  const childList: React.ReactNode[] = [];
+  const hasChildren = childItems.length > 0;
+
+  if (hasChildren) {
+    renderQueue.push({
+      items: childItems,
+      parentList: childList,
+      startIndex: index + 1,
+    });
+  }
+
+  return (
+    <AnchorItem
+      onFollow={context.onFollowHandler}
+      isActive={currentItem.href === context.currentActiveHref}
+      key={index}
+      index={index}
+      anchor={currentItem}
+    >
+      {hasChildren && <ol className={clsx(styles['anchor-list'], testUtilsStyles['anchor-list'])}>{childList}</ol>}
+    </AnchorItem>
+  );
+};
+
+const processQueueItem = (
+  items: AnchorNavigationProps.Anchor[],
+  startIndex: number,
+  parentList: React.ReactNode[],
+  renderQueue: AnchorRenderQueueItem[],
+  context: RenderContext
+) => {
+  let currentIndex = 0;
+  while (currentIndex < items.length) {
+    const currentItem = items[currentIndex];
+    const childItems = collectChildItems(items, currentIndex, currentItem.level);
+
+    parentList.push(createAnchorItem(currentItem, startIndex + currentIndex, childItems, renderQueue, context));
+
+    currentIndex += childItems.length + 1;
+  }
+};
+
+export const renderNestedAnchors = (items: AnchorNavigationProps.Anchor[], context: RenderContext): React.ReactNode => {
+  const rootList: React.ReactNode[] = [];
+  const renderQueue: AnchorRenderQueueItem[] = [];
+
+  renderQueue.push({ items, parentList: rootList, startIndex: 0 });
+
+  while (renderQueue.length > 0) {
+    const currentItem = renderQueue.shift()!;
+    processQueueItem(currentItem.items, currentItem.startIndex, currentItem.parentList, renderQueue, context);
+  }
+
+  return rootList;
+};

--- a/src/anchor-navigation/utils.tsx
+++ b/src/anchor-navigation/utils.tsx
@@ -45,6 +45,7 @@ const createAnchorItem = (
 ) => {
   const childList: React.ReactNode[] = [];
   const hasChildren = childItems.length > 0;
+  const olClassNAme = clsx(styles['anchor-list'], testUtilsStyles['anchor-list']);
 
   if (hasChildren) {
     renderQueue.push({
@@ -62,7 +63,7 @@ const createAnchorItem = (
       index={index}
       anchor={currentItem}
     >
-      {hasChildren && <ol className={clsx(styles['anchor-list'], testUtilsStyles['anchor-list'])}>{childList}</ol>}
+      {hasChildren && <ol className={olClassNAme}>{childList}</ol>}
     </AnchorItem>
   );
 };
@@ -80,11 +81,11 @@ const processQueueItem = (
     const childItems = collectChildItems(items, currentIndex, currentItem.level);
 
     parentList.push(createAnchorItem(currentItem, startIndex + currentIndex, childItems, renderQueue, context));
-
     currentIndex += childItems.length + 1;
   }
 };
 
+// Perform a queue-based breadth-first traversal that groups child items under their parents based on level hierarchy.
 export const renderNestedAnchors = (items: AnchorNavigationProps.Anchor[], context: RenderContext): React.ReactNode => {
   const rootList: React.ReactNode[] = [];
   const renderQueue: AnchorRenderQueueItem[] = [];


### PR DESCRIPTION
### Description

Nested lists are not marked up properly. Screen reader users may not be able to understand the hierarchy of these controls. With this change, they get marked up as expected.

Related links, issue #, if available: AWSUI-60224

### How has this been tested?

- added additional unit test.
- tested manually on the simple test page in in the most recent browser versions (Chrome, FF, Safari, Edge).
- dry-run build to live: 7271978138
- green dry run including screenshot tests in my dev pipeline.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
