### PR TITLE
feat: Add findInfo test-util to side navigation

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -521,6 +521,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_expandable-link-group_l0dv0",
     "awsui_header-link_l0dv0",
     "awsui_header_l0dv0",
+    "awsui_info_1fhsi",
     "awsui_items-control_l0dv0",
     "awsui_link-active_l0dv0",
     "awsui_link_l0dv0",

--- a/src/side-navigation/__tests__/side-navigation.test.tsx
+++ b/src/side-navigation/__tests__/side-navigation.test.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 
+import Badge from '../../../lib/components/badge';
 import Select from '../../../lib/components/select';
 import SideNavigation, { SideNavigationProps } from '../../../lib/components/side-navigation';
 import createWrapper from '../../../lib/components/test-utils/dom';
@@ -274,13 +275,9 @@ describe('SideNavigation', () => {
 
     it('has an additional info when "info" property is specified', () => {
       const wrapper = renderSideNavigation({
-        items: [
-          { type: 'link', text: 'Page 1', href: '#something', info: <span data-testid="info">Additional info</span> },
-        ],
+        items: [{ type: 'link', text: 'Page 1', href: '#something', info: <Badge>Additional info</Badge> }],
       });
-      expect(wrapper.findItemByIndex(1)?.find('[data-testid="info"]')?.getElement()).toHaveTextContent(
-        'Additional info'
-      );
+      expect(wrapper.findItemByIndex(1)!.findInfo()!.findBadge()!.getElement()).toHaveTextContent('Additional info');
     });
 
     it('still renders the component if multiple links with info have the same href', () => {

--- a/src/side-navigation/parts.tsx
+++ b/src/side-navigation/parts.tsx
@@ -18,6 +18,7 @@ import { hasActiveLink } from './util';
 
 import analyticsSelectors from './analytics-metadata/styles.css.js';
 import styles from './styles.css.js';
+import testUtilStyles from './test-classes/styles.css.js';
 
 interface BaseItemComponentProps {
   activeHref?: string;
@@ -312,7 +313,7 @@ function Link({ definition, expanded, activeHref, fireFollow, position }: LinkPr
           </span>
         )}
       </a>
-      {definition.info && <span className={styles.info}>{definition.info}</span>}
+      {definition.info && <span className={clsx(styles.info, testUtilStyles.info)}>{definition.info}</span>}
     </>
   );
 }

--- a/src/side-navigation/test-classes/styles.scss
+++ b/src/side-navigation/test-classes/styles.scss
@@ -1,0 +1,7 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+.info {
+  /* used in test-utils */
+}

--- a/src/test-utils/dom/side-navigation/index.ts
+++ b/src/test-utils/dom/side-navigation/index.ts
@@ -5,6 +5,7 @@ import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-
 import ExpandableSectionWrapper from '../expandable-section';
 
 import styles from '../../../side-navigation/styles.selectors.js';
+import testUtilStyles from '../../../side-navigation/test-classes/styles.selectors.js';
 
 export default class SideNavigationWrapper extends ComponentWrapper {
   static rootSelector: string = styles.root;
@@ -60,6 +61,10 @@ export class SideNavigationItemWrapper extends ComponentWrapper {
 
   findLink(): ElementWrapper<HTMLAnchorElement> | null {
     return this.findByClassName(styles.link);
+  }
+
+  findInfo(): ElementWrapper<HTMLAnchorElement> | null {
+    return this.findByClassName(testUtilStyles.info);
   }
 
   findSectionTitle(): ElementWrapper | null {


### PR DESCRIPTION
### Description

Support this use-case

```js
<SideNavigation
  items={[{ type: 'link', text: 'Something', info: 'find me' }]}
/>
```

```js
expect(createWrapper().findItemByIndex(1).findInfoSlot().getElement()).toHaveTextContent('find me');
```

Current utilities do not allow to specifically target only the info slot

Related links, issue #, if available: n/a

### How has this been tested?

Updated existing unit test to incorporate this use-case

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
