### PR TITLE
fix: Fixes popover placement when rendered inside inline-size container

### DIFF
--- a/pages/popover/scenario-in-container-query.page.tsx
+++ b/pages/popover/scenario-in-container-query.page.tsx
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+import { Box, SpaceBetween } from '~components';
+import Popover, { PopoverProps } from '~components/popover';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+import styles from './scenario-in-container-query.scss';
+
+export default function () {
+  const popoverProps: PopoverProps = {
+    size: 'medium',
+    position: 'bottom',
+    header: 'Memory error',
+    content: (
+      <>
+        This instance contains insufficient memory. Stop the instance, choose a different instance type with more
+        memory, and restart it.
+      </>
+    ),
+    dismissAriaLabel: 'Close',
+  };
+
+  return (
+    <Box margin="m">
+      <h1>Popover inside a container with CSS container query</h1>
+
+      <ScreenshotArea>
+        <SpaceBetween size="m">
+          <div>
+            <Popover {...{ ...popoverProps, id: 'popover-0', children: 'popover-0' }} />
+          </div>
+
+          <div className={styles['container-inline-size']}>
+            <Popover {...{ ...popoverProps, id: 'popover-1', children: 'popover-1' }} />
+          </div>
+        </SpaceBetween>
+      </ScreenshotArea>
+    </Box>
+  );
+}

--- a/pages/popover/scenario-in-container-query.scss
+++ b/pages/popover/scenario-in-container-query.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.container-inline-size {
+  container-type: inline-size;
+}

--- a/pages/popover/scenario-in-modal.page.tsx
+++ b/pages/popover/scenario-in-modal.page.tsx
@@ -13,7 +13,7 @@ export default function () {
 
   return (
     <article>
-      <h1>Popover inside table</h1>
+      <h1>Popover inside modal</h1>
       <Button formAction="none" onClick={() => setVisible(true)}>
         Show modal
       </Button>

--- a/src/internal/utils/dom.ts
+++ b/src/internal/utils/dom.ts
@@ -10,7 +10,9 @@ export function isContainingBlock(element: HTMLElement): boolean {
   return (
     (!!computedStyle.transform && computedStyle.transform !== 'none') ||
     (!!computedStyle.perspective && computedStyle.perspective !== 'none') ||
-    (!!computedStyle.containerType && computedStyle.containerType !== 'normal') ||
+    (!!computedStyle.containerType &&
+      computedStyle.containerType !== 'normal' &&
+      computedStyle.containerType !== 'inline-size') ||
     computedStyle.contain?.split(' ').some(s => ['layout', 'paint', 'strict', 'content'].includes(s))
   );
 }

--- a/src/popover/__integ__/popover-containing-block.test.ts
+++ b/src/popover/__integ__/popover-containing-block.test.ts
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+import createWrapper from '../../../lib/components/test-utils/selectors';
+
+import styles from '../../../lib/components/popover/styles.selectors.js';
+
+test(
+  'Places popover under the trigger when it is inside container query with type "inline-size"',
+  useBrowser(async browser => {
+    const findPopover = (id: string) => createWrapper().findPopover(`[id="popover-${id}"]`);
+    const popoverTrigger = (id: string) => findPopover(id).findTrigger().toSelector();
+    const popoverDismiss = (id: string) => findPopover(id).findDismissButton().toSelector();
+    const popoverArrow = (id: string) => findPopover(id).findByClassName(styles.arrow).toSelector();
+
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/popover/scenario-in-container-query');
+    await page.click(popoverTrigger('0'));
+
+    const triggerRect0 = await page.getBoundingBox(popoverTrigger('0'));
+    const contentRect0 = await page.getBoundingBox(popoverArrow('0'));
+    expect(contentRect0.top - triggerRect0.bottom).toBeLessThanOrEqual(1);
+
+    await page.click(popoverDismiss('0'));
+    await page.click(popoverTrigger('1'));
+
+    const triggerRect1 = await page.getBoundingBox(popoverTrigger('1'));
+    const contentRect1 = await page.getBoundingBox(popoverArrow('1'));
+    expect(contentRect1.top - triggerRect1.bottom).toBeLessThanOrEqual(1);
+  })
+);


### PR DESCRIPTION
### Description

Fixing a bug with incorrect popover placement when rendered inside a container with `containerType: inline-size`.

Before:

<img width="462" alt="Screenshot 2025-03-26 at 09 21 03" src="https://github.com/user-attachments/assets/42362315-e807-40e7-81ce-73c997b0a575" />


After:

<img width="462" alt="Screenshot 2025-03-26 at 09 21 22" src="https://github.com/user-attachments/assets/ca1d8253-96c9-4994-b79f-58ec7ea0ffe2" />


### How has this been tested?

* Added new test page and integ test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
