### PR TITLE
revert: Revert "feat: Extend support to React 19"

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "weekstart": "^1.1.0"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17 || ^18 || ^19",
-    "react-dom": "^16.8 || ^17 || ^18 || ^19"
+    "react": "^16.8 || ^17 || ^18",
+    "react-dom": "^16.8 || ^17 || ^18"
   },
   "devDependencies": {
     "@babel/core": "^7.23.7",


### PR DESCRIPTION
Reverts cloudscape-design/components#3378.

This change would unfortunately break a number of dependent packages that depend on "react@^18", but don't have a dependency listed for "react-dom" (and that makes npm pull "react-dom@latest", which has a dependency violation with "react@^18").

We'd need to address this in all those packages first before attempting this again.