### PR TITLE
chore: Add new screenshot tests ahead of expected visual changes

### DIFF
--- a/pages/alert/runtime-action.page.tsx
+++ b/pages/alert/runtime-action.page.tsx
@@ -41,13 +41,48 @@ awsuiPlugins.alert.registerAction({
   unmountContent: container => unmountComponentAtNode(container),
 });
 
+const multilinetext = (
+  <>
+    <p>Text on multiple lines</p>
+    <p>Lorem ipsum dolor sit amet,consectetur adipisicing elit, sed do eiusmod tempor</p>
+    <p>incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis</p>
+    <p>nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+  </>
+);
+
+const longText = (
+  <>
+    One long line of text that should wrap. Lorem ipsum dolor sit amet,consectetur adipisicing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+    laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit cillum dolore eu fugiat
+    nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+    est laborum.
+  </>
+);
+
+const longTextWithUnbreakableWord = (
+  <>
+    One long line of text that should wrap, with a very long word. Lorem ipsum dolor sit amet,consectetur adipisicing
+    elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+    exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+    reprehenderitinvoluptatevelitessereprehenderitinvoluptatevelitessereprehenderitinvoluptatevelitessereprehenderitinvoluptatevelitesse
+    cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+    deserunt mollit anim id est laborum.
+  </>
+);
+
 /* eslint-disable react/jsx-key */
 const permutations = createPermutations<AlertProps>([
   {
     dismissible: [true, false],
     i18nStrings: [i18nStrings],
     header: ['Alert'],
-    children: ['Content'],
+    children: [
+      'Content that is less than one line long for most screen sizes',
+      multilinetext,
+      longText,
+      longTextWithUnbreakableWord,
+    ],
     type: ['success', 'error'],
     action: [
       null,

--- a/pages/flashbar/runtime-action.page.tsx
+++ b/pages/flashbar/runtime-action.page.tsx
@@ -40,12 +40,42 @@ awsuiPlugins.flashbar.registerAction({
   unmountContent: container => unmountComponentAtNode(container),
 });
 
+const multilinetext = (
+  <>
+    <p>Text on multiple lines</p>
+    <p>Lorem ipsum dolor sit amet,consectetur adipisicing elit, sed do eiusmod tempor</p>
+    <p>incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis</p>
+    <p>nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+  </>
+);
+
+const longText = (
+  <>
+    One long line of text that should wrap. Lorem ipsum dolor sit amet,consectetur adipisicing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+    laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit cillum dolore eu fugiat
+    nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+    est laborum.
+  </>
+);
+
+const longTextWithUnbreakableWord = (
+  <>
+    One long line of text that should wrap, with a very long word. Lorem ipsum dolor sit amet,consectetur adipisicing
+    elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+    exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+    reprehenderitinvoluptatevelitessereprehenderitinvoluptatevelitessereprehenderitinvoluptatevelitessereprehenderitinvoluptatevelitesse
+    cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+    deserunt mollit anim id est laborum.
+  </>
+);
+
 /* eslint-disable react/jsx-key */
 const permutations = createPermutations<FlashbarProps.MessageDefinition>([
   {
     dismissible: [true, false],
     header: ['Flash message'],
-    content: ['Content'],
+    content: ['Content', multilinetext, longText, longTextWithUnbreakableWord],
     type: ['success', 'error'],
     action: [
       null,


### PR DESCRIPTION
### Description

Adding some new scenarios to dev pages ahead of expected changes, so that those changes can be validated effectively.

Related links, issue #, if available: #3338

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
