### PR TITLE
chore: Pass theme through to funnel metrics

### DIFF
--- a/src/internal/analytics/__integ__/static-multi-page-create.test.ts
+++ b/src/internal/analytics/__integ__/static-multi-page-create.test.ts
@@ -64,7 +64,7 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
         funnelType: 'multi-page',
         resourceType: 'Components',
         optionalStepNumbers: [2],
-        componentTheme: 'vr',
+        componentTheme: 'default',
         totalFunnelSteps: 3,
         stepConfiguration: [
           {

--- a/src/internal/analytics/__integ__/static-single-page-flow.test.ts
+++ b/src/internal/analytics/__integ__/static-single-page-flow.test.ts
@@ -63,7 +63,7 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
         funnelType: 'single-page',
         resourceType: 'Components',
         optionalStepNumbers: [],
-        componentTheme: 'vr',
+        componentTheme: 'default',
         totalFunnelSteps: 1,
         stepConfiguration: [
           {
@@ -454,7 +454,7 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
         funnelVersion: expect.any(String),
         funnelType: 'single-page',
         optionalStepNumbers: [],
-        componentTheme: 'vr',
+        componentTheme: 'default',
         totalFunnelSteps: 1,
         stepConfiguration: [
           {

--- a/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
+++ b/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
@@ -22,6 +22,13 @@ import Modal from '../../../../../lib/components/modal';
 import Table from '../../../../../lib/components/table';
 import { mockedFunnelInteractionId, mockFunnelMetrics, mockInnerText, mockPerformanceMetrics } from '../mocks';
 
+jest.mock('../../../../../lib/components/internal/environment', () => ({
+  THEME: 'polaris',
+  ALWAYS_VISUAL_REFRESH: true,
+  PACKAGE_SOURCE: '',
+  PACKAGE_VERSION: '',
+}));
+
 describe('AnalyticsFunnel', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useRef, useState } from 'react';
 
-import { PACKAGE_VERSION } from '../../environment';
+import { PACKAGE_VERSION, THEME } from '../../environment';
 import { useDebounceCallback } from '../../hooks/use-debounce-callback';
 import { useUniqueId } from '../../hooks/use-unique-id';
 import { useVisualRefresh } from '../../hooks/use-visual-mode';
@@ -157,6 +157,7 @@ const InnerAnalyticsFunnel = ({ mounted = true, children, stepConfiguration, ...
         },
       ];
 
+      const componentTheme = THEME === 'polaris' && isVisualRefresh ? 'vr' : THEME;
       funnelInteractionId = FunnelMetrics.funnelStart({
         funnelName,
         funnelIdentifier: props.funnelIdentifier,
@@ -166,7 +167,7 @@ const InnerAnalyticsFunnel = ({ mounted = true, children, stepConfiguration, ...
         funnelType: props.funnelType,
         totalFunnelSteps: props.totalFunnelSteps,
         componentVersion: PACKAGE_VERSION,
-        componentTheme: isVisualRefresh ? 'vr' : 'classic',
+        componentTheme,
         funnelVersion: FUNNEL_VERSION,
         stepConfiguration: stepConfiguration ?? singleStepFlowStepConfiguration,
         resourceType: props.funnelResourceType || getTextFromSelector(`[${DATA_ATTR_RESOURCE_TYPE}]`),

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -157,7 +157,12 @@ const InnerAnalyticsFunnel = ({ mounted = true, children, stepConfiguration, ...
         },
       ];
 
-      const componentTheme = THEME === 'polaris' && isVisualRefresh ? 'vr' : THEME;
+      let componentTheme = THEME;
+      if (THEME === 'polaris') {
+        // This is the only place we specify the theme as classic so we cannot reuse the getVisualTheme function :(
+        componentTheme = isVisualRefresh ? 'vr' : 'classic';
+      }
+
       funnelInteractionId = FunnelMetrics.funnelStart({
         funnelName,
         funnelIdentifier: props.funnelIdentifier,
@@ -167,7 +172,7 @@ const InnerAnalyticsFunnel = ({ mounted = true, children, stepConfiguration, ...
         funnelType: props.funnelType,
         totalFunnelSteps: props.totalFunnelSteps,
         componentVersion: PACKAGE_VERSION,
-        componentTheme,
+        componentTheme: componentTheme,
         funnelVersion: FUNNEL_VERSION,
         stepConfiguration: stepConfiguration ?? singleStepFlowStepConfiguration,
         resourceType: props.funnelResourceType || getTextFromSelector(`[${DATA_ATTR_RESOURCE_TYPE}]`),

--- a/src/internal/hooks/use-telemetry/index.ts
+++ b/src/internal/hooks/use-telemetry/index.ts
@@ -3,9 +3,11 @@
 import { ComponentConfiguration, useComponentMetrics } from '@cloudscape-design/component-toolkit/internal';
 
 import { PACKAGE_SOURCE, PACKAGE_VERSION, THEME } from '../../environment';
+import { getVisualTheme } from '../../utils/get-visual-theme';
 import { useVisualRefresh } from '../use-visual-mode';
 
 export function useTelemetry(componentName: string, config?: ComponentConfiguration) {
-  const theme = useVisualRefresh() ? 'vr' : THEME;
+  const isVisualRefresh = useVisualRefresh();
+  const theme = getVisualTheme(THEME, isVisualRefresh);
   useComponentMetrics(componentName, { packageSource: PACKAGE_SOURCE, packageVersion: PACKAGE_VERSION, theme }, config);
 }

--- a/src/internal/utils/__tests__/get-visual-theme.test.ts
+++ b/src/internal/utils/__tests__/get-visual-theme.test.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { getVisualTheme } from '../../../../lib/components/internal/utils/get-visual-theme';
+
+describe('getVisualTheme', () => {
+  it('returns vr when theme is polaris and VR is active', () => {
+    expect(getVisualTheme('polaris', true)).toBe('vr');
+  });
+
+  it('returns polaris when theme is polaris and VR is not active', () => {
+    expect(getVisualTheme('polaris', false)).toBe('polaris');
+  });
+
+  it('returns defined theme by default', () => {
+    expect(getVisualTheme('custom', false)).toBe('custom');
+    expect(getVisualTheme('custom', true)).toBe('custom');
+  });
+});

--- a/src/internal/utils/get-visual-theme.ts
+++ b/src/internal/utils/get-visual-theme.ts
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const getVisualTheme = (theme: string, isVR: boolean) => {
+  if (theme === 'polaris' && isVR) {
+    return 'vr';
+  }
+
+  return theme;
+};


### PR DESCRIPTION
### Description

- Pass the given environment theme down to the funnel metrics.
- Extract common visual theme code into helper function

Related links, issue #, if available: n/a

### How has this been tested?
- Updated unit test
- Internal pipeline testing

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
