### PR TITLE
fix: Fixes table editable success state placement when items order change

### DIFF
--- a/pages/table/editable.page.tsx
+++ b/pages/table/editable.page.tsx
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { ForwardedRef, forwardRef, useContext, useEffect, useRef, useState } from 'react';
 
+import { useCollection } from '@cloudscape-design/collection-hooks';
+
 import { Box, Button, Checkbox, Modal, SpaceBetween } from '~components';
 import Alert from '~components/alert';
 import Autosuggest, { AutosuggestProps } from '~components/autosuggest';
@@ -88,6 +90,7 @@ const columns: TableProps.ColumnDefinition<DistributionInfo>[] = [
   {
     id: 'DomainName',
     header: 'Domain name',
+    sortingField: 'DomainName',
     minWidth: 180,
     editConfig: {
       ariaLabel: 'Domain name',
@@ -241,10 +244,12 @@ const Demo = forwardRef(
     { setModalVisible }: { setModalVisible: React.Dispatch<React.SetStateAction<boolean>> },
     tableRef: ForwardedRef<TableProps.Ref>
   ) => {
-    const [items, setItems] = useState(initialItems);
+    const [allItems, setItems] = useState(initialItems);
     const {
       urlParams: { resizableColumns = true, enableKeyboardNavigation = false, expandableRows = false },
     } = useContext(AppContext as PageContext);
+
+    const { items, collectionProps } = useCollection(allItems, { sorting: {} });
 
     const handleSubmit: TableProps.SubmitEditFunction<DistributionInfo> = async (currentItem, column, newValue) => {
       let value = newValue;
@@ -276,6 +281,8 @@ const Demo = forwardRef(
 
     return (
       <Table
+        {...collectionProps}
+        trackBy="Id"
         ref={tableRef}
         header={
           <Header headingTagOverride="h1" counter={`(${items.length})`}>

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -16982,7 +16982,7 @@ for performance optimizations.
 It is also used in the following situations:
 - to connect \`items\` and \`selectedItems\` values when they reference different objects.
 - to connect \`items\` and \`expandableRows.expandedItems\` values when they reference different objects.
-- to attach successful edit state to correct item if its row index changes after editing.
+- to attach successful edit state to the correct item if its row index changes after editing.
 ",
       "inlineType": {
         "name": "TableProps.TrackBy",

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -16979,7 +16979,10 @@ If there is an unknown total of items in a table, leave this property undefined.
       "description": "Specifies a property that uniquely identifies an individual item.
 When it's set, it's used to provide [keys for React](https://reactjs.org/docs/lists-and-keys.html#keys)
 for performance optimizations.
-It's also used to connect \`items\` and \`selectedItems\` or \`expandableRows.expandedItems\` values when they reference different objects.
+It is also used in the following situations:
+- to connect \`items\` and \`selectedItems\` values when they reference different objects.
+- to connect \`items\` and \`expandableRows.expandedItems\` values when they reference different objects.
+- to attach successful edit state to correct item if its row index changes after editing.
 ",
       "inlineType": {
         "name": "TableProps.TrackBy",

--- a/src/table/__integ__/inline-editing.test.ts
+++ b/src/table/__integ__/inline-editing.test.ts
@@ -165,7 +165,7 @@ describe.each([false, true])('enableKeyboardNavigation=%s', enableKeyboardNaviga
         await page.keys(['Tab', 'Tab']);
         await page.keys(['ArrowDown', 'ArrowRight']);
       } else {
-        await page.keys(range(11).map(() => 'Tab'));
+        await page.keys(range(12).map(() => 'Tab'));
       }
       const targetRow = (expandableRows ? distributionIdRow1 : domainNameRow1) as [number, number];
       await expect(page.isFocused(cellEditButton$(...targetRow))).resolves.toBe(true);

--- a/src/table/__tests__/table-editable.test.tsx
+++ b/src/table/__tests__/table-editable.test.tsx
@@ -1,0 +1,109 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+
+import Table, { TableProps } from '../../../lib/components/table';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+import bodyCellStyles from '../../../lib/components/table/body-cell/styles.css.js';
+
+jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
+  useMobile: jest.fn(),
+}));
+
+interface Item {
+  id: number;
+  name: string;
+}
+
+const editableColumns: TableProps.ColumnDefinition<Item>[] = [
+  { header: 'id', cell: (item: Item) => item.id, editConfig: { editingCell: item => item.id } },
+  { header: 'name', cell: (item: Item) => item.name, editConfig: { editingCell: item => item.name } },
+];
+
+const defaultItems: Item[] = [
+  { id: 1, name: 'Apples' },
+  { id: 2, name: 'Oranges' },
+  { id: 3, name: 'Bananas' },
+];
+
+function renderTable(jsx: React.ReactElement) {
+  const { container, rerender } = render(jsx);
+  const wrapper = createWrapper(container).findTable()!;
+  return { wrapper, rerender };
+}
+
+test('should show success icon after edit is saved', () => {
+  const { wrapper } = renderTable(<Table columnDefinitions={editableColumns} items={defaultItems} />);
+
+  // No success icon by default
+  expect(wrapper.findBodyCell(1, 1)!.findByClassName(bodyCellStyles['body-cell-success'])).toBe(null);
+
+  // Shows no icon if edit was discarded
+  wrapper.findBodyCell(1, 1)!.click();
+  wrapper.findEditingCellCancelButton()!.click();
+  expect(wrapper.findBodyCell(1, 1)!.findByClassName(bodyCellStyles['body-cell-success'])).toBe(null);
+
+  // Shows success icon if edit completes successfully
+  wrapper.findBodyCell(1, 1)!.click();
+  wrapper.findEditingCellSaveButton()!.click();
+  expect(wrapper.findBodyCell(1, 1)!.findByClassName(bodyCellStyles['body-cell-success'])).not.toBe(null);
+});
+
+test('should render table header with icons to indicate editable columns', () => {
+  const { wrapper } = renderTable(<Table columnDefinitions={editableColumns} items={defaultItems} />);
+  const columnHeaders = wrapper.findColumnHeaders();
+  columnHeaders.forEach(header => {
+    expect(header.getElement().querySelector('svg')).toBeInTheDocument();
+  });
+});
+
+test('should cancel edit using ref imperative method', async () => {
+  const ref = React.createRef<any>();
+  const { wrapper } = renderTable(
+    <Table
+      columnDefinitions={editableColumns}
+      items={defaultItems}
+      submitEdit={async () => {
+        await new Promise((resolve, reject) => setTimeout(reject, 1000));
+      }}
+      ref={ref}
+    />
+  );
+
+  const button = wrapper.findEditCellButton(2, 2)!;
+
+  fireEvent.click(button.getElement());
+  act(() => {
+    ref.current.cancelEdit();
+  });
+  await waitFor(() => {
+    expect(wrapper.find(`[data-inline-editing-active="true"]`)?.getElement()).toBeUndefined();
+  });
+});
+
+test('should change success icon placement if rows order change', () => {
+  const { wrapper, rerender } = renderTable(
+    <Table columnDefinitions={editableColumns} items={defaultItems} trackBy="id" />
+  );
+
+  wrapper.findBodyCell(1, 1)!.click();
+  wrapper.findEditingCellSaveButton()!.click();
+  expect(wrapper.findBodyCell(1, 1)!.findByClassName(bodyCellStyles['body-cell-success'])).not.toBe(null);
+
+  rerender(<Table columnDefinitions={editableColumns} items={[...defaultItems].reverse()} trackBy="id" />);
+  expect(wrapper.findBodyCell(3, 1)!.findByClassName(bodyCellStyles['body-cell-success'])).not.toBe(null);
+});
+
+test('should hide success icon if columns order change', () => {
+  const { wrapper, rerender } = renderTable(<Table columnDefinitions={editableColumns} items={defaultItems} />);
+
+  wrapper.findBodyCell(1, 1)!.click();
+  wrapper.findEditingCellSaveButton()!.click();
+  expect(wrapper.findBodyCell(1, 1)!.findByClassName(bodyCellStyles['body-cell-success'])).not.toBe(null);
+
+  rerender(<Table columnDefinitions={[...editableColumns].reverse()} items={defaultItems} trackBy="id" />);
+  expect(wrapper.findByClassName(bodyCellStyles['body-cell-success'])).toBe(null);
+});

--- a/src/table/__tests__/table.test.tsx
+++ b/src/table/__tests__/table.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 
 import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
 import PropertyFilter from '../../../lib/components/property-filter';
@@ -56,10 +56,6 @@ const defaultColumns: TableProps.ColumnDefinition<Item>[] = [
 const defaultColumnsWithIds: TableProps.ColumnDefinition<Item>[] = [
   { id: 'id', header: 'id', cell: item => item.id },
   { id: 'name', header: 'name', cell: item => item.name },
-];
-const editableColumns: TableProps.ColumnDefinition<Item>[] = [
-  { header: 'id', cell: (item: Item) => item.id, editConfig: { editingCell: item => item.id } },
-  { header: 'name', cell: (item: Item) => item.name, editConfig: { editingCell: item => item.name } },
 ];
 
 const statefulColumns: TableProps.ColumnDefinition<Item>[] = [
@@ -218,55 +214,6 @@ test('should render row headers if defined', () => {
     const cellElement = wrapper.findBodyCell(index + 1, 1)?.getElement();
     expect(cellElement?.tagName).toBe('TH');
     expect(cellElement).toHaveAttribute('scope', 'row');
-  });
-});
-
-test('should render table header with icons to indicate editable columns', () => {
-  const { wrapper } = renderTable(<Table columnDefinitions={editableColumns} items={defaultItems} />);
-  const columnHeaders = wrapper.findColumnHeaders();
-  columnHeaders.forEach(header => {
-    expect(header.getElement().querySelector('svg')).toBeInTheDocument();
-  });
-});
-
-test('should show success icon after edit is saved', () => {
-  const { wrapper } = renderTable(<Table columnDefinitions={editableColumns} items={defaultItems} />);
-
-  // No success icon by default
-  expect(wrapper.findBodyCell(1, 1)!.findByClassName(bodyCellStyles['body-cell-success'])).toBe(null);
-
-  // Shows no icon if edit was discarded
-  wrapper.findBodyCell(1, 1)!.click();
-  wrapper.findEditingCellCancelButton()!.click();
-  expect(wrapper.findBodyCell(1, 1)!.findByClassName(bodyCellStyles['body-cell-success'])).toBe(null);
-
-  // Shows success icon if edit completes successfully
-  wrapper.findBodyCell(1, 1)!.click();
-  wrapper.findEditingCellSaveButton()!.click();
-  expect(wrapper.findBodyCell(1, 1)!.findByClassName(bodyCellStyles['body-cell-success'])).not.toBe(null);
-});
-
-test('should cancel edit using ref imperative method', async () => {
-  const ref = React.createRef<any>();
-  const { wrapper } = renderTable(
-    <Table
-      columnDefinitions={editableColumns}
-      items={defaultItems}
-      submitEdit={async () => {
-        await new Promise((resolve, reject) => setTimeout(reject, 1000));
-      }}
-      ref={ref}
-    />
-  );
-
-  const button = wrapper.findEditCellButton(2, 2)!;
-
-  fireEvent.click(button.getElement());
-  act(() => {
-    ref.current.cancelEdit();
-  });
-  await waitFor(() => {
-    expect(wrapper.find(`[data-inline-editing-active="true"]`)?.getElement()).toBeUndefined();
   });
 });
 

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -67,7 +67,7 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * It is also used in the following situations:
    * - to connect `items` and `selectedItems` values when they reference different objects.
    * - to connect `items` and `expandableRows.expandedItems` values when they reference different objects.
-   * - to attach successful edit state to correct item if its row index changes after editing.
+   * - to attach successful edit state to the correct item if its row index changes after editing.
    */
   trackBy?: TableProps.TrackBy<T>;
 

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -64,7 +64,10 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * When it's set, it's used to provide [keys for React](https://reactjs.org/docs/lists-and-keys.html#keys)
    * for performance optimizations.
    *
-   * It's also used to connect `items` and `selectedItems` or `expandableRows.expandedItems` values when they reference different objects.
+   * It is also used in the following situations:
+   * - to connect `items` and `selectedItems` values when they reference different objects.
+   * - to connect `items` and `expandableRows.expandedItems` values when they reference different objects.
+   * - to attach successful edit state to correct item if its row index changes after editing.
    */
   trackBy?: TableProps.TrackBy<T>;
 

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -569,9 +569,10 @@ const InternalTable = React.forwardRef(
                             tableRole,
                           };
                           if (row.type === 'data') {
+                            const rowId = `${getTableItemKey(row.item)}`;
                             return (
                               <tr
-                                key={getTableItemKey(row.item)}
+                                key={rowId}
                                 className={clsx(styles.row, sharedCellProps.isSelected && styles['row-selected'])}
                                 onFocus={({ currentTarget }) => {
                                   // When an element inside table row receives focus we want to adjust the scroll.
@@ -597,15 +598,17 @@ const InternalTable = React.forwardRef(
                                       onFocusDown: moveFocusDown,
                                       onFocusUp: moveFocusUp,
                                       rowIndex,
-                                      itemKey: `${getTableItemKey(row.item)}`,
+                                      itemKey: rowId,
                                     }}
                                     verticalAlign={cellVerticalAlign}
                                   />
                                 )}
 
                                 {visibleColumnDefinitions.map((column, colIndex) => {
-                                  const isEditing = cellEditing.checkEditing({ rowIndex, colIndex });
-                                  const successfulEdit = cellEditing.checkLastSuccessfulEdit({ rowIndex, colIndex });
+                                  const colId = `${getColumnKey(column, colIndex)}`;
+                                  const cellId = { row: rowId, col: colId };
+                                  const isEditing = cellEditing.checkEditing(cellId);
+                                  const successfulEdit = cellEditing.checkLastSuccessfulEdit(cellId);
                                   const isEditable = !!column.editConfig && !cellEditing.isLoading;
                                   const cellExpandableProps =
                                     isExpandable && colIndex === 0 ? expandableProps : undefined;
@@ -619,14 +622,14 @@ const InternalTable = React.forwardRef(
                                           selector: `table thead tr th:nth-child(${colIndex + (selectionType ? 2 : 1)})`,
                                           root: 'component',
                                         },
-                                        item: `${getTableItemKey(row.item)}`,
+                                        item: rowId,
                                       } as GeneratedAnalyticsMetadataTableComponent['innerContext'],
                                     },
                                   };
 
                                   return (
                                     <TableBodyCell
-                                      key={getColumnKey(column, colIndex)}
+                                      key={colId}
                                       {...sharedCellProps}
                                       resizableStyle={{
                                         width: column.width,
@@ -642,10 +645,8 @@ const InternalTable = React.forwardRef(
                                       isRowHeader={column.isRowHeader}
                                       successfulEdit={successfulEdit}
                                       resizableColumns={resizableColumns}
-                                      onEditStart={() => cellEditing.startEdit({ rowIndex, colIndex })}
-                                      onEditEnd={editCancelled =>
-                                        cellEditing.completeEdit({ rowIndex, colIndex }, editCancelled)
-                                      }
+                                      onEditStart={() => cellEditing.startEdit(cellId)}
+                                      onEditEnd={editCancelled => cellEditing.completeEdit(cellId, editCancelled)}
                                       submitEdit={cellEditing.submitEdit}
                                       columnId={column.id ?? colIndex}
                                       colIndex={colIndex + colIndexOffset}

--- a/src/table/use-cell-editing.ts
+++ b/src/table/use-cell-editing.ts
@@ -7,8 +7,8 @@ import { CancelableEventHandler, fireCancelableEvent } from '../internal/events'
 import { TableProps } from './interfaces';
 
 interface CellId {
-  rowIndex: number;
-  colIndex: number;
+  row: string; // Item ID (from trackBy) or row index
+  col: string; // Column ID or column index
 }
 
 interface CellEditingProps {
@@ -38,11 +38,10 @@ export function useCellEditing({ onCancel, onSubmit }: CellEditingProps) {
     }
   };
 
-  const checkEditing = ({ rowIndex, colIndex }: CellId) =>
-    rowIndex === currentEditCell?.rowIndex && colIndex === currentEditCell.colIndex;
+  const checkEditing = ({ row, col }: CellId) => row === currentEditCell?.row && col === currentEditCell.col;
 
-  const checkLastSuccessfulEdit = ({ rowIndex, colIndex }: CellId) =>
-    rowIndex === lastSuccessfulEditCell?.rowIndex && colIndex === lastSuccessfulEditCell.colIndex;
+  const checkLastSuccessfulEdit = ({ row, col }: CellId) =>
+    row === lastSuccessfulEditCell?.row && col === lastSuccessfulEditCell.col;
 
   const submitEdit = onSubmit
     ? async (...args: Parameters<typeof onSubmit>) => {


### PR DESCRIPTION
### Description

Once a table cell is edited, the successful state it added to a cell by col- and row index. If column definitions change, it causes the focus to be lost and the successful state resets. However, if rows order change, e.g. because the new value is sorted differently, the successful state then stays attached to the wrong cell. The PR fixes that for tables with trackBy property used.

See before:


https://github.com/user-attachments/assets/cee720b3-62ad-45e4-8f59-0f96eb1d8041

See after:


https://github.com/user-attachments/assets/36630e92-2cdf-4f0e-bf9c-91e459306aee



Rel: AWSUI-60542

### How has this been tested?

* New unit tests
* Manual tests in the integ test page

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
