### PR TITLE
fix: Remove awsui-visual-refresh class from portal propagation

### DIFF
--- a/src/internal/hooks/use-portal-mode-classes/__tests__/use-portal-mode-classes.test.tsx
+++ b/src/internal/hooks/use-portal-mode-classes/__tests__/use-portal-mode-classes.test.tsx
@@ -49,17 +49,6 @@ describe('usePortalModeClasses', () => {
     expect(screen.getByTestId('subject')).toHaveClass('awsui-polaris-compact-mode awsui-compact-mode', { exact: true });
   });
 
-  test('should detect visual refresh mode', () => {
-    // This assumes implementation details about the implementation of useVisualRefresh hook. It works
-    // as an integration test.
-    window.CSS.supports = jest.fn(() => true);
-
-    (useVisualRefresh as jest.Mock).mockImplementation(() => true);
-
-    render(<RenderTest refClasses="" />);
-    expect(screen.getByTestId('subject')).toHaveClass('awsui-visual-refresh', { exact: true });
-  });
-
   test('should detect contexts', () => {
     render(
       <VisualContext contextName="content-header">

--- a/src/internal/hooks/use-portal-mode-classes/index.ts
+++ b/src/internal/hooks/use-portal-mode-classes/index.ts
@@ -6,17 +6,14 @@ import clsx from 'clsx';
 import { useCurrentMode, useDensityMode } from '@cloudscape-design/component-toolkit/internal';
 
 import { useVisualContext } from '../../components/visual-context';
-import { useVisualRefresh } from '../use-visual-mode';
 
 export function usePortalModeClasses(ref: React.RefObject<HTMLElement>) {
   const colorMode = useCurrentMode(ref);
   const densityMode = useDensityMode(ref);
   const context = useVisualContext(ref);
-  const visualRefresh = useVisualRefresh();
   return clsx({
     'awsui-polaris-dark-mode awsui-dark-mode': colorMode === 'dark',
     'awsui-polaris-compact-mode awsui-compact-mode': densityMode === 'compact',
-    'awsui-visual-refresh': visualRefresh,
     [`awsui-context-${context}`]: context,
   });
 }


### PR DESCRIPTION
### Description

in VR only artifacts, we render this class in the DOM even if it is not needed for the implementation.

However this has an unwanted side effects as other code incorrectly assumes the current page is using dual classic/refresh artifacts

Related links, issue #, if available: n/a

### How has this been tested?

PR build passes, no regressions for the current code

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
