### PR TITLE
chore: Use native ul/li elements for slider labels

### DIFF
--- a/src/slider/__tests__/slider.test.tsx
+++ b/src/slider/__tests__/slider.test.tsx
@@ -5,6 +5,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
+import '../../__a11y__/to-validate-a11y';
 import TestI18nProvider from '../../../lib/components/i18n/testing';
 import customCssProps from '../../../lib/components/internal/generated/custom-css-properties';
 import Slider, { SliderProps } from '../../../lib/components/slider';
@@ -336,7 +337,7 @@ describe('Slider a11y', () => {
       ariaLabel: 'aria label',
     });
 
-    expect(wrapper.getElement()).toValidateA11y;
+    expect(wrapper.getElement()).toValidateA11y();
   });
 
   test('Renders correct aria label', () => {

--- a/src/slider/slider-labels.tsx
+++ b/src/slider/slider-labels.tsx
@@ -83,8 +83,7 @@ export default function SliderLabels({
 
   return (
     <>
-      <div
-        role="list"
+      <ul
         aria-hidden={!valueFormatter && !referenceValues ? 'true' : undefined}
         className={clsx(styles.labels, {
           [styles['labels-noref']]: getVisibleReferenceValues().length === 0,
@@ -94,19 +93,17 @@ export default function SliderLabels({
         }}
         id={!ariaDescription ? labelsId : undefined}
       >
-        <span
-          role="listitem"
+        <li
           className={clsx(styles.label, styles['labels-min'])}
           style={{
             [customCssProps.sliderMinEnd]: getLabelPosition(0).min,
           }}
         >
           {valueFormatter ? valueFormatter(min) : min}
-        </span>
+        </li>
         {getVisibleReferenceValues().map(step => {
           return (
-            <span
-              role="listitem"
+            <li
               key={step}
               style={{
                 [customCssProps.sliderReferenceColumn]: getLabelPosition(step).posStart,
@@ -115,19 +112,18 @@ export default function SliderLabels({
               className={clsx(styles.label, styles['labels-reference'])}
             >
               {valueFormatter ? valueFormatter(step) : step}
-            </span>
+            </li>
           );
         })}
-        <span
-          role="listitem"
+        <li
           className={clsx(styles.label, styles['labels-max'])}
           style={{
             [customCssProps.sliderMaxStart]: !referenceValues ? 2 : getLabelPosition(0).max,
           }}
         >
           {valueFormatter ? valueFormatter(max) : max}
-        </span>
-      </div>
+        </li>
+      </ul>
       {ariaDescription && (
         <div className={styles['labels-aria-description']} id={labelsId}>
           {ariaDescription}

--- a/src/slider/styles.scss
+++ b/src/slider/styles.scss
@@ -96,7 +96,13 @@
     )
     3fr;
   grid-auto-rows: 100%;
+
+  list-style: none;
+  padding-block: 0;
   padding-block-start: awsui.$space-m;
+  padding-inline: 0;
+  margin-block: 0;
+  margin-inline: 0;
 
   &-noref {
     grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
### Description

See #3359 for context — touching that file revealed a broken a11y test; which this PR hopefully addresses.

Related links, issue #, if available: n/a

### How has this been tested?

The added test was failing because it preferred using native elements; I wasn't sure why they couldn't be used either, so I'm testing that out in this PR.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
