### PR TITLE
feat: Infinite maxRows for PromptInput using -1 value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17128,7 +17128,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.1",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -19803,17 +19805,17 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.2.tgz",
-      "integrity": "sha512-qHlU6AawrgAIHlueGQHQ+ETcPLAauXbnoTKl3RKq20W0T8x0DKVAo5xWIYjHSyvHxQlcYbFdR0jp4T9bDVITFA==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.3.tgz",
+      "integrity": "sha512-nQFqAFzZDeRxsu7S3C7LbuxslHhk+gnJZHyethuGKAn2IVleIbTB9I3vJSQiSR+DifUqmdzfPMoMPJfLqMF2vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.7.9",
+        "axios": "^1.8.2",
         "joi": "^17.13.3",
         "lodash": "^4.17.21",
         "minimist": "^1.2.8",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.2"
       },
       "bin": {
         "wait-on": "bin/wait-on"

--- a/pages/prompt-input/simple.page.tsx
+++ b/pages/prompt-input/simple.page.tsx
@@ -31,6 +31,8 @@ type DemoContext = React.Context<
     hasText: boolean;
     hasSecondaryContent: boolean;
     hasSecondaryActions: boolean;
+    hasInfiniteMaxRows: boolean;
+    hasParentMaxHeightRestriction: boolean;
   }>
 >;
 
@@ -43,8 +45,18 @@ export default function PromptInputPage() {
   const [files, setFiles] = useState<File[]>([]);
   const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
 
-  const { isDisabled, isReadOnly, isInvalid, hasWarning, hasText, hasSecondaryActions, hasSecondaryContent } =
-    urlParams;
+  const {
+    isDisabled,
+    isReadOnly,
+    isInvalid,
+    hasWarning,
+    hasText,
+    hasSecondaryActions,
+    hasSecondaryContent,
+    hasInfiniteMaxRows,
+    hasParentMaxHeightRestriction,
+  } = urlParams;
+
   const [items, setItems] = React.useState([
     { label: 'Item 1', dismissLabel: 'Remove item 1', disabled: isDisabled },
     { label: 'Item 2', dismissLabel: 'Remove item 2', disabled: isDisabled },
@@ -131,6 +143,26 @@ export default function PromptInputPage() {
               >
                 Secondary actions
               </Checkbox>
+              <Checkbox
+                checked={hasInfiniteMaxRows}
+                onChange={() =>
+                  setUrlParams({
+                    hasInfiniteMaxRows: !hasInfiniteMaxRows,
+                  })
+                }
+              >
+                Infinite max rows
+              </Checkbox>
+              <Checkbox
+                checked={hasParentMaxHeightRestriction}
+                onChange={() =>
+                  setUrlParams({
+                    hasParentMaxHeightRestriction: !hasParentMaxHeightRestriction,
+                  })
+                }
+              >
+                Restrict parent container maxHeight
+              </Checkbox>
             </FormField>
             <button id="placeholder-text-button" onClick={() => setUrlParams({ hasText: true })}>
               Fill with placeholder text
@@ -155,70 +187,72 @@ export default function PromptInputPage() {
                 label={<span>User prompt</span>}
                 i18nStrings={{ errorIconAriaLabel: 'Error' }}
               >
-                <PromptInput
-                  data-testid="prompt-input"
-                  ariaLabel="Chat input"
-                  actionButtonIconName="send"
-                  actionButtonAriaLabel="Submit prompt"
-                  value={textareaValue}
-                  onChange={(event: any) => setTextareaValue(event.detail.value)}
-                  onAction={event => window.alert(`Submitted the following: ${event.detail.value}`)}
-                  placeholder="Ask a question"
-                  maxRows={4}
-                  disabled={isDisabled}
-                  readOnly={isReadOnly}
-                  invalid={isInvalid || textareaValue.length > MAX_CHARS}
-                  warning={hasWarning}
-                  ref={ref}
-                  disableSecondaryActionsPaddings={true}
-                  secondaryActions={
-                    hasSecondaryActions ? (
-                      <Box padding={{ left: 'xxs', top: 'xs' }}>
-                        <ButtonGroup
-                          ref={buttonGroupRef}
-                          ariaLabel="Chat actions"
-                          onFilesChange={({ detail }) => detail.id.includes('files') && setFiles(detail.files)}
-                          items={[
-                            {
-                              type: 'icon-file-input',
-                              id: 'files',
-                              text: 'Upload files',
-                              multiple: true,
-                            },
-                            {
-                              type: 'icon-button',
-                              id: 'expand',
-                              iconName: 'expand',
-                              text: 'Go full page',
-                              disabled: isDisabled || isReadOnly,
-                            },
-                            {
-                              type: 'icon-button',
-                              id: 'remove',
-                              iconName: 'remove',
-                              text: 'Remove',
-                              disabled: isDisabled || isReadOnly,
-                            },
-                          ]}
-                          variant="icon"
+                <div style={{ maxHeight: hasParentMaxHeightRestriction ? '180px' : undefined }}>
+                  <PromptInput
+                    data-testid="prompt-input"
+                    ariaLabel="Chat input"
+                    actionButtonIconName="send"
+                    actionButtonAriaLabel="Submit prompt"
+                    value={textareaValue}
+                    onChange={(event: any) => setTextareaValue(event.detail.value)}
+                    onAction={event => window.alert(`Submitted the following: ${event.detail.value}`)}
+                    placeholder="Ask a question"
+                    maxRows={hasInfiniteMaxRows ? -1 : 4}
+                    disabled={isDisabled}
+                    readOnly={isReadOnly}
+                    invalid={isInvalid || textareaValue.length > MAX_CHARS}
+                    warning={hasWarning}
+                    ref={ref}
+                    disableSecondaryActionsPaddings={true}
+                    secondaryActions={
+                      hasSecondaryActions ? (
+                        <Box padding={{ left: 'xxs', top: 'xs' }}>
+                          <ButtonGroup
+                            ref={buttonGroupRef}
+                            ariaLabel="Chat actions"
+                            onFilesChange={({ detail }) => detail.id.includes('files') && setFiles(detail.files)}
+                            items={[
+                              {
+                                type: 'icon-file-input',
+                                id: 'files',
+                                text: 'Upload files',
+                                multiple: true,
+                              },
+                              {
+                                type: 'icon-button',
+                                id: 'expand',
+                                iconName: 'expand',
+                                text: 'Go full page',
+                                disabled: isDisabled || isReadOnly,
+                              },
+                              {
+                                type: 'icon-button',
+                                id: 'remove',
+                                iconName: 'remove',
+                                text: 'Remove',
+                                disabled: isDisabled || isReadOnly,
+                              },
+                            ]}
+                            variant="icon"
+                          />
+                        </Box>
+                      ) : undefined
+                    }
+                    secondaryContent={
+                      hasSecondaryContent && files.length > 0 ? (
+                        <FileTokenGroup
+                          items={files.map(file => ({
+                            file,
+                          }))}
+                          showFileThumbnail={true}
+                          onDismiss={onDismiss}
+                          i18nStrings={i18nStrings}
+                          alignment="horizontal"
                         />
-                      </Box>
-                    ) : undefined
-                  }
-                  secondaryContent={
-                    hasSecondaryContent && files.length > 0 ? (
-                      <FileTokenGroup
-                        items={files.map(file => ({
-                          file,
-                        }))}
-                        showFileThumbnail={true}
-                        onDismiss={onDismiss}
-                        i18nStrings={i18nStrings}
-                        alignment="horizontal"
-                      />
-                    ) : undefined
-                  }
-                />
+                      ) : undefined
+                    }
+                  />
+                </div>
               </FormField>
               <div />
             </ColumnLayout>

--- a/pages/prompt-input/simple.page.tsx
+++ b/pages/prompt-input/simple.page.tsx
@@ -32,7 +32,6 @@ type DemoContext = React.Context<
     hasSecondaryContent: boolean;
     hasSecondaryActions: boolean;
     hasInfiniteMaxRows: boolean;
-    hasParentMaxHeightRestriction: boolean;
   }>
 >;
 
@@ -54,7 +53,6 @@ export default function PromptInputPage() {
     hasSecondaryActions,
     hasSecondaryContent,
     hasInfiniteMaxRows,
-    hasParentMaxHeightRestriction,
   } = urlParams;
 
   const [items, setItems] = React.useState([
@@ -153,16 +151,6 @@ export default function PromptInputPage() {
               >
                 Infinite max rows
               </Checkbox>
-              <Checkbox
-                checked={hasParentMaxHeightRestriction}
-                onChange={() =>
-                  setUrlParams({
-                    hasParentMaxHeightRestriction: !hasParentMaxHeightRestriction,
-                  })
-                }
-              >
-                Restrict parent container maxHeight
-              </Checkbox>
             </FormField>
             <button id="placeholder-text-button" onClick={() => setUrlParams({ hasText: true })}>
               Fill with placeholder text
@@ -187,72 +175,70 @@ export default function PromptInputPage() {
                 label={<span>User prompt</span>}
                 i18nStrings={{ errorIconAriaLabel: 'Error' }}
               >
-                <div style={{ maxHeight: hasParentMaxHeightRestriction ? '180px' : undefined }}>
-                  <PromptInput
-                    data-testid="prompt-input"
-                    ariaLabel="Chat input"
-                    actionButtonIconName="send"
-                    actionButtonAriaLabel="Submit prompt"
-                    value={textareaValue}
-                    onChange={(event: any) => setTextareaValue(event.detail.value)}
-                    onAction={event => window.alert(`Submitted the following: ${event.detail.value}`)}
-                    placeholder="Ask a question"
-                    maxRows={hasInfiniteMaxRows ? -1 : 4}
-                    disabled={isDisabled}
-                    readOnly={isReadOnly}
-                    invalid={isInvalid || textareaValue.length > MAX_CHARS}
-                    warning={hasWarning}
-                    ref={ref}
-                    disableSecondaryActionsPaddings={true}
-                    secondaryActions={
-                      hasSecondaryActions ? (
-                        <Box padding={{ left: 'xxs', top: 'xs' }}>
-                          <ButtonGroup
-                            ref={buttonGroupRef}
-                            ariaLabel="Chat actions"
-                            onFilesChange={({ detail }) => detail.id.includes('files') && setFiles(detail.files)}
-                            items={[
-                              {
-                                type: 'icon-file-input',
-                                id: 'files',
-                                text: 'Upload files',
-                                multiple: true,
-                              },
-                              {
-                                type: 'icon-button',
-                                id: 'expand',
-                                iconName: 'expand',
-                                text: 'Go full page',
-                                disabled: isDisabled || isReadOnly,
-                              },
-                              {
-                                type: 'icon-button',
-                                id: 'remove',
-                                iconName: 'remove',
-                                text: 'Remove',
-                                disabled: isDisabled || isReadOnly,
-                              },
-                            ]}
-                            variant="icon"
-                          />
-                        </Box>
-                      ) : undefined
-                    }
-                    secondaryContent={
-                      hasSecondaryContent && files.length > 0 ? (
-                        <FileTokenGroup
-                          items={files.map(file => ({
-                            file,
-                          }))}
-                          showFileThumbnail={true}
-                          onDismiss={onDismiss}
-                          i18nStrings={i18nStrings}
-                          alignment="horizontal"
+                <PromptInput
+                  data-testid="prompt-input"
+                  ariaLabel="Chat input"
+                  actionButtonIconName="send"
+                  actionButtonAriaLabel="Submit prompt"
+                  value={textareaValue}
+                  onChange={(event: any) => setTextareaValue(event.detail.value)}
+                  onAction={event => window.alert(`Submitted the following: ${event.detail.value}`)}
+                  placeholder="Ask a question"
+                  maxRows={hasInfiniteMaxRows ? -1 : 4}
+                  disabled={isDisabled}
+                  readOnly={isReadOnly}
+                  invalid={isInvalid || textareaValue.length > MAX_CHARS}
+                  warning={hasWarning}
+                  ref={ref}
+                  disableSecondaryActionsPaddings={true}
+                  secondaryActions={
+                    hasSecondaryActions ? (
+                      <Box padding={{ left: 'xxs', top: 'xs' }}>
+                        <ButtonGroup
+                          ref={buttonGroupRef}
+                          ariaLabel="Chat actions"
+                          onFilesChange={({ detail }) => detail.id.includes('files') && setFiles(detail.files)}
+                          items={[
+                            {
+                              type: 'icon-file-input',
+                              id: 'files',
+                              text: 'Upload files',
+                              multiple: true,
+                            },
+                            {
+                              type: 'icon-button',
+                              id: 'expand',
+                              iconName: 'expand',
+                              text: 'Go full page',
+                              disabled: isDisabled || isReadOnly,
+                            },
+                            {
+                              type: 'icon-button',
+                              id: 'remove',
+                              iconName: 'remove',
+                              text: 'Remove',
+                              disabled: isDisabled || isReadOnly,
+                            },
+                          ]}
+                          variant="icon"
                         />
-                      ) : undefined
-                    }
-                  />
-                </div>
+                      </Box>
+                    ) : undefined
+                  }
+                  secondaryContent={
+                    hasSecondaryContent && files.length > 0 ? (
+                      <FileTokenGroup
+                        items={files.map(file => ({
+                          file,
+                        }))}
+                        showFileThumbnail={true}
+                        onDismiss={onDismiss}
+                        i18nStrings={i18nStrings}
+                        alignment="horizontal"
+                      />
+                    ) : undefined
+                  }
+                />
               </FormField>
               <div />
             </ColumnLayout>

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -13487,7 +13487,8 @@ single form field.",
     },
     {
       "defaultValue": "3",
-      "description": "Specifies the maximum number of lines of text the textarea will expand to.",
+      "description": "Specifies the maximum number of lines of text the textarea will expand to.
+Defaults to 3. Use -1 for infinite rows.",
       "name": "maxRows",
       "optional": true,
       "type": "number",

--- a/src/prompt-input/__integ__/prompt-input.test.ts
+++ b/src/prompt-input/__integ__/prompt-input.test.ts
@@ -14,10 +14,12 @@ class PromptInputPage extends BasePageObject {
   }
 }
 
-const setupTest = (testFn: (page: PromptInputPage) => Promise<void>) => {
+const setupTest = (testFn: (page: PromptInputPage) => Promise<void>, additionalUrlParams?: string[]) => {
   return useBrowser(async browser => {
     const page = new PromptInputPage(browser);
-    await browser.url(`#/light/prompt-input/simple/?isReadOnly=true`);
+    await browser.url(
+      `#/light/prompt-input/simple/?isReadOnly=true${additionalUrlParams ? '&' + additionalUrlParams.join('&') : ''}`
+    );
     await page.waitForVisible(getPromptInputWrapper().toSelector());
     await testFn(page);
   });
@@ -30,6 +32,18 @@ describe('Prompt input', () => {
       await page.click('#placeholder-text-button');
       await expect(page.getPromptInputHeight()).resolves.toEqual(96);
     })
+  );
+
+  test(
+    'Height should update infinitely based on maxRows property being set to -1',
+    setupTest(
+      async page => {
+        await expect(page.getPromptInputHeight()).resolves.toEqual(32);
+        await page.click('#placeholder-text-button');
+        await expect(page.getPromptInputHeight()).resolves.toEqual(192);
+      },
+      ['hasInfiniteMaxRows=true']
+    )
   );
 
   test(

--- a/src/prompt-input/__integ__/prompt-input.test.ts
+++ b/src/prompt-input/__integ__/prompt-input.test.ts
@@ -31,6 +31,17 @@ describe('Prompt input', () => {
       await expect(page.getPromptInputHeight()).resolves.toEqual(32);
       await page.click('#placeholder-text-button');
       await expect(page.getPromptInputHeight()).resolves.toEqual(96);
+
+      const clientHeight = await page.getElementProperty(
+        getPromptInputWrapper().findNativeTextarea().toSelector(),
+        'clientHeight'
+      );
+      const scrollHeight = await page.getElementProperty(
+        getPromptInputWrapper().findNativeTextarea().toSelector(),
+        'scrollHeight'
+      );
+
+      await expect(Number(clientHeight)).toBeLessThan(Number(scrollHeight));
     })
   );
 
@@ -40,7 +51,17 @@ describe('Prompt input', () => {
       async page => {
         await expect(page.getPromptInputHeight()).resolves.toEqual(32);
         await page.click('#placeholder-text-button');
-        await expect(page.getPromptInputHeight()).resolves.toEqual(192);
+
+        const clientHeight = await page.getElementProperty(
+          getPromptInputWrapper().findNativeTextarea().toSelector(),
+          'clientHeight'
+        );
+        const scrollHeight = await page.getElementProperty(
+          getPromptInputWrapper().findNativeTextarea().toSelector(),
+          'scrollHeight'
+        );
+
+        await expect(Number(clientHeight)).toEqual(Number(scrollHeight));
       },
       ['hasInfiniteMaxRows=true']
     )

--- a/src/prompt-input/__tests__/prompt-input.test.tsx
+++ b/src/prompt-input/__tests__/prompt-input.test.tsx
@@ -293,6 +293,12 @@ describe('min and max rows', () => {
     const { wrapper } = renderPromptInput({ value: '', maxRows: 4 });
     expect(wrapper.findNativeTextarea().getElement()).toHaveAttribute('rows', '1');
   });
+
+  test('does not update when max rows is set to -1', () => {
+    const ref = React.createRef<HTMLTextAreaElement>();
+    const { wrapper } = renderPromptInput({ value: '', maxRows: -1, ref });
+    expect(wrapper.findNativeTextarea().getElement()).toHaveAttribute('rows', '1');
+  });
 });
 
 describe('secondary actions', () => {

--- a/src/prompt-input/interfaces.ts
+++ b/src/prompt-input/interfaces.ts
@@ -81,6 +81,7 @@ export interface PromptInputProps
 
   /**
    * Specifies the maximum number of lines of text the textarea will expand to.
+   * Defaults to 3. Use -1 for infinite rows.
    */
   maxRows?: number;
 

--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -113,25 +113,14 @@ const InternalPromptInput = React.forwardRef(
         // this is required so the scrollHeight becomes dynamic, otherwise it will be locked at the highest value for the size it reached e.g. 500px
         textareaRef.current.style.height = 'auto';
 
+        const minTextareaHeight = `calc(${LINE_HEIGHT} +  ${tokens.spaceScaledXxs} * 2)`; // the min height of Textarea with 1 row
+
         if (maxRows === -1) {
           const scrollHeight = `calc(${textareaRef.current.scrollHeight}px)`;
-
-          // Respect the maxHeight of the parent container
-          let maxHeightPx = `calc(${Number.MAX_SAFE_INTEGER}px)`;
-          const parentElementMaxHeight =
-            textareaRef.current.parentElement?.parentElement?.parentElement?.style.maxHeight; // There are a few internal parent containers to jump through to get the maxHeight
-          // maxHeight is a string which is empty if not defined or contains px if it is
-          if (parentElementMaxHeight && parentElementMaxHeight.length > 0) {
-            maxHeightPx = parentElementMaxHeight;
-          }
-
-          const maxRowsHeight = `min(${scrollHeight}, ${maxHeightPx})`; // the min between the scrollable area and the parent element maxHeight
-          const minTextareaHeight = `calc(${LINE_HEIGHT} +  ${tokens.spaceScaledXxs} * 2)`; // the min height of Textarea with 1 row
-          textareaRef.current.style.height = `max(${maxRowsHeight}, ${minTextareaHeight})`;
+          textareaRef.current.style.height = `max(${scrollHeight}, ${minTextareaHeight})`;
         } else {
           const maxRowsHeight = `calc(${maxRows <= 0 ? DEFAULT_MAX_ROWS : maxRows} * (${LINE_HEIGHT} + ${PADDING} / 2) + ${PADDING})`;
           const scrollHeight = `calc(${textareaRef.current.scrollHeight}px)`;
-          const minTextareaHeight = `calc(${LINE_HEIGHT} +  ${tokens.spaceScaledXxs} * 2)`; // the min height of Textarea with 1 row
           textareaRef.current.style.height = `min(max(${scrollHeight}, ${minTextareaHeight}), ${maxRowsHeight})`;
         }
       }

--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -116,7 +116,6 @@ const InternalPromptInput = React.forwardRef(
         const minTextareaHeight = `calc(${LINE_HEIGHT} +  ${tokens.spaceScaledXxs} * 2)`; // the min height of Textarea with 1 row
 
         if (maxRows === -1) {
-          /* istanbul ignore next: clientHeight and scrollHeight tested in integ, not possible to test in unit */
           const scrollHeight = `calc(${textareaRef.current.scrollHeight}px)`;
           textareaRef.current.style.height = `max(${scrollHeight}, ${minTextareaHeight})`;
         } else {

--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -70,6 +70,7 @@ const InternalPromptInput = React.forwardRef(
 
     const PADDING = isRefresh ? tokens.spaceXxs : tokens.spaceXxxs;
     const LINE_HEIGHT = tokens.lineHeightBodyM;
+    const DEFAULT_MAX_ROWS = 3;
 
     useImperativeHandle(
       ref,
@@ -109,11 +110,30 @@ const InternalPromptInput = React.forwardRef(
 
     const adjustTextareaHeight = useCallback(() => {
       if (textareaRef.current) {
+        // this is required so the scrollHeight becomes dynamic, otherwise it will be locked at the highest value for the size it reached e.g. 500px
         textareaRef.current.style.height = 'auto';
-        const maxRowsHeight = `calc(${maxRows <= 0 ? 3 : maxRows} * (${LINE_HEIGHT} + ${PADDING} / 2) + ${PADDING})`;
-        const scrollHeight = `calc(${textareaRef.current.scrollHeight}px)`;
-        const minTextareaHeight = `calc(${LINE_HEIGHT} +  ${tokens.spaceScaledXxs} * 2)`; // the min height of Textarea with 1 row
-        textareaRef.current.style.height = `min(max(${scrollHeight}, ${minTextareaHeight}), ${maxRowsHeight})`;
+
+        if (maxRows === -1) {
+          const scrollHeight = `calc(${textareaRef.current.scrollHeight}px)`;
+
+          // Respect the maxHeight of the parent container
+          let maxHeightPx = `calc(${Number.MAX_SAFE_INTEGER}px)`;
+          const parentElementMaxHeight =
+            textareaRef.current.parentElement?.parentElement?.parentElement?.style.maxHeight; // There are a few internal parent containers to jump through to get the maxHeight
+          // maxHeight is a string which is empty if not defined or contains px if it is
+          if (parentElementMaxHeight && parentElementMaxHeight.length > 0) {
+            maxHeightPx = parentElementMaxHeight;
+          }
+
+          const maxRowsHeight = `min(${scrollHeight}, ${maxHeightPx})`; // the min between the scrollable area and the parent element maxHeight
+          const minTextareaHeight = `calc(${LINE_HEIGHT} +  ${tokens.spaceScaledXxs} * 2)`; // the min height of Textarea with 1 row
+          textareaRef.current.style.height = `max(${maxRowsHeight}, ${minTextareaHeight})`;
+        } else {
+          const maxRowsHeight = `calc(${maxRows <= 0 ? DEFAULT_MAX_ROWS : maxRows} * (${LINE_HEIGHT} + ${PADDING} / 2) + ${PADDING})`;
+          const scrollHeight = `calc(${textareaRef.current.scrollHeight}px)`;
+          const minTextareaHeight = `calc(${LINE_HEIGHT} +  ${tokens.spaceScaledXxs} * 2)`; // the min height of Textarea with 1 row
+          textareaRef.current.style.height = `min(max(${scrollHeight}, ${minTextareaHeight}), ${maxRowsHeight})`;
+        }
       }
     }, [maxRows, LINE_HEIGHT, PADDING]);
 

--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -116,6 +116,7 @@ const InternalPromptInput = React.forwardRef(
         const minTextareaHeight = `calc(${LINE_HEIGHT} +  ${tokens.spaceScaledXxs} * 2)`; // the min height of Textarea with 1 row
 
         if (maxRows === -1) {
+          /* istanbul ignore next: clientHeight and scrollHeight tested in integ, not possible to test in unit */
           const scrollHeight = `calc(${textareaRef.current.scrollHeight}px)`;
           textareaRef.current.style.height = `max(${scrollHeight}, ${minTextareaHeight})`;
         } else {


### PR DESCRIPTION
### Description

Add support for using `-1` in the `maxRows` prop to enable infinite expansion in the `PromptInput` component (i.e. no scrollbar and no height limit)

Related links, issue #, if available:
`AWSUI-60455`
https://github.com/cloudscape-design/components/issues/3283

### How has this been tested?

Added an integration test to assert that the height is not limited by anything other than inputted text.
On simple demo page for this component there's a checkbox to enable infinite max rows, enabling it will allow you to manually test the change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
