### PR TITLE
chore: Emit funnelStepError instead of funnelError where possible

### DIFF
--- a/pages/funnel-analytics/static-single-page-flow.page.tsx
+++ b/pages/funnel-analytics/static-single-page-flow.page.tsx
@@ -30,7 +30,7 @@ import { MockedFunnelMetrics } from './mock-funnel';
 setFunnelMetrics(MockedFunnelMetrics);
 
 export default function StaticSinglePageCreatePage() {
-  const [mounted, setUnmounted] = useState(true);
+  const [mounted, setMounted] = useState(true);
   const [modalVisible, setModalVisible] = useState(false);
   const [value, setValue] = useState('');
   const [value2, setValue2] = useState('');
@@ -89,7 +89,7 @@ export default function StaticSinglePageCreatePage() {
         />
       }
       content={
-        mounted && (
+        mounted ? (
           <Form
             analyticsMetadata={{
               instanceIdentifier: 'single-page-demo',
@@ -98,7 +98,7 @@ export default function StaticSinglePageCreatePage() {
             errorText={errorText}
             actions={
               <SpaceBetween size="xs" direction="horizontal">
-                <Button data-testid="unmount" onClick={() => setUnmounted(false)}>
+                <Button data-testid="unmount" onClick={() => setMounted(false)}>
                   Unmount component
                 </Button>
                 <Button data-testid="embedded-form-modal" onClick={() => setModalVisible(true)}>
@@ -109,7 +109,7 @@ export default function StaticSinglePageCreatePage() {
                     <Form>I am a form</Form>
                   </Modal>
                 )}
-                <Button data-testid="cancel" onClick={() => setUnmounted(false)}>
+                <Button data-testid="cancel" onClick={() => setMounted(false)}>
                   Cancel
                 </Button>
                 <Button
@@ -120,7 +120,7 @@ export default function StaticSinglePageCreatePage() {
                       setErrorText('There is an error');
                     } else {
                       setErrorText('');
-                      setUnmounted(false);
+                      setMounted(false);
                     }
                   }}
                 >
@@ -213,6 +213,8 @@ export default function StaticSinglePageCreatePage() {
               </ExpandableSection>
             </SpaceBetween>
           </Form>
+        ) : (
+          'Form unmounted'
         )
       }
     />

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -36,7 +36,10 @@ const typeToIcon: Record<AlertProps.Type, IconProps['name']> = {
   info: 'status-info',
 };
 
-type InternalAlertProps = SomeRequired<AlertProps, 'type'> & InternalBaseComponentProps<HTMLDivElement>;
+type InternalAlertProps = SomeRequired<AlertProps, 'type'> &
+  InternalBaseComponentProps<HTMLDivElement> & {
+    messageSlotId?: string;
+  };
 
 const useDiscoveredAction = createUseDiscoveredAction(awsuiPluginsInternal.alert.onActionRegistered);
 const useDiscoveredContent = createUseDiscoveredContent('alert', awsuiPluginsInternal.alertContent);
@@ -57,6 +60,7 @@ const InternalAlert = React.forwardRef(
       __internalRootRef = null,
       statusIconAriaLabel: deprecatedStatusIconAriaLabel,
       dismissAriaLabel: deprecatedDismissAriaLabel,
+      messageSlotId,
       ...rest
     }: InternalAlertProps,
     ref: React.Ref<AlertProps.Ref>
@@ -135,7 +139,7 @@ const InternalAlert = React.forwardRef(
                 <div className={clsx(styles.icon, styles.text)}>
                   <InternalIcon name={typeToIcon[type]} size={size} ariaLabel={statusIconAriaLabel} />
                 </div>
-                <div className={clsx(styles.message, styles.text)}>
+                <div className={clsx(styles.message, styles.text)} id={messageSlotId}>
                   <div
                     className={clsx(
                       header && styles.header,

--- a/src/form/internal.tsx
+++ b/src/form/internal.tsx
@@ -19,6 +19,7 @@ import styles from './styles.css.js';
 
 type InternalFormProps = {
   __injectAnalyticsComponentMetadata?: boolean;
+  __errorSlotId?: string;
 } & FormProps &
   InternalBaseComponentProps;
 
@@ -31,6 +32,7 @@ export default function InternalForm({
   secondaryActions,
   __internalRootRef,
   __injectAnalyticsComponentMetadata,
+  __errorSlotId,
   ...props
 }: InternalFormProps) {
   const baseProps = getBaseProps(props);
@@ -57,7 +59,9 @@ export default function InternalForm({
       {errorText && (
         <InternalBox margin={{ top: 'l' }}>
           <InternalAlert type="error" statusIconAriaLabel={errorIconAriaLabel}>
-            <div className={styles.error}>{errorText}</div>
+            <div className={styles.error} id={__errorSlotId}>
+              {errorText}
+            </div>
           </InternalAlert>
         </InternalBox>
       )}

--- a/src/internal/analytics/__tests__/mocks.ts
+++ b/src/internal/analytics/__tests__/mocks.ts
@@ -9,7 +9,7 @@ import {
 
 export const mockedFunnelInteractionId = 'mocked-funnel-id';
 export function mockFunnelMetrics() {
-  setFunnelMetrics({
+  const mockObject = {
     funnelStart: jest.fn(() => mockedFunnelInteractionId),
     funnelError: jest.fn(),
     funnelComplete: jest.fn(),
@@ -26,7 +26,10 @@ export function mockFunnelMetrics() {
     funnelSubStepError: jest.fn(),
     helpPanelInteracted: jest.fn(),
     externalLinkInteracted: jest.fn(),
-  });
+  } satisfies Parameters<typeof setFunnelMetrics>[0];
+
+  setFunnelMetrics(mockObject);
+  return mockObject;
 }
 
 export function mockPerformanceMetrics() {


### PR DESCRIPTION
### Description

Where possible, we now emit the `funnelStepError` event instead of `funnelError`. The `funnelStepError` event has more information about the context in which the event happened.

This applies to three components:
- Alert (when it is placed inside a step)
- Form (which itself makes up a single step)
- Wizard

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
