### PR TITLE
chore: Remove console error from screenshot-area

### DIFF
--- a/pages/utils/screenshot-area.tsx
+++ b/pages/utils/screenshot-area.tsx
@@ -38,7 +38,7 @@ export default function ScreenshotArea({
 
   // Reporting the excessive height as a console error makes integration and screenshot tests for this page fail.
   if (isExceedingHeightWarning) {
-    console.error(isExceedingHeightWarning);
+    console.warn(isExceedingHeightWarning);
   }
 
   return (

--- a/src/__integ__/screenshot-area.test.ts
+++ b/src/__integ__/screenshot-area.test.ts
@@ -17,23 +17,16 @@ class ScreenshotAreaPage extends BasePageObject {
   }
 }
 
-test('shows warning message when the page height exceeds the limit and hides when it does not', async () => {
-  try {
-    await useBrowser(async browser => {
-      const page = new ScreenshotAreaPage(browser);
-      await browser.url('#light/utils/screenshot-area-warning');
-      await page.waitForVisible('.screenshot-area');
-      await expect(page.isWarningDisplayed()).resolves.toBe(false);
-      await page.clickAddItems();
-      await expect(page.isWarningDisplayed()).resolves.toBe(true);
-      await page.clickRemoveItems();
-      await expect(page.isWarningDisplayed()).resolves.toBe(false);
-    })();
-  } catch (error: any) {
-    if (error.message.includes('Unexpected errors in browser console')) {
-      // The console errors are expected in this test
-    } else {
-      throw error;
-    }
-  }
-});
+test(
+  'shows warning message when the page height exceeds the limit and hides when it does not',
+  useBrowser(async browser => {
+    const page = new ScreenshotAreaPage(browser);
+    await browser.url('#light/utils/screenshot-area-warning');
+    await page.waitForVisible('.screenshot-area');
+    await expect(page.isWarningDisplayed()).resolves.toBe(false);
+    await page.clickAddItems();
+    await expect(page.isWarningDisplayed()).resolves.toBe(true);
+    await page.clickRemoveItems();
+    await expect(page.isWarningDisplayed()).resolves.toBe(false);
+  })
+);


### PR DESCRIPTION
### Description

This removes console.error() recently introduced to screenshot area as it causes failures in screenshot tests that use narrow viewport sizes, which makes many pages to exceed the 16000px limit.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
