### PR TITLE
fix: Fixes select inline label style

### DIFF
--- a/src/select/parts/styles.scss
+++ b/src/select/parts/styles.scss
@@ -132,13 +132,7 @@ $inlineLabel-border-radius: 2px;
 }
 
 .inline-label {
-  // Stepped gradient background for inline label overlap between input and background.
-  background-image: linear-gradient(
-    to bottom,
-    transparent calc(100% - (awsui.$border-width-field + awsui.$border-control-focus-ring-shadow-spread + 5px)),
-    awsui.$color-background-input-default 1px
-  );
-  background-position: bottom;
+  background: awsui.$color-background-input-default;
   box-sizing: border-box;
   display: inline-block;
   color: awsui.$color-text-form-label;


### PR DESCRIPTION
### Description

Fixing inline label visual issues in Safari or when theming is used to override border width from 2px to 1px.

Issue in Safari (at certain zoom levels)

<img width="669" alt="Screenshot 2025-03-25 at 09 58 29" src="https://github.com/user-attachments/assets/e343a1f5-7d25-4a27-bd02-9e1581296ebb" />

Closes https://github.com/cloudscape-design/components/issues/3368

The feature was introduced here: https://github.com/cloudscape-design/components/pull/2355

### How has this been tested?

* New permutations were added here: https://github.com/cloudscape-design/components/pull/3380

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
