### PR TITLE
fix: Add aria-label to app layout toolbars

### DIFF
--- a/src/app-layout/__tests__/desktop.test.tsx
+++ b/src/app-layout/__tests__/desktop.test.tsx
@@ -256,9 +256,9 @@ describeEachAppLayout({ themes: ['classic'], sizes: ['desktop'] }, () => {
     const { wrapper } = renderComponent(
       <AppLayout toolsHide={true} drawers={[testDrawer]} ariaLabels={{ drawers: 'Drawers' }} />
     );
-    fireEvent.click(screen.getByLabelText('Drawers'));
+    fireEvent.click(screen.getByLabelText('Drawers', { selector: '[role=region]' }));
     expect(wrapper.findActiveDrawer()).toBeTruthy();
-    fireEvent.click(screen.getByLabelText('Drawers'));
+    fireEvent.click(screen.getByLabelText('Drawers', { selector: '[role=region]' }));
     expect(wrapper.findActiveDrawer()).toBeFalsy();
   });
 
@@ -266,11 +266,11 @@ describeEachAppLayout({ themes: ['classic'], sizes: ['desktop'] }, () => {
     const { wrapper } = renderComponent(
       <AppLayout toolsHide={true} drawers={manyDrawers} ariaLabels={{ drawers: 'Drawers' }} />
     );
-    fireEvent.click(screen.getByLabelText('Drawers'));
+    fireEvent.click(screen.getByLabelText('Drawers', { selector: '[role=region]' }));
     expect(wrapper.findActiveDrawer()).toBeFalsy();
   });
 
-  test('renders roles only when aria labels are not provided', () => {
+  test('renders roles only when aria labels are not provided (classic)', () => {
     const { wrapper } = renderComponent(<AppLayout navigationHide={true} drawers={[testDrawerWithoutLabels]} />);
     const drawersAside = within(wrapper.findByClassName(drawerStyles['drawer-closed'])!.getElement()).getByRole(
       'region'
@@ -284,7 +284,7 @@ describeEachAppLayout({ themes: ['classic'], sizes: ['desktop'] }, () => {
     );
   });
 
-  test('renders roles and aria labels when provided', () => {
+  test('renders roles and aria labels when provided (classic)', () => {
     const { wrapper } = renderComponent(<AppLayout drawers={[testDrawer]} ariaLabels={{ drawers: 'Drawers' }} />);
     const drawersAside = within(wrapper.findByClassName(drawerStyles['drawer-closed'])!.getElement()).getByRole(
       'region'

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -249,7 +249,12 @@ export const DrawerTriggersBar = ({
       >
         {!isMobile && (
           <aside aria-label={ariaLabels?.drawers} role="region">
-            <div className={styles['drawer-triggers-wrapper']} role="toolbar" aria-orientation="vertical">
+            <div
+              className={styles['drawer-triggers-wrapper']}
+              aria-label={ariaLabels?.drawers}
+              role="toolbar"
+              aria-orientation="vertical"
+            >
               {visibleItems.map((item, index) => {
                 return (
                   <DrawerTrigger

--- a/src/app-layout/mobile-toolbar/index.tsx
+++ b/src/app-layout/mobile-toolbar/index.tsx
@@ -127,7 +127,12 @@ export function MobileToolbar({
       )}
       {drawers && (
         <aside aria-label={ariaLabels?.drawers} role="region">
-          <div className={styles['drawers-container']} role="toolbar" aria-orientation="horizontal">
+          <div
+            className={styles['drawers-container']}
+            aria-label={ariaLabels?.drawers}
+            role="toolbar"
+            aria-orientation="horizontal"
+          >
             {visibleItems.map((item, index) => (
               <div
                 className={clsx(styles['mobile-toggle'], styles['mobile-toggle-type-drawer'])}

--- a/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
@@ -119,7 +119,12 @@ export function DrawerTriggers({
       ref={triggersContainerRef}
       role="region"
     >
-      <div className={styles['drawers-trigger-content']} role="toolbar" aria-orientation="horizontal">
+      <div
+        className={styles['drawers-trigger-content']}
+        aria-label={ariaLabels?.drawers}
+        role="toolbar"
+        aria-orientation="horizontal"
+      >
         {splitPanelToggleProps && (
           <>
             <TriggerButton
@@ -193,7 +198,7 @@ export function DrawerTriggers({
               iconSvg={item.trigger!.iconSvg}
               key={item.id}
               onClick={() => {
-                onActiveGlobalDrawersChange && onActiveGlobalDrawersChange(item.id, { initiatedByUserAction: true });
+                onActiveGlobalDrawersChange?.(item.id, { initiatedByUserAction: true });
               }}
               ref={globalDrawersFocusControl?.refs[item.id]?.toggle}
               selected={activeGlobalDrawersIds.includes(item.id)}

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -240,6 +240,7 @@ function DesktopTriggers() {
           [styles['has-multiple-triggers']]: hasMultipleTriggers,
           [styles['has-open-drawer']]: hasOpenDrawer,
         })}
+        aria-label={drawersAriaLabel}
         role="toolbar"
         aria-orientation="vertical"
       >
@@ -347,7 +348,12 @@ export function MobileTriggers() {
       aria-label={drawersAriaLabel}
       role="region"
     >
-      <div className={styles['drawers-mobile-triggers-container']} role="toolbar" aria-orientation="horizontal">
+      <div
+        className={styles['drawers-mobile-triggers-container']}
+        aria-label={drawersAriaLabel}
+        role="toolbar"
+        aria-orientation="horizontal"
+      >
         {visibleItems.map(item => {
           const isForPreviousActiveDrawer = previousActiveDrawerId?.current === item.id;
           return (


### PR DESCRIPTION
### Description

The `role=toolbar` elements are unlabelled. It's fine to repeat the label of the `role=region` parents here, since the role itself is different even if the aria label is identical. Had to fiddle a couple of tests that were selecting by label, but hopefully the downstream user impact is minimal because it's still not the first element returned (which was the case with some a11y fixes earlier).

Related links, issue #, if available: AWSUI-60452

### How has this been tested?

Unit tests, but I'm going to be a dry-run build to be double sure (see build 7294528292).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
