### PR TITLE
fix: Tolerate multiselect options with child options explicitly set to undefined

### DIFF
--- a/src/internal/components/option/utils/filter-options.ts
+++ b/src/internal/components/option/utils/filter-options.ts
@@ -74,4 +74,4 @@ export const isInteractive = (option?: DropdownOption) => !!option && !option.di
 export const isGroupInteractive = (option?: DropdownOption) => !!option && !option.disabled;
 
 export const isGroup = (option?: OptionDefinition | OptionGroup): option is OptionGroup =>
-  !!option && 'options' in option;
+  !!option && 'options' in option && !!option.options;

--- a/src/internal/components/option/utils/flatten-options.ts
+++ b/src/internal/components/option/utils/flatten-options.ts
@@ -1,12 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { DropdownOption, OptionDefinition, OptionGroup } from '../interfaces';
+import { isGroup } from './filter-options';
 
 export const flattenOptions = (options: ReadonlyArray<OptionDefinition | OptionGroup>) => {
   const parentMap = new Map<DropdownOption, DropdownOption>();
 
   const flatOptions = options.reduce<DropdownOption[]>((acc, option) => {
-    if ('options' in option) {
+    if (isGroup(option)) {
       const { options, ...rest } = option;
       const parentDropdownOption: DropdownOption = { type: 'parent', option };
       const allOptionsDisabled = options.every(option => option.disabled);

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -835,3 +835,11 @@ test('group options can have description, label tag, tags, disabled reason', () 
   expect(groupOption.findTags()![1].getElement().textContent).toBe('Tag 2');
   expect(groupOption.findDisabledReason()!.getElement().textContent).toBe('Disabled reason');
 });
+
+test('tolerates options with { options: undefined }, and considers them to not be groups', () => {
+  const { wrapper } = renderMultiselect(
+    <Multiselect options={[{ value: 'option1', options: undefined }]} selectedOptions={[]} />
+  );
+  wrapper.openDropdown();
+  expect(wrapper.findDropdown().findOptionByValue('option1')).not.toBeNull();
+});


### PR DESCRIPTION
### Description

I came across this while writing a dev page where Multiselect options are handled via a `.map` call, [here](https://github.com/cloudscape-design/components/pull/3336/files#diff-e00abc4c2fe924a47acef423bc1d007b249f510859d0debce5b25d86a0af001fR60-R69).

There is no good reason why this should crash the component.

This fix is also part of #3336 but I am trying to separate things out. Also, better to have an explicit test for this.

Related: `AWSUI-59006`

### How has this been tested?

- Added a unit test
- A dev page (and therefore also integration tests) in #3336 relies on this

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
