### PR TITLE
chore: Create smaller dev pages for Bar chart

### DIFF
--- a/pages/bar-chart/horizontal-bars-permutations.page.tsx
+++ b/pages/bar-chart/horizontal-bars-permutations.page.tsx
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import BarChart, { BarChartProps } from '~components/bar-chart';
+
+import { commonProps, multipleBarsData } from '../mixed-line-bar-chart/common';
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
+
+const permutations = createPermutations<BarChartProps<string>>([
+  {
+    i18nStrings: [commonProps.i18nStrings],
+    ariaLabel: ['Test chart'],
+    height: [200],
+    series: [multipleBarsData, [multipleBarsData[0], multipleBarsData[1]]],
+    xScaleType: ['categorical'],
+    xDomain: [undefined, ['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']],
+    yDomain: [undefined, [0, 15]],
+    horizontalBars: [true],
+    stackedBars: [false],
+    xTitle: ['X Title'],
+    yTitle: ['Y Title'],
+  },
+]);
+
+export default function () {
+  return (
+    <>
+      <h1>Bar chart permutations - horizontal bars</h1>
+      <ScreenshotArea disableAnimations={true}>
+        <PermutationsView permutations={permutations} render={permutation => <BarChart<any> {...permutation} />} />
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/pages/bar-chart/horizontal-stacked-bars-permutations.page.tsx
+++ b/pages/bar-chart/horizontal-stacked-bars-permutations.page.tsx
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import BarChart, { BarChartProps } from '~components/bar-chart';
+
+import { commonProps, multipleBarsData } from '../mixed-line-bar-chart/common';
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
+
+const permutations = createPermutations<BarChartProps<string>>([
+  {
+    i18nStrings: [commonProps.i18nStrings],
+    ariaLabel: ['Test chart'],
+    height: [200],
+    series: [multipleBarsData, [multipleBarsData[0], multipleBarsData[1]]],
+    xScaleType: ['categorical'],
+    xDomain: [undefined, ['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']],
+    yDomain: [undefined, [0, 15]],
+    horizontalBars: [true],
+    stackedBars: [true],
+    xTitle: ['X Title'],
+    yTitle: ['Y Title'],
+  },
+]);
+
+export default function () {
+  return (
+    <>
+      <h1>Bar chart permutations - horizontal stacked bars</h1>
+      <ScreenshotArea disableAnimations={true}>
+        <PermutationsView permutations={permutations} render={permutation => <BarChart<any> {...permutation} />} />
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/pages/bar-chart/other-permutations.page.tsx
+++ b/pages/bar-chart/other-permutations.page.tsx
@@ -1,0 +1,151 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import BarChart, { BarChartProps } from '~components/bar-chart';
+import { colorChartsThresholdInfo, colorChartsThresholdNeutral } from '~design-tokens';
+
+import {
+  commonProps,
+  data1,
+  data2,
+  dateTimeFormatter,
+  latencyData,
+  multipleNegativeBarsData,
+  multipleNegativeBarsDataWithThreshold,
+  negativeData,
+} from '../mixed-line-bar-chart/common';
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
+import { smallBarsData } from './common';
+
+const timeLatencyData = latencyData.map(({ time, p90 }) => ({ x: time, y: p90 }));
+
+const stringPermutations = createPermutations<BarChartProps<string>>([
+  // Skipping things like empty states because these are already covered extensively for line and mixed charts
+
+  // Stacked bars with mix of positive/negative numbers
+  {
+    i18nStrings: [commonProps.i18nStrings],
+    ariaLabel: ['Test chart'],
+    height: [200],
+    series: [multipleNegativeBarsData],
+    xScaleType: ['categorical'],
+    xDomain: [['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']],
+    yDomain: [[-6, 10]],
+    horizontalBars: [true, false],
+    stackedBars: [true],
+    xTitle: ['X Title'],
+    yTitle: ['Y Title'],
+  },
+]);
+
+const timePermutations = createPermutations<BarChartProps<Date>>([
+  // Date/time series
+  {
+    i18nStrings: [{ ...commonProps.i18nStrings, xTickFormatter: dateTimeFormatter }],
+    ariaLabel: ['Test chart'],
+    height: [200],
+    series: [
+      [
+        { title: 'Series 1', type: 'bar', data: timeLatencyData },
+        { title: 'Series 2', type: 'bar', data: timeLatencyData },
+        { title: 'Threshold', type: 'threshold', y: 150, color: colorChartsThresholdNeutral },
+      ],
+    ],
+    xScaleType: ['categorical'],
+    yDomain: [[100, 300]],
+    xTitle: ['Time'],
+    yTitle: ['Latency (ms)'],
+    hideFilter: [true],
+    hideLegend: [true],
+  },
+  // Negative data
+  {
+    i18nStrings: [{ ...commonProps.i18nStrings, xTickFormatter: dateTimeFormatter }],
+    ariaLabel: ['Test chart'],
+    height: [200],
+    series: [[{ title: 'Series 1', type: 'bar', data: negativeData }]],
+    xScaleType: ['categorical'],
+    yDomain: [[-10000, 50000]],
+    horizontalBars: [false, true],
+    xTitle: ['X axis'],
+    yTitle: ['Y axis'],
+    hideFilter: [true],
+    hideLegend: [true],
+  },
+]);
+
+const numberPermutations = createPermutations<BarChartProps<number>>([
+  // Categorical with numbers
+  {
+    i18nStrings: [commonProps.i18nStrings],
+    ariaLabel: ['Test chart'],
+    height: [200],
+    series: [
+      [
+        { title: 'Series 1', type: 'bar', data: data2 },
+        { title: 'Series 2', type: 'bar', data: data1 },
+        { title: 'Threshold', type: 'threshold', y: 150, color: colorChartsThresholdInfo },
+      ],
+    ],
+    xScaleType: ['categorical'],
+    yDomain: [[0, 310]],
+    xTitle: ['Food'],
+    yTitle: ['Calories'],
+    hideFilter: [true],
+    hideLegend: [true],
+  },
+]);
+
+const thresholdPermutations = createPermutations<BarChartProps<string>>([
+  {
+    i18nStrings: [commonProps.i18nStrings],
+    ariaLabel: ['Test chart'],
+    height: [200],
+    series: [multipleNegativeBarsDataWithThreshold],
+    xScaleType: ['categorical'],
+    xDomain: [['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']],
+    yDomain: [[-6, 10]],
+    horizontalBars: [true, false],
+    stackedBars: [true, false],
+    xTitle: ['X Title'],
+    yTitle: ['Y Title'],
+  },
+]);
+
+const smallGroupsPermutations = createPermutations<BarChartProps<string>>([
+  {
+    i18nStrings: [commonProps.i18nStrings],
+    ariaLabel: ['Test chart'],
+    height: [200],
+    series: [smallBarsData],
+    xScaleType: ['categorical'],
+    xDomain: [['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']],
+    yDomain: [[0, 1000]],
+    horizontalBars: [true, false],
+    stackedBars: [true],
+    xTitle: ['X Title'],
+    yTitle: ['Y Title'],
+  },
+]);
+
+const permutations = [
+  ...stringPermutations,
+  ...timePermutations,
+  ...numberPermutations,
+  ...thresholdPermutations,
+  ...smallGroupsPermutations,
+];
+
+export default function () {
+  return (
+    <>
+      <h1>Bar chart permutations</h1>
+      <ScreenshotArea disableAnimations={true}>
+        <PermutationsView permutations={permutations} render={permutation => <BarChart<any> {...permutation} />} />
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/pages/bar-chart/other-permutations.page.tsx
+++ b/pages/bar-chart/other-permutations.page.tsx
@@ -12,7 +12,6 @@ import {
   dateTimeFormatter,
   latencyData,
   multipleNegativeBarsData,
-  multipleNegativeBarsDataWithThreshold,
   negativeData,
 } from '../mixed-line-bar-chart/common';
 import createPermutations from '../utils/permutations';
@@ -99,22 +98,6 @@ const numberPermutations = createPermutations<BarChartProps<number>>([
   },
 ]);
 
-const thresholdPermutations = createPermutations<BarChartProps<string>>([
-  {
-    i18nStrings: [commonProps.i18nStrings],
-    ariaLabel: ['Test chart'],
-    height: [200],
-    series: [multipleNegativeBarsDataWithThreshold],
-    xScaleType: ['categorical'],
-    xDomain: [['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']],
-    yDomain: [[-6, 10]],
-    horizontalBars: [true, false],
-    stackedBars: [true, false],
-    xTitle: ['X Title'],
-    yTitle: ['Y Title'],
-  },
-]);
-
 const smallGroupsPermutations = createPermutations<BarChartProps<string>>([
   {
     i18nStrings: [commonProps.i18nStrings],
@@ -131,13 +114,7 @@ const smallGroupsPermutations = createPermutations<BarChartProps<string>>([
   },
 ]);
 
-const permutations = [
-  ...stringPermutations,
-  ...timePermutations,
-  ...numberPermutations,
-  ...thresholdPermutations,
-  ...smallGroupsPermutations,
-];
+const permutations = [...stringPermutations, ...timePermutations, ...numberPermutations, ...smallGroupsPermutations];
 
 export default function () {
   return (

--- a/pages/bar-chart/threshold-permutations.page.tsx
+++ b/pages/bar-chart/threshold-permutations.page.tsx
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import BarChart, { BarChartProps } from '~components/bar-chart';
+
+import { commonProps, multipleNegativeBarsDataWithThreshold } from '../mixed-line-bar-chart/common';
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
+
+const permutations = createPermutations<BarChartProps<string>>([
+  {
+    i18nStrings: [commonProps.i18nStrings],
+    ariaLabel: ['Test chart'],
+    height: [200],
+    series: [multipleNegativeBarsDataWithThreshold],
+    xScaleType: ['categorical'],
+    xDomain: [['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']],
+    yDomain: [[-6, 10]],
+    horizontalBars: [true, false],
+    stackedBars: [true, false],
+    xTitle: ['X Title'],
+    yTitle: ['Y Title'],
+  },
+]);
+
+export default function () {
+  return (
+    <>
+      <h1>Bar chart permutations</h1>
+      <ScreenshotArea disableAnimations={true}>
+        <PermutationsView permutations={permutations} render={permutation => <BarChart<any> {...permutation} />} />
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/pages/bar-chart/threshold-permutations.page.tsx
+++ b/pages/bar-chart/threshold-permutations.page.tsx
@@ -28,7 +28,7 @@ const permutations = createPermutations<BarChartProps<string>>([
 export default function () {
   return (
     <>
-      <h1>Bar chart permutations</h1>
+      <h1>Bar chart permutations - thresholds</h1>
       <ScreenshotArea disableAnimations={true}>
         <PermutationsView permutations={permutations} render={permutation => <BarChart<any> {...permutation} />} />
       </ScreenshotArea>

--- a/pages/bar-chart/vertical-bars-permutations.page.tsx
+++ b/pages/bar-chart/vertical-bars-permutations.page.tsx
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import BarChart, { BarChartProps } from '~components/bar-chart';
+
+import { commonProps, multipleBarsData } from '../mixed-line-bar-chart/common';
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
+
+const permutations = createPermutations<BarChartProps<string>>([
+  {
+    i18nStrings: [commonProps.i18nStrings],
+    ariaLabel: ['Test chart'],
+    height: [200],
+    series: [multipleBarsData, [multipleBarsData[0], multipleBarsData[1]]],
+    xScaleType: ['categorical'],
+    xDomain: [undefined, ['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']],
+    yDomain: [undefined, [0, 15]],
+    horizontalBars: [false],
+    stackedBars: [false],
+    xTitle: ['X Title'],
+    yTitle: ['Y Title'],
+  },
+]);
+
+export default function () {
+  return (
+    <>
+      <h1>Bar chart permutations - vertical bars</h1>
+      <ScreenshotArea disableAnimations={true}>
+        <PermutationsView permutations={permutations} render={permutation => <BarChart<any> {...permutation} />} />
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/pages/bar-chart/vertical-stacked-bars-permutations.page.tsx
+++ b/pages/bar-chart/vertical-stacked-bars-permutations.page.tsx
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import BarChart, { BarChartProps } from '~components/bar-chart';
+
+import { commonProps, multipleBarsData } from '../mixed-line-bar-chart/common';
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
+
+const permutations = createPermutations<BarChartProps<string>>([
+  {
+    i18nStrings: [commonProps.i18nStrings],
+    ariaLabel: ['Test chart'],
+    height: [200],
+    series: [multipleBarsData, [multipleBarsData[0], multipleBarsData[1]]],
+    xScaleType: ['categorical'],
+    xDomain: [undefined, ['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']],
+    yDomain: [undefined, [0, 15]],
+    horizontalBars: [false],
+    stackedBars: [true],
+    xTitle: ['X Title'],
+    yTitle: ['Y Title'],
+  },
+]);
+
+export default function () {
+  return (
+    <>
+      <h1>Bar chart permutations - vertical stacked bars</h1>
+      <ScreenshotArea disableAnimations={true}>
+        <PermutationsView permutations={permutations} render={permutation => <BarChart<any> {...permutation} />} />
+      </ScreenshotArea>
+    </>
+  );
+}


### PR DESCRIPTION
### Description

Currently the dev page `bar-chart/permutations` takes around 11 seconds to load (LCP), and is too tall for permutation screenshots. Split it into smaller parts.

To do so without operational disruptions, let's follow these steps:
1. Create new pages from parts of the existing page (this PR)
2. Deploy
3. Create new tests for the new pages
5. Remove old permutations page and its tests

Related issue: `AWSUI-60431`

### How has this been tested?

Compared load time on Chrome with performance dev tools. Each of the new pages takes between 0.33 and 0.78 seconds to load (LCP).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
