### PR TITLE
fix: Remove unnecessary background color from wizard header

### DIFF
--- a/src/wizard/styles.scss
+++ b/src/wizard/styles.scss
@@ -226,7 +226,6 @@
   display: contents;
 
   > .form-header {
-    background-color: awsui.$color-background-layout-main;
     grid-column: 2;
     grid-row: 1;
     color: awsui.$color-text-body-default;


### PR DESCRIPTION
### Description

The header background color in wizard is unnecessary, it had the same color with wizard bg so the color diff isn't visible unless the wizard background is themed.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
