### PR TITLE
chore: Remove Visual Refresh toggle

### DIFF
--- a/pages/app/components/theme-switcher.tsx
+++ b/pages/app/components/theme-switcher.tsx
@@ -4,7 +4,6 @@ import React, { useContext } from 'react';
 
 import { Density, Mode } from '@cloudscape-design/global-styles';
 
-import { ALWAYS_VISUAL_REFRESH } from '~components/internal/environment';
 import SpaceBetween from '~components/space-between';
 
 import AppContext from '../app-context';
@@ -12,28 +11,8 @@ import AppContext from '../app-context';
 export default function ThemeSwitcher() {
   const { mode, urlParams, setUrlParams, setMode } = useContext(AppContext);
 
-  const vrSwitchProps: React.InputHTMLAttributes<HTMLInputElement> = {
-    id: 'visual-refresh-toggle',
-    type: 'checkbox',
-  };
-
-  if (ALWAYS_VISUAL_REFRESH) {
-    vrSwitchProps.checked = true;
-    vrSwitchProps.readOnly = true;
-  } else {
-    vrSwitchProps.checked = urlParams.visualRefresh;
-    vrSwitchProps.onChange = event => {
-      setUrlParams({ visualRefresh: event.target.checked });
-      window.location.reload();
-    };
-  }
-
   return (
     <SpaceBetween direction="horizontal" size="xs">
-      <label>
-        <input {...vrSwitchProps} />
-        Visual refresh
-      </label>
       <label>
         <input
           id="mode-toggle"

--- a/src/icon/__integ__/icon.test.ts
+++ b/src/icon/__integ__/icon.test.ts
@@ -8,17 +8,12 @@ import createWrapper from '../../../lib/components/test-utils/selectors';
 import styles from '../../../lib/components/icon/styles.selectors.js';
 
 const dynamicIconSelector = createWrapper().findIcon('#dynamic-test-2').toSelector();
-const staticIconSelector = createWrapper().findIcon('#static-test').toSelector();
 const removedIconSelector = createWrapper().findIcon('#visibility-test-1').toSelector();
 const hiddenIconSelector = createWrapper().findIcon('#visibility-test-2').toSelector();
 
 const dynamicHeightInput = '#height-input';
 
 class IconSizeInherit extends BasePageObject {
-  async toggleMode() {
-    await this.click('label=Visual refresh');
-  }
-
   async toggleVisibility() {
     await this.click('#visibility-toggle');
   }
@@ -34,13 +29,11 @@ class IconSizeInherit extends BasePageObject {
 }
 
 describe('Icon', () => {
-  const setupTest = (testFn: (page: IconSizeInherit) => Promise<void>) => {
+  const setupTest = (testFn: (page: IconSizeInherit) => Promise<void>, classic?: boolean) => {
     return useBrowser(async browser => {
       const page = new IconSizeInherit(browser);
-      await browser.url('#/light/icon/size-inherit');
+      await browser.url(`#/light/icon/size-inherit?visualRefresh=${!classic}`);
       await page.waitForVisible(dynamicIconSelector);
-      // The default theme is VR by default, so we toggle once to go to classic mode
-      await page.toggleMode();
       await testFn(page);
     });
   };
@@ -57,18 +50,6 @@ describe('Icon', () => {
     })
   );
   test(
-    'Should update icon height and size on visual mode change',
-    setupTest(async page => {
-      await expect(page.getHeight(staticIconSelector)).resolves.toEqual(22);
-      await expect(page.hasSize('size-normal', staticIconSelector)).resolves.toBe(true);
-
-      await page.toggleMode();
-
-      await expect(page.getHeight(staticIconSelector)).resolves.toEqual(24);
-      await expect(page.hasSize('size-medium', staticIconSelector)).resolves.toBe(true);
-    })
-  );
-  test(
     'Hidden icon should have correct height and size after becoming visible',
     setupTest(async page => {
       await expect(page.isExisting(removedIconSelector)).resolves.toBe(false);
@@ -76,11 +57,29 @@ describe('Icon', () => {
       await expect(page.isExisting(removedIconSelector)).resolves.toBe(true);
       await expect(page.isExisting(hiddenIconSelector)).resolves.toBe(true);
 
-      await expect(page.getHeight(removedIconSelector)).resolves.toEqual(36);
-      await expect(page.hasSize('size-big', removedIconSelector)).resolves.toBe(true);
+      await expect(page.getHeight(removedIconSelector)).resolves.toEqual(30);
+      await expect(page.hasSize('size-medium', removedIconSelector)).resolves.toBe(true);
 
       await expect(page.getHeight(hiddenIconSelector)).resolves.toEqual(27);
       await expect(page.hasSize('size-medium', hiddenIconSelector)).resolves.toBe(true);
     })
   );
+
+  describe('Classic', () => {
+    test(
+      'Hidden icon should have correct height and size after becoming visible',
+      setupTest(async page => {
+        await expect(page.isExisting(removedIconSelector)).resolves.toBe(false);
+        await page.toggleVisibility();
+        await expect(page.isExisting(removedIconSelector)).resolves.toBe(true);
+        await expect(page.isExisting(hiddenIconSelector)).resolves.toBe(true);
+
+        await expect(page.getHeight(removedIconSelector)).resolves.toEqual(36);
+        await expect(page.hasSize('size-big', removedIconSelector)).resolves.toBe(true);
+
+        await expect(page.getHeight(hiddenIconSelector)).resolves.toEqual(27);
+        await expect(page.hasSize('size-medium', hiddenIconSelector)).resolves.toBe(true);
+      }, true)
+    );
+  });
 });


### PR DESCRIPTION
### Description

Removes the checkbox toggle on the dev pages for Visual Refresh.

Related links, issue #, if available: n/a

### How has this been tested?

- Local dev pages
- Pipeline

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
