### PR TITLE
chore: Apply consistent border rounding to inline label

### DIFF
--- a/src/select/parts/styles.scss
+++ b/src/select/parts/styles.scss
@@ -132,7 +132,11 @@ $inlineLabel-border-radius: 2px;
 }
 
 .inline-label {
-  background: awsui.$color-background-input-default;
+  background: awsui.$color-background-container-header;
+  border-start-start-radius: $inlineLabel-border-radius;
+  border-start-end-radius: $inlineLabel-border-radius;
+  border-end-start-radius: $inlineLabel-border-radius;
+  border-end-end-radius: $inlineLabel-border-radius;
   box-sizing: border-box;
   display: inline-block;
   color: awsui.$color-text-form-label;
@@ -147,14 +151,6 @@ $inlineLabel-border-radius: 2px;
   padding-inline: awsui.$space-scaled-xxs;
   max-inline-size: calc(100% - (2 * awsui.$space-field-horizontal));
   z-index: 1;
-
-  &.inline-label-disabled {
-    background: awsui.$color-background-container-header;
-    border-start-start-radius: $inlineLabel-border-radius;
-    border-start-end-radius: $inlineLabel-border-radius;
-    border-end-start-radius: $inlineLabel-border-radius;
-    border-end-end-radius: $inlineLabel-border-radius;
-  }
 }
 
 .disabled-reason-tooltip {

--- a/src/select/parts/trigger.tsx
+++ b/src/select/parts/trigger.tsx
@@ -129,10 +129,7 @@ const Trigger = React.forwardRef(
       <>
         {inlineLabelText ? (
           <div className={styles['inline-label-wrapper']}>
-            <label
-              htmlFor={controlId}
-              className={clsx(styles['inline-label'], disabled && styles['inline-label-disabled'])}
-            >
+            <label htmlFor={controlId} className={styles['inline-label']}>
               {inlineLabelText}
             </label>
             <div className={styles['inline-label-trigger-wrapper']}>{triggerButton}</div>


### PR DESCRIPTION
### Description

This is a follow-up for https://github.com/cloudscape-design/components/pull/3372

The change makes styling of inline labels consistent between active and disabled states. Previously, the border radius was missing from the active state. The radius is visible when page's background is different from the label background.

<img width="767" alt="Screenshot 2025-03-26 at 16 53 10" src="https://github.com/user-attachments/assets/ad5c3f79-5269-47ed-8142-1e02a5fc2b9f" />


### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
