### PR TITLE
fix: Disables select native search when read-only

### DIFF
--- a/pages/select/select.test.page.tsx
+++ b/pages/select/select.test.page.tsx
@@ -155,6 +155,19 @@ export default function SelectPage() {
               }}
             />
           </Box>
+          <Box padding="s">
+            <Box variant="h1">Read-only select</Box>
+            <Select
+              id="select_native_search_readonly"
+              readOnly={true}
+              options={options}
+              selectedOption={selectedOption1}
+              placeholder="Choose option"
+              onChange={(e: any) => {
+                setSelectedOption1(e.detail.selectedOption);
+              }}
+            />
+          </Box>
         </Box>
       </ScreenshotArea>
     </article>

--- a/src/select/__integ__/select-native-search.test.ts
+++ b/src/select/__integ__/select-native-search.test.ts
@@ -136,7 +136,7 @@ describe(`Select (Native Search)`, () => {
     );
 
     test(
-      'selects the match with dropdown closed -- extended option with missing properties, searches entire option',
+      'selects the match with dropdown closed -- extended option with missing properties, searches entire option - "ano"',
       setupTest(optionsType, async page => {
         await page.focusSelect();
         await page.keys(['a', 'n', 'o']);
@@ -154,12 +154,28 @@ describe(`Select (Native Search)`, () => {
     );
 
     test(
-      'selects the match with dropdown closed -- extended option with missing properties, searches entire option',
+      'selects the match with dropdown closed -- extended option with missing properties, searches entire option - "third"',
       setupTest(optionsType, async page => {
         await page.focusSelect();
         await page.keys(['t', 'h', 'i', 'r', 'd']);
         await expect(page.getTriggerLabel()).resolves.toMatch('Third thing');
       })
     );
+  });
+
+  describe('Options - Read-only', () => {
+    test('cannot use native search on read-only select', async () => {
+      await setupTest('simple', async page => {
+        await page.focusSelect();
+        await page.keys(['o']);
+        await expect(page.getTriggerLabel()).resolves.toBe('Option 1');
+      })();
+
+      await setupTest('readonly', async page => {
+        await page.focusSelect();
+        await page.keys(['o']);
+        await expect(page.getTriggerLabel()).resolves.toBe('Choose option');
+      })();
+    });
   });
 });

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -138,7 +138,7 @@ const InternalSelect = React.forwardRef(
     });
 
     const handleNativeSearch = useNativeSearch({
-      isEnabled: filteringType === 'none',
+      isEnabled: filteringType === 'none' && !readOnly,
       options: filteredOptions,
       highlightOption: !isOpen ? selectOption : highlightOption,
       highlightedOption: !isOpen ? selectedOption : highlightedOption?.option,


### PR DESCRIPTION
### Description

The native select search allows options selection by matching keyboard input - this has to be disabled when component is in read-only mode. We don't have to explicitly disable it for disabled mode because in that case the component is not focusable anyways.

Rel: AWSUI-60557

Closes https://github.com/cloudscape-design/components/issues/3384

### How has this been tested?

* Added new integration test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
