### PR TITLE
feat: CopyToClipboard - Allow separate content from text to copy for inline variant

### DIFF
--- a/pages/copy-to-clipboard/simple.page.tsx
+++ b/pages/copy-to-clipboard/simple.page.tsx
@@ -61,6 +61,16 @@ export default function DateInputScenario() {
             copyErrorText="Lorem ipsum sentence failed to copy"
           />
 
+          <CopyToClipboard
+            data-testid="copy-sentence"
+            variant="inline"
+            copyButtonAriaLabel="Copy lorem ipsum sentence"
+            textToCopy={sentence}
+            content={'Custom text: copy the lorem ipsum sentence'}
+            copySuccessText="Lorem ipsum sentence copied"
+            copyErrorText="Lorem ipsum sentence failed to copy"
+          />
+
           <div style={{ width: '150px' }}>
             <div style={{ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
               <CopyToClipboard

--- a/pages/copy-to-clipboard/simple.page.tsx
+++ b/pages/copy-to-clipboard/simple.page.tsx
@@ -66,7 +66,7 @@ export default function DateInputScenario() {
             variant="inline"
             copyButtonAriaLabel="Copy lorem ipsum sentence"
             textToCopy={sentence}
-            content={'Custom text: copy the lorem ipsum sentence'}
+            textToDisplay={'Custom text: copy the lorem ipsum sentence'}
             copySuccessText="Lorem ipsum sentence copied"
             copyErrorText="Lorem ipsum sentence failed to copy"
           />

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -111,8 +111,8 @@ If the label is assigned via the \`i18nStrings\` property, this label will be ig
         "name": "AlertProps.Type",
         "type": "union",
         "values": [
-          "success",
           "error",
+          "success",
           "warning",
           "info",
         ],
@@ -165,9 +165,9 @@ exports[`Documenter definition for anchor-navigation matches the snapshot: ancho
     {
       "cancelable": false,
       "description": "Fired when an active anchor link changes.
+
 Note: This event is triggered both by the component's internal scroll-spy logic,
-or when the \`activeHref\` prop is manually updated.
-",
+or when the \`activeHref\` prop is manually updated.",
       "detailInlineType": {
         "name": "AnchorNavigationProps.Anchor",
         "properties": [
@@ -242,23 +242,23 @@ controlled manner, and internal scroll-spy will be disabled.",
     },
     {
       "description": "List of anchors. Each anchor object has the following properties:
+
 * \`text\` (string) - The text for the anchor item.
 * \`href\` (string) - The \`id\` attribute of the target HTML element that the anchor refers to.
 For example: \`"#section1.1"\`
 * \`level\` (number) - Level of nesting of the anchor.
 * \`info\` (string | undefined) - Additional information to display next to the link, for example: "New" or "Updated".
 
-Note: The list of anchors should be sorted in the order they appear on the page.
-",
+Note: The list of anchors should be sorted in the order they appear on the page.",
       "name": "anchors",
       "optional": false,
       "type": "Array<AnchorNavigationProps.Anchor>",
     },
     {
       "description": "Adds \`aria-labelledby\` to the component.
+
 Use this property for identifying the header or title that labels the anchor navigation.
-To use it correctly, define an ID for the element either as label, and set the property to that ID.
-",
+To use it correctly, define an ID for the element either as label, and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -283,8 +283,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "defaultValue": "0",
       "description": "Specifies the height (in pixels) to be considered as an offset when activating anchors.
 This is useful when you have a fixed or sticky header that might overlap with the content as you scroll.
-Defaults to 0.
-",
+
+Defaults to 0.",
       "name": "scrollSpyOffset",
       "optional": true,
       "type": "number",
@@ -319,7 +319,6 @@ exports[`Documenter definition for annotation-context matches the snapshot: anno
       "cancelable": false,
       "description": "Fired when the user clicks the "Finish" button on the last step of
 the tutorial.",
-      "detailType": "void",
       "name": "onFinish",
     },
     {
@@ -346,16 +345,16 @@ button on a popover, when the user clicks on a closed hotspot icon,
 or when the AnnotationOverlay determines that the current hotspot
 has disappeared from the page and a different one should be
 selected (e.g. when navigating between pages).
+
 Use the \`reason\` property of the event detail to determine why
-this event was fired.
-",
+this event was fired.",
       "detailInlineType": {
         "name": "AnnotationContextProps.StepChangeDetail",
         "properties": [
           {
             "name": "reason",
             "optional": false,
-            "type": ""auto-fallback" | "next" | "open" | "previous"",
+            "type": ""open" | "next" | "previous" | "auto-fallback"",
           },
           {
             "name": "step",
@@ -375,20 +374,66 @@ this event was fired.
     {
       "description": "The currently launched tutorial. This should be the object received
 in the \`detail\` property of the \`onStartTutorial\` event.",
+      "inlineType": {
+        "name": "TutorialPanelProps.Tutorial",
+        "properties": [
+          {
+            "name": "completed",
+            "optional": false,
+            "type": "boolean",
+          },
+          {
+            "name": "completedScreenDescription",
+            "optional": true,
+            "type": "React.ReactNode",
+          },
+          {
+            "name": "description",
+            "optional": true,
+            "type": "React.ReactNode",
+          },
+          {
+            "name": "learnMoreUrl",
+            "optional": true,
+            "type": "string | null",
+          },
+          {
+            "name": "prerequisitesAlert",
+            "optional": true,
+            "type": "React.ReactNode",
+          },
+          {
+            "name": "prerequisitesNeeded",
+            "optional": true,
+            "type": "boolean",
+          },
+          {
+            "name": "tasks",
+            "optional": false,
+            "type": "ReadonlyArray<TutorialPanelProps.Task>",
+          },
+          {
+            "name": "title",
+            "optional": false,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
       "name": "currentTutorial",
       "optional": false,
-      "type": "AnnotationContextProps.Tutorial | null",
+      "type": "TutorialPanelProps.Tutorial | null",
     },
     {
       "description": "An object containing all the necessary localized strings required by the component. The object should contain:
+
 * \`finishButtonText\` - Specifies the text that's displayed in the finish button.
 * \`labelDismissAnnotation\` - Specifies the aria-label for the dismiss button.
 * \`labelHotspot\` - Specifies the aria-label for the hotspot button. The \`openState\` argument is deprecated, it's handled by the hotspot button aria-expanded attribute.
 * \`nextButtonText\` - Specifies the text that's displayed in the next button.
 * \`previousButtonText\` - Specifies the text that's displayed in the previous button.
 * \`stepCounterText\` - Specifies the step counter text that's displayed in the annotation popover.
-* \`taskTitle\` - Specifies the title text that's displayed in the annotation popover.
-",
+* \`taskTitle\` - Specifies the title text that's displayed in the annotation popover.",
       "inlineType": {
         "name": "AnnotationContextProps.I18nStrings",
         "properties": [
@@ -460,7 +505,7 @@ exports[`Documenter definition for app-layout matches the snapshot: app-layout 1
           {
             "name": "activeDrawerId",
             "optional": false,
-            "type": "null | string",
+            "type": "string | null",
           },
         ],
         "type": "object",
@@ -596,7 +641,7 @@ to control the state by listening to \`toolsChange\` and providing \`toolsOpen\`
       "description": "The active drawer id. If you want to clear the active drawer, use \`null\`.",
       "name": "activeDrawerId",
       "optional": true,
-      "type": "null | string",
+      "type": "string | null",
     },
     {
       "analyticsTag": "",
@@ -626,6 +671,7 @@ to control the state by listening to \`toolsChange\` and providing \`toolsOpen\`
     },
     {
       "description": "Aria labels for the drawer operating buttons. Use this property to ensure accessibility.
+
 * \`navigation\` (string) - Label for the landmark that wraps the navigation drawer.
 * \`navigationClose\` (string) - Label for the button that closes the navigation drawer.
 * \`navigationToggle\` (string) - Label for the button that opens the navigation drawer.
@@ -731,9 +777,9 @@ Individual properties will always take precedence over the default coming from t
           "default",
           "form",
           "table",
+          "dashboard",
           "cards",
           "wizard",
-          "dashboard",
         ],
       },
       "name": "contentType",
@@ -763,6 +809,7 @@ Individual properties will always take precedence over the default coming from t
     },
     {
       "description": "Drawers property. If you set both \`drawers\` and \`tools\`, \`drawers\` will take precedence.
+
 Each Drawer is an item in the drawers wrapper with the following properties:
 * id (string) - the id of the drawer.
 * content (React.ReactNode) - the content in the drawer.
@@ -781,8 +828,7 @@ Each Drawer is an item in the drawers wrapper with the following properties:
 - \`drawerName\` (string) - Label for the drawer itself, and for the drawer trigger button tooltip text.
 - \`closeButton\` (string) - (Optional) Label for the close button.
 - \`triggerButton\` (string) - (Optional) Label for the trigger button.
-- \`resizeHandle\` (string) - (Optional) Label for the resize handle.
-",
+- \`resizeHandle\` (string) - (Optional) Label for the resize handle.",
       "name": "drawers",
       "optional": true,
       "type": "Array<AppLayoutProps.Drawer>",
@@ -806,7 +852,7 @@ Each Drawer is an item in the drawers wrapper with the following properties:
 * \`default\` - Does not apply any visual treatment.
 * \`high-contrast\` - Applies high-contrast to both slots. Use in conjunction with \`headerVariant="high-contrast"\` in ContentLayout.",
       "inlineType": {
-        "name": "",
+        "name": ""default" | "high-contrast"",
         "type": "union",
         "values": [
           "default",
@@ -829,8 +875,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Maximum main content panel width in pixels.
-If set to \`Number.MAX_VALUE\`, the main content panel will occupy the full available width.
-",
+
+If set to \`Number.MAX_VALUE\`, the main content panel will occupy the full available width.",
       "name": "maxContentWidth",
       "optional": true,
       "type": "number",
@@ -868,8 +914,8 @@ If set to \`Number.MAX_VALUE\`, the main content panel will occupy the full avai
     },
     {
       "description": "Controls the split panel preferences.
-By default, the preference is \`{ position: 'bottom' }\`
-",
+
+By default, the preference is \`{ position: 'bottom' }\`",
       "inlineType": {
         "name": "AppLayoutProps.SplitPanelPreferences",
         "properties": [
@@ -943,15 +989,15 @@ content area so it is always visible.",
     },
     {
       "description": "Displayed on top of the main content in the scrollable area.
-Conceived to contain notifications (flash messages).
-",
+
+Conceived to contain notifications (flash messages).",
       "isDefault": false,
       "name": "notifications",
     },
     {
       "description": "Use this slot to add the [split panel component](/components/split-panel/) to the app layout.
-Note: If provided, this property should be set to \`null\` or \`undefined\` if a split panel should not be rendered.
-",
+
+Note: If provided, this property should be set to \`null\` or \`undefined\` if a split panel should not be rendered.",
       "isDefault": false,
       "name": "splitPanel",
     },
@@ -977,7 +1023,7 @@ exports[`Documenter definition for app-layout-toolbar matches the snapshot: app-
           {
             "name": "activeDrawerId",
             "optional": false,
-            "type": "null | string",
+            "type": "string | null",
           },
         ],
         "type": "object",
@@ -1119,7 +1165,7 @@ to control the state by listening to \`toolsChange\` and providing \`toolsOpen\`
       "description": "The active drawer id. If you want to clear the active drawer, use \`null\`.",
       "name": "activeDrawerId",
       "optional": true,
-      "type": "null | string",
+      "type": "string | null",
     },
     {
       "analyticsTag": "",
@@ -1149,6 +1195,7 @@ to control the state by listening to \`toolsChange\` and providing \`toolsOpen\`
     },
     {
       "description": "Aria labels for the drawer operating buttons. Use this property to ensure accessibility.
+
 * \`navigation\` (string) - Label for the landmark that wraps the navigation drawer.
 * \`navigationClose\` (string) - Label for the button that closes the navigation drawer.
 * \`navigationToggle\` (string) - Label for the button that opens the navigation drawer.
@@ -1254,9 +1301,9 @@ Individual properties will always take precedence over the default coming from t
           "default",
           "form",
           "table",
+          "dashboard",
           "cards",
           "wizard",
-          "dashboard",
         ],
       },
       "name": "contentType",
@@ -1279,6 +1326,7 @@ Individual properties will always take precedence over the default coming from t
     },
     {
       "description": "Drawers property. If you set both \`drawers\` and \`tools\`, \`drawers\` will take precedence.
+
 Each Drawer is an item in the drawers wrapper with the following properties:
 * id (string) - the id of the drawer.
 * content (React.ReactNode) - the content in the drawer.
@@ -1298,11 +1346,10 @@ If not set, a corresponding trigger button is not displayed, while the drawer mi
 - \`drawerName\` (string) - Label for the drawer itself, and for the drawer trigger button tooltip text.
 - \`closeButton\` (string) - (Optional) Label for the close button.
 - \`triggerButton\` (string) - (Optional) Label for the trigger button.
-- \`resizeHandle\` (string) - (Optional) Label for the resize handle.
-",
+- \`resizeHandle\` (string) - (Optional) Label for the resize handle.",
       "name": "drawers",
       "optional": true,
-      "type": "Array<AppLayoutToolbarProps.Drawer>",
+      "type": "Array<AppLayoutProps.Drawer>",
     },
     {
       "defaultValue": "'#b #f'",
@@ -1323,7 +1370,7 @@ If not set, a corresponding trigger button is not displayed, while the drawer mi
 * \`default\` - Does not apply any visual treatment.
 * \`high-contrast\` - Applies high-contrast to both slots. Use in conjunction with \`headerVariant="high-contrast"\` in ContentLayout.",
       "inlineType": {
-        "name": "",
+        "name": ""default" | "high-contrast"",
         "type": "union",
         "values": [
           "default",
@@ -1346,8 +1393,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Maximum main content panel width in pixels.
-If set to \`Number.MAX_VALUE\`, the main content panel will occupy the full available width.
-",
+
+If set to \`Number.MAX_VALUE\`, the main content panel will occupy the full available width.",
       "name": "maxContentWidth",
       "optional": true,
       "type": "number",
@@ -1392,8 +1439,8 @@ while navigation drawer might be displayed, but opened using a custom trigger.",
     },
     {
       "description": "Controls the split panel preferences.
-By default, the preference is \`{ position: 'bottom' }\`
-",
+
+By default, the preference is \`{ position: 'bottom' }\`",
       "inlineType": {
         "name": "AppLayoutProps.SplitPanelPreferences",
         "properties": [
@@ -1467,15 +1514,15 @@ content area so it is always visible.",
     },
     {
       "description": "Displayed on top of the main content in the scrollable area.
-Conceived to contain notifications (flash messages).
-",
+
+Conceived to contain notifications (flash messages).",
       "isDefault": false,
       "name": "notifications",
     },
     {
       "description": "Use this slot to add the [split panel component](/components/split-panel/) to the app layout.
-Note: If provided, this property should be set to \`null\` or \`undefined\` if a split panel should not be rendered.
-",
+
+Note: If provided, this property should be set to \`null\` or \`undefined\` if a split panel should not be rendered.",
       "isDefault": false,
       "name": "splitPanel",
     },
@@ -1497,7 +1544,7 @@ exports[`Documenter definition for area-chart matches the snapshot: area-chart 1
       "description": "Called when the values of the internal filter component changed.
 This will **not** be called for any custom filter components you have defined in \`additionalFilters\`.",
       "detailInlineType": {
-        "name": "CartesianChartProps.FilterChangeDetail",
+        "name": "CartesianChartProps.FilterChangeDetail<Series>",
         "properties": [
           {
             "name": "visibleSeries",
@@ -1507,14 +1554,14 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.FilterChangeDetail<AreaChartProps.Series<T>>",
+      "detailType": "CartesianChartProps.FilterChangeDetail<Series>",
       "name": "onFilterChange",
     },
     {
       "cancelable": false,
       "description": "Called when the highlighted series has changed because of user interaction.",
       "detailInlineType": {
-        "name": "CartesianChartProps.HighlightChangeDetail",
+        "name": "CartesianChartProps.HighlightChangeDetail<Series>",
         "properties": [
           {
             "name": "highlightedSeries",
@@ -1524,7 +1571,7 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.HighlightChangeDetail<AreaChartProps.Series<T>>",
+      "detailType": "CartesianChartProps.HighlightChangeDetail<Series>",
       "name": "onHighlightChange",
     },
     {
@@ -1570,7 +1617,7 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "Additional content that is displayed at the bottom of the detail popover.",
       "inlineType": {
-        "name": "CartesianChartProps.DetailPopoverFooter",
+        "name": "CartesianChartProps.DetailPopoverFooter<T>",
         "parameters": [
           {
             "name": "xValue",
@@ -1585,10 +1632,10 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
       "type": "CartesianChartProps.DetailPopoverFooter<T>",
     },
     {
-      "defaultValue": ""medium"",
+      "defaultValue": "'medium'",
       "description": "Determines the maximum width the detail popover will be limited to.",
       "inlineType": {
-        "name": "",
+        "name": ""small" | "medium" | "large"",
         "type": "union",
         "values": [
           "small",
@@ -1603,9 +1650,15 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "Function to format the displayed values total.",
       "inlineType": {
-        "name": "AreaChartProps.TickFormatter",
-        "properties": [],
-        "type": "object",
+        "name": "AreaChartProps.TickFormatter<number>",
+        "parameters": [
+          {
+            "name": "value",
+            "type": "T",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
       },
       "name": "detailTotalFormatter",
       "optional": true,
@@ -1650,18 +1703,27 @@ It is highly recommended to keep this set to \`false\`.",
     {
       "description": "The currently highlighted data series, usually through hovering over a series or the legend.
 A value of \`null\` means no series is highlighted.
+
 - If you do not set this property, series are highlighted automatically when hovering over one of the triggers (uncontrolled behavior).
-- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).
-",
+- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).",
+      "inlineType": {
+        "name": "NonNullable<Series>",
+        "type": "union",
+        "values": [
+          "Series",
+          "{}",
+        ],
+      },
       "name": "highlightedSeries",
       "optional": true,
-      "type": "AreaChartProps.Series<T> | null",
+      "type": "NonNullable<Series>",
     },
     {
+      "defaultValue": "{}",
       "description": "An object containing all the necessary localized strings required by the component.",
       "i18nTag": true,
       "inlineType": {
-        "name": "AreaChartProps.I18nStrings",
+        "name": "AreaChartProps.I18nStrings<T>",
         "properties": [
           {
             "name": "chartAriaRoleDescription",
@@ -1711,7 +1773,7 @@ A value of \`null\` means no series is highlighted.
           {
             "name": "xTickFormatter",
             "optional": true,
-            "type": "AreaChartProps.TickFormatter<T>",
+            "type": "CartesianChartProps.TickFormatter<T>",
           },
           {
             "name": "yAxisAriaRoleDescription",
@@ -1721,7 +1783,7 @@ A value of \`null\` means no series is highlighted.
           {
             "name": "yTickFormatter",
             "optional": true,
-            "type": "AreaChartProps.TickFormatter<number>",
+            "type": "CartesianChartProps.TickFormatter<number>",
           },
         ],
         "type": "object",
@@ -1762,29 +1824,29 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "description": "Array that represents the source of data for the displayed chart.
 Each element can represent an area series, or a threshold, and can have the following properties:
+
 * \`title\` (string): A human-readable title for this series
 * \`type\` (string): Series type (\`"area"\`, or \`"threshold"\`)
 * \`data\` (Array): An array of data points, represented as objects with \`x\` and \`y\` properties. The \`x\` values must be consistent across all series
 * \`color\` (string): (Optional) A color hex value for this series. When assigned, it takes priority over the automatically assigned color
-* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.
-",
+* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.",
       "name": "series",
       "optional": false,
       "type": "ReadonlyArray<AreaChartProps.Series<T>>",
     },
     {
-      "defaultValue": ""finished"",
+      "defaultValue": "'finished'",
       "description": "Specifies the current status of loading data.
 * \`loading\`: data fetching is in progress.
 * \`finished\`: data has loaded successfully.
 * \`error\`: an error occurred during fetch. You should provide user an option to recover.",
       "inlineType": {
-        "name": "",
+        "name": ""error" | "finished" | "loading"",
         "type": "union",
         "values": [
-          "loading",
-          "finished",
           "error",
+          "finished",
+          "loading",
         ],
       },
       "name": "statusType",
@@ -1797,29 +1859,29 @@ Each element can represent an area series, or a threshold, and can have the foll
 - If you explicitly set this property, you must set an \`onFilterChange\` listener to update this property when the visible series should change, or when one of your custom filters changes the number of visible series (controlled behavior).",
       "name": "visibleSeries",
       "optional": true,
-      "type": "ReadonlyArray<AreaChartProps.Series<T>>",
+      "type": "ReadonlyArray<Series>",
     },
     {
       "description": "Determines the domain of the x axis, i.e. the range of values that will be visible in the chart.
 For numerical and time-based data this is represented as an array with two values: \`[minimumValue, maximumValue]\`.
 For categorical data this is represented as an array of strings that determine the categories to display.
+
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.
-",
+When controlling this directly, make sure to update the value based on filtering changes.",
       "name": "xDomain",
       "optional": true,
       "type": "ReadonlyArray<T>",
     },
     {
-      "defaultValue": ""linear"",
+      "defaultValue": "'linear'",
       "description": "Determines the type of scale for values on the x axis.",
       "inlineType": {
         "name": "ScaleType",
         "type": "union",
         "values": [
           "linear",
-          "log",
           "time",
+          "log",
           "categorical",
         ],
       },
@@ -1830,7 +1892,7 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Function to format the displayed label of an x axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter",
+        "name": "CartesianChartProps.TickFormatter<T>",
         "parameters": [
           {
             "name": "value",
@@ -1853,18 +1915,18 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Determines the domain of the y axis, i.e. the range of values that will be visible in the chart.
 The domain is defined by a tuple: \`[minimumValue, maximumValue]\`.
+
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.
-",
+When controlling this directly, make sure to update the value based on filtering changes.",
       "name": "yDomain",
       "optional": true,
       "type": "ReadonlyArray<number>",
     },
     {
-      "defaultValue": ""linear"",
+      "defaultValue": "'linear'",
       "description": "Determines the type of scale for values on the y axis.",
       "inlineType": {
-        "name": "",
+        "name": ""linear" | "log"",
         "type": "union",
         "values": [
           "linear",
@@ -1878,7 +1940,7 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Function to format the displayed label of a y axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter",
+        "name": "CartesianChartProps.TickFormatter<number>",
         "parameters": [
           {
             "name": "value",
@@ -2011,13 +2073,25 @@ The function receives the following properties:
 - \`ref\` (\`ReactRef\`): A React ref that should be passed to the rendered button.
 - \`breakpoint\` (\`Breakpoint\`): The current breakpoint, for responsive behavior.
 - \`ownRow\` (\`boolean\`): Whether the button is rendered on its own row.",
+      "inlineType": {
+        "name": "(props: AttributeEditorProps.RowActionsProps<T>) => React.ReactNode",
+        "parameters": [
+          {
+            "name": "props",
+            "type": "AttributeEditorProps.RowActionsProps<T>",
+          },
+        ],
+        "returnType": "React.ReactNode",
+        "type": "function",
+      },
       "name": "customRowActions",
       "optional": true,
-      "type": "(props: AttributeEditorProps.RowActionsProps<T>) => React.ReactNode",
+      "type": "((props: AttributeEditorProps.RowActionsProps<T>) => React.ReactNode)",
     },
     {
       "description": "Defines the editor configuration. Each object in the array represents one form field in the row.
 If more than 6 attributes are specified, a \`gridLayout\` must be provided.
+
 * \`label\` (ReactNode) - Text label for the form field.
 * \`info\` (ReactNode) - Info link for the form field.
 * \`errorText\` ((item, itemIndex) => ReactNode) - Error message text to display as a control validation message.
@@ -2025,8 +2099,7 @@ If more than 6 attributes are specified, a \`gridLayout\` must be provided.
 * \`warningText\` ((item, itemIndex) => ReactNode) - Warning message text to display as a control validation message.
    It renders the form field in a warning state if the returned value is not \`null\` or \`undefined\`.
 * \`constraintText\` ((item, itemIndex) => ReactNode) - Text to display as a constraint message below the field.
-* \`control\` ((item, itemIndex) => ReactNode) - A control to use as the input for the field.
-",
+* \`control\` ((item, itemIndex) => ReactNode) - A control to use as the input for the field.",
       "name": "definition",
       "optional": false,
       "type": "ReadonlyArray<AttributeEditorProps.FieldDefinition<T>>",
@@ -2040,6 +2113,7 @@ If more than 6 attributes are specified, a \`gridLayout\` must be provided.
     {
       "description": "Optionally specifies the layout of the attributes. By default, all attributes will be
 equally spaced and wrapped into multiple rows on smaller viewports.
+
 A \`gridLayout\` is an array of breakpoint definitions. Each definition consists of:
 - \`rows\` (\`number[][]\`): the rows in which to display the attributes. Each row consists of a list of numbers indicating
   the relative width of each attribute. For example, \`[[1, 1, 1, 1]]\` is a single row of four evenly-spaced attributes,
@@ -2048,8 +2122,7 @@ A \`gridLayout\` is an array of breakpoint definitions. Each definition consists
 - \`removeButton\`: optionally configures the remove (or row action) button placement. If this is not provided, the button will be
   placed at the end of a single row, or below if multiple rows are present. The \`removeButton\` property supports contains two properties:
   - \`ownRow\` (\`boolean\`): forces the remove button onto its own row.
-  - \`width\` (\`number | 'auto'\`): a number indicating the relative width (equivalent to a \`rows\` entry), or 'auto' to fit to the button width.
-",
+  - \`width\` (\`number | 'auto'\`): a number indicating the relative width (equivalent to a \`rows\` entry), or 'auto' to fit to the button width.",
       "name": "gridLayout",
       "optional": true,
       "type": "ReadonlyArray<AttributeEditorProps.GridLayout>",
@@ -2057,7 +2130,7 @@ A \`gridLayout\` is an array of breakpoint definitions. Each definition consists
     {
       "description": "An object containing all the necessary localized strings required by the component.",
       "inlineType": {
-        "name": "AttributeEditorProps.I18nStrings",
+        "name": "AttributeEditorProps.I18nStrings<T>",
         "properties": [
           {
             "name": "errorIconAriaLabel",
@@ -2072,7 +2145,7 @@ A \`gridLayout\` is an array of breakpoint definitions. Each definition consists
           {
             "name": "removeButtonAriaLabel",
             "optional": true,
-            "type": "(item: T) => string",
+            "type": "((item: T) => string)",
           },
           {
             "name": "warningIconAriaLabel",
@@ -2101,7 +2174,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
 button is not rendered and the user can't remove the item.
 By default, all items are removable.",
       "inlineType": {
-        "name": "AttributeEditorProps.IsItemRemovableFunction",
+        "name": "AttributeEditorProps.IsItemRemovableFunction<T>",
         "parameters": [
           {
             "name": "item",
@@ -2125,9 +2198,20 @@ The display of a row is handled by the \`definition\` property.",
     },
     {
       "description": "Adds an \`aria-label\` to the remove button.",
+      "inlineType": {
+        "name": "(item: T) => string",
+        "parameters": [
+          {
+            "name": "item",
+            "type": "T",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
       "name": "removeButtonAriaLabel",
       "optional": true,
-      "type": "(item: T) => string",
+      "type": "((item: T) => string)",
     },
     {
       "description": "Specifies the text that's displayed in the remove button.",
@@ -2159,7 +2243,6 @@ exports[`Documenter definition for autosuggest matches the snapshot: autosuggest
     {
       "cancelable": false,
       "description": "Called when input focus is removed from the UI control.",
-      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -2167,7 +2250,7 @@ exports[`Documenter definition for autosuggest matches the snapshot: autosuggest
       "description": "Called whenever a user changes the input value (by typing or pasting).
 The event \`detail\` contains the current value of the field.",
       "detailInlineType": {
-        "name": "InputProps.ChangeDetail",
+        "name": "BaseChangeDetail",
         "properties": [
           {
             "name": "value",
@@ -2177,13 +2260,12 @@ The event \`detail\` contains the current value of the field.",
         ],
         "type": "object",
       },
-      "detailType": "InputProps.ChangeDetail",
+      "detailType": "BaseChangeDetail",
       "name": "onChange",
     },
     {
       "cancelable": false,
       "description": "Called when input focus is moved to the UI control.",
-      "detailType": "null",
       "name": "onFocus",
     },
     {
@@ -2192,7 +2274,7 @@ The event \`detail\` contains the current value of the field.",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "InputProps.KeyDetail",
+        "name": "BaseKeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -2232,7 +2314,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "InputProps.KeyDetail",
+      "detailType": "BaseKeyDetail",
       "name": "onKeyDown",
     },
     {
@@ -2241,7 +2323,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "InputProps.KeyDetail",
+        "name": "BaseKeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -2281,12 +2363,13 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "InputProps.KeyDetail",
+      "detailType": "BaseKeyDetail",
       "name": "onKeyUp",
     },
     {
       "cancelable": false,
       "description": "Use this event to implement the asynchronous behavior for the component.
+
 The event is called in the following situations:
 * The user scrolls to the end of the list of options, if \`statusType\` is set to \`pending\`.
 * The user clicks on the recovery button in the error state.
@@ -2296,8 +2379,7 @@ The event is called in the following situations:
 The detail object contains the following properties:
 * \`filteringText\` - The value that you need to use to fetch options.
 * \`firstPage\` - Indicates that you should fetch the first page of options that match the \`filteringText\`.
-* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).
-",
+* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).",
       "detailInlineType": {
         "name": "OptionsLoadItemsDetail",
         "properties": [
@@ -2332,7 +2414,7 @@ Instead, use \`onSelect\` in combination with the \`onChange\` handler only as a
           {
             "name": "selectedOption",
             "optional": true,
-            "type": "AutosuggestProps.Option",
+            "type": "OptionDefinition",
           },
           {
             "name": "value",
@@ -2365,20 +2447,20 @@ Instead, use \`onSelect\` in combination with the \`onChange\` handler only as a
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-Use this if you don't have a visible label for this control.
-",
+
+Use this if you don't have a visible label for this control.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -2386,11 +2468,11 @@ Use this if you don't have a visible label for this control.
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -2428,9 +2510,9 @@ scrolled out of the viewport.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -2490,25 +2572,41 @@ receive focus.",
       "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
+
 Set this property if the dropdown would otherwise be constrained by a scrollable container,
 for example inside table and split view layouts.
 
 We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.
-",
+because fixed positioning results in a slight, visible lag when scrolling complex pages.",
       "name": "expandToViewport",
       "optional": true,
       "type": "boolean",
     },
     {
       "description": "Specifies the text to display with the number of matches at the bottom of the dropdown menu while filtering.",
+      "inlineType": {
+        "name": "(matchesCount: number, totalCount: number) => string",
+        "parameters": [
+          {
+            "name": "matchesCount",
+            "type": "number",
+          },
+          {
+            "name": "totalCount",
+            "type": "number",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
       "name": "filteringResultsText",
       "optional": true,
-      "type": "(matchesCount: number, totalCount: number) => string",
+      "type": "((matchesCount: number, totalCount: number) => string)",
     },
     {
       "defaultValue": "'auto'",
       "description": "Determines how filtering is applied to the list of \`options\`:
+
 * \`auto\` - The component will automatically filter options based on user input.
 * \`manual\` - You will set up \`onChange\` or \`onLoadItems\` event listeners and filter options on your side or request
 them from server.
@@ -2521,14 +2619,13 @@ If you set this property to \`manual\`, this default filtering mechanism is disa
 displayed in the dropdown list. In that case make sure that you use the \`onChange\` or \`onLoadItems\` events in order
 to set the \`options\` property to the options that are relevant for the user, given the filtering input value.
 
-Note: Manual filtering doesn't disable match highlighting.
-",
+Note: Manual filtering doesn't disable match highlighting.",
       "inlineType": {
         "name": "OptionsFilteringType",
         "type": "union",
         "values": [
-          "none",
           "auto",
+          "none",
           "manual",
         ],
       },
@@ -2576,6 +2673,7 @@ single form field.",
     {
       "description": "Specifies an array of options that are displayed to the user as a dropdown list.
 The options can be grouped using \`OptionGroup\` objects.
+
 #### Option
 - \`value\` (string) - The returned value of the option when selected.
 - \`label\` (string) - (Optional) Option text displayed to the user.
@@ -2601,13 +2699,7 @@ If you want to use the built-in filtering capabilities of this component, provid
 a list of all valid options here and they will be automatically filtered based on the user's filtering input.
 
 Alternatively, you can listen to the \`onChange\` or \`onLoadItems\` event and set new options
-on your own.
-",
-      "inlineType": {
-        "name": "AutosuggestProps.Options",
-        "properties": [],
-        "type": "object",
-      },
+on your own.",
       "name": "options",
       "optional": true,
       "type": "AutosuggestProps.Options",
@@ -2622,8 +2714,8 @@ on your own.
       "description": "Specifies if the control is read-only, which prevents the
 user from modifying the value but includes it in a form
 submission. A read-only control can receive focus.
-Don't use read-only inputs outside a form.
-",
+
+Don't use read-only inputs outside a form.",
       "name": "readOnly",
       "optional": true,
       "type": "boolean",
@@ -2643,15 +2735,15 @@ the option's name and properties, and its selected state if
 the \`selectedLabel\` property is defined.
 The highlighted option is provided, and its group (if groups
 are used and it differs from the group of the previously highlighted option).
+
 For more information, see the
-[accessibility guidelines](/components/autosuggest/?tabId=usage#accessibility-guidelines).
-",
+[accessibility guidelines](/components/autosuggest/?tabId=usage#accessibility-guidelines).",
       "inlineType": {
         "name": "AutosuggestProps.ContainingOptionAndGroupString",
         "parameters": [
           {
             "name": "option",
-            "type": "AutosuggestProps.Option",
+            "type": "OptionDefinition",
           },
           {
             "name": "group",
@@ -2685,10 +2777,10 @@ This is required to provide a good screen reader experience. For more informatio
         "name": "DropdownStatusProps.StatusType",
         "type": "union",
         "values": [
-          "pending",
-          "loading",
-          "finished",
           "error",
+          "finished",
+          "loading",
+          "pending",
         ],
       },
       "name": "statusType",
@@ -2706,11 +2798,11 @@ This is required to provide a good screen reader experience. For more informatio
 that makes the filtering experience smoother. We don't recommend enabling the feature if you
 have less than 500 options, because the improvements to performance are offset by a
 visible scrolling lag.
+
 When you set this flag to \`true\`, it removes options that are not currently in view from the DOM.
 If your test accesses such options, you need to first scroll the options container
 to the correct offset, before performing any operations on them. Use the element returned
-by the \`findOptionsContainer\` test utility for this.
-",
+by the \`findOptionsContainer\` test utility for this.",
       "name": "virtualScroll",
       "optional": true,
       "type": "boolean",
@@ -2755,15 +2847,15 @@ exports[`Documenter definition for badge matches the snapshot: badge 1`] = `
       "type": "string",
     },
     {
-      "defaultValue": ""grey"",
+      "defaultValue": "'grey'",
       "description": "Specifies the badge color.",
       "inlineType": {
-        "name": "",
+        "name": ""blue" | "green" | "grey" | "red" | "severity-critical" | "severity-high" | "severity-medium" | "severity-low" | "severity-neutral"",
         "type": "union",
         "values": [
           "blue",
-          "grey",
           "green",
+          "grey",
           "red",
           "severity-critical",
           "severity-high",
@@ -2805,7 +2897,7 @@ exports[`Documenter definition for bar-chart matches the snapshot: bar-chart 1`]
       "description": "Called when the values of the internal filter component changed.
 This will **not** be called for any custom filter components you have defined in \`additionalFilters\`.",
       "detailInlineType": {
-        "name": "CartesianChartProps.FilterChangeDetail",
+        "name": "CartesianChartProps.FilterChangeDetail<Series>",
         "properties": [
           {
             "name": "visibleSeries",
@@ -2815,14 +2907,14 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.FilterChangeDetail<MixedLineBarChartProps.ChartSeries<T>>",
+      "detailType": "CartesianChartProps.FilterChangeDetail<Series>",
       "name": "onFilterChange",
     },
     {
       "cancelable": false,
       "description": "Called when the highlighted series has changed because of user interaction.",
       "detailInlineType": {
-        "name": "CartesianChartProps.HighlightChangeDetail",
+        "name": "CartesianChartProps.HighlightChangeDetail<Series>",
         "properties": [
           {
             "name": "highlightedSeries",
@@ -2832,7 +2924,7 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.HighlightChangeDetail<MixedLineBarChartProps.ChartSeries<T>>",
+      "detailType": "CartesianChartProps.HighlightChangeDetail<Series>",
       "name": "onHighlightChange",
     },
     {
@@ -2878,7 +2970,7 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "Additional content that is displayed at the bottom of the detail popover.",
       "inlineType": {
-        "name": "CartesianChartProps.DetailPopoverFooter",
+        "name": "CartesianChartProps.DetailPopoverFooter<T>",
         "parameters": [
           {
             "name": "xValue",
@@ -2895,15 +2987,15 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "A function that determines the details that are displayed in the popover for each series.
 Use this for wrapping keys or values in external links, or to display a metric breakdown by adding an additional level of nested items.
+
 The function is called with the parameters \`{ series, x, y }\` representing the series, the highlighted x coordinate value and its corresponding y value respectively,
 and should return the following properties:
 * \`key\` (ReactNode) - Name of the series.
 * \`value\` (ReactNode) - Value of the series at the highlighted x coordinate.
 * \`subItems\` (ReadonlyArray<{ key: ReactNode; value: ReactNode }>) - (Optional) List of nested key-value pairs.
-* \`expandable\` (boolean) - (Optional) Determines whether the optional list of nested items provided via \`subItems\` is expandable. This is \`false\` by default.
-",
+* \`expandable\` (boolean) - (Optional) Determines whether the optional list of nested items provided via \`subItems\` is expandable. This is \`false\` by default.",
       "inlineType": {
-        "name": "MixedLineBarChartProps.DetailPopoverSeriesContent",
+        "name": "MixedLineBarChartProps.DetailPopoverSeriesContent<T>",
         "parameters": [
           {
             "name": "data",
@@ -2918,10 +3010,10 @@ and should return the following properties:
       "type": "MixedLineBarChartProps.DetailPopoverSeriesContent<T>",
     },
     {
-      "defaultValue": ""medium"",
+      "defaultValue": "'medium'",
       "description": "Determines the maximum width the detail popover will be limited to.",
       "inlineType": {
-        "name": "",
+        "name": ""small" | "medium" | "large"",
         "type": "union",
         "values": [
           "small",
@@ -2980,12 +3072,20 @@ It is highly recommended to keep this set to \`false\`.",
     {
       "description": "The currently highlighted data series, usually through hovering over a series or the legend.
 A value of \`null\` means no series is highlighted.
+
 - If you do not set this property, series are highlighted automatically when hovering over one of the triggers (uncontrolled behavior).
-- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).
-",
+- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).",
+      "inlineType": {
+        "name": "NonNullable<Series>",
+        "type": "union",
+        "values": [
+          "Series",
+          "{}",
+        ],
+      },
       "name": "highlightedSeries",
       "optional": true,
-      "type": "MixedLineBarChartProps.ChartSeries<T> | null",
+      "type": "NonNullable<Series>",
     },
     {
       "defaultValue": "false",
@@ -2999,7 +3099,7 @@ This can only be used when the chart consists exclusively of bar series.",
       "description": "An object containing all the necessary localized strings required by the component.",
       "i18nTag": true,
       "inlineType": {
-        "name": "CartesianChartProps.I18nStrings",
+        "name": "CartesianChartProps.I18nStrings<T>",
         "properties": [
           {
             "name": "chartAriaRoleDescription",
@@ -3091,12 +3191,12 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "defaultValue": "[]",
       "description": "Array that represents the source of data for the displayed chart.
 Each element can represent a bar series or a threshold, and can have the following properties:
+
 * \`title\` (string): A human-readable title for this series
 * \`type\` (string): Series type (\`"bar"\`, or \`"threshold"\`)
 * \`data\` (Array): An array of data points, represented as objects with \`x\` and \`y\` properties
 * \`color\` (string): (Optional) A color hex value for this series. When assigned, it takes priority over the automatically assigned color
-* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.
-",
+* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.",
       "name": "series",
       "optional": false,
       "type": "ReadonlyArray<BarSeries<T>>",
@@ -3109,18 +3209,18 @@ Each element can represent a bar series or a threshold, and can have the followi
       "type": "boolean",
     },
     {
-      "defaultValue": ""finished"",
+      "defaultValue": "'finished'",
       "description": "Specifies the current status of loading data.
 * \`loading\`: data fetching is in progress.
 * \`finished\`: data has loaded successfully.
 * \`error\`: an error occurred during fetch. You should provide user an option to recover.",
       "inlineType": {
-        "name": "",
+        "name": ""error" | "finished" | "loading"",
         "type": "union",
         "values": [
-          "loading",
-          "finished",
           "error",
+          "finished",
+          "loading",
         ],
       },
       "name": "statusType",
@@ -3133,21 +3233,21 @@ Each element can represent a bar series or a threshold, and can have the followi
 - If you explicitly set this property, you must set an \`onFilterChange\` listener to update this property when the visible series should change, or when one of your custom filters changes the number of visible series (controlled behavior).",
       "name": "visibleSeries",
       "optional": true,
-      "type": "ReadonlyArray<MixedLineBarChartProps.ChartSeries<T>>",
+      "type": "ReadonlyArray<Series>",
     },
     {
       "description": "Determines the domain of the x axis, i.e. the range of values that will be visible in the chart.
 For numerical and time-based data this is represented as an array with two values: \`[minimumValue, maximumValue]\`.
 For categorical data this is represented as an array of strings that determine the categories to display.
+
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.
-",
+When controlling this directly, make sure to update the value based on filtering changes.",
       "name": "xDomain",
       "optional": true,
       "type": "ReadonlyArray<T>",
     },
     {
-      "defaultValue": ""categorical"",
+      "defaultValue": "'categorical'",
       "description": "Determines the type of scale for values on the x axis.
 Use \`categorical\` for bar charts.",
       "inlineType": {
@@ -3155,8 +3255,8 @@ Use \`categorical\` for bar charts.",
         "type": "union",
         "values": [
           "linear",
-          "log",
           "time",
+          "log",
           "categorical",
         ],
       },
@@ -3167,7 +3267,7 @@ Use \`categorical\` for bar charts.",
     {
       "description": "Function to format the displayed label of an x axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter",
+        "name": "CartesianChartProps.TickFormatter<T>",
         "parameters": [
           {
             "name": "value",
@@ -3190,18 +3290,18 @@ Use \`categorical\` for bar charts.",
     {
       "description": "Determines the domain of the y axis, i.e. the range of values that will be visible in the chart.
 The domain is defined by a tuple: \`[minimumValue, maximumValue]\`.
+
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.
-",
+When controlling this directly, make sure to update the value based on filtering changes.",
       "name": "yDomain",
       "optional": true,
       "type": "ReadonlyArray<number>",
     },
     {
-      "defaultValue": ""linear"",
+      "defaultValue": "'linear'",
       "description": "Determines the type of scale for values on the y axis.",
       "inlineType": {
-        "name": "",
+        "name": ""linear" | "log"",
         "type": "union",
         "values": [
           "linear",
@@ -3215,7 +3315,7 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Function to format the displayed label of a y axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter",
+        "name": "CartesianChartProps.TickFormatter<number>",
         "parameters": [
           {
             "name": "value",
@@ -3273,6 +3373,7 @@ exports[`Documenter definition for box matches the snapshot: box 1`] = `
     },
     {
       "description": "Overrides the text color. You can set it to the following values:
+
 - \`inherit\` - Inherits the color from the parent element. For example, use this to style content
      in Flashbars and to style the \`empty\` and \`noMatch\` slots of the Table and Cards components.
 - \`text-label\` - Specifies the text color for non-form labels. For example, use it for the key in key/value pairs.
@@ -3283,8 +3384,7 @@ exports[`Documenter definition for box matches the snapshot: box 1`] = `
 - \`text-status-inactive\` - Specifies the color for inactive and loading text and icons.
 - \`text-status-warning\` - Specifies the color for warning text and icons.
 
-Note: If you don't set it, the text color depends on the variant.
-",
+Note: If you don't set it, the text color depends on the variant.",
       "inlineType": {
         "name": "BoxProps.Color",
         "type": "union",
@@ -3305,21 +3405,21 @@ Note: If you don't set it, the text color depends on the variant.
     },
     {
       "description": "Overrides the display of the element. You can set it to the following values:
+
 - \`block\` - Specifies block display.
 - \`inline\` - Specifies inline display.
 - \`inline-block\` - Specifies inline-block display.
 - \`none\` - Hides the box.
 
-Note: If you don't set it, the display depends on the variant.
-",
+Note: If you don't set it, the display depends on the variant.",
       "inlineType": {
         "name": "BoxProps.Display",
         "type": "union",
         "values": [
-          "block",
           "inline",
-          "inline-block",
           "none",
+          "block",
+          "inline-block",
         ],
       },
       "name": "display",
@@ -3366,9 +3466,9 @@ Note: If you don't set it, the display depends on the variant.
         "name": "BoxProps.FontWeight",
         "type": "union",
         "values": [
-          "light",
-          "normal",
           "bold",
+          "normal",
+          "light",
           "heavy",
         ],
       },
@@ -3387,7 +3487,9 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
+      "defaultValue": "{}",
       "description": "Adds margins to the element. It can be the following:
+
 - A single string with a size. This applies the same margin to all sides (that is, top, right, bottom, left).
 - An object specifying the size of the margin per side. The object has the following format:
 \`\`\`
@@ -3405,14 +3507,32 @@ The size can be \`n\`, \`xxxs\`, \`xxs\`, \`xs\`, \`s\`, \`m\`, \`l\`, \`xl\`, \
 Sizes are automatically scaled down in compact mode.
 
  For example, \`margin="s"\` adds a small margin to all sides.
-\`margin={{ right: "l", bottom: "s" }}\` adds a small margin to the bottom and a large margin to the right.
-",
+\`margin={{ right: "l", bottom: "s" }}\` adds a small margin to the bottom and a large margin to the right.",
+      "inlineType": {
+        "name": "BoxProps.SpacingSize | BoxProps.Spacing",
+        "type": "union",
+        "values": [
+          ""s"",
+          ""m"",
+          ""n"",
+          ""xxxs"",
+          ""xxs"",
+          ""xs"",
+          ""l"",
+          ""xl"",
+          ""xxl"",
+          ""xxxl"",
+          "BoxProps.Spacing",
+        ],
+      },
       "name": "margin",
       "optional": true,
-      "type": "BoxProps.Spacing | BoxProps.SpacingSize",
+      "type": "BoxProps.SpacingSize | BoxProps.Spacing",
     },
     {
+      "defaultValue": "{}",
       "description": "Adds padding to the element. It can be the following:
+
 - A single string with a size. This applies the same padding to all sides (that is, top, right, bottom, left).
 - An object specifying the size of padding per side. The object has the following format:
 \`\`\`
@@ -3430,11 +3550,27 @@ The size can be \`n\`, \`xxxs\`, \`xxs\`, \`xs\`, \`s\`, \`m\`, \`l\`, \`xl\`, \
 Sizes are automatically scaled down in compact mode.
 
  For example, \`padding="s"\` adds small padding to all sides.
-\`padding={{ right: "l", bottom: "s" }}\` adds small padding to the bottom and large padding to the right.
-",
+\`padding={{ right: "l", bottom: "s" }}\` adds small padding to the bottom and large padding to the right.",
+      "inlineType": {
+        "name": "BoxProps.SpacingSize | BoxProps.Spacing",
+        "type": "union",
+        "values": [
+          ""s"",
+          ""m"",
+          ""n"",
+          ""xxxs"",
+          ""xxs"",
+          ""xs"",
+          ""l"",
+          ""xl"",
+          ""xxl"",
+          ""xxxl"",
+          "BoxProps.Spacing",
+        ],
+      },
       "name": "padding",
       "optional": true,
-      "type": "BoxProps.Spacing | BoxProps.SpacingSize",
+      "type": "BoxProps.SpacingSize | BoxProps.Spacing",
     },
     {
       "description": "Overrides the default HTML tag provided by the variant.",
@@ -3448,8 +3584,8 @@ Sizes are automatically scaled down in compact mode.
         "name": "BoxProps.TextAlign",
         "type": "union",
         "values": [
-          "left",
           "center",
+          "left",
           "right",
         ],
       },
@@ -3458,8 +3594,9 @@ Sizes are automatically scaled down in compact mode.
       "type": "string",
     },
     {
-      "defaultValue": ""div"",
+      "defaultValue": "'div'",
       "description": "Defines the style of element to display.
+
 - If you set it to \`'div'\`, \`'span'\`, \`'h1'\`, \`'h2'\`, \`'h3'\`, \`'h4'\`, \`'h5'\`, \`'p'\`, \`'strong'\`, \`'small'\`, \`'code'\`, \`'pre'\`, or \`'samp'\`, the variant is also used as the HTML tag name.
 - If you set it to \`awsui-key-label\`, the component will render a \`div\`,
   styled for use as a key label in key-value pairs.
@@ -3468,28 +3605,27 @@ Sizes are automatically scaled down in compact mode.
 - If you set it to \`awsui-value-large\`, the component will render a \`span\`,
   styled using "Display large light" typography.
 
-Override the HTML tag by using property \`tagOverride\`.
-",
+Override the HTML tag by using property \`tagOverride\`.",
       "inlineType": {
         "name": "BoxProps.Variant",
         "type": "union",
         "values": [
+          "small",
+          "code",
           "div",
-          "span",
           "h1",
           "h2",
           "h3",
           "h4",
           "h5",
           "p",
-          "strong",
-          "small",
-          "code",
           "pre",
           "samp",
+          "span",
+          "strong",
+          "awsui-value-large",
           "awsui-key-label",
           "awsui-gen-ai-label",
-          "awsui-value-large",
         ],
       },
       "name": "variant",
@@ -3516,12 +3652,12 @@ exports[`Documenter definition for breadcrumb-group matches the snapshot: breadc
       "cancelable": true,
       "description": "Called when the user clicks on a breadcrumb item.",
       "detailInlineType": {
-        "name": "BreadcrumbGroupProps.ClickDetail",
+        "name": "BreadcrumbGroupProps.ClickDetail<T>",
         "properties": [
           {
             "name": "external",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "href",
@@ -3554,12 +3690,12 @@ exports[`Documenter definition for breadcrumb-group matches the snapshot: breadc
       "description": "Called when the user clicks on a breadcrumb item with the left mouse button
 without pressing modifier keys (that is, CTRL, ALT, SHIFT, META).",
       "detailInlineType": {
-        "name": "BreadcrumbGroupProps.ClickDetail",
+        "name": "BreadcrumbGroupProps.ClickDetail<T>",
         "properties": [
           {
             "name": "external",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "href",
@@ -3624,14 +3760,14 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "defaultValue": "[]",
       "description": "An array of breadcrumb items that describes the link hierarchy for this navigation.
 Each option has the following properties:
+
 * \`text\` (string) - Specifies the title text of the breadcrumb item.
 * \`href\` (string) - Specifies the URL for the link in the breadcrumb item.
 You should specify the link even if you have a click handler for a breadcrumb item
 to ensure that valid markup is generated.
 
 Note: The last breadcrumb item is automatically considered the current item, and it's
-not a link.
-",
+not a link.",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<T>",
@@ -3687,12 +3823,12 @@ exports[`Documenter definition for button matches the snapshot: button 1`] = `
       "description": "Called when the user clicks on the button with the left mouse button without pressing
 modifier keys (that is, CTRL, ALT, SHIFT, META), and the button has an \`href\` set.",
       "detailInlineType": {
-        "name": "ButtonProps.FollowDetail",
+        "name": "BaseNavigationDetail",
         "properties": [
           {
             "name": "external",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "href",
@@ -3707,7 +3843,7 @@ modifier keys (that is, CTRL, ALT, SHIFT, META), and the button has an \`href\` 
         ],
         "type": "object",
       },
-      "detailType": "ButtonProps.FollowDetail",
+      "detailType": "BaseNavigationDetail",
       "name": "onFollow",
     },
   ],
@@ -3778,9 +3914,18 @@ Applicable for all button variants, except link.",
       "description": "Specifies whether the linked URL, when selected, will prompt the user to download instead of navigate.
 You can specify a string value that will be suggested as the name of the downloaded file.
 This property only applies when an \`href\` is provided.",
+      "inlineType": {
+        "name": "string | boolean",
+        "type": "union",
+        "values": [
+          "string",
+          "false",
+          "true",
+        ],
+      },
       "name": "download",
       "optional": true,
-      "type": "boolean | string",
+      "type": "string | boolean",
     },
     {
       "defaultValue": "false",
@@ -3792,7 +3937,7 @@ If an href is provided, it opens the link in a new tab.",
     },
     {
       "description": "The id of the <form> element to associate with the button. The value of this attribute must be the id of a <form> in the same document.
- Use when a button is not the descendant of a form element, such as when used in a modal.",
+Use when a button is not the descendant of a form element, such as when used in a modal.",
       "name": "form",
       "optional": true,
       "type": "string",
@@ -3804,8 +3949,8 @@ If an href is provided, it opens the link in a new tab.",
         "name": "ButtonProps.FormAction",
         "type": "union",
         "values": [
-          "submit",
           "none",
+          "submit",
         ],
       },
       "name": "formAction",
@@ -3827,6 +3972,7 @@ For example, if you have a 'help' button that links to a documentation page.",
     },
     {
       "description": "An object containing all the necessary localized strings required by the component. The object should contain:
+
 * \`externalIconAriaLabel\` - (optional) Specifies the aria-label for the external icon when \`external\` is set to \`true\`.",
       "i18nTag": true,
       "inlineType": {
@@ -3872,6 +4018,29 @@ This property is ignored if you use a predefined icon or if you set your custom 
         "name": "IconProps.Name",
         "type": "union",
         "values": [
+          "search",
+          "map",
+          "filter",
+          "key",
+          "file",
+          "pause",
+          "play",
+          "remove",
+          "copy",
+          "menu",
+          "script",
+          "close",
+          "status-pending",
+          "refresh",
+          "external",
+          "group",
+          "calendar",
+          "ellipsis",
+          "zoom-in",
+          "zoom-out",
+          "download",
+          "security",
+          "edit",
           "add-plus",
           "anchor-link",
           "angle-left-double",
@@ -3890,7 +4059,6 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "backward-10-seconds",
           "bug",
           "call",
-          "calendar",
           "caret-down-filled",
           "caret-down",
           "caret-left-filled",
@@ -3899,20 +4067,14 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "caret-up",
           "check",
           "contact",
-          "close",
           "closed-caption",
           "closed-caption-unavailable",
-          "copy",
           "command-prompt",
           "delete-marker",
-          "download",
           "drag-indicator",
-          "edit",
-          "ellipsis",
           "envelope",
           "exit-full-screen",
           "expand",
-          "external",
           "face-happy",
           "face-happy-filled",
           "face-neutral",
@@ -3920,8 +4082,6 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "face-sad",
           "face-sad-filled",
           "file-open",
-          "file",
-          "filter",
           "flag",
           "folder-open",
           "folder",
@@ -3931,31 +4091,20 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "globe",
           "grid-view",
           "group-active",
-          "group",
           "heart",
           "heart-filled",
           "insert-row",
-          "key",
           "keyboard",
           "list-view",
           "location-pin",
           "lock-private",
-          "map",
-          "menu",
           "microphone",
           "microphone-off",
           "mini-player",
           "multiscreen",
           "notification",
-          "pause",
-          "play",
           "redo",
-          "refresh",
-          "remove",
           "resize-area",
-          "script",
-          "search",
-          "security",
           "settings",
           "send",
           "share",
@@ -3966,7 +4115,6 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "status-in-progress",
           "status-info",
           "status-negative",
-          "status-pending",
           "status-positive",
           "status-stopped",
           "status-warning",
@@ -3996,8 +4144,6 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "view-full",
           "view-horizontal",
           "view-vertical",
-          "zoom-in",
-          "zoom-out",
           "zoom-to-fit",
         ],
       },
@@ -4007,8 +4153,8 @@ This property is ignored if you use a predefined icon or if you set your custom 
     },
     {
       "description": "Specifies the URL of a custom icon. Use this property if the icon you want isn't available.
-If you set both \`iconUrl\` and \`iconSvg\`, \`iconSvg\` will take precedence.
-",
+
+If you set both \`iconUrl\` and \`iconSvg\`, \`iconSvg\` will take precedence.",
       "name": "iconUrl",
       "optional": true,
       "type": "string",
@@ -4063,10 +4209,10 @@ This property only applies when an \`href\` is provided.",
         "name": "ButtonProps.Variant",
         "type": "union",
         "values": [
-          "normal",
-          "primary",
           "link",
+          "normal",
           "icon",
+          "primary",
           "inline-icon",
           "inline-link",
         ],
@@ -4092,6 +4238,7 @@ This property only applies when an \`href\` is provided.",
     },
     {
       "description": "Specifies the SVG of a custom icon.
+
 Use this property if you want your custom icon to inherit colors dictated by variant or hover states.
 When this property is set, the component will be decorated with \`aria-hidden="true"\`. Ensure that the \`svg\` element:
 - has attribute \`focusable="false"\`.
@@ -4108,8 +4255,7 @@ You can still set the stroke to \`currentColor\` to inherit the color of the sur
 If you set both \`iconUrl\` and \`iconSvg\`, \`iconSvg\` will take precedence.
 
 *Note:* Remember to remove any additional elements (for example: \`defs\`) and related CSS classes from SVG files exported from design software.
-In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.
-",
+In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.",
       "isDefault": false,
       "name": "iconSvg",
     },
@@ -4130,12 +4276,12 @@ exports[`Documenter definition for button-dropdown matches the snapshot: button-
           {
             "name": "checked",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "external",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "href",
@@ -4168,12 +4314,12 @@ modifier keys (that is, CTRL, ALT, SHIFT, META), and the item has an \`href\` se
           {
             "name": "checked",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "external",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "href",
@@ -4253,23 +4399,23 @@ If provided, the disabled button becomes focusable.",
     },
     {
       "defaultValue": "false",
-      "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
-Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
-[React Portals](https://reactjs.org/docs/portals.html).
-Set this property if the dropdown would otherwise be constrained by a scrollable container,
-for example inside table and split view layouts.
-
-We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.
-",
-      "name": "expandToViewport",
+      "description": "Controls expandability of the item groups.",
+      "name": "expandableGroups",
       "optional": true,
       "type": "boolean",
     },
     {
       "defaultValue": "false",
-      "description": "Controls expandability of the item groups.",
-      "name": "expandableGroups",
+      "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
+Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
+[React Portals](https://reactjs.org/docs/portals.html).
+
+Set this property if the dropdown would otherwise be constrained by a scrollable container,
+for example inside table and split view layouts.
+
+We recommend you use discretion, and don't enable this property unless necessary
+because fixed positioning results in a slight, visible lag when scrolling complex pages.",
+      "name": "expandToViewport",
       "optional": true,
       "type": "boolean",
     },
@@ -4290,6 +4436,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Array of objects with a number of supported types.
+
 The following properties are supported across all types:
 
 - \`type\` (string) - The type of the item. Can be \`action\`, \`group\`, \`checkbox\`. Defaults to \`action\` if \`items\` undefined and \`group\` otherwise.
@@ -4324,9 +4471,7 @@ When \`type\` is set to "checkbox", the values set to \`href\`, \`external\` and
 ### group
 
 - \`items\` (ReadonlyArray<Item>) - an array of item objects. Items will be rendered as nested menu items but only for the first nesting level, multi-nesting is not supported.
-An item which belongs to nested group has the following properties: \`id\`, \`text\`, \`disabled\`, and \`description\`.
-
-",
+An item which belongs to nested group has the following properties: \`id\`, \`text\`, \`disabled\`, and \`description\`.",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<ButtonDropdownProps.ItemOrGroup>",
@@ -4348,14 +4493,14 @@ It prevents clicks.",
     {
       "description": "A standalone action that is shown prior to the dropdown trigger.
 Use it with "primary" and "normal" variant only.
+
 Main action properties:
 * \`text\` (string) - Specifies the text shown in the main action.
 * \`external\` (boolean) - Marks the main action as external by adding an icon after the text. The link will open in a new tab when clicked. Note that this only works when \`href\` is also provided.
 * \`externalIconAriaLabel\` (string) - Adds an ARIA label to the external icon.
 
 The main action also supports the following properties of the [button](/components/button/?tabId=api) component:
-\`ariaLabel\`, \`disabled\`, \`loading\`, \`loadingText\`, \`href\`, \`target\`, \`rel\`, \`download\`, \`iconAlt\`, \`iconName\`, \`iconUrl\`, \`iconSvg\`, \`onClick\`, \`onFollow\`.
-",
+\`ariaLabel\`, \`disabled\`, \`loading\`, \`loadingText\`, \`href\`, \`target\`, \`rel\`, \`download\`, \`iconAlt\`, \`iconName\`, \`iconUrl\`, \`iconSvg\`, \`onClick\`, \`onFollow\`.",
       "inlineType": {
         "name": "ButtonDropdownProps.MainAction",
         "properties": [
@@ -4367,7 +4512,7 @@ The main action also supports the following properties of the [button](/componen
           {
             "name": "disabled",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "disabledReason",
@@ -4377,12 +4522,12 @@ The main action also supports the following properties of the [button](/componen
           {
             "name": "download",
             "optional": true,
-            "type": "boolean | string",
+            "type": "string | boolean",
           },
           {
             "name": "external",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "externalIconAriaLabel",
@@ -4417,7 +4562,7 @@ The main action also supports the following properties of the [button](/componen
           {
             "name": "loading",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "loadingText",
@@ -4432,7 +4577,7 @@ The main action also supports the following properties of the [button](/componen
           {
             "name": "onFollow",
             "optional": true,
-            "type": "CancelableEventHandler<ButtonProps.FollowDetail>",
+            "type": "CancelableEventHandler<BaseNavigationDetail>",
           },
           {
             "name": "rel",
@@ -4468,8 +4613,8 @@ The main action also supports the following properties of the [button](/componen
         "type": "union",
         "values": [
           "normal",
-          "primary",
           "icon",
+          "primary",
           "inline-icon",
         ],
       },
@@ -4497,7 +4642,7 @@ exports[`Documenter definition for button-group matches the snapshot: button-gro
       "cancelable": false,
       "description": "Called when the user uploads files. The event detail object contains the id and files from the file input item.",
       "detailInlineType": {
-        "name": "InternalButtonGroupProps.FilesChangeDetails",
+        "name": "ButtonGroupProps.FilesChangeDetails",
         "properties": [
           {
             "name": "files",
@@ -4512,19 +4657,19 @@ exports[`Documenter definition for button-group matches the snapshot: button-gro
         ],
         "type": "object",
       },
-      "detailType": "InternalButtonGroupProps.FilesChangeDetails",
+      "detailType": "ButtonGroupProps.FilesChangeDetails",
       "name": "onFilesChange",
     },
     {
       "cancelable": false,
       "description": "Called when the user clicks on an item, and the item is not disabled. The event detail object contains the id of the clicked item.",
       "detailInlineType": {
-        "name": "InternalButtonGroupProps.ItemClickDetails",
+        "name": "ButtonGroupProps.ItemClickDetails",
         "properties": [
           {
             "name": "checked",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "id",
@@ -4534,12 +4679,12 @@ exports[`Documenter definition for button-group matches the snapshot: button-gro
           {
             "name": "pressed",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
         ],
         "type": "object",
       },
-      "detailType": "InternalButtonGroupProps.ItemClickDetails",
+      "detailType": "ButtonGroupProps.ItemClickDetails",
       "name": "onItemClick",
     },
   ],
@@ -4575,6 +4720,7 @@ Use this to provide a unique accessible name for each button group on the page."
     {
       "defaultValue": "false",
       "description": "Use this property to determine dropdown placement strategy for all menu dropdown items.
+
 By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
@@ -4583,8 +4729,7 @@ Set this property if the dropdown would otherwise be constrained by a scrollable
 for example inside table and split view layouts.
 
 We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.
-",
+because fixed positioning results in a slight, visible lag when scrolling complex pages.",
       "name": "dropdownExpandToViewport",
       "optional": true,
       "type": "boolean",
@@ -4600,6 +4745,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Array of objects with a number of supported types.
+
 ### icon-button
 
 * \`id\` (string) - The unique identifier of the button, used as detail in \`onItemClick\` handler and to focus the button using \`ref.focus(id)\`.
@@ -4652,8 +4798,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
 ### group
 
 * \`text\` (string) - The name of the group rendered as ARIA label for this group.
-* \`items\` ((ButtonGroupProps.IconButton | ButtonGroupProps.MenuDropdown)[]) - The array of items that belong to this group.
-",
+* \`items\` ((ButtonGroupProps.IconButton | ButtonGroupProps.MenuDropdown)[]) - The array of items that belong to this group.",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<ButtonGroupProps.ItemOrGroup>",
@@ -4661,16 +4806,9 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "description": "Determines the general styling of the button dropdown.
 * \`icon\` for icon buttons.",
-      "inlineType": {
-        "name": "ButtonGroupProps.Variant",
-        "type": "union",
-        "values": [
-          "icon",
-        ],
-      },
       "name": "variant",
       "optional": false,
-      "type": "string",
+      "type": ""icon"",
     },
   ],
   "regions": [],
@@ -4747,7 +4885,7 @@ If provided, the date becomes focusable.",
       "type": "CalendarProps.DateDisabledReasonFunction",
     },
     {
-      "defaultValue": ""day"",
+      "defaultValue": "'day'",
       "description": "Specifies the granularity at which users will be able to select a date.
 Defaults to \`day\`.",
       "inlineType": {
@@ -4816,6 +4954,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
+      "defaultValue": "() => true",
       "description": "Defines whether a particular date is enabled in the calendar or not.
 If you disable a date in the calendar, users can still enter this date using a keyboard.
 We recommend that you also validate these constraints on the client-side and server-side
@@ -4836,7 +4975,7 @@ as you would for other form elements.",
       "type": "CalendarProps.IsDateEnabledFunction",
     },
     {
-      "defaultValue": """",
+      "defaultValue": "''",
       "description": "Specifies the locale to use to render month names and determine the starting day of the week.
 If you don't provide this, the locale is determined by the page and browser locales.
 Supported values and formats are listed in the
@@ -4893,7 +5032,7 @@ exports[`Documenter definition for cards matches the snapshot: cards 1`] = `
       "description": "Called when a user interaction causes a change in the list of selected items.
 The event \`detail\` contains the current list of \`selectedItems\`.",
       "detailInlineType": {
-        "name": "CardsProps.SelectionChangeDetail",
+        "name": "CardsProps.SelectionChangeDetail<T>",
         "properties": [
           {
             "name": "selectedItems",
@@ -4924,13 +5063,14 @@ scroll parent up to reveal the first card or row of cards.",
 * \`selectionGroupLabel\` (string) - Specifies the label for the group selection control.
 * \`cardsLabel\` (string) - Provides alternative text for the cards list.
                            By default the contents of the \`header\` are used.
+
 You can use the first arguments of type \`SelectionState\` to access the current selection
 state of the component (for example, the \`selectedItems\` list). The label function for individual
 items also receives the corresponding  \`Item\` object. You can use the group label to
 add a meaningful description to the whole selection.",
       "i18nTag": true,
       "inlineType": {
-        "name": "CardsProps.AriaLabels",
+        "name": "CardsProps.AriaLabels<T>",
         "properties": [
           {
             "name": "cardsLabel",
@@ -4955,31 +5095,31 @@ add a meaningful description to the whole selection.",
       "type": "CardsProps.AriaLabels<T>",
     },
     {
-      "description": " Defines what to display in each card. It has the following properties:
- * \`header\` ((item) => ReactNode) - Responsible for displaying the card header. You receive the current item as an argument.
-     Use \`fontSize="inherit"\` on [link](/components/link/) components inside card header.
- * \`sections\` (array) - Responsible for displaying the card content. Cards can have many sections in their
-   body. Each entry in the array is responsible for displaying a section. An entry has the following properties:
-   * \`id\`: (string) - A unique identifier for the section. The property is used as a [keys](https://reactjs.org/docs/lists-and-keys.html#keys)
-  source for React rendering, and to match entries in the \`visibleSections\` property (if it's defined).
-   * \`header\`: (ReactNode) - Responsible for displaying the section header.
-   * \`content\`: ((item) => ReactNode) - Responsible for displaying the section content. You receive the current item as an argument.
-   * \`width\`: (number) - Specifies the width of the card section in percent. Use this to display multiple sections in
-   the same row. The default value is 100%.
- All of the above properties are optional.
-",
+      "description": "Defines what to display in each card. It has the following properties:
+* \`header\` ((item) => ReactNode) - Responsible for displaying the card header. You receive the current item as an argument.
+    Use \`fontSize="inherit"\` on [link](/components/link/) components inside card header.
+* \`sections\` (array) - Responsible for displaying the card content. Cards can have many sections in their
+  body. Each entry in the array is responsible for displaying a section. An entry has the following properties:
+  * \`id\`: (string) - A unique identifier for the section. The property is used as a [keys](https://reactjs.org/docs/lists-and-keys.html#keys)
+ source for React rendering, and to match entries in the \`visibleSections\` property (if it's defined).
+  * \`header\`: (ReactNode) - Responsible for displaying the section header.
+  * \`content\`: ((item) => ReactNode) - Responsible for displaying the section content. You receive the current item as an argument.
+  * \`width\`: (number) - Specifies the width of the card section in percent. Use this to display multiple sections in
+  the same row. The default value is 100%.
+
+All of the above properties are optional.",
       "inlineType": {
-        "name": "CardsProps.CardDefinition",
+        "name": "CardsProps.CardDefinition<T>",
         "properties": [
+          {
+            "name": "header",
+            "optional": true,
+            "type": "((item: T) => React.ReactNode)",
+          },
           {
             "name": "sections",
             "optional": true,
             "type": "ReadonlyArray<CardsProps.SectionDefinition<T>>",
-          },
-          {
-            "name": "header",
-            "optional": true,
-            "type": "(item: T) => React.ReactNode",
           },
         ],
         "type": "object",
@@ -4994,6 +5134,7 @@ add a meaningful description to the whole selection.",
 It's an array whose entries are objects containing the following:
 - \`cards\` (number) - Specifies the number of cards per row.
 - \`minWidth\` (number) - Specifies the minimum container width (in pixels) for which this configuration object should apply.
+
 For example, with this configuration:
 \`\`\`
 [{
@@ -5034,8 +5175,7 @@ Default value:
   minWidth: 1920,
   cards: 6
 }]
-\`\`\`
-",
+\`\`\`",
       "name": "cardsPerRow",
       "optional": true,
       "type": "ReadonlyArray<CardsProps.CardsLayout>",
@@ -5056,8 +5196,8 @@ Don't use this property if the card has any other interactive elements.",
     },
     {
       "defaultValue": "1",
-      "description": " Use this property to inform screen readers which range of cards is currently displayed.
- It specifies the index (1-based) of the first card.",
+      "description": "Use this property to inform screen readers which range of cards is currently displayed.
+It specifies the index (1-based) of the first card.",
       "name": "firstIndex",
       "optional": true,
       "type": "number",
@@ -5074,7 +5214,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "description": "Determines which items are disabled. If an item is disabled, users can't select it.",
       "inlineType": {
-        "name": "CardsProps.IsItemDisabled",
+        "name": "CardsProps.IsItemDisabled<T>",
         "parameters": [
           {
             "name": "item",
@@ -5091,8 +5231,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "defaultValue": "[]",
       "description": "Specifies the items that serve as data source for a card.
-The \`cardDefinition\` property handles the display of this data.
-",
+
+The \`cardDefinition\` property handles the display of this data.",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<T>",
@@ -5115,9 +5255,20 @@ The function argument takes the following properties:
 * \`firstIndex\` (number) - The provided \`firstIndex\` property which defaults to 1 when not defined.
 * \`lastIndex\` (number) - The index of the last visible item of the table.
 * \`totalItemsCount\` (optional, number) - The provided \`totalItemsCount\` property.",
+      "inlineType": {
+        "name": "(data: CardsProps.LiveAnnouncement) => string",
+        "parameters": [
+          {
+            "name": "data",
+            "type": "CardsProps.LiveAnnouncement",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
       "name": "renderAriaLive",
       "optional": true,
-      "type": "(data: CardsProps.LiveAnnouncement) => string",
+      "type": "((data: CardsProps.LiveAnnouncement) => string)",
     },
     {
       "description": "Specifies the list of selected items.",
@@ -5164,10 +5315,10 @@ If there is an unknown total number of cards, leave this property undefined.",
       "description": "Specifies the property inside items that uniquely identifies them.
 When it's set, it's used to provide [keys for React](https://reactjs.org/docs/lists-and-keys.html#keys)
 for performance optimizations.
-It's also used for connecting \`items\` and \`selectedItems\` values when they don't reference the same object.
-",
+
+It's also used for connecting \`items\` and \`selectedItems\` values when they don't reference the same object.",
       "inlineType": {
-        "name": "CardsProps.TrackBy",
+        "name": "CardsProps.TrackBy<T>",
         "type": "union",
         "values": [
           "string",
@@ -5184,7 +5335,7 @@ It's also used for connecting \`items\` and \`selectedItems\` values when they d
 * \`container\` - Use this variant to have the cards displayed as a container.
 * \`full-page\` – Use this variant when cards are the entire content of a page.",
       "inlineType": {
-        "name": "",
+        "name": ""container" | "full-page"",
         "type": "union",
         "values": [
           "container",
@@ -5198,10 +5349,10 @@ It's also used for connecting \`items\` and \`selectedItems\` values when they d
     },
     {
       "description": "Specifies an array containing the \`id\` of each visible section. If not set, all sections are displayed.
+
 Use it in conjunction with the visible content preference of the [collection preferences](/components/collection-preferences/) component.
 
-The order of \`id\`s doesn't influence the order of display of sections, which is controlled by the \`cardDefinition\` property.
-",
+The order of \`id\`s doesn't influence the order of display of sections, which is controlled by the \`cardDefinition\` property.",
       "name": "visibleSections",
       "optional": true,
       "type": "ReadonlyArray<string>",
@@ -5294,20 +5445,20 @@ If the component controls any secondary content (for example, another form field
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-Use this if you don't have a visible label for this control.
-",
+
+Use this if you don't have a visible label for this control.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -5315,11 +5466,11 @@ Use this if you don't have a visible label for this control.
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -5494,7 +5645,6 @@ The event \`detail\` contains the value of all the preferences as submitted by t
       "cancelable": false,
       "description": "Called when the user clicks the recovery button in the error state.
 Use this to retry loading the code editor or to provide another option for the user to recover from the error.",
-      "detailType": "void",
       "name": "onRecoveryClick",
     },
     {
@@ -5506,7 +5656,7 @@ Use this to retry loading the code editor or to provide another option for the u
           {
             "name": "annotations",
             "optional": false,
-            "type": "Array<Annotation>",
+            "type": "Array<Ace.Annotation>",
           },
         ],
         "type": "object",
@@ -5534,12 +5684,12 @@ Use this to retry loading the code editor or to provide another option for the u
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -5553,11 +5703,11 @@ and set the property to a string of each ID separated by spaces (for example, \`
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -5572,9 +5722,9 @@ To use it correctly, define an ID for the element you want to use as label and s
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -5588,13 +5738,20 @@ is provided by its parent form field component.
     {
       "description": "Use this property to specify a different dynamic modal root for the dialog.
 The function will be called when a user clicks on the trigger button.",
+      "inlineType": {
+        "name": "() => Promise<HTMLElement>",
+        "parameters": [],
+        "returnType": "Promise<HTMLElement>",
+        "type": "function",
+      },
       "name": "getModalRoot",
       "optional": true,
-      "type": "() => Promise<HTMLElement>",
+      "type": "(() => Promise<HTMLElement>)",
     },
     {
       "description": "An object containing all the necessary localized strings required by the component.
 The object should contain, among others:
+
 * \`loadingState\` - Specifies the text to display while the component is loading.
 * \`errorState\` - Specifies the text to display if there is an error loading Ace.
 * \`errorStateRecovery\`: Specifies the text for the recovery button that's displayed next to the error text.
@@ -5606,10 +5763,15 @@ The object should contain, among others:
           {
             "name": "cursorPosition",
             "optional": true,
-            "type": "(row: number, column: number) => string",
+            "type": "((row: number, column: number) => string)",
           },
           {
             "name": "editorGroupAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "errorsTab",
             "optional": true,
             "type": "string",
           },
@@ -5620,11 +5782,6 @@ The object should contain, among others:
           },
           {
             "name": "errorStateRecovery",
-            "optional": true,
-            "type": "string",
-          },
-          {
-            "name": "errorsTab",
             "optional": true,
             "type": "string",
           },
@@ -5735,8 +5892,174 @@ Alternatively, this can be used to set a language that is not supported by the d
 For more info on custom languages, see the [Code editor API](/components/code-editor?tabId=api) page.",
       "inlineType": {
         "name": "CodeEditorProps.Language",
-        "properties": [],
-        "type": "object",
+        "type": "union",
+        "values": [
+          ""stylus"",
+          ""mask"",
+          ""html"",
+          ""ruby"",
+          ""svg"",
+          ""text"",
+          ""json"",
+          ""red"",
+          ""space"",
+          ""dot"",
+          ""d"",
+          ""r"",
+          ""properties"",
+          ""slim"",
+          ""abap"",
+          ""abc"",
+          ""actionscript"",
+          ""ada"",
+          ""alda"",
+          ""apache_conf"",
+          ""apex"",
+          ""aql"",
+          ""asciidoc"",
+          ""asl"",
+          ""assembly_x86"",
+          ""autohotkey"",
+          ""batchfile"",
+          ""c_cpp"",
+          ""c9search"",
+          ""cirru"",
+          ""clojure"",
+          ""cobol"",
+          ""coffee"",
+          ""coldfusion"",
+          ""crystal"",
+          ""csharp"",
+          ""csound_document"",
+          ""csound_orchestra"",
+          ""csound_score"",
+          ""css"",
+          ""curly"",
+          ""dart"",
+          ""diff"",
+          ""django"",
+          ""dockerfile"",
+          ""drools"",
+          ""edifact"",
+          ""eiffel"",
+          ""ejs"",
+          ""elixir"",
+          ""elm"",
+          ""erlang"",
+          ""forth"",
+          ""fortran"",
+          ""fsharp"",
+          ""fsl"",
+          ""ftl"",
+          ""gcode"",
+          ""gherkin"",
+          ""gitignore"",
+          ""glsl"",
+          ""gobstones"",
+          ""golang"",
+          ""graphqlschema"",
+          ""groovy"",
+          ""haml"",
+          ""handlebars"",
+          ""haskell"",
+          ""haskell_cabal"",
+          ""haxe"",
+          ""hjson"",
+          ""html_elixir"",
+          ""html_ruby"",
+          ""ini"",
+          ""io"",
+          ""jack"",
+          ""jade"",
+          ""java"",
+          ""javascript"",
+          ""json5"",
+          ""jsoniq"",
+          ""jsp"",
+          ""jssm"",
+          ""jsx"",
+          ""julia"",
+          ""kotlin"",
+          ""latex"",
+          ""less"",
+          ""liquid"",
+          ""lisp"",
+          ""livescript"",
+          ""logiql"",
+          ""lsl"",
+          ""lua"",
+          ""luapage"",
+          ""lucene"",
+          ""makefile"",
+          ""markdown"",
+          ""matlab"",
+          ""maze"",
+          ""mediawiki"",
+          ""mel"",
+          ""mixal"",
+          ""mushcode"",
+          ""mysql"",
+          ""nginx"",
+          ""nim"",
+          ""nix"",
+          ""nsis"",
+          ""nunjucks"",
+          ""objectivec"",
+          ""ocaml"",
+          ""pascal"",
+          ""perl"",
+          ""perl6"",
+          ""pgsql"",
+          ""php"",
+          ""php_laravel_blade"",
+          ""pig"",
+          ""powershell"",
+          ""praat"",
+          ""prisma"",
+          ""prolog"",
+          ""protobuf"",
+          ""puppet"",
+          ""python"",
+          ""qml"",
+          ""razor"",
+          ""rdoc"",
+          ""rhtml"",
+          ""rst"",
+          ""rust"",
+          ""sass"",
+          ""scad"",
+          ""scala"",
+          ""scheme"",
+          ""scss"",
+          ""sh"",
+          ""sjs"",
+          ""smarty"",
+          ""snippets"",
+          ""soy_template"",
+          ""sql"",
+          ""sqlserver"",
+          ""swift"",
+          ""tcl"",
+          ""terraform"",
+          ""tex"",
+          ""textile"",
+          ""toml"",
+          ""tsx"",
+          ""twig"",
+          ""typescript"",
+          ""vala"",
+          ""vbscript"",
+          ""velocity"",
+          ""verilog"",
+          ""vhdl"",
+          ""visualforce"",
+          ""wollok"",
+          ""xml"",
+          ""xquery"",
+          ""yaml"",
+          ""zeek"",
+          "string & { _?: undefined; }",
+        ],
       },
       "name": "language",
       "optional": false,
@@ -5756,6 +6079,7 @@ For more info on custom languages, see the [Code editor API](/components/code-ed
     },
     {
       "description": "Specifies the component preferences.
+
 If set to \`undefined\`, the component uses the following default value:
 
 \`\`\`
@@ -5765,8 +6089,23 @@ If set to \`undefined\`, the component uses the following default value:
 }
 \`\`\`
 
-You can use any theme provided by Ace.
-",
+You can use any theme provided by Ace.",
+      "inlineType": {
+        "name": "Partial<CodeEditorProps.Preferences>",
+        "properties": [
+          {
+            "name": "theme",
+            "optional": false,
+            "type": "CodeEditorProps.Theme",
+          },
+          {
+            "name": "wrapLines",
+            "optional": false,
+            "type": "boolean",
+          },
+        ],
+        "type": "object",
+      },
       "name": "preferences",
       "optional": true,
       "type": "Partial<CodeEditorProps.Preferences>",
@@ -5775,9 +6114,20 @@ You can use any theme provided by Ace.
       "description": "Use this property when \`getModalRoot\` is used to clean up the modal root
 element after a user closes the dialog. The function receives the return value
 of the most recent getModalRoot call as an argument.",
+      "inlineType": {
+        "name": "(rootElement: HTMLElement) => void",
+        "parameters": [
+          {
+            "name": "rootElement",
+            "type": "HTMLElement",
+          },
+        ],
+        "returnType": "void",
+        "type": "function",
+      },
       "name": "removeModalRoot",
       "optional": true,
-      "type": "(rootElement: HTMLElement) => void",
+      "type": "((rootElement: HTMLElement) => void)",
     },
     {
       "description": "List of Ace themes available for selection in preferences dialog. Make sure you include at least one light and at
@@ -5826,6 +6176,7 @@ exports[`Documenter definition for collection-preferences matches the snapshot: 
     {
       "cancelable": false,
       "description": "Called when the user confirms a preference change using the confirm button in the modal footer.
+
 The event \`detail\` contains the following:
 - \`contentDensity\` (boolean) - (Optional) The current content density preference value. Available only if you specify the \`contentDensityPreference\` property.
 - \`contentDisplay\` (ReadonlyArray<ContentDisplayItem>) - (Optional) The ordered list of table columns and their visibility. Available only if you specify the \`contentDisplayPreference\` property.
@@ -5836,15 +6187,14 @@ The event \`detail\` contains the following:
 - \`visibleContent\` (ReadonlyArray<string>) - (Optional) The list of selected content \`id\`s. Available only if you specify the \`visibleContentPreference\` property.
 - \`wrapLines\` (boolean) - (Optional) The current line wrapping preference value. Available only if you specify the \`wrapLinesPreference\` property.
 
-The values for all configured preferences are present even if the user didn't change their values.
-",
+The values for all configured preferences are present even if the user didn't change their values.",
       "detailInlineType": {
-        "name": "CollectionPreferencesProps.Preferences",
+        "name": "CollectionPreferencesProps.Preferences<CustomPreferenceType>",
         "properties": [
           {
             "name": "contentDensity",
             "optional": true,
-            "type": ""comfortable" | "compact"",
+            "type": ""compact" | "comfortable"",
           },
           {
             "name": "contentDisplay",
@@ -5854,7 +6204,7 @@ The values for all configured preferences are present even if the user didn't ch
           {
             "name": "custom",
             "optional": true,
-            "type": "CollectionPreferencesProps.Preferences.CustomPreferenceType",
+            "type": "CustomPreferenceType",
           },
           {
             "name": "pageSize",
@@ -5864,12 +6214,12 @@ The values for all configured preferences are present even if the user didn't ch
           {
             "name": "stickyColumns",
             "optional": true,
-            "type": "CollectionPreferencesProps.StickyColumns",
+            "type": "StickyColumns",
           },
           {
             "name": "stripedRows",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "visibleContent",
@@ -5879,7 +6229,7 @@ The values for all configured preferences are present even if the user didn't ch
           {
             "name": "wrapLines",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
         ],
         "type": "object",
@@ -5914,6 +6264,7 @@ The values for all configured preferences are present even if the user didn't ch
     },
     {
       "description": "Configures the content density preference (Comfortable / Compact).
+
 If you set it, the component displays this preference in the modal.
 
 It contains the following:
@@ -5944,6 +6295,7 @@ You must set the current value in the \`preferences.contentDensity\` property.",
     },
     {
       "description": "Configures the built-in content display preference for order and visibility of the table columns.
+
 Recommended for table and not applicable for cards.
 
 Cannot be used together with \`visibleContentPreference\`.
@@ -5990,7 +6342,7 @@ You must provide an ordered list of the items to display in the \`preferences.co
           {
             "name": "enableColumnFiltering",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "i18nStrings",
@@ -6005,17 +6357,17 @@ You must provide an ordered list of the items to display in the \`preferences.co
           {
             "name": "liveAnnouncementDndItemCommitted",
             "optional": true,
-            "type": "(initialPosition: number, finalPosition: number, total: number) => string",
+            "type": "((initialPosition: number, finalPosition: number, total: number) => string)",
           },
           {
             "name": "liveAnnouncementDndItemReordered",
             "optional": true,
-            "type": "(initialPosition: number, currentPosition: number, total: number) => string",
+            "type": "((initialPosition: number, currentPosition: number, total: number) => string)",
           },
           {
             "name": "liveAnnouncementDndStarted",
             "optional": true,
-            "type": "(position: number, total: number) => string",
+            "type": "((position: number, total: number) => string)",
           },
           {
             "name": "options",
@@ -6036,6 +6388,7 @@ You must provide an ordered list of the items to display in the \`preferences.co
     },
     {
       "description": "Configures custom preferences. The function receives two parameters:
+
 - \`customValue\` (CustomPreferenceType) - Current value for your custom preference. It is initialized using the value you provide in \`preferences.custom\`.
 - \`setCustomValue\` - A function that is called to notify a state update.
 
@@ -6052,11 +6405,25 @@ When the user cancels the changes, the \`customValue\` is reset to the one prese
 **Display**
 - If any of the built-in preferences (\`pageSizePreference\`, \`wrapLinesPreference\`, or \`visibleContentPreference\`) are displayed,
 the custom content is displayed at the bottom of the left column within the modal.
-- If no built-in preference is displayed, the custom content occupies the whole modal.
-",
+- If no built-in preference is displayed, the custom content occupies the whole modal.",
+      "inlineType": {
+        "name": "(customValue: CustomPreferenceType, setCustomValue: React.Dispatch<CustomPreferenceType>) => React.ReactNode",
+        "parameters": [
+          {
+            "name": "customValue",
+            "type": "CustomPreferenceType",
+          },
+          {
+            "name": "setCustomValue",
+            "type": "React.Dispatch<CustomPreferenceType>",
+          },
+        ],
+        "returnType": "React.ReactNode",
+        "type": "function",
+      },
       "name": "customPreference",
       "optional": true,
-      "type": "(customValue: CustomPreferenceType, setCustomValue: React.Dispatch<CustomPreferenceType>) => React.ReactNode",
+      "type": "((customValue: CustomPreferenceType, setCustomValue: React.Dispatch<CustomPreferenceType>) => React.ReactNode)",
     },
     {
       "defaultValue": "false",
@@ -6068,9 +6435,15 @@ the custom content is displayed at the bottom of the left column within the moda
     {
       "description": "Use this property to specify a different dynamic modal root for the dialog.
 The function will be called when a user clicks on the trigger button.",
+      "inlineType": {
+        "name": "() => Promise<HTMLElement>",
+        "parameters": [],
+        "returnType": "Promise<HTMLElement>",
+        "type": "function",
+      },
       "name": "getModalRoot",
       "optional": true,
-      "type": "() => Promise<HTMLElement>",
+      "type": "(() => Promise<HTMLElement>)",
     },
     {
       "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
@@ -6083,6 +6456,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Configures the built-in "page size selection" preference.
+
 If you set it, the component displays this preference in the modal.
 
 It contains the following:
@@ -6115,20 +6489,20 @@ You must set the current value in the \`preferences.pageSize\` property.",
     },
     {
       "description": "Specifies the current preference values. This includes both built-in and custom preferences.
+
 It contains the following:
 - \`pageSize\` (number) - (Optional)
 - \`wrapLines\` (boolean) - (Optional)
 - \`contentDisplay\` (ReadonlyArray<ContentDisplayItem>) - (Optional) Specifies the list of content and their visibility. The order of the elements influences the display.
 - \`visibleContent\` (ReadonlyArray<string>) - Specifies the list of visible content \`id\`s. The order of the \`id\`s does not influence the display. If the \`contentDisplay\` property is set, this property is ignored.
-- \`custom\` (CustomPreferenceType) - Specifies the value for your custom preference.
-",
+- \`custom\` (CustomPreferenceType) - Specifies the value for your custom preference.",
       "inlineType": {
-        "name": "CollectionPreferencesProps.Preferences",
+        "name": "CollectionPreferencesProps.Preferences<CustomPreferenceType>",
         "properties": [
           {
             "name": "contentDensity",
             "optional": true,
-            "type": ""comfortable" | "compact"",
+            "type": ""compact" | "comfortable"",
           },
           {
             "name": "contentDisplay",
@@ -6138,7 +6512,7 @@ It contains the following:
           {
             "name": "custom",
             "optional": true,
-            "type": "CollectionPreferencesProps.Preferences.CustomPreferenceType",
+            "type": "CustomPreferenceType",
           },
           {
             "name": "pageSize",
@@ -6148,12 +6522,12 @@ It contains the following:
           {
             "name": "stickyColumns",
             "optional": true,
-            "type": "CollectionPreferencesProps.StickyColumns",
+            "type": "StickyColumns",
           },
           {
             "name": "stripedRows",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "visibleContent",
@@ -6163,7 +6537,7 @@ It contains the following:
           {
             "name": "wrapLines",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
         ],
         "type": "object",
@@ -6176,32 +6550,43 @@ It contains the following:
       "description": "Use this property when \`getModalRoot\` is used to clean up the modal root
 element after a user closes the dialog. The function receives the return value
 of the most recent getModalRoot call as an argument.",
+      "inlineType": {
+        "name": "(rootElement: HTMLElement) => void",
+        "parameters": [
+          {
+            "name": "rootElement",
+            "type": "HTMLElement",
+          },
+        ],
+        "returnType": "void",
+        "type": "function",
+      },
       "name": "removeModalRoot",
       "optional": true,
-      "type": "(rootElement: HTMLElement) => void",
+      "type": "((rootElement: HTMLElement) => void)",
     },
     {
       "description": "Configures the sticky columns preference that can be set for both left and right columns.
+
 If you set it, the component displays this preference in the modal.
 
 It contains the following:
 - \`label\` (string) - Specifies the label for each radio group.
 - \`description\` (string) - Specifies the text displayed below each radio group label.
 
-You must set the current value in the \`preferences.stickyColumns\` property.
-",
+You must set the current value in the \`preferences.stickyColumns\` property.",
       "inlineType": {
         "name": "CollectionPreferencesProps.StickyColumnsPreference",
         "properties": [
           {
             "name": "firstColumns",
             "optional": true,
-            "type": "CollectionPreferencesProps.StickyColumnPreference",
+            "type": "StickyColumnPreference",
           },
           {
             "name": "lastColumns",
             "optional": true,
-            "type": "CollectionPreferencesProps.StickyColumnPreference",
+            "type": "StickyColumnPreference",
           },
         ],
         "type": "object",
@@ -6212,6 +6597,7 @@ You must set the current value in the \`preferences.stickyColumns\` property.
     },
     {
       "description": "Configures the built-in "striped rows" preference.
+
 If you set it, the component displays this preference in the modal.
 
 It contains the following:
@@ -6249,6 +6635,7 @@ You must set the current value in the \`preferences.stripedRows\` property.",
     },
     {
       "description": "Configures the built-in visible sections preference for cards or visible columns for table.
+
 Recommended for cards. For table use \`contentDisplayPreference\` instead.
 
 Cannot be used together with \`contentDisplayPreference\`.
@@ -6268,8 +6655,7 @@ Each group of options contains the following:
 
 You must set the current list of visible content \`id\`s in the \`preferences.visibleContent\` property.
 
-**Deprecated** in table, replaced by \`contentDisplayPreference\`.
-",
+**Deprecated** in table, replaced by \`contentDisplayPreference\`.",
       "inlineType": {
         "name": "CollectionPreferencesProps.VisibleContentPreference",
         "properties": [
@@ -6292,6 +6678,7 @@ You must set the current list of visible content \`id\`s in the \`preferences.vi
     },
     {
       "description": "Configures the built-in "wrap lines" preference.
+
 If you set it, the component displays this preference in the modal.
 
 It contains the following:
@@ -6339,18 +6726,18 @@ exports[`Documenter definition for column-layout matches the snapshot: column-la
   "name": "ColumnLayout",
   "properties": [
     {
-      "defaultValue": ""none"",
+      "defaultValue": "'none'",
       "description": "Controls whether dividers are placed between rows and columns.
-Note: This is not supported when used with \`minColumnWidth\`.
-",
+
+Note: This is not supported when used with \`minColumnWidth\`.",
       "inlineType": {
         "name": "ColumnLayoutProps.Borders",
         "type": "union",
         "values": [
-          "none",
-          "vertical",
-          "horizontal",
           "all",
+          "none",
+          "horizontal",
+          "vertical",
         ],
       },
       "name": "borders",
@@ -6390,15 +6777,15 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Use together with \`columns\` to specify the desired minimum width for each column in pixels.
+
 The number of columns is determined by the value of this property, the available space,
-and the maximum number of columns as defined by the \`columns\` property.
-",
+and the maximum number of columns as defined by the \`columns\` property.",
       "name": "minColumnWidth",
       "optional": true,
       "type": "number",
     },
     {
-      "defaultValue": ""default"",
+      "defaultValue": "'default'",
       "description": "Specifies the content type. This determines the spacing of the grid.",
       "inlineType": {
         "name": "ColumnLayoutProps.Variant",
@@ -6474,9 +6861,9 @@ exports[`Documenter definition for container matches the snapshot: container 1`]
       "defaultValue": "false",
       "description": "Enabling this property will make the container to fit into available height. If content is too short, the container
 will stretch, if too long, the container will shrink and show vertical scrollbar.
+
 Use this property to align heights of multiple containers displayed in a single row. It is recommended to stretch
-all containers to the height of the longest one, to avoid extra vertical scroll areas.
-",
+all containers to the height of the longest one, to avoid extra vertical scroll areas.",
       "name": "fitHeight",
       "optional": true,
       "type": "boolean",
@@ -6491,8 +6878,10 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "description": "Use this slot to render a media element. Supported element types are 'img', 'video', and 'picture'.
+      "description": "
+Use this slot to render a media element. Supported element types are 'img', 'video', and 'picture'.
 You can define different positions and sizes for the media element within the container.
+
 * \`content\` - Use this slot to render your media element. We support \`img\`, \`video\`, \`picture\`, and \`iframe\` elements.
 
 * \`position\` - Defines the media slot's position within the container. Defaults to \`top\`.
@@ -6504,31 +6893,29 @@ If no width is provided, the media slot will take a maximum of 66% of the contai
 
 * \`height\` - Defines the height of the media slot when position on the top. Corresponds to the \`height\` CSS-property.
 When this value is set, media elements larger than the defined width may be cropped, with 'object-fit: cover' centering it.   * Note: This value is only considered if \`position\` is set to \`top\`.
-If no height is provided, the media slot will be displayed at its full height.
-
-",
+If no height is provided, the media slot will be displayed at its full height.",
       "inlineType": {
         "name": "ContainerProps.Media",
         "properties": [
           {
             "name": "content",
-            "optional": false,
+            "optional": true,
             "type": "React.ReactNode",
           },
           {
             "name": "height",
             "optional": true,
-            "type": "number | string",
+            "type": "string | number",
           },
           {
             "name": "position",
             "optional": true,
-            "type": ""side" | "top"",
+            "type": ""top" | "side"",
           },
           {
             "name": "width",
             "optional": true,
-            "type": "number | string",
+            "type": "string | number",
           },
         ],
         "type": "object",
@@ -6538,13 +6925,13 @@ If no height is provided, the media slot will be displayed at its full height.
       "type": "ContainerProps.Media",
     },
     {
-      "defaultValue": ""default"",
+      "defaultValue": "'default'",
       "description": "Specify a container variant with one of the following:
 * \`default\` - Use this variant in standalone context.
 * \`stacked\` - Use this variant adjacent to other stacked containers (such as a container,
               table).",
       "inlineType": {
-        "name": "",
+        "name": ""default" | "stacked"",
         "type": "union",
         "values": [
           "default",
@@ -6608,16 +6995,24 @@ If true, the overlap will be removed.",
     },
     {
       "description": "Use this property to style the background of the header.
+
 It can be:
 * a string representing the CSS \`background\` value for the header element.
 * a function that receives the mode ("light" or "dark") as a parameter and returns a string.
 
  The header background spans across the full available width, independent of the specified \`maxContentWidth\`.
- If set, the component will not add the default background color to the header.
-",
+ If set, the component will not add the default background color to the header.",
+      "inlineType": {
+        "name": "string | ((mode: "dark" | "light") => string)",
+        "type": "union",
+        "values": [
+          "string",
+          "(mode: "dark" | "light") => string",
+        ],
+      },
       "name": "headerBackgroundStyle",
       "optional": true,
-      "type": "((mode: "dark" | "light") => string) | string",
+      "type": "string | ((mode: "dark" | "light") => string)",
     },
     {
       "description": "Determines the visual treatment for the header. Specifically:
@@ -6626,12 +7021,12 @@ It can be:
     If you are using the AppLayout component, set \`headerVariant="high-contrast"\` to apply the same treatment to the breadcrumbs and notifications slots.
 * \`divider\` - Adds a horizontal separator between the header and the content.",
       "inlineType": {
-        "name": "",
+        "name": ""default" | "divider" | "high-contrast"",
         "type": "union",
         "values": [
           "default",
-          "high-contrast",
           "divider",
+          "high-contrast",
         ],
       },
       "name": "headerVariant",
@@ -6662,8 +7057,8 @@ If not set, all elements will occupy the full available width.",
       "description": "Use this slot to add the [breadcrumb group component](/components/breadcrumb-group/) to the content layout:
 * if your application does not use the [app layout component](/components/app-layout/), which already offers a \`breadcrumbs\` slot.
 * If your page uses the [app layout component](/components/app-layout/) with \`disableContentPaddings=true\`.
-Do not use in conjunction with the \`breadcrumbs\` slot in the [app layout component](/components/app-layout/).
-",
+
+Do not use in conjunction with the \`breadcrumbs\` slot in the [app layout component](/components/app-layout/).",
       "isDefault": false,
       "name": "breadcrumbs",
     },
@@ -6682,8 +7077,8 @@ Do not use in conjunction with the \`breadcrumbs\` slot in the [app layout compo
       "description": "Use this slot to display [notifications](/components/flashbar/) to the content layout:
 * If your page does not use the [app layout component](/components/app-layout/), which already offers a \`notifications\` slot.
 * If your page uses the [app layout component](/components/app-layout/) with \`disableContentPaddings=true\`.
-Do not use in conjunction with the \`notifications\` slot in the [app layout component](/components/app-layout/).
-",
+
+Do not use in conjunction with the \`notifications\` slot in the [app layout component](/components/app-layout/).",
       "isDefault": false,
       "name": "notifications",
     },
@@ -6769,21 +7164,21 @@ Enable this setting if you need the popover to ignore its parent stacking contex
       "type": "string",
     },
     {
-      "defaultValue": ""button"",
+      "defaultValue": "'button'",
       "description": "Determines the general styling of the copy button as follows:
+
 * \`button\` to display a standalone secondary button with an icon, and \`copyButtonText\` as text.
 * \`icon\` to display a standalone icon-only (no text) button.
 * \`inline\` to display an icon-only (no text) button within a text context.
 
-Defaults to \`button\`.
-",
+Defaults to \`button\`.",
       "inlineType": {
         "name": "CopyToClipboardProps.Variant",
         "type": "union",
         "values": [
+          "inline",
           "button",
           "icon",
-          "inline",
         ],
       },
       "name": "variant",
@@ -6802,7 +7197,6 @@ exports[`Documenter definition for date-input matches the snapshot: date-input 1
     {
       "cancelable": false,
       "description": "Called when input focus is removed from the UI control.",
-      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -6810,7 +7204,7 @@ exports[`Documenter definition for date-input matches the snapshot: date-input 1
       "description": "Called whenever a user changes the input value (by typing or pasting).
 The event \`detail\` contains the current value of the field.",
       "detailInlineType": {
-        "name": "InputProps.ChangeDetail",
+        "name": "BaseChangeDetail",
         "properties": [
           {
             "name": "value",
@@ -6820,36 +7214,48 @@ The event \`detail\` contains the current value of the field.",
         ],
         "type": "object",
       },
-      "detailType": "InputProps.ChangeDetail",
+      "detailType": "BaseChangeDetail",
       "name": "onChange",
     },
     {
       "cancelable": false,
       "description": "Called when input focus is moved to the UI control.",
-      "detailType": "null",
       "name": "onFocus",
     },
   ],
-  "functions": [],
+  "functions": [
+    {
+      "description": "Sets input focus onto the UI control.",
+      "name": "focus",
+      "parameters": [],
+      "returnType": "void",
+    },
+    {
+      "description": "Selects all text in the input control.",
+      "name": "select",
+      "parameters": [],
+      "returnType": "void",
+    },
+  ],
   "name": "DateInput",
   "properties": [
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-Use this if you don't have a visible label for this control.
-",
+
+Use this if you don't have a visible label for this control.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -6857,11 +7263,11 @@ Use this if you don't have a visible label for this control.
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -6892,9 +7298,9 @@ scrolled out of the viewport.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -6943,8 +7349,8 @@ single form field.",
       "description": "Specifies if the control is read-only, which prevents the
 user from modifying the value but includes it in a form
 submission. A read-only control can receive focus.
-Don't use read-only inputs outside a form.
-",
+
+Don't use read-only inputs outside a form.",
       "name": "readOnly",
       "optional": true,
       "type": "boolean",
@@ -6980,7 +7386,6 @@ exports[`Documenter definition for date-picker matches the snapshot: date-picker
     {
       "cancelable": false,
       "description": "Called when input focus is removed from the UI control.",
-      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -7004,7 +7409,6 @@ The event \`detail\` contains the current value of the field.",
     {
       "cancelable": false,
       "description": "Called when input focus is moved to the UI control.",
-      "detailType": "null",
       "name": "onFocus",
     },
   ],
@@ -7021,20 +7425,20 @@ The event \`detail\` contains the current value of the field.",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-Use this if you don't have a visible label for this control.
-",
+
+Use this if you don't have a visible label for this control.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -7042,11 +7446,11 @@ Use this if you don't have a visible label for this control.
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -7078,9 +7482,9 @@ scrolled out of the viewport.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -7117,12 +7521,12 @@ receive focus.",
       "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
+
 Set this property if the dropdown would otherwise be constrained by a scrollable container,
 for example inside table and split view layouts.
 
 We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.
-",
+because fixed positioning results in a slight, visible lag when scrolling complex pages.",
       "name": "expandToViewport",
       "optional": true,
       "type": "boolean",
@@ -7148,7 +7552,7 @@ Defaults to \`day\`.",
 the component.",
       "i18nTag": true,
       "inlineType": {
-        "name": "DatePickerProps.I18nStrings",
+        "name": "CalendarProps.I18nStrings",
         "properties": [
           {
             "name": "currentMonthAriaLabel",
@@ -7185,7 +7589,7 @@ the component.",
       },
       "name": "i18nStrings",
       "optional": true,
-      "type": "DatePickerProps.I18nStrings",
+      "type": "CalendarProps.I18nStrings",
     },
     {
       "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
@@ -7258,7 +7662,7 @@ a human-readable localised string representing the current value of the input.
         "parameters": [
           {
             "name": "selectedDate",
-            "type": "null | string",
+            "type": "string | null",
           },
         ],
         "returnType": "string",
@@ -7287,8 +7691,8 @@ a human-readable localised string representing the current value of the input.
       "description": "Specifies if the control is read-only, which prevents the
 user from modifying the value but includes it in a form
 submission. A read-only control can receive focus.
-Do not use read-only inputs outside of a form.
-",
+
+Do not use read-only inputs outside of a form.",
       "name": "readOnly",
       "optional": true,
       "type": "boolean",
@@ -7339,7 +7743,6 @@ exports[`Documenter definition for date-range-picker matches the snapshot: date-
     {
       "cancelable": false,
       "description": "Fired when keyboard focus is removed from the UI control.",
-      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -7363,7 +7766,6 @@ The event \`detail\` contains the current value of the field.",
     {
       "cancelable": false,
       "description": "Fired when keyboard focus is set onto the UI control.",
-      "detailType": "null",
       "name": "onFocus",
     },
   ],
@@ -7380,12 +7782,12 @@ The event \`detail\` contains the current value of the field.",
     {
       "defaultValue": "'iso'",
       "description": "Specifies the time format to use for displaying the absolute time range.
+
 It can take the following values:
 * \`iso\`: ISO 8601 format, e.g.: 2024-01-30T13:32:32+01:00 (or 2024-01-30 when \`dateOnly\` is true)
 * \`long-localized\`: a more human-readable, localized format, e.g.: January 30, 2024, 13:32:32 (UTC+1) (or January 30, 2024 when \`dateOnly\` is true)
 
-Defaults to \`iso\`.
-",
+Defaults to \`iso\`.",
       "inlineType": {
         "name": "DateRangePickerProps.AbsoluteFormat",
         "type": "union",
@@ -7401,12 +7803,12 @@ Defaults to \`iso\`.
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -7414,11 +7816,11 @@ and set the property to a string of each ID separated by spaces (for example, \`
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -7433,9 +7835,9 @@ To use it correctly, define an ID for the element you want to use as label and s
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -7488,13 +7890,13 @@ If provided, the date becomes focusable.",
     {
       "defaultValue": "false",
       "description": "Hides time inputs and changes the input format to date-only, e.g. 2021-04-06.
+
 Do not use \`dateOnly\` flag conditionally. The component does not trigger the value update
 when the flag changes which means the value format can become inconsistent.
 
 This does not apply when the 'granularity' is set to 'month'
 
-Default: \`false\`.
-",
+Default: \`false\`.",
       "name": "dateOnly",
       "optional": true,
       "type": "boolean",
@@ -7512,12 +7914,12 @@ modifying the value. A disabled component cannot receive focus.",
       "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
+
 Set this property if the dropdown would otherwise be constrained by a scrollable container,
 for example inside table and split view layouts.
 
 We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.
-",
+because fixed positioning results in a slight, visible lag when scrolling complex pages.",
       "name": "expandToViewport",
       "optional": true,
       "type": "boolean",
@@ -7525,13 +7927,13 @@ because fixed positioning results in a slight, visible lag when scrolling comple
     {
       "description": "A function that defines timezone offset from UTC in minutes for selected dates.
 Use it to define time relative to the desired timezone.
+
 The function is called for the start date and the end date and takes a UTC date
 corresponding the selected value as an argument.
 
 Has no effect when \`dateOnly\` is true.
 
-Default: the user's current time offset as provided by the browser.
-",
+Default: the user's current time offset as provided by the browser.",
       "inlineType": {
         "name": "DateRangePickerProps.GetTimeOffsetFunction",
         "parameters": [
@@ -7674,12 +8076,12 @@ Defaults to \`false\`.",
           {
             "name": "formatRelativeRange",
             "optional": true,
-            "type": "(value: DateRangePickerProps.RelativeValue) => string",
+            "type": "((value: DateRangePickerProps.RelativeValue) => string)",
           },
           {
             "name": "formatUnit",
             "optional": true,
-            "type": "(unit: DateRangePickerProps.TimeUnit, value: number) => string",
+            "type": "((unit: DateRangePickerProps.TimeUnit, value: number) => string)",
           },
           {
             "name": "modeSelectionLabel",
@@ -7729,7 +8131,7 @@ Defaults to \`false\`.",
           {
             "name": "renderSelectedAbsoluteRangeAriaLive",
             "optional": true,
-            "type": "(startDate: string, endDate: string) => string",
+            "type": "((startDate: string, endDate: string) => string)",
           },
           {
             "name": "startDateLabel",
@@ -7802,8 +8204,8 @@ server-side, in the same way as for other form elements.",
     {
       "defaultValue": "() => ({ valid: true })",
       "description": "A function that defines whether a particular range is valid or not.
-Ensure that your function checks for missing fields in the value.
-",
+
+Ensure that your function checks for missing fields in the value.",
       "inlineType": {
         "name": "DateRangePickerProps.ValidationFunction",
         "parameters": [
@@ -7838,12 +8240,12 @@ are as-per the [JavaScript Intl API specification](https://developer.mozilla.org
     {
       "defaultValue": "'default'",
       "description": "Determines the range selector mode as follows:
+
 * \`default\` for combined absolute/relative range selector.
 * \`absolute-only\` for absolute-only range selector.
 * \`relative-only\` for relative-only range selector.
 
-By default, the range selector mode is \`default\`.
-",
+By default, the range selector mode is \`default\`.",
       "inlineType": {
         "name": "DateRangePickerProps.RangeSelectorMode",
         "type": "union",
@@ -7891,10 +8293,10 @@ but you can override it using this property.",
     {
       "defaultValue": "'hh:mm:ss'",
       "description": "Specifies the format of the time input for absolute ranges.
+
 Use to restrict the granularity of time that the user can enter.
 
-Has no effect when \`dateOnly\` is true or \`granularity\` is set to 'month'.
-",
+Has no effect when \`dateOnly\` is true or \`granularity\` is set to 'month'.",
       "inlineType": {
         "name": "TimeInputProps.Format",
         "type": "union",
@@ -7912,10 +8314,10 @@ Has no effect when \`dateOnly\` is true or \`granularity\` is set to 'month'.
       "deprecatedTag": "Use \`getTimeOffset\` instead.",
       "description": "The time offset from UTC in minutes that should be used to
 display and produce values.
+
 Has no effect when \`dateOnly\` is true.
 
-Default: the user's current time offset as provided by the browser.
-",
+Default: the user's current time offset as provided by the browser.",
       "name": "timeOffset",
       "optional": true,
       "type": "number",
@@ -7923,9 +8325,17 @@ Default: the user's current time offset as provided by the browser.
     {
       "description": "The current date range value. Can be either an absolute time range
 or a relative time range.",
+      "inlineType": {
+        "name": "DateRangePickerProps.Value",
+        "type": "union",
+        "values": [
+          "DateRangePickerProps.AbsoluteValue",
+          "DateRangePickerProps.RelativeValue",
+        ],
+      },
       "name": "value",
       "optional": false,
-      "type": "DateRangePickerProps.Value | null",
+      "type": "DateRangePickerProps.Value",
     },
     {
       "description": "Overrides the warning state. Usually the warning state
@@ -8001,8 +8411,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Header of the drawer.
-It should contain the only \`h2\` used in the drawer.
-",
+
+It should contain the only \`h2\` used in the drawer.",
       "isDefault": false,
       "name": "header",
     },
@@ -8132,7 +8542,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": ""default"",
+      "defaultValue": "'default'",
       "description": "The possible variants of an expandable section are as follows:
  * \`default\` - Use this variant in any context.
  * \`footer\` - Use this variant in container footers.
@@ -8145,12 +8555,12 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
         "name": "ExpandableSectionProps.Variant",
         "type": "union",
         "values": [
+          "inline",
           "default",
-          "footer",
           "container",
+          "footer",
           "navigation",
           "stacked",
-          "inline",
         ],
       },
       "name": "variant",
@@ -8167,7 +8577,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "deprecatedTag": "Use \`headerText\` instead.",
-      "description": "",
       "isDefault": false,
       "name": "header",
     },
@@ -8285,12 +8694,12 @@ The event \`detail\` contains the current value of the component.",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -8305,11 +8714,11 @@ that don't have visible text, and to distinguish between multiple file inputs wi
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -8336,9 +8745,9 @@ To use it correctly, define an ID for the element you want to use as label and s
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -8378,7 +8787,7 @@ If you want to clear the selection, use empty array.",
     {
       "description": "Variant of the file input. Defaults to "button".",
       "inlineType": {
-        "name": "",
+        "name": ""button" | "icon"",
         "type": "union",
         "values": [
           "button",
@@ -8400,8 +8809,8 @@ exports[`Documenter definition for file-token-group matches the snapshot: file-t
   "events": [
     {
       "cancelable": false,
-      "description": " Called when the user clicks on the dismiss button. The token won't be automatically removed.
- Make sure that you add a listener to this event to update your application state.",
+      "description": "Called when the user clicks on the dismiss button. The token won't be automatically removed.
+Make sure that you add a listener to this event to update your application state.",
       "detailInlineType": {
         "name": "FileTokenGroupProps.DismissDetail",
         "properties": [
@@ -8459,12 +8868,12 @@ exports[`Documenter definition for file-token-group matches the snapshot: file-t
           {
             "name": "formatFileLastModified",
             "optional": true,
-            "type": "(date: Date) => string",
+            "type": "((date: Date) => string)",
           },
           {
             "name": "formatFileSize",
             "optional": true,
-            "type": "(sizeInBytes: number) => string",
+            "type": "((sizeInBytes: number) => string)",
           },
           {
             "name": "limitShowFewer",
@@ -8479,7 +8888,7 @@ exports[`Documenter definition for file-token-group matches the snapshot: file-t
           {
             "name": "removeFileAriaLabel",
             "optional": true,
-            "type": "(fileIndex: number) => string",
+            "type": "((fileIndex: number) => string)",
           },
           {
             "name": "warningIconAriaLabel",
@@ -8503,12 +8912,13 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "description": "An array of objects representing token items. Each token has the following properties:
+      "description": "
+An array of objects representing token items. Each token has the following properties:
+
 - \`file\` (string) - File value.
 - \`loading\` (boolean) - (Optional) Determine whether the token is loading.
 - \`errorText\` (string) - (Optional) Text that displays as a validation error message.
-- \`warningText\` (string) - (Optional) - Text that displays as a validation warning message.
-",
+- \`warningText\` (string) - (Optional) - Text that displays as a validation warning message.",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<FileTokenGroupProps.Item>",
@@ -8605,12 +9015,12 @@ The event \`detail\` contains the current value of the component.",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -8618,11 +9028,11 @@ and set the property to a string of each ID separated by spaces (for example, \`
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -8643,9 +9053,9 @@ To use it correctly, define an ID for the element you want to use as label and s
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -8654,7 +9064,7 @@ is provided by its parent form field component.
       "description": "An array of file errors corresponding to the files in the \`value\`.",
       "name": "fileErrors",
       "optional": true,
-      "type": "ReadonlyArray<null | string>",
+      "type": "ReadonlyArray<string | null>",
     },
     {
       "description": "Alignment of the file tokens. Defaults to "vertical".",
@@ -8662,8 +9072,8 @@ is provided by its parent form field component.
         "name": "FileUploadProps.FileTokenAlignment",
         "type": "union",
         "values": [
-          "vertical",
           "horizontal",
+          "vertical",
         ],
       },
       "name": "fileTokenAlignment",
@@ -8674,7 +9084,7 @@ is provided by its parent form field component.
       "description": "An array of file warnings corresponding to the files in the \`value\`.",
       "name": "fileWarnings",
       "optional": true,
-      "type": "ReadonlyArray<null | string>",
+      "type": "ReadonlyArray<string | null>",
     },
     {
       "description": "An object containing all the localized strings required by the component:
@@ -8693,7 +9103,7 @@ is provided by its parent form field component.
           {
             "name": "dropzoneText",
             "optional": true,
-            "type": "(multiple: boolean) => string",
+            "type": "((multiple: boolean) => string)",
           },
           {
             "name": "errorIconAriaLabel",
@@ -8703,12 +9113,12 @@ is provided by its parent form field component.
           {
             "name": "formatFileLastModified",
             "optional": true,
-            "type": "(date: Date) => string",
+            "type": "((date: Date) => string)",
           },
           {
             "name": "formatFileSize",
             "optional": true,
-            "type": "(sizeInBytes: number) => string",
+            "type": "((sizeInBytes: number) => string)",
           },
           {
             "name": "limitShowFewer",
@@ -8723,12 +9133,12 @@ is provided by its parent form field component.
           {
             "name": "removeFileAriaLabel",
             "optional": true,
-            "type": "(fileIndex: number) => string",
+            "type": "((fileIndex: number) => string)",
           },
           {
             "name": "uploadButtonText",
             "optional": true,
-            "type": "(multiple: boolean) => string",
+            "type": "((multiple: boolean) => string)",
           },
           {
             "name": "warningIconAriaLabel",
@@ -8835,6 +9245,7 @@ exports[`Documenter definition for flashbar matches the snapshot: flashbar 1`] =
     },
     {
       "description": "An object containing all the necessary localized strings required by the component. The object should contain:
+
 * \`ariaLabel\` - Specifies the ARIA label for the list of notifications.
 
 If \`stackItems\` is set to \`true\`, it should also contain:
@@ -8861,12 +9272,12 @@ If \`stackItems\` is set to \`true\`, it should also contain:
             "type": "string",
           },
           {
-            "name": "inProgressIconAriaLabel",
+            "name": "infoIconAriaLabel",
             "optional": true,
             "type": "string",
           },
           {
-            "name": "infoIconAriaLabel",
+            "name": "inProgressIconAriaLabel",
             "optional": true,
             "type": "string",
           },
@@ -8910,6 +9321,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "analyticsTag": "",
       "description": "Specifies flash messages that appear in the same order that they are listed.
 The value is an array of flash message definition objects.
+
 A flash message object contains the following properties:
 * \`header\` (ReactNode) - Specifies the heading text.
 * \`content\` (ReactNode) - Specifies the primary text displayed in the flash element.
@@ -9012,17 +9424,17 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": ""full-page"",
+      "defaultValue": "'full-page'",
       "deprecatedTag": "You can safely remove this property as there is no longer any visual difference between \`full-page\` and \`embedded\` variants.",
       "description": "Specify a form variant with one of the following:
 * \`full-page\` - Use this variant when the form contains the entire content of the page.
 * \`embedded\` - Use this variant when the form doesn't occupy the full page.",
       "inlineType": {
-        "name": "",
+        "name": ""embedded" | "full-page"",
         "type": "union",
         "values": [
-          "full-page",
           "embedded",
+          "full-page",
         ],
       },
       "name": "variant",
@@ -9096,10 +9508,10 @@ exports[`Documenter definition for form-field matches the snapshot: form-field 1
     {
       "description": "The ID of the primary form control. You can use this to set the
 \`for\` attribute of a label for accessibility.
+
 If you don't set this property, the control group automatically sets
 the label to the ID of an inner form control (for example, an [input](/components/input) component).
-This only works well if you're using a single control in the form field.
-",
+This only works well if you're using a single control in the form field.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -9139,14 +9551,14 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "defaultValue": "false",
       "description": "Determines whether the primary control should expand to 12 columns.
+
 By default (or when this property is set to \`false\`), the primary control
 occupies 9 columns. The secondary control uses the remaining 3 columns.
 On smaller viewports, both components occupy 12 columns and stack on top of each other.
 
 If this property is set to \`true\`, the primary control uses the full
 12 columns. The secondary control (if present) also uses 12 columns, and the two
-controls stack on top of each other.
-",
+controls stack on top of each other.",
       "name": "stretch",
       "optional": true,
       "type": "boolean",
@@ -9226,6 +9638,7 @@ exports[`Documenter definition for grid matches the snapshot: grid 1`] = `
       "defaultValue": "[]",
       "description": "An array of element definitions that specifies how the columns must be
 arranged. Each element definition can have the following properties:
+
 - \`colspan\` (number | GridProps.BreakpointMapping) - The number (1-12) of grid elements for this column to span.
 - \`offset\` (number | GridProps.BreakpointMapping) - The number (0-11) of grid elements by which to offset the column.
 - \`pull\` (number | GridProps.BreakpointMapping) - The number (0-12) of grid elements by which to pull the column to the left.
@@ -9237,8 +9650,7 @@ breakpoints) or an object where the key is one of the supported breakpoints
 applied for that breakpoint and those above it. You must provide a \`default\` value for \`colspan\`.
 
 We recommend that you don't use the \`pull\` and \`push\` properties of the element definition
-for accessibility reasons.
-",
+for accessibility reasons.",
       "name": "gridDefinition",
       "optional": true,
       "type": "ReadonlyArray<GridProps.ElementDefinition>",
@@ -9256,10 +9668,10 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
   "regions": [
     {
       "description": "The elements to align in the grid.
+
 You can provide any elements here. The number of elements
 should match the number of objects defined in the \`gridDefinition\`
-property.
-",
+property.",
       "isDefault": true,
       "name": "children",
     },
@@ -9316,7 +9728,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": ""h2"",
+      "defaultValue": "'h2'",
       "description": "Specifies the variant of the header:
 * \`h1\` - Use this for page level headers.
 * \`h2\` - Use this for container level headers.
@@ -9405,9 +9817,9 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
   "regions": [
     {
       "description": "Main content of the help panel.
+
 Use \`p, a, h3, h4, h5, span, div, ul, ol, li, code, pre, dl, dt, dd, hr, br, i, em, b, strong\` tags to format the content.
-Use \`code\` for inline code or \`pre\` for code blocks.
-",
+Use \`code\` for inline code or \`pre\` for code blocks.",
       "isDefault": true,
       "name": "children",
     },
@@ -9418,8 +9830,8 @@ Use \`code\` for inline code or \`pre\` for code blocks.
     },
     {
       "description": "Header of the help panel.
-It should contain the only \`h2\` used in the help panel.
-",
+
+It should contain the only \`h2\` used in the help panel.",
       "isDefault": false,
       "name": "header",
     },
@@ -9442,18 +9854,18 @@ exports[`Documenter definition for hotspot matches the snapshot: hotspot 1`] = `
       "type": "string",
     },
     {
-      "defaultValue": ""top"",
+      "defaultValue": "'top'",
       "description": "The direction that the annotation popover should open in.
 Change this property if in the default direction the annotation popover
 overlaps too much with other content on the page.",
       "inlineType": {
-        "name": "",
+        "name": ""left" | "top" | "bottom" | "right"",
         "type": "union",
         "values": [
-          "top",
-          "right",
-          "bottom",
           "left",
+          "top",
+          "bottom",
+          "right",
         ],
       },
       "name": "direction",
@@ -9478,10 +9890,10 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": ""right"",
+      "defaultValue": "'right'",
       "description": "On which side of the content the hotspot icon should be displayed.",
       "inlineType": {
-        "name": "",
+        "name": ""left" | "right"",
         "type": "union",
         "values": [
           "left",
@@ -9496,6 +9908,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
   "regions": [
     {
       "description": "Content that should be wrapped by the hotspot icon. Optional.
+
 If you supply this property, the hotspot will wrap it in an element with
 \`flex: 1\`, in order to give the children the maximum available space. The
 hotspot icon will be placed floating next to the children. Use
@@ -9504,8 +9917,7 @@ available width, or a button.
 
 If you do not supply this property, the hotspot icon will behave as an inline
 element. Use this if you want to place the hotspot icon on a label, e.g. a
-checkbox's label.
-",
+checkbox's label.",
       "isDefault": true,
       "name": "children",
     },
@@ -9556,6 +9968,29 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
         "name": "IconProps.Name",
         "type": "union",
         "values": [
+          "search",
+          "map",
+          "filter",
+          "key",
+          "file",
+          "pause",
+          "play",
+          "remove",
+          "copy",
+          "menu",
+          "script",
+          "close",
+          "status-pending",
+          "refresh",
+          "external",
+          "group",
+          "calendar",
+          "ellipsis",
+          "zoom-in",
+          "zoom-out",
+          "download",
+          "security",
+          "edit",
           "add-plus",
           "anchor-link",
           "angle-left-double",
@@ -9574,7 +10009,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
           "backward-10-seconds",
           "bug",
           "call",
-          "calendar",
           "caret-down-filled",
           "caret-down",
           "caret-left-filled",
@@ -9583,20 +10017,14 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
           "caret-up",
           "check",
           "contact",
-          "close",
           "closed-caption",
           "closed-caption-unavailable",
-          "copy",
           "command-prompt",
           "delete-marker",
-          "download",
           "drag-indicator",
-          "edit",
-          "ellipsis",
           "envelope",
           "exit-full-screen",
           "expand",
-          "external",
           "face-happy",
           "face-happy-filled",
           "face-neutral",
@@ -9604,8 +10032,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
           "face-sad",
           "face-sad-filled",
           "file-open",
-          "file",
-          "filter",
           "flag",
           "folder-open",
           "folder",
@@ -9615,31 +10041,20 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
           "globe",
           "grid-view",
           "group-active",
-          "group",
           "heart",
           "heart-filled",
           "insert-row",
-          "key",
           "keyboard",
           "list-view",
           "location-pin",
           "lock-private",
-          "map",
-          "menu",
           "microphone",
           "microphone-off",
           "mini-player",
           "multiscreen",
           "notification",
-          "pause",
-          "play",
           "redo",
-          "refresh",
-          "remove",
           "resize-area",
-          "script",
-          "search",
-          "security",
           "settings",
           "send",
           "share",
@@ -9650,7 +10065,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
           "status-in-progress",
           "status-info",
           "status-negative",
-          "status-pending",
           "status-positive",
           "status-stopped",
           "status-warning",
@@ -9680,8 +10094,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
           "view-full",
           "view-horizontal",
           "view-vertical",
-          "zoom-in",
-          "zoom-out",
           "zoom-to-fit",
         ],
       },
@@ -9690,22 +10102,22 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": ""normal"",
+      "defaultValue": "'normal'",
       "description": "Specifies the size of the icon.
+
 If you set size to \`inherit\`, an icon size will be assigned based on the icon's inherited line height.
 For icons used alongside text, ensure the icon is placed inside the acompanying text tag.
-The icon will be vertically centered based on the height.
-",
+The icon will be vertically centered based on the height.",
       "inlineType": {
         "name": "IconProps.Size",
         "type": "union",
         "values": [
+          "big",
           "small",
           "normal",
           "medium",
-          "big",
-          "large",
           "inherit",
+          "large",
         ],
       },
       "name": "size",
@@ -9716,27 +10128,27 @@ The icon will be vertically centered based on the height.
     {
       "description": "Specifies the URL of a custom icon. Use this property if the icon you want isn't available, and your custom icon cannot be an SVG.
 For SVG icons, use the \`svg\` slot instead.
-If you set both \`url\` and \`svg\`, \`svg\` will take precedence.
-",
+
+If you set both \`url\` and \`svg\`, \`svg\` will take precedence.",
       "name": "url",
       "optional": true,
       "type": "string",
     },
     {
-      "defaultValue": ""normal"",
+      "defaultValue": "'normal'",
       "description": "Specifies the color variant of the icon. The \`normal\` variant picks up the current color of its context.",
       "inlineType": {
         "name": "IconProps.Variant",
         "type": "union",
         "values": [
-          "normal",
-          "disabled",
-          "error",
-          "inverted",
           "link",
-          "subtle",
+          "normal",
+          "error",
+          "disabled",
           "success",
           "warning",
+          "inverted",
+          "subtle",
         ],
       },
       "name": "variant",
@@ -9747,6 +10159,7 @@ If you set both \`url\` and \`svg\`, \`svg\` will take precedence.
   "regions": [
     {
       "description": "Specifies the SVG of a custom icon.
+
 Use this property if the icon you want isn't available, and you want your custom icon to inherit colors dictated by variant or hover states.
 When this property is set, the component will be decorated with \`aria-hidden="true"\`. Ensure that the \`svg\` element:
 - has attribute \`focusable="false"\`.
@@ -9763,8 +10176,7 @@ You can still set the stroke to \`currentColor\` to inherit the color of the sur
 If you set both \`url\` and \`svg\`, \`svg\` will take precedence.
 
 *Note:* Remember to remove any additional elements (for example: \`defs\`) and related CSS classes from SVG files exported from design software.
-In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.
-",
+In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.",
       "isDefault": false,
       "name": "svg",
     },
@@ -9779,7 +10191,6 @@ exports[`Documenter definition for input matches the snapshot: input 1`] = `
     {
       "cancelable": false,
       "description": "Called when input focus is removed from the UI control.",
-      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -9787,7 +10198,7 @@ exports[`Documenter definition for input matches the snapshot: input 1`] = `
       "description": "Called whenever a user changes the input value (by typing or pasting).
 The event \`detail\` contains the current value of the field.",
       "detailInlineType": {
-        "name": "InputProps.ChangeDetail",
+        "name": "BaseChangeDetail",
         "properties": [
           {
             "name": "value",
@@ -9797,13 +10208,12 @@ The event \`detail\` contains the current value of the field.",
         ],
         "type": "object",
       },
-      "detailType": "InputProps.ChangeDetail",
+      "detailType": "BaseChangeDetail",
       "name": "onChange",
     },
     {
       "cancelable": false,
       "description": "Called when input focus is moved to the UI control.",
-      "detailType": "null",
       "name": "onFocus",
     },
     {
@@ -9812,7 +10222,7 @@ The event \`detail\` contains the current value of the field.",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "InputProps.KeyDetail",
+        "name": "BaseKeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -9852,7 +10262,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "InputProps.KeyDetail",
+      "detailType": "BaseKeyDetail",
       "name": "onKeyDown",
     },
     {
@@ -9861,7 +10271,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "InputProps.KeyDetail",
+        "name": "BaseKeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -9901,7 +10311,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "InputProps.KeyDetail",
+      "detailType": "BaseKeyDetail",
       "name": "onKeyUp",
     },
   ],
@@ -9924,20 +10334,20 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-Use this if you don't have a visible label for this control.
-",
+
+Use this if you don't have a visible label for this control.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -9945,11 +10355,11 @@ Use this if you don't have a visible label for this control.
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -9965,12 +10375,21 @@ To use it correctly, define an ID for the element you want to use as label and s
       "description": "Specifies whether to enable a browser's autocomplete functionality for this input.
 In some cases it might be appropriate to disable autocomplete (for example, for security-sensitive fields).
 To use it correctly, set the \`name\` property.
+
 You can either provide a boolean value to set the property to "on" or "off", or specify a string value
-for the [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.
-",
+for the [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.",
+      "inlineType": {
+        "name": "string | boolean",
+        "type": "union",
+        "values": [
+          "string",
+          "false",
+          "true",
+        ],
+      },
       "name": "autoComplete",
       "optional": true,
-      "type": "boolean | string",
+      "type": "string | boolean",
     },
     {
       "description": "Indicates whether the control should be focused as
@@ -9999,9 +10418,9 @@ scrolled out of the viewport.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -10042,14 +10461,14 @@ This value may not be supported by all browsers or devices.",
         "name": "InputProps.InputMode",
         "type": "union",
         "values": [
+          "search",
+          "numeric",
           "none",
+          "url",
           "text",
           "decimal",
-          "numeric",
           "tel",
-          "search",
           "email",
-          "url",
         ],
       },
       "name": "inputMode",
@@ -10082,8 +10501,8 @@ single form field.",
       "description": "Specifies if the control is read-only, which prevents the
 user from modifying the value but includes it in a form
 submission. A read-only control can receive focus.
-Don't use read-only inputs outside a form.
-",
+
+Don't use read-only inputs outside a form.",
       "name": "readOnly",
       "optional": true,
       "type": "boolean",
@@ -10093,10 +10512,10 @@ Don't use read-only inputs outside a form.
 This value controls the native browser capability to check for spelling/grammar errors.
 If not set, the browser default behavior is to perform spellchecking.
 For more details, check the [spellcheck MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck).
+
 Enhanced spellchecking features of your browser and/or operating system may send input values to external parties.
 Make sure it’s deactivated for fields with sensitive information to prevent
-inadvertently sending data (such as user passwords) to third parties.
-",
+inadvertently sending data (such as user passwords) to third parties.",
       "name": "spellcheck",
       "optional": true,
       "type": "boolean",
@@ -10110,7 +10529,7 @@ including the date, month, week, time, datetime-local, number and range types.",
         "type": "union",
         "values": [
           "number",
-          "any",
+          ""any"",
         ],
       },
       "name": "step",
@@ -10126,12 +10545,12 @@ be slightly different across browsers.",
         "name": "InputProps.Type",
         "type": "union",
         "values": [
-          "text",
-          "password",
-          "search",
           "number",
-          "email",
+          "search",
           "url",
+          "text",
+          "email",
+          "password",
         ],
       },
       "name": "type",
@@ -10212,6 +10631,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "description": "An array of either key-value pairs individual items or groups.
 They could be combined.
 Each item has \`type\` prop, which might be either \`group\` or \`pair\`. Defaults to \`pair\` if not specified.
+
 Each key-value pair definition has the following properties:
   * \`type\` (string) - (Optional) Item type (pair).
   * \`label\` (string) - The key label.
@@ -10222,8 +10642,7 @@ Each group definition has the following properties:
   * \`type\` (string) - Item type (group).
   * \`title\` (string) - (Optional) An optional title for this column.
   * \`items\` (ReadonlyArray<KeyValuePairProps.KeyValuePair>) - An array of
-    key-value pair items.
-",
+    key-value pair items.",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<KeyValuePairsProps.Item>",
@@ -10231,10 +10650,10 @@ Each group definition has the following properties:
     {
       "defaultValue": "150",
       "description": "Use to specify the desired minimum width for each column in pixels.
+
 The number of columns is determined by the value of this property, the available space,
 and the maximum number of columns as defined by the \`columns\` property.
-If not set, defaults to 150.
-",
+If not set, defaults to 150.",
       "name": "minColumnWidth",
       "optional": true,
       "type": "number",
@@ -10253,7 +10672,7 @@ exports[`Documenter definition for line-chart matches the snapshot: line-chart 1
       "description": "Called when the values of the internal filter component changed.
 This will **not** be called for any custom filter components you have defined in \`additionalFilters\`.",
       "detailInlineType": {
-        "name": "CartesianChartProps.FilterChangeDetail",
+        "name": "CartesianChartProps.FilterChangeDetail<Series>",
         "properties": [
           {
             "name": "visibleSeries",
@@ -10263,14 +10682,14 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.FilterChangeDetail<MixedLineBarChartProps.ChartSeries<T>>",
+      "detailType": "CartesianChartProps.FilterChangeDetail<Series>",
       "name": "onFilterChange",
     },
     {
       "cancelable": false,
       "description": "Called when the highlighted series has changed because of user interaction.",
       "detailInlineType": {
-        "name": "CartesianChartProps.HighlightChangeDetail",
+        "name": "CartesianChartProps.HighlightChangeDetail<Series>",
         "properties": [
           {
             "name": "highlightedSeries",
@@ -10280,7 +10699,7 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.HighlightChangeDetail<MixedLineBarChartProps.ChartSeries<T>>",
+      "detailType": "CartesianChartProps.HighlightChangeDetail<Series>",
       "name": "onHighlightChange",
     },
     {
@@ -10326,7 +10745,7 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "Additional content that is displayed at the bottom of the detail popover.",
       "inlineType": {
-        "name": "CartesianChartProps.DetailPopoverFooter",
+        "name": "CartesianChartProps.DetailPopoverFooter<T>",
         "parameters": [
           {
             "name": "xValue",
@@ -10343,15 +10762,15 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "A function that determines the details that are displayed in the popover for each series.
 Use this for wrapping keys or values in external links, or to display a metric breakdown by adding an additional level of nested items.
+
 The function is called with the parameters \`{ series, x, y }\` representing the series, the highlighted x coordinate value and its corresponding y value respectively,
 and should return the following properties:
 * \`key\` (ReactNode) - Name of the series.
 * \`value\` (ReactNode) - Value of the series at the highlighted x coordinate.
 * \`subItems\` (ReadonlyArray<{ key: ReactNode; value: ReactNode }>) - (Optional) List of nested key-value pairs.
-* \`expandable\` (boolean) - (Optional) Determines whether the optional list of nested items provided via \`subItems\` is expandable. This is \`false\` by default.
-",
+* \`expandable\` (boolean) - (Optional) Determines whether the optional list of nested items provided via \`subItems\` is expandable. This is \`false\` by default.",
       "inlineType": {
-        "name": "MixedLineBarChartProps.DetailPopoverSeriesContent",
+        "name": "MixedLineBarChartProps.DetailPopoverSeriesContent<T>",
         "parameters": [
           {
             "name": "data",
@@ -10366,10 +10785,10 @@ and should return the following properties:
       "type": "MixedLineBarChartProps.DetailPopoverSeriesContent<T>",
     },
     {
-      "defaultValue": ""medium"",
+      "defaultValue": "'medium'",
       "description": "Determines the maximum width the detail popover will be limited to.",
       "inlineType": {
-        "name": "",
+        "name": ""small" | "medium" | "large"",
         "type": "union",
         "values": [
           "small",
@@ -10428,18 +10847,26 @@ It is highly recommended to keep this set to \`false\`.",
     {
       "description": "The currently highlighted data series, usually through hovering over a series or the legend.
 A value of \`null\` means no series is highlighted.
+
 - If you do not set this property, series are highlighted automatically when hovering over one of the triggers (uncontrolled behavior).
-- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).
-",
+- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).",
+      "inlineType": {
+        "name": "NonNullable<Series>",
+        "type": "union",
+        "values": [
+          "Series",
+          "{}",
+        ],
+      },
       "name": "highlightedSeries",
       "optional": true,
-      "type": "MixedLineBarChartProps.ChartSeries<T> | null",
+      "type": "NonNullable<Series>",
     },
     {
       "description": "An object containing all the necessary localized strings required by the component.",
       "i18nTag": true,
       "inlineType": {
-        "name": "CartesianChartProps.I18nStrings",
+        "name": "CartesianChartProps.I18nStrings<T>",
         "properties": [
           {
             "name": "chartAriaRoleDescription",
@@ -10531,29 +10958,29 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "defaultValue": "[]",
       "description": "Array that represents the source of data for the displayed chart.
 Each element can represent a line series or a threshold, and can have the following properties:
+
 * \`title\` (string): A human-readable title for this series
 * \`type\` (string): Series type (\`"line"\`, or \`"threshold"\`)
 * \`data\` (Array): An array of data points, represented as objects with \`x\` and \`y\` properties
 * \`color\` (string): (Optional) A color hex value for this series. When assigned, it takes priority over the automatically assigned color
-* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.
-",
+* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.",
       "name": "series",
       "optional": false,
       "type": "ReadonlyArray<LineSeries<T>>",
     },
     {
-      "defaultValue": ""finished"",
+      "defaultValue": "'finished'",
       "description": "Specifies the current status of loading data.
 * \`loading\`: data fetching is in progress.
 * \`finished\`: data has loaded successfully.
 * \`error\`: an error occurred during fetch. You should provide user an option to recover.",
       "inlineType": {
-        "name": "",
+        "name": ""error" | "finished" | "loading"",
         "type": "union",
         "values": [
-          "loading",
-          "finished",
           "error",
+          "finished",
+          "loading",
         ],
       },
       "name": "statusType",
@@ -10566,29 +10993,29 @@ Each element can represent a line series or a threshold, and can have the follow
 - If you explicitly set this property, you must set an \`onFilterChange\` listener to update this property when the visible series should change, or when one of your custom filters changes the number of visible series (controlled behavior).",
       "name": "visibleSeries",
       "optional": true,
-      "type": "ReadonlyArray<MixedLineBarChartProps.ChartSeries<T>>",
+      "type": "ReadonlyArray<Series>",
     },
     {
       "description": "Determines the domain of the x axis, i.e. the range of values that will be visible in the chart.
 For numerical and time-based data this is represented as an array with two values: \`[minimumValue, maximumValue]\`.
 For categorical data this is represented as an array of strings that determine the categories to display.
+
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.
-",
+When controlling this directly, make sure to update the value based on filtering changes.",
       "name": "xDomain",
       "optional": true,
       "type": "ReadonlyArray<T>",
     },
     {
-      "defaultValue": ""linear"",
+      "defaultValue": "'linear'",
       "description": "Determines the type of scale for values on the x axis.",
       "inlineType": {
         "name": "ScaleType",
         "type": "union",
         "values": [
           "linear",
-          "log",
           "time",
+          "log",
           "categorical",
         ],
       },
@@ -10599,7 +11026,7 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Function to format the displayed label of an x axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter",
+        "name": "CartesianChartProps.TickFormatter<T>",
         "parameters": [
           {
             "name": "value",
@@ -10622,18 +11049,18 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Determines the domain of the y axis, i.e. the range of values that will be visible in the chart.
 The domain is defined by a tuple: \`[minimumValue, maximumValue]\`.
+
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.
-",
+When controlling this directly, make sure to update the value based on filtering changes.",
       "name": "yDomain",
       "optional": true,
       "type": "ReadonlyArray<number>",
     },
     {
-      "defaultValue": ""linear"",
+      "defaultValue": "'linear'",
       "description": "Determines the type of scale for values on the y axis.",
       "inlineType": {
-        "name": "",
+        "name": ""linear" | "log"",
         "type": "union",
         "values": [
           "linear",
@@ -10647,7 +11074,7 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Function to format the displayed label of a y axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter",
+        "name": "CartesianChartProps.TickFormatter<number>",
         "parameters": [
           {
             "name": "value",
@@ -10734,16 +11161,16 @@ exports[`Documenter definition for link matches the snapshot: link 1`] = `
       "cancelable": true,
       "description": "Called when a link is clicked without any modifier keys. If the link has no \`href\` provided, it will be called on
 all clicks.
+
 If you want to implement client-side routing yourself, use this event and prevent default browser navigation
-(by calling \`preventDefault\`).
-",
+(by calling \`preventDefault\`).",
       "detailInlineType": {
-        "name": "LinkProps.FollowDetail",
+        "name": "BaseNavigationDetail",
         "properties": [
           {
             "name": "external",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "href",
@@ -10758,7 +11185,7 @@ If you want to implement client-side routing yourself, use this event and preven
         ],
         "type": "object",
       },
-      "detailType": "LinkProps.FollowDetail",
+      "detailType": "BaseNavigationDetail",
       "name": "onFollow",
     },
   ],
@@ -10788,11 +11215,11 @@ If you want to implement client-side routing yourself, use this event and preven
     {
       "defaultValue": "'normal'",
       "description": "Determines the text color of the link and its icon.
+
 - \`normal\`: Use in most cases where a link is required.
 - \`inverted\`: Use to style links inside Flashbars.
 
-This property is overridden if the variant is \`info\`.
-",
+This property is overridden if the variant is \`info\`.",
       "inlineType": {
         "name": "LinkProps.Color",
         "type": "union",
@@ -10828,6 +11255,7 @@ This property is overridden if the variant is \`info\`.",
         "name": "LinkProps.FontSize",
         "type": "union",
         "values": [
+          "inherit",
           "body-s",
           "body-m",
           "heading-xs",
@@ -10836,7 +11264,6 @@ This property is overridden if the variant is \`info\`.",
           "heading-l",
           "heading-xl",
           "display-l",
-          "inherit",
         ],
       },
       "name": "fontSize",
@@ -10872,15 +11299,16 @@ By default, the component sets the \`rel\` attribute to "noopener noreferrer" wh
 in a new tab. If you set this property to \`_blank\`, the component
 automatically adds \`rel="noopener noreferrer"\` to avoid performance
 and security issues.
+
 For other options see the documentation for <a> tag's
-[target attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target).
-",
+[target attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target).",
       "name": "target",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Determines the visual style of the link as follows:
+
 - \`primary\` - Displays the link text with bold styling for sufficient contrast with surrounding text.
     Use this for links where the context doesn't imply interactivity such as
     "Learn more" links and links within paragraphs.
@@ -10894,15 +11322,14 @@ The default is \`secondary\`, except inside the following components where it de
 - Cards
 - Alert
 - Popover
-- Help Panel (main \`content\` only)
-",
+- Help Panel (main \`content\` only)",
       "inlineType": {
         "name": "LinkProps.Variant",
         "type": "union",
         "values": [
+          "info",
           "primary",
           "secondary",
-          "info",
           "awsui-value-large",
         ],
       },
@@ -10961,14 +11388,14 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": ""div"",
+      "defaultValue": "'div'",
       "description": "The tag name to use for the wrapper around the \`children\` slot.",
       "inlineType": {
         "name": "LiveRegionProps.TagName",
         "type": "union",
         "values": [
-          "span",
           "div",
+          "span",
         ],
       },
       "name": "tagName",
@@ -10997,7 +11424,7 @@ exports[`Documenter definition for mixed-line-bar-chart matches the snapshot: mi
       "description": "Called when the values of the internal filter component changed.
 This will **not** be called for any custom filter components you have defined in \`additionalFilters\`.",
       "detailInlineType": {
-        "name": "CartesianChartProps.FilterChangeDetail",
+        "name": "CartesianChartProps.FilterChangeDetail<Series>",
         "properties": [
           {
             "name": "visibleSeries",
@@ -11007,14 +11434,14 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.FilterChangeDetail<MixedLineBarChartProps.ChartSeries<T>>",
+      "detailType": "CartesianChartProps.FilterChangeDetail<Series>",
       "name": "onFilterChange",
     },
     {
       "cancelable": false,
       "description": "Called when the highlighted series has changed because of user interaction.",
       "detailInlineType": {
-        "name": "CartesianChartProps.HighlightChangeDetail",
+        "name": "CartesianChartProps.HighlightChangeDetail<Series>",
         "properties": [
           {
             "name": "highlightedSeries",
@@ -11024,7 +11451,7 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.HighlightChangeDetail<MixedLineBarChartProps.ChartSeries<T>>",
+      "detailType": "CartesianChartProps.HighlightChangeDetail<Series>",
       "name": "onHighlightChange",
     },
     {
@@ -11070,7 +11497,7 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "Additional content that is displayed at the bottom of the detail popover.",
       "inlineType": {
-        "name": "CartesianChartProps.DetailPopoverFooter",
+        "name": "CartesianChartProps.DetailPopoverFooter<T>",
         "parameters": [
           {
             "name": "xValue",
@@ -11087,15 +11514,15 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "A function that determines the details that are displayed in the popover for each series.
 Use this for wrapping keys or values in external links, or to display a metric breakdown by adding an additional level of nested items.
+
 The function is called with the parameters \`{ series, x, y }\` representing the series, the highlighted x coordinate value and its corresponding y value respectively,
 and should return the following properties:
 * \`key\` (ReactNode) - Name of the series.
 * \`value\` (ReactNode) - Value of the series at the highlighted x coordinate.
 * \`subItems\` (ReadonlyArray<{ key: ReactNode; value: ReactNode }>) - (Optional) List of nested key-value pairs.
-* \`expandable\` (boolean) - (Optional) Determines whether the optional list of nested items provided via \`subItems\` is expandable. This is \`false\` by default.
-",
+* \`expandable\` (boolean) - (Optional) Determines whether the optional list of nested items provided via \`subItems\` is expandable. This is \`false\` by default.",
       "inlineType": {
-        "name": "MixedLineBarChartProps.DetailPopoverSeriesContent",
+        "name": "MixedLineBarChartProps.DetailPopoverSeriesContent<T>",
         "parameters": [
           {
             "name": "data",
@@ -11110,10 +11537,10 @@ and should return the following properties:
       "type": "MixedLineBarChartProps.DetailPopoverSeriesContent<T>",
     },
     {
-      "defaultValue": ""medium"",
+      "defaultValue": "'medium'",
       "description": "Determines the maximum width the detail popover will be limited to.",
       "inlineType": {
-        "name": "",
+        "name": ""small" | "medium" | "large"",
         "type": "union",
         "values": [
           "small",
@@ -11172,12 +11599,20 @@ It is highly recommended to keep this set to \`false\`.",
     {
       "description": "The currently highlighted data series, usually through hovering over a series or the legend.
 A value of \`null\` means no series is highlighted.
+
 - If you do not set this property, series are highlighted automatically when hovering over one of the triggers (uncontrolled behavior).
-- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).
-",
+- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).",
+      "inlineType": {
+        "name": "NonNullable<Series>",
+        "type": "union",
+        "values": [
+          "Series",
+          "{}",
+        ],
+      },
       "name": "highlightedSeries",
       "optional": true,
-      "type": "MixedLineBarChartProps.ChartSeries<T> | null",
+      "type": "NonNullable<Series>",
     },
     {
       "defaultValue": "false",
@@ -11191,7 +11626,7 @@ This can only be used when the chart consists exclusively of bar series.",
       "description": "An object containing all the necessary localized strings required by the component.",
       "i18nTag": true,
       "inlineType": {
-        "name": "CartesianChartProps.I18nStrings",
+        "name": "CartesianChartProps.I18nStrings<T>",
         "properties": [
           {
             "name": "chartAriaRoleDescription",
@@ -11283,13 +11718,13 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "defaultValue": "[]",
       "description": "Array that represents the source of data for the displayed chart.
 Each element can represent a line series, bar series, or a threshold, and can have the following properties:
+
 * \`title\` (string): A human-readable title for this series.
 * \`type\` (string): Series type (\`"line"\`, \`"bar"\`, or \`"threshold"\`).
 * \`data\` (Array): For line and bar series, an array of data points, represented as objects with \`x\` and \`y\` properties.
 * \`y\` (number): For threshold series, the value of the threshold.
 * \`color\` (string): (Optional) A color hex value for this series. When assigned, it takes priority over the automatically assigned color.
-* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.
-",
+* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.",
       "name": "series",
       "optional": false,
       "type": "ReadonlyArray<MixedLineBarChartProps.ChartSeries<T>>",
@@ -11302,18 +11737,18 @@ Each element can represent a line series, bar series, or a threshold, and can ha
       "type": "boolean",
     },
     {
-      "defaultValue": ""finished"",
+      "defaultValue": "'finished'",
       "description": "Specifies the current status of loading data.
 * \`loading\`: data fetching is in progress.
 * \`finished\`: data has loaded successfully.
 * \`error\`: an error occurred during fetch. You should provide user an option to recover.",
       "inlineType": {
-        "name": "",
+        "name": ""error" | "finished" | "loading"",
         "type": "union",
         "values": [
-          "loading",
-          "finished",
           "error",
+          "finished",
+          "loading",
         ],
       },
       "name": "statusType",
@@ -11326,21 +11761,21 @@ Each element can represent a line series, bar series, or a threshold, and can ha
 - If you explicitly set this property, you must set an \`onFilterChange\` listener to update this property when the visible series should change, or when one of your custom filters changes the number of visible series (controlled behavior).",
       "name": "visibleSeries",
       "optional": true,
-      "type": "ReadonlyArray<MixedLineBarChartProps.ChartSeries<T>>",
+      "type": "ReadonlyArray<Series>",
     },
     {
       "description": "Determines the domain of the x axis, i.e. the range of values that will be visible in the chart.
 For numerical and time-based data this is represented as an array with two values: \`[minimumValue, maximumValue]\`.
 For categorical data this is represented as an array of strings that determine the categories to display.
+
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.
-",
+When controlling this directly, make sure to update the value based on filtering changes.",
       "name": "xDomain",
       "optional": true,
       "type": "ReadonlyArray<T>",
     },
     {
-      "defaultValue": ""linear"",
+      "defaultValue": "'linear'",
       "description": "Determines the type of scale for values on the x axis.
 Use \`categorical\` for charts with bars.",
       "inlineType": {
@@ -11348,8 +11783,8 @@ Use \`categorical\` for charts with bars.",
         "type": "union",
         "values": [
           "linear",
-          "log",
           "time",
+          "log",
           "categorical",
         ],
       },
@@ -11360,7 +11795,7 @@ Use \`categorical\` for charts with bars.",
     {
       "description": "Function to format the displayed label of an x axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter",
+        "name": "CartesianChartProps.TickFormatter<T>",
         "parameters": [
           {
             "name": "value",
@@ -11383,18 +11818,18 @@ Use \`categorical\` for charts with bars.",
     {
       "description": "Determines the domain of the y axis, i.e. the range of values that will be visible in the chart.
 The domain is defined by a tuple: \`[minimumValue, maximumValue]\`.
+
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.
-",
+When controlling this directly, make sure to update the value based on filtering changes.",
       "name": "yDomain",
       "optional": true,
       "type": "ReadonlyArray<number>",
     },
     {
-      "defaultValue": ""linear"",
+      "defaultValue": "'linear'",
       "description": "Determines the type of scale for values on the y axis.",
       "inlineType": {
-        "name": "",
+        "name": ""linear" | "log"",
         "type": "union",
         "values": [
           "linear",
@@ -11408,7 +11843,7 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Function to format the displayed label of a y axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter",
+        "name": "CartesianChartProps.TickFormatter<number>",
         "parameters": [
           {
             "name": "value",
@@ -11532,9 +11967,15 @@ The event detail contains the \`reason\`, which can be any of the following:
     {
       "description": "Use this property to specify a different dynamic modal root for the dialog.
 The function will be called when a user clicks on the trigger button.",
+      "inlineType": {
+        "name": "() => Promise<HTMLElement>",
+        "parameters": [],
+        "returnType": "Promise<HTMLElement>",
+        "type": "function",
+      },
       "name": "getModalRoot",
       "optional": true,
-      "type": "() => Promise<HTMLElement>",
+      "type": "(() => Promise<HTMLElement>)",
     },
     {
       "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
@@ -11557,12 +11998,23 @@ render to an element under \`document.body\`.",
       "description": "Use this property when \`getModalRoot\` is used to clean up the modal root
 element after a user closes the dialog. The function receives the return value
 of the most recent getModalRoot call as an argument.",
+      "inlineType": {
+        "name": "(rootElement: HTMLElement) => void",
+        "parameters": [
+          {
+            "name": "rootElement",
+            "type": "HTMLElement",
+          },
+        ],
+        "returnType": "void",
+        "type": "function",
+      },
       "name": "removeModalRoot",
       "optional": true,
-      "type": "(rootElement: HTMLElement) => void",
+      "type": "((rootElement: HTMLElement) => void)",
     },
     {
-      "defaultValue": ""medium"",
+      "defaultValue": "'medium'",
       "description": "Sets the width of the modal. \`max\` uses variable width up to the
 largest size allowed by the design guidelines. Other sizes
 (\`small\`/\`medium\`/\`large\`) have fixed widths.",
@@ -11571,9 +12023,9 @@ largest size allowed by the design guidelines. Other sizes
         "type": "union",
         "values": [
           "small",
+          "max",
           "medium",
           "large",
-          "max",
         ],
       },
       "name": "size",
@@ -11627,7 +12079,7 @@ The event \`detail\` contains the current \`selectedOptions\`.",
           {
             "name": "selectedOptions",
             "optional": false,
-            "type": "ReadonlyArray<MultiselectProps.Option>",
+            "type": "ReadonlyArray<OptionDefinition>",
           },
         ],
         "type": "object",
@@ -11643,6 +12095,7 @@ The event \`detail\` contains the current \`selectedOptions\`.",
     {
       "cancelable": false,
       "description": "Use this event to implement the asynchronous behavior for the component.
+
 The event is called in the following situations:
 * The user scrolls to the end of the list of options, if \`statusType\` is set to \`pending\`.
 * The user clicks on the recovery button in the error state.
@@ -11652,8 +12105,7 @@ The event is called in the following situations:
 The detail object contains the following properties:
 * \`filteringText\` - The value that you need to use to fetch options.
 * \`firstPage\` - Indicates that you should fetch the first page of options that match the \`filteringText\`.
-* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).
-",
+* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).",
       "detailInlineType": {
         "name": "OptionsLoadItemsDetail",
         "properties": [
@@ -11692,12 +12144,12 @@ The detail object contains the following properties:
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -11712,11 +12164,11 @@ Use this if you don't have a visible label for this control.",
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -11754,7 +12206,7 @@ To use it correctly, define an ID for the element you want to use as label and s
         "parameters": [
           {
             "name": "option",
-            "type": "MultiselectProps.Option",
+            "type": "OptionDefinition",
           },
         ],
         "returnType": "string",
@@ -11793,12 +12245,12 @@ To use it correctly, define an ID for the element you want to use as label and s
       "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
+
 Set this property if the dropdown would otherwise be constrained by a scrollable container,
 for example inside table and split view layouts.
 
 We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.
-",
+because fixed positioning results in a slight, visible lag when scrolling complex pages.",
       "name": "expandToViewport",
       "optional": true,
       "type": "boolean",
@@ -11824,13 +12276,29 @@ because fixed positioning results in a slight, visible lag when scrolling comple
     },
     {
       "description": "Specifies the text to display with the number of matches at the bottom of the dropdown menu while filtering.",
+      "inlineType": {
+        "name": "(matchesCount: number, totalCount: number) => string",
+        "parameters": [
+          {
+            "name": "matchesCount",
+            "type": "number",
+          },
+          {
+            "name": "totalCount",
+            "type": "number",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
       "name": "filteringResultsText",
       "optional": true,
-      "type": "(matchesCount: number, totalCount: number) => string",
+      "type": "((matchesCount: number, totalCount: number) => string)",
     },
     {
       "defaultValue": "'none'",
       "description": "Determines how filtering is applied to the list of \`options\`:
+
 * \`auto\` - The component will automatically filter options based on user input.
 * \`manual\` - You will set up \`onChange\` or \`onLoadItems\` event listeners and filter options on your side or request
 them from server.
@@ -11843,14 +12311,13 @@ If you set this property to \`manual\`, this default filtering mechanism is disa
 displayed in the dropdown list. In that case make sure that you use the \`onChange\` or \`onLoadItems\` events in order
 to set the \`options\` property to the options that are relevant for the user, given the filtering input value.
 
-Note: Manual filtering doesn't disable match highlighting.
-",
+Note: Manual filtering doesn't disable match highlighting.",
       "inlineType": {
         "name": "OptionsFilteringType",
         "type": "union",
         "values": [
-          "none",
           "auto",
+          "none",
           "manual",
         ],
       },
@@ -11874,6 +12341,7 @@ Only use this if the selected options are displayed elsewhere on the page.",
     },
     {
       "description": "An object containing all the localized strings required by the component.
+
 * \`selectAllText\` (string) - Specifies the text to be displayed next to the checkbox that selects or deselects all options.
 * \`tokenLimitShowFewer\` (string) - Specifies the text to be displayed in the "Show fewer" button for the token group control.
 * \`tokenLimitShowMore\` (string) - Specifies the text to be displayed in the "Show more" button for the token group control. This string should not contain the number of hidden tokens
@@ -11944,7 +12412,6 @@ single form field.",
     },
     {
       "deprecatedTag": "Has no effect.",
-      "description": "",
       "name": "name",
       "optional": true,
       "type": "string",
@@ -11953,6 +12420,7 @@ single form field.",
       "defaultValue": "[]",
       "description": "Specifies an array of options that are displayed to the user as a dropdown list.
 The options can be grouped using \`OptionGroup\` objects.
+
 #### Option
 - \`value\` (string) - The returned value of the option when selected.
 
@@ -11980,13 +12448,7 @@ If you want to use the built-in filtering capabilities of this component, provid
 a list of all valid options here and they will be automatically filtered based on the user's filtering input.
 
 Alternatively, you can listen to the \`onChange\` or \`onLoadItems\` event and set new options
-on your own.
-",
-      "inlineType": {
-        "name": "SelectProps.Options",
-        "properties": [],
-        "type": "object",
-      },
+on your own.",
       "name": "options",
       "optional": true,
       "type": "SelectProps.Options",
@@ -12019,19 +12481,19 @@ the option's name and properties, and its selected state if
 the \`selectedLabel\` property is defined.
 The highlighted option is provided, and its group (if groups
 are used and it differs from the group of the previously highlighted option).
+
 For more information, see the
-[accessibility guidelines](/components/select/?tabId=usage#accessibility-guidelines).
-",
+[accessibility guidelines](/components/select/?tabId=usage#accessibility-guidelines).",
       "inlineType": {
         "name": "SelectProps.ContainingOptionAndGroupString",
         "parameters": [
           {
             "name": "option",
-            "type": "SelectProps.Option",
+            "type": "OptionDefinition",
           },
           {
             "name": "group",
-            "type": "SelectProps.OptionGroup",
+            "type": "OptionGroup",
           },
         ],
         "returnType": "string",
@@ -12056,7 +12518,7 @@ This is required to provide a good screen reader experience. For more informatio
 Provide an empty array to clear the selection.",
       "name": "selectedOptions",
       "optional": false,
-      "type": "ReadonlyArray<MultiselectProps.Option>",
+      "type": "ReadonlyArray<OptionDefinition>",
     },
     {
       "defaultValue": "'finished'",
@@ -12069,10 +12531,10 @@ Provide an empty array to clear the selection.",
         "name": "DropdownStatusProps.StatusType",
         "type": "union",
         "values": [
-          "pending",
-          "loading",
-          "finished",
           "error",
+          "finished",
+          "loading",
+          "pending",
         ],
       },
       "name": "statusType",
@@ -12104,11 +12566,11 @@ Use to assign unique labels when there are multiple token groups with the same \
 that makes the filtering experience smoother. We don't recommend enabling the feature if you
 have less than 500 options, because the improvements to performance are offset by a
 visible scrolling lag.
+
 When you set this flag to \`true\`, it removes options that are not currently in view from the DOM.
 If your test accesses such options, you need to first scroll the options container
 to the correct offset, before performing any operations on them. Use the element returned
-by the \`findOptionsContainer\` test utility for this.
-",
+by the \`findOptionsContainer\` test utility for this.",
       "name": "virtualScroll",
       "optional": true,
       "type": "boolean",
@@ -12224,6 +12686,7 @@ exports[`Documenter definition for pagination matches the snapshot: pagination 1
 * \`previousPageLabel\` (string) - Previous page button.
 * \`pageLabel\` (number => string) - Individual page button, this function is called for every page number that's rendered.
 * \`nextPageLabel\` (string) - Next page button
+
 Example:
 \`\`\`
 {
@@ -12245,7 +12708,7 @@ Example:
           {
             "name": "pageLabel",
             "optional": true,
-            "type": "(pageNumber: number) => string",
+            "type": "((pageNumber: number) => string)",
           },
           {
             "name": "paginationLabel",
@@ -12307,7 +12770,7 @@ exports[`Documenter definition for pie-chart matches the snapshot: pie-chart 1`]
       "description": "Called when the values of the internal filter component changes.
 This isn't called for any custom filter components you've defined in \`additionalFilters\`.",
       "detailInlineType": {
-        "name": "PieChartProps.FilterChangeDetail",
+        "name": "PieChartProps.FilterChangeDetail<T>",
         "properties": [
           {
             "name": "visibleSegments",
@@ -12324,7 +12787,7 @@ This isn't called for any custom filter components you've defined in \`additiona
       "cancelable": false,
       "description": "Called when the highlighted segmented changes because of a user interaction.",
       "detailInlineType": {
-        "name": "PieChartProps.HighlightChangeDetail",
+        "name": "PieChartProps.HighlightChangeDetail<T>",
         "properties": [
           {
             "name": "highlightedSegment",
@@ -12380,6 +12843,7 @@ Use either \`ariaLabel\` or \`ariaLabelledby\` (you can't use both).",
     {
       "description": "An array that represents the source of data for the displayed segments.
 Each element can have the following properties:
+
 * \`title\` (string) - A human-readable title for this data point.
 * \`value\` (number) - Numeric value that determines the segment size.
                        A segment with a value of zero (0) or lower (negative number) won't have a segment.
@@ -12388,8 +12852,7 @@ Each element can have the following properties:
 
 As long as your data object implements the properties above, you can also define additional properties
 that are relevant to your data visualization.
-The full data object will be passed down to events and properties like \`detailPopoverContent\`.
-",
+The full data object will be passed down to events and properties like \`detailPopoverContent\`.",
       "name": "data",
       "optional": false,
       "type": "ReadonlyArray<T>",
@@ -12398,12 +12861,12 @@ The full data object will be passed down to events and properties like \`detailP
       "description": "A function that determines the details that are displayed in the popover when hovering over a segment.
 The function is called with the data of the target segment and is expected to return an array of detail pairs.
 By default, each segment displays two detail pairs: count and percentage.
+
 Each pair has the following properties:
 * \`key\` (ReactNode) - Name of the detail or metric.
-* \`value\` (ReactNode) - The value of this detail for the target segment.
-",
+* \`value\` (ReactNode) - The value of this detail for the target segment.",
       "inlineType": {
-        "name": "PieChartProps.DetailPopoverContentFunction",
+        "name": "PieChartProps.DetailPopoverContentFunction<T>",
         "parameters": [
           {
             "name": "segment",
@@ -12424,7 +12887,7 @@ Each pair has the following properties:
     {
       "description": "Additional content that is displayed at the bottom of the detail popover.",
       "inlineType": {
-        "name": "PieChartProps.DetailPopoverFooter",
+        "name": "PieChartProps.DetailPopoverFooter<T>",
         "parameters": [
           {
             "name": "segment",
@@ -12439,7 +12902,7 @@ Each pair has the following properties:
       "type": "PieChartProps.DetailPopoverFooter<T>",
     },
     {
-      "defaultValue": ""medium"",
+      "defaultValue": "'medium'",
       "description": "Determines the maximum width of the popover.",
       "inlineType": {
         "name": "PopoverProps.Size",
@@ -12502,14 +12965,36 @@ We highly recommend that you leave this unspecified or set to \`false\`.",
       "description": "Specifies the currently highlighted data segment. Highlighting is typically the result of
 a user hovering over or selecting a segment in the chart or the legend.
 A value of \`null\` means no segment is being highlighted.
+
 - If you don't set this property, segments are highlighted automatically when a user hovers over or selects one of the triggers (that is, uncontrolled behavior).
-- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a segment should be highlighted (that is, controlled behavior).
-",
+- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a segment should be highlighted (that is, controlled behavior).",
+      "inlineType": {
+        "name": "T",
+        "properties": [
+          {
+            "name": "color",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "title",
+            "optional": false,
+            "type": "string",
+          },
+          {
+            "name": "value",
+            "optional": false,
+            "type": "number",
+          },
+        ],
+        "type": "object",
+      },
       "name": "highlightedSegment",
       "optional": true,
       "type": "T | null",
     },
     {
+      "defaultValue": "{}",
       "description": "An object that contains all of the localized strings required by the component.",
       "i18nTag": true,
       "inlineType": {
@@ -12614,7 +13099,7 @@ This is usually the unit of the \`innerMetricValue\`.",
 This is an optional description that explains the segment and is displayed underneath the label.
 The function is called with the data object of each segment and is expected to return the description as a string.",
       "inlineType": {
-        "name": "PieChartProps.SegmentDescriptionFunction",
+        "name": "PieChartProps.SegmentDescriptionFunction<T>",
         "parameters": [
           {
             "name": "segment",
@@ -12633,11 +13118,11 @@ The function is called with the data object of each segment and is expected to r
       "type": "PieChartProps.SegmentDescriptionFunction<T>",
     },
     {
-      "defaultValue": ""medium"",
+      "defaultValue": "'medium'",
       "description": "Specifies the size of the pie or donut chart.
 When used with \`fitHeight\`, this property defines the minimum size of the chart area.",
       "inlineType": {
-        "name": "",
+        "name": ""small" | "medium" | "large"",
         "type": "union",
         "values": [
           "small",
@@ -12650,18 +13135,18 @@ When used with \`fitHeight\`, this property defines the minimum size of the char
       "type": "string",
     },
     {
-      "defaultValue": ""finished"",
+      "defaultValue": "'finished'",
       "description": "Specifies the current status of loading data.
 * \`loading\` - Indicates that data fetching is in progress.
 * \`finished\` - Indicates that data has loaded successfully.
 * \`error\` - Indicates that an error occurred during fetch. You should provide an option to enable the user to recover.",
       "inlineType": {
-        "name": "",
+        "name": ""error" | "finished" | "loading"",
         "type": "union",
         "values": [
-          "loading",
-          "finished",
           "error",
+          "finished",
+          "loading",
         ],
       },
       "name": "statusType",
@@ -12669,12 +13154,12 @@ When used with \`fitHeight\`, this property defines the minimum size of the char
       "type": "string",
     },
     {
-      "defaultValue": ""pie"",
+      "defaultValue": "'pie'",
       "description": "Visual variant of the pie chart. Currently supports the default \`pie\` variant and the \`donut\` variant.
 The donut variant provides a slot in the center of the chart that can contain additional information.
 For more information, see \`innerContent\`.",
       "inlineType": {
-        "name": "",
+        "name": ""pie" | "donut"",
         "type": "union",
         "values": [
           "pie",
@@ -12687,9 +13172,9 @@ For more information, see \`innerContent\`.",
     },
     {
       "description": "An array of data segment objects that determines which data segments are currently visible (that is, not filtered out).
+
 - If you don't set this property, segments are filtered automatically when using the default filtering of the component (that is, uncontrolled behavior).
-- If you explicitly set this property, you must set an \`onFilterChange\` listener to update this property when the list of filtered segments changes (that is, controlled behavior).
-",
+- If you explicitly set this property, you must set an \`onFilterChange\` listener to update this property when the list of filtered segments changes (that is, controlled behavior).",
       "name": "visibleSegments",
       "optional": true,
       "type": "ReadonlyArray<T>",
@@ -12783,10 +13268,10 @@ automatically chooses a better direction based on available space.",
         "name": "PopoverProps.Position",
         "type": "union",
         "values": [
-          "top",
-          "right",
-          "bottom",
           "left",
+          "top",
+          "bottom",
+          "right",
         ],
       },
       "name": "position",
@@ -12800,8 +13285,8 @@ automatically chooses a better direction based on available space.",
 Enabling this property will allow the popover to be rendered in the root stack context using
 [React Portals](https://reactjs.org/docs/portals.html).
 Enable this setting if you need the popover to ignore its parent stacking context, such as in side navigation.
-Note: Using popover rendered with portal within a Modal is not supported.
-",
+
+Note: Using popover rendered with portal within a Modal is not supported.",
       "name": "renderWithPortal",
       "optional": true,
       "type": "boolean",
@@ -12839,9 +13324,9 @@ that don't have visible text, and to distinguish between multiple triggers with 
         "name": "PopoverProps.TriggerType",
         "type": "union",
         "values": [
+          "custom",
           "text",
           "text-inline",
-          "custom",
         ],
       },
       "name": "triggerType",
@@ -12880,9 +13365,9 @@ exports[`Documenter definition for progress-bar matches the snapshot: progress-b
     {
       "cancelable": false,
       "description": "Called when the user clicks the result state button.
+
 Note: If you are using the \`flash\` variant, the result button isn't displayed.
-Use the \`buttonText\` property and the \`onButtonClick\` event listener of the flashbar item instead.
-",
+Use the \`buttonText\` property and the \`onButtonClick\` event listener of the flashbar item instead.",
       "name": "onResultButtonClick",
     },
   ],
@@ -12926,27 +13411,27 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "description": "Specifies the text for the button that's displayed when the \`status\` is set to \`error\` or \`success\`.
 If \`resultButtonText\` is empty, the result button isn't displayed.
+
 Note: If you use the \`flash\` variant, the result button isn't displayed.
-Add a button using the \`action\` property of the flashbar item instead.
-",
+Add a button using the \`action\` property of the flashbar item instead.",
       "name": "resultButtonText",
       "optional": true,
       "type": "string",
     },
     {
-      "defaultValue": ""in-progress"",
+      "defaultValue": "'in-progress'",
       "description": "Specifies the status of the progress bar. You can set it to one of the following:
+
 - \`"in-progress"\` - Displays a progress bar.
 - \`"success"\` or \`"error"\` - Displays a result state and replaces the progress element with a status indicator,
-\`resultText\`, and a result button.
-",
+\`resultText\`, and a result button.",
       "inlineType": {
         "name": "ProgressBarProps.Status",
         "type": "union",
         "values": [
+          "error",
           "in-progress",
           "success",
-          "error",
         ],
       },
       "name": "status",
@@ -12961,20 +13446,20 @@ Add a button using the \`action\` property of the flashbar item instead.
       "type": "number",
     },
     {
-      "defaultValue": ""standalone"",
+      "defaultValue": "'standalone'",
       "description": "Enables the correct styling of the progress bar in different contexts. You can set it to one of the following:
+
 - \`"flash"\` - Use this variatn when using the progress bar within a flash component.
              Note that the result button isn't displayed when using this variant.
              Use the \`buttonText\` property and the \`onButtonClick\` event listener of the flashbar item instead of the result button provided by the progress bar.
 - \`"key-value"\` - Use this variant when using the progress bar within the key-value pairs pattern.
-- \`"standalone"\` Use in all other cases. This is the default value.
-",
+- \`"standalone"\` Use in all other cases. This is the default value.",
       "inlineType": {
         "name": "ProgressBarProps.Variant",
         "type": "union",
         "values": [
-          "standalone",
           "flash",
+          "standalone",
           "key-value",
         ],
       },
@@ -12996,8 +13481,8 @@ Add a button using the \`action\` property of the flashbar item instead.
     },
     {
       "description": "Short description of the operation that appears at the top of the component.
-Make sure that you always provide a label for accessibility.
-",
+
+Make sure that you always provide a label for accessibility.",
       "isDefault": false,
       "name": "label",
     },
@@ -13019,7 +13504,7 @@ exports[`Documenter definition for prompt-input matches the snapshot: prompt-inp
       "description": "Called whenever a user clicks the action button or presses the "Enter" key.
 The event \`detail\` contains the current value of the field.",
       "detailInlineType": {
-        "name": "PromptInputProps.ActionDetail",
+        "name": "BaseChangeDetail",
         "properties": [
           {
             "name": "value",
@@ -13029,13 +13514,12 @@ The event \`detail\` contains the current value of the field.",
         ],
         "type": "object",
       },
-      "detailType": "PromptInputProps.ActionDetail",
+      "detailType": "BaseChangeDetail",
       "name": "onAction",
     },
     {
       "cancelable": false,
       "description": "Called when input focus is removed from the UI control.",
-      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -13043,7 +13527,7 @@ The event \`detail\` contains the current value of the field.",
       "description": "Called whenever a user changes the input value (by typing or pasting).
 The event \`detail\` contains the current value of the field.",
       "detailInlineType": {
-        "name": "InputProps.ChangeDetail",
+        "name": "BaseChangeDetail",
         "properties": [
           {
             "name": "value",
@@ -13053,13 +13537,12 @@ The event \`detail\` contains the current value of the field.",
         ],
         "type": "object",
       },
-      "detailType": "InputProps.ChangeDetail",
+      "detailType": "BaseChangeDetail",
       "name": "onChange",
     },
     {
       "cancelable": false,
       "description": "Called when input focus is moved to the UI control.",
-      "detailType": "null",
       "name": "onFocus",
     },
     {
@@ -13068,7 +13551,7 @@ The event \`detail\` contains the current value of the field.",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "InputProps.KeyDetail",
+        "name": "BaseKeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -13108,7 +13591,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "InputProps.KeyDetail",
+      "detailType": "BaseKeyDetail",
       "name": "onKeyDown",
     },
     {
@@ -13117,7 +13600,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "InputProps.KeyDetail",
+        "name": "BaseKeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -13157,7 +13640,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "InputProps.KeyDetail",
+      "detailType": "BaseKeyDetail",
       "name": "onKeyUp",
     },
   ],
@@ -13176,23 +13659,23 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
     },
     {
       "description": "Selects a range of text in the textarea control.
+
 See https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/setSelectionRange
 for more details on this method. Be aware that using this method in React has some
-common pitfalls: https://stackoverflow.com/questions/60129605/is-javascripts-setselectionrange-incompatible-with-react-hooks
-",
+common pitfalls: https://stackoverflow.com/questions/60129605/is-javascripts-setselectionrange-incompatible-with-react-hooks",
       "name": "setSelectionRange",
       "parameters": [
         {
           "name": "start",
-          "type": "null | number",
+          "type": "number | null",
         },
         {
           "name": "end",
-          "type": "null | number",
+          "type": "number | null",
         },
         {
           "name": "direction",
-          "type": ""backward" | "forward" | "none"",
+          "type": ""none" | "forward" | "backward"",
         },
       ],
       "returnType": "void",
@@ -13220,6 +13703,29 @@ This property is ignored if you use a predefined icon or if you set your custom 
         "name": "IconProps.Name",
         "type": "union",
         "values": [
+          "search",
+          "map",
+          "filter",
+          "key",
+          "file",
+          "pause",
+          "play",
+          "remove",
+          "copy",
+          "menu",
+          "script",
+          "close",
+          "status-pending",
+          "refresh",
+          "external",
+          "group",
+          "calendar",
+          "ellipsis",
+          "zoom-in",
+          "zoom-out",
+          "download",
+          "security",
+          "edit",
           "add-plus",
           "anchor-link",
           "angle-left-double",
@@ -13238,7 +13744,6 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "backward-10-seconds",
           "bug",
           "call",
-          "calendar",
           "caret-down-filled",
           "caret-down",
           "caret-left-filled",
@@ -13247,20 +13752,14 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "caret-up",
           "check",
           "contact",
-          "close",
           "closed-caption",
           "closed-caption-unavailable",
-          "copy",
           "command-prompt",
           "delete-marker",
-          "download",
           "drag-indicator",
-          "edit",
-          "ellipsis",
           "envelope",
           "exit-full-screen",
           "expand",
-          "external",
           "face-happy",
           "face-happy-filled",
           "face-neutral",
@@ -13268,8 +13767,6 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "face-sad",
           "face-sad-filled",
           "file-open",
-          "file",
-          "filter",
           "flag",
           "folder-open",
           "folder",
@@ -13279,31 +13776,20 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "globe",
           "grid-view",
           "group-active",
-          "group",
           "heart",
           "heart-filled",
           "insert-row",
-          "key",
           "keyboard",
           "list-view",
           "location-pin",
           "lock-private",
-          "map",
-          "menu",
           "microphone",
           "microphone-off",
           "mini-player",
           "multiscreen",
           "notification",
-          "pause",
-          "play",
           "redo",
-          "refresh",
-          "remove",
           "resize-area",
-          "script",
-          "search",
-          "security",
           "settings",
           "send",
           "share",
@@ -13314,7 +13800,6 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "status-in-progress",
           "status-info",
           "status-negative",
-          "status-pending",
           "status-positive",
           "status-stopped",
           "status-warning",
@@ -13344,8 +13829,6 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "view-full",
           "view-horizontal",
           "view-vertical",
-          "zoom-in",
-          "zoom-out",
           "zoom-to-fit",
         ],
       },
@@ -13355,8 +13838,8 @@ This property is ignored if you use a predefined icon or if you set your custom 
     },
     {
       "description": "Specifies the URL of a custom icon. Use this property if the icon you want isn't available.
-If you set both \`actionButtonIconUrl\` and \`actionButtonIconSvg\`, \`actionButtonIconSvg\` will take precedence.
-",
+
+If you set both \`actionButtonIconUrl\` and \`actionButtonIconSvg\`, \`actionButtonIconSvg\` will take precedence.",
       "name": "actionButtonIconUrl",
       "optional": true,
       "type": "string",
@@ -13364,20 +13847,20 @@ If you set both \`actionButtonIconUrl\` and \`actionButtonIconSvg\`, \`actionBut
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-Use this if you don't have a visible label for this control.
-",
+
+Use this if you don't have a visible label for this control.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -13385,11 +13868,11 @@ Use this if you don't have a visible label for this control.
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -13404,12 +13887,21 @@ To use it correctly, define an ID for the element you want to use as label and s
       "description": "Specifies whether to enable a browser's autocomplete functionality for this input.
 In some cases it might be appropriate to disable autocomplete (for example, for security-sensitive fields).
 To use it correctly, set the \`name\` property.
+
 You can either provide a boolean value to set the property to "on" or "off", or specify a string value
-for the [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.
-",
+for the [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.",
+      "inlineType": {
+        "name": "string | boolean",
+        "type": "union",
+        "values": [
+          "string",
+          "false",
+          "true",
+        ],
+      },
       "name": "autoComplete",
       "optional": true,
-      "type": "boolean | string",
+      "type": "string | boolean",
     },
     {
       "description": "Indicates whether the control should be focused as
@@ -13431,9 +13923,9 @@ scrolled out of the viewport.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -13455,6 +13947,15 @@ of the user's browser.",
       "type": "boolean",
     },
     {
+      "description": "Specifies if the control is disabled, which prevents the
+user from modifying the value and prevents the value from
+being included in a form submission. A disabled control can't
+receive focus.",
+      "name": "disabled",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
       "description": "Determines whether the secondary actions area of the input has padding. If true, removes the default padding from the secondary actions area.",
       "name": "disableSecondaryActionsPaddings",
       "optional": true,
@@ -13463,15 +13964,6 @@ of the user's browser.",
     {
       "description": "Determines whether the secondary content area of the input has padding. If true, removes the default padding from the secondary content area.",
       "name": "disableSecondaryContentPaddings",
-      "optional": true,
-      "type": "boolean",
-    },
-    {
-      "description": "Specifies if the control is disabled, which prevents the
-user from modifying the value and prevents the value from
-being included in a form submission. A disabled control can't
-receive focus.",
-      "name": "disabled",
       "optional": true,
       "type": "boolean",
     },
@@ -13525,8 +14017,8 @@ Defaults to 3. Use -1 for infinite rows.",
       "description": "Specifies if the control is read-only, which prevents the
 user from modifying the value but includes it in a form
 submission. A read-only control can receive focus.
-Don't use read-only inputs outside a form.
-",
+
+Don't use read-only inputs outside a form.",
       "name": "readOnly",
       "optional": true,
       "type": "boolean",
@@ -13536,10 +14028,10 @@ Don't use read-only inputs outside a form.
 This value controls the native browser capability to check for spelling/grammar errors.
 If not set, the browser default behavior is to perform spellchecking.
 For more details, check the [spellcheck MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck).
+
 Enhanced spellchecking features of your browser and/or operating system may send input values to external parties.
 Make sure it’s deactivated for fields with sensitive information to prevent
-inadvertently sending data (such as user passwords) to third parties.
-",
+inadvertently sending data (such as user passwords) to third parties.",
       "name": "spellcheck",
       "optional": true,
       "type": "boolean",
@@ -13567,6 +14059,7 @@ with the input using \`ariaDescribedby\`.",
   "regions": [
     {
       "description": "Specifies the SVG of a custom icon.
+
 Use this property if you want your custom icon to inherit colors dictated by variant or hover states.
 When this property is set, the component will be decorated with \`aria-hidden="true"\`. Ensure that the \`svg\` element:
 - has attribute \`focusable="false"\`.
@@ -13583,8 +14076,7 @@ You can still set the stroke to \`currentColor\` to inherit the color of the sur
 If you set both \`actionButtonIconUrl\` and \`actionButtonIconSvg\`, \`iconSvg\` will take precedence.
 
 *Note:* Remember to remove any additional elements (for example: \`defs\`) and related CSS classes from SVG files exported from design software.
-In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.
-",
+In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.",
       "isDefault": false,
       "name": "actionButtonIconSvg",
     },
@@ -13610,29 +14102,45 @@ exports[`Documenter definition for property-filter matches the snapshot: propert
       "cancelable": false,
       "description": "Fired when the \`query\` gets changed. Filter the dataset in response to this event using the values in the \`detail\` object.",
       "detailInlineType": {
-        "name": "PropertyFilterProps.Query",
-        "properties": [],
+        "name": "PropertyFilterQuery",
+        "properties": [
+          {
+            "name": "operation",
+            "optional": false,
+            "type": "PropertyFilterOperation",
+          },
+          {
+            "name": "tokenGroups",
+            "optional": true,
+            "type": "ReadonlyArray<PropertyFilterToken | PropertyFilterTokenGroup>",
+          },
+          {
+            "name": "tokens",
+            "optional": false,
+            "type": "ReadonlyArray<PropertyFilterToken>",
+          },
+        ],
         "type": "object",
       },
-      "detailType": "PropertyFilterProps.Query",
+      "detailType": "PropertyFilterQuery",
       "name": "onChange",
     },
     {
       "cancelable": false,
       "description": "Use this event to asynchronously load filteringOptions, component currently needs.  The detail object contains following properties:
+
 * \`filteringProperty\` - The property for which you need to fetch the options.
 * \`filteringOperator\` - The operator for which you need to fetch the options.
 * \`filteringText\` - The value that you need to use to fetch options.
 * \`firstPage\` - Indicates that you should fetch the first page of options for a \`filteringProperty\` that match the \`filteringText\`.
-* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).
-",
+* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).",
       "detailInlineType": {
         "name": "PropertyFilterProps.LoadItemsDetail",
         "properties": [
           {
             "name": "filteringOperator",
             "optional": true,
-            "type": "PropertyFilterProps.ComparisonOperator",
+            "type": "string",
           },
           {
             "name": "filteringProperty",
@@ -13674,12 +14182,12 @@ exports[`Documenter definition for property-filter matches the snapshot: propert
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -13687,11 +14195,11 @@ and set the property to a string of each ID separated by spaces (for example, \`
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -13713,9 +14221,9 @@ events to fire calling for more properties.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -13724,9 +14232,9 @@ is provided by its parent form field component.
       "description": "Accepts a human-readable, localized string that indicates the number of results. For example, "1 match" or "165 matches."
 If the total number of results is unknown, also include an indication that there may be more results than
 the number listed. For example, "25+ matches."
+
 The count text is only displayed when \`query.tokens\` isn't empty.
-When the \`countText\` or \`query\` changes, it will be announced to assistive technologies.
-",
+When the \`countText\` or \`query\` changes, it will be announced to assistive technologies.",
       "name": "countText",
       "optional": true,
       "type": "string",
@@ -13734,27 +14242,27 @@ When the \`countText\` or \`query\` changes, it will be announced to assistive t
     {
       "defaultValue": "[]",
       "description": "An array of objects that contain localized, human-readable strings for the labels of custom groups within the filtering dropdown. Use group property to associate the strings with your custom group of options. Define the following values for each group:
+
 * properties [string]: The group label in the filtering dropdown that contains the list of properties from this group. For example: Tags.
 * values [string]: The group label in the filtering dropdown that contains the list of values from this group. For example: Tags values.
-* group [string]: The identifier of a custom group.
-",
+* group [string]: The identifier of a custom group.",
       "name": "customGroupsText",
       "optional": true,
       "type": "Array<PropertyFilterProps.GroupText>",
-    },
-    {
-      "defaultValue": "false",
-      "description": "Set \`disableFreeTextFiltering\` only if you can’t filter the dataset using a filter that is applied to every column,
-instead of a specific property. This would stop the user from creating such tokens.",
-      "name": "disableFreeTextFiltering",
-      "optional": true,
-      "type": "boolean",
     },
     {
       "description": "If set to \`true\`, the filtering input will be disabled.
 Use it, for example, if you are fetching new items upon filtering change
 in order to prevent the user from changing the filtering query.",
       "name": "disabled",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
+      "defaultValue": "false",
+      "description": "Set \`disableFreeTextFiltering\` only if you can’t filter the dataset using a filter that is applied to every column,
+instead of a specific property. This would stop the user from creating such tokens.",
+      "name": "disableFreeTextFiltering",
       "optional": true,
       "type": "boolean",
     },
@@ -13770,12 +14278,12 @@ When \`true\`, the \`query.tokens\` property is ignored and \`query.tokenGroups\
       "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
+
 Set this property if the dropdown would otherwise be constrained by a scrollable container,
 for example inside table and split view layouts.
 
 We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.
-",
+because fixed positioning results in a slight, visible lag when scrolling complex pages.",
       "name": "expandToViewport",
       "optional": true,
       "type": "boolean",
@@ -13808,6 +14316,7 @@ See the [Autosuggest API](/components/autosuggest/?tabId=api) page for more deta
     {
       "defaultValue": "[]",
       "description": "An array of possible values of the individual \`filteringProperties\`. Each element has the following properties:
+
 * \`propertyKey\` [string]: The key of the corresponding filtering property in the \`filteringProperties\` array.
 * \`value\` [string]: The value that will be used as a suggestion when creating or modifying a filtering token.
 * \`label\` [string]: Optional suggestion label to be matched instead of the value.
@@ -13824,11 +14333,10 @@ const filteringOptions = [
   { propertyKey: 'state', value: 'STOPPING', label: getStateLabel('STOPPING') },
   { propertyKey: 'state', value: 'RUNNING', label: getStateLabel('RUNNING') },
 ]
-\`\`\`
-",
+\`\`\`",
       "name": "filteringOptions",
       "optional": true,
-      "type": "ReadonlyArray<PropertyFilterProps.FilteringOption>",
+      "type": "ReadonlyArray<PropertyFilterOption>",
     },
     {
       "description": "Placeholder for the filtering input.",
@@ -13838,13 +14346,13 @@ const filteringOptions = [
     },
     {
       "description": "An array of properties by which the data set can be filtered. Each element has the following properties:
+
 * groupValuesLabel [string]: Localized string to display for the 'Values' group label for a specific property.
 * key [string]: The identifier of this property.
 * propertyLabel [string]: A human-readable string for the property.
 * operators [Array]: A list of all operators supported by this property. If you omit the equals operator because your API does not support it, make sure to set \`defaultOperator\` to a supported operator from this list.
 * group [string]: Optional identifier of a custom group that this filtering option is assigned to. Use to create additional groups below the default one. Make sure to also define labels for the group in the customGroupsText property. Notice that only one level of options nesting is supported.
-* defaultOperator [ComparisonOperator]: Optional parameter that changes the default operator used with this filtering property. Use it only if your API does not support "equals" filtering terms with this property.
-",
+* defaultOperator [ComparisonOperator]: Optional parameter that changes the default operator used with this filtering property. Use it only if your API does not support "equals" filtering terms with this property.",
       "name": "filteringProperties",
       "optional": false,
       "type": "ReadonlyArray<PropertyFilterProps.FilteringProperty>",
@@ -13866,10 +14374,10 @@ Use the \`onLoadItems\` event to perform a recovery action (for example, retryin
         "name": "DropdownStatusProps.StatusType",
         "type": "union",
         "values": [
-          "pending",
-          "loading",
-          "finished",
           "error",
+          "finished",
+          "loading",
+          "pending",
         ],
       },
       "name": "filteringStatusType",
@@ -13878,17 +14386,28 @@ Use the \`onLoadItems\` event to perform a recovery action (for example, retryin
     },
     {
       "description": "An object configuring the operators for free text filtering, which has the following properties:
+
 * operators [Array]: A list of all operators supported for free text filtering. If you omit the contains operator because your API does not support it, make sure to set \`defaultOperator\` to a supported operator from this list.
-* defaultOperator [ComparisonOperator]: An optional parameter that changes the default operator used for free text filtering. Use this parameter only if your API does not support "contains" free test filtering terms.
-",
+* defaultOperator [ComparisonOperator]: An optional parameter that changes the default operator used for free text filtering. Use this parameter only if your API does not support "contains" free test filtering terms.",
       "inlineType": {
-        "name": "PropertyFilterProps.FreeTextFiltering",
-        "properties": [],
+        "name": "PropertyFilterFreeTextFiltering",
+        "properties": [
+          {
+            "name": "defaultOperator",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "operators",
+            "optional": true,
+            "type": "ReadonlyArray<string>",
+          },
+        ],
         "type": "object",
       },
       "name": "freeTextFiltering",
       "optional": true,
-      "type": "PropertyFilterProps.FreeTextFiltering",
+      "type": "PropertyFilterFreeTextFiltering",
     },
     {
       "defaultValue": "false",
@@ -13896,8 +14415,8 @@ Use the \`onLoadItems\` event to perform a recovery action (for example, retryin
 (applied to the property and value token) are hidden from the user. Only use when you have a custom
 filtering logic which combines tokens in different way than the default one. When used, ensure that
 operations are communicated to the user in another way.
-This property cannot be set when \`enableTokenGroups=true\`.
-",
+
+This property cannot be set when \`enableTokenGroups=true\`.",
       "name": "hideOperations",
       "optional": true,
       "type": "boolean",
@@ -13961,12 +14480,12 @@ This property cannot be set when \`enableTokenGroups=true\`.
           {
             "name": "formatToken",
             "optional": true,
-            "type": "(token: PropertyFilterProps.FormattedToken) => string",
+            "type": "((token: PropertyFilterProps.FormattedToken) => string)",
           },
           {
             "name": "groupEditAriaLabel",
             "optional": true,
-            "type": "(group: PropertyFilterProps.FormattedTokenGroup) => string",
+            "type": "((group: PropertyFilterProps.FormattedTokenGroup) => string)",
           },
           {
             "name": "groupPropertiesText",
@@ -14039,12 +14558,12 @@ This property cannot be set when \`enableTokenGroups=true\`.
             "type": "string",
           },
           {
-            "name": "operatorText",
+            "name": "operatorsText",
             "optional": true,
             "type": "string",
           },
           {
-            "name": "operatorsText",
+            "name": "operatorText",
             "optional": true,
             "type": "string",
           },
@@ -14056,17 +14575,17 @@ This property cannot be set when \`enableTokenGroups=true\`.
           {
             "name": "removeTokenButtonAriaLabel",
             "optional": true,
-            "type": "(token: PropertyFilterProps.FormattedToken) => string",
+            "type": "((token: PropertyFilterProps.FormattedToken) => string)",
           },
           {
             "name": "tokenEditorAddExistingTokenAriaLabel",
             "optional": true,
-            "type": "(token: PropertyFilterProps.FormattedToken) => string",
+            "type": "((token: PropertyFilterProps.FormattedToken) => string)",
           },
           {
             "name": "tokenEditorAddExistingTokenLabel",
             "optional": true,
-            "type": "(token: PropertyFilterProps.FormattedToken) => string",
+            "type": "((token: PropertyFilterProps.FormattedToken) => string)",
           },
           {
             "name": "tokenEditorAddNewTokenLabel",
@@ -14081,12 +14600,12 @@ This property cannot be set when \`enableTokenGroups=true\`.
           {
             "name": "tokenEditorTokenActionsAriaLabel",
             "optional": true,
-            "type": "(token: PropertyFilterProps.FormattedToken) => string",
+            "type": "((token: PropertyFilterProps.FormattedToken) => string)",
           },
           {
             "name": "tokenEditorTokenRemoveAriaLabel",
             "optional": true,
-            "type": "(token: PropertyFilterProps.FormattedToken) => string",
+            "type": "((token: PropertyFilterProps.FormattedToken) => string)",
           },
           {
             "name": "tokenEditorTokenRemoveFromGroupLabel",
@@ -14146,19 +14665,35 @@ If set to \`true\`, the live announcement of countText by assistive technologies
 The \`operation\` property has two valid values: "and", "or", and controls the join operation to be applied between tokens when filtering the items.
 The \`tokens\` property is an array of objects that will be displayed to the user beneath the filtering input. When \`enableTokenGroups=true\`, the
 \`tokenGroups\` property is used instead, which supports nested tokens.
+
 Each token has the following properties:
 * value [unknown]: The value of the token to be used as a filter. Can be null or string for default tokens, string[] for enum tokens, and anything for tokens with custom forms.
 * propertyKey [string]: The key of the corresponding property in filteringProperties.
-* operator ['<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^' | '!^']: The operator which indicates how to filter the dataset using this token.
-",
+* operator ['<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^' | '!^']: The operator which indicates how to filter the dataset using this token.",
       "inlineType": {
-        "name": "PropertyFilterProps.Query",
-        "properties": [],
+        "name": "PropertyFilterQuery",
+        "properties": [
+          {
+            "name": "operation",
+            "optional": false,
+            "type": "PropertyFilterOperation",
+          },
+          {
+            "name": "tokenGroups",
+            "optional": true,
+            "type": "ReadonlyArray<PropertyFilterToken | PropertyFilterTokenGroup>",
+          },
+          {
+            "name": "tokens",
+            "optional": false,
+            "type": "ReadonlyArray<PropertyFilterToken>",
+          },
+        ],
         "type": "object",
       },
       "name": "query",
       "optional": false,
-      "type": "PropertyFilterProps.Query",
+      "type": "PropertyFilterQuery",
     },
     {
       "description": "Specifies the maximum number of displayed tokens. If the property isn't set, all of the tokens are displayed.",
@@ -14261,12 +14796,12 @@ If the radio group controls any secondary content (for example, another form fie
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -14281,11 +14816,11 @@ don't set this property because the form field component automatically sets the 
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -14305,7 +14840,11 @@ To use it correctly, define an ID for the element you want to use as label and s
     },
     {
       "deprecatedTag": "Has no effect.",
-      "description": "",
+      "description": "Specifies the ID of the native form element. You can use it to relate
+a label element's \`for\` attribute to this control.
+
+It defaults to an automatically generated ID that
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -14321,13 +14860,13 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Specifies an array of radio buttons to display. Each of these objects have the following properties:
+
 - \`value\` (string) - Sets the value of the radio button. Assigned to the radio group when a user selects the radio button.
 - \`label\` (ReactNode) - Specifies a label for the radio button.
 - \`description\` (ReactNode) - (Optional) Specifies descriptive text that appears below the label.
 - \`disabled\` (boolean) - (Optional) Determines whether the radio button is disabled, which prevents the user from selecting it.
 - \`controlId\` (string) - (Optional) Sets the ID of the internal input. You can use it to relate a label element's \`for\` attribute to this control.
-       In general it's not recommended to set this because the ID is automatically set by the radio group component.
-",
+       In general it's not recommended to set this because the ID is automatically set by the radio group component.",
       "name": "items",
       "optional": true,
       "type": "ReadonlyArray<RadioGroupProps.RadioButtonDefinition>",
@@ -14351,7 +14890,7 @@ being included in a form submission. A read-only control is still focusable.",
 If you want to clear the selection, use \`null\`.",
       "name": "value",
       "optional": false,
-      "type": "null | string",
+      "type": "string | null",
     },
   ],
   "regions": [],
@@ -14399,12 +14938,12 @@ path of the selected resource and \`errorText\` that may contain a validation er
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -14418,11 +14957,11 @@ and set the property to a string of each ID separated by spaces (for example, \`
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -14431,9 +14970,20 @@ To use it correctly, define an ID for the element you want to use as label and s
       "description": "Optionally overrides whether a bucket should be disabled for selection in the Buckets view or not.
 It has higher priority than \`selectableItemsTypes\`. Example: if \`selectableItemsTypes\` has \`['buckets']\` value and
 \`bucketsIsItemDisabled\` returns false for a bucket, then the bucket is disabled for selection.",
+      "inlineType": {
+        "name": "(item: S3ResourceSelectorProps.Bucket) => boolean",
+        "parameters": [
+          {
+            "name": "item",
+            "type": "S3ResourceSelectorProps.Bucket",
+          },
+        ],
+        "returnType": "boolean",
+        "type": "function",
+      },
       "name": "bucketsIsItemDisabled",
       "optional": true,
-      "type": "(item: S3ResourceSelectorProps.Bucket) => boolean",
+      "type": "((item: S3ResourceSelectorProps.Bucket) => boolean)",
     },
     {
       "defaultValue": "['Name', 'CreationDate']",
@@ -14456,6 +15006,12 @@ that resolves to a list of objects with the following properties:
 - \`Name\` (string) - Name of the bucket.
 - \`CreationDate\` (string) - (Optional) Creation date of the bucket.
 - \`Region\` (string) - (Optional) Region of the bucket.",
+      "inlineType": {
+        "name": "() => Promise<ReadonlyArray<S3ResourceSelectorProps.Bucket>>",
+        "parameters": [],
+        "returnType": "Promise<ReadonlyArray<S3ResourceSelectorProps.Bucket>>",
+        "type": "function",
+      },
       "name": "fetchBuckets",
       "optional": false,
       "type": "() => Promise<ReadonlyArray<S3ResourceSelectorProps.Bucket>>",
@@ -14467,6 +15023,21 @@ The return type of the function should be a promise that resolves to a list of o
 - \`LastModified\` (string) - (Optional) Date when this object was last modified.
 - \`Size\` (number) - (Optional) Size of the object.
 - \`IsFolder\` (boolean) - (Optional)  Determines whether the entry is an object prefix (folder).",
+      "inlineType": {
+        "name": "(bucketName: string, pathPrefix: string) => Promise<ReadonlyArray<S3ResourceSelectorProps.Object>>",
+        "parameters": [
+          {
+            "name": "bucketName",
+            "type": "string",
+          },
+          {
+            "name": "pathPrefix",
+            "type": "string",
+          },
+        ],
+        "returnType": "Promise<ReadonlyArray<S3ResourceSelectorProps.Object>>",
+        "type": "function",
+      },
       "name": "fetchObjects",
       "optional": false,
       "type": "(bucketName: string, pathPrefix: string) => Promise<ReadonlyArray<S3ResourceSelectorProps.Object>>",
@@ -14477,6 +15048,21 @@ The return type of the function should be a promise that resolves to a list of v
 - \`VersionId\` (string) - Version ID of an object.
 - \`LastModified\` (string) - (Optional) Date when this object was last modified.
 - \`Size\` (number) - (Optional) Size of the object version.",
+      "inlineType": {
+        "name": "(bucketName: string, pathPrefix: string) => Promise<ReadonlyArray<S3ResourceSelectorProps.Version>>",
+        "parameters": [
+          {
+            "name": "bucketName",
+            "type": "string",
+          },
+          {
+            "name": "pathPrefix",
+            "type": "string",
+          },
+        ],
+        "returnType": "Promise<ReadonlyArray<S3ResourceSelectorProps.Version>>",
+        "type": "function",
+      },
       "name": "fetchVersions",
       "optional": false,
       "type": "(bucketName: string, pathPrefix: string) => Promise<ReadonlyArray<S3ResourceSelectorProps.Version>>",
@@ -14484,9 +15070,15 @@ The return type of the function should be a promise that resolves to a list of v
     {
       "description": "Use this property to specify a different dynamic modal root for the dialog.
 The function will be called when a user clicks on the trigger button.",
+      "inlineType": {
+        "name": "() => Promise<HTMLElement>",
+        "parameters": [],
+        "returnType": "Promise<HTMLElement>",
+        "type": "function",
+      },
       "name": "getModalRoot",
       "optional": true,
-      "type": "() => Promise<HTMLElement>",
+      "type": "(() => Promise<HTMLElement>)",
     },
     {
       "description": "An object containing all the necessary localized strings required by the component.",
@@ -14552,7 +15144,7 @@ The function will be called when a user clicks on the trigger button.",
           {
             "name": "filteringCounterText",
             "optional": true,
-            "type": "(count: number) => string",
+            "type": "((count: number) => string)",
           },
           {
             "name": "filteringNoMatches",
@@ -14622,7 +15214,7 @@ The function will be called when a user clicks on the trigger button.",
           {
             "name": "labelFiltering",
             "optional": true,
-            "type": "(itemsType: string) => string",
+            "type": "((itemsType: string) => string)",
           },
           {
             "name": "labelIconFolder",
@@ -14650,16 +15242,6 @@ The function will be called when a user clicks on the trigger button.",
             "type": "string",
           },
           {
-            "name": "labelSortedAscending",
-            "optional": true,
-            "type": "SortingColumnContainingString",
-          },
-          {
-            "name": "labelSortedDescending",
-            "optional": true,
-            "type": "SortingColumnContainingString",
-          },
-          {
             "name": "labelsBucketsSelection",
             "optional": true,
             "type": "SelectionLabels<S3ResourceSelectorProps.Bucket>",
@@ -14668,6 +15250,16 @@ The function will be called when a user clicks on the trigger button.",
             "name": "labelsObjectsSelection",
             "optional": true,
             "type": "SelectionLabels<S3ResourceSelectorProps.Object>",
+          },
+          {
+            "name": "labelSortedAscending",
+            "optional": true,
+            "type": "SortingColumnContainingString",
+          },
+          {
+            "name": "labelSortedDescending",
+            "optional": true,
+            "type": "SortingColumnContainingString",
           },
           {
             "name": "labelsPagination",
@@ -14808,11 +15400,11 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "description": "Adds \`aria-labelledby\` to the S3 URI input. If you're using this component within a form field,
 you do not need to set this property, as the form field component will set it automatically.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "inputAriaDescribedby",
       "optional": true,
       "type": "string",
@@ -14832,9 +15424,20 @@ To use it correctly, define an ID for the element you want to use as label and s
     {
       "description": "Optionally overrides whether an object should be disabled for selection in the Objects view or not. Similar to
 \`bucketsIsItemDisabled\` this property takes precedence over the \`selectableItemsTypes\` property.",
+      "inlineType": {
+        "name": "(item: S3ResourceSelectorProps.Object) => boolean",
+        "parameters": [
+          {
+            "name": "item",
+            "type": "S3ResourceSelectorProps.Object",
+          },
+        ],
+        "returnType": "boolean",
+        "type": "function",
+      },
       "name": "objectsIsItemDisabled",
       "optional": true,
-      "type": "(item: S3ResourceSelectorProps.Object) => boolean",
+      "type": "((item: S3ResourceSelectorProps.Object) => boolean)",
     },
     {
       "defaultValue": "['Key', 'LastModified', 'Size']",
@@ -14848,9 +15451,20 @@ and 'Size'.",
       "description": "Use this property when \`getModalRoot\` is used to clean up the modal root
 element after a user closes the dialog. The function receives the return value
 of the most recent getModalRoot call as an argument.",
+      "inlineType": {
+        "name": "(rootElement: HTMLElement) => void",
+        "parameters": [
+          {
+            "name": "rootElement",
+            "type": "HTMLElement",
+          },
+        ],
+        "returnType": "void",
+        "type": "function",
+      },
       "name": "removeModalRoot",
       "optional": true,
-      "type": "(rootElement: HTMLElement) => void",
+      "type": "((rootElement: HTMLElement) => void)",
     },
     {
       "description": "The current selected resource. Resource has the following properties:
@@ -14892,9 +15506,20 @@ customizing \`objectsIsItemDisabled\` function).",
     {
       "description": "Optionally overrides whether a version should be disabled for selection in the Versions view or not. Similar to
 \`bucketsIsItemDisabled\` this property takes precedence over the \`selectableItemsTypes\` property.",
+      "inlineType": {
+        "name": "(item: S3ResourceSelectorProps.Version) => boolean",
+        "parameters": [
+          {
+            "name": "item",
+            "type": "S3ResourceSelectorProps.Version",
+          },
+        ],
+        "returnType": "boolean",
+        "type": "function",
+      },
       "name": "versionsIsItemDisabled",
       "optional": true,
-      "type": "(item: S3ResourceSelectorProps.Version) => boolean",
+      "type": "((item: S3ResourceSelectorProps.Version) => boolean)",
     },
     {
       "defaultValue": "['ID', 'LastModified', 'Size']",
@@ -14978,6 +15603,7 @@ the label is visible and attached to the select component, unless \`ariaLabelled
     },
     {
       "description": "An array of objects representing options. Each segment has the following properties:
+
 - \`id\` (string) - The ID of the segment.
 - \`disabled\` [boolean] - (Optional) Determines whether the segment is disabled, which prevents the user from selecting it.
 - \`disabledReason\` (string) - (Optional) Displays tooltip near the segment when disabled. Use to provide additional context.
@@ -14986,8 +15612,7 @@ the label is visible and attached to the select component, unless \`ariaLabelled
            This is required when you use an icon without \`text\`.
 - \`iconUrl\` (string) - (Optional) Specifies the URL of a custom icon.
 - \`iconSvg\` (ReactNode) - (Optional) Custom SVG icon. Equivalent to the \`svg\` slot of the [icon component](/components/icon/).
-- \`text\` (string) - (Optional) Specifies the text of the segment.
-",
+- \`text\` (string) - (Optional) Specifies the text of the segment.",
       "name": "options",
       "optional": true,
       "type": "ReadonlyArray<SegmentedControlProps.Option>",
@@ -14996,7 +15621,7 @@ the label is visible and attached to the select component, unless \`ariaLabelled
       "description": "ID of the selected option. If you want to clear the selection, use \`null\`.",
       "name": "selectedId",
       "optional": false,
-      "type": "null | string",
+      "type": "string | null",
     },
   ],
   "regions": [],
@@ -15022,7 +15647,7 @@ The event \`detail\` contains the current \`selectedOption\`.",
           {
             "name": "selectedOption",
             "optional": false,
-            "type": "SelectProps.Option",
+            "type": "OptionDefinition",
           },
         ],
         "type": "object",
@@ -15038,6 +15663,7 @@ The event \`detail\` contains the current \`selectedOption\`.",
     {
       "cancelable": false,
       "description": "Use this event to implement the asynchronous behavior for the component.
+
 The event is called in the following situations:
 * The user scrolls to the end of the list of options, if \`statusType\` is set to \`pending\`.
 * The user clicks on the recovery button in the error state.
@@ -15047,8 +15673,7 @@ The event is called in the following situations:
 The detail object contains the following properties:
 * \`filteringText\` - The value that you need to use to fetch options.
 * \`firstPage\` - Indicates that you should fetch the first page of options that match the \`filteringText\`.
-* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).
-",
+* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).",
       "detailInlineType": {
         "name": "OptionsLoadItemsDetail",
         "properties": [
@@ -15087,12 +15712,12 @@ The detail object contains the following properties:
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -15107,11 +15732,11 @@ Use this if you don't have a visible label for this control.",
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't using \`inlineLabelText\` and isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -15164,12 +15789,12 @@ To use it correctly, define an ID for the element you want to use as label and s
       "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
+
 Set this property if the dropdown would otherwise be constrained by a scrollable container,
 for example inside table and split view layouts.
 
 We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.
-",
+because fixed positioning results in a slight, visible lag when scrolling complex pages.",
       "name": "expandToViewport",
       "optional": true,
       "type": "boolean",
@@ -15195,13 +15820,29 @@ because fixed positioning results in a slight, visible lag when scrolling comple
     },
     {
       "description": "Specifies the text to display with the number of matches at the bottom of the dropdown menu while filtering.",
+      "inlineType": {
+        "name": "(matchesCount: number, totalCount: number) => string",
+        "parameters": [
+          {
+            "name": "matchesCount",
+            "type": "number",
+          },
+          {
+            "name": "totalCount",
+            "type": "number",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
       "name": "filteringResultsText",
       "optional": true,
-      "type": "(matchesCount: number, totalCount: number) => string",
+      "type": "((matchesCount: number, totalCount: number) => string)",
     },
     {
       "defaultValue": "'none'",
       "description": "Determines how filtering is applied to the list of \`options\`:
+
 * \`auto\` - The component will automatically filter options based on user input.
 * \`manual\` - You will set up \`onChange\` or \`onLoadItems\` event listeners and filter options on your side or request
 them from server.
@@ -15214,14 +15855,13 @@ If you set this property to \`manual\`, this default filtering mechanism is disa
 displayed in the dropdown list. In that case make sure that you use the \`onChange\` or \`onLoadItems\` events in order
 to set the \`options\` property to the options that are relevant for the user, given the filtering input value.
 
-Note: Manual filtering doesn't disable match highlighting.
-",
+Note: Manual filtering doesn't disable match highlighting.",
       "inlineType": {
         "name": "OptionsFilteringType",
         "type": "union",
         "values": [
-          "none",
           "auto",
+          "none",
           "manual",
         ],
       },
@@ -15269,7 +15909,6 @@ single form field.",
     },
     {
       "deprecatedTag": "Has no effect.",
-      "description": "",
       "name": "name",
       "optional": true,
       "type": "string",
@@ -15278,6 +15917,7 @@ single form field.",
       "defaultValue": "[]",
       "description": "Specifies an array of options that are displayed to the user as a dropdown list.
 The options can be grouped using \`OptionGroup\` objects.
+
 #### Option
 - \`value\` (string) - The returned value of the option when selected.
 
@@ -15305,13 +15945,7 @@ If you want to use the built-in filtering capabilities of this component, provid
 a list of all valid options here and they will be automatically filtered based on the user's filtering input.
 
 Alternatively, you can listen to the \`onChange\` or \`onLoadItems\` event and set new options
-on your own.
-",
-      "inlineType": {
-        "name": "SelectProps.Options",
-        "properties": [],
-        "type": "object",
-      },
+on your own.",
       "name": "options",
       "optional": true,
       "type": "SelectProps.Options",
@@ -15344,19 +15978,19 @@ the option's name and properties, and its selected state if
 the \`selectedLabel\` property is defined.
 The highlighted option is provided, and its group (if groups
 are used and it differs from the group of the previously highlighted option).
+
 For more information, see the
-[accessibility guidelines](/components/select/?tabId=usage#accessibility-guidelines).
-",
+[accessibility guidelines](/components/select/?tabId=usage#accessibility-guidelines).",
       "inlineType": {
         "name": "SelectProps.ContainingOptionAndGroupString",
         "parameters": [
           {
             "name": "option",
-            "type": "SelectProps.Option",
+            "type": "OptionDefinition",
           },
           {
             "name": "group",
-            "type": "SelectProps.OptionGroup",
+            "type": "OptionGroup",
           },
         ],
         "returnType": "string",
@@ -15378,9 +16012,85 @@ This is required to provide a good screen reader experience. For more informatio
     {
       "description": "Specifies the currently selected option.
 If you want to clear the selection, use \`null\`.",
+      "inlineType": {
+        "name": "OptionDefinition",
+        "properties": [
+          {
+            "name": "__labelPrefix",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "description",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "disabled",
+            "optional": true,
+            "type": "boolean",
+          },
+          {
+            "name": "disabledReason",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "filteringTags",
+            "optional": true,
+            "type": "ReadonlyArray<string>",
+          },
+          {
+            "name": "iconAlt",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "iconName",
+            "optional": true,
+            "type": "IconProps.Name",
+          },
+          {
+            "name": "iconSvg",
+            "optional": true,
+            "type": "React.ReactNode",
+          },
+          {
+            "name": "iconUrl",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "label",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "labelTag",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "lang",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "tags",
+            "optional": true,
+            "type": "ReadonlyArray<string>",
+          },
+          {
+            "name": "value",
+            "optional": true,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
       "name": "selectedOption",
       "optional": false,
-      "type": "SelectProps.Option | null",
+      "type": "OptionDefinition | null",
     },
     {
       "defaultValue": "'finished'",
@@ -15393,10 +16103,10 @@ If you want to clear the selection, use \`null\`.",
         "name": "DropdownStatusProps.StatusType",
         "type": "union",
         "values": [
-          "pending",
-          "loading",
-          "finished",
           "error",
+          "finished",
+          "loading",
+          "pending",
         ],
       },
       "name": "statusType",
@@ -15423,11 +16133,11 @@ If you want to clear the selection, use \`null\`.",
 that makes the filtering experience smoother. We don't recommend enabling the feature if you
 have less than 500 options, because the improvements to performance are offset by a
 visible scrolling lag.
+
 When you set this flag to \`true\`, it removes options that are not currently in view from the DOM.
 If your test accesses such options, you need to first scroll the options container
 to the correct offset, before performing any operations on them. Use the element returned
-by the \`findOptionsContainer\` test utility for this.
-",
+by the \`findOptionsContainer\` test utility for this.",
       "name": "virtualScroll",
       "optional": true,
       "type": "boolean",
@@ -15470,6 +16180,7 @@ exports[`Documenter definition for side-navigation matches the snapshot: side-na
       "cancelable": false,
       "description": "Fired when the expansion state of \`Section\` or \`ExpandablePageGroup\` items changes
 as a result of a user interaction. The event \`detail\` contains an object with information about the changed item.
+
 - \`item\` (object) - Specifies the item that was changed.
 - \`expanded\` (boolean) - Specifies whether the item is expanded or not.
 - \`expandableParents\` (array) - A list of parent items that have a type of \`Section\`
@@ -15478,15 +16189,14 @@ as a result of a user interaction. The event \`detail\` contains an object with 
     of the navigation items.
 
 Note: If the expansion is a result of the activation of a nested link
-upon changing the \`activeHref\` property, this event isn't raised.
-",
+upon changing the \`activeHref\` property, this event isn't raised.",
       "detailInlineType": {
         "name": "SideNavigationProps.ChangeDetail",
         "properties": [
           {
             "name": "expandableParents",
             "optional": false,
-            "type": "ReadonlyArray<SideNavigationProps.ExpandableLinkGroup | SideNavigationProps.Section>",
+            "type": "ReadonlyArray<SideNavigationProps.Section | SideNavigationProps.ExpandableLinkGroup>",
           },
           {
             "name": "expanded",
@@ -15496,7 +16206,7 @@ upon changing the \`activeHref\` property, this event isn't raised.
           {
             "name": "item",
             "optional": false,
-            "type": "SideNavigationProps.ExpandableLinkGroup | SideNavigationProps.Section",
+            "type": "SideNavigationProps.Section | SideNavigationProps.ExpandableLinkGroup",
           },
         ],
         "type": "object",
@@ -15510,16 +16220,16 @@ upon changing the \`activeHref\` property, this event isn't raised.
 The event \`detail\` contains a definition of the clicked item.
 Use this event to prevent default browser navigation (by calling \`preventDefault\` method)
 and branch your own routing.
+
 If the event is prevented the \`activeHref\` property won't be automatically set
-to the href of the clicked item so you'll have to do it yourself.
-",
+to the href of the clicked item so you'll have to do it yourself.",
       "detailInlineType": {
         "name": "SideNavigationProps.FollowDetail",
         "properties": [
           {
             "name": "external",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "href",
@@ -15544,7 +16254,7 @@ to the href of the clicked item so you'll have to do it yourself.
           {
             "name": "type",
             "optional": true,
-            "type": ""expandable-link-group" | "link" | "link-group" | "section-header"",
+            "type": ""link" | "section-header" | "link-group" | "expandable-link-group"",
           },
         ],
         "type": "object",
@@ -15559,10 +16269,10 @@ to the href of the clicked item so you'll have to do it yourself.
     {
       "description": "Specifies the \`href\` of the currently active link.
 All items within the navigation with a matching \`href\` are highlighted.
+
 \`Sections\` and \`Expandable Page Groups\` that contain a highlighted item
 are automatically expanded, unless their definitions have the \`defaultExpanded\`
-property explicitly set to \`false\`.
-",
+property explicitly set to \`false\`.",
       "name": "activeHref",
       "optional": true,
       "type": "string",
@@ -15576,11 +16286,11 @@ property explicitly set to \`false\`.
     },
     {
       "description": "Controls the header that appears at the top of the navigation component.
+
 It contains the following:
 - \`text\` (string) - Specifies the header text.
 - \`href\` (string) - Specifies the \`href\` that the header links to.
-- \`logo\` (object) - Specifies a logo image.
-",
+- \`logo\` (object) - Specifies a logo image.",
       "inlineType": {
         "name": "SideNavigationProps.Header",
         "properties": [
@@ -15619,6 +16329,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "defaultValue": "[]",
       "description": "Specifies the items to be displayed in the navigation.
 Allowed objects are: \`Link\`, \`Divider\`, \`Section\`, \`LinkGroup\` and \`ExpandableLinkGroup\`.
+
 You can inject extra properties (for example, an ID)
 in order to identify the item when it's used in an event \`detail\`
 (for more information, see the events section below).
@@ -15678,8 +16389,7 @@ Object that represents an expandable group of links.
    If not explicitly set, the group is collapsed by default, unless one of the nested links is active.
 - \`items\` (array) - Specifies the content of the section. You can use any valid item from this list.
     Although there is no technical limitation to the nesting level,
-    our UX recommendation is to use only one level.
-",
+    our UX recommendation is to use only one level.",
       "name": "items",
       "optional": true,
       "type": "ReadonlyArray<SideNavigationProps.Item>",
@@ -15724,28 +16434,28 @@ The event \`detail\` contains the current \`value\`.",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an aria-description for slider labels.
-Use when sliders have formatted reference values.
-",
+
+Use when sliders have formatted reference values.",
       "name": "ariaDescription",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-Use this if you don't have a visible label for this control.
-",
+
+Use this if you don't have a visible label for this control.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -15753,11 +16463,11 @@ Use this if you don't have a visible label for this control.
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -15772,9 +16482,9 @@ To use it correctly, define an ID for the element you want to use as label and s
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -15874,9 +16584,20 @@ being included in a form submission. A read-only control is still focusable.",
     },
     {
       "description": "Formats the values. This will format both the labels and the tooltip.",
+      "inlineType": {
+        "name": "(value: number) => string",
+        "parameters": [
+          {
+            "name": "value",
+            "type": "number",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
       "name": "valueFormatter",
       "optional": true,
-      "type": "(value: number) => string",
+      "type": "((value: number) => string)",
     },
     {
       "description": "Overrides the warning state. Usually the warning state
@@ -15910,8 +16631,8 @@ exports[`Documenter definition for space-between matches the snapshot: space-bet
         "type": "union",
         "values": [
           "center",
-          "start",
           "end",
+          "start",
         ],
       },
       "name": "alignItems",
@@ -15926,14 +16647,14 @@ exports[`Documenter definition for space-between matches the snapshot: space-bet
       "type": "string",
     },
     {
-      "defaultValue": ""vertical"",
+      "defaultValue": "'vertical'",
       "description": "Defines the direction in which the content is laid out.",
       "inlineType": {
         "name": "SpaceBetweenProps.Direction",
         "type": "union",
         "values": [
-          "vertical",
           "horizontal",
+          "vertical",
         ],
       },
       "name": "direction",
@@ -15955,11 +16676,11 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
         "name": "SpaceBetweenProps.Size",
         "type": "union",
         "values": [
+          "s",
+          "m",
           "xxxs",
           "xxs",
           "xs",
-          "s",
-          "m",
           "l",
           "xl",
           "xxl",
@@ -16004,14 +16725,14 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": ""normal"",
+      "defaultValue": "'normal'",
       "description": "Specifies the size of the spinner.",
       "inlineType": {
         "name": "SpinnerProps.Size",
         "type": "union",
         "values": [
-          "normal",
           "big",
+          "normal",
           "large",
         ],
       },
@@ -16020,7 +16741,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": ""normal"",
+      "defaultValue": "'normal'",
       "description": "Specifies the color variant of the spinner. The \`normal\` variant picks up the current color of its context.",
       "inlineType": {
         "name": "SpinnerProps.Variant",
@@ -16055,14 +16776,14 @@ exports[`Documenter definition for split-panel matches the snapshot: split-panel
       "type": "string",
     },
     {
-      "defaultValue": ""collapse"",
+      "defaultValue": "'collapse'",
       "description": "Determines whether the split panel collapses or hides completely when closed.",
       "inlineType": {
-        "name": "",
+        "name": ""hide" | "collapse"",
         "type": "union",
         "values": [
-          "collapse",
           "hide",
+          "collapse",
         ],
       },
       "name": "closeBehavior",
@@ -16083,6 +16804,7 @@ exports[`Documenter definition for split-panel matches the snapshot: split-panel
       "type": "boolean",
     },
     {
+      "defaultValue": "{}",
       "description": "An object containing all the necessary localized strings required by the component.
 - \`closeButtonAriaLabel\` - The text of the panel close button aria label.
 - \`openButtonAriaLabel\` - The text of the panel open button aria label.
@@ -16195,8 +16917,8 @@ exports[`Documenter definition for status-indicator matches the snapshot: status
         "type": "union",
         "values": [
           "blue",
-          "grey",
           "green",
+          "grey",
           "red",
           "yellow",
         ],
@@ -16222,20 +16944,20 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": ""success"",
+      "defaultValue": "'success'",
       "description": "Specifies the status type.",
       "inlineType": {
         "name": "StatusIndicatorProps.Type",
         "type": "union",
         "values": [
           "error",
-          "warning",
-          "success",
-          "info",
-          "stopped",
-          "pending",
           "in-progress",
+          "stopped",
           "loading",
+          "pending",
+          "success",
+          "warning",
+          "info",
         ],
       },
       "name": "type",
@@ -16307,12 +17029,12 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "An array of individual steps
+
 Each step definition has the following properties:
  * \`status\` (string) - Status of the step corresponding to a status indicator.
  * \`statusIconAriaLabel\` - (string) - (Optional) Alternative text for the status icon.
  * \`header\` (ReactNode) - Summary corresponding to the step.
- * \`details\` (ReactNode) - (Optional) Additional information corresponding to the step.
-",
+ * \`details\` (ReactNode) - (Optional) Additional information corresponding to the step.",
       "name": "steps",
       "optional": false,
       "type": "ReadonlyArray<StepsProps.Step>",
@@ -16354,11 +17076,11 @@ validation states, or show warning for unsaved changes.",
       "cancelable": false,
       "description": "Note: This feature is provided for backwards compatibility. Its use is not recommended,
 and it may be deprecated in the future.
+
 Called when the user clicked at a table row. The event detail contains the index of the
-clicked row and the row object itself. Use this event to define a row click behavior.
-",
+clicked row and the row object itself. Use this event to define a row click behavior.",
       "detailInlineType": {
-        "name": "TableProps.OnRowClickDetail",
+        "name": "TableProps.OnRowClickDetail<T>",
         "properties": [
           {
             "name": "item",
@@ -16380,12 +17102,12 @@ clicked row and the row object itself. Use this event to define a row click beha
       "cancelable": true,
       "description": "Note: This feature is provided for backwards compatibility. Its use is not recommended,
 and it may be deprecated in the future.
+
 Called when the user clicked at a table row with the right mouse click. The event detail
 contains the index of the clicked row and the row object itself. Use this event to override
-the default browser context menu behavior.
-",
+the default browser context menu behavior.",
       "detailInlineType": {
-        "name": "TableProps.OnRowContextMenuDetail",
+        "name": "TableProps.OnRowContextMenuDetail<T>",
         "properties": [
           {
             "name": "clientX",
@@ -16418,7 +17140,7 @@ the default browser context menu behavior.
       "description": "Fired when a user interaction triggers a change in the list of selected items.
 The event \`detail\` contains the current list of \`selectedItems\`.",
       "detailInlineType": {
-        "name": "TableProps.SelectionChangeDetail",
+        "name": "TableProps.SelectionChangeDetail<T>",
         "properties": [
           {
             "name": "selectedItems",
@@ -16436,12 +17158,12 @@ The event \`detail\` contains the current list of \`selectedItems\`.",
       "description": "Called when either the column to sort by or the direction of sorting changes upon user interaction.
 The event detail contains the current sortingColumn and isDescending.",
       "detailInlineType": {
-        "name": "TableProps.SortingState",
+        "name": "TableProps.SortingState<T>",
         "properties": [
           {
             "name": "isDescending",
             "optional": true,
-            "type": "false | true",
+            "type": "boolean",
           },
           {
             "name": "sortingColumn",
@@ -16523,37 +17245,37 @@ add a meaningful description to the whole selection.
 * \`collapseButtonLabel\` (Item) => string - Specifies an alternative text for row collapse button.",
       "i18nTag": true,
       "inlineType": {
-        "name": "TableProps.AriaLabels",
+        "name": "TableProps.AriaLabels<T>",
         "properties": [
           {
             "name": "activateEditLabel",
             "optional": true,
-            "type": "(column: TableProps.ColumnDefinition<any>, item: T) => string",
+            "type": "((column: TableProps.ColumnDefinition<any>, item: T) => string)",
           },
           {
             "name": "allItemsSelectionLabel",
             "optional": true,
-            "type": "(data: TableProps.SelectionState<T>) => string",
+            "type": "((data: TableProps.SelectionState<T>) => string)",
           },
           {
             "name": "cancelEditLabel",
             "optional": true,
-            "type": "(column: TableProps.ColumnDefinition<any>) => string",
+            "type": "((column: TableProps.ColumnDefinition<any>) => string)",
           },
           {
             "name": "collapseButtonLabel",
             "optional": true,
-            "type": "(item: T) => string",
+            "type": "((item: T) => string)",
           },
           {
             "name": "expandButtonLabel",
             "optional": true,
-            "type": "(item: T) => string",
+            "type": "((item: T) => string)",
           },
           {
             "name": "itemSelectionLabel",
             "optional": true,
-            "type": "(data: TableProps.SelectionState<T>, row: T) => string",
+            "type": "((data: TableProps.SelectionState<T>, row: T) => string)",
           },
           {
             "name": "resizerRoleDescription",
@@ -16568,17 +17290,17 @@ add a meaningful description to the whole selection.
           {
             "name": "submitEditLabel",
             "optional": true,
-            "type": "(column: TableProps.ColumnDefinition<any>) => string",
+            "type": "((column: TableProps.ColumnDefinition<any>) => string)",
           },
           {
             "name": "submittingEditText",
             "optional": true,
-            "type": "(column: TableProps.ColumnDefinition<any>) => string",
+            "type": "((column: TableProps.ColumnDefinition<any>) => string)",
           },
           {
             "name": "successfulEditLabel",
             "optional": true,
-            "type": "(column: TableProps.ColumnDefinition<any>) => string",
+            "type": "((column: TableProps.ColumnDefinition<any>) => string)",
           },
           {
             "name": "tableLabel",
@@ -16598,11 +17320,11 @@ add a meaningful description to the whole selection.
 This property affects all cells, including the ones in the selection column.
 To target individual cells use \`columnDefinitions.verticalAlign\`, that takes precedence over \`cellVerticalAlign\`.",
       "inlineType": {
-        "name": "",
+        "name": ""top" | "middle"",
         "type": "union",
         "values": [
-          "middle",
           "top",
+          "middle",
         ],
       },
       "name": "cellVerticalAlign",
@@ -16669,10 +17391,10 @@ To target individual cells use \`columnDefinitions.verticalAlign\`, that takes p
     },
     {
       "description": "Specifies an array that represents the table columns in the order in which they will be displayed, together with their visibility.
+
 If not set, all columns are displayed and the order is dictated by the \`columnDefinitions\` property.
 
-Use it in conjunction with the content display preference of the [collection preferences](/components/collection-preferences/) component.
-",
+Use it in conjunction with the content display preference of the [collection preferences](/components/collection-preferences/) component.",
       "name": "columnDisplay",
       "optional": true,
       "type": "ReadonlyArray<TableProps.ColumnDisplayProperties>",
@@ -16681,11 +17403,11 @@ Use it in conjunction with the content display preference of the [collection pre
       "defaultValue": "'comfortable'",
       "description": "Toggles the content density of the table. Defaults to \`'comfortable'\`.",
       "inlineType": {
-        "name": "",
+        "name": ""compact" | "comfortable"",
         "type": "union",
         "values": [
-          "comfortable",
           "compact",
+          "comfortable",
         ],
       },
       "name": "contentDensity",
@@ -16695,8 +17417,8 @@ Use it in conjunction with the content display preference of the [collection pre
     {
       "description": "Use this property to activate advanced keyboard navigation and focusing behaviors.
 When set to \`true\`, table cells become navigable with arrow keys, and the entire table has a single tab stop.
-By default, the keyboard navigation is active for tables with expandable rows.
-",
+
+By default, the keyboard navigation is active for tables with expandable rows.",
       "name": "enableKeyboardNavigation",
       "optional": true,
       "type": "boolean",
@@ -16708,7 +17430,7 @@ By default, the keyboard navigation is active for tables with expandable rows.
 * \`expandedItems\` (Item[]) - Use it to represent the expanded state of items.
 * \`onExpandableItemToggle\` (TableProps.OnExpandableItemToggle<T>) - Called when an item's expand toggle is clicked.",
       "inlineType": {
-        "name": "TableProps.ExpandableRows",
+        "name": "TableProps.ExpandableRows<T>",
         "properties": [
           {
             "name": "expandedItems",
@@ -16718,7 +17440,7 @@ By default, the keyboard navigation is active for tables with expandable rows.
           {
             "name": "getItemChildren",
             "optional": false,
-            "type": "(item: T) => typeOperator",
+            "type": "(item: T) => ReadonlyArray<T>",
           },
           {
             "name": "isItemExpandable",
@@ -16739,8 +17461,8 @@ By default, the keyboard navigation is active for tables with expandable rows.
     },
     {
       "defaultValue": "1",
-      "description": " Use this property to inform screen readers which range of items is currently displayed in the table.
- It specifies the index (1-based) of the first item in the table.",
+      "description": "Use this property to inform screen readers which range of items is currently displayed in the table.
+It specifies the index (1-based) of the first item in the table.",
       "name": "firstIndex",
       "optional": true,
       "type": "number",
@@ -16753,7 +17475,7 @@ table with \`item=null\` and then for each expanded item. The function result is
 * \`finished\` - Indicates that loading has finished and no more requests are expected.
 * \`error\` - Indicates that an error occurred during fetch.",
       "inlineType": {
-        "name": "TableProps.GetLoadingStatus",
+        "name": "TableProps.GetLoadingStatus<T>",
         "parameters": [
           {
             "name": "item",
@@ -16779,7 +17501,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "description": "Determines whether a given item is disabled. If an item is disabled, the user can't select it.",
       "inlineType": {
-        "name": "TableProps.IsItemDisabled",
+        "name": "TableProps.IsItemDisabled<T>",
         "parameters": [
           {
             "name": "item",
@@ -16821,37 +17543,92 @@ The function argument takes the following properties:
 * \`visibleItemsCount\` (number) - The number of rendered table items.
 * \`totalItemsCount\` (optional, number) - The provided \`totalItemsCount\` property.
 Important: in tables with expandable rows the \`firstIndex\`, \`lastIndex\`, and \`totalItemsCount\` reflect the top-level items only.",
+      "inlineType": {
+        "name": "(data: TableProps.LiveAnnouncement) => string",
+        "parameters": [
+          {
+            "name": "data",
+            "type": "TableProps.LiveAnnouncement",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
       "name": "renderAriaLive",
       "optional": true,
-      "type": "(data: TableProps.LiveAnnouncement) => string",
+      "type": "((data: TableProps.LiveAnnouncement) => string)",
     },
     {
       "description": "Renders loader row content for empty row state: the loading status is "finished",
 and the row is expanded but has empty children array.
+
 The empty loader state is only supported for expandable rows. Use \`empty\` slot if
-the table items array is empty.
-",
+the table items array is empty.",
+      "inlineType": {
+        "name": "(detail: TableProps.RenderLoaderEmptyDetail<T>) => React.ReactNode",
+        "parameters": [
+          {
+            "name": "detail",
+            "type": "TableProps.RenderLoaderEmptyDetail<T>",
+          },
+        ],
+        "returnType": "React.ReactNode",
+        "type": "function",
+      },
       "name": "renderLoaderEmpty",
       "optional": true,
-      "type": "(detail: TableProps.RenderLoaderEmptyDetail<T>) => React.ReactNode",
+      "type": "((detail: TableProps.RenderLoaderEmptyDetail<T>) => React.ReactNode)",
     },
     {
       "description": "Renders loader row content for error state.",
+      "inlineType": {
+        "name": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
+        "parameters": [
+          {
+            "name": "detail",
+            "type": "TableProps.RenderLoaderDetail<T>",
+          },
+        ],
+        "returnType": "React.ReactNode",
+        "type": "function",
+      },
       "name": "renderLoaderError",
       "optional": true,
-      "type": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
+      "type": "((detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode)",
     },
     {
       "description": "Renders loader row content for loading state.",
+      "inlineType": {
+        "name": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
+        "parameters": [
+          {
+            "name": "detail",
+            "type": "TableProps.RenderLoaderDetail<T>",
+          },
+        ],
+        "returnType": "React.ReactNode",
+        "type": "function",
+      },
       "name": "renderLoaderLoading",
       "optional": true,
-      "type": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
+      "type": "((detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode)",
     },
     {
       "description": "Renders loader row content for pending state.",
+      "inlineType": {
+        "name": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
+        "parameters": [
+          {
+            "name": "detail",
+            "type": "TableProps.RenderLoaderDetail<T>",
+          },
+        ],
+        "returnType": "React.ReactNode",
+        "type": "function",
+      },
       "name": "renderLoaderPending",
       "optional": true,
-      "type": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
+      "type": "((detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode)",
     },
     {
       "description": "Specifies if columns can be resized. If set to \`true\`, users can resize the columns in the table.",
@@ -16884,12 +17661,12 @@ the table items array is empty.
       "description": "Specifies the definition object of the currently sorted column. Make sure you pass an object that's
 present in the \`columnDefinitions\` array.",
       "inlineType": {
-        "name": "TableProps.SortingColumn",
+        "name": "TableProps.SortingColumn<T>",
         "properties": [
           {
             "name": "sortingComparator",
             "optional": true,
-            "type": "(a: T, b: T) => number",
+            "type": "((a: T, b: T) => number)",
           },
           {
             "name": "sortingField",
@@ -16918,12 +17695,11 @@ to prevent the user from sorting before items are fully loaded.",
     },
     {
       "description": "Specifies the number of first and/or last columns that should be sticky.
+
 If the available scrollable space is less than a certain threshold, the feature is deactivated.
 
 Use it in conjunction with the sticky columns preference of the
-[collection preferences](/components/collection-preferences/) component.
-
-",
+[collection preferences](/components/collection-preferences/) component.",
       "inlineType": {
         "name": "TableProps.StickyColumns",
         "properties": [
@@ -16946,8 +17722,8 @@ Use it in conjunction with the sticky columns preference of the
     },
     {
       "description": "If set to \`true\`, the table header remains visible when the user scrolls down.
-Do not use \`stickyHeader\` conditionally. Instead, keep its value constant during the component lifecycle.
-",
+
+Do not use \`stickyHeader\` conditionally. Instead, keep its value constant during the component lifecycle.",
       "name": "stickyHeader",
       "optional": true,
       "type": "boolean",
@@ -16969,7 +17745,7 @@ need to position the sticky header below other fixed position elements on the pa
       "description": "Specifies a function that will be called after user submits an inline edit.
 Return a promise to keep loading state while the submit request is in progress.",
       "inlineType": {
-        "name": "TableProps.SubmitEditFunction",
+        "name": "TableProps.SubmitEditFunction<T, unknown>",
         "parameters": [
           {
             "name": "item",
@@ -16984,12 +17760,12 @@ Return a promise to keep loading state while the submit request is in progress."
             "type": "ValueType",
           },
         ],
-        "returnType": "Promise<void> | void",
+        "returnType": "void | Promise<void>",
         "type": "function",
       },
       "name": "submitEdit",
       "optional": true,
-      "type": "TableProps.SubmitEditFunction<T>",
+      "type": "TableProps.SubmitEditFunction<T, unknown>",
     },
     {
       "description": "Use this property to inform screen readers how many items there are in a table.
@@ -17003,13 +17779,13 @@ If there is an unknown total of items in a table, leave this property undefined.
       "description": "Specifies a property that uniquely identifies an individual item.
 When it's set, it's used to provide [keys for React](https://reactjs.org/docs/lists-and-keys.html#keys)
 for performance optimizations.
+
 It is also used in the following situations:
 - to connect \`items\` and \`selectedItems\` values when they reference different objects.
 - to connect \`items\` and \`expandableRows.expandedItems\` values when they reference different objects.
-- to attach successful edit state to the correct item if its row index changes after editing.
-",
+- to attach successful edit state to the correct item if its row index changes after editing.",
       "inlineType": {
-        "name": "TableProps.TrackBy",
+        "name": "TableProps.TrackBy<T>",
         "type": "union",
         "values": [
           "string",
@@ -17038,9 +17814,9 @@ It is also used in the following situations:
         "values": [
           "container",
           "embedded",
-          "borderless",
           "stacked",
           "full-page",
+          "borderless",
         ],
       },
       "name": "variant",
@@ -17051,10 +17827,10 @@ It is also used in the following situations:
     {
       "deprecatedTag": "Replaced by \`columnDisplay\`.",
       "description": "Specifies an array containing the \`id\`s of visible columns. If not set, all columns are displayed.
+
 Use it in conjunction with the visible content preference of the [collection preferences](/components/collection-preferences/) component.
 
-The order of ids doesn't influence the order in which columns are displayed - this is dictated by the \`columnDefinitions\` property.
-",
+The order of ids doesn't influence the order in which columns are displayed - this is dictated by the \`columnDefinitions\` property.",
       "name": "visibleColumns",
       "optional": true,
       "type": "ReadonlyArray<string>",
@@ -17215,7 +17991,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": ""automatic"",
+      "defaultValue": "'automatic'",
       "description": "Determines how the active tab is switched when navigating using
 the keyboard. The options are:
 - 'automatic' (default): the active tab is switched using the arrow keys.
@@ -17224,11 +18000,11 @@ We recommend using 'automatic' in most situations to provide consistent
 and quick switching between tabs. Use 'manual' only if there is a specific
 need to introduce friction to the switching of tabs.",
       "inlineType": {
-        "name": "",
+        "name": ""manual" | "automatic"",
         "type": "union",
         "values": [
-          "automatic",
           "manual",
+          "automatic",
         ],
       },
       "name": "keyboardActivationMode",
@@ -17237,6 +18013,7 @@ need to introduce friction to the switching of tabs.",
     },
     {
       "description": "Specifies the tabs to display. Each tab object has the following properties:
+
 - \`id\` (string) - The tab identifier. This value needs to be passed to the Tabs component as \`activeTabId\` to select this tab.
 - \`label\` (ReactNode) - Tab label shown in the UI.
 - \`content\` (ReactNode) - (Optional) Tab content to render in the container.
@@ -17255,16 +18032,15 @@ need to introduce friction to the switching of tabs.",
    if your application routing can handle such deep links. You can manually update routing on the current page
    using the \`activeTabHref\` property of the \`change\` event's detail.
 - \`contentRenderStrategy\` (string) - (Optional) Determines when tab content is rendered:
-- \`'active'\`: (Default) Only render content when the tab is active.
+  - \`'active'\`: (Default) Only render content when the tab is active.
   - \`'eager'\`: Always render tab content (hidden when the tab is not active).
-  - \`'lazy'\`: Like 'eager', but content is only rendered after the tab is first activated.
-",
+  - \`'lazy'\`: Like 'eager', but content is only rendered after the tab is first activated.",
       "name": "tabs",
       "optional": false,
       "type": "ReadonlyArray<TabsProps.Tab>",
     },
     {
-      "defaultValue": ""default"",
+      "defaultValue": "'default'",
       "description": "The possible visual variants of tabs are the following:
 * \`default\` - Use in any context.
 * \`container\` - Use this variant to have the tabs displayed within a container header.
@@ -17390,12 +18166,12 @@ character validation. You should use this property only when absolutely necessar
           {
             "name": "enteredKeyLabel",
             "optional": true,
-            "type": "(enteredText: string) => string",
+            "type": "((enteredText: string) => string)",
           },
           {
             "name": "enteredValueLabel",
             "optional": true,
-            "type": "(enteredText: string) => string",
+            "type": "((enteredText: string) => string)",
           },
           {
             "name": "errorIconAriaLabel",
@@ -17428,17 +18204,17 @@ character validation. You should use this property only when absolutely necessar
             "type": "string",
           },
           {
-            "name": "keySuggestion",
-            "optional": true,
-            "type": "string",
-          },
-          {
             "name": "keysSuggestionError",
             "optional": true,
             "type": "string",
           },
           {
             "name": "keysSuggestionLoading",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "keySuggestion",
             "optional": true,
             "type": "string",
           },
@@ -17470,22 +18246,22 @@ character validation. You should use this property only when absolutely necessar
           {
             "name": "removeButtonAriaLabel",
             "optional": true,
-            "type": "(item: TagEditorProps.Tag) => string",
+            "type": "((item: TagEditorProps.Tag) => string)",
           },
           {
             "name": "tagLimit",
             "optional": true,
-            "type": "(availableTags: number, tagLimit: number) => string",
+            "type": "((availableTags: number, tagLimit: number) => string)",
           },
           {
             "name": "tagLimitExceeded",
             "optional": true,
-            "type": "(tagLimit: number) => string",
+            "type": "((tagLimit: number) => string)",
           },
           {
             "name": "tagLimitReached",
             "optional": true,
-            "type": "(tagLimit: number) => string",
+            "type": "((tagLimit: number) => string)",
           },
           {
             "name": "tooManyKeysSuggestion",
@@ -17518,17 +18294,17 @@ character validation. You should use this property only when absolutely necessar
             "type": "string",
           },
           {
-            "name": "valueSuggestion",
-            "optional": true,
-            "type": "string",
-          },
-          {
             "name": "valuesSuggestionError",
             "optional": true,
             "type": "string",
           },
           {
             "name": "valuesSuggestionLoading",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "valueSuggestion",
             "optional": true,
             "type": "string",
           },
@@ -17552,23 +18328,37 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "description": "Specifies a function that returns all the keys for a resource.
 The expected return type of the function should be a promise that
 resolves to a list of strings of all the keys (for example, \`['key1', 'key2']\`).",
+      "inlineType": {
+        "name": "(key: string) => Promise<ReadonlyArray<string>>",
+        "parameters": [
+          {
+            "name": "key",
+            "type": "string",
+          },
+        ],
+        "returnType": "Promise<ReadonlyArray<string>>",
+        "type": "function",
+      },
       "name": "keysRequest",
       "optional": true,
-      "type": "(key: string) => Promise<ReadonlyArray<string>>",
+      "type": "((key: string) => Promise<ReadonlyArray<string>>)",
     },
     {
+      "defaultValue": "false",
       "description": "Renders the component in a loading state.",
       "name": "loading",
       "optional": true,
       "type": "boolean",
     },
     {
+      "defaultValue": "50",
       "description": "Specifies the maximum number of tags that a customer can add.",
       "name": "tagLimit",
       "optional": true,
       "type": "number",
     },
     {
+      "defaultValue": "[]",
       "description": "Specifies an array of tags that are displayed to the user. Each tag item has the following properties:
 - \`key\` (string) - The key of the tag that's displayed in the corresponding key field.
 - \`value\` (string) - The value of the tag that's displayed in the corresponding value field.
@@ -17587,11 +18377,26 @@ resolves to a list of strings of all the keys (for example, \`['key1', 'key2']\`
       "description": "Specifies a function that returns all the values for a specified key
 of a resource. The expected return type of the function should be a promise
 that resolves to a list of strings of all the values (for example, \`['value1', 'value2']\`).
-You should return a rejected promise when the \`key\` parameter is an empty string.
-",
+
+You should return a rejected promise when the \`key\` parameter is an empty string.",
+      "inlineType": {
+        "name": "(key: string, value: string) => Promise<ReadonlyArray<string>>",
+        "parameters": [
+          {
+            "name": "key",
+            "type": "string",
+          },
+          {
+            "name": "value",
+            "type": "string",
+          },
+        ],
+        "returnType": "Promise<ReadonlyArray<string>>",
+        "type": "function",
+      },
       "name": "valuesRequest",
       "optional": true,
-      "type": "(key: string, value: string) => Promise<ReadonlyArray<string>>",
+      "type": "((key: string, value: string) => Promise<ReadonlyArray<string>>)",
     },
   ],
   "regions": [],
@@ -17686,12 +18491,12 @@ period of time. If you want a delayed handler to invoke a filtering API call, yo
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -17699,11 +18504,11 @@ and set the property to a string of each ID separated by spaces (for example, \`
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -17718,9 +18523,9 @@ To use it correctly, define an ID for the element you want to use as label and s
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -17729,9 +18534,9 @@ is provided by its parent form field component.
       "description": "Accepts a human-readable, localized string that indicates the number of results. For example, "1 match" or "165 matches."
 If the total number of results is unknown, also include an indication that there may be more results than
 the number listed. For example, "25+ matches."
+
 The count text is only displayed when \`filteringText\` isn't empty.
-When the \`countText\` or \`filteringText\` changes, it will be announced to assistive technologies.
-",
+When the \`countText\` or \`filteringText\` changes, it will be announced to assistive technologies.",
       "name": "countText",
       "optional": true,
       "type": "string",
@@ -17806,7 +18611,6 @@ exports[`Documenter definition for textarea matches the snapshot: textarea 1`] =
     {
       "cancelable": false,
       "description": "Called when input focus is removed from the UI control.",
-      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -17814,7 +18618,7 @@ exports[`Documenter definition for textarea matches the snapshot: textarea 1`] =
       "description": "Called whenever a user changes the input value (by typing or pasting).
 The event \`detail\` contains the current value of the field.",
       "detailInlineType": {
-        "name": "InputProps.ChangeDetail",
+        "name": "BaseChangeDetail",
         "properties": [
           {
             "name": "value",
@@ -17824,13 +18628,12 @@ The event \`detail\` contains the current value of the field.",
         ],
         "type": "object",
       },
-      "detailType": "InputProps.ChangeDetail",
+      "detailType": "BaseChangeDetail",
       "name": "onChange",
     },
     {
       "cancelable": false,
       "description": "Called when input focus is moved to the UI control.",
-      "detailType": "null",
       "name": "onFocus",
     },
     {
@@ -17839,7 +18642,7 @@ The event \`detail\` contains the current value of the field.",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "InputProps.KeyDetail",
+        "name": "BaseKeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -17879,7 +18682,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "InputProps.KeyDetail",
+      "detailType": "BaseKeyDetail",
       "name": "onKeyDown",
     },
     {
@@ -17888,7 +18691,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "InputProps.KeyDetail",
+        "name": "BaseKeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -17928,7 +18731,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "InputProps.KeyDetail",
+      "detailType": "BaseKeyDetail",
       "name": "onKeyUp",
     },
   ],
@@ -17945,20 +18748,20 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-Use this if you don't have a visible label for this control.
-",
+
+Use this if you don't have a visible label for this control.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -17966,11 +18769,11 @@ Use this if you don't have a visible label for this control.
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -17986,12 +18789,21 @@ To use it correctly, define an ID for the element you want to use as label and s
       "description": "Specifies whether to enable a browser's autocomplete functionality for this input.
 In some cases it might be appropriate to disable autocomplete (for example, for security-sensitive fields).
 To use it correctly, set the \`name\` property.
+
 You can either provide a boolean value to set the property to "on" or "off", or specify a string value
-for the [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.
-",
+for the [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.",
+      "inlineType": {
+        "name": "string | boolean",
+        "type": "union",
+        "values": [
+          "string",
+          "false",
+          "true",
+        ],
+      },
       "name": "autoComplete",
       "optional": true,
-      "type": "boolean | string",
+      "type": "string | boolean",
     },
     {
       "description": "Indicates whether the control should be focused as
@@ -18013,9 +18825,9 @@ scrolled out of the viewport.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -18085,8 +18897,8 @@ single form field.",
       "description": "Specifies if the control is read-only, which prevents the
 user from modifying the value but includes it in a form
 submission. A read-only control can receive focus.
-Don't use read-only inputs outside a form.
-",
+
+Don't use read-only inputs outside a form.",
       "name": "readOnly",
       "optional": true,
       "type": "boolean",
@@ -18102,10 +18914,10 @@ Don't use read-only inputs outside a form.
 This value controls the native browser capability to check for spelling/grammar errors.
 If not set, the browser default behavior is to perform spellchecking.
 For more details, check the [spellcheck MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck).
+
 Enhanced spellchecking features of your browser and/or operating system may send input values to external parties.
 Make sure it’s deactivated for fields with sensitive information to prevent
-inadvertently sending data (such as user passwords) to third parties.
-",
+inadvertently sending data (such as user passwords) to third parties.",
       "name": "spellcheck",
       "optional": true,
       "type": "boolean",
@@ -18176,12 +18988,12 @@ If the component controls any secondary content (for example, another form field
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -18196,11 +19008,11 @@ because the form field component automatically sets the correct labels to make t
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -18229,9 +19041,9 @@ It is set to 2 if 4 or 8 items are supplied in order to optimize the layout.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -18247,14 +19059,14 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "List of tile definitions. Each tile has the following properties:
+
 - \`value\` [string] - The value that will be associated with the tile. This is the value the tiles will get when the radio button is selected.
 - \`label\` [ReactNode] - A short description for the option the tile represents.
 - \`description\` [ReactNode] - (Optional) Further explanatory guidance on the tile option, shown below the \`label\`.
 - \`image\` [ReactNode] - (Optional) Visually distinctive image for the tile option, shown below the \`description\`.
 - \`disabled\` [boolean] - (Optional) Specifies whether the tile is disabled. Users can't select disabled tiles.
 - \`controlId\` [string] - (Optional) The ID of the internal input. You can use this to relate a label element's \`for\` attribute to this control.
-           We recommend that you don't set this property because it's automatically set by the tiles component.
-",
+           We recommend that you don't set this property because it's automatically set by the tiles component.",
       "name": "items",
       "optional": true,
       "type": "ReadonlyArray<TilesProps.TilesDefinition>",
@@ -18278,7 +19090,7 @@ being included in a form submission. A read-only control is still focusable.",
 If you want to clear the selection, use \`null\`.",
       "name": "value",
       "optional": false,
-      "type": "null | string",
+      "type": "string | null",
     },
   ],
   "regions": [],
@@ -18292,7 +19104,6 @@ exports[`Documenter definition for time-input matches the snapshot: time-input 1
     {
       "cancelable": false,
       "description": "Called when input focus is removed from the UI control.",
-      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -18300,7 +19111,7 @@ exports[`Documenter definition for time-input matches the snapshot: time-input 1
       "description": "Called whenever a user changes the input value (by typing or pasting).
 The event \`detail\` contains the current value of the field.",
       "detailInlineType": {
-        "name": "InputProps.ChangeDetail",
+        "name": "BaseChangeDetail",
         "properties": [
           {
             "name": "value",
@@ -18310,13 +19121,12 @@ The event \`detail\` contains the current value of the field.",
         ],
         "type": "object",
       },
-      "detailType": "InputProps.ChangeDetail",
+      "detailType": "BaseChangeDetail",
       "name": "onChange",
     },
     {
       "cancelable": false,
       "description": "Called when input focus is moved to the UI control.",
-      "detailType": "null",
       "name": "onFocus",
     },
   ],
@@ -18333,20 +19143,20 @@ The event \`detail\` contains the current value of the field.",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-Use this if you don't have a visible label for this control.
-",
+
+Use this if you don't have a visible label for this control.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -18354,11 +19164,11 @@ Use this if you don't have a visible label for this control.
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -18398,9 +19208,9 @@ scrolled out of the viewport.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
+
 It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -18427,8 +19237,8 @@ receive focus.",
     {
       "defaultValue": "'hh:mm:ss'",
       "description": "Specifies the format of the time input.
-Use it to restrict the granularity of time that the user can enter.
-",
+
+Use it to restrict the granularity of time that the user can enter.",
       "inlineType": {
         "name": "TimeInputProps.Format",
         "type": "union",
@@ -18477,8 +19287,8 @@ single form field.",
       "description": "Specifies if the control is read-only, which prevents the
 user from modifying the value but includes it in a form
 submission. A read-only control can receive focus.
-Don't use read-only inputs outside a form.
-",
+
+Don't use read-only inputs outside a form.",
       "name": "readOnly",
       "optional": true,
       "type": "boolean",
@@ -18566,20 +19376,20 @@ If the component controls any secondary content (for example, another form field
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
-",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-Use this if you don't have a visible label for this control.
-",
+
+Use this if you don't have a visible label for this control.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -18587,11 +19397,11 @@ Use this if you don't have a visible label for this control.
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
+
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
-",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -18754,6 +19564,7 @@ If an href is provided, it opens the link in a new tab.",
     },
     {
       "description": "An object containing all the necessary localized strings required by the component. The object should contain:
+
 * \`externalIconAriaLabel\` - (optional) Specifies the aria-label for the external icon when \`external\` is set to \`true\`.",
       "i18nTag": true,
       "inlineType": {
@@ -18777,6 +19588,29 @@ If an href is provided, it opens the link in a new tab.",
         "name": "IconProps.Name",
         "type": "union",
         "values": [
+          "search",
+          "map",
+          "filter",
+          "key",
+          "file",
+          "pause",
+          "play",
+          "remove",
+          "copy",
+          "menu",
+          "script",
+          "close",
+          "status-pending",
+          "refresh",
+          "external",
+          "group",
+          "calendar",
+          "ellipsis",
+          "zoom-in",
+          "zoom-out",
+          "download",
+          "security",
+          "edit",
           "add-plus",
           "anchor-link",
           "angle-left-double",
@@ -18795,7 +19629,6 @@ If an href is provided, it opens the link in a new tab.",
           "backward-10-seconds",
           "bug",
           "call",
-          "calendar",
           "caret-down-filled",
           "caret-down",
           "caret-left-filled",
@@ -18804,20 +19637,14 @@ If an href is provided, it opens the link in a new tab.",
           "caret-up",
           "check",
           "contact",
-          "close",
           "closed-caption",
           "closed-caption-unavailable",
-          "copy",
           "command-prompt",
           "delete-marker",
-          "download",
           "drag-indicator",
-          "edit",
-          "ellipsis",
           "envelope",
           "exit-full-screen",
           "expand",
-          "external",
           "face-happy",
           "face-happy-filled",
           "face-neutral",
@@ -18825,8 +19652,6 @@ If an href is provided, it opens the link in a new tab.",
           "face-sad",
           "face-sad-filled",
           "file-open",
-          "file",
-          "filter",
           "flag",
           "folder-open",
           "folder",
@@ -18836,31 +19661,20 @@ If an href is provided, it opens the link in a new tab.",
           "globe",
           "grid-view",
           "group-active",
-          "group",
           "heart",
           "heart-filled",
           "insert-row",
-          "key",
           "keyboard",
           "list-view",
           "location-pin",
           "lock-private",
-          "map",
-          "menu",
           "microphone",
           "microphone-off",
           "mini-player",
           "multiscreen",
           "notification",
-          "pause",
-          "play",
           "redo",
-          "refresh",
-          "remove",
           "resize-area",
-          "script",
-          "search",
-          "security",
           "settings",
           "send",
           "share",
@@ -18871,7 +19685,6 @@ If an href is provided, it opens the link in a new tab.",
           "status-in-progress",
           "status-info",
           "status-negative",
-          "status-pending",
           "status-positive",
           "status-stopped",
           "status-warning",
@@ -18901,8 +19714,6 @@ If an href is provided, it opens the link in a new tab.",
           "view-full",
           "view-horizontal",
           "view-vertical",
-          "zoom-in",
-          "zoom-out",
           "zoom-to-fit",
         ],
       },
@@ -18912,8 +19723,8 @@ If an href is provided, it opens the link in a new tab.",
     },
     {
       "description": "Specifies the URL of a custom icon. Use this property if the icon you want isn't available.
-If you set both \`iconUrl\` and \`iconSvg\`, \`iconSvg\` will take precedence.
-",
+
+If you set both \`iconUrl\` and \`iconSvg\`, \`iconSvg\` will take precedence.",
       "name": "iconUrl",
       "optional": true,
       "type": "string",
@@ -18954,6 +19765,29 @@ It prevents users from clicking the button, but it can still be focused.",
         "name": "IconProps.Name",
         "type": "union",
         "values": [
+          "search",
+          "map",
+          "filter",
+          "key",
+          "file",
+          "pause",
+          "play",
+          "remove",
+          "copy",
+          "menu",
+          "script",
+          "close",
+          "status-pending",
+          "refresh",
+          "external",
+          "group",
+          "calendar",
+          "ellipsis",
+          "zoom-in",
+          "zoom-out",
+          "download",
+          "security",
+          "edit",
           "add-plus",
           "anchor-link",
           "angle-left-double",
@@ -18972,7 +19806,6 @@ It prevents users from clicking the button, but it can still be focused.",
           "backward-10-seconds",
           "bug",
           "call",
-          "calendar",
           "caret-down-filled",
           "caret-down",
           "caret-left-filled",
@@ -18981,20 +19814,14 @@ It prevents users from clicking the button, but it can still be focused.",
           "caret-up",
           "check",
           "contact",
-          "close",
           "closed-caption",
           "closed-caption-unavailable",
-          "copy",
           "command-prompt",
           "delete-marker",
-          "download",
           "drag-indicator",
-          "edit",
-          "ellipsis",
           "envelope",
           "exit-full-screen",
           "expand",
-          "external",
           "face-happy",
           "face-happy-filled",
           "face-neutral",
@@ -19002,8 +19829,6 @@ It prevents users from clicking the button, but it can still be focused.",
           "face-sad",
           "face-sad-filled",
           "file-open",
-          "file",
-          "filter",
           "flag",
           "folder-open",
           "folder",
@@ -19013,31 +19838,20 @@ It prevents users from clicking the button, but it can still be focused.",
           "globe",
           "grid-view",
           "group-active",
-          "group",
           "heart",
           "heart-filled",
           "insert-row",
-          "key",
           "keyboard",
           "list-view",
           "location-pin",
           "lock-private",
-          "map",
-          "menu",
           "microphone",
           "microphone-off",
           "mini-player",
           "multiscreen",
           "notification",
-          "pause",
-          "play",
           "redo",
-          "refresh",
-          "remove",
           "resize-area",
-          "script",
-          "search",
-          "security",
           "settings",
           "send",
           "share",
@@ -19048,7 +19862,6 @@ It prevents users from clicking the button, but it can still be focused.",
           "status-in-progress",
           "status-info",
           "status-negative",
-          "status-pending",
           "status-positive",
           "status-stopped",
           "status-warning",
@@ -19078,8 +19891,6 @@ It prevents users from clicking the button, but it can still be focused.",
           "view-full",
           "view-horizontal",
           "view-vertical",
-          "zoom-in",
-          "zoom-out",
           "zoom-to-fit",
         ],
       },
@@ -19089,8 +19900,8 @@ It prevents users from clicking the button, but it can still be focused.",
     },
     {
       "description": "Specifies the URL of a custom icon in pressed state. Use this property if the icon needed for your use case isn't available.
-\`pressedIconSvg\` will take precedence if you set both \`pressedIconUrl\` and \`pressedIconSvg\`.
-",
+
+\`pressedIconSvg\` will take precedence if you set both \`pressedIconUrl\` and \`pressedIconSvg\`.",
       "name": "pressedIconUrl",
       "optional": true,
       "type": "string",
@@ -19100,8 +19911,8 @@ It prevents users from clicking the button, but it can still be focused.",
       "description": "Determines the general styling of the toggle button as follows:
 * \`normal\` for secondary buttons.
 * \`icon\` to display an icon only (no text).
-Defaults to \`normal\` if not specified.
-",
+
+Defaults to \`normal\` if not specified.",
       "inlineType": {
         "name": "ToggleButtonProps.Variant",
         "type": "union",
@@ -19131,6 +19942,7 @@ Defaults to \`normal\` if not specified.
     },
     {
       "description": "Specifies the SVG of a custom icon.
+
 Use this property if you want your custom icon to inherit colors dictated by variant or hover states.
 When this property is set, the component will be decorated with \`aria-hidden="true"\`. Ensure that the \`svg\` element:
 - has attribute \`focusable="false"\`.
@@ -19147,13 +19959,13 @@ You can still set the stroke to \`currentColor\` to inherit the color of the sur
 If you set both \`iconUrl\` and \`iconSvg\`, \`iconSvg\` will take precedence.
 
 *Note:* Remember to remove any additional elements (for example: \`defs\`) and related CSS classes from SVG files exported from design software.
-In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.
-",
+In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.",
       "isDefault": false,
       "name": "iconSvg",
     },
     {
       "description": "Specifies the SVG of a custom icon in pressed state.
+
 Use this property if you want your custom icon to inherit colors dictated by variant or hover states.
 When this property is set, the component will be decorated with \`aria-hidden="true"\`. Ensure that the \`svg\` element:
 - has attribute \`focusable="false"\`
@@ -19170,8 +19982,7 @@ You can still set the stroke to \`currentColor\` to inherit the color of the sur
 If you set both \`pressedIconUrl\` and \`pressedIconSvg\`, \`pressedIconSvg\` will take precedence.
 
 *Note:* Remember to remove any additional elements (for example: \`defs\`) and related CSS classes from SVG files exported from design software.
-In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.
-",
+In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.",
       "isDefault": false,
       "name": "pressedIconSvg",
     },
@@ -19185,8 +19996,8 @@ exports[`Documenter definition for token-group matches the snapshot: token-group
   "events": [
     {
       "cancelable": false,
-      "description": " Called when the user clicks on the dismiss button. The token won't be automatically removed.
- Make sure that you add a listener to this event to update your application state.",
+      "description": "Called when the user clicks on the dismiss button. The token won't be automatically removed.
+Make sure that you add a listener to this event to update your application state.",
       "detailInlineType": {
         "name": "TokenGroupProps.DismissDetail",
         "properties": [
@@ -19206,7 +20017,7 @@ exports[`Documenter definition for token-group matches the snapshot: token-group
   "name": "TokenGroup",
   "properties": [
     {
-      "defaultValue": ""horizontal"",
+      "defaultValue": "'horizontal'",
       "description": "Specifies the direction in which tokens are aligned (\`horizontal | vertical\`).",
       "inlineType": {
         "name": "TokenGroupProps.Alignment",
@@ -19268,7 +20079,9 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "defaultValue": "[]",
-      "description": "An array of objects representing token items. Each token has the following properties:
+      "description": "
+An array of objects representing token items. Each token has the following properties:
+
 - \`label\` (string) - Title text of the token.
 - \`description\` (string) - (Optional) Further information about the token that appears below the label.
 - \`disabled\` [boolean] - (Optional) Determines whether the token is disabled.
@@ -19278,8 +20091,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
 - \`iconName\` (string) - (Optional) Specifies the name of an [icon](/components/icon/) to display in the token.
 - \`iconAlt\` (string) - (Optional) Specifies alternate text for a custom icon, for use with \`iconUrl\`.
 - \`iconUrl\` (string) - (Optional) URL of a custom icon.
-- \`iconSvg\` (ReactNode) - (Optional) Custom SVG icon. Equivalent to the \`svg\` slot of the [icon component](/components/icon/).
-",
+- \`iconSvg\` (ReactNode) - (Optional) Custom SVG icon. Equivalent to the \`svg\` slot of the [icon component](/components/icon/).",
       "name": "items",
       "optional": true,
       "type": "ReadonlyArray<TokenGroupProps.Item>",
@@ -19384,11 +20196,11 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Properties describing the product identity. They are as follows:
+
 * \`title\` (string) - Specifies the title text.
 * \`logo\` ({ src: string, alt: string }) - Specifies the logo for the product. Use fixed width and height for SVG images to ensure proper rendering.
 * \`href\` (string) - Specifies the \`href\` that the header links to.
-* \`onFollow\` (() => void) - Specifies the event handler called when the identity is clicked without any modifier keys.
-",
+* \`onFollow\` (() => void) - Specifies the event handler called when the identity is clicked without any modifier keys.",
       "inlineType": {
         "name": "TopNavigationProps.Identity",
         "properties": [
@@ -19405,7 +20217,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
           {
             "name": "onFollow",
             "optional": true,
-            "type": "CancelableEventHandler",
+            "type": "CancelableEventHandler<{}>",
           },
           {
             "name": "title",
@@ -19423,6 +20235,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "defaultValue": "[]",
       "description": "A list of utility navigation elements.
 The supported utility types are: \`button\` and \`menu-dropdown\`.
+
 The following properties are supported across all utility types:
 
 * \`type\` (string) - The type of the utility. Can be \`button\` or \`menu-dropdown\`.
@@ -19454,8 +20267,7 @@ The following properties are supported across all utility types:
 * \`items\` (ButtonDropdownProps.Items) - An array of dropdown items. This follows the same structure as the \`items\` property of the [button dropdown component](/components/button-dropdown), with the exception of the checkbox item type.
 * \`onItemClick\` (NonCancelableEventHandler<ButtonDropdownProps.ItemClickDetails>) - Specifies the event handler called when a dropdown item is selected.
 * \`onItemFollow\` (NonCancelableEventHandler<ButtonDropdownProps.ItemClickDetails>) - Specifies the event handler called when a dropdown item is selected without pressing modifier keys, and the item has an \`href\` set.
-* \`expandableGroups\` (boolean) - Controls expandability of the item groups.
-",
+* \`expandableGroups\` (boolean) - Controls expandability of the item groups.",
       "name": "utilities",
       "optional": true,
       "type": "ReadonlyArray<TopNavigationProps.Utility>",
@@ -19545,6 +20357,11 @@ exports[`Documenter definition for tutorial-panel matches the snapshot: tutorial
             "type": "string",
           },
           {
+            "name": "labelsTaskStatus",
+            "optional": false,
+            "type": "{ pending: string; 'in-progress': string; success: string; }",
+          },
+          {
             "name": "labelTotalSteps",
             "optional": false,
             "type": "(totalStepCount: number) => string",
@@ -19553,11 +20370,6 @@ exports[`Documenter definition for tutorial-panel matches the snapshot: tutorial
             "name": "labelTutorialListDownloadLink",
             "optional": true,
             "type": "string",
-          },
-          {
-            "name": "labelsTaskStatus",
-            "optional": false,
-            "type": "unknown",
           },
           {
             "name": "learnMoreLinkText",
@@ -19596,7 +20408,7 @@ exports[`Documenter definition for tutorial-panel matches the snapshot: tutorial
           },
           {
             "name": "tutorialListDescription",
-            "optional": false,
+            "optional": true,
             "type": "React.ReactNode",
           },
           {
@@ -19635,6 +20447,7 @@ specified in the \`i18nStrings\` property.",
     },
     {
       "description": "List of all available tutorials. An array of objects with the following properties:
+
 * \`title\` (string) - Name of the tutorial
 
 * \`description\` (ReactNode) - Short description of the tutorial's content.
@@ -19672,8 +20485,7 @@ specified in the \`i18nStrings\` property.",
 
   If this property is set to \`true\`, the tutorial list will show a status indicator underneath the tutorial title with
   a message that indicates that this tutorial has already been completed by the user (e.g. "Tutorial completed"), and
-  the "Start tutorial" button will be replaced by a "Restart tutorial" button.
-",
+  the "Start tutorial" button will be replaced by a "Restart tutorial" button.",
       "name": "tutorials",
       "optional": false,
       "type": "ReadonlyArray<TutorialPanelProps.Tutorial>",
@@ -19696,12 +20508,12 @@ If a user has entered data in the form, you should prompt the user with a modal 
     {
       "cancelable": false,
       "description": "Called when a user clicks the *next* button, the *previous* button, or an enabled step link in the navigation pane.
+
 The event \`detail\` includes the following:
 - \`requestedStepIndex\` - The index of the requested step.
 - \`reason\` - The user action that triggered the navigation event. It can be \`next\` (when the user clicks the *next* button),
 \`previous\` (when the user clicks the *previous* button), \`step\` (an enabled step link in the navigation pane),
-or \`skip\` (when navigated using navigation pane or the *skip-to* button to the previously unvisited step).
-",
+or \`skip\` (when navigated using navigation pane or the *skip-to* button to the previously unvisited step).",
       "detailInlineType": {
         "name": "WizardProps.NavigateDetail",
         "properties": [
@@ -19732,14 +20544,14 @@ or \`skip\` (when navigated using navigation pane or the *skip-to* button to the
   "properties": [
     {
       "description": "Index of the step that's currently displayed. The first step has an index of zero (0).
+
 If you don't set this property, the component starts on the first step and switches step automatically
 when a user navigates using the buttons or an enabled step link in the navigation pane (that is, uncontrolled behavior).
 
 If you provide a value for this property, you must also set an \`onNavigate\` listener to update the property when
 a user navigates (that is, controlled behavior).
 
-If you set it to a value that exceeds the maximum value (that is, the number of steps minus 1), its value is ignored and the component uses the maximum value.
-",
+If you set it to a value that exceeds the maximum value (that is, the number of steps minus 1), its value is ignored and the component uses the maximum value.",
       "name": "activeStepIndex",
       "optional": true,
       "type": "number",
@@ -19748,13 +20560,13 @@ If you set it to a value that exceeds the maximum value (that is, the number of 
       "defaultValue": "false",
       "description": "When set to \`false\`, the *skip-to* button is never shown.
 When set to \`true\`, the *skip-to* button may appear to offer faster navigation for the user.
+
 The *skip-to* button only allows to skip optional steps. It is shown when there is one or more optional
 steps ahead having no required steps in-between.
 
 Note: the *skip-to* button requires the function i18nStrings.skipToButtonLabel to be defined.
 
-Defaults to \`false\`.
-",
+Defaults to \`false\`.",
       "name": "allowSkipTo",
       "optional": true,
       "type": "boolean",
@@ -19799,6 +20611,7 @@ Defaults to \`false\`.
     },
     {
       "description": "An object containing all the necessary localized strings required by the component.
+
 - \`stepNumberLabel\` ((stepNumber: number) => string) - A function that accepts a number (1-based indexing),
    and returns a human-readable, localized string displaying the step number in the navigation pane. For example, "Step 1" or "Step 2".
 - \`collapsedStepsLabel\` ((stepNumber: number, stepsCount: number) => string) - A function that accepts two number parameters (1-based indexing),
@@ -19823,6 +20636,11 @@ Defaults to \`false\`.
             "name": "cancelButton",
             "optional": true,
             "type": "string",
+          },
+          {
+            "name": "collapsedStepsLabel",
+            "optional": true,
+            "type": "((stepNumber: number, stepsCount: number) => string)",
           },
           {
             "name": "errorIconAriaLabel",
@@ -19855,6 +20673,16 @@ Defaults to \`false\`.
             "type": "string",
           },
           {
+            "name": "skipToButtonLabel",
+            "optional": true,
+            "type": "((targetStep: WizardProps.Step, targetStepNumber: number) => string)",
+          },
+          {
+            "name": "stepNumberLabel",
+            "optional": true,
+            "type": "((stepNumber: number) => string)",
+          },
+          {
             "name": "submitButton",
             "optional": true,
             "type": "string",
@@ -19863,21 +20691,6 @@ Defaults to \`false\`.
             "name": "submitButtonLoadingAnnouncement",
             "optional": true,
             "type": "string",
-          },
-          {
-            "name": "collapsedStepsLabel",
-            "optional": true,
-            "type": "(stepNumber: number, stepsCount: number) => string",
-          },
-          {
-            "name": "skipToButtonLabel",
-            "optional": true,
-            "type": "(targetStep: WizardProps.Step, targetStepNumber: number) => string",
-          },
-          {
-            "name": "stepNumberLabel",
-            "optional": true,
-            "type": "(stepNumber: number) => string",
           },
         ],
         "type": "object",
@@ -19898,8 +20711,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "defaultValue": "false",
       "description": "Renders the *next* or *submit* button in a loading state.
-Use this if you need to wait for a response from the server before the user can proceed to the next step, such as during server-side validation or retrieving the next step's information.
-",
+
+Use this if you need to wait for a response from the server before the user can proceed to the next step, such as during server-side validation or retrieving the next step's information.",
       "name": "isLoadingNextStep",
       "optional": true,
       "type": "boolean",
@@ -19907,6 +20720,7 @@ Use this if you need to wait for a response from the server before the user can 
     {
       "analyticsTag": "",
       "description": "Array of step objects. Each object represents a step in the wizard with the following properties:
+
 - \`title\` (string) - Text that's displayed as the title in the navigation pane and form header.
 - \`info\` (ReactNode) - (Optional) Area for a page level info link that's displayed in the form header.
    The page level info link should trigger the default help panel content for the step. Use the [link component](/components/link/) to display the link.

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -111,8 +111,8 @@ If the label is assigned via the \`i18nStrings\` property, this label will be ig
         "name": "AlertProps.Type",
         "type": "union",
         "values": [
-          "error",
           "success",
+          "error",
           "warning",
           "info",
         ],
@@ -165,9 +165,9 @@ exports[`Documenter definition for anchor-navigation matches the snapshot: ancho
     {
       "cancelable": false,
       "description": "Fired when an active anchor link changes.
-
 Note: This event is triggered both by the component's internal scroll-spy logic,
-or when the \`activeHref\` prop is manually updated.",
+or when the \`activeHref\` prop is manually updated.
+",
       "detailInlineType": {
         "name": "AnchorNavigationProps.Anchor",
         "properties": [
@@ -242,23 +242,23 @@ controlled manner, and internal scroll-spy will be disabled.",
     },
     {
       "description": "List of anchors. Each anchor object has the following properties:
-
 * \`text\` (string) - The text for the anchor item.
 * \`href\` (string) - The \`id\` attribute of the target HTML element that the anchor refers to.
 For example: \`"#section1.1"\`
 * \`level\` (number) - Level of nesting of the anchor.
 * \`info\` (string | undefined) - Additional information to display next to the link, for example: "New" or "Updated".
 
-Note: The list of anchors should be sorted in the order they appear on the page.",
+Note: The list of anchors should be sorted in the order they appear on the page.
+",
       "name": "anchors",
       "optional": false,
       "type": "Array<AnchorNavigationProps.Anchor>",
     },
     {
       "description": "Adds \`aria-labelledby\` to the component.
-
 Use this property for identifying the header or title that labels the anchor navigation.
-To use it correctly, define an ID for the element either as label, and set the property to that ID.",
+To use it correctly, define an ID for the element either as label, and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -283,8 +283,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "defaultValue": "0",
       "description": "Specifies the height (in pixels) to be considered as an offset when activating anchors.
 This is useful when you have a fixed or sticky header that might overlap with the content as you scroll.
-
-Defaults to 0.",
+Defaults to 0.
+",
       "name": "scrollSpyOffset",
       "optional": true,
       "type": "number",
@@ -319,6 +319,7 @@ exports[`Documenter definition for annotation-context matches the snapshot: anno
       "cancelable": false,
       "description": "Fired when the user clicks the "Finish" button on the last step of
 the tutorial.",
+      "detailType": "void",
       "name": "onFinish",
     },
     {
@@ -345,16 +346,16 @@ button on a popover, when the user clicks on a closed hotspot icon,
 or when the AnnotationOverlay determines that the current hotspot
 has disappeared from the page and a different one should be
 selected (e.g. when navigating between pages).
-
 Use the \`reason\` property of the event detail to determine why
-this event was fired.",
+this event was fired.
+",
       "detailInlineType": {
         "name": "AnnotationContextProps.StepChangeDetail",
         "properties": [
           {
             "name": "reason",
             "optional": false,
-            "type": ""open" | "next" | "previous" | "auto-fallback"",
+            "type": ""auto-fallback" | "next" | "open" | "previous"",
           },
           {
             "name": "step",
@@ -374,66 +375,20 @@ this event was fired.",
     {
       "description": "The currently launched tutorial. This should be the object received
 in the \`detail\` property of the \`onStartTutorial\` event.",
-      "inlineType": {
-        "name": "TutorialPanelProps.Tutorial",
-        "properties": [
-          {
-            "name": "completed",
-            "optional": false,
-            "type": "boolean",
-          },
-          {
-            "name": "completedScreenDescription",
-            "optional": true,
-            "type": "React.ReactNode",
-          },
-          {
-            "name": "description",
-            "optional": true,
-            "type": "React.ReactNode",
-          },
-          {
-            "name": "learnMoreUrl",
-            "optional": true,
-            "type": "string | null",
-          },
-          {
-            "name": "prerequisitesAlert",
-            "optional": true,
-            "type": "React.ReactNode",
-          },
-          {
-            "name": "prerequisitesNeeded",
-            "optional": true,
-            "type": "boolean",
-          },
-          {
-            "name": "tasks",
-            "optional": false,
-            "type": "ReadonlyArray<TutorialPanelProps.Task>",
-          },
-          {
-            "name": "title",
-            "optional": false,
-            "type": "string",
-          },
-        ],
-        "type": "object",
-      },
       "name": "currentTutorial",
       "optional": false,
-      "type": "TutorialPanelProps.Tutorial | null",
+      "type": "AnnotationContextProps.Tutorial | null",
     },
     {
       "description": "An object containing all the necessary localized strings required by the component. The object should contain:
-
 * \`finishButtonText\` - Specifies the text that's displayed in the finish button.
 * \`labelDismissAnnotation\` - Specifies the aria-label for the dismiss button.
 * \`labelHotspot\` - Specifies the aria-label for the hotspot button. The \`openState\` argument is deprecated, it's handled by the hotspot button aria-expanded attribute.
 * \`nextButtonText\` - Specifies the text that's displayed in the next button.
 * \`previousButtonText\` - Specifies the text that's displayed in the previous button.
 * \`stepCounterText\` - Specifies the step counter text that's displayed in the annotation popover.
-* \`taskTitle\` - Specifies the title text that's displayed in the annotation popover.",
+* \`taskTitle\` - Specifies the title text that's displayed in the annotation popover.
+",
       "inlineType": {
         "name": "AnnotationContextProps.I18nStrings",
         "properties": [
@@ -505,7 +460,7 @@ exports[`Documenter definition for app-layout matches the snapshot: app-layout 1
           {
             "name": "activeDrawerId",
             "optional": false,
-            "type": "string | null",
+            "type": "null | string",
           },
         ],
         "type": "object",
@@ -641,7 +596,7 @@ to control the state by listening to \`toolsChange\` and providing \`toolsOpen\`
       "description": "The active drawer id. If you want to clear the active drawer, use \`null\`.",
       "name": "activeDrawerId",
       "optional": true,
-      "type": "string | null",
+      "type": "null | string",
     },
     {
       "analyticsTag": "",
@@ -671,7 +626,6 @@ to control the state by listening to \`toolsChange\` and providing \`toolsOpen\`
     },
     {
       "description": "Aria labels for the drawer operating buttons. Use this property to ensure accessibility.
-
 * \`navigation\` (string) - Label for the landmark that wraps the navigation drawer.
 * \`navigationClose\` (string) - Label for the button that closes the navigation drawer.
 * \`navigationToggle\` (string) - Label for the button that opens the navigation drawer.
@@ -777,9 +731,9 @@ Individual properties will always take precedence over the default coming from t
           "default",
           "form",
           "table",
-          "dashboard",
           "cards",
           "wizard",
+          "dashboard",
         ],
       },
       "name": "contentType",
@@ -809,7 +763,6 @@ Individual properties will always take precedence over the default coming from t
     },
     {
       "description": "Drawers property. If you set both \`drawers\` and \`tools\`, \`drawers\` will take precedence.
-
 Each Drawer is an item in the drawers wrapper with the following properties:
 * id (string) - the id of the drawer.
 * content (React.ReactNode) - the content in the drawer.
@@ -828,7 +781,8 @@ Each Drawer is an item in the drawers wrapper with the following properties:
 - \`drawerName\` (string) - Label for the drawer itself, and for the drawer trigger button tooltip text.
 - \`closeButton\` (string) - (Optional) Label for the close button.
 - \`triggerButton\` (string) - (Optional) Label for the trigger button.
-- \`resizeHandle\` (string) - (Optional) Label for the resize handle.",
+- \`resizeHandle\` (string) - (Optional) Label for the resize handle.
+",
       "name": "drawers",
       "optional": true,
       "type": "Array<AppLayoutProps.Drawer>",
@@ -852,7 +806,7 @@ Each Drawer is an item in the drawers wrapper with the following properties:
 * \`default\` - Does not apply any visual treatment.
 * \`high-contrast\` - Applies high-contrast to both slots. Use in conjunction with \`headerVariant="high-contrast"\` in ContentLayout.",
       "inlineType": {
-        "name": ""default" | "high-contrast"",
+        "name": "",
         "type": "union",
         "values": [
           "default",
@@ -875,8 +829,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Maximum main content panel width in pixels.
-
-If set to \`Number.MAX_VALUE\`, the main content panel will occupy the full available width.",
+If set to \`Number.MAX_VALUE\`, the main content panel will occupy the full available width.
+",
       "name": "maxContentWidth",
       "optional": true,
       "type": "number",
@@ -914,8 +868,8 @@ If set to \`Number.MAX_VALUE\`, the main content panel will occupy the full avai
     },
     {
       "description": "Controls the split panel preferences.
-
-By default, the preference is \`{ position: 'bottom' }\`",
+By default, the preference is \`{ position: 'bottom' }\`
+",
       "inlineType": {
         "name": "AppLayoutProps.SplitPanelPreferences",
         "properties": [
@@ -989,15 +943,15 @@ content area so it is always visible.",
     },
     {
       "description": "Displayed on top of the main content in the scrollable area.
-
-Conceived to contain notifications (flash messages).",
+Conceived to contain notifications (flash messages).
+",
       "isDefault": false,
       "name": "notifications",
     },
     {
       "description": "Use this slot to add the [split panel component](/components/split-panel/) to the app layout.
-
-Note: If provided, this property should be set to \`null\` or \`undefined\` if a split panel should not be rendered.",
+Note: If provided, this property should be set to \`null\` or \`undefined\` if a split panel should not be rendered.
+",
       "isDefault": false,
       "name": "splitPanel",
     },
@@ -1023,7 +977,7 @@ exports[`Documenter definition for app-layout-toolbar matches the snapshot: app-
           {
             "name": "activeDrawerId",
             "optional": false,
-            "type": "string | null",
+            "type": "null | string",
           },
         ],
         "type": "object",
@@ -1165,7 +1119,7 @@ to control the state by listening to \`toolsChange\` and providing \`toolsOpen\`
       "description": "The active drawer id. If you want to clear the active drawer, use \`null\`.",
       "name": "activeDrawerId",
       "optional": true,
-      "type": "string | null",
+      "type": "null | string",
     },
     {
       "analyticsTag": "",
@@ -1195,7 +1149,6 @@ to control the state by listening to \`toolsChange\` and providing \`toolsOpen\`
     },
     {
       "description": "Aria labels for the drawer operating buttons. Use this property to ensure accessibility.
-
 * \`navigation\` (string) - Label for the landmark that wraps the navigation drawer.
 * \`navigationClose\` (string) - Label for the button that closes the navigation drawer.
 * \`navigationToggle\` (string) - Label for the button that opens the navigation drawer.
@@ -1301,9 +1254,9 @@ Individual properties will always take precedence over the default coming from t
           "default",
           "form",
           "table",
-          "dashboard",
           "cards",
           "wizard",
+          "dashboard",
         ],
       },
       "name": "contentType",
@@ -1326,7 +1279,6 @@ Individual properties will always take precedence over the default coming from t
     },
     {
       "description": "Drawers property. If you set both \`drawers\` and \`tools\`, \`drawers\` will take precedence.
-
 Each Drawer is an item in the drawers wrapper with the following properties:
 * id (string) - the id of the drawer.
 * content (React.ReactNode) - the content in the drawer.
@@ -1346,10 +1298,11 @@ If not set, a corresponding trigger button is not displayed, while the drawer mi
 - \`drawerName\` (string) - Label for the drawer itself, and for the drawer trigger button tooltip text.
 - \`closeButton\` (string) - (Optional) Label for the close button.
 - \`triggerButton\` (string) - (Optional) Label for the trigger button.
-- \`resizeHandle\` (string) - (Optional) Label for the resize handle.",
+- \`resizeHandle\` (string) - (Optional) Label for the resize handle.
+",
       "name": "drawers",
       "optional": true,
-      "type": "Array<AppLayoutProps.Drawer>",
+      "type": "Array<AppLayoutToolbarProps.Drawer>",
     },
     {
       "defaultValue": "'#b #f'",
@@ -1370,7 +1323,7 @@ If not set, a corresponding trigger button is not displayed, while the drawer mi
 * \`default\` - Does not apply any visual treatment.
 * \`high-contrast\` - Applies high-contrast to both slots. Use in conjunction with \`headerVariant="high-contrast"\` in ContentLayout.",
       "inlineType": {
-        "name": ""default" | "high-contrast"",
+        "name": "",
         "type": "union",
         "values": [
           "default",
@@ -1393,8 +1346,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Maximum main content panel width in pixels.
-
-If set to \`Number.MAX_VALUE\`, the main content panel will occupy the full available width.",
+If set to \`Number.MAX_VALUE\`, the main content panel will occupy the full available width.
+",
       "name": "maxContentWidth",
       "optional": true,
       "type": "number",
@@ -1439,8 +1392,8 @@ while navigation drawer might be displayed, but opened using a custom trigger.",
     },
     {
       "description": "Controls the split panel preferences.
-
-By default, the preference is \`{ position: 'bottom' }\`",
+By default, the preference is \`{ position: 'bottom' }\`
+",
       "inlineType": {
         "name": "AppLayoutProps.SplitPanelPreferences",
         "properties": [
@@ -1514,15 +1467,15 @@ content area so it is always visible.",
     },
     {
       "description": "Displayed on top of the main content in the scrollable area.
-
-Conceived to contain notifications (flash messages).",
+Conceived to contain notifications (flash messages).
+",
       "isDefault": false,
       "name": "notifications",
     },
     {
       "description": "Use this slot to add the [split panel component](/components/split-panel/) to the app layout.
-
-Note: If provided, this property should be set to \`null\` or \`undefined\` if a split panel should not be rendered.",
+Note: If provided, this property should be set to \`null\` or \`undefined\` if a split panel should not be rendered.
+",
       "isDefault": false,
       "name": "splitPanel",
     },
@@ -1544,7 +1497,7 @@ exports[`Documenter definition for area-chart matches the snapshot: area-chart 1
       "description": "Called when the values of the internal filter component changed.
 This will **not** be called for any custom filter components you have defined in \`additionalFilters\`.",
       "detailInlineType": {
-        "name": "CartesianChartProps.FilterChangeDetail<Series>",
+        "name": "CartesianChartProps.FilterChangeDetail",
         "properties": [
           {
             "name": "visibleSeries",
@@ -1554,14 +1507,14 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.FilterChangeDetail<Series>",
+      "detailType": "CartesianChartProps.FilterChangeDetail<AreaChartProps.Series<T>>",
       "name": "onFilterChange",
     },
     {
       "cancelable": false,
       "description": "Called when the highlighted series has changed because of user interaction.",
       "detailInlineType": {
-        "name": "CartesianChartProps.HighlightChangeDetail<Series>",
+        "name": "CartesianChartProps.HighlightChangeDetail",
         "properties": [
           {
             "name": "highlightedSeries",
@@ -1571,7 +1524,7 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.HighlightChangeDetail<Series>",
+      "detailType": "CartesianChartProps.HighlightChangeDetail<AreaChartProps.Series<T>>",
       "name": "onHighlightChange",
     },
     {
@@ -1617,7 +1570,7 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "Additional content that is displayed at the bottom of the detail popover.",
       "inlineType": {
-        "name": "CartesianChartProps.DetailPopoverFooter<T>",
+        "name": "CartesianChartProps.DetailPopoverFooter",
         "parameters": [
           {
             "name": "xValue",
@@ -1632,10 +1585,10 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
       "type": "CartesianChartProps.DetailPopoverFooter<T>",
     },
     {
-      "defaultValue": "'medium'",
+      "defaultValue": ""medium"",
       "description": "Determines the maximum width the detail popover will be limited to.",
       "inlineType": {
-        "name": ""small" | "medium" | "large"",
+        "name": "",
         "type": "union",
         "values": [
           "small",
@@ -1650,15 +1603,9 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "Function to format the displayed values total.",
       "inlineType": {
-        "name": "AreaChartProps.TickFormatter<number>",
-        "parameters": [
-          {
-            "name": "value",
-            "type": "T",
-          },
-        ],
-        "returnType": "string",
-        "type": "function",
+        "name": "AreaChartProps.TickFormatter",
+        "properties": [],
+        "type": "object",
       },
       "name": "detailTotalFormatter",
       "optional": true,
@@ -1703,27 +1650,18 @@ It is highly recommended to keep this set to \`false\`.",
     {
       "description": "The currently highlighted data series, usually through hovering over a series or the legend.
 A value of \`null\` means no series is highlighted.
-
 - If you do not set this property, series are highlighted automatically when hovering over one of the triggers (uncontrolled behavior).
-- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).",
-      "inlineType": {
-        "name": "NonNullable<Series>",
-        "type": "union",
-        "values": [
-          "Series",
-          "{}",
-        ],
-      },
+- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).
+",
       "name": "highlightedSeries",
       "optional": true,
-      "type": "NonNullable<Series>",
+      "type": "AreaChartProps.Series<T> | null",
     },
     {
-      "defaultValue": "{}",
       "description": "An object containing all the necessary localized strings required by the component.",
       "i18nTag": true,
       "inlineType": {
-        "name": "AreaChartProps.I18nStrings<T>",
+        "name": "AreaChartProps.I18nStrings",
         "properties": [
           {
             "name": "chartAriaRoleDescription",
@@ -1773,7 +1711,7 @@ A value of \`null\` means no series is highlighted.
           {
             "name": "xTickFormatter",
             "optional": true,
-            "type": "CartesianChartProps.TickFormatter<T>",
+            "type": "AreaChartProps.TickFormatter<T>",
           },
           {
             "name": "yAxisAriaRoleDescription",
@@ -1783,7 +1721,7 @@ A value of \`null\` means no series is highlighted.
           {
             "name": "yTickFormatter",
             "optional": true,
-            "type": "CartesianChartProps.TickFormatter<number>",
+            "type": "AreaChartProps.TickFormatter<number>",
           },
         ],
         "type": "object",
@@ -1824,29 +1762,29 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "description": "Array that represents the source of data for the displayed chart.
 Each element can represent an area series, or a threshold, and can have the following properties:
-
 * \`title\` (string): A human-readable title for this series
 * \`type\` (string): Series type (\`"area"\`, or \`"threshold"\`)
 * \`data\` (Array): An array of data points, represented as objects with \`x\` and \`y\` properties. The \`x\` values must be consistent across all series
 * \`color\` (string): (Optional) A color hex value for this series. When assigned, it takes priority over the automatically assigned color
-* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.",
+* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.
+",
       "name": "series",
       "optional": false,
       "type": "ReadonlyArray<AreaChartProps.Series<T>>",
     },
     {
-      "defaultValue": "'finished'",
+      "defaultValue": ""finished"",
       "description": "Specifies the current status of loading data.
 * \`loading\`: data fetching is in progress.
 * \`finished\`: data has loaded successfully.
 * \`error\`: an error occurred during fetch. You should provide user an option to recover.",
       "inlineType": {
-        "name": ""error" | "finished" | "loading"",
+        "name": "",
         "type": "union",
         "values": [
-          "error",
-          "finished",
           "loading",
+          "finished",
+          "error",
         ],
       },
       "name": "statusType",
@@ -1859,29 +1797,29 @@ Each element can represent an area series, or a threshold, and can have the foll
 - If you explicitly set this property, you must set an \`onFilterChange\` listener to update this property when the visible series should change, or when one of your custom filters changes the number of visible series (controlled behavior).",
       "name": "visibleSeries",
       "optional": true,
-      "type": "ReadonlyArray<Series>",
+      "type": "ReadonlyArray<AreaChartProps.Series<T>>",
     },
     {
       "description": "Determines the domain of the x axis, i.e. the range of values that will be visible in the chart.
 For numerical and time-based data this is represented as an array with two values: \`[minimumValue, maximumValue]\`.
 For categorical data this is represented as an array of strings that determine the categories to display.
-
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.",
+When controlling this directly, make sure to update the value based on filtering changes.
+",
       "name": "xDomain",
       "optional": true,
       "type": "ReadonlyArray<T>",
     },
     {
-      "defaultValue": "'linear'",
+      "defaultValue": ""linear"",
       "description": "Determines the type of scale for values on the x axis.",
       "inlineType": {
         "name": "ScaleType",
         "type": "union",
         "values": [
           "linear",
-          "time",
           "log",
+          "time",
           "categorical",
         ],
       },
@@ -1892,7 +1830,7 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Function to format the displayed label of an x axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter<T>",
+        "name": "CartesianChartProps.TickFormatter",
         "parameters": [
           {
             "name": "value",
@@ -1915,18 +1853,18 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Determines the domain of the y axis, i.e. the range of values that will be visible in the chart.
 The domain is defined by a tuple: \`[minimumValue, maximumValue]\`.
-
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.",
+When controlling this directly, make sure to update the value based on filtering changes.
+",
       "name": "yDomain",
       "optional": true,
       "type": "ReadonlyArray<number>",
     },
     {
-      "defaultValue": "'linear'",
+      "defaultValue": ""linear"",
       "description": "Determines the type of scale for values on the y axis.",
       "inlineType": {
-        "name": ""linear" | "log"",
+        "name": "",
         "type": "union",
         "values": [
           "linear",
@@ -1940,7 +1878,7 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Function to format the displayed label of a y axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter<number>",
+        "name": "CartesianChartProps.TickFormatter",
         "parameters": [
           {
             "name": "value",
@@ -2073,25 +2011,13 @@ The function receives the following properties:
 - \`ref\` (\`ReactRef\`): A React ref that should be passed to the rendered button.
 - \`breakpoint\` (\`Breakpoint\`): The current breakpoint, for responsive behavior.
 - \`ownRow\` (\`boolean\`): Whether the button is rendered on its own row.",
-      "inlineType": {
-        "name": "(props: AttributeEditorProps.RowActionsProps<T>) => React.ReactNode",
-        "parameters": [
-          {
-            "name": "props",
-            "type": "AttributeEditorProps.RowActionsProps<T>",
-          },
-        ],
-        "returnType": "React.ReactNode",
-        "type": "function",
-      },
       "name": "customRowActions",
       "optional": true,
-      "type": "((props: AttributeEditorProps.RowActionsProps<T>) => React.ReactNode)",
+      "type": "(props: AttributeEditorProps.RowActionsProps<T>) => React.ReactNode",
     },
     {
       "description": "Defines the editor configuration. Each object in the array represents one form field in the row.
 If more than 6 attributes are specified, a \`gridLayout\` must be provided.
-
 * \`label\` (ReactNode) - Text label for the form field.
 * \`info\` (ReactNode) - Info link for the form field.
 * \`errorText\` ((item, itemIndex) => ReactNode) - Error message text to display as a control validation message.
@@ -2099,7 +2025,8 @@ If more than 6 attributes are specified, a \`gridLayout\` must be provided.
 * \`warningText\` ((item, itemIndex) => ReactNode) - Warning message text to display as a control validation message.
    It renders the form field in a warning state if the returned value is not \`null\` or \`undefined\`.
 * \`constraintText\` ((item, itemIndex) => ReactNode) - Text to display as a constraint message below the field.
-* \`control\` ((item, itemIndex) => ReactNode) - A control to use as the input for the field.",
+* \`control\` ((item, itemIndex) => ReactNode) - A control to use as the input for the field.
+",
       "name": "definition",
       "optional": false,
       "type": "ReadonlyArray<AttributeEditorProps.FieldDefinition<T>>",
@@ -2113,7 +2040,6 @@ If more than 6 attributes are specified, a \`gridLayout\` must be provided.
     {
       "description": "Optionally specifies the layout of the attributes. By default, all attributes will be
 equally spaced and wrapped into multiple rows on smaller viewports.
-
 A \`gridLayout\` is an array of breakpoint definitions. Each definition consists of:
 - \`rows\` (\`number[][]\`): the rows in which to display the attributes. Each row consists of a list of numbers indicating
   the relative width of each attribute. For example, \`[[1, 1, 1, 1]]\` is a single row of four evenly-spaced attributes,
@@ -2122,7 +2048,8 @@ A \`gridLayout\` is an array of breakpoint definitions. Each definition consists
 - \`removeButton\`: optionally configures the remove (or row action) button placement. If this is not provided, the button will be
   placed at the end of a single row, or below if multiple rows are present. The \`removeButton\` property supports contains two properties:
   - \`ownRow\` (\`boolean\`): forces the remove button onto its own row.
-  - \`width\` (\`number | 'auto'\`): a number indicating the relative width (equivalent to a \`rows\` entry), or 'auto' to fit to the button width.",
+  - \`width\` (\`number | 'auto'\`): a number indicating the relative width (equivalent to a \`rows\` entry), or 'auto' to fit to the button width.
+",
       "name": "gridLayout",
       "optional": true,
       "type": "ReadonlyArray<AttributeEditorProps.GridLayout>",
@@ -2130,7 +2057,7 @@ A \`gridLayout\` is an array of breakpoint definitions. Each definition consists
     {
       "description": "An object containing all the necessary localized strings required by the component.",
       "inlineType": {
-        "name": "AttributeEditorProps.I18nStrings<T>",
+        "name": "AttributeEditorProps.I18nStrings",
         "properties": [
           {
             "name": "errorIconAriaLabel",
@@ -2145,7 +2072,7 @@ A \`gridLayout\` is an array of breakpoint definitions. Each definition consists
           {
             "name": "removeButtonAriaLabel",
             "optional": true,
-            "type": "((item: T) => string)",
+            "type": "(item: T) => string",
           },
           {
             "name": "warningIconAriaLabel",
@@ -2174,7 +2101,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
 button is not rendered and the user can't remove the item.
 By default, all items are removable.",
       "inlineType": {
-        "name": "AttributeEditorProps.IsItemRemovableFunction<T>",
+        "name": "AttributeEditorProps.IsItemRemovableFunction",
         "parameters": [
           {
             "name": "item",
@@ -2198,20 +2125,9 @@ The display of a row is handled by the \`definition\` property.",
     },
     {
       "description": "Adds an \`aria-label\` to the remove button.",
-      "inlineType": {
-        "name": "(item: T) => string",
-        "parameters": [
-          {
-            "name": "item",
-            "type": "T",
-          },
-        ],
-        "returnType": "string",
-        "type": "function",
-      },
       "name": "removeButtonAriaLabel",
       "optional": true,
-      "type": "((item: T) => string)",
+      "type": "(item: T) => string",
     },
     {
       "description": "Specifies the text that's displayed in the remove button.",
@@ -2243,6 +2159,7 @@ exports[`Documenter definition for autosuggest matches the snapshot: autosuggest
     {
       "cancelable": false,
       "description": "Called when input focus is removed from the UI control.",
+      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -2250,7 +2167,7 @@ exports[`Documenter definition for autosuggest matches the snapshot: autosuggest
       "description": "Called whenever a user changes the input value (by typing or pasting).
 The event \`detail\` contains the current value of the field.",
       "detailInlineType": {
-        "name": "BaseChangeDetail",
+        "name": "InputProps.ChangeDetail",
         "properties": [
           {
             "name": "value",
@@ -2260,12 +2177,13 @@ The event \`detail\` contains the current value of the field.",
         ],
         "type": "object",
       },
-      "detailType": "BaseChangeDetail",
+      "detailType": "InputProps.ChangeDetail",
       "name": "onChange",
     },
     {
       "cancelable": false,
       "description": "Called when input focus is moved to the UI control.",
+      "detailType": "null",
       "name": "onFocus",
     },
     {
@@ -2274,7 +2192,7 @@ The event \`detail\` contains the current value of the field.",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "BaseKeyDetail",
+        "name": "InputProps.KeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -2314,7 +2232,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "BaseKeyDetail",
+      "detailType": "InputProps.KeyDetail",
       "name": "onKeyDown",
     },
     {
@@ -2323,7 +2241,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "BaseKeyDetail",
+        "name": "InputProps.KeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -2363,13 +2281,12 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "BaseKeyDetail",
+      "detailType": "InputProps.KeyDetail",
       "name": "onKeyUp",
     },
     {
       "cancelable": false,
       "description": "Use this event to implement the asynchronous behavior for the component.
-
 The event is called in the following situations:
 * The user scrolls to the end of the list of options, if \`statusType\` is set to \`pending\`.
 * The user clicks on the recovery button in the error state.
@@ -2379,7 +2296,8 @@ The event is called in the following situations:
 The detail object contains the following properties:
 * \`filteringText\` - The value that you need to use to fetch options.
 * \`firstPage\` - Indicates that you should fetch the first page of options that match the \`filteringText\`.
-* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).",
+* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).
+",
       "detailInlineType": {
         "name": "OptionsLoadItemsDetail",
         "properties": [
@@ -2414,7 +2332,7 @@ Instead, use \`onSelect\` in combination with the \`onChange\` handler only as a
           {
             "name": "selectedOption",
             "optional": true,
-            "type": "OptionDefinition",
+            "type": "AutosuggestProps.Option",
           },
           {
             "name": "value",
@@ -2447,20 +2365,20 @@ Instead, use \`onSelect\` in combination with the \`onChange\` handler only as a
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-
-Use this if you don't have a visible label for this control.",
+Use this if you don't have a visible label for this control.
+",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -2468,11 +2386,11 @@ Use this if you don't have a visible label for this control.",
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -2510,9 +2428,9 @@ scrolled out of the viewport.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -2572,41 +2490,25 @@ receive focus.",
       "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
-
 Set this property if the dropdown would otherwise be constrained by a scrollable container,
 for example inside table and split view layouts.
 
 We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.",
+because fixed positioning results in a slight, visible lag when scrolling complex pages.
+",
       "name": "expandToViewport",
       "optional": true,
       "type": "boolean",
     },
     {
       "description": "Specifies the text to display with the number of matches at the bottom of the dropdown menu while filtering.",
-      "inlineType": {
-        "name": "(matchesCount: number, totalCount: number) => string",
-        "parameters": [
-          {
-            "name": "matchesCount",
-            "type": "number",
-          },
-          {
-            "name": "totalCount",
-            "type": "number",
-          },
-        ],
-        "returnType": "string",
-        "type": "function",
-      },
       "name": "filteringResultsText",
       "optional": true,
-      "type": "((matchesCount: number, totalCount: number) => string)",
+      "type": "(matchesCount: number, totalCount: number) => string",
     },
     {
       "defaultValue": "'auto'",
       "description": "Determines how filtering is applied to the list of \`options\`:
-
 * \`auto\` - The component will automatically filter options based on user input.
 * \`manual\` - You will set up \`onChange\` or \`onLoadItems\` event listeners and filter options on your side or request
 them from server.
@@ -2619,13 +2521,14 @@ If you set this property to \`manual\`, this default filtering mechanism is disa
 displayed in the dropdown list. In that case make sure that you use the \`onChange\` or \`onLoadItems\` events in order
 to set the \`options\` property to the options that are relevant for the user, given the filtering input value.
 
-Note: Manual filtering doesn't disable match highlighting.",
+Note: Manual filtering doesn't disable match highlighting.
+",
       "inlineType": {
         "name": "OptionsFilteringType",
         "type": "union",
         "values": [
-          "auto",
           "none",
+          "auto",
           "manual",
         ],
       },
@@ -2673,7 +2576,6 @@ single form field.",
     {
       "description": "Specifies an array of options that are displayed to the user as a dropdown list.
 The options can be grouped using \`OptionGroup\` objects.
-
 #### Option
 - \`value\` (string) - The returned value of the option when selected.
 - \`label\` (string) - (Optional) Option text displayed to the user.
@@ -2699,7 +2601,13 @@ If you want to use the built-in filtering capabilities of this component, provid
 a list of all valid options here and they will be automatically filtered based on the user's filtering input.
 
 Alternatively, you can listen to the \`onChange\` or \`onLoadItems\` event and set new options
-on your own.",
+on your own.
+",
+      "inlineType": {
+        "name": "AutosuggestProps.Options",
+        "properties": [],
+        "type": "object",
+      },
       "name": "options",
       "optional": true,
       "type": "AutosuggestProps.Options",
@@ -2714,8 +2622,8 @@ on your own.",
       "description": "Specifies if the control is read-only, which prevents the
 user from modifying the value but includes it in a form
 submission. A read-only control can receive focus.
-
-Don't use read-only inputs outside a form.",
+Don't use read-only inputs outside a form.
+",
       "name": "readOnly",
       "optional": true,
       "type": "boolean",
@@ -2735,15 +2643,15 @@ the option's name and properties, and its selected state if
 the \`selectedLabel\` property is defined.
 The highlighted option is provided, and its group (if groups
 are used and it differs from the group of the previously highlighted option).
-
 For more information, see the
-[accessibility guidelines](/components/autosuggest/?tabId=usage#accessibility-guidelines).",
+[accessibility guidelines](/components/autosuggest/?tabId=usage#accessibility-guidelines).
+",
       "inlineType": {
         "name": "AutosuggestProps.ContainingOptionAndGroupString",
         "parameters": [
           {
             "name": "option",
-            "type": "OptionDefinition",
+            "type": "AutosuggestProps.Option",
           },
           {
             "name": "group",
@@ -2777,10 +2685,10 @@ This is required to provide a good screen reader experience. For more informatio
         "name": "DropdownStatusProps.StatusType",
         "type": "union",
         "values": [
-          "error",
-          "finished",
-          "loading",
           "pending",
+          "loading",
+          "finished",
+          "error",
         ],
       },
       "name": "statusType",
@@ -2798,11 +2706,11 @@ This is required to provide a good screen reader experience. For more informatio
 that makes the filtering experience smoother. We don't recommend enabling the feature if you
 have less than 500 options, because the improvements to performance are offset by a
 visible scrolling lag.
-
 When you set this flag to \`true\`, it removes options that are not currently in view from the DOM.
 If your test accesses such options, you need to first scroll the options container
 to the correct offset, before performing any operations on them. Use the element returned
-by the \`findOptionsContainer\` test utility for this.",
+by the \`findOptionsContainer\` test utility for this.
+",
       "name": "virtualScroll",
       "optional": true,
       "type": "boolean",
@@ -2847,15 +2755,15 @@ exports[`Documenter definition for badge matches the snapshot: badge 1`] = `
       "type": "string",
     },
     {
-      "defaultValue": "'grey'",
+      "defaultValue": ""grey"",
       "description": "Specifies the badge color.",
       "inlineType": {
-        "name": ""blue" | "green" | "grey" | "red" | "severity-critical" | "severity-high" | "severity-medium" | "severity-low" | "severity-neutral"",
+        "name": "",
         "type": "union",
         "values": [
           "blue",
-          "green",
           "grey",
+          "green",
           "red",
           "severity-critical",
           "severity-high",
@@ -2897,7 +2805,7 @@ exports[`Documenter definition for bar-chart matches the snapshot: bar-chart 1`]
       "description": "Called when the values of the internal filter component changed.
 This will **not** be called for any custom filter components you have defined in \`additionalFilters\`.",
       "detailInlineType": {
-        "name": "CartesianChartProps.FilterChangeDetail<Series>",
+        "name": "CartesianChartProps.FilterChangeDetail",
         "properties": [
           {
             "name": "visibleSeries",
@@ -2907,14 +2815,14 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.FilterChangeDetail<Series>",
+      "detailType": "CartesianChartProps.FilterChangeDetail<MixedLineBarChartProps.ChartSeries<T>>",
       "name": "onFilterChange",
     },
     {
       "cancelable": false,
       "description": "Called when the highlighted series has changed because of user interaction.",
       "detailInlineType": {
-        "name": "CartesianChartProps.HighlightChangeDetail<Series>",
+        "name": "CartesianChartProps.HighlightChangeDetail",
         "properties": [
           {
             "name": "highlightedSeries",
@@ -2924,7 +2832,7 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.HighlightChangeDetail<Series>",
+      "detailType": "CartesianChartProps.HighlightChangeDetail<MixedLineBarChartProps.ChartSeries<T>>",
       "name": "onHighlightChange",
     },
     {
@@ -2970,7 +2878,7 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "Additional content that is displayed at the bottom of the detail popover.",
       "inlineType": {
-        "name": "CartesianChartProps.DetailPopoverFooter<T>",
+        "name": "CartesianChartProps.DetailPopoverFooter",
         "parameters": [
           {
             "name": "xValue",
@@ -2987,15 +2895,15 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "A function that determines the details that are displayed in the popover for each series.
 Use this for wrapping keys or values in external links, or to display a metric breakdown by adding an additional level of nested items.
-
 The function is called with the parameters \`{ series, x, y }\` representing the series, the highlighted x coordinate value and its corresponding y value respectively,
 and should return the following properties:
 * \`key\` (ReactNode) - Name of the series.
 * \`value\` (ReactNode) - Value of the series at the highlighted x coordinate.
 * \`subItems\` (ReadonlyArray<{ key: ReactNode; value: ReactNode }>) - (Optional) List of nested key-value pairs.
-* \`expandable\` (boolean) - (Optional) Determines whether the optional list of nested items provided via \`subItems\` is expandable. This is \`false\` by default.",
+* \`expandable\` (boolean) - (Optional) Determines whether the optional list of nested items provided via \`subItems\` is expandable. This is \`false\` by default.
+",
       "inlineType": {
-        "name": "MixedLineBarChartProps.DetailPopoverSeriesContent<T>",
+        "name": "MixedLineBarChartProps.DetailPopoverSeriesContent",
         "parameters": [
           {
             "name": "data",
@@ -3010,10 +2918,10 @@ and should return the following properties:
       "type": "MixedLineBarChartProps.DetailPopoverSeriesContent<T>",
     },
     {
-      "defaultValue": "'medium'",
+      "defaultValue": ""medium"",
       "description": "Determines the maximum width the detail popover will be limited to.",
       "inlineType": {
-        "name": ""small" | "medium" | "large"",
+        "name": "",
         "type": "union",
         "values": [
           "small",
@@ -3072,20 +2980,12 @@ It is highly recommended to keep this set to \`false\`.",
     {
       "description": "The currently highlighted data series, usually through hovering over a series or the legend.
 A value of \`null\` means no series is highlighted.
-
 - If you do not set this property, series are highlighted automatically when hovering over one of the triggers (uncontrolled behavior).
-- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).",
-      "inlineType": {
-        "name": "NonNullable<Series>",
-        "type": "union",
-        "values": [
-          "Series",
-          "{}",
-        ],
-      },
+- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).
+",
       "name": "highlightedSeries",
       "optional": true,
-      "type": "NonNullable<Series>",
+      "type": "MixedLineBarChartProps.ChartSeries<T> | null",
     },
     {
       "defaultValue": "false",
@@ -3099,7 +2999,7 @@ This can only be used when the chart consists exclusively of bar series.",
       "description": "An object containing all the necessary localized strings required by the component.",
       "i18nTag": true,
       "inlineType": {
-        "name": "CartesianChartProps.I18nStrings<T>",
+        "name": "CartesianChartProps.I18nStrings",
         "properties": [
           {
             "name": "chartAriaRoleDescription",
@@ -3191,12 +3091,12 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "defaultValue": "[]",
       "description": "Array that represents the source of data for the displayed chart.
 Each element can represent a bar series or a threshold, and can have the following properties:
-
 * \`title\` (string): A human-readable title for this series
 * \`type\` (string): Series type (\`"bar"\`, or \`"threshold"\`)
 * \`data\` (Array): An array of data points, represented as objects with \`x\` and \`y\` properties
 * \`color\` (string): (Optional) A color hex value for this series. When assigned, it takes priority over the automatically assigned color
-* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.",
+* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.
+",
       "name": "series",
       "optional": false,
       "type": "ReadonlyArray<BarSeries<T>>",
@@ -3209,18 +3109,18 @@ Each element can represent a bar series or a threshold, and can have the followi
       "type": "boolean",
     },
     {
-      "defaultValue": "'finished'",
+      "defaultValue": ""finished"",
       "description": "Specifies the current status of loading data.
 * \`loading\`: data fetching is in progress.
 * \`finished\`: data has loaded successfully.
 * \`error\`: an error occurred during fetch. You should provide user an option to recover.",
       "inlineType": {
-        "name": ""error" | "finished" | "loading"",
+        "name": "",
         "type": "union",
         "values": [
-          "error",
-          "finished",
           "loading",
+          "finished",
+          "error",
         ],
       },
       "name": "statusType",
@@ -3233,21 +3133,21 @@ Each element can represent a bar series or a threshold, and can have the followi
 - If you explicitly set this property, you must set an \`onFilterChange\` listener to update this property when the visible series should change, or when one of your custom filters changes the number of visible series (controlled behavior).",
       "name": "visibleSeries",
       "optional": true,
-      "type": "ReadonlyArray<Series>",
+      "type": "ReadonlyArray<MixedLineBarChartProps.ChartSeries<T>>",
     },
     {
       "description": "Determines the domain of the x axis, i.e. the range of values that will be visible in the chart.
 For numerical and time-based data this is represented as an array with two values: \`[minimumValue, maximumValue]\`.
 For categorical data this is represented as an array of strings that determine the categories to display.
-
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.",
+When controlling this directly, make sure to update the value based on filtering changes.
+",
       "name": "xDomain",
       "optional": true,
       "type": "ReadonlyArray<T>",
     },
     {
-      "defaultValue": "'categorical'",
+      "defaultValue": ""categorical"",
       "description": "Determines the type of scale for values on the x axis.
 Use \`categorical\` for bar charts.",
       "inlineType": {
@@ -3255,8 +3155,8 @@ Use \`categorical\` for bar charts.",
         "type": "union",
         "values": [
           "linear",
-          "time",
           "log",
+          "time",
           "categorical",
         ],
       },
@@ -3267,7 +3167,7 @@ Use \`categorical\` for bar charts.",
     {
       "description": "Function to format the displayed label of an x axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter<T>",
+        "name": "CartesianChartProps.TickFormatter",
         "parameters": [
           {
             "name": "value",
@@ -3290,18 +3190,18 @@ Use \`categorical\` for bar charts.",
     {
       "description": "Determines the domain of the y axis, i.e. the range of values that will be visible in the chart.
 The domain is defined by a tuple: \`[minimumValue, maximumValue]\`.
-
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.",
+When controlling this directly, make sure to update the value based on filtering changes.
+",
       "name": "yDomain",
       "optional": true,
       "type": "ReadonlyArray<number>",
     },
     {
-      "defaultValue": "'linear'",
+      "defaultValue": ""linear"",
       "description": "Determines the type of scale for values on the y axis.",
       "inlineType": {
-        "name": ""linear" | "log"",
+        "name": "",
         "type": "union",
         "values": [
           "linear",
@@ -3315,7 +3215,7 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Function to format the displayed label of a y axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter<number>",
+        "name": "CartesianChartProps.TickFormatter",
         "parameters": [
           {
             "name": "value",
@@ -3373,7 +3273,6 @@ exports[`Documenter definition for box matches the snapshot: box 1`] = `
     },
     {
       "description": "Overrides the text color. You can set it to the following values:
-
 - \`inherit\` - Inherits the color from the parent element. For example, use this to style content
      in Flashbars and to style the \`empty\` and \`noMatch\` slots of the Table and Cards components.
 - \`text-label\` - Specifies the text color for non-form labels. For example, use it for the key in key/value pairs.
@@ -3384,7 +3283,8 @@ exports[`Documenter definition for box matches the snapshot: box 1`] = `
 - \`text-status-inactive\` - Specifies the color for inactive and loading text and icons.
 - \`text-status-warning\` - Specifies the color for warning text and icons.
 
-Note: If you don't set it, the text color depends on the variant.",
+Note: If you don't set it, the text color depends on the variant.
+",
       "inlineType": {
         "name": "BoxProps.Color",
         "type": "union",
@@ -3405,21 +3305,21 @@ Note: If you don't set it, the text color depends on the variant.",
     },
     {
       "description": "Overrides the display of the element. You can set it to the following values:
-
 - \`block\` - Specifies block display.
 - \`inline\` - Specifies inline display.
 - \`inline-block\` - Specifies inline-block display.
 - \`none\` - Hides the box.
 
-Note: If you don't set it, the display depends on the variant.",
+Note: If you don't set it, the display depends on the variant.
+",
       "inlineType": {
         "name": "BoxProps.Display",
         "type": "union",
         "values": [
-          "inline",
-          "none",
           "block",
+          "inline",
           "inline-block",
+          "none",
         ],
       },
       "name": "display",
@@ -3466,9 +3366,9 @@ Note: If you don't set it, the display depends on the variant.",
         "name": "BoxProps.FontWeight",
         "type": "union",
         "values": [
-          "bold",
-          "normal",
           "light",
+          "normal",
+          "bold",
           "heavy",
         ],
       },
@@ -3487,9 +3387,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": "{}",
       "description": "Adds margins to the element. It can be the following:
-
 - A single string with a size. This applies the same margin to all sides (that is, top, right, bottom, left).
 - An object specifying the size of the margin per side. The object has the following format:
 \`\`\`
@@ -3507,32 +3405,14 @@ The size can be \`n\`, \`xxxs\`, \`xxs\`, \`xs\`, \`s\`, \`m\`, \`l\`, \`xl\`, \
 Sizes are automatically scaled down in compact mode.
 
  For example, \`margin="s"\` adds a small margin to all sides.
-\`margin={{ right: "l", bottom: "s" }}\` adds a small margin to the bottom and a large margin to the right.",
-      "inlineType": {
-        "name": "BoxProps.SpacingSize | BoxProps.Spacing",
-        "type": "union",
-        "values": [
-          ""s"",
-          ""m"",
-          ""n"",
-          ""xxxs"",
-          ""xxs"",
-          ""xs"",
-          ""l"",
-          ""xl"",
-          ""xxl"",
-          ""xxxl"",
-          "BoxProps.Spacing",
-        ],
-      },
+\`margin={{ right: "l", bottom: "s" }}\` adds a small margin to the bottom and a large margin to the right.
+",
       "name": "margin",
       "optional": true,
-      "type": "BoxProps.SpacingSize | BoxProps.Spacing",
+      "type": "BoxProps.Spacing | BoxProps.SpacingSize",
     },
     {
-      "defaultValue": "{}",
       "description": "Adds padding to the element. It can be the following:
-
 - A single string with a size. This applies the same padding to all sides (that is, top, right, bottom, left).
 - An object specifying the size of padding per side. The object has the following format:
 \`\`\`
@@ -3550,27 +3430,11 @@ The size can be \`n\`, \`xxxs\`, \`xxs\`, \`xs\`, \`s\`, \`m\`, \`l\`, \`xl\`, \
 Sizes are automatically scaled down in compact mode.
 
  For example, \`padding="s"\` adds small padding to all sides.
-\`padding={{ right: "l", bottom: "s" }}\` adds small padding to the bottom and large padding to the right.",
-      "inlineType": {
-        "name": "BoxProps.SpacingSize | BoxProps.Spacing",
-        "type": "union",
-        "values": [
-          ""s"",
-          ""m"",
-          ""n"",
-          ""xxxs"",
-          ""xxs"",
-          ""xs"",
-          ""l"",
-          ""xl"",
-          ""xxl"",
-          ""xxxl"",
-          "BoxProps.Spacing",
-        ],
-      },
+\`padding={{ right: "l", bottom: "s" }}\` adds small padding to the bottom and large padding to the right.
+",
       "name": "padding",
       "optional": true,
-      "type": "BoxProps.SpacingSize | BoxProps.Spacing",
+      "type": "BoxProps.Spacing | BoxProps.SpacingSize",
     },
     {
       "description": "Overrides the default HTML tag provided by the variant.",
@@ -3584,8 +3448,8 @@ Sizes are automatically scaled down in compact mode.
         "name": "BoxProps.TextAlign",
         "type": "union",
         "values": [
-          "center",
           "left",
+          "center",
           "right",
         ],
       },
@@ -3594,9 +3458,8 @@ Sizes are automatically scaled down in compact mode.
       "type": "string",
     },
     {
-      "defaultValue": "'div'",
+      "defaultValue": ""div"",
       "description": "Defines the style of element to display.
-
 - If you set it to \`'div'\`, \`'span'\`, \`'h1'\`, \`'h2'\`, \`'h3'\`, \`'h4'\`, \`'h5'\`, \`'p'\`, \`'strong'\`, \`'small'\`, \`'code'\`, \`'pre'\`, or \`'samp'\`, the variant is also used as the HTML tag name.
 - If you set it to \`awsui-key-label\`, the component will render a \`div\`,
   styled for use as a key label in key-value pairs.
@@ -3605,27 +3468,28 @@ Sizes are automatically scaled down in compact mode.
 - If you set it to \`awsui-value-large\`, the component will render a \`span\`,
   styled using "Display large light" typography.
 
-Override the HTML tag by using property \`tagOverride\`.",
+Override the HTML tag by using property \`tagOverride\`.
+",
       "inlineType": {
         "name": "BoxProps.Variant",
         "type": "union",
         "values": [
-          "small",
-          "code",
           "div",
+          "span",
           "h1",
           "h2",
           "h3",
           "h4",
           "h5",
           "p",
+          "strong",
+          "small",
+          "code",
           "pre",
           "samp",
-          "span",
-          "strong",
-          "awsui-value-large",
           "awsui-key-label",
           "awsui-gen-ai-label",
+          "awsui-value-large",
         ],
       },
       "name": "variant",
@@ -3652,12 +3516,12 @@ exports[`Documenter definition for breadcrumb-group matches the snapshot: breadc
       "cancelable": true,
       "description": "Called when the user clicks on a breadcrumb item.",
       "detailInlineType": {
-        "name": "BreadcrumbGroupProps.ClickDetail<T>",
+        "name": "BreadcrumbGroupProps.ClickDetail",
         "properties": [
           {
             "name": "external",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "href",
@@ -3690,12 +3554,12 @@ exports[`Documenter definition for breadcrumb-group matches the snapshot: breadc
       "description": "Called when the user clicks on a breadcrumb item with the left mouse button
 without pressing modifier keys (that is, CTRL, ALT, SHIFT, META).",
       "detailInlineType": {
-        "name": "BreadcrumbGroupProps.ClickDetail<T>",
+        "name": "BreadcrumbGroupProps.ClickDetail",
         "properties": [
           {
             "name": "external",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "href",
@@ -3760,14 +3624,14 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "defaultValue": "[]",
       "description": "An array of breadcrumb items that describes the link hierarchy for this navigation.
 Each option has the following properties:
-
 * \`text\` (string) - Specifies the title text of the breadcrumb item.
 * \`href\` (string) - Specifies the URL for the link in the breadcrumb item.
 You should specify the link even if you have a click handler for a breadcrumb item
 to ensure that valid markup is generated.
 
 Note: The last breadcrumb item is automatically considered the current item, and it's
-not a link.",
+not a link.
+",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<T>",
@@ -3823,12 +3687,12 @@ exports[`Documenter definition for button matches the snapshot: button 1`] = `
       "description": "Called when the user clicks on the button with the left mouse button without pressing
 modifier keys (that is, CTRL, ALT, SHIFT, META), and the button has an \`href\` set.",
       "detailInlineType": {
-        "name": "BaseNavigationDetail",
+        "name": "ButtonProps.FollowDetail",
         "properties": [
           {
             "name": "external",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "href",
@@ -3843,7 +3707,7 @@ modifier keys (that is, CTRL, ALT, SHIFT, META), and the button has an \`href\` 
         ],
         "type": "object",
       },
-      "detailType": "BaseNavigationDetail",
+      "detailType": "ButtonProps.FollowDetail",
       "name": "onFollow",
     },
   ],
@@ -3914,18 +3778,9 @@ Applicable for all button variants, except link.",
       "description": "Specifies whether the linked URL, when selected, will prompt the user to download instead of navigate.
 You can specify a string value that will be suggested as the name of the downloaded file.
 This property only applies when an \`href\` is provided.",
-      "inlineType": {
-        "name": "string | boolean",
-        "type": "union",
-        "values": [
-          "string",
-          "false",
-          "true",
-        ],
-      },
       "name": "download",
       "optional": true,
-      "type": "string | boolean",
+      "type": "boolean | string",
     },
     {
       "defaultValue": "false",
@@ -3937,7 +3792,7 @@ If an href is provided, it opens the link in a new tab.",
     },
     {
       "description": "The id of the <form> element to associate with the button. The value of this attribute must be the id of a <form> in the same document.
-Use when a button is not the descendant of a form element, such as when used in a modal.",
+ Use when a button is not the descendant of a form element, such as when used in a modal.",
       "name": "form",
       "optional": true,
       "type": "string",
@@ -3949,8 +3804,8 @@ Use when a button is not the descendant of a form element, such as when used in 
         "name": "ButtonProps.FormAction",
         "type": "union",
         "values": [
-          "none",
           "submit",
+          "none",
         ],
       },
       "name": "formAction",
@@ -3972,7 +3827,6 @@ For example, if you have a 'help' button that links to a documentation page.",
     },
     {
       "description": "An object containing all the necessary localized strings required by the component. The object should contain:
-
 * \`externalIconAriaLabel\` - (optional) Specifies the aria-label for the external icon when \`external\` is set to \`true\`.",
       "i18nTag": true,
       "inlineType": {
@@ -4018,29 +3872,6 @@ This property is ignored if you use a predefined icon or if you set your custom 
         "name": "IconProps.Name",
         "type": "union",
         "values": [
-          "search",
-          "map",
-          "filter",
-          "key",
-          "file",
-          "pause",
-          "play",
-          "remove",
-          "copy",
-          "menu",
-          "script",
-          "close",
-          "status-pending",
-          "refresh",
-          "external",
-          "group",
-          "calendar",
-          "ellipsis",
-          "zoom-in",
-          "zoom-out",
-          "download",
-          "security",
-          "edit",
           "add-plus",
           "anchor-link",
           "angle-left-double",
@@ -4059,6 +3890,7 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "backward-10-seconds",
           "bug",
           "call",
+          "calendar",
           "caret-down-filled",
           "caret-down",
           "caret-left-filled",
@@ -4067,14 +3899,20 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "caret-up",
           "check",
           "contact",
+          "close",
           "closed-caption",
           "closed-caption-unavailable",
+          "copy",
           "command-prompt",
           "delete-marker",
+          "download",
           "drag-indicator",
+          "edit",
+          "ellipsis",
           "envelope",
           "exit-full-screen",
           "expand",
+          "external",
           "face-happy",
           "face-happy-filled",
           "face-neutral",
@@ -4082,6 +3920,8 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "face-sad",
           "face-sad-filled",
           "file-open",
+          "file",
+          "filter",
           "flag",
           "folder-open",
           "folder",
@@ -4091,20 +3931,31 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "globe",
           "grid-view",
           "group-active",
+          "group",
           "heart",
           "heart-filled",
           "insert-row",
+          "key",
           "keyboard",
           "list-view",
           "location-pin",
           "lock-private",
+          "map",
+          "menu",
           "microphone",
           "microphone-off",
           "mini-player",
           "multiscreen",
           "notification",
+          "pause",
+          "play",
           "redo",
+          "refresh",
+          "remove",
           "resize-area",
+          "script",
+          "search",
+          "security",
           "settings",
           "send",
           "share",
@@ -4115,6 +3966,7 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "status-in-progress",
           "status-info",
           "status-negative",
+          "status-pending",
           "status-positive",
           "status-stopped",
           "status-warning",
@@ -4144,6 +3996,8 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "view-full",
           "view-horizontal",
           "view-vertical",
+          "zoom-in",
+          "zoom-out",
           "zoom-to-fit",
         ],
       },
@@ -4153,8 +4007,8 @@ This property is ignored if you use a predefined icon or if you set your custom 
     },
     {
       "description": "Specifies the URL of a custom icon. Use this property if the icon you want isn't available.
-
-If you set both \`iconUrl\` and \`iconSvg\`, \`iconSvg\` will take precedence.",
+If you set both \`iconUrl\` and \`iconSvg\`, \`iconSvg\` will take precedence.
+",
       "name": "iconUrl",
       "optional": true,
       "type": "string",
@@ -4209,10 +4063,10 @@ This property only applies when an \`href\` is provided.",
         "name": "ButtonProps.Variant",
         "type": "union",
         "values": [
-          "link",
           "normal",
-          "icon",
           "primary",
+          "link",
+          "icon",
           "inline-icon",
           "inline-link",
         ],
@@ -4238,7 +4092,6 @@ This property only applies when an \`href\` is provided.",
     },
     {
       "description": "Specifies the SVG of a custom icon.
-
 Use this property if you want your custom icon to inherit colors dictated by variant or hover states.
 When this property is set, the component will be decorated with \`aria-hidden="true"\`. Ensure that the \`svg\` element:
 - has attribute \`focusable="false"\`.
@@ -4255,7 +4108,8 @@ You can still set the stroke to \`currentColor\` to inherit the color of the sur
 If you set both \`iconUrl\` and \`iconSvg\`, \`iconSvg\` will take precedence.
 
 *Note:* Remember to remove any additional elements (for example: \`defs\`) and related CSS classes from SVG files exported from design software.
-In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.",
+In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.
+",
       "isDefault": false,
       "name": "iconSvg",
     },
@@ -4276,12 +4130,12 @@ exports[`Documenter definition for button-dropdown matches the snapshot: button-
           {
             "name": "checked",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "external",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "href",
@@ -4314,12 +4168,12 @@ modifier keys (that is, CTRL, ALT, SHIFT, META), and the item has an \`href\` se
           {
             "name": "checked",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "external",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "href",
@@ -4399,23 +4253,23 @@ If provided, the disabled button becomes focusable.",
     },
     {
       "defaultValue": "false",
-      "description": "Controls expandability of the item groups.",
-      "name": "expandableGroups",
+      "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
+Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
+[React Portals](https://reactjs.org/docs/portals.html).
+Set this property if the dropdown would otherwise be constrained by a scrollable container,
+for example inside table and split view layouts.
+
+We recommend you use discretion, and don't enable this property unless necessary
+because fixed positioning results in a slight, visible lag when scrolling complex pages.
+",
+      "name": "expandToViewport",
       "optional": true,
       "type": "boolean",
     },
     {
       "defaultValue": "false",
-      "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
-Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
-[React Portals](https://reactjs.org/docs/portals.html).
-
-Set this property if the dropdown would otherwise be constrained by a scrollable container,
-for example inside table and split view layouts.
-
-We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.",
-      "name": "expandToViewport",
+      "description": "Controls expandability of the item groups.",
+      "name": "expandableGroups",
       "optional": true,
       "type": "boolean",
     },
@@ -4436,7 +4290,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Array of objects with a number of supported types.
-
 The following properties are supported across all types:
 
 - \`type\` (string) - The type of the item. Can be \`action\`, \`group\`, \`checkbox\`. Defaults to \`action\` if \`items\` undefined and \`group\` otherwise.
@@ -4471,7 +4324,9 @@ When \`type\` is set to "checkbox", the values set to \`href\`, \`external\` and
 ### group
 
 - \`items\` (ReadonlyArray<Item>) - an array of item objects. Items will be rendered as nested menu items but only for the first nesting level, multi-nesting is not supported.
-An item which belongs to nested group has the following properties: \`id\`, \`text\`, \`disabled\`, and \`description\`.",
+An item which belongs to nested group has the following properties: \`id\`, \`text\`, \`disabled\`, and \`description\`.
+
+",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<ButtonDropdownProps.ItemOrGroup>",
@@ -4493,14 +4348,14 @@ It prevents clicks.",
     {
       "description": "A standalone action that is shown prior to the dropdown trigger.
 Use it with "primary" and "normal" variant only.
-
 Main action properties:
 * \`text\` (string) - Specifies the text shown in the main action.
 * \`external\` (boolean) - Marks the main action as external by adding an icon after the text. The link will open in a new tab when clicked. Note that this only works when \`href\` is also provided.
 * \`externalIconAriaLabel\` (string) - Adds an ARIA label to the external icon.
 
 The main action also supports the following properties of the [button](/components/button/?tabId=api) component:
-\`ariaLabel\`, \`disabled\`, \`loading\`, \`loadingText\`, \`href\`, \`target\`, \`rel\`, \`download\`, \`iconAlt\`, \`iconName\`, \`iconUrl\`, \`iconSvg\`, \`onClick\`, \`onFollow\`.",
+\`ariaLabel\`, \`disabled\`, \`loading\`, \`loadingText\`, \`href\`, \`target\`, \`rel\`, \`download\`, \`iconAlt\`, \`iconName\`, \`iconUrl\`, \`iconSvg\`, \`onClick\`, \`onFollow\`.
+",
       "inlineType": {
         "name": "ButtonDropdownProps.MainAction",
         "properties": [
@@ -4512,7 +4367,7 @@ The main action also supports the following properties of the [button](/componen
           {
             "name": "disabled",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "disabledReason",
@@ -4522,12 +4377,12 @@ The main action also supports the following properties of the [button](/componen
           {
             "name": "download",
             "optional": true,
-            "type": "string | boolean",
+            "type": "boolean | string",
           },
           {
             "name": "external",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "externalIconAriaLabel",
@@ -4562,7 +4417,7 @@ The main action also supports the following properties of the [button](/componen
           {
             "name": "loading",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "loadingText",
@@ -4577,7 +4432,7 @@ The main action also supports the following properties of the [button](/componen
           {
             "name": "onFollow",
             "optional": true,
-            "type": "CancelableEventHandler<BaseNavigationDetail>",
+            "type": "CancelableEventHandler<ButtonProps.FollowDetail>",
           },
           {
             "name": "rel",
@@ -4613,8 +4468,8 @@ The main action also supports the following properties of the [button](/componen
         "type": "union",
         "values": [
           "normal",
-          "icon",
           "primary",
+          "icon",
           "inline-icon",
         ],
       },
@@ -4642,7 +4497,7 @@ exports[`Documenter definition for button-group matches the snapshot: button-gro
       "cancelable": false,
       "description": "Called when the user uploads files. The event detail object contains the id and files from the file input item.",
       "detailInlineType": {
-        "name": "ButtonGroupProps.FilesChangeDetails",
+        "name": "InternalButtonGroupProps.FilesChangeDetails",
         "properties": [
           {
             "name": "files",
@@ -4657,19 +4512,19 @@ exports[`Documenter definition for button-group matches the snapshot: button-gro
         ],
         "type": "object",
       },
-      "detailType": "ButtonGroupProps.FilesChangeDetails",
+      "detailType": "InternalButtonGroupProps.FilesChangeDetails",
       "name": "onFilesChange",
     },
     {
       "cancelable": false,
       "description": "Called when the user clicks on an item, and the item is not disabled. The event detail object contains the id of the clicked item.",
       "detailInlineType": {
-        "name": "ButtonGroupProps.ItemClickDetails",
+        "name": "InternalButtonGroupProps.ItemClickDetails",
         "properties": [
           {
             "name": "checked",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "id",
@@ -4679,12 +4534,12 @@ exports[`Documenter definition for button-group matches the snapshot: button-gro
           {
             "name": "pressed",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
         ],
         "type": "object",
       },
-      "detailType": "ButtonGroupProps.ItemClickDetails",
+      "detailType": "InternalButtonGroupProps.ItemClickDetails",
       "name": "onItemClick",
     },
   ],
@@ -4720,7 +4575,6 @@ Use this to provide a unique accessible name for each button group on the page."
     {
       "defaultValue": "false",
       "description": "Use this property to determine dropdown placement strategy for all menu dropdown items.
-
 By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
@@ -4729,7 +4583,8 @@ Set this property if the dropdown would otherwise be constrained by a scrollable
 for example inside table and split view layouts.
 
 We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.",
+because fixed positioning results in a slight, visible lag when scrolling complex pages.
+",
       "name": "dropdownExpandToViewport",
       "optional": true,
       "type": "boolean",
@@ -4745,7 +4600,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Array of objects with a number of supported types.
-
 ### icon-button
 
 * \`id\` (string) - The unique identifier of the button, used as detail in \`onItemClick\` handler and to focus the button using \`ref.focus(id)\`.
@@ -4798,7 +4652,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
 ### group
 
 * \`text\` (string) - The name of the group rendered as ARIA label for this group.
-* \`items\` ((ButtonGroupProps.IconButton | ButtonGroupProps.MenuDropdown)[]) - The array of items that belong to this group.",
+* \`items\` ((ButtonGroupProps.IconButton | ButtonGroupProps.MenuDropdown)[]) - The array of items that belong to this group.
+",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<ButtonGroupProps.ItemOrGroup>",
@@ -4806,9 +4661,16 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "description": "Determines the general styling of the button dropdown.
 * \`icon\` for icon buttons.",
+      "inlineType": {
+        "name": "ButtonGroupProps.Variant",
+        "type": "union",
+        "values": [
+          "icon",
+        ],
+      },
       "name": "variant",
       "optional": false,
-      "type": ""icon"",
+      "type": "string",
     },
   ],
   "regions": [],
@@ -4885,7 +4747,7 @@ If provided, the date becomes focusable.",
       "type": "CalendarProps.DateDisabledReasonFunction",
     },
     {
-      "defaultValue": "'day'",
+      "defaultValue": ""day"",
       "description": "Specifies the granularity at which users will be able to select a date.
 Defaults to \`day\`.",
       "inlineType": {
@@ -4954,7 +4816,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": "() => true",
       "description": "Defines whether a particular date is enabled in the calendar or not.
 If you disable a date in the calendar, users can still enter this date using a keyboard.
 We recommend that you also validate these constraints on the client-side and server-side
@@ -4975,7 +4836,7 @@ as you would for other form elements.",
       "type": "CalendarProps.IsDateEnabledFunction",
     },
     {
-      "defaultValue": "''",
+      "defaultValue": """",
       "description": "Specifies the locale to use to render month names and determine the starting day of the week.
 If you don't provide this, the locale is determined by the page and browser locales.
 Supported values and formats are listed in the
@@ -5032,7 +4893,7 @@ exports[`Documenter definition for cards matches the snapshot: cards 1`] = `
       "description": "Called when a user interaction causes a change in the list of selected items.
 The event \`detail\` contains the current list of \`selectedItems\`.",
       "detailInlineType": {
-        "name": "CardsProps.SelectionChangeDetail<T>",
+        "name": "CardsProps.SelectionChangeDetail",
         "properties": [
           {
             "name": "selectedItems",
@@ -5063,14 +4924,13 @@ scroll parent up to reveal the first card or row of cards.",
 * \`selectionGroupLabel\` (string) - Specifies the label for the group selection control.
 * \`cardsLabel\` (string) - Provides alternative text for the cards list.
                            By default the contents of the \`header\` are used.
-
 You can use the first arguments of type \`SelectionState\` to access the current selection
 state of the component (for example, the \`selectedItems\` list). The label function for individual
 items also receives the corresponding  \`Item\` object. You can use the group label to
 add a meaningful description to the whole selection.",
       "i18nTag": true,
       "inlineType": {
-        "name": "CardsProps.AriaLabels<T>",
+        "name": "CardsProps.AriaLabels",
         "properties": [
           {
             "name": "cardsLabel",
@@ -5095,31 +4955,31 @@ add a meaningful description to the whole selection.",
       "type": "CardsProps.AriaLabels<T>",
     },
     {
-      "description": "Defines what to display in each card. It has the following properties:
-* \`header\` ((item) => ReactNode) - Responsible for displaying the card header. You receive the current item as an argument.
-    Use \`fontSize="inherit"\` on [link](/components/link/) components inside card header.
-* \`sections\` (array) - Responsible for displaying the card content. Cards can have many sections in their
-  body. Each entry in the array is responsible for displaying a section. An entry has the following properties:
-  * \`id\`: (string) - A unique identifier for the section. The property is used as a [keys](https://reactjs.org/docs/lists-and-keys.html#keys)
- source for React rendering, and to match entries in the \`visibleSections\` property (if it's defined).
-  * \`header\`: (ReactNode) - Responsible for displaying the section header.
-  * \`content\`: ((item) => ReactNode) - Responsible for displaying the section content. You receive the current item as an argument.
-  * \`width\`: (number) - Specifies the width of the card section in percent. Use this to display multiple sections in
-  the same row. The default value is 100%.
-
-All of the above properties are optional.",
+      "description": " Defines what to display in each card. It has the following properties:
+ * \`header\` ((item) => ReactNode) - Responsible for displaying the card header. You receive the current item as an argument.
+     Use \`fontSize="inherit"\` on [link](/components/link/) components inside card header.
+ * \`sections\` (array) - Responsible for displaying the card content. Cards can have many sections in their
+   body. Each entry in the array is responsible for displaying a section. An entry has the following properties:
+   * \`id\`: (string) - A unique identifier for the section. The property is used as a [keys](https://reactjs.org/docs/lists-and-keys.html#keys)
+  source for React rendering, and to match entries in the \`visibleSections\` property (if it's defined).
+   * \`header\`: (ReactNode) - Responsible for displaying the section header.
+   * \`content\`: ((item) => ReactNode) - Responsible for displaying the section content. You receive the current item as an argument.
+   * \`width\`: (number) - Specifies the width of the card section in percent. Use this to display multiple sections in
+   the same row. The default value is 100%.
+ All of the above properties are optional.
+",
       "inlineType": {
-        "name": "CardsProps.CardDefinition<T>",
+        "name": "CardsProps.CardDefinition",
         "properties": [
-          {
-            "name": "header",
-            "optional": true,
-            "type": "((item: T) => React.ReactNode)",
-          },
           {
             "name": "sections",
             "optional": true,
             "type": "ReadonlyArray<CardsProps.SectionDefinition<T>>",
+          },
+          {
+            "name": "header",
+            "optional": true,
+            "type": "(item: T) => React.ReactNode",
           },
         ],
         "type": "object",
@@ -5134,7 +4994,6 @@ All of the above properties are optional.",
 It's an array whose entries are objects containing the following:
 - \`cards\` (number) - Specifies the number of cards per row.
 - \`minWidth\` (number) - Specifies the minimum container width (in pixels) for which this configuration object should apply.
-
 For example, with this configuration:
 \`\`\`
 [{
@@ -5175,7 +5034,8 @@ Default value:
   minWidth: 1920,
   cards: 6
 }]
-\`\`\`",
+\`\`\`
+",
       "name": "cardsPerRow",
       "optional": true,
       "type": "ReadonlyArray<CardsProps.CardsLayout>",
@@ -5196,8 +5056,8 @@ Don't use this property if the card has any other interactive elements.",
     },
     {
       "defaultValue": "1",
-      "description": "Use this property to inform screen readers which range of cards is currently displayed.
-It specifies the index (1-based) of the first card.",
+      "description": " Use this property to inform screen readers which range of cards is currently displayed.
+ It specifies the index (1-based) of the first card.",
       "name": "firstIndex",
       "optional": true,
       "type": "number",
@@ -5214,7 +5074,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "description": "Determines which items are disabled. If an item is disabled, users can't select it.",
       "inlineType": {
-        "name": "CardsProps.IsItemDisabled<T>",
+        "name": "CardsProps.IsItemDisabled",
         "parameters": [
           {
             "name": "item",
@@ -5231,8 +5091,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "defaultValue": "[]",
       "description": "Specifies the items that serve as data source for a card.
-
-The \`cardDefinition\` property handles the display of this data.",
+The \`cardDefinition\` property handles the display of this data.
+",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<T>",
@@ -5255,20 +5115,9 @@ The function argument takes the following properties:
 * \`firstIndex\` (number) - The provided \`firstIndex\` property which defaults to 1 when not defined.
 * \`lastIndex\` (number) - The index of the last visible item of the table.
 * \`totalItemsCount\` (optional, number) - The provided \`totalItemsCount\` property.",
-      "inlineType": {
-        "name": "(data: CardsProps.LiveAnnouncement) => string",
-        "parameters": [
-          {
-            "name": "data",
-            "type": "CardsProps.LiveAnnouncement",
-          },
-        ],
-        "returnType": "string",
-        "type": "function",
-      },
       "name": "renderAriaLive",
       "optional": true,
-      "type": "((data: CardsProps.LiveAnnouncement) => string)",
+      "type": "(data: CardsProps.LiveAnnouncement) => string",
     },
     {
       "description": "Specifies the list of selected items.",
@@ -5315,10 +5164,10 @@ If there is an unknown total number of cards, leave this property undefined.",
       "description": "Specifies the property inside items that uniquely identifies them.
 When it's set, it's used to provide [keys for React](https://reactjs.org/docs/lists-and-keys.html#keys)
 for performance optimizations.
-
-It's also used for connecting \`items\` and \`selectedItems\` values when they don't reference the same object.",
+It's also used for connecting \`items\` and \`selectedItems\` values when they don't reference the same object.
+",
       "inlineType": {
-        "name": "CardsProps.TrackBy<T>",
+        "name": "CardsProps.TrackBy",
         "type": "union",
         "values": [
           "string",
@@ -5335,7 +5184,7 @@ It's also used for connecting \`items\` and \`selectedItems\` values when they d
 * \`container\` - Use this variant to have the cards displayed as a container.
 * \`full-page\` – Use this variant when cards are the entire content of a page.",
       "inlineType": {
-        "name": ""container" | "full-page"",
+        "name": "",
         "type": "union",
         "values": [
           "container",
@@ -5349,10 +5198,10 @@ It's also used for connecting \`items\` and \`selectedItems\` values when they d
     },
     {
       "description": "Specifies an array containing the \`id\` of each visible section. If not set, all sections are displayed.
-
 Use it in conjunction with the visible content preference of the [collection preferences](/components/collection-preferences/) component.
 
-The order of \`id\`s doesn't influence the order of display of sections, which is controlled by the \`cardDefinition\` property.",
+The order of \`id\`s doesn't influence the order of display of sections, which is controlled by the \`cardDefinition\` property.
+",
       "name": "visibleSections",
       "optional": true,
       "type": "ReadonlyArray<string>",
@@ -5445,20 +5294,20 @@ If the component controls any secondary content (for example, another form field
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-
-Use this if you don't have a visible label for this control.",
+Use this if you don't have a visible label for this control.
+",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -5466,11 +5315,11 @@ Use this if you don't have a visible label for this control.",
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -5645,6 +5494,7 @@ The event \`detail\` contains the value of all the preferences as submitted by t
       "cancelable": false,
       "description": "Called when the user clicks the recovery button in the error state.
 Use this to retry loading the code editor or to provide another option for the user to recover from the error.",
+      "detailType": "void",
       "name": "onRecoveryClick",
     },
     {
@@ -5656,7 +5506,7 @@ Use this to retry loading the code editor or to provide another option for the u
           {
             "name": "annotations",
             "optional": false,
-            "type": "Array<Ace.Annotation>",
+            "type": "Array<Annotation>",
           },
         ],
         "type": "object",
@@ -5684,12 +5534,12 @@ Use this to retry loading the code editor or to provide another option for the u
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -5703,11 +5553,11 @@ and set the property to a string of each ID separated by spaces (for example, \`
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -5722,9 +5572,9 @@ To use it correctly, define an ID for the element you want to use as label and s
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -5738,20 +5588,13 @@ is provided by its parent form field component.",
     {
       "description": "Use this property to specify a different dynamic modal root for the dialog.
 The function will be called when a user clicks on the trigger button.",
-      "inlineType": {
-        "name": "() => Promise<HTMLElement>",
-        "parameters": [],
-        "returnType": "Promise<HTMLElement>",
-        "type": "function",
-      },
       "name": "getModalRoot",
       "optional": true,
-      "type": "(() => Promise<HTMLElement>)",
+      "type": "() => Promise<HTMLElement>",
     },
     {
       "description": "An object containing all the necessary localized strings required by the component.
 The object should contain, among others:
-
 * \`loadingState\` - Specifies the text to display while the component is loading.
 * \`errorState\` - Specifies the text to display if there is an error loading Ace.
 * \`errorStateRecovery\`: Specifies the text for the recovery button that's displayed next to the error text.
@@ -5763,15 +5606,10 @@ The object should contain, among others:
           {
             "name": "cursorPosition",
             "optional": true,
-            "type": "((row: number, column: number) => string)",
+            "type": "(row: number, column: number) => string",
           },
           {
             "name": "editorGroupAriaLabel",
-            "optional": true,
-            "type": "string",
-          },
-          {
-            "name": "errorsTab",
             "optional": true,
             "type": "string",
           },
@@ -5782,6 +5620,11 @@ The object should contain, among others:
           },
           {
             "name": "errorStateRecovery",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "errorsTab",
             "optional": true,
             "type": "string",
           },
@@ -5892,174 +5735,8 @@ Alternatively, this can be used to set a language that is not supported by the d
 For more info on custom languages, see the [Code editor API](/components/code-editor?tabId=api) page.",
       "inlineType": {
         "name": "CodeEditorProps.Language",
-        "type": "union",
-        "values": [
-          ""stylus"",
-          ""mask"",
-          ""html"",
-          ""ruby"",
-          ""svg"",
-          ""text"",
-          ""json"",
-          ""red"",
-          ""space"",
-          ""dot"",
-          ""d"",
-          ""r"",
-          ""properties"",
-          ""slim"",
-          ""abap"",
-          ""abc"",
-          ""actionscript"",
-          ""ada"",
-          ""alda"",
-          ""apache_conf"",
-          ""apex"",
-          ""aql"",
-          ""asciidoc"",
-          ""asl"",
-          ""assembly_x86"",
-          ""autohotkey"",
-          ""batchfile"",
-          ""c_cpp"",
-          ""c9search"",
-          ""cirru"",
-          ""clojure"",
-          ""cobol"",
-          ""coffee"",
-          ""coldfusion"",
-          ""crystal"",
-          ""csharp"",
-          ""csound_document"",
-          ""csound_orchestra"",
-          ""csound_score"",
-          ""css"",
-          ""curly"",
-          ""dart"",
-          ""diff"",
-          ""django"",
-          ""dockerfile"",
-          ""drools"",
-          ""edifact"",
-          ""eiffel"",
-          ""ejs"",
-          ""elixir"",
-          ""elm"",
-          ""erlang"",
-          ""forth"",
-          ""fortran"",
-          ""fsharp"",
-          ""fsl"",
-          ""ftl"",
-          ""gcode"",
-          ""gherkin"",
-          ""gitignore"",
-          ""glsl"",
-          ""gobstones"",
-          ""golang"",
-          ""graphqlschema"",
-          ""groovy"",
-          ""haml"",
-          ""handlebars"",
-          ""haskell"",
-          ""haskell_cabal"",
-          ""haxe"",
-          ""hjson"",
-          ""html_elixir"",
-          ""html_ruby"",
-          ""ini"",
-          ""io"",
-          ""jack"",
-          ""jade"",
-          ""java"",
-          ""javascript"",
-          ""json5"",
-          ""jsoniq"",
-          ""jsp"",
-          ""jssm"",
-          ""jsx"",
-          ""julia"",
-          ""kotlin"",
-          ""latex"",
-          ""less"",
-          ""liquid"",
-          ""lisp"",
-          ""livescript"",
-          ""logiql"",
-          ""lsl"",
-          ""lua"",
-          ""luapage"",
-          ""lucene"",
-          ""makefile"",
-          ""markdown"",
-          ""matlab"",
-          ""maze"",
-          ""mediawiki"",
-          ""mel"",
-          ""mixal"",
-          ""mushcode"",
-          ""mysql"",
-          ""nginx"",
-          ""nim"",
-          ""nix"",
-          ""nsis"",
-          ""nunjucks"",
-          ""objectivec"",
-          ""ocaml"",
-          ""pascal"",
-          ""perl"",
-          ""perl6"",
-          ""pgsql"",
-          ""php"",
-          ""php_laravel_blade"",
-          ""pig"",
-          ""powershell"",
-          ""praat"",
-          ""prisma"",
-          ""prolog"",
-          ""protobuf"",
-          ""puppet"",
-          ""python"",
-          ""qml"",
-          ""razor"",
-          ""rdoc"",
-          ""rhtml"",
-          ""rst"",
-          ""rust"",
-          ""sass"",
-          ""scad"",
-          ""scala"",
-          ""scheme"",
-          ""scss"",
-          ""sh"",
-          ""sjs"",
-          ""smarty"",
-          ""snippets"",
-          ""soy_template"",
-          ""sql"",
-          ""sqlserver"",
-          ""swift"",
-          ""tcl"",
-          ""terraform"",
-          ""tex"",
-          ""textile"",
-          ""toml"",
-          ""tsx"",
-          ""twig"",
-          ""typescript"",
-          ""vala"",
-          ""vbscript"",
-          ""velocity"",
-          ""verilog"",
-          ""vhdl"",
-          ""visualforce"",
-          ""wollok"",
-          ""xml"",
-          ""xquery"",
-          ""yaml"",
-          ""zeek"",
-          "string & { _?: undefined; }",
-        ],
+        "properties": [],
+        "type": "object",
       },
       "name": "language",
       "optional": false,
@@ -6079,7 +5756,6 @@ For more info on custom languages, see the [Code editor API](/components/code-ed
     },
     {
       "description": "Specifies the component preferences.
-
 If set to \`undefined\`, the component uses the following default value:
 
 \`\`\`
@@ -6089,23 +5765,8 @@ If set to \`undefined\`, the component uses the following default value:
 }
 \`\`\`
 
-You can use any theme provided by Ace.",
-      "inlineType": {
-        "name": "Partial<CodeEditorProps.Preferences>",
-        "properties": [
-          {
-            "name": "theme",
-            "optional": false,
-            "type": "CodeEditorProps.Theme",
-          },
-          {
-            "name": "wrapLines",
-            "optional": false,
-            "type": "boolean",
-          },
-        ],
-        "type": "object",
-      },
+You can use any theme provided by Ace.
+",
       "name": "preferences",
       "optional": true,
       "type": "Partial<CodeEditorProps.Preferences>",
@@ -6114,20 +5775,9 @@ You can use any theme provided by Ace.",
       "description": "Use this property when \`getModalRoot\` is used to clean up the modal root
 element after a user closes the dialog. The function receives the return value
 of the most recent getModalRoot call as an argument.",
-      "inlineType": {
-        "name": "(rootElement: HTMLElement) => void",
-        "parameters": [
-          {
-            "name": "rootElement",
-            "type": "HTMLElement",
-          },
-        ],
-        "returnType": "void",
-        "type": "function",
-      },
       "name": "removeModalRoot",
       "optional": true,
-      "type": "((rootElement: HTMLElement) => void)",
+      "type": "(rootElement: HTMLElement) => void",
     },
     {
       "description": "List of Ace themes available for selection in preferences dialog. Make sure you include at least one light and at
@@ -6176,7 +5826,6 @@ exports[`Documenter definition for collection-preferences matches the snapshot: 
     {
       "cancelable": false,
       "description": "Called when the user confirms a preference change using the confirm button in the modal footer.
-
 The event \`detail\` contains the following:
 - \`contentDensity\` (boolean) - (Optional) The current content density preference value. Available only if you specify the \`contentDensityPreference\` property.
 - \`contentDisplay\` (ReadonlyArray<ContentDisplayItem>) - (Optional) The ordered list of table columns and their visibility. Available only if you specify the \`contentDisplayPreference\` property.
@@ -6187,14 +5836,15 @@ The event \`detail\` contains the following:
 - \`visibleContent\` (ReadonlyArray<string>) - (Optional) The list of selected content \`id\`s. Available only if you specify the \`visibleContentPreference\` property.
 - \`wrapLines\` (boolean) - (Optional) The current line wrapping preference value. Available only if you specify the \`wrapLinesPreference\` property.
 
-The values for all configured preferences are present even if the user didn't change their values.",
+The values for all configured preferences are present even if the user didn't change their values.
+",
       "detailInlineType": {
-        "name": "CollectionPreferencesProps.Preferences<CustomPreferenceType>",
+        "name": "CollectionPreferencesProps.Preferences",
         "properties": [
           {
             "name": "contentDensity",
             "optional": true,
-            "type": ""compact" | "comfortable"",
+            "type": ""comfortable" | "compact"",
           },
           {
             "name": "contentDisplay",
@@ -6204,7 +5854,7 @@ The values for all configured preferences are present even if the user didn't ch
           {
             "name": "custom",
             "optional": true,
-            "type": "CustomPreferenceType",
+            "type": "CollectionPreferencesProps.Preferences.CustomPreferenceType",
           },
           {
             "name": "pageSize",
@@ -6214,12 +5864,12 @@ The values for all configured preferences are present even if the user didn't ch
           {
             "name": "stickyColumns",
             "optional": true,
-            "type": "StickyColumns",
+            "type": "CollectionPreferencesProps.StickyColumns",
           },
           {
             "name": "stripedRows",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "visibleContent",
@@ -6229,7 +5879,7 @@ The values for all configured preferences are present even if the user didn't ch
           {
             "name": "wrapLines",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
         ],
         "type": "object",
@@ -6264,7 +5914,6 @@ The values for all configured preferences are present even if the user didn't ch
     },
     {
       "description": "Configures the content density preference (Comfortable / Compact).
-
 If you set it, the component displays this preference in the modal.
 
 It contains the following:
@@ -6295,7 +5944,6 @@ You must set the current value in the \`preferences.contentDensity\` property.",
     },
     {
       "description": "Configures the built-in content display preference for order and visibility of the table columns.
-
 Recommended for table and not applicable for cards.
 
 Cannot be used together with \`visibleContentPreference\`.
@@ -6342,7 +5990,7 @@ You must provide an ordered list of the items to display in the \`preferences.co
           {
             "name": "enableColumnFiltering",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "i18nStrings",
@@ -6357,17 +6005,17 @@ You must provide an ordered list of the items to display in the \`preferences.co
           {
             "name": "liveAnnouncementDndItemCommitted",
             "optional": true,
-            "type": "((initialPosition: number, finalPosition: number, total: number) => string)",
+            "type": "(initialPosition: number, finalPosition: number, total: number) => string",
           },
           {
             "name": "liveAnnouncementDndItemReordered",
             "optional": true,
-            "type": "((initialPosition: number, currentPosition: number, total: number) => string)",
+            "type": "(initialPosition: number, currentPosition: number, total: number) => string",
           },
           {
             "name": "liveAnnouncementDndStarted",
             "optional": true,
-            "type": "((position: number, total: number) => string)",
+            "type": "(position: number, total: number) => string",
           },
           {
             "name": "options",
@@ -6388,7 +6036,6 @@ You must provide an ordered list of the items to display in the \`preferences.co
     },
     {
       "description": "Configures custom preferences. The function receives two parameters:
-
 - \`customValue\` (CustomPreferenceType) - Current value for your custom preference. It is initialized using the value you provide in \`preferences.custom\`.
 - \`setCustomValue\` - A function that is called to notify a state update.
 
@@ -6405,25 +6052,11 @@ When the user cancels the changes, the \`customValue\` is reset to the one prese
 **Display**
 - If any of the built-in preferences (\`pageSizePreference\`, \`wrapLinesPreference\`, or \`visibleContentPreference\`) are displayed,
 the custom content is displayed at the bottom of the left column within the modal.
-- If no built-in preference is displayed, the custom content occupies the whole modal.",
-      "inlineType": {
-        "name": "(customValue: CustomPreferenceType, setCustomValue: React.Dispatch<CustomPreferenceType>) => React.ReactNode",
-        "parameters": [
-          {
-            "name": "customValue",
-            "type": "CustomPreferenceType",
-          },
-          {
-            "name": "setCustomValue",
-            "type": "React.Dispatch<CustomPreferenceType>",
-          },
-        ],
-        "returnType": "React.ReactNode",
-        "type": "function",
-      },
+- If no built-in preference is displayed, the custom content occupies the whole modal.
+",
       "name": "customPreference",
       "optional": true,
-      "type": "((customValue: CustomPreferenceType, setCustomValue: React.Dispatch<CustomPreferenceType>) => React.ReactNode)",
+      "type": "(customValue: CustomPreferenceType, setCustomValue: React.Dispatch<CustomPreferenceType>) => React.ReactNode",
     },
     {
       "defaultValue": "false",
@@ -6435,15 +6068,9 @@ the custom content is displayed at the bottom of the left column within the moda
     {
       "description": "Use this property to specify a different dynamic modal root for the dialog.
 The function will be called when a user clicks on the trigger button.",
-      "inlineType": {
-        "name": "() => Promise<HTMLElement>",
-        "parameters": [],
-        "returnType": "Promise<HTMLElement>",
-        "type": "function",
-      },
       "name": "getModalRoot",
       "optional": true,
-      "type": "(() => Promise<HTMLElement>)",
+      "type": "() => Promise<HTMLElement>",
     },
     {
       "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
@@ -6456,7 +6083,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Configures the built-in "page size selection" preference.
-
 If you set it, the component displays this preference in the modal.
 
 It contains the following:
@@ -6489,20 +6115,20 @@ You must set the current value in the \`preferences.pageSize\` property.",
     },
     {
       "description": "Specifies the current preference values. This includes both built-in and custom preferences.
-
 It contains the following:
 - \`pageSize\` (number) - (Optional)
 - \`wrapLines\` (boolean) - (Optional)
 - \`contentDisplay\` (ReadonlyArray<ContentDisplayItem>) - (Optional) Specifies the list of content and their visibility. The order of the elements influences the display.
 - \`visibleContent\` (ReadonlyArray<string>) - Specifies the list of visible content \`id\`s. The order of the \`id\`s does not influence the display. If the \`contentDisplay\` property is set, this property is ignored.
-- \`custom\` (CustomPreferenceType) - Specifies the value for your custom preference.",
+- \`custom\` (CustomPreferenceType) - Specifies the value for your custom preference.
+",
       "inlineType": {
-        "name": "CollectionPreferencesProps.Preferences<CustomPreferenceType>",
+        "name": "CollectionPreferencesProps.Preferences",
         "properties": [
           {
             "name": "contentDensity",
             "optional": true,
-            "type": ""compact" | "comfortable"",
+            "type": ""comfortable" | "compact"",
           },
           {
             "name": "contentDisplay",
@@ -6512,7 +6138,7 @@ It contains the following:
           {
             "name": "custom",
             "optional": true,
-            "type": "CustomPreferenceType",
+            "type": "CollectionPreferencesProps.Preferences.CustomPreferenceType",
           },
           {
             "name": "pageSize",
@@ -6522,12 +6148,12 @@ It contains the following:
           {
             "name": "stickyColumns",
             "optional": true,
-            "type": "StickyColumns",
+            "type": "CollectionPreferencesProps.StickyColumns",
           },
           {
             "name": "stripedRows",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "visibleContent",
@@ -6537,7 +6163,7 @@ It contains the following:
           {
             "name": "wrapLines",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
         ],
         "type": "object",
@@ -6550,43 +6176,32 @@ It contains the following:
       "description": "Use this property when \`getModalRoot\` is used to clean up the modal root
 element after a user closes the dialog. The function receives the return value
 of the most recent getModalRoot call as an argument.",
-      "inlineType": {
-        "name": "(rootElement: HTMLElement) => void",
-        "parameters": [
-          {
-            "name": "rootElement",
-            "type": "HTMLElement",
-          },
-        ],
-        "returnType": "void",
-        "type": "function",
-      },
       "name": "removeModalRoot",
       "optional": true,
-      "type": "((rootElement: HTMLElement) => void)",
+      "type": "(rootElement: HTMLElement) => void",
     },
     {
       "description": "Configures the sticky columns preference that can be set for both left and right columns.
-
 If you set it, the component displays this preference in the modal.
 
 It contains the following:
 - \`label\` (string) - Specifies the label for each radio group.
 - \`description\` (string) - Specifies the text displayed below each radio group label.
 
-You must set the current value in the \`preferences.stickyColumns\` property.",
+You must set the current value in the \`preferences.stickyColumns\` property.
+",
       "inlineType": {
         "name": "CollectionPreferencesProps.StickyColumnsPreference",
         "properties": [
           {
             "name": "firstColumns",
             "optional": true,
-            "type": "StickyColumnPreference",
+            "type": "CollectionPreferencesProps.StickyColumnPreference",
           },
           {
             "name": "lastColumns",
             "optional": true,
-            "type": "StickyColumnPreference",
+            "type": "CollectionPreferencesProps.StickyColumnPreference",
           },
         ],
         "type": "object",
@@ -6597,7 +6212,6 @@ You must set the current value in the \`preferences.stickyColumns\` property.",
     },
     {
       "description": "Configures the built-in "striped rows" preference.
-
 If you set it, the component displays this preference in the modal.
 
 It contains the following:
@@ -6635,7 +6249,6 @@ You must set the current value in the \`preferences.stripedRows\` property.",
     },
     {
       "description": "Configures the built-in visible sections preference for cards or visible columns for table.
-
 Recommended for cards. For table use \`contentDisplayPreference\` instead.
 
 Cannot be used together with \`contentDisplayPreference\`.
@@ -6655,7 +6268,8 @@ Each group of options contains the following:
 
 You must set the current list of visible content \`id\`s in the \`preferences.visibleContent\` property.
 
-**Deprecated** in table, replaced by \`contentDisplayPreference\`.",
+**Deprecated** in table, replaced by \`contentDisplayPreference\`.
+",
       "inlineType": {
         "name": "CollectionPreferencesProps.VisibleContentPreference",
         "properties": [
@@ -6678,7 +6292,6 @@ You must set the current list of visible content \`id\`s in the \`preferences.vi
     },
     {
       "description": "Configures the built-in "wrap lines" preference.
-
 If you set it, the component displays this preference in the modal.
 
 It contains the following:
@@ -6726,18 +6339,18 @@ exports[`Documenter definition for column-layout matches the snapshot: column-la
   "name": "ColumnLayout",
   "properties": [
     {
-      "defaultValue": "'none'",
+      "defaultValue": ""none"",
       "description": "Controls whether dividers are placed between rows and columns.
-
-Note: This is not supported when used with \`minColumnWidth\`.",
+Note: This is not supported when used with \`minColumnWidth\`.
+",
       "inlineType": {
         "name": "ColumnLayoutProps.Borders",
         "type": "union",
         "values": [
-          "all",
           "none",
-          "horizontal",
           "vertical",
+          "horizontal",
+          "all",
         ],
       },
       "name": "borders",
@@ -6777,15 +6390,15 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Use together with \`columns\` to specify the desired minimum width for each column in pixels.
-
 The number of columns is determined by the value of this property, the available space,
-and the maximum number of columns as defined by the \`columns\` property.",
+and the maximum number of columns as defined by the \`columns\` property.
+",
       "name": "minColumnWidth",
       "optional": true,
       "type": "number",
     },
     {
-      "defaultValue": "'default'",
+      "defaultValue": ""default"",
       "description": "Specifies the content type. This determines the spacing of the grid.",
       "inlineType": {
         "name": "ColumnLayoutProps.Variant",
@@ -6861,9 +6474,9 @@ exports[`Documenter definition for container matches the snapshot: container 1`]
       "defaultValue": "false",
       "description": "Enabling this property will make the container to fit into available height. If content is too short, the container
 will stretch, if too long, the container will shrink and show vertical scrollbar.
-
 Use this property to align heights of multiple containers displayed in a single row. It is recommended to stretch
-all containers to the height of the longest one, to avoid extra vertical scroll areas.",
+all containers to the height of the longest one, to avoid extra vertical scroll areas.
+",
       "name": "fitHeight",
       "optional": true,
       "type": "boolean",
@@ -6878,10 +6491,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "description": "
-Use this slot to render a media element. Supported element types are 'img', 'video', and 'picture'.
+      "description": "Use this slot to render a media element. Supported element types are 'img', 'video', and 'picture'.
 You can define different positions and sizes for the media element within the container.
-
 * \`content\` - Use this slot to render your media element. We support \`img\`, \`video\`, \`picture\`, and \`iframe\` elements.
 
 * \`position\` - Defines the media slot's position within the container. Defaults to \`top\`.
@@ -6893,29 +6504,31 @@ If no width is provided, the media slot will take a maximum of 66% of the contai
 
 * \`height\` - Defines the height of the media slot when position on the top. Corresponds to the \`height\` CSS-property.
 When this value is set, media elements larger than the defined width may be cropped, with 'object-fit: cover' centering it.   * Note: This value is only considered if \`position\` is set to \`top\`.
-If no height is provided, the media slot will be displayed at its full height.",
+If no height is provided, the media slot will be displayed at its full height.
+
+",
       "inlineType": {
         "name": "ContainerProps.Media",
         "properties": [
           {
             "name": "content",
-            "optional": true,
+            "optional": false,
             "type": "React.ReactNode",
           },
           {
             "name": "height",
             "optional": true,
-            "type": "string | number",
+            "type": "number | string",
           },
           {
             "name": "position",
             "optional": true,
-            "type": ""top" | "side"",
+            "type": ""side" | "top"",
           },
           {
             "name": "width",
             "optional": true,
-            "type": "string | number",
+            "type": "number | string",
           },
         ],
         "type": "object",
@@ -6925,13 +6538,13 @@ If no height is provided, the media slot will be displayed at its full height.",
       "type": "ContainerProps.Media",
     },
     {
-      "defaultValue": "'default'",
+      "defaultValue": ""default"",
       "description": "Specify a container variant with one of the following:
 * \`default\` - Use this variant in standalone context.
 * \`stacked\` - Use this variant adjacent to other stacked containers (such as a container,
               table).",
       "inlineType": {
-        "name": ""default" | "stacked"",
+        "name": "",
         "type": "union",
         "values": [
           "default",
@@ -6995,24 +6608,16 @@ If true, the overlap will be removed.",
     },
     {
       "description": "Use this property to style the background of the header.
-
 It can be:
 * a string representing the CSS \`background\` value for the header element.
 * a function that receives the mode ("light" or "dark") as a parameter and returns a string.
 
  The header background spans across the full available width, independent of the specified \`maxContentWidth\`.
- If set, the component will not add the default background color to the header.",
-      "inlineType": {
-        "name": "string | ((mode: "dark" | "light") => string)",
-        "type": "union",
-        "values": [
-          "string",
-          "(mode: "dark" | "light") => string",
-        ],
-      },
+ If set, the component will not add the default background color to the header.
+",
       "name": "headerBackgroundStyle",
       "optional": true,
-      "type": "string | ((mode: "dark" | "light") => string)",
+      "type": "((mode: "dark" | "light") => string) | string",
     },
     {
       "description": "Determines the visual treatment for the header. Specifically:
@@ -7021,12 +6626,12 @@ It can be:
     If you are using the AppLayout component, set \`headerVariant="high-contrast"\` to apply the same treatment to the breadcrumbs and notifications slots.
 * \`divider\` - Adds a horizontal separator between the header and the content.",
       "inlineType": {
-        "name": ""default" | "divider" | "high-contrast"",
+        "name": "",
         "type": "union",
         "values": [
           "default",
-          "divider",
           "high-contrast",
+          "divider",
         ],
       },
       "name": "headerVariant",
@@ -7057,8 +6662,8 @@ If not set, all elements will occupy the full available width.",
       "description": "Use this slot to add the [breadcrumb group component](/components/breadcrumb-group/) to the content layout:
 * if your application does not use the [app layout component](/components/app-layout/), which already offers a \`breadcrumbs\` slot.
 * If your page uses the [app layout component](/components/app-layout/) with \`disableContentPaddings=true\`.
-
-Do not use in conjunction with the \`breadcrumbs\` slot in the [app layout component](/components/app-layout/).",
+Do not use in conjunction with the \`breadcrumbs\` slot in the [app layout component](/components/app-layout/).
+",
       "isDefault": false,
       "name": "breadcrumbs",
     },
@@ -7077,8 +6682,8 @@ Do not use in conjunction with the \`breadcrumbs\` slot in the [app layout compo
       "description": "Use this slot to display [notifications](/components/flashbar/) to the content layout:
 * If your page does not use the [app layout component](/components/app-layout/), which already offers a \`notifications\` slot.
 * If your page uses the [app layout component](/components/app-layout/) with \`disableContentPaddings=true\`.
-
-Do not use in conjunction with the \`notifications\` slot in the [app layout component](/components/app-layout/).",
+Do not use in conjunction with the \`notifications\` slot in the [app layout component](/components/app-layout/).
+",
       "isDefault": false,
       "name": "notifications",
     },
@@ -7166,19 +6771,19 @@ Enable this setting if you need the popover to ignore its parent stacking contex
     {
       "defaultValue": ""button"",
       "description": "Determines the general styling of the copy button as follows:
-
 * \`button\` to display a standalone secondary button with an icon, and \`copyButtonText\` as text.
 * \`icon\` to display a standalone icon-only (no text) button.
 * \`inline\` to display an icon-only (no text) button within a text context.
 
-Defaults to \`button\`.",
+Defaults to \`button\`.
+",
       "inlineType": {
         "name": "CopyToClipboardProps.Variant",
         "type": "union",
         "values": [
-          "inline",
           "button",
           "icon",
+          "inline",
         ],
       },
       "name": "variant",
@@ -7197,6 +6802,7 @@ exports[`Documenter definition for date-input matches the snapshot: date-input 1
     {
       "cancelable": false,
       "description": "Called when input focus is removed from the UI control.",
+      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -7204,7 +6810,7 @@ exports[`Documenter definition for date-input matches the snapshot: date-input 1
       "description": "Called whenever a user changes the input value (by typing or pasting).
 The event \`detail\` contains the current value of the field.",
       "detailInlineType": {
-        "name": "BaseChangeDetail",
+        "name": "InputProps.ChangeDetail",
         "properties": [
           {
             "name": "value",
@@ -7214,48 +6820,36 @@ The event \`detail\` contains the current value of the field.",
         ],
         "type": "object",
       },
-      "detailType": "BaseChangeDetail",
+      "detailType": "InputProps.ChangeDetail",
       "name": "onChange",
     },
     {
       "cancelable": false,
       "description": "Called when input focus is moved to the UI control.",
+      "detailType": "null",
       "name": "onFocus",
     },
   ],
-  "functions": [
-    {
-      "description": "Sets input focus onto the UI control.",
-      "name": "focus",
-      "parameters": [],
-      "returnType": "void",
-    },
-    {
-      "description": "Selects all text in the input control.",
-      "name": "select",
-      "parameters": [],
-      "returnType": "void",
-    },
-  ],
+  "functions": [],
   "name": "DateInput",
   "properties": [
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-
-Use this if you don't have a visible label for this control.",
+Use this if you don't have a visible label for this control.
+",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -7263,11 +6857,11 @@ Use this if you don't have a visible label for this control.",
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -7298,9 +6892,9 @@ scrolled out of the viewport.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -7349,8 +6943,8 @@ single form field.",
       "description": "Specifies if the control is read-only, which prevents the
 user from modifying the value but includes it in a form
 submission. A read-only control can receive focus.
-
-Don't use read-only inputs outside a form.",
+Don't use read-only inputs outside a form.
+",
       "name": "readOnly",
       "optional": true,
       "type": "boolean",
@@ -7386,6 +6980,7 @@ exports[`Documenter definition for date-picker matches the snapshot: date-picker
     {
       "cancelable": false,
       "description": "Called when input focus is removed from the UI control.",
+      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -7409,6 +7004,7 @@ The event \`detail\` contains the current value of the field.",
     {
       "cancelable": false,
       "description": "Called when input focus is moved to the UI control.",
+      "detailType": "null",
       "name": "onFocus",
     },
   ],
@@ -7425,20 +7021,20 @@ The event \`detail\` contains the current value of the field.",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-
-Use this if you don't have a visible label for this control.",
+Use this if you don't have a visible label for this control.
+",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -7446,11 +7042,11 @@ Use this if you don't have a visible label for this control.",
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -7482,9 +7078,9 @@ scrolled out of the viewport.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -7521,12 +7117,12 @@ receive focus.",
       "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
-
 Set this property if the dropdown would otherwise be constrained by a scrollable container,
 for example inside table and split view layouts.
 
 We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.",
+because fixed positioning results in a slight, visible lag when scrolling complex pages.
+",
       "name": "expandToViewport",
       "optional": true,
       "type": "boolean",
@@ -7552,7 +7148,7 @@ Defaults to \`day\`.",
 the component.",
       "i18nTag": true,
       "inlineType": {
-        "name": "CalendarProps.I18nStrings",
+        "name": "DatePickerProps.I18nStrings",
         "properties": [
           {
             "name": "currentMonthAriaLabel",
@@ -7589,7 +7185,7 @@ the component.",
       },
       "name": "i18nStrings",
       "optional": true,
-      "type": "CalendarProps.I18nStrings",
+      "type": "DatePickerProps.I18nStrings",
     },
     {
       "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
@@ -7662,7 +7258,7 @@ a human-readable localised string representing the current value of the input.
         "parameters": [
           {
             "name": "selectedDate",
-            "type": "string | null",
+            "type": "null | string",
           },
         ],
         "returnType": "string",
@@ -7691,8 +7287,8 @@ a human-readable localised string representing the current value of the input.
       "description": "Specifies if the control is read-only, which prevents the
 user from modifying the value but includes it in a form
 submission. A read-only control can receive focus.
-
-Do not use read-only inputs outside of a form.",
+Do not use read-only inputs outside of a form.
+",
       "name": "readOnly",
       "optional": true,
       "type": "boolean",
@@ -7743,6 +7339,7 @@ exports[`Documenter definition for date-range-picker matches the snapshot: date-
     {
       "cancelable": false,
       "description": "Fired when keyboard focus is removed from the UI control.",
+      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -7766,6 +7363,7 @@ The event \`detail\` contains the current value of the field.",
     {
       "cancelable": false,
       "description": "Fired when keyboard focus is set onto the UI control.",
+      "detailType": "null",
       "name": "onFocus",
     },
   ],
@@ -7782,12 +7380,12 @@ The event \`detail\` contains the current value of the field.",
     {
       "defaultValue": "'iso'",
       "description": "Specifies the time format to use for displaying the absolute time range.
-
 It can take the following values:
 * \`iso\`: ISO 8601 format, e.g.: 2024-01-30T13:32:32+01:00 (or 2024-01-30 when \`dateOnly\` is true)
 * \`long-localized\`: a more human-readable, localized format, e.g.: January 30, 2024, 13:32:32 (UTC+1) (or January 30, 2024 when \`dateOnly\` is true)
 
-Defaults to \`iso\`.",
+Defaults to \`iso\`.
+",
       "inlineType": {
         "name": "DateRangePickerProps.AbsoluteFormat",
         "type": "union",
@@ -7803,12 +7401,12 @@ Defaults to \`iso\`.",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -7816,11 +7414,11 @@ and set the property to a string of each ID separated by spaces (for example, \`
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -7835,9 +7433,9 @@ To use it correctly, define an ID for the element you want to use as label and s
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -7890,13 +7488,13 @@ If provided, the date becomes focusable.",
     {
       "defaultValue": "false",
       "description": "Hides time inputs and changes the input format to date-only, e.g. 2021-04-06.
-
 Do not use \`dateOnly\` flag conditionally. The component does not trigger the value update
 when the flag changes which means the value format can become inconsistent.
 
 This does not apply when the 'granularity' is set to 'month'
 
-Default: \`false\`.",
+Default: \`false\`.
+",
       "name": "dateOnly",
       "optional": true,
       "type": "boolean",
@@ -7914,12 +7512,12 @@ modifying the value. A disabled component cannot receive focus.",
       "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
-
 Set this property if the dropdown would otherwise be constrained by a scrollable container,
 for example inside table and split view layouts.
 
 We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.",
+because fixed positioning results in a slight, visible lag when scrolling complex pages.
+",
       "name": "expandToViewport",
       "optional": true,
       "type": "boolean",
@@ -7927,13 +7525,13 @@ because fixed positioning results in a slight, visible lag when scrolling comple
     {
       "description": "A function that defines timezone offset from UTC in minutes for selected dates.
 Use it to define time relative to the desired timezone.
-
 The function is called for the start date and the end date and takes a UTC date
 corresponding the selected value as an argument.
 
 Has no effect when \`dateOnly\` is true.
 
-Default: the user's current time offset as provided by the browser.",
+Default: the user's current time offset as provided by the browser.
+",
       "inlineType": {
         "name": "DateRangePickerProps.GetTimeOffsetFunction",
         "parameters": [
@@ -8076,12 +7674,12 @@ Defaults to \`false\`.",
           {
             "name": "formatRelativeRange",
             "optional": true,
-            "type": "((value: DateRangePickerProps.RelativeValue) => string)",
+            "type": "(value: DateRangePickerProps.RelativeValue) => string",
           },
           {
             "name": "formatUnit",
             "optional": true,
-            "type": "((unit: DateRangePickerProps.TimeUnit, value: number) => string)",
+            "type": "(unit: DateRangePickerProps.TimeUnit, value: number) => string",
           },
           {
             "name": "modeSelectionLabel",
@@ -8131,7 +7729,7 @@ Defaults to \`false\`.",
           {
             "name": "renderSelectedAbsoluteRangeAriaLive",
             "optional": true,
-            "type": "((startDate: string, endDate: string) => string)",
+            "type": "(startDate: string, endDate: string) => string",
           },
           {
             "name": "startDateLabel",
@@ -8204,8 +7802,8 @@ server-side, in the same way as for other form elements.",
     {
       "defaultValue": "() => ({ valid: true })",
       "description": "A function that defines whether a particular range is valid or not.
-
-Ensure that your function checks for missing fields in the value.",
+Ensure that your function checks for missing fields in the value.
+",
       "inlineType": {
         "name": "DateRangePickerProps.ValidationFunction",
         "parameters": [
@@ -8240,12 +7838,12 @@ are as-per the [JavaScript Intl API specification](https://developer.mozilla.org
     {
       "defaultValue": "'default'",
       "description": "Determines the range selector mode as follows:
-
 * \`default\` for combined absolute/relative range selector.
 * \`absolute-only\` for absolute-only range selector.
 * \`relative-only\` for relative-only range selector.
 
-By default, the range selector mode is \`default\`.",
+By default, the range selector mode is \`default\`.
+",
       "inlineType": {
         "name": "DateRangePickerProps.RangeSelectorMode",
         "type": "union",
@@ -8293,10 +7891,10 @@ but you can override it using this property.",
     {
       "defaultValue": "'hh:mm:ss'",
       "description": "Specifies the format of the time input for absolute ranges.
-
 Use to restrict the granularity of time that the user can enter.
 
-Has no effect when \`dateOnly\` is true or \`granularity\` is set to 'month'.",
+Has no effect when \`dateOnly\` is true or \`granularity\` is set to 'month'.
+",
       "inlineType": {
         "name": "TimeInputProps.Format",
         "type": "union",
@@ -8314,10 +7912,10 @@ Has no effect when \`dateOnly\` is true or \`granularity\` is set to 'month'.",
       "deprecatedTag": "Use \`getTimeOffset\` instead.",
       "description": "The time offset from UTC in minutes that should be used to
 display and produce values.
-
 Has no effect when \`dateOnly\` is true.
 
-Default: the user's current time offset as provided by the browser.",
+Default: the user's current time offset as provided by the browser.
+",
       "name": "timeOffset",
       "optional": true,
       "type": "number",
@@ -8325,17 +7923,9 @@ Default: the user's current time offset as provided by the browser.",
     {
       "description": "The current date range value. Can be either an absolute time range
 or a relative time range.",
-      "inlineType": {
-        "name": "DateRangePickerProps.Value",
-        "type": "union",
-        "values": [
-          "DateRangePickerProps.AbsoluteValue",
-          "DateRangePickerProps.RelativeValue",
-        ],
-      },
       "name": "value",
       "optional": false,
-      "type": "DateRangePickerProps.Value",
+      "type": "DateRangePickerProps.Value | null",
     },
     {
       "description": "Overrides the warning state. Usually the warning state
@@ -8411,8 +8001,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Header of the drawer.
-
-It should contain the only \`h2\` used in the drawer.",
+It should contain the only \`h2\` used in the drawer.
+",
       "isDefault": false,
       "name": "header",
     },
@@ -8542,7 +8132,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": "'default'",
+      "defaultValue": ""default"",
       "description": "The possible variants of an expandable section are as follows:
  * \`default\` - Use this variant in any context.
  * \`footer\` - Use this variant in container footers.
@@ -8555,12 +8145,12 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
         "name": "ExpandableSectionProps.Variant",
         "type": "union",
         "values": [
-          "inline",
           "default",
-          "container",
           "footer",
+          "container",
           "navigation",
           "stacked",
+          "inline",
         ],
       },
       "name": "variant",
@@ -8577,6 +8167,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "deprecatedTag": "Use \`headerText\` instead.",
+      "description": "",
       "isDefault": false,
       "name": "header",
     },
@@ -8694,12 +8285,12 @@ The event \`detail\` contains the current value of the component.",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -8714,11 +8305,11 @@ that don't have visible text, and to distinguish between multiple file inputs wi
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -8745,9 +8336,9 @@ To use it correctly, define an ID for the element you want to use as label and s
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -8787,7 +8378,7 @@ If you want to clear the selection, use empty array.",
     {
       "description": "Variant of the file input. Defaults to "button".",
       "inlineType": {
-        "name": ""button" | "icon"",
+        "name": "",
         "type": "union",
         "values": [
           "button",
@@ -8809,8 +8400,8 @@ exports[`Documenter definition for file-token-group matches the snapshot: file-t
   "events": [
     {
       "cancelable": false,
-      "description": "Called when the user clicks on the dismiss button. The token won't be automatically removed.
-Make sure that you add a listener to this event to update your application state.",
+      "description": " Called when the user clicks on the dismiss button. The token won't be automatically removed.
+ Make sure that you add a listener to this event to update your application state.",
       "detailInlineType": {
         "name": "FileTokenGroupProps.DismissDetail",
         "properties": [
@@ -8868,12 +8459,12 @@ Make sure that you add a listener to this event to update your application state
           {
             "name": "formatFileLastModified",
             "optional": true,
-            "type": "((date: Date) => string)",
+            "type": "(date: Date) => string",
           },
           {
             "name": "formatFileSize",
             "optional": true,
-            "type": "((sizeInBytes: number) => string)",
+            "type": "(sizeInBytes: number) => string",
           },
           {
             "name": "limitShowFewer",
@@ -8888,7 +8479,7 @@ Make sure that you add a listener to this event to update your application state
           {
             "name": "removeFileAriaLabel",
             "optional": true,
-            "type": "((fileIndex: number) => string)",
+            "type": "(fileIndex: number) => string",
           },
           {
             "name": "warningIconAriaLabel",
@@ -8912,13 +8503,12 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "description": "
-An array of objects representing token items. Each token has the following properties:
-
+      "description": "An array of objects representing token items. Each token has the following properties:
 - \`file\` (string) - File value.
 - \`loading\` (boolean) - (Optional) Determine whether the token is loading.
 - \`errorText\` (string) - (Optional) Text that displays as a validation error message.
-- \`warningText\` (string) - (Optional) - Text that displays as a validation warning message.",
+- \`warningText\` (string) - (Optional) - Text that displays as a validation warning message.
+",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<FileTokenGroupProps.Item>",
@@ -9015,12 +8605,12 @@ The event \`detail\` contains the current value of the component.",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -9028,11 +8618,11 @@ and set the property to a string of each ID separated by spaces (for example, \`
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -9053,9 +8643,9 @@ To use it correctly, define an ID for the element you want to use as label and s
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -9064,7 +8654,7 @@ is provided by its parent form field component.",
       "description": "An array of file errors corresponding to the files in the \`value\`.",
       "name": "fileErrors",
       "optional": true,
-      "type": "ReadonlyArray<string | null>",
+      "type": "ReadonlyArray<null | string>",
     },
     {
       "description": "Alignment of the file tokens. Defaults to "vertical".",
@@ -9072,8 +8662,8 @@ is provided by its parent form field component.",
         "name": "FileUploadProps.FileTokenAlignment",
         "type": "union",
         "values": [
-          "horizontal",
           "vertical",
+          "horizontal",
         ],
       },
       "name": "fileTokenAlignment",
@@ -9084,7 +8674,7 @@ is provided by its parent form field component.",
       "description": "An array of file warnings corresponding to the files in the \`value\`.",
       "name": "fileWarnings",
       "optional": true,
-      "type": "ReadonlyArray<string | null>",
+      "type": "ReadonlyArray<null | string>",
     },
     {
       "description": "An object containing all the localized strings required by the component:
@@ -9103,7 +8693,7 @@ is provided by its parent form field component.",
           {
             "name": "dropzoneText",
             "optional": true,
-            "type": "((multiple: boolean) => string)",
+            "type": "(multiple: boolean) => string",
           },
           {
             "name": "errorIconAriaLabel",
@@ -9113,12 +8703,12 @@ is provided by its parent form field component.",
           {
             "name": "formatFileLastModified",
             "optional": true,
-            "type": "((date: Date) => string)",
+            "type": "(date: Date) => string",
           },
           {
             "name": "formatFileSize",
             "optional": true,
-            "type": "((sizeInBytes: number) => string)",
+            "type": "(sizeInBytes: number) => string",
           },
           {
             "name": "limitShowFewer",
@@ -9133,12 +8723,12 @@ is provided by its parent form field component.",
           {
             "name": "removeFileAriaLabel",
             "optional": true,
-            "type": "((fileIndex: number) => string)",
+            "type": "(fileIndex: number) => string",
           },
           {
             "name": "uploadButtonText",
             "optional": true,
-            "type": "((multiple: boolean) => string)",
+            "type": "(multiple: boolean) => string",
           },
           {
             "name": "warningIconAriaLabel",
@@ -9245,7 +8835,6 @@ exports[`Documenter definition for flashbar matches the snapshot: flashbar 1`] =
     },
     {
       "description": "An object containing all the necessary localized strings required by the component. The object should contain:
-
 * \`ariaLabel\` - Specifies the ARIA label for the list of notifications.
 
 If \`stackItems\` is set to \`true\`, it should also contain:
@@ -9272,12 +8861,12 @@ If \`stackItems\` is set to \`true\`, it should also contain:
             "type": "string",
           },
           {
-            "name": "infoIconAriaLabel",
+            "name": "inProgressIconAriaLabel",
             "optional": true,
             "type": "string",
           },
           {
-            "name": "inProgressIconAriaLabel",
+            "name": "infoIconAriaLabel",
             "optional": true,
             "type": "string",
           },
@@ -9321,7 +8910,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "analyticsTag": "",
       "description": "Specifies flash messages that appear in the same order that they are listed.
 The value is an array of flash message definition objects.
-
 A flash message object contains the following properties:
 * \`header\` (ReactNode) - Specifies the heading text.
 * \`content\` (ReactNode) - Specifies the primary text displayed in the flash element.
@@ -9424,17 +9012,17 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": "'full-page'",
+      "defaultValue": ""full-page"",
       "deprecatedTag": "You can safely remove this property as there is no longer any visual difference between \`full-page\` and \`embedded\` variants.",
       "description": "Specify a form variant with one of the following:
 * \`full-page\` - Use this variant when the form contains the entire content of the page.
 * \`embedded\` - Use this variant when the form doesn't occupy the full page.",
       "inlineType": {
-        "name": ""embedded" | "full-page"",
+        "name": "",
         "type": "union",
         "values": [
-          "embedded",
           "full-page",
+          "embedded",
         ],
       },
       "name": "variant",
@@ -9508,10 +9096,10 @@ exports[`Documenter definition for form-field matches the snapshot: form-field 1
     {
       "description": "The ID of the primary form control. You can use this to set the
 \`for\` attribute of a label for accessibility.
-
 If you don't set this property, the control group automatically sets
 the label to the ID of an inner form control (for example, an [input](/components/input) component).
-This only works well if you're using a single control in the form field.",
+This only works well if you're using a single control in the form field.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -9551,14 +9139,14 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "defaultValue": "false",
       "description": "Determines whether the primary control should expand to 12 columns.
-
 By default (or when this property is set to \`false\`), the primary control
 occupies 9 columns. The secondary control uses the remaining 3 columns.
 On smaller viewports, both components occupy 12 columns and stack on top of each other.
 
 If this property is set to \`true\`, the primary control uses the full
 12 columns. The secondary control (if present) also uses 12 columns, and the two
-controls stack on top of each other.",
+controls stack on top of each other.
+",
       "name": "stretch",
       "optional": true,
       "type": "boolean",
@@ -9638,7 +9226,6 @@ exports[`Documenter definition for grid matches the snapshot: grid 1`] = `
       "defaultValue": "[]",
       "description": "An array of element definitions that specifies how the columns must be
 arranged. Each element definition can have the following properties:
-
 - \`colspan\` (number | GridProps.BreakpointMapping) - The number (1-12) of grid elements for this column to span.
 - \`offset\` (number | GridProps.BreakpointMapping) - The number (0-11) of grid elements by which to offset the column.
 - \`pull\` (number | GridProps.BreakpointMapping) - The number (0-12) of grid elements by which to pull the column to the left.
@@ -9650,7 +9237,8 @@ breakpoints) or an object where the key is one of the supported breakpoints
 applied for that breakpoint and those above it. You must provide a \`default\` value for \`colspan\`.
 
 We recommend that you don't use the \`pull\` and \`push\` properties of the element definition
-for accessibility reasons.",
+for accessibility reasons.
+",
       "name": "gridDefinition",
       "optional": true,
       "type": "ReadonlyArray<GridProps.ElementDefinition>",
@@ -9668,10 +9256,10 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
   "regions": [
     {
       "description": "The elements to align in the grid.
-
 You can provide any elements here. The number of elements
 should match the number of objects defined in the \`gridDefinition\`
-property.",
+property.
+",
       "isDefault": true,
       "name": "children",
     },
@@ -9728,7 +9316,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": "'h2'",
+      "defaultValue": ""h2"",
       "description": "Specifies the variant of the header:
 * \`h1\` - Use this for page level headers.
 * \`h2\` - Use this for container level headers.
@@ -9817,9 +9405,9 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
   "regions": [
     {
       "description": "Main content of the help panel.
-
 Use \`p, a, h3, h4, h5, span, div, ul, ol, li, code, pre, dl, dt, dd, hr, br, i, em, b, strong\` tags to format the content.
-Use \`code\` for inline code or \`pre\` for code blocks.",
+Use \`code\` for inline code or \`pre\` for code blocks.
+",
       "isDefault": true,
       "name": "children",
     },
@@ -9830,8 +9418,8 @@ Use \`code\` for inline code or \`pre\` for code blocks.",
     },
     {
       "description": "Header of the help panel.
-
-It should contain the only \`h2\` used in the help panel.",
+It should contain the only \`h2\` used in the help panel.
+",
       "isDefault": false,
       "name": "header",
     },
@@ -9854,18 +9442,18 @@ exports[`Documenter definition for hotspot matches the snapshot: hotspot 1`] = `
       "type": "string",
     },
     {
-      "defaultValue": "'top'",
+      "defaultValue": ""top"",
       "description": "The direction that the annotation popover should open in.
 Change this property if in the default direction the annotation popover
 overlaps too much with other content on the page.",
       "inlineType": {
-        "name": ""left" | "top" | "bottom" | "right"",
+        "name": "",
         "type": "union",
         "values": [
-          "left",
           "top",
-          "bottom",
           "right",
+          "bottom",
+          "left",
         ],
       },
       "name": "direction",
@@ -9890,10 +9478,10 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": "'right'",
+      "defaultValue": ""right"",
       "description": "On which side of the content the hotspot icon should be displayed.",
       "inlineType": {
-        "name": ""left" | "right"",
+        "name": "",
         "type": "union",
         "values": [
           "left",
@@ -9908,7 +9496,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
   "regions": [
     {
       "description": "Content that should be wrapped by the hotspot icon. Optional.
-
 If you supply this property, the hotspot will wrap it in an element with
 \`flex: 1\`, in order to give the children the maximum available space. The
 hotspot icon will be placed floating next to the children. Use
@@ -9917,7 +9504,8 @@ available width, or a button.
 
 If you do not supply this property, the hotspot icon will behave as an inline
 element. Use this if you want to place the hotspot icon on a label, e.g. a
-checkbox's label.",
+checkbox's label.
+",
       "isDefault": true,
       "name": "children",
     },
@@ -9968,29 +9556,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
         "name": "IconProps.Name",
         "type": "union",
         "values": [
-          "search",
-          "map",
-          "filter",
-          "key",
-          "file",
-          "pause",
-          "play",
-          "remove",
-          "copy",
-          "menu",
-          "script",
-          "close",
-          "status-pending",
-          "refresh",
-          "external",
-          "group",
-          "calendar",
-          "ellipsis",
-          "zoom-in",
-          "zoom-out",
-          "download",
-          "security",
-          "edit",
           "add-plus",
           "anchor-link",
           "angle-left-double",
@@ -10009,6 +9574,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
           "backward-10-seconds",
           "bug",
           "call",
+          "calendar",
           "caret-down-filled",
           "caret-down",
           "caret-left-filled",
@@ -10017,14 +9583,20 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
           "caret-up",
           "check",
           "contact",
+          "close",
           "closed-caption",
           "closed-caption-unavailable",
+          "copy",
           "command-prompt",
           "delete-marker",
+          "download",
           "drag-indicator",
+          "edit",
+          "ellipsis",
           "envelope",
           "exit-full-screen",
           "expand",
+          "external",
           "face-happy",
           "face-happy-filled",
           "face-neutral",
@@ -10032,6 +9604,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
           "face-sad",
           "face-sad-filled",
           "file-open",
+          "file",
+          "filter",
           "flag",
           "folder-open",
           "folder",
@@ -10041,20 +9615,31 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
           "globe",
           "grid-view",
           "group-active",
+          "group",
           "heart",
           "heart-filled",
           "insert-row",
+          "key",
           "keyboard",
           "list-view",
           "location-pin",
           "lock-private",
+          "map",
+          "menu",
           "microphone",
           "microphone-off",
           "mini-player",
           "multiscreen",
           "notification",
+          "pause",
+          "play",
           "redo",
+          "refresh",
+          "remove",
           "resize-area",
+          "script",
+          "search",
+          "security",
           "settings",
           "send",
           "share",
@@ -10065,6 +9650,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
           "status-in-progress",
           "status-info",
           "status-negative",
+          "status-pending",
           "status-positive",
           "status-stopped",
           "status-warning",
@@ -10094,6 +9680,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
           "view-full",
           "view-horizontal",
           "view-vertical",
+          "zoom-in",
+          "zoom-out",
           "zoom-to-fit",
         ],
       },
@@ -10102,22 +9690,22 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": "'normal'",
+      "defaultValue": ""normal"",
       "description": "Specifies the size of the icon.
-
 If you set size to \`inherit\`, an icon size will be assigned based on the icon's inherited line height.
 For icons used alongside text, ensure the icon is placed inside the acompanying text tag.
-The icon will be vertically centered based on the height.",
+The icon will be vertically centered based on the height.
+",
       "inlineType": {
         "name": "IconProps.Size",
         "type": "union",
         "values": [
-          "big",
           "small",
           "normal",
           "medium",
-          "inherit",
+          "big",
           "large",
+          "inherit",
         ],
       },
       "name": "size",
@@ -10128,27 +9716,27 @@ The icon will be vertically centered based on the height.",
     {
       "description": "Specifies the URL of a custom icon. Use this property if the icon you want isn't available, and your custom icon cannot be an SVG.
 For SVG icons, use the \`svg\` slot instead.
-
-If you set both \`url\` and \`svg\`, \`svg\` will take precedence.",
+If you set both \`url\` and \`svg\`, \`svg\` will take precedence.
+",
       "name": "url",
       "optional": true,
       "type": "string",
     },
     {
-      "defaultValue": "'normal'",
+      "defaultValue": ""normal"",
       "description": "Specifies the color variant of the icon. The \`normal\` variant picks up the current color of its context.",
       "inlineType": {
         "name": "IconProps.Variant",
         "type": "union",
         "values": [
-          "link",
           "normal",
-          "error",
           "disabled",
+          "error",
+          "inverted",
+          "link",
+          "subtle",
           "success",
           "warning",
-          "inverted",
-          "subtle",
         ],
       },
       "name": "variant",
@@ -10159,7 +9747,6 @@ If you set both \`url\` and \`svg\`, \`svg\` will take precedence.",
   "regions": [
     {
       "description": "Specifies the SVG of a custom icon.
-
 Use this property if the icon you want isn't available, and you want your custom icon to inherit colors dictated by variant or hover states.
 When this property is set, the component will be decorated with \`aria-hidden="true"\`. Ensure that the \`svg\` element:
 - has attribute \`focusable="false"\`.
@@ -10176,7 +9763,8 @@ You can still set the stroke to \`currentColor\` to inherit the color of the sur
 If you set both \`url\` and \`svg\`, \`svg\` will take precedence.
 
 *Note:* Remember to remove any additional elements (for example: \`defs\`) and related CSS classes from SVG files exported from design software.
-In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.",
+In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.
+",
       "isDefault": false,
       "name": "svg",
     },
@@ -10191,6 +9779,7 @@ exports[`Documenter definition for input matches the snapshot: input 1`] = `
     {
       "cancelable": false,
       "description": "Called when input focus is removed from the UI control.",
+      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -10198,7 +9787,7 @@ exports[`Documenter definition for input matches the snapshot: input 1`] = `
       "description": "Called whenever a user changes the input value (by typing or pasting).
 The event \`detail\` contains the current value of the field.",
       "detailInlineType": {
-        "name": "BaseChangeDetail",
+        "name": "InputProps.ChangeDetail",
         "properties": [
           {
             "name": "value",
@@ -10208,12 +9797,13 @@ The event \`detail\` contains the current value of the field.",
         ],
         "type": "object",
       },
-      "detailType": "BaseChangeDetail",
+      "detailType": "InputProps.ChangeDetail",
       "name": "onChange",
     },
     {
       "cancelable": false,
       "description": "Called when input focus is moved to the UI control.",
+      "detailType": "null",
       "name": "onFocus",
     },
     {
@@ -10222,7 +9812,7 @@ The event \`detail\` contains the current value of the field.",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "BaseKeyDetail",
+        "name": "InputProps.KeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -10262,7 +9852,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "BaseKeyDetail",
+      "detailType": "InputProps.KeyDetail",
       "name": "onKeyDown",
     },
     {
@@ -10271,7 +9861,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "BaseKeyDetail",
+        "name": "InputProps.KeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -10311,7 +9901,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "BaseKeyDetail",
+      "detailType": "InputProps.KeyDetail",
       "name": "onKeyUp",
     },
   ],
@@ -10334,20 +9924,20 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-
-Use this if you don't have a visible label for this control.",
+Use this if you don't have a visible label for this control.
+",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -10355,11 +9945,11 @@ Use this if you don't have a visible label for this control.",
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -10375,21 +9965,12 @@ To use it correctly, define an ID for the element you want to use as label and s
       "description": "Specifies whether to enable a browser's autocomplete functionality for this input.
 In some cases it might be appropriate to disable autocomplete (for example, for security-sensitive fields).
 To use it correctly, set the \`name\` property.
-
 You can either provide a boolean value to set the property to "on" or "off", or specify a string value
-for the [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.",
-      "inlineType": {
-        "name": "string | boolean",
-        "type": "union",
-        "values": [
-          "string",
-          "false",
-          "true",
-        ],
-      },
+for the [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.
+",
       "name": "autoComplete",
       "optional": true,
-      "type": "string | boolean",
+      "type": "boolean | string",
     },
     {
       "description": "Indicates whether the control should be focused as
@@ -10418,9 +9999,9 @@ scrolled out of the viewport.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -10461,14 +10042,14 @@ This value may not be supported by all browsers or devices.",
         "name": "InputProps.InputMode",
         "type": "union",
         "values": [
-          "search",
-          "numeric",
           "none",
-          "url",
           "text",
           "decimal",
+          "numeric",
           "tel",
+          "search",
           "email",
+          "url",
         ],
       },
       "name": "inputMode",
@@ -10501,8 +10082,8 @@ single form field.",
       "description": "Specifies if the control is read-only, which prevents the
 user from modifying the value but includes it in a form
 submission. A read-only control can receive focus.
-
-Don't use read-only inputs outside a form.",
+Don't use read-only inputs outside a form.
+",
       "name": "readOnly",
       "optional": true,
       "type": "boolean",
@@ -10512,10 +10093,10 @@ Don't use read-only inputs outside a form.",
 This value controls the native browser capability to check for spelling/grammar errors.
 If not set, the browser default behavior is to perform spellchecking.
 For more details, check the [spellcheck MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck).
-
 Enhanced spellchecking features of your browser and/or operating system may send input values to external parties.
 Make sure it’s deactivated for fields with sensitive information to prevent
-inadvertently sending data (such as user passwords) to third parties.",
+inadvertently sending data (such as user passwords) to third parties.
+",
       "name": "spellcheck",
       "optional": true,
       "type": "boolean",
@@ -10529,7 +10110,7 @@ including the date, month, week, time, datetime-local, number and range types.",
         "type": "union",
         "values": [
           "number",
-          ""any"",
+          "any",
         ],
       },
       "name": "step",
@@ -10545,12 +10126,12 @@ be slightly different across browsers.",
         "name": "InputProps.Type",
         "type": "union",
         "values": [
-          "number",
-          "search",
-          "url",
           "text",
-          "email",
           "password",
+          "search",
+          "number",
+          "email",
+          "url",
         ],
       },
       "name": "type",
@@ -10631,7 +10212,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "description": "An array of either key-value pairs individual items or groups.
 They could be combined.
 Each item has \`type\` prop, which might be either \`group\` or \`pair\`. Defaults to \`pair\` if not specified.
-
 Each key-value pair definition has the following properties:
   * \`type\` (string) - (Optional) Item type (pair).
   * \`label\` (string) - The key label.
@@ -10642,7 +10222,8 @@ Each group definition has the following properties:
   * \`type\` (string) - Item type (group).
   * \`title\` (string) - (Optional) An optional title for this column.
   * \`items\` (ReadonlyArray<KeyValuePairProps.KeyValuePair>) - An array of
-    key-value pair items.",
+    key-value pair items.
+",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<KeyValuePairsProps.Item>",
@@ -10650,10 +10231,10 @@ Each group definition has the following properties:
     {
       "defaultValue": "150",
       "description": "Use to specify the desired minimum width for each column in pixels.
-
 The number of columns is determined by the value of this property, the available space,
 and the maximum number of columns as defined by the \`columns\` property.
-If not set, defaults to 150.",
+If not set, defaults to 150.
+",
       "name": "minColumnWidth",
       "optional": true,
       "type": "number",
@@ -10672,7 +10253,7 @@ exports[`Documenter definition for line-chart matches the snapshot: line-chart 1
       "description": "Called when the values of the internal filter component changed.
 This will **not** be called for any custom filter components you have defined in \`additionalFilters\`.",
       "detailInlineType": {
-        "name": "CartesianChartProps.FilterChangeDetail<Series>",
+        "name": "CartesianChartProps.FilterChangeDetail",
         "properties": [
           {
             "name": "visibleSeries",
@@ -10682,14 +10263,14 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.FilterChangeDetail<Series>",
+      "detailType": "CartesianChartProps.FilterChangeDetail<MixedLineBarChartProps.ChartSeries<T>>",
       "name": "onFilterChange",
     },
     {
       "cancelable": false,
       "description": "Called when the highlighted series has changed because of user interaction.",
       "detailInlineType": {
-        "name": "CartesianChartProps.HighlightChangeDetail<Series>",
+        "name": "CartesianChartProps.HighlightChangeDetail",
         "properties": [
           {
             "name": "highlightedSeries",
@@ -10699,7 +10280,7 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.HighlightChangeDetail<Series>",
+      "detailType": "CartesianChartProps.HighlightChangeDetail<MixedLineBarChartProps.ChartSeries<T>>",
       "name": "onHighlightChange",
     },
     {
@@ -10745,7 +10326,7 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "Additional content that is displayed at the bottom of the detail popover.",
       "inlineType": {
-        "name": "CartesianChartProps.DetailPopoverFooter<T>",
+        "name": "CartesianChartProps.DetailPopoverFooter",
         "parameters": [
           {
             "name": "xValue",
@@ -10762,15 +10343,15 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "A function that determines the details that are displayed in the popover for each series.
 Use this for wrapping keys or values in external links, or to display a metric breakdown by adding an additional level of nested items.
-
 The function is called with the parameters \`{ series, x, y }\` representing the series, the highlighted x coordinate value and its corresponding y value respectively,
 and should return the following properties:
 * \`key\` (ReactNode) - Name of the series.
 * \`value\` (ReactNode) - Value of the series at the highlighted x coordinate.
 * \`subItems\` (ReadonlyArray<{ key: ReactNode; value: ReactNode }>) - (Optional) List of nested key-value pairs.
-* \`expandable\` (boolean) - (Optional) Determines whether the optional list of nested items provided via \`subItems\` is expandable. This is \`false\` by default.",
+* \`expandable\` (boolean) - (Optional) Determines whether the optional list of nested items provided via \`subItems\` is expandable. This is \`false\` by default.
+",
       "inlineType": {
-        "name": "MixedLineBarChartProps.DetailPopoverSeriesContent<T>",
+        "name": "MixedLineBarChartProps.DetailPopoverSeriesContent",
         "parameters": [
           {
             "name": "data",
@@ -10785,10 +10366,10 @@ and should return the following properties:
       "type": "MixedLineBarChartProps.DetailPopoverSeriesContent<T>",
     },
     {
-      "defaultValue": "'medium'",
+      "defaultValue": ""medium"",
       "description": "Determines the maximum width the detail popover will be limited to.",
       "inlineType": {
-        "name": ""small" | "medium" | "large"",
+        "name": "",
         "type": "union",
         "values": [
           "small",
@@ -10847,26 +10428,18 @@ It is highly recommended to keep this set to \`false\`.",
     {
       "description": "The currently highlighted data series, usually through hovering over a series or the legend.
 A value of \`null\` means no series is highlighted.
-
 - If you do not set this property, series are highlighted automatically when hovering over one of the triggers (uncontrolled behavior).
-- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).",
-      "inlineType": {
-        "name": "NonNullable<Series>",
-        "type": "union",
-        "values": [
-          "Series",
-          "{}",
-        ],
-      },
+- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).
+",
       "name": "highlightedSeries",
       "optional": true,
-      "type": "NonNullable<Series>",
+      "type": "MixedLineBarChartProps.ChartSeries<T> | null",
     },
     {
       "description": "An object containing all the necessary localized strings required by the component.",
       "i18nTag": true,
       "inlineType": {
-        "name": "CartesianChartProps.I18nStrings<T>",
+        "name": "CartesianChartProps.I18nStrings",
         "properties": [
           {
             "name": "chartAriaRoleDescription",
@@ -10958,29 +10531,29 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "defaultValue": "[]",
       "description": "Array that represents the source of data for the displayed chart.
 Each element can represent a line series or a threshold, and can have the following properties:
-
 * \`title\` (string): A human-readable title for this series
 * \`type\` (string): Series type (\`"line"\`, or \`"threshold"\`)
 * \`data\` (Array): An array of data points, represented as objects with \`x\` and \`y\` properties
 * \`color\` (string): (Optional) A color hex value for this series. When assigned, it takes priority over the automatically assigned color
-* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.",
+* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.
+",
       "name": "series",
       "optional": false,
       "type": "ReadonlyArray<LineSeries<T>>",
     },
     {
-      "defaultValue": "'finished'",
+      "defaultValue": ""finished"",
       "description": "Specifies the current status of loading data.
 * \`loading\`: data fetching is in progress.
 * \`finished\`: data has loaded successfully.
 * \`error\`: an error occurred during fetch. You should provide user an option to recover.",
       "inlineType": {
-        "name": ""error" | "finished" | "loading"",
+        "name": "",
         "type": "union",
         "values": [
-          "error",
-          "finished",
           "loading",
+          "finished",
+          "error",
         ],
       },
       "name": "statusType",
@@ -10993,29 +10566,29 @@ Each element can represent a line series or a threshold, and can have the follow
 - If you explicitly set this property, you must set an \`onFilterChange\` listener to update this property when the visible series should change, or when one of your custom filters changes the number of visible series (controlled behavior).",
       "name": "visibleSeries",
       "optional": true,
-      "type": "ReadonlyArray<Series>",
+      "type": "ReadonlyArray<MixedLineBarChartProps.ChartSeries<T>>",
     },
     {
       "description": "Determines the domain of the x axis, i.e. the range of values that will be visible in the chart.
 For numerical and time-based data this is represented as an array with two values: \`[minimumValue, maximumValue]\`.
 For categorical data this is represented as an array of strings that determine the categories to display.
-
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.",
+When controlling this directly, make sure to update the value based on filtering changes.
+",
       "name": "xDomain",
       "optional": true,
       "type": "ReadonlyArray<T>",
     },
     {
-      "defaultValue": "'linear'",
+      "defaultValue": ""linear"",
       "description": "Determines the type of scale for values on the x axis.",
       "inlineType": {
         "name": "ScaleType",
         "type": "union",
         "values": [
           "linear",
-          "time",
           "log",
+          "time",
           "categorical",
         ],
       },
@@ -11026,7 +10599,7 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Function to format the displayed label of an x axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter<T>",
+        "name": "CartesianChartProps.TickFormatter",
         "parameters": [
           {
             "name": "value",
@@ -11049,18 +10622,18 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Determines the domain of the y axis, i.e. the range of values that will be visible in the chart.
 The domain is defined by a tuple: \`[minimumValue, maximumValue]\`.
-
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.",
+When controlling this directly, make sure to update the value based on filtering changes.
+",
       "name": "yDomain",
       "optional": true,
       "type": "ReadonlyArray<number>",
     },
     {
-      "defaultValue": "'linear'",
+      "defaultValue": ""linear"",
       "description": "Determines the type of scale for values on the y axis.",
       "inlineType": {
-        "name": ""linear" | "log"",
+        "name": "",
         "type": "union",
         "values": [
           "linear",
@@ -11074,7 +10647,7 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Function to format the displayed label of a y axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter<number>",
+        "name": "CartesianChartProps.TickFormatter",
         "parameters": [
           {
             "name": "value",
@@ -11161,16 +10734,16 @@ exports[`Documenter definition for link matches the snapshot: link 1`] = `
       "cancelable": true,
       "description": "Called when a link is clicked without any modifier keys. If the link has no \`href\` provided, it will be called on
 all clicks.
-
 If you want to implement client-side routing yourself, use this event and prevent default browser navigation
-(by calling \`preventDefault\`).",
+(by calling \`preventDefault\`).
+",
       "detailInlineType": {
-        "name": "BaseNavigationDetail",
+        "name": "LinkProps.FollowDetail",
         "properties": [
           {
             "name": "external",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "href",
@@ -11185,7 +10758,7 @@ If you want to implement client-side routing yourself, use this event and preven
         ],
         "type": "object",
       },
-      "detailType": "BaseNavigationDetail",
+      "detailType": "LinkProps.FollowDetail",
       "name": "onFollow",
     },
   ],
@@ -11215,11 +10788,11 @@ If you want to implement client-side routing yourself, use this event and preven
     {
       "defaultValue": "'normal'",
       "description": "Determines the text color of the link and its icon.
-
 - \`normal\`: Use in most cases where a link is required.
 - \`inverted\`: Use to style links inside Flashbars.
 
-This property is overridden if the variant is \`info\`.",
+This property is overridden if the variant is \`info\`.
+",
       "inlineType": {
         "name": "LinkProps.Color",
         "type": "union",
@@ -11255,7 +10828,6 @@ This property is overridden if the variant is \`info\`.",
         "name": "LinkProps.FontSize",
         "type": "union",
         "values": [
-          "inherit",
           "body-s",
           "body-m",
           "heading-xs",
@@ -11264,6 +10836,7 @@ This property is overridden if the variant is \`info\`.",
           "heading-l",
           "heading-xl",
           "display-l",
+          "inherit",
         ],
       },
       "name": "fontSize",
@@ -11299,16 +10872,15 @@ By default, the component sets the \`rel\` attribute to "noopener noreferrer" wh
 in a new tab. If you set this property to \`_blank\`, the component
 automatically adds \`rel="noopener noreferrer"\` to avoid performance
 and security issues.
-
 For other options see the documentation for <a> tag's
-[target attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target).",
+[target attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target).
+",
       "name": "target",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Determines the visual style of the link as follows:
-
 - \`primary\` - Displays the link text with bold styling for sufficient contrast with surrounding text.
     Use this for links where the context doesn't imply interactivity such as
     "Learn more" links and links within paragraphs.
@@ -11322,14 +10894,15 @@ The default is \`secondary\`, except inside the following components where it de
 - Cards
 - Alert
 - Popover
-- Help Panel (main \`content\` only)",
+- Help Panel (main \`content\` only)
+",
       "inlineType": {
         "name": "LinkProps.Variant",
         "type": "union",
         "values": [
-          "info",
           "primary",
           "secondary",
+          "info",
           "awsui-value-large",
         ],
       },
@@ -11388,14 +10961,14 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": "'div'",
+      "defaultValue": ""div"",
       "description": "The tag name to use for the wrapper around the \`children\` slot.",
       "inlineType": {
         "name": "LiveRegionProps.TagName",
         "type": "union",
         "values": [
-          "div",
           "span",
+          "div",
         ],
       },
       "name": "tagName",
@@ -11424,7 +10997,7 @@ exports[`Documenter definition for mixed-line-bar-chart matches the snapshot: mi
       "description": "Called when the values of the internal filter component changed.
 This will **not** be called for any custom filter components you have defined in \`additionalFilters\`.",
       "detailInlineType": {
-        "name": "CartesianChartProps.FilterChangeDetail<Series>",
+        "name": "CartesianChartProps.FilterChangeDetail",
         "properties": [
           {
             "name": "visibleSeries",
@@ -11434,14 +11007,14 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.FilterChangeDetail<Series>",
+      "detailType": "CartesianChartProps.FilterChangeDetail<MixedLineBarChartProps.ChartSeries<T>>",
       "name": "onFilterChange",
     },
     {
       "cancelable": false,
       "description": "Called when the highlighted series has changed because of user interaction.",
       "detailInlineType": {
-        "name": "CartesianChartProps.HighlightChangeDetail<Series>",
+        "name": "CartesianChartProps.HighlightChangeDetail",
         "properties": [
           {
             "name": "highlightedSeries",
@@ -11451,7 +11024,7 @@ This will **not** be called for any custom filter components you have defined in
         ],
         "type": "object",
       },
-      "detailType": "CartesianChartProps.HighlightChangeDetail<Series>",
+      "detailType": "CartesianChartProps.HighlightChangeDetail<MixedLineBarChartProps.ChartSeries<T>>",
       "name": "onHighlightChange",
     },
     {
@@ -11497,7 +11070,7 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "Additional content that is displayed at the bottom of the detail popover.",
       "inlineType": {
-        "name": "CartesianChartProps.DetailPopoverFooter<T>",
+        "name": "CartesianChartProps.DetailPopoverFooter",
         "parameters": [
           {
             "name": "xValue",
@@ -11514,15 +11087,15 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     {
       "description": "A function that determines the details that are displayed in the popover for each series.
 Use this for wrapping keys or values in external links, or to display a metric breakdown by adding an additional level of nested items.
-
 The function is called with the parameters \`{ series, x, y }\` representing the series, the highlighted x coordinate value and its corresponding y value respectively,
 and should return the following properties:
 * \`key\` (ReactNode) - Name of the series.
 * \`value\` (ReactNode) - Value of the series at the highlighted x coordinate.
 * \`subItems\` (ReadonlyArray<{ key: ReactNode; value: ReactNode }>) - (Optional) List of nested key-value pairs.
-* \`expandable\` (boolean) - (Optional) Determines whether the optional list of nested items provided via \`subItems\` is expandable. This is \`false\` by default.",
+* \`expandable\` (boolean) - (Optional) Determines whether the optional list of nested items provided via \`subItems\` is expandable. This is \`false\` by default.
+",
       "inlineType": {
-        "name": "MixedLineBarChartProps.DetailPopoverSeriesContent<T>",
+        "name": "MixedLineBarChartProps.DetailPopoverSeriesContent",
         "parameters": [
           {
             "name": "data",
@@ -11537,10 +11110,10 @@ and should return the following properties:
       "type": "MixedLineBarChartProps.DetailPopoverSeriesContent<T>",
     },
     {
-      "defaultValue": "'medium'",
+      "defaultValue": ""medium"",
       "description": "Determines the maximum width the detail popover will be limited to.",
       "inlineType": {
-        "name": ""small" | "medium" | "large"",
+        "name": "",
         "type": "union",
         "values": [
           "small",
@@ -11599,20 +11172,12 @@ It is highly recommended to keep this set to \`false\`.",
     {
       "description": "The currently highlighted data series, usually through hovering over a series or the legend.
 A value of \`null\` means no series is highlighted.
-
 - If you do not set this property, series are highlighted automatically when hovering over one of the triggers (uncontrolled behavior).
-- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).",
-      "inlineType": {
-        "name": "NonNullable<Series>",
-        "type": "union",
-        "values": [
-          "Series",
-          "{}",
-        ],
-      },
+- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a series should be highlighted (controlled behavior).
+",
       "name": "highlightedSeries",
       "optional": true,
-      "type": "NonNullable<Series>",
+      "type": "MixedLineBarChartProps.ChartSeries<T> | null",
     },
     {
       "defaultValue": "false",
@@ -11626,7 +11191,7 @@ This can only be used when the chart consists exclusively of bar series.",
       "description": "An object containing all the necessary localized strings required by the component.",
       "i18nTag": true,
       "inlineType": {
-        "name": "CartesianChartProps.I18nStrings<T>",
+        "name": "CartesianChartProps.I18nStrings",
         "properties": [
           {
             "name": "chartAriaRoleDescription",
@@ -11718,13 +11283,13 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "defaultValue": "[]",
       "description": "Array that represents the source of data for the displayed chart.
 Each element can represent a line series, bar series, or a threshold, and can have the following properties:
-
 * \`title\` (string): A human-readable title for this series.
 * \`type\` (string): Series type (\`"line"\`, \`"bar"\`, or \`"threshold"\`).
 * \`data\` (Array): For line and bar series, an array of data points, represented as objects with \`x\` and \`y\` properties.
 * \`y\` (number): For threshold series, the value of the threshold.
 * \`color\` (string): (Optional) A color hex value for this series. When assigned, it takes priority over the automatically assigned color.
-* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.",
+* \`valueFormatter\` (Function): (Optional) A function that formats data values before rendering in the UI, For example, in the details popover.
+",
       "name": "series",
       "optional": false,
       "type": "ReadonlyArray<MixedLineBarChartProps.ChartSeries<T>>",
@@ -11737,18 +11302,18 @@ Each element can represent a line series, bar series, or a threshold, and can ha
       "type": "boolean",
     },
     {
-      "defaultValue": "'finished'",
+      "defaultValue": ""finished"",
       "description": "Specifies the current status of loading data.
 * \`loading\`: data fetching is in progress.
 * \`finished\`: data has loaded successfully.
 * \`error\`: an error occurred during fetch. You should provide user an option to recover.",
       "inlineType": {
-        "name": ""error" | "finished" | "loading"",
+        "name": "",
         "type": "union",
         "values": [
-          "error",
-          "finished",
           "loading",
+          "finished",
+          "error",
         ],
       },
       "name": "statusType",
@@ -11761,21 +11326,21 @@ Each element can represent a line series, bar series, or a threshold, and can ha
 - If you explicitly set this property, you must set an \`onFilterChange\` listener to update this property when the visible series should change, or when one of your custom filters changes the number of visible series (controlled behavior).",
       "name": "visibleSeries",
       "optional": true,
-      "type": "ReadonlyArray<Series>",
+      "type": "ReadonlyArray<MixedLineBarChartProps.ChartSeries<T>>",
     },
     {
       "description": "Determines the domain of the x axis, i.e. the range of values that will be visible in the chart.
 For numerical and time-based data this is represented as an array with two values: \`[minimumValue, maximumValue]\`.
 For categorical data this is represented as an array of strings that determine the categories to display.
-
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.",
+When controlling this directly, make sure to update the value based on filtering changes.
+",
       "name": "xDomain",
       "optional": true,
       "type": "ReadonlyArray<T>",
     },
     {
-      "defaultValue": "'linear'",
+      "defaultValue": ""linear"",
       "description": "Determines the type of scale for values on the x axis.
 Use \`categorical\` for charts with bars.",
       "inlineType": {
@@ -11783,8 +11348,8 @@ Use \`categorical\` for charts with bars.",
         "type": "union",
         "values": [
           "linear",
-          "time",
           "log",
+          "time",
           "categorical",
         ],
       },
@@ -11795,7 +11360,7 @@ Use \`categorical\` for charts with bars.",
     {
       "description": "Function to format the displayed label of an x axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter<T>",
+        "name": "CartesianChartProps.TickFormatter",
         "parameters": [
           {
             "name": "value",
@@ -11818,18 +11383,18 @@ Use \`categorical\` for charts with bars.",
     {
       "description": "Determines the domain of the y axis, i.e. the range of values that will be visible in the chart.
 The domain is defined by a tuple: \`[minimumValue, maximumValue]\`.
-
 It is recommended to set this explicitly. If not, the component will determine a domain that fits all data points.
-When controlling this directly, make sure to update the value based on filtering changes.",
+When controlling this directly, make sure to update the value based on filtering changes.
+",
       "name": "yDomain",
       "optional": true,
       "type": "ReadonlyArray<number>",
     },
     {
-      "defaultValue": "'linear'",
+      "defaultValue": ""linear"",
       "description": "Determines the type of scale for values on the y axis.",
       "inlineType": {
-        "name": ""linear" | "log"",
+        "name": "",
         "type": "union",
         "values": [
           "linear",
@@ -11843,7 +11408,7 @@ When controlling this directly, make sure to update the value based on filtering
     {
       "description": "Function to format the displayed label of a y axis tick.",
       "inlineType": {
-        "name": "CartesianChartProps.TickFormatter<number>",
+        "name": "CartesianChartProps.TickFormatter",
         "parameters": [
           {
             "name": "value",
@@ -11967,15 +11532,9 @@ The event detail contains the \`reason\`, which can be any of the following:
     {
       "description": "Use this property to specify a different dynamic modal root for the dialog.
 The function will be called when a user clicks on the trigger button.",
-      "inlineType": {
-        "name": "() => Promise<HTMLElement>",
-        "parameters": [],
-        "returnType": "Promise<HTMLElement>",
-        "type": "function",
-      },
       "name": "getModalRoot",
       "optional": true,
-      "type": "(() => Promise<HTMLElement>)",
+      "type": "() => Promise<HTMLElement>",
     },
     {
       "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
@@ -11998,23 +11557,12 @@ render to an element under \`document.body\`.",
       "description": "Use this property when \`getModalRoot\` is used to clean up the modal root
 element after a user closes the dialog. The function receives the return value
 of the most recent getModalRoot call as an argument.",
-      "inlineType": {
-        "name": "(rootElement: HTMLElement) => void",
-        "parameters": [
-          {
-            "name": "rootElement",
-            "type": "HTMLElement",
-          },
-        ],
-        "returnType": "void",
-        "type": "function",
-      },
       "name": "removeModalRoot",
       "optional": true,
-      "type": "((rootElement: HTMLElement) => void)",
+      "type": "(rootElement: HTMLElement) => void",
     },
     {
-      "defaultValue": "'medium'",
+      "defaultValue": ""medium"",
       "description": "Sets the width of the modal. \`max\` uses variable width up to the
 largest size allowed by the design guidelines. Other sizes
 (\`small\`/\`medium\`/\`large\`) have fixed widths.",
@@ -12023,9 +11571,9 @@ largest size allowed by the design guidelines. Other sizes
         "type": "union",
         "values": [
           "small",
-          "max",
           "medium",
           "large",
+          "max",
         ],
       },
       "name": "size",
@@ -12079,7 +11627,7 @@ The event \`detail\` contains the current \`selectedOptions\`.",
           {
             "name": "selectedOptions",
             "optional": false,
-            "type": "ReadonlyArray<OptionDefinition>",
+            "type": "ReadonlyArray<MultiselectProps.Option>",
           },
         ],
         "type": "object",
@@ -12095,7 +11643,6 @@ The event \`detail\` contains the current \`selectedOptions\`.",
     {
       "cancelable": false,
       "description": "Use this event to implement the asynchronous behavior for the component.
-
 The event is called in the following situations:
 * The user scrolls to the end of the list of options, if \`statusType\` is set to \`pending\`.
 * The user clicks on the recovery button in the error state.
@@ -12105,7 +11652,8 @@ The event is called in the following situations:
 The detail object contains the following properties:
 * \`filteringText\` - The value that you need to use to fetch options.
 * \`firstPage\` - Indicates that you should fetch the first page of options that match the \`filteringText\`.
-* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).",
+* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).
+",
       "detailInlineType": {
         "name": "OptionsLoadItemsDetail",
         "properties": [
@@ -12144,12 +11692,12 @@ The detail object contains the following properties:
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -12164,11 +11712,11 @@ Use this if you don't have a visible label for this control.",
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -12206,7 +11754,7 @@ To use it correctly, define an ID for the element you want to use as label and s
         "parameters": [
           {
             "name": "option",
-            "type": "OptionDefinition",
+            "type": "MultiselectProps.Option",
           },
         ],
         "returnType": "string",
@@ -12245,12 +11793,12 @@ To use it correctly, define an ID for the element you want to use as label and s
       "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
-
 Set this property if the dropdown would otherwise be constrained by a scrollable container,
 for example inside table and split view layouts.
 
 We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.",
+because fixed positioning results in a slight, visible lag when scrolling complex pages.
+",
       "name": "expandToViewport",
       "optional": true,
       "type": "boolean",
@@ -12276,29 +11824,13 @@ because fixed positioning results in a slight, visible lag when scrolling comple
     },
     {
       "description": "Specifies the text to display with the number of matches at the bottom of the dropdown menu while filtering.",
-      "inlineType": {
-        "name": "(matchesCount: number, totalCount: number) => string",
-        "parameters": [
-          {
-            "name": "matchesCount",
-            "type": "number",
-          },
-          {
-            "name": "totalCount",
-            "type": "number",
-          },
-        ],
-        "returnType": "string",
-        "type": "function",
-      },
       "name": "filteringResultsText",
       "optional": true,
-      "type": "((matchesCount: number, totalCount: number) => string)",
+      "type": "(matchesCount: number, totalCount: number) => string",
     },
     {
       "defaultValue": "'none'",
       "description": "Determines how filtering is applied to the list of \`options\`:
-
 * \`auto\` - The component will automatically filter options based on user input.
 * \`manual\` - You will set up \`onChange\` or \`onLoadItems\` event listeners and filter options on your side or request
 them from server.
@@ -12311,13 +11843,14 @@ If you set this property to \`manual\`, this default filtering mechanism is disa
 displayed in the dropdown list. In that case make sure that you use the \`onChange\` or \`onLoadItems\` events in order
 to set the \`options\` property to the options that are relevant for the user, given the filtering input value.
 
-Note: Manual filtering doesn't disable match highlighting.",
+Note: Manual filtering doesn't disable match highlighting.
+",
       "inlineType": {
         "name": "OptionsFilteringType",
         "type": "union",
         "values": [
-          "auto",
           "none",
+          "auto",
           "manual",
         ],
       },
@@ -12341,7 +11874,6 @@ Only use this if the selected options are displayed elsewhere on the page.",
     },
     {
       "description": "An object containing all the localized strings required by the component.
-
 * \`selectAllText\` (string) - Specifies the text to be displayed next to the checkbox that selects or deselects all options.
 * \`tokenLimitShowFewer\` (string) - Specifies the text to be displayed in the "Show fewer" button for the token group control.
 * \`tokenLimitShowMore\` (string) - Specifies the text to be displayed in the "Show more" button for the token group control. This string should not contain the number of hidden tokens
@@ -12412,6 +11944,7 @@ single form field.",
     },
     {
       "deprecatedTag": "Has no effect.",
+      "description": "",
       "name": "name",
       "optional": true,
       "type": "string",
@@ -12420,7 +11953,6 @@ single form field.",
       "defaultValue": "[]",
       "description": "Specifies an array of options that are displayed to the user as a dropdown list.
 The options can be grouped using \`OptionGroup\` objects.
-
 #### Option
 - \`value\` (string) - The returned value of the option when selected.
 
@@ -12448,7 +11980,13 @@ If you want to use the built-in filtering capabilities of this component, provid
 a list of all valid options here and they will be automatically filtered based on the user's filtering input.
 
 Alternatively, you can listen to the \`onChange\` or \`onLoadItems\` event and set new options
-on your own.",
+on your own.
+",
+      "inlineType": {
+        "name": "SelectProps.Options",
+        "properties": [],
+        "type": "object",
+      },
       "name": "options",
       "optional": true,
       "type": "SelectProps.Options",
@@ -12481,19 +12019,19 @@ the option's name and properties, and its selected state if
 the \`selectedLabel\` property is defined.
 The highlighted option is provided, and its group (if groups
 are used and it differs from the group of the previously highlighted option).
-
 For more information, see the
-[accessibility guidelines](/components/select/?tabId=usage#accessibility-guidelines).",
+[accessibility guidelines](/components/select/?tabId=usage#accessibility-guidelines).
+",
       "inlineType": {
         "name": "SelectProps.ContainingOptionAndGroupString",
         "parameters": [
           {
             "name": "option",
-            "type": "OptionDefinition",
+            "type": "SelectProps.Option",
           },
           {
             "name": "group",
-            "type": "OptionGroup",
+            "type": "SelectProps.OptionGroup",
           },
         ],
         "returnType": "string",
@@ -12518,7 +12056,7 @@ This is required to provide a good screen reader experience. For more informatio
 Provide an empty array to clear the selection.",
       "name": "selectedOptions",
       "optional": false,
-      "type": "ReadonlyArray<OptionDefinition>",
+      "type": "ReadonlyArray<MultiselectProps.Option>",
     },
     {
       "defaultValue": "'finished'",
@@ -12531,10 +12069,10 @@ Provide an empty array to clear the selection.",
         "name": "DropdownStatusProps.StatusType",
         "type": "union",
         "values": [
-          "error",
-          "finished",
-          "loading",
           "pending",
+          "loading",
+          "finished",
+          "error",
         ],
       },
       "name": "statusType",
@@ -12566,11 +12104,11 @@ Use to assign unique labels when there are multiple token groups with the same \
 that makes the filtering experience smoother. We don't recommend enabling the feature if you
 have less than 500 options, because the improvements to performance are offset by a
 visible scrolling lag.
-
 When you set this flag to \`true\`, it removes options that are not currently in view from the DOM.
 If your test accesses such options, you need to first scroll the options container
 to the correct offset, before performing any operations on them. Use the element returned
-by the \`findOptionsContainer\` test utility for this.",
+by the \`findOptionsContainer\` test utility for this.
+",
       "name": "virtualScroll",
       "optional": true,
       "type": "boolean",
@@ -12686,7 +12224,6 @@ exports[`Documenter definition for pagination matches the snapshot: pagination 1
 * \`previousPageLabel\` (string) - Previous page button.
 * \`pageLabel\` (number => string) - Individual page button, this function is called for every page number that's rendered.
 * \`nextPageLabel\` (string) - Next page button
-
 Example:
 \`\`\`
 {
@@ -12708,7 +12245,7 @@ Example:
           {
             "name": "pageLabel",
             "optional": true,
-            "type": "((pageNumber: number) => string)",
+            "type": "(pageNumber: number) => string",
           },
           {
             "name": "paginationLabel",
@@ -12770,7 +12307,7 @@ exports[`Documenter definition for pie-chart matches the snapshot: pie-chart 1`]
       "description": "Called when the values of the internal filter component changes.
 This isn't called for any custom filter components you've defined in \`additionalFilters\`.",
       "detailInlineType": {
-        "name": "PieChartProps.FilterChangeDetail<T>",
+        "name": "PieChartProps.FilterChangeDetail",
         "properties": [
           {
             "name": "visibleSegments",
@@ -12787,7 +12324,7 @@ This isn't called for any custom filter components you've defined in \`additiona
       "cancelable": false,
       "description": "Called when the highlighted segmented changes because of a user interaction.",
       "detailInlineType": {
-        "name": "PieChartProps.HighlightChangeDetail<T>",
+        "name": "PieChartProps.HighlightChangeDetail",
         "properties": [
           {
             "name": "highlightedSegment",
@@ -12843,7 +12380,6 @@ Use either \`ariaLabel\` or \`ariaLabelledby\` (you can't use both).",
     {
       "description": "An array that represents the source of data for the displayed segments.
 Each element can have the following properties:
-
 * \`title\` (string) - A human-readable title for this data point.
 * \`value\` (number) - Numeric value that determines the segment size.
                        A segment with a value of zero (0) or lower (negative number) won't have a segment.
@@ -12852,7 +12388,8 @@ Each element can have the following properties:
 
 As long as your data object implements the properties above, you can also define additional properties
 that are relevant to your data visualization.
-The full data object will be passed down to events and properties like \`detailPopoverContent\`.",
+The full data object will be passed down to events and properties like \`detailPopoverContent\`.
+",
       "name": "data",
       "optional": false,
       "type": "ReadonlyArray<T>",
@@ -12861,12 +12398,12 @@ The full data object will be passed down to events and properties like \`detailP
       "description": "A function that determines the details that are displayed in the popover when hovering over a segment.
 The function is called with the data of the target segment and is expected to return an array of detail pairs.
 By default, each segment displays two detail pairs: count and percentage.
-
 Each pair has the following properties:
 * \`key\` (ReactNode) - Name of the detail or metric.
-* \`value\` (ReactNode) - The value of this detail for the target segment.",
+* \`value\` (ReactNode) - The value of this detail for the target segment.
+",
       "inlineType": {
-        "name": "PieChartProps.DetailPopoverContentFunction<T>",
+        "name": "PieChartProps.DetailPopoverContentFunction",
         "parameters": [
           {
             "name": "segment",
@@ -12887,7 +12424,7 @@ Each pair has the following properties:
     {
       "description": "Additional content that is displayed at the bottom of the detail popover.",
       "inlineType": {
-        "name": "PieChartProps.DetailPopoverFooter<T>",
+        "name": "PieChartProps.DetailPopoverFooter",
         "parameters": [
           {
             "name": "segment",
@@ -12902,7 +12439,7 @@ Each pair has the following properties:
       "type": "PieChartProps.DetailPopoverFooter<T>",
     },
     {
-      "defaultValue": "'medium'",
+      "defaultValue": ""medium"",
       "description": "Determines the maximum width of the popover.",
       "inlineType": {
         "name": "PopoverProps.Size",
@@ -12965,36 +12502,14 @@ We highly recommend that you leave this unspecified or set to \`false\`.",
       "description": "Specifies the currently highlighted data segment. Highlighting is typically the result of
 a user hovering over or selecting a segment in the chart or the legend.
 A value of \`null\` means no segment is being highlighted.
-
 - If you don't set this property, segments are highlighted automatically when a user hovers over or selects one of the triggers (that is, uncontrolled behavior).
-- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a segment should be highlighted (that is, controlled behavior).",
-      "inlineType": {
-        "name": "T",
-        "properties": [
-          {
-            "name": "color",
-            "optional": true,
-            "type": "string",
-          },
-          {
-            "name": "title",
-            "optional": false,
-            "type": "string",
-          },
-          {
-            "name": "value",
-            "optional": false,
-            "type": "number",
-          },
-        ],
-        "type": "object",
-      },
+- If you explicitly set this property, you must set an \`onHighlightChange\` listener to update this property when a segment should be highlighted (that is, controlled behavior).
+",
       "name": "highlightedSegment",
       "optional": true,
       "type": "T | null",
     },
     {
-      "defaultValue": "{}",
       "description": "An object that contains all of the localized strings required by the component.",
       "i18nTag": true,
       "inlineType": {
@@ -13099,7 +12614,7 @@ This is usually the unit of the \`innerMetricValue\`.",
 This is an optional description that explains the segment and is displayed underneath the label.
 The function is called with the data object of each segment and is expected to return the description as a string.",
       "inlineType": {
-        "name": "PieChartProps.SegmentDescriptionFunction<T>",
+        "name": "PieChartProps.SegmentDescriptionFunction",
         "parameters": [
           {
             "name": "segment",
@@ -13118,11 +12633,11 @@ The function is called with the data object of each segment and is expected to r
       "type": "PieChartProps.SegmentDescriptionFunction<T>",
     },
     {
-      "defaultValue": "'medium'",
+      "defaultValue": ""medium"",
       "description": "Specifies the size of the pie or donut chart.
 When used with \`fitHeight\`, this property defines the minimum size of the chart area.",
       "inlineType": {
-        "name": ""small" | "medium" | "large"",
+        "name": "",
         "type": "union",
         "values": [
           "small",
@@ -13135,18 +12650,18 @@ When used with \`fitHeight\`, this property defines the minimum size of the char
       "type": "string",
     },
     {
-      "defaultValue": "'finished'",
+      "defaultValue": ""finished"",
       "description": "Specifies the current status of loading data.
 * \`loading\` - Indicates that data fetching is in progress.
 * \`finished\` - Indicates that data has loaded successfully.
 * \`error\` - Indicates that an error occurred during fetch. You should provide an option to enable the user to recover.",
       "inlineType": {
-        "name": ""error" | "finished" | "loading"",
+        "name": "",
         "type": "union",
         "values": [
-          "error",
-          "finished",
           "loading",
+          "finished",
+          "error",
         ],
       },
       "name": "statusType",
@@ -13154,12 +12669,12 @@ When used with \`fitHeight\`, this property defines the minimum size of the char
       "type": "string",
     },
     {
-      "defaultValue": "'pie'",
+      "defaultValue": ""pie"",
       "description": "Visual variant of the pie chart. Currently supports the default \`pie\` variant and the \`donut\` variant.
 The donut variant provides a slot in the center of the chart that can contain additional information.
 For more information, see \`innerContent\`.",
       "inlineType": {
-        "name": ""pie" | "donut"",
+        "name": "",
         "type": "union",
         "values": [
           "pie",
@@ -13172,9 +12687,9 @@ For more information, see \`innerContent\`.",
     },
     {
       "description": "An array of data segment objects that determines which data segments are currently visible (that is, not filtered out).
-
 - If you don't set this property, segments are filtered automatically when using the default filtering of the component (that is, uncontrolled behavior).
-- If you explicitly set this property, you must set an \`onFilterChange\` listener to update this property when the list of filtered segments changes (that is, controlled behavior).",
+- If you explicitly set this property, you must set an \`onFilterChange\` listener to update this property when the list of filtered segments changes (that is, controlled behavior).
+",
       "name": "visibleSegments",
       "optional": true,
       "type": "ReadonlyArray<T>",
@@ -13268,10 +12783,10 @@ automatically chooses a better direction based on available space.",
         "name": "PopoverProps.Position",
         "type": "union",
         "values": [
-          "left",
           "top",
-          "bottom",
           "right",
+          "bottom",
+          "left",
         ],
       },
       "name": "position",
@@ -13285,8 +12800,8 @@ automatically chooses a better direction based on available space.",
 Enabling this property will allow the popover to be rendered in the root stack context using
 [React Portals](https://reactjs.org/docs/portals.html).
 Enable this setting if you need the popover to ignore its parent stacking context, such as in side navigation.
-
-Note: Using popover rendered with portal within a Modal is not supported.",
+Note: Using popover rendered with portal within a Modal is not supported.
+",
       "name": "renderWithPortal",
       "optional": true,
       "type": "boolean",
@@ -13324,9 +12839,9 @@ that don't have visible text, and to distinguish between multiple triggers with 
         "name": "PopoverProps.TriggerType",
         "type": "union",
         "values": [
-          "custom",
           "text",
           "text-inline",
+          "custom",
         ],
       },
       "name": "triggerType",
@@ -13365,9 +12880,9 @@ exports[`Documenter definition for progress-bar matches the snapshot: progress-b
     {
       "cancelable": false,
       "description": "Called when the user clicks the result state button.
-
 Note: If you are using the \`flash\` variant, the result button isn't displayed.
-Use the \`buttonText\` property and the \`onButtonClick\` event listener of the flashbar item instead.",
+Use the \`buttonText\` property and the \`onButtonClick\` event listener of the flashbar item instead.
+",
       "name": "onResultButtonClick",
     },
   ],
@@ -13411,27 +12926,27 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "description": "Specifies the text for the button that's displayed when the \`status\` is set to \`error\` or \`success\`.
 If \`resultButtonText\` is empty, the result button isn't displayed.
-
 Note: If you use the \`flash\` variant, the result button isn't displayed.
-Add a button using the \`action\` property of the flashbar item instead.",
+Add a button using the \`action\` property of the flashbar item instead.
+",
       "name": "resultButtonText",
       "optional": true,
       "type": "string",
     },
     {
-      "defaultValue": "'in-progress'",
+      "defaultValue": ""in-progress"",
       "description": "Specifies the status of the progress bar. You can set it to one of the following:
-
 - \`"in-progress"\` - Displays a progress bar.
 - \`"success"\` or \`"error"\` - Displays a result state and replaces the progress element with a status indicator,
-\`resultText\`, and a result button.",
+\`resultText\`, and a result button.
+",
       "inlineType": {
         "name": "ProgressBarProps.Status",
         "type": "union",
         "values": [
-          "error",
           "in-progress",
           "success",
+          "error",
         ],
       },
       "name": "status",
@@ -13446,20 +12961,20 @@ Add a button using the \`action\` property of the flashbar item instead.",
       "type": "number",
     },
     {
-      "defaultValue": "'standalone'",
+      "defaultValue": ""standalone"",
       "description": "Enables the correct styling of the progress bar in different contexts. You can set it to one of the following:
-
 - \`"flash"\` - Use this variatn when using the progress bar within a flash component.
              Note that the result button isn't displayed when using this variant.
              Use the \`buttonText\` property and the \`onButtonClick\` event listener of the flashbar item instead of the result button provided by the progress bar.
 - \`"key-value"\` - Use this variant when using the progress bar within the key-value pairs pattern.
-- \`"standalone"\` Use in all other cases. This is the default value.",
+- \`"standalone"\` Use in all other cases. This is the default value.
+",
       "inlineType": {
         "name": "ProgressBarProps.Variant",
         "type": "union",
         "values": [
-          "flash",
           "standalone",
+          "flash",
           "key-value",
         ],
       },
@@ -13481,8 +12996,8 @@ Add a button using the \`action\` property of the flashbar item instead.",
     },
     {
       "description": "Short description of the operation that appears at the top of the component.
-
-Make sure that you always provide a label for accessibility.",
+Make sure that you always provide a label for accessibility.
+",
       "isDefault": false,
       "name": "label",
     },
@@ -13504,7 +13019,7 @@ exports[`Documenter definition for prompt-input matches the snapshot: prompt-inp
       "description": "Called whenever a user clicks the action button or presses the "Enter" key.
 The event \`detail\` contains the current value of the field.",
       "detailInlineType": {
-        "name": "BaseChangeDetail",
+        "name": "PromptInputProps.ActionDetail",
         "properties": [
           {
             "name": "value",
@@ -13514,12 +13029,13 @@ The event \`detail\` contains the current value of the field.",
         ],
         "type": "object",
       },
-      "detailType": "BaseChangeDetail",
+      "detailType": "PromptInputProps.ActionDetail",
       "name": "onAction",
     },
     {
       "cancelable": false,
       "description": "Called when input focus is removed from the UI control.",
+      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -13527,7 +13043,7 @@ The event \`detail\` contains the current value of the field.",
       "description": "Called whenever a user changes the input value (by typing or pasting).
 The event \`detail\` contains the current value of the field.",
       "detailInlineType": {
-        "name": "BaseChangeDetail",
+        "name": "InputProps.ChangeDetail",
         "properties": [
           {
             "name": "value",
@@ -13537,12 +13053,13 @@ The event \`detail\` contains the current value of the field.",
         ],
         "type": "object",
       },
-      "detailType": "BaseChangeDetail",
+      "detailType": "InputProps.ChangeDetail",
       "name": "onChange",
     },
     {
       "cancelable": false,
       "description": "Called when input focus is moved to the UI control.",
+      "detailType": "null",
       "name": "onFocus",
     },
     {
@@ -13551,7 +13068,7 @@ The event \`detail\` contains the current value of the field.",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "BaseKeyDetail",
+        "name": "InputProps.KeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -13591,7 +13108,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "BaseKeyDetail",
+      "detailType": "InputProps.KeyDetail",
       "name": "onKeyDown",
     },
     {
@@ -13600,7 +13117,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "BaseKeyDetail",
+        "name": "InputProps.KeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -13640,7 +13157,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "BaseKeyDetail",
+      "detailType": "InputProps.KeyDetail",
       "name": "onKeyUp",
     },
   ],
@@ -13659,23 +13176,23 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
     },
     {
       "description": "Selects a range of text in the textarea control.
-
 See https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/setSelectionRange
 for more details on this method. Be aware that using this method in React has some
-common pitfalls: https://stackoverflow.com/questions/60129605/is-javascripts-setselectionrange-incompatible-with-react-hooks",
+common pitfalls: https://stackoverflow.com/questions/60129605/is-javascripts-setselectionrange-incompatible-with-react-hooks
+",
       "name": "setSelectionRange",
       "parameters": [
         {
           "name": "start",
-          "type": "number | null",
+          "type": "null | number",
         },
         {
           "name": "end",
-          "type": "number | null",
+          "type": "null | number",
         },
         {
           "name": "direction",
-          "type": ""none" | "forward" | "backward"",
+          "type": ""backward" | "forward" | "none"",
         },
       ],
       "returnType": "void",
@@ -13703,29 +13220,6 @@ This property is ignored if you use a predefined icon or if you set your custom 
         "name": "IconProps.Name",
         "type": "union",
         "values": [
-          "search",
-          "map",
-          "filter",
-          "key",
-          "file",
-          "pause",
-          "play",
-          "remove",
-          "copy",
-          "menu",
-          "script",
-          "close",
-          "status-pending",
-          "refresh",
-          "external",
-          "group",
-          "calendar",
-          "ellipsis",
-          "zoom-in",
-          "zoom-out",
-          "download",
-          "security",
-          "edit",
           "add-plus",
           "anchor-link",
           "angle-left-double",
@@ -13744,6 +13238,7 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "backward-10-seconds",
           "bug",
           "call",
+          "calendar",
           "caret-down-filled",
           "caret-down",
           "caret-left-filled",
@@ -13752,14 +13247,20 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "caret-up",
           "check",
           "contact",
+          "close",
           "closed-caption",
           "closed-caption-unavailable",
+          "copy",
           "command-prompt",
           "delete-marker",
+          "download",
           "drag-indicator",
+          "edit",
+          "ellipsis",
           "envelope",
           "exit-full-screen",
           "expand",
+          "external",
           "face-happy",
           "face-happy-filled",
           "face-neutral",
@@ -13767,6 +13268,8 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "face-sad",
           "face-sad-filled",
           "file-open",
+          "file",
+          "filter",
           "flag",
           "folder-open",
           "folder",
@@ -13776,20 +13279,31 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "globe",
           "grid-view",
           "group-active",
+          "group",
           "heart",
           "heart-filled",
           "insert-row",
+          "key",
           "keyboard",
           "list-view",
           "location-pin",
           "lock-private",
+          "map",
+          "menu",
           "microphone",
           "microphone-off",
           "mini-player",
           "multiscreen",
           "notification",
+          "pause",
+          "play",
           "redo",
+          "refresh",
+          "remove",
           "resize-area",
+          "script",
+          "search",
+          "security",
           "settings",
           "send",
           "share",
@@ -13800,6 +13314,7 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "status-in-progress",
           "status-info",
           "status-negative",
+          "status-pending",
           "status-positive",
           "status-stopped",
           "status-warning",
@@ -13829,6 +13344,8 @@ This property is ignored if you use a predefined icon or if you set your custom 
           "view-full",
           "view-horizontal",
           "view-vertical",
+          "zoom-in",
+          "zoom-out",
           "zoom-to-fit",
         ],
       },
@@ -13838,8 +13355,8 @@ This property is ignored if you use a predefined icon or if you set your custom 
     },
     {
       "description": "Specifies the URL of a custom icon. Use this property if the icon you want isn't available.
-
-If you set both \`actionButtonIconUrl\` and \`actionButtonIconSvg\`, \`actionButtonIconSvg\` will take precedence.",
+If you set both \`actionButtonIconUrl\` and \`actionButtonIconSvg\`, \`actionButtonIconSvg\` will take precedence.
+",
       "name": "actionButtonIconUrl",
       "optional": true,
       "type": "string",
@@ -13847,20 +13364,20 @@ If you set both \`actionButtonIconUrl\` and \`actionButtonIconSvg\`, \`actionBut
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-
-Use this if you don't have a visible label for this control.",
+Use this if you don't have a visible label for this control.
+",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -13868,11 +13385,11 @@ Use this if you don't have a visible label for this control.",
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -13887,21 +13404,12 @@ To use it correctly, define an ID for the element you want to use as label and s
       "description": "Specifies whether to enable a browser's autocomplete functionality for this input.
 In some cases it might be appropriate to disable autocomplete (for example, for security-sensitive fields).
 To use it correctly, set the \`name\` property.
-
 You can either provide a boolean value to set the property to "on" or "off", or specify a string value
-for the [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.",
-      "inlineType": {
-        "name": "string | boolean",
-        "type": "union",
-        "values": [
-          "string",
-          "false",
-          "true",
-        ],
-      },
+for the [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.
+",
       "name": "autoComplete",
       "optional": true,
-      "type": "string | boolean",
+      "type": "boolean | string",
     },
     {
       "description": "Indicates whether the control should be focused as
@@ -13923,9 +13431,9 @@ scrolled out of the viewport.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -13947,15 +13455,6 @@ of the user's browser.",
       "type": "boolean",
     },
     {
-      "description": "Specifies if the control is disabled, which prevents the
-user from modifying the value and prevents the value from
-being included in a form submission. A disabled control can't
-receive focus.",
-      "name": "disabled",
-      "optional": true,
-      "type": "boolean",
-    },
-    {
       "description": "Determines whether the secondary actions area of the input has padding. If true, removes the default padding from the secondary actions area.",
       "name": "disableSecondaryActionsPaddings",
       "optional": true,
@@ -13964,6 +13463,15 @@ receive focus.",
     {
       "description": "Determines whether the secondary content area of the input has padding. If true, removes the default padding from the secondary content area.",
       "name": "disableSecondaryContentPaddings",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
+      "description": "Specifies if the control is disabled, which prevents the
+user from modifying the value and prevents the value from
+being included in a form submission. A disabled control can't
+receive focus.",
+      "name": "disabled",
       "optional": true,
       "type": "boolean",
     },
@@ -14017,8 +13525,8 @@ Defaults to 3. Use -1 for infinite rows.",
       "description": "Specifies if the control is read-only, which prevents the
 user from modifying the value but includes it in a form
 submission. A read-only control can receive focus.
-
-Don't use read-only inputs outside a form.",
+Don't use read-only inputs outside a form.
+",
       "name": "readOnly",
       "optional": true,
       "type": "boolean",
@@ -14028,10 +13536,10 @@ Don't use read-only inputs outside a form.",
 This value controls the native browser capability to check for spelling/grammar errors.
 If not set, the browser default behavior is to perform spellchecking.
 For more details, check the [spellcheck MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck).
-
 Enhanced spellchecking features of your browser and/or operating system may send input values to external parties.
 Make sure it’s deactivated for fields with sensitive information to prevent
-inadvertently sending data (such as user passwords) to third parties.",
+inadvertently sending data (such as user passwords) to third parties.
+",
       "name": "spellcheck",
       "optional": true,
       "type": "boolean",
@@ -14059,7 +13567,6 @@ with the input using \`ariaDescribedby\`.",
   "regions": [
     {
       "description": "Specifies the SVG of a custom icon.
-
 Use this property if you want your custom icon to inherit colors dictated by variant or hover states.
 When this property is set, the component will be decorated with \`aria-hidden="true"\`. Ensure that the \`svg\` element:
 - has attribute \`focusable="false"\`.
@@ -14076,7 +13583,8 @@ You can still set the stroke to \`currentColor\` to inherit the color of the sur
 If you set both \`actionButtonIconUrl\` and \`actionButtonIconSvg\`, \`iconSvg\` will take precedence.
 
 *Note:* Remember to remove any additional elements (for example: \`defs\`) and related CSS classes from SVG files exported from design software.
-In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.",
+In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.
+",
       "isDefault": false,
       "name": "actionButtonIconSvg",
     },
@@ -14102,45 +13610,29 @@ exports[`Documenter definition for property-filter matches the snapshot: propert
       "cancelable": false,
       "description": "Fired when the \`query\` gets changed. Filter the dataset in response to this event using the values in the \`detail\` object.",
       "detailInlineType": {
-        "name": "PropertyFilterQuery",
-        "properties": [
-          {
-            "name": "operation",
-            "optional": false,
-            "type": "PropertyFilterOperation",
-          },
-          {
-            "name": "tokenGroups",
-            "optional": true,
-            "type": "ReadonlyArray<PropertyFilterToken | PropertyFilterTokenGroup>",
-          },
-          {
-            "name": "tokens",
-            "optional": false,
-            "type": "ReadonlyArray<PropertyFilterToken>",
-          },
-        ],
+        "name": "PropertyFilterProps.Query",
+        "properties": [],
         "type": "object",
       },
-      "detailType": "PropertyFilterQuery",
+      "detailType": "PropertyFilterProps.Query",
       "name": "onChange",
     },
     {
       "cancelable": false,
       "description": "Use this event to asynchronously load filteringOptions, component currently needs.  The detail object contains following properties:
-
 * \`filteringProperty\` - The property for which you need to fetch the options.
 * \`filteringOperator\` - The operator for which you need to fetch the options.
 * \`filteringText\` - The value that you need to use to fetch options.
 * \`firstPage\` - Indicates that you should fetch the first page of options for a \`filteringProperty\` that match the \`filteringText\`.
-* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).",
+* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).
+",
       "detailInlineType": {
         "name": "PropertyFilterProps.LoadItemsDetail",
         "properties": [
           {
             "name": "filteringOperator",
             "optional": true,
-            "type": "string",
+            "type": "PropertyFilterProps.ComparisonOperator",
           },
           {
             "name": "filteringProperty",
@@ -14182,12 +13674,12 @@ exports[`Documenter definition for property-filter matches the snapshot: propert
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -14195,11 +13687,11 @@ and set the property to a string of each ID separated by spaces (for example, \`
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -14221,9 +13713,9 @@ events to fire calling for more properties.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -14232,9 +13724,9 @@ is provided by its parent form field component.",
       "description": "Accepts a human-readable, localized string that indicates the number of results. For example, "1 match" or "165 matches."
 If the total number of results is unknown, also include an indication that there may be more results than
 the number listed. For example, "25+ matches."
-
 The count text is only displayed when \`query.tokens\` isn't empty.
-When the \`countText\` or \`query\` changes, it will be announced to assistive technologies.",
+When the \`countText\` or \`query\` changes, it will be announced to assistive technologies.
+",
       "name": "countText",
       "optional": true,
       "type": "string",
@@ -14242,27 +13734,27 @@ When the \`countText\` or \`query\` changes, it will be announced to assistive t
     {
       "defaultValue": "[]",
       "description": "An array of objects that contain localized, human-readable strings for the labels of custom groups within the filtering dropdown. Use group property to associate the strings with your custom group of options. Define the following values for each group:
-
 * properties [string]: The group label in the filtering dropdown that contains the list of properties from this group. For example: Tags.
 * values [string]: The group label in the filtering dropdown that contains the list of values from this group. For example: Tags values.
-* group [string]: The identifier of a custom group.",
+* group [string]: The identifier of a custom group.
+",
       "name": "customGroupsText",
       "optional": true,
       "type": "Array<PropertyFilterProps.GroupText>",
-    },
-    {
-      "description": "If set to \`true\`, the filtering input will be disabled.
-Use it, for example, if you are fetching new items upon filtering change
-in order to prevent the user from changing the filtering query.",
-      "name": "disabled",
-      "optional": true,
-      "type": "boolean",
     },
     {
       "defaultValue": "false",
       "description": "Set \`disableFreeTextFiltering\` only if you can’t filter the dataset using a filter that is applied to every column,
 instead of a specific property. This would stop the user from creating such tokens.",
       "name": "disableFreeTextFiltering",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
+      "description": "If set to \`true\`, the filtering input will be disabled.
+Use it, for example, if you are fetching new items upon filtering change
+in order to prevent the user from changing the filtering query.",
+      "name": "disabled",
       "optional": true,
       "type": "boolean",
     },
@@ -14278,12 +13770,12 @@ When \`true\`, the \`query.tokens\` property is ignored and \`query.tokenGroups\
       "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
-
 Set this property if the dropdown would otherwise be constrained by a scrollable container,
 for example inside table and split view layouts.
 
 We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.",
+because fixed positioning results in a slight, visible lag when scrolling complex pages.
+",
       "name": "expandToViewport",
       "optional": true,
       "type": "boolean",
@@ -14316,7 +13808,6 @@ See the [Autosuggest API](/components/autosuggest/?tabId=api) page for more deta
     {
       "defaultValue": "[]",
       "description": "An array of possible values of the individual \`filteringProperties\`. Each element has the following properties:
-
 * \`propertyKey\` [string]: The key of the corresponding filtering property in the \`filteringProperties\` array.
 * \`value\` [string]: The value that will be used as a suggestion when creating or modifying a filtering token.
 * \`label\` [string]: Optional suggestion label to be matched instead of the value.
@@ -14333,10 +13824,11 @@ const filteringOptions = [
   { propertyKey: 'state', value: 'STOPPING', label: getStateLabel('STOPPING') },
   { propertyKey: 'state', value: 'RUNNING', label: getStateLabel('RUNNING') },
 ]
-\`\`\`",
+\`\`\`
+",
       "name": "filteringOptions",
       "optional": true,
-      "type": "ReadonlyArray<PropertyFilterOption>",
+      "type": "ReadonlyArray<PropertyFilterProps.FilteringOption>",
     },
     {
       "description": "Placeholder for the filtering input.",
@@ -14346,13 +13838,13 @@ const filteringOptions = [
     },
     {
       "description": "An array of properties by which the data set can be filtered. Each element has the following properties:
-
 * groupValuesLabel [string]: Localized string to display for the 'Values' group label for a specific property.
 * key [string]: The identifier of this property.
 * propertyLabel [string]: A human-readable string for the property.
 * operators [Array]: A list of all operators supported by this property. If you omit the equals operator because your API does not support it, make sure to set \`defaultOperator\` to a supported operator from this list.
 * group [string]: Optional identifier of a custom group that this filtering option is assigned to. Use to create additional groups below the default one. Make sure to also define labels for the group in the customGroupsText property. Notice that only one level of options nesting is supported.
-* defaultOperator [ComparisonOperator]: Optional parameter that changes the default operator used with this filtering property. Use it only if your API does not support "equals" filtering terms with this property.",
+* defaultOperator [ComparisonOperator]: Optional parameter that changes the default operator used with this filtering property. Use it only if your API does not support "equals" filtering terms with this property.
+",
       "name": "filteringProperties",
       "optional": false,
       "type": "ReadonlyArray<PropertyFilterProps.FilteringProperty>",
@@ -14374,10 +13866,10 @@ Use the \`onLoadItems\` event to perform a recovery action (for example, retryin
         "name": "DropdownStatusProps.StatusType",
         "type": "union",
         "values": [
-          "error",
-          "finished",
-          "loading",
           "pending",
+          "loading",
+          "finished",
+          "error",
         ],
       },
       "name": "filteringStatusType",
@@ -14386,28 +13878,17 @@ Use the \`onLoadItems\` event to perform a recovery action (for example, retryin
     },
     {
       "description": "An object configuring the operators for free text filtering, which has the following properties:
-
 * operators [Array]: A list of all operators supported for free text filtering. If you omit the contains operator because your API does not support it, make sure to set \`defaultOperator\` to a supported operator from this list.
-* defaultOperator [ComparisonOperator]: An optional parameter that changes the default operator used for free text filtering. Use this parameter only if your API does not support "contains" free test filtering terms.",
+* defaultOperator [ComparisonOperator]: An optional parameter that changes the default operator used for free text filtering. Use this parameter only if your API does not support "contains" free test filtering terms.
+",
       "inlineType": {
-        "name": "PropertyFilterFreeTextFiltering",
-        "properties": [
-          {
-            "name": "defaultOperator",
-            "optional": true,
-            "type": "string",
-          },
-          {
-            "name": "operators",
-            "optional": true,
-            "type": "ReadonlyArray<string>",
-          },
-        ],
+        "name": "PropertyFilterProps.FreeTextFiltering",
+        "properties": [],
         "type": "object",
       },
       "name": "freeTextFiltering",
       "optional": true,
-      "type": "PropertyFilterFreeTextFiltering",
+      "type": "PropertyFilterProps.FreeTextFiltering",
     },
     {
       "defaultValue": "false",
@@ -14415,8 +13896,8 @@ Use the \`onLoadItems\` event to perform a recovery action (for example, retryin
 (applied to the property and value token) are hidden from the user. Only use when you have a custom
 filtering logic which combines tokens in different way than the default one. When used, ensure that
 operations are communicated to the user in another way.
-
-This property cannot be set when \`enableTokenGroups=true\`.",
+This property cannot be set when \`enableTokenGroups=true\`.
+",
       "name": "hideOperations",
       "optional": true,
       "type": "boolean",
@@ -14480,12 +13961,12 @@ This property cannot be set when \`enableTokenGroups=true\`.",
           {
             "name": "formatToken",
             "optional": true,
-            "type": "((token: PropertyFilterProps.FormattedToken) => string)",
+            "type": "(token: PropertyFilterProps.FormattedToken) => string",
           },
           {
             "name": "groupEditAriaLabel",
             "optional": true,
-            "type": "((group: PropertyFilterProps.FormattedTokenGroup) => string)",
+            "type": "(group: PropertyFilterProps.FormattedTokenGroup) => string",
           },
           {
             "name": "groupPropertiesText",
@@ -14558,12 +14039,12 @@ This property cannot be set when \`enableTokenGroups=true\`.",
             "type": "string",
           },
           {
-            "name": "operatorsText",
+            "name": "operatorText",
             "optional": true,
             "type": "string",
           },
           {
-            "name": "operatorText",
+            "name": "operatorsText",
             "optional": true,
             "type": "string",
           },
@@ -14575,17 +14056,17 @@ This property cannot be set when \`enableTokenGroups=true\`.",
           {
             "name": "removeTokenButtonAriaLabel",
             "optional": true,
-            "type": "((token: PropertyFilterProps.FormattedToken) => string)",
+            "type": "(token: PropertyFilterProps.FormattedToken) => string",
           },
           {
             "name": "tokenEditorAddExistingTokenAriaLabel",
             "optional": true,
-            "type": "((token: PropertyFilterProps.FormattedToken) => string)",
+            "type": "(token: PropertyFilterProps.FormattedToken) => string",
           },
           {
             "name": "tokenEditorAddExistingTokenLabel",
             "optional": true,
-            "type": "((token: PropertyFilterProps.FormattedToken) => string)",
+            "type": "(token: PropertyFilterProps.FormattedToken) => string",
           },
           {
             "name": "tokenEditorAddNewTokenLabel",
@@ -14600,12 +14081,12 @@ This property cannot be set when \`enableTokenGroups=true\`.",
           {
             "name": "tokenEditorTokenActionsAriaLabel",
             "optional": true,
-            "type": "((token: PropertyFilterProps.FormattedToken) => string)",
+            "type": "(token: PropertyFilterProps.FormattedToken) => string",
           },
           {
             "name": "tokenEditorTokenRemoveAriaLabel",
             "optional": true,
-            "type": "((token: PropertyFilterProps.FormattedToken) => string)",
+            "type": "(token: PropertyFilterProps.FormattedToken) => string",
           },
           {
             "name": "tokenEditorTokenRemoveFromGroupLabel",
@@ -14665,35 +14146,19 @@ If set to \`true\`, the live announcement of countText by assistive technologies
 The \`operation\` property has two valid values: "and", "or", and controls the join operation to be applied between tokens when filtering the items.
 The \`tokens\` property is an array of objects that will be displayed to the user beneath the filtering input. When \`enableTokenGroups=true\`, the
 \`tokenGroups\` property is used instead, which supports nested tokens.
-
 Each token has the following properties:
 * value [unknown]: The value of the token to be used as a filter. Can be null or string for default tokens, string[] for enum tokens, and anything for tokens with custom forms.
 * propertyKey [string]: The key of the corresponding property in filteringProperties.
-* operator ['<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^' | '!^']: The operator which indicates how to filter the dataset using this token.",
+* operator ['<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^' | '!^']: The operator which indicates how to filter the dataset using this token.
+",
       "inlineType": {
-        "name": "PropertyFilterQuery",
-        "properties": [
-          {
-            "name": "operation",
-            "optional": false,
-            "type": "PropertyFilterOperation",
-          },
-          {
-            "name": "tokenGroups",
-            "optional": true,
-            "type": "ReadonlyArray<PropertyFilterToken | PropertyFilterTokenGroup>",
-          },
-          {
-            "name": "tokens",
-            "optional": false,
-            "type": "ReadonlyArray<PropertyFilterToken>",
-          },
-        ],
+        "name": "PropertyFilterProps.Query",
+        "properties": [],
         "type": "object",
       },
       "name": "query",
       "optional": false,
-      "type": "PropertyFilterQuery",
+      "type": "PropertyFilterProps.Query",
     },
     {
       "description": "Specifies the maximum number of displayed tokens. If the property isn't set, all of the tokens are displayed.",
@@ -14796,12 +14261,12 @@ If the radio group controls any secondary content (for example, another form fie
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -14816,11 +14281,11 @@ don't set this property because the form field component automatically sets the 
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -14840,11 +14305,7 @@ To use it correctly, define an ID for the element you want to use as label and s
     },
     {
       "deprecatedTag": "Has no effect.",
-      "description": "Specifies the ID of the native form element. You can use it to relate
-a label element's \`for\` attribute to this control.
-
-It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+      "description": "",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -14860,13 +14321,13 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Specifies an array of radio buttons to display. Each of these objects have the following properties:
-
 - \`value\` (string) - Sets the value of the radio button. Assigned to the radio group when a user selects the radio button.
 - \`label\` (ReactNode) - Specifies a label for the radio button.
 - \`description\` (ReactNode) - (Optional) Specifies descriptive text that appears below the label.
 - \`disabled\` (boolean) - (Optional) Determines whether the radio button is disabled, which prevents the user from selecting it.
 - \`controlId\` (string) - (Optional) Sets the ID of the internal input. You can use it to relate a label element's \`for\` attribute to this control.
-       In general it's not recommended to set this because the ID is automatically set by the radio group component.",
+       In general it's not recommended to set this because the ID is automatically set by the radio group component.
+",
       "name": "items",
       "optional": true,
       "type": "ReadonlyArray<RadioGroupProps.RadioButtonDefinition>",
@@ -14890,7 +14351,7 @@ being included in a form submission. A read-only control is still focusable.",
 If you want to clear the selection, use \`null\`.",
       "name": "value",
       "optional": false,
-      "type": "string | null",
+      "type": "null | string",
     },
   ],
   "regions": [],
@@ -14938,12 +14399,12 @@ path of the selected resource and \`errorText\` that may contain a validation er
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -14957,11 +14418,11 @@ and set the property to a string of each ID separated by spaces (for example, \`
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -14970,20 +14431,9 @@ To use it correctly, define an ID for the element you want to use as label and s
       "description": "Optionally overrides whether a bucket should be disabled for selection in the Buckets view or not.
 It has higher priority than \`selectableItemsTypes\`. Example: if \`selectableItemsTypes\` has \`['buckets']\` value and
 \`bucketsIsItemDisabled\` returns false for a bucket, then the bucket is disabled for selection.",
-      "inlineType": {
-        "name": "(item: S3ResourceSelectorProps.Bucket) => boolean",
-        "parameters": [
-          {
-            "name": "item",
-            "type": "S3ResourceSelectorProps.Bucket",
-          },
-        ],
-        "returnType": "boolean",
-        "type": "function",
-      },
       "name": "bucketsIsItemDisabled",
       "optional": true,
-      "type": "((item: S3ResourceSelectorProps.Bucket) => boolean)",
+      "type": "(item: S3ResourceSelectorProps.Bucket) => boolean",
     },
     {
       "defaultValue": "['Name', 'CreationDate']",
@@ -15006,12 +14456,6 @@ that resolves to a list of objects with the following properties:
 - \`Name\` (string) - Name of the bucket.
 - \`CreationDate\` (string) - (Optional) Creation date of the bucket.
 - \`Region\` (string) - (Optional) Region of the bucket.",
-      "inlineType": {
-        "name": "() => Promise<ReadonlyArray<S3ResourceSelectorProps.Bucket>>",
-        "parameters": [],
-        "returnType": "Promise<ReadonlyArray<S3ResourceSelectorProps.Bucket>>",
-        "type": "function",
-      },
       "name": "fetchBuckets",
       "optional": false,
       "type": "() => Promise<ReadonlyArray<S3ResourceSelectorProps.Bucket>>",
@@ -15023,21 +14467,6 @@ The return type of the function should be a promise that resolves to a list of o
 - \`LastModified\` (string) - (Optional) Date when this object was last modified.
 - \`Size\` (number) - (Optional) Size of the object.
 - \`IsFolder\` (boolean) - (Optional)  Determines whether the entry is an object prefix (folder).",
-      "inlineType": {
-        "name": "(bucketName: string, pathPrefix: string) => Promise<ReadonlyArray<S3ResourceSelectorProps.Object>>",
-        "parameters": [
-          {
-            "name": "bucketName",
-            "type": "string",
-          },
-          {
-            "name": "pathPrefix",
-            "type": "string",
-          },
-        ],
-        "returnType": "Promise<ReadonlyArray<S3ResourceSelectorProps.Object>>",
-        "type": "function",
-      },
       "name": "fetchObjects",
       "optional": false,
       "type": "(bucketName: string, pathPrefix: string) => Promise<ReadonlyArray<S3ResourceSelectorProps.Object>>",
@@ -15048,21 +14477,6 @@ The return type of the function should be a promise that resolves to a list of v
 - \`VersionId\` (string) - Version ID of an object.
 - \`LastModified\` (string) - (Optional) Date when this object was last modified.
 - \`Size\` (number) - (Optional) Size of the object version.",
-      "inlineType": {
-        "name": "(bucketName: string, pathPrefix: string) => Promise<ReadonlyArray<S3ResourceSelectorProps.Version>>",
-        "parameters": [
-          {
-            "name": "bucketName",
-            "type": "string",
-          },
-          {
-            "name": "pathPrefix",
-            "type": "string",
-          },
-        ],
-        "returnType": "Promise<ReadonlyArray<S3ResourceSelectorProps.Version>>",
-        "type": "function",
-      },
       "name": "fetchVersions",
       "optional": false,
       "type": "(bucketName: string, pathPrefix: string) => Promise<ReadonlyArray<S3ResourceSelectorProps.Version>>",
@@ -15070,15 +14484,9 @@ The return type of the function should be a promise that resolves to a list of v
     {
       "description": "Use this property to specify a different dynamic modal root for the dialog.
 The function will be called when a user clicks on the trigger button.",
-      "inlineType": {
-        "name": "() => Promise<HTMLElement>",
-        "parameters": [],
-        "returnType": "Promise<HTMLElement>",
-        "type": "function",
-      },
       "name": "getModalRoot",
       "optional": true,
-      "type": "(() => Promise<HTMLElement>)",
+      "type": "() => Promise<HTMLElement>",
     },
     {
       "description": "An object containing all the necessary localized strings required by the component.",
@@ -15144,7 +14552,7 @@ The function will be called when a user clicks on the trigger button.",
           {
             "name": "filteringCounterText",
             "optional": true,
-            "type": "((count: number) => string)",
+            "type": "(count: number) => string",
           },
           {
             "name": "filteringNoMatches",
@@ -15214,7 +14622,7 @@ The function will be called when a user clicks on the trigger button.",
           {
             "name": "labelFiltering",
             "optional": true,
-            "type": "((itemsType: string) => string)",
+            "type": "(itemsType: string) => string",
           },
           {
             "name": "labelIconFolder",
@@ -15242,16 +14650,6 @@ The function will be called when a user clicks on the trigger button.",
             "type": "string",
           },
           {
-            "name": "labelsBucketsSelection",
-            "optional": true,
-            "type": "SelectionLabels<S3ResourceSelectorProps.Bucket>",
-          },
-          {
-            "name": "labelsObjectsSelection",
-            "optional": true,
-            "type": "SelectionLabels<S3ResourceSelectorProps.Object>",
-          },
-          {
             "name": "labelSortedAscending",
             "optional": true,
             "type": "SortingColumnContainingString",
@@ -15260,6 +14658,16 @@ The function will be called when a user clicks on the trigger button.",
             "name": "labelSortedDescending",
             "optional": true,
             "type": "SortingColumnContainingString",
+          },
+          {
+            "name": "labelsBucketsSelection",
+            "optional": true,
+            "type": "SelectionLabels<S3ResourceSelectorProps.Bucket>",
+          },
+          {
+            "name": "labelsObjectsSelection",
+            "optional": true,
+            "type": "SelectionLabels<S3ResourceSelectorProps.Object>",
           },
           {
             "name": "labelsPagination",
@@ -15400,11 +14808,11 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "description": "Adds \`aria-labelledby\` to the S3 URI input. If you're using this component within a form field,
 you do not need to set this property, as the form field component will set it automatically.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "inputAriaDescribedby",
       "optional": true,
       "type": "string",
@@ -15424,20 +14832,9 @@ To use it correctly, define an ID for the element you want to use as label and s
     {
       "description": "Optionally overrides whether an object should be disabled for selection in the Objects view or not. Similar to
 \`bucketsIsItemDisabled\` this property takes precedence over the \`selectableItemsTypes\` property.",
-      "inlineType": {
-        "name": "(item: S3ResourceSelectorProps.Object) => boolean",
-        "parameters": [
-          {
-            "name": "item",
-            "type": "S3ResourceSelectorProps.Object",
-          },
-        ],
-        "returnType": "boolean",
-        "type": "function",
-      },
       "name": "objectsIsItemDisabled",
       "optional": true,
-      "type": "((item: S3ResourceSelectorProps.Object) => boolean)",
+      "type": "(item: S3ResourceSelectorProps.Object) => boolean",
     },
     {
       "defaultValue": "['Key', 'LastModified', 'Size']",
@@ -15451,20 +14848,9 @@ and 'Size'.",
       "description": "Use this property when \`getModalRoot\` is used to clean up the modal root
 element after a user closes the dialog. The function receives the return value
 of the most recent getModalRoot call as an argument.",
-      "inlineType": {
-        "name": "(rootElement: HTMLElement) => void",
-        "parameters": [
-          {
-            "name": "rootElement",
-            "type": "HTMLElement",
-          },
-        ],
-        "returnType": "void",
-        "type": "function",
-      },
       "name": "removeModalRoot",
       "optional": true,
-      "type": "((rootElement: HTMLElement) => void)",
+      "type": "(rootElement: HTMLElement) => void",
     },
     {
       "description": "The current selected resource. Resource has the following properties:
@@ -15506,20 +14892,9 @@ customizing \`objectsIsItemDisabled\` function).",
     {
       "description": "Optionally overrides whether a version should be disabled for selection in the Versions view or not. Similar to
 \`bucketsIsItemDisabled\` this property takes precedence over the \`selectableItemsTypes\` property.",
-      "inlineType": {
-        "name": "(item: S3ResourceSelectorProps.Version) => boolean",
-        "parameters": [
-          {
-            "name": "item",
-            "type": "S3ResourceSelectorProps.Version",
-          },
-        ],
-        "returnType": "boolean",
-        "type": "function",
-      },
       "name": "versionsIsItemDisabled",
       "optional": true,
-      "type": "((item: S3ResourceSelectorProps.Version) => boolean)",
+      "type": "(item: S3ResourceSelectorProps.Version) => boolean",
     },
     {
       "defaultValue": "['ID', 'LastModified', 'Size']",
@@ -15603,7 +14978,6 @@ the label is visible and attached to the select component, unless \`ariaLabelled
     },
     {
       "description": "An array of objects representing options. Each segment has the following properties:
-
 - \`id\` (string) - The ID of the segment.
 - \`disabled\` [boolean] - (Optional) Determines whether the segment is disabled, which prevents the user from selecting it.
 - \`disabledReason\` (string) - (Optional) Displays tooltip near the segment when disabled. Use to provide additional context.
@@ -15612,7 +14986,8 @@ the label is visible and attached to the select component, unless \`ariaLabelled
            This is required when you use an icon without \`text\`.
 - \`iconUrl\` (string) - (Optional) Specifies the URL of a custom icon.
 - \`iconSvg\` (ReactNode) - (Optional) Custom SVG icon. Equivalent to the \`svg\` slot of the [icon component](/components/icon/).
-- \`text\` (string) - (Optional) Specifies the text of the segment.",
+- \`text\` (string) - (Optional) Specifies the text of the segment.
+",
       "name": "options",
       "optional": true,
       "type": "ReadonlyArray<SegmentedControlProps.Option>",
@@ -15621,7 +14996,7 @@ the label is visible and attached to the select component, unless \`ariaLabelled
       "description": "ID of the selected option. If you want to clear the selection, use \`null\`.",
       "name": "selectedId",
       "optional": false,
-      "type": "string | null",
+      "type": "null | string",
     },
   ],
   "regions": [],
@@ -15647,7 +15022,7 @@ The event \`detail\` contains the current \`selectedOption\`.",
           {
             "name": "selectedOption",
             "optional": false,
-            "type": "OptionDefinition",
+            "type": "SelectProps.Option",
           },
         ],
         "type": "object",
@@ -15663,7 +15038,6 @@ The event \`detail\` contains the current \`selectedOption\`.",
     {
       "cancelable": false,
       "description": "Use this event to implement the asynchronous behavior for the component.
-
 The event is called in the following situations:
 * The user scrolls to the end of the list of options, if \`statusType\` is set to \`pending\`.
 * The user clicks on the recovery button in the error state.
@@ -15673,7 +15047,8 @@ The event is called in the following situations:
 The detail object contains the following properties:
 * \`filteringText\` - The value that you need to use to fetch options.
 * \`firstPage\` - Indicates that you should fetch the first page of options that match the \`filteringText\`.
-* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).",
+* \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).
+",
       "detailInlineType": {
         "name": "OptionsLoadItemsDetail",
         "properties": [
@@ -15712,12 +15087,12 @@ The detail object contains the following properties:
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -15732,11 +15107,11 @@ Use this if you don't have a visible label for this control.",
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't using \`inlineLabelText\` and isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -15789,12 +15164,12 @@ To use it correctly, define an ID for the element you want to use as label and s
       "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
-
 Set this property if the dropdown would otherwise be constrained by a scrollable container,
 for example inside table and split view layouts.
 
 We recommend you use discretion, and don't enable this property unless necessary
-because fixed positioning results in a slight, visible lag when scrolling complex pages.",
+because fixed positioning results in a slight, visible lag when scrolling complex pages.
+",
       "name": "expandToViewport",
       "optional": true,
       "type": "boolean",
@@ -15820,29 +15195,13 @@ because fixed positioning results in a slight, visible lag when scrolling comple
     },
     {
       "description": "Specifies the text to display with the number of matches at the bottom of the dropdown menu while filtering.",
-      "inlineType": {
-        "name": "(matchesCount: number, totalCount: number) => string",
-        "parameters": [
-          {
-            "name": "matchesCount",
-            "type": "number",
-          },
-          {
-            "name": "totalCount",
-            "type": "number",
-          },
-        ],
-        "returnType": "string",
-        "type": "function",
-      },
       "name": "filteringResultsText",
       "optional": true,
-      "type": "((matchesCount: number, totalCount: number) => string)",
+      "type": "(matchesCount: number, totalCount: number) => string",
     },
     {
       "defaultValue": "'none'",
       "description": "Determines how filtering is applied to the list of \`options\`:
-
 * \`auto\` - The component will automatically filter options based on user input.
 * \`manual\` - You will set up \`onChange\` or \`onLoadItems\` event listeners and filter options on your side or request
 them from server.
@@ -15855,13 +15214,14 @@ If you set this property to \`manual\`, this default filtering mechanism is disa
 displayed in the dropdown list. In that case make sure that you use the \`onChange\` or \`onLoadItems\` events in order
 to set the \`options\` property to the options that are relevant for the user, given the filtering input value.
 
-Note: Manual filtering doesn't disable match highlighting.",
+Note: Manual filtering doesn't disable match highlighting.
+",
       "inlineType": {
         "name": "OptionsFilteringType",
         "type": "union",
         "values": [
-          "auto",
           "none",
+          "auto",
           "manual",
         ],
       },
@@ -15909,6 +15269,7 @@ single form field.",
     },
     {
       "deprecatedTag": "Has no effect.",
+      "description": "",
       "name": "name",
       "optional": true,
       "type": "string",
@@ -15917,7 +15278,6 @@ single form field.",
       "defaultValue": "[]",
       "description": "Specifies an array of options that are displayed to the user as a dropdown list.
 The options can be grouped using \`OptionGroup\` objects.
-
 #### Option
 - \`value\` (string) - The returned value of the option when selected.
 
@@ -15945,7 +15305,13 @@ If you want to use the built-in filtering capabilities of this component, provid
 a list of all valid options here and they will be automatically filtered based on the user's filtering input.
 
 Alternatively, you can listen to the \`onChange\` or \`onLoadItems\` event and set new options
-on your own.",
+on your own.
+",
+      "inlineType": {
+        "name": "SelectProps.Options",
+        "properties": [],
+        "type": "object",
+      },
       "name": "options",
       "optional": true,
       "type": "SelectProps.Options",
@@ -15978,19 +15344,19 @@ the option's name and properties, and its selected state if
 the \`selectedLabel\` property is defined.
 The highlighted option is provided, and its group (if groups
 are used and it differs from the group of the previously highlighted option).
-
 For more information, see the
-[accessibility guidelines](/components/select/?tabId=usage#accessibility-guidelines).",
+[accessibility guidelines](/components/select/?tabId=usage#accessibility-guidelines).
+",
       "inlineType": {
         "name": "SelectProps.ContainingOptionAndGroupString",
         "parameters": [
           {
             "name": "option",
-            "type": "OptionDefinition",
+            "type": "SelectProps.Option",
           },
           {
             "name": "group",
-            "type": "OptionGroup",
+            "type": "SelectProps.OptionGroup",
           },
         ],
         "returnType": "string",
@@ -16012,85 +15378,9 @@ This is required to provide a good screen reader experience. For more informatio
     {
       "description": "Specifies the currently selected option.
 If you want to clear the selection, use \`null\`.",
-      "inlineType": {
-        "name": "OptionDefinition",
-        "properties": [
-          {
-            "name": "__labelPrefix",
-            "optional": true,
-            "type": "string",
-          },
-          {
-            "name": "description",
-            "optional": true,
-            "type": "string",
-          },
-          {
-            "name": "disabled",
-            "optional": true,
-            "type": "boolean",
-          },
-          {
-            "name": "disabledReason",
-            "optional": true,
-            "type": "string",
-          },
-          {
-            "name": "filteringTags",
-            "optional": true,
-            "type": "ReadonlyArray<string>",
-          },
-          {
-            "name": "iconAlt",
-            "optional": true,
-            "type": "string",
-          },
-          {
-            "name": "iconName",
-            "optional": true,
-            "type": "IconProps.Name",
-          },
-          {
-            "name": "iconSvg",
-            "optional": true,
-            "type": "React.ReactNode",
-          },
-          {
-            "name": "iconUrl",
-            "optional": true,
-            "type": "string",
-          },
-          {
-            "name": "label",
-            "optional": true,
-            "type": "string",
-          },
-          {
-            "name": "labelTag",
-            "optional": true,
-            "type": "string",
-          },
-          {
-            "name": "lang",
-            "optional": true,
-            "type": "string",
-          },
-          {
-            "name": "tags",
-            "optional": true,
-            "type": "ReadonlyArray<string>",
-          },
-          {
-            "name": "value",
-            "optional": true,
-            "type": "string",
-          },
-        ],
-        "type": "object",
-      },
       "name": "selectedOption",
       "optional": false,
-      "type": "OptionDefinition | null",
+      "type": "SelectProps.Option | null",
     },
     {
       "defaultValue": "'finished'",
@@ -16103,10 +15393,10 @@ If you want to clear the selection, use \`null\`.",
         "name": "DropdownStatusProps.StatusType",
         "type": "union",
         "values": [
-          "error",
-          "finished",
-          "loading",
           "pending",
+          "loading",
+          "finished",
+          "error",
         ],
       },
       "name": "statusType",
@@ -16133,11 +15423,11 @@ If you want to clear the selection, use \`null\`.",
 that makes the filtering experience smoother. We don't recommend enabling the feature if you
 have less than 500 options, because the improvements to performance are offset by a
 visible scrolling lag.
-
 When you set this flag to \`true\`, it removes options that are not currently in view from the DOM.
 If your test accesses such options, you need to first scroll the options container
 to the correct offset, before performing any operations on them. Use the element returned
-by the \`findOptionsContainer\` test utility for this.",
+by the \`findOptionsContainer\` test utility for this.
+",
       "name": "virtualScroll",
       "optional": true,
       "type": "boolean",
@@ -16180,7 +15470,6 @@ exports[`Documenter definition for side-navigation matches the snapshot: side-na
       "cancelable": false,
       "description": "Fired when the expansion state of \`Section\` or \`ExpandablePageGroup\` items changes
 as a result of a user interaction. The event \`detail\` contains an object with information about the changed item.
-
 - \`item\` (object) - Specifies the item that was changed.
 - \`expanded\` (boolean) - Specifies whether the item is expanded or not.
 - \`expandableParents\` (array) - A list of parent items that have a type of \`Section\`
@@ -16189,14 +15478,15 @@ as a result of a user interaction. The event \`detail\` contains an object with 
     of the navigation items.
 
 Note: If the expansion is a result of the activation of a nested link
-upon changing the \`activeHref\` property, this event isn't raised.",
+upon changing the \`activeHref\` property, this event isn't raised.
+",
       "detailInlineType": {
         "name": "SideNavigationProps.ChangeDetail",
         "properties": [
           {
             "name": "expandableParents",
             "optional": false,
-            "type": "ReadonlyArray<SideNavigationProps.Section | SideNavigationProps.ExpandableLinkGroup>",
+            "type": "ReadonlyArray<SideNavigationProps.ExpandableLinkGroup | SideNavigationProps.Section>",
           },
           {
             "name": "expanded",
@@ -16206,7 +15496,7 @@ upon changing the \`activeHref\` property, this event isn't raised.",
           {
             "name": "item",
             "optional": false,
-            "type": "SideNavigationProps.Section | SideNavigationProps.ExpandableLinkGroup",
+            "type": "SideNavigationProps.ExpandableLinkGroup | SideNavigationProps.Section",
           },
         ],
         "type": "object",
@@ -16220,16 +15510,16 @@ upon changing the \`activeHref\` property, this event isn't raised.",
 The event \`detail\` contains a definition of the clicked item.
 Use this event to prevent default browser navigation (by calling \`preventDefault\` method)
 and branch your own routing.
-
 If the event is prevented the \`activeHref\` property won't be automatically set
-to the href of the clicked item so you'll have to do it yourself.",
+to the href of the clicked item so you'll have to do it yourself.
+",
       "detailInlineType": {
         "name": "SideNavigationProps.FollowDetail",
         "properties": [
           {
             "name": "external",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "href",
@@ -16254,7 +15544,7 @@ to the href of the clicked item so you'll have to do it yourself.",
           {
             "name": "type",
             "optional": true,
-            "type": ""link" | "section-header" | "link-group" | "expandable-link-group"",
+            "type": ""expandable-link-group" | "link" | "link-group" | "section-header"",
           },
         ],
         "type": "object",
@@ -16269,10 +15559,10 @@ to the href of the clicked item so you'll have to do it yourself.",
     {
       "description": "Specifies the \`href\` of the currently active link.
 All items within the navigation with a matching \`href\` are highlighted.
-
 \`Sections\` and \`Expandable Page Groups\` that contain a highlighted item
 are automatically expanded, unless their definitions have the \`defaultExpanded\`
-property explicitly set to \`false\`.",
+property explicitly set to \`false\`.
+",
       "name": "activeHref",
       "optional": true,
       "type": "string",
@@ -16286,11 +15576,11 @@ property explicitly set to \`false\`.",
     },
     {
       "description": "Controls the header that appears at the top of the navigation component.
-
 It contains the following:
 - \`text\` (string) - Specifies the header text.
 - \`href\` (string) - Specifies the \`href\` that the header links to.
-- \`logo\` (object) - Specifies a logo image.",
+- \`logo\` (object) - Specifies a logo image.
+",
       "inlineType": {
         "name": "SideNavigationProps.Header",
         "properties": [
@@ -16329,7 +15619,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "defaultValue": "[]",
       "description": "Specifies the items to be displayed in the navigation.
 Allowed objects are: \`Link\`, \`Divider\`, \`Section\`, \`LinkGroup\` and \`ExpandableLinkGroup\`.
-
 You can inject extra properties (for example, an ID)
 in order to identify the item when it's used in an event \`detail\`
 (for more information, see the events section below).
@@ -16389,7 +15678,8 @@ Object that represents an expandable group of links.
    If not explicitly set, the group is collapsed by default, unless one of the nested links is active.
 - \`items\` (array) - Specifies the content of the section. You can use any valid item from this list.
     Although there is no technical limitation to the nesting level,
-    our UX recommendation is to use only one level.",
+    our UX recommendation is to use only one level.
+",
       "name": "items",
       "optional": true,
       "type": "ReadonlyArray<SideNavigationProps.Item>",
@@ -16434,28 +15724,28 @@ The event \`detail\` contains the current \`value\`.",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an aria-description for slider labels.
-
-Use when sliders have formatted reference values.",
+Use when sliders have formatted reference values.
+",
       "name": "ariaDescription",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-
-Use this if you don't have a visible label for this control.",
+Use this if you don't have a visible label for this control.
+",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -16463,11 +15753,11 @@ Use this if you don't have a visible label for this control.",
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -16482,9 +15772,9 @@ To use it correctly, define an ID for the element you want to use as label and s
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -16584,20 +15874,9 @@ being included in a form submission. A read-only control is still focusable.",
     },
     {
       "description": "Formats the values. This will format both the labels and the tooltip.",
-      "inlineType": {
-        "name": "(value: number) => string",
-        "parameters": [
-          {
-            "name": "value",
-            "type": "number",
-          },
-        ],
-        "returnType": "string",
-        "type": "function",
-      },
       "name": "valueFormatter",
       "optional": true,
-      "type": "((value: number) => string)",
+      "type": "(value: number) => string",
     },
     {
       "description": "Overrides the warning state. Usually the warning state
@@ -16631,8 +15910,8 @@ exports[`Documenter definition for space-between matches the snapshot: space-bet
         "type": "union",
         "values": [
           "center",
-          "end",
           "start",
+          "end",
         ],
       },
       "name": "alignItems",
@@ -16647,14 +15926,14 @@ exports[`Documenter definition for space-between matches the snapshot: space-bet
       "type": "string",
     },
     {
-      "defaultValue": "'vertical'",
+      "defaultValue": ""vertical"",
       "description": "Defines the direction in which the content is laid out.",
       "inlineType": {
         "name": "SpaceBetweenProps.Direction",
         "type": "union",
         "values": [
-          "horizontal",
           "vertical",
+          "horizontal",
         ],
       },
       "name": "direction",
@@ -16676,11 +15955,11 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
         "name": "SpaceBetweenProps.Size",
         "type": "union",
         "values": [
-          "s",
-          "m",
           "xxxs",
           "xxs",
           "xs",
+          "s",
+          "m",
           "l",
           "xl",
           "xxl",
@@ -16725,14 +16004,14 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": "'normal'",
+      "defaultValue": ""normal"",
       "description": "Specifies the size of the spinner.",
       "inlineType": {
         "name": "SpinnerProps.Size",
         "type": "union",
         "values": [
-          "big",
           "normal",
+          "big",
           "large",
         ],
       },
@@ -16741,7 +16020,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": "'normal'",
+      "defaultValue": ""normal"",
       "description": "Specifies the color variant of the spinner. The \`normal\` variant picks up the current color of its context.",
       "inlineType": {
         "name": "SpinnerProps.Variant",
@@ -16776,14 +16055,14 @@ exports[`Documenter definition for split-panel matches the snapshot: split-panel
       "type": "string",
     },
     {
-      "defaultValue": "'collapse'",
+      "defaultValue": ""collapse"",
       "description": "Determines whether the split panel collapses or hides completely when closed.",
       "inlineType": {
-        "name": ""hide" | "collapse"",
+        "name": "",
         "type": "union",
         "values": [
-          "hide",
           "collapse",
+          "hide",
         ],
       },
       "name": "closeBehavior",
@@ -16804,7 +16083,6 @@ exports[`Documenter definition for split-panel matches the snapshot: split-panel
       "type": "boolean",
     },
     {
-      "defaultValue": "{}",
       "description": "An object containing all the necessary localized strings required by the component.
 - \`closeButtonAriaLabel\` - The text of the panel close button aria label.
 - \`openButtonAriaLabel\` - The text of the panel open button aria label.
@@ -16917,8 +16195,8 @@ exports[`Documenter definition for status-indicator matches the snapshot: status
         "type": "union",
         "values": [
           "blue",
-          "green",
           "grey",
+          "green",
           "red",
           "yellow",
         ],
@@ -16944,20 +16222,20 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": "'success'",
+      "defaultValue": ""success"",
       "description": "Specifies the status type.",
       "inlineType": {
         "name": "StatusIndicatorProps.Type",
         "type": "union",
         "values": [
           "error",
-          "in-progress",
-          "stopped",
-          "loading",
-          "pending",
-          "success",
           "warning",
+          "success",
           "info",
+          "stopped",
+          "pending",
+          "in-progress",
+          "loading",
         ],
       },
       "name": "type",
@@ -17029,12 +16307,12 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "An array of individual steps
-
 Each step definition has the following properties:
  * \`status\` (string) - Status of the step corresponding to a status indicator.
  * \`statusIconAriaLabel\` - (string) - (Optional) Alternative text for the status icon.
  * \`header\` (ReactNode) - Summary corresponding to the step.
- * \`details\` (ReactNode) - (Optional) Additional information corresponding to the step.",
+ * \`details\` (ReactNode) - (Optional) Additional information corresponding to the step.
+",
       "name": "steps",
       "optional": false,
       "type": "ReadonlyArray<StepsProps.Step>",
@@ -17076,11 +16354,11 @@ validation states, or show warning for unsaved changes.",
       "cancelable": false,
       "description": "Note: This feature is provided for backwards compatibility. Its use is not recommended,
 and it may be deprecated in the future.
-
 Called when the user clicked at a table row. The event detail contains the index of the
-clicked row and the row object itself. Use this event to define a row click behavior.",
+clicked row and the row object itself. Use this event to define a row click behavior.
+",
       "detailInlineType": {
-        "name": "TableProps.OnRowClickDetail<T>",
+        "name": "TableProps.OnRowClickDetail",
         "properties": [
           {
             "name": "item",
@@ -17102,12 +16380,12 @@ clicked row and the row object itself. Use this event to define a row click beha
       "cancelable": true,
       "description": "Note: This feature is provided for backwards compatibility. Its use is not recommended,
 and it may be deprecated in the future.
-
 Called when the user clicked at a table row with the right mouse click. The event detail
 contains the index of the clicked row and the row object itself. Use this event to override
-the default browser context menu behavior.",
+the default browser context menu behavior.
+",
       "detailInlineType": {
-        "name": "TableProps.OnRowContextMenuDetail<T>",
+        "name": "TableProps.OnRowContextMenuDetail",
         "properties": [
           {
             "name": "clientX",
@@ -17140,7 +16418,7 @@ the default browser context menu behavior.",
       "description": "Fired when a user interaction triggers a change in the list of selected items.
 The event \`detail\` contains the current list of \`selectedItems\`.",
       "detailInlineType": {
-        "name": "TableProps.SelectionChangeDetail<T>",
+        "name": "TableProps.SelectionChangeDetail",
         "properties": [
           {
             "name": "selectedItems",
@@ -17158,12 +16436,12 @@ The event \`detail\` contains the current list of \`selectedItems\`.",
       "description": "Called when either the column to sort by or the direction of sorting changes upon user interaction.
 The event detail contains the current sortingColumn and isDescending.",
       "detailInlineType": {
-        "name": "TableProps.SortingState<T>",
+        "name": "TableProps.SortingState",
         "properties": [
           {
             "name": "isDescending",
             "optional": true,
-            "type": "boolean",
+            "type": "false | true",
           },
           {
             "name": "sortingColumn",
@@ -17245,37 +16523,37 @@ add a meaningful description to the whole selection.
 * \`collapseButtonLabel\` (Item) => string - Specifies an alternative text for row collapse button.",
       "i18nTag": true,
       "inlineType": {
-        "name": "TableProps.AriaLabels<T>",
+        "name": "TableProps.AriaLabels",
         "properties": [
           {
             "name": "activateEditLabel",
             "optional": true,
-            "type": "((column: TableProps.ColumnDefinition<any>, item: T) => string)",
+            "type": "(column: TableProps.ColumnDefinition<any>, item: T) => string",
           },
           {
             "name": "allItemsSelectionLabel",
             "optional": true,
-            "type": "((data: TableProps.SelectionState<T>) => string)",
+            "type": "(data: TableProps.SelectionState<T>) => string",
           },
           {
             "name": "cancelEditLabel",
             "optional": true,
-            "type": "((column: TableProps.ColumnDefinition<any>) => string)",
+            "type": "(column: TableProps.ColumnDefinition<any>) => string",
           },
           {
             "name": "collapseButtonLabel",
             "optional": true,
-            "type": "((item: T) => string)",
+            "type": "(item: T) => string",
           },
           {
             "name": "expandButtonLabel",
             "optional": true,
-            "type": "((item: T) => string)",
+            "type": "(item: T) => string",
           },
           {
             "name": "itemSelectionLabel",
             "optional": true,
-            "type": "((data: TableProps.SelectionState<T>, row: T) => string)",
+            "type": "(data: TableProps.SelectionState<T>, row: T) => string",
           },
           {
             "name": "resizerRoleDescription",
@@ -17290,17 +16568,17 @@ add a meaningful description to the whole selection.
           {
             "name": "submitEditLabel",
             "optional": true,
-            "type": "((column: TableProps.ColumnDefinition<any>) => string)",
+            "type": "(column: TableProps.ColumnDefinition<any>) => string",
           },
           {
             "name": "submittingEditText",
             "optional": true,
-            "type": "((column: TableProps.ColumnDefinition<any>) => string)",
+            "type": "(column: TableProps.ColumnDefinition<any>) => string",
           },
           {
             "name": "successfulEditLabel",
             "optional": true,
-            "type": "((column: TableProps.ColumnDefinition<any>) => string)",
+            "type": "(column: TableProps.ColumnDefinition<any>) => string",
           },
           {
             "name": "tableLabel",
@@ -17320,11 +16598,11 @@ add a meaningful description to the whole selection.
 This property affects all cells, including the ones in the selection column.
 To target individual cells use \`columnDefinitions.verticalAlign\`, that takes precedence over \`cellVerticalAlign\`.",
       "inlineType": {
-        "name": ""top" | "middle"",
+        "name": "",
         "type": "union",
         "values": [
-          "top",
           "middle",
+          "top",
         ],
       },
       "name": "cellVerticalAlign",
@@ -17391,10 +16669,10 @@ To target individual cells use \`columnDefinitions.verticalAlign\`, that takes p
     },
     {
       "description": "Specifies an array that represents the table columns in the order in which they will be displayed, together with their visibility.
-
 If not set, all columns are displayed and the order is dictated by the \`columnDefinitions\` property.
 
-Use it in conjunction with the content display preference of the [collection preferences](/components/collection-preferences/) component.",
+Use it in conjunction with the content display preference of the [collection preferences](/components/collection-preferences/) component.
+",
       "name": "columnDisplay",
       "optional": true,
       "type": "ReadonlyArray<TableProps.ColumnDisplayProperties>",
@@ -17403,11 +16681,11 @@ Use it in conjunction with the content display preference of the [collection pre
       "defaultValue": "'comfortable'",
       "description": "Toggles the content density of the table. Defaults to \`'comfortable'\`.",
       "inlineType": {
-        "name": ""compact" | "comfortable"",
+        "name": "",
         "type": "union",
         "values": [
-          "compact",
           "comfortable",
+          "compact",
         ],
       },
       "name": "contentDensity",
@@ -17417,8 +16695,8 @@ Use it in conjunction with the content display preference of the [collection pre
     {
       "description": "Use this property to activate advanced keyboard navigation and focusing behaviors.
 When set to \`true\`, table cells become navigable with arrow keys, and the entire table has a single tab stop.
-
-By default, the keyboard navigation is active for tables with expandable rows.",
+By default, the keyboard navigation is active for tables with expandable rows.
+",
       "name": "enableKeyboardNavigation",
       "optional": true,
       "type": "boolean",
@@ -17430,7 +16708,7 @@ By default, the keyboard navigation is active for tables with expandable rows.",
 * \`expandedItems\` (Item[]) - Use it to represent the expanded state of items.
 * \`onExpandableItemToggle\` (TableProps.OnExpandableItemToggle<T>) - Called when an item's expand toggle is clicked.",
       "inlineType": {
-        "name": "TableProps.ExpandableRows<T>",
+        "name": "TableProps.ExpandableRows",
         "properties": [
           {
             "name": "expandedItems",
@@ -17440,7 +16718,7 @@ By default, the keyboard navigation is active for tables with expandable rows.",
           {
             "name": "getItemChildren",
             "optional": false,
-            "type": "(item: T) => ReadonlyArray<T>",
+            "type": "(item: T) => typeOperator",
           },
           {
             "name": "isItemExpandable",
@@ -17461,8 +16739,8 @@ By default, the keyboard navigation is active for tables with expandable rows.",
     },
     {
       "defaultValue": "1",
-      "description": "Use this property to inform screen readers which range of items is currently displayed in the table.
-It specifies the index (1-based) of the first item in the table.",
+      "description": " Use this property to inform screen readers which range of items is currently displayed in the table.
+ It specifies the index (1-based) of the first item in the table.",
       "name": "firstIndex",
       "optional": true,
       "type": "number",
@@ -17475,7 +16753,7 @@ table with \`item=null\` and then for each expanded item. The function result is
 * \`finished\` - Indicates that loading has finished and no more requests are expected.
 * \`error\` - Indicates that an error occurred during fetch.",
       "inlineType": {
-        "name": "TableProps.GetLoadingStatus<T>",
+        "name": "TableProps.GetLoadingStatus",
         "parameters": [
           {
             "name": "item",
@@ -17501,7 +16779,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "description": "Determines whether a given item is disabled. If an item is disabled, the user can't select it.",
       "inlineType": {
-        "name": "TableProps.IsItemDisabled<T>",
+        "name": "TableProps.IsItemDisabled",
         "parameters": [
           {
             "name": "item",
@@ -17543,92 +16821,37 @@ The function argument takes the following properties:
 * \`visibleItemsCount\` (number) - The number of rendered table items.
 * \`totalItemsCount\` (optional, number) - The provided \`totalItemsCount\` property.
 Important: in tables with expandable rows the \`firstIndex\`, \`lastIndex\`, and \`totalItemsCount\` reflect the top-level items only.",
-      "inlineType": {
-        "name": "(data: TableProps.LiveAnnouncement) => string",
-        "parameters": [
-          {
-            "name": "data",
-            "type": "TableProps.LiveAnnouncement",
-          },
-        ],
-        "returnType": "string",
-        "type": "function",
-      },
       "name": "renderAriaLive",
       "optional": true,
-      "type": "((data: TableProps.LiveAnnouncement) => string)",
+      "type": "(data: TableProps.LiveAnnouncement) => string",
     },
     {
       "description": "Renders loader row content for empty row state: the loading status is "finished",
 and the row is expanded but has empty children array.
-
 The empty loader state is only supported for expandable rows. Use \`empty\` slot if
-the table items array is empty.",
-      "inlineType": {
-        "name": "(detail: TableProps.RenderLoaderEmptyDetail<T>) => React.ReactNode",
-        "parameters": [
-          {
-            "name": "detail",
-            "type": "TableProps.RenderLoaderEmptyDetail<T>",
-          },
-        ],
-        "returnType": "React.ReactNode",
-        "type": "function",
-      },
+the table items array is empty.
+",
       "name": "renderLoaderEmpty",
       "optional": true,
-      "type": "((detail: TableProps.RenderLoaderEmptyDetail<T>) => React.ReactNode)",
+      "type": "(detail: TableProps.RenderLoaderEmptyDetail<T>) => React.ReactNode",
     },
     {
       "description": "Renders loader row content for error state.",
-      "inlineType": {
-        "name": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
-        "parameters": [
-          {
-            "name": "detail",
-            "type": "TableProps.RenderLoaderDetail<T>",
-          },
-        ],
-        "returnType": "React.ReactNode",
-        "type": "function",
-      },
       "name": "renderLoaderError",
       "optional": true,
-      "type": "((detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode)",
+      "type": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
     },
     {
       "description": "Renders loader row content for loading state.",
-      "inlineType": {
-        "name": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
-        "parameters": [
-          {
-            "name": "detail",
-            "type": "TableProps.RenderLoaderDetail<T>",
-          },
-        ],
-        "returnType": "React.ReactNode",
-        "type": "function",
-      },
       "name": "renderLoaderLoading",
       "optional": true,
-      "type": "((detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode)",
+      "type": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
     },
     {
       "description": "Renders loader row content for pending state.",
-      "inlineType": {
-        "name": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
-        "parameters": [
-          {
-            "name": "detail",
-            "type": "TableProps.RenderLoaderDetail<T>",
-          },
-        ],
-        "returnType": "React.ReactNode",
-        "type": "function",
-      },
       "name": "renderLoaderPending",
       "optional": true,
-      "type": "((detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode)",
+      "type": "(detail: TableProps.RenderLoaderDetail<T>) => React.ReactNode",
     },
     {
       "description": "Specifies if columns can be resized. If set to \`true\`, users can resize the columns in the table.",
@@ -17661,12 +16884,12 @@ the table items array is empty.",
       "description": "Specifies the definition object of the currently sorted column. Make sure you pass an object that's
 present in the \`columnDefinitions\` array.",
       "inlineType": {
-        "name": "TableProps.SortingColumn<T>",
+        "name": "TableProps.SortingColumn",
         "properties": [
           {
             "name": "sortingComparator",
             "optional": true,
-            "type": "((a: T, b: T) => number)",
+            "type": "(a: T, b: T) => number",
           },
           {
             "name": "sortingField",
@@ -17695,11 +16918,12 @@ to prevent the user from sorting before items are fully loaded.",
     },
     {
       "description": "Specifies the number of first and/or last columns that should be sticky.
-
 If the available scrollable space is less than a certain threshold, the feature is deactivated.
 
 Use it in conjunction with the sticky columns preference of the
-[collection preferences](/components/collection-preferences/) component.",
+[collection preferences](/components/collection-preferences/) component.
+
+",
       "inlineType": {
         "name": "TableProps.StickyColumns",
         "properties": [
@@ -17722,8 +16946,8 @@ Use it in conjunction with the sticky columns preference of the
     },
     {
       "description": "If set to \`true\`, the table header remains visible when the user scrolls down.
-
-Do not use \`stickyHeader\` conditionally. Instead, keep its value constant during the component lifecycle.",
+Do not use \`stickyHeader\` conditionally. Instead, keep its value constant during the component lifecycle.
+",
       "name": "stickyHeader",
       "optional": true,
       "type": "boolean",
@@ -17745,7 +16969,7 @@ need to position the sticky header below other fixed position elements on the pa
       "description": "Specifies a function that will be called after user submits an inline edit.
 Return a promise to keep loading state while the submit request is in progress.",
       "inlineType": {
-        "name": "TableProps.SubmitEditFunction<T, unknown>",
+        "name": "TableProps.SubmitEditFunction",
         "parameters": [
           {
             "name": "item",
@@ -17760,12 +16984,12 @@ Return a promise to keep loading state while the submit request is in progress."
             "type": "ValueType",
           },
         ],
-        "returnType": "void | Promise<void>",
+        "returnType": "Promise<void> | void",
         "type": "function",
       },
       "name": "submitEdit",
       "optional": true,
-      "type": "TableProps.SubmitEditFunction<T, unknown>",
+      "type": "TableProps.SubmitEditFunction<T>",
     },
     {
       "description": "Use this property to inform screen readers how many items there are in a table.
@@ -17779,13 +17003,13 @@ If there is an unknown total of items in a table, leave this property undefined.
       "description": "Specifies a property that uniquely identifies an individual item.
 When it's set, it's used to provide [keys for React](https://reactjs.org/docs/lists-and-keys.html#keys)
 for performance optimizations.
-
 It is also used in the following situations:
 - to connect \`items\` and \`selectedItems\` values when they reference different objects.
 - to connect \`items\` and \`expandableRows.expandedItems\` values when they reference different objects.
-- to attach successful edit state to the correct item if its row index changes after editing.",
+- to attach successful edit state to the correct item if its row index changes after editing.
+",
       "inlineType": {
-        "name": "TableProps.TrackBy<T>",
+        "name": "TableProps.TrackBy",
         "type": "union",
         "values": [
           "string",
@@ -17814,9 +17038,9 @@ It is also used in the following situations:
         "values": [
           "container",
           "embedded",
+          "borderless",
           "stacked",
           "full-page",
-          "borderless",
         ],
       },
       "name": "variant",
@@ -17827,10 +17051,10 @@ It is also used in the following situations:
     {
       "deprecatedTag": "Replaced by \`columnDisplay\`.",
       "description": "Specifies an array containing the \`id\`s of visible columns. If not set, all columns are displayed.
-
 Use it in conjunction with the visible content preference of the [collection preferences](/components/collection-preferences/) component.
 
-The order of ids doesn't influence the order in which columns are displayed - this is dictated by the \`columnDefinitions\` property.",
+The order of ids doesn't influence the order in which columns are displayed - this is dictated by the \`columnDefinitions\` property.
+",
       "name": "visibleColumns",
       "optional": true,
       "type": "ReadonlyArray<string>",
@@ -17991,7 +17215,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "defaultValue": "'automatic'",
+      "defaultValue": ""automatic"",
       "description": "Determines how the active tab is switched when navigating using
 the keyboard. The options are:
 - 'automatic' (default): the active tab is switched using the arrow keys.
@@ -18000,11 +17224,11 @@ We recommend using 'automatic' in most situations to provide consistent
 and quick switching between tabs. Use 'manual' only if there is a specific
 need to introduce friction to the switching of tabs.",
       "inlineType": {
-        "name": ""manual" | "automatic"",
+        "name": "",
         "type": "union",
         "values": [
-          "manual",
           "automatic",
+          "manual",
         ],
       },
       "name": "keyboardActivationMode",
@@ -18013,7 +17237,6 @@ need to introduce friction to the switching of tabs.",
     },
     {
       "description": "Specifies the tabs to display. Each tab object has the following properties:
-
 - \`id\` (string) - The tab identifier. This value needs to be passed to the Tabs component as \`activeTabId\` to select this tab.
 - \`label\` (ReactNode) - Tab label shown in the UI.
 - \`content\` (ReactNode) - (Optional) Tab content to render in the container.
@@ -18032,15 +17255,16 @@ need to introduce friction to the switching of tabs.",
    if your application routing can handle such deep links. You can manually update routing on the current page
    using the \`activeTabHref\` property of the \`change\` event's detail.
 - \`contentRenderStrategy\` (string) - (Optional) Determines when tab content is rendered:
-  - \`'active'\`: (Default) Only render content when the tab is active.
+- \`'active'\`: (Default) Only render content when the tab is active.
   - \`'eager'\`: Always render tab content (hidden when the tab is not active).
-  - \`'lazy'\`: Like 'eager', but content is only rendered after the tab is first activated.",
+  - \`'lazy'\`: Like 'eager', but content is only rendered after the tab is first activated.
+",
       "name": "tabs",
       "optional": false,
       "type": "ReadonlyArray<TabsProps.Tab>",
     },
     {
-      "defaultValue": "'default'",
+      "defaultValue": ""default"",
       "description": "The possible visual variants of tabs are the following:
 * \`default\` - Use in any context.
 * \`container\` - Use this variant to have the tabs displayed within a container header.
@@ -18166,12 +17390,12 @@ character validation. You should use this property only when absolutely necessar
           {
             "name": "enteredKeyLabel",
             "optional": true,
-            "type": "((enteredText: string) => string)",
+            "type": "(enteredText: string) => string",
           },
           {
             "name": "enteredValueLabel",
             "optional": true,
-            "type": "((enteredText: string) => string)",
+            "type": "(enteredText: string) => string",
           },
           {
             "name": "errorIconAriaLabel",
@@ -18204,17 +17428,17 @@ character validation. You should use this property only when absolutely necessar
             "type": "string",
           },
           {
+            "name": "keySuggestion",
+            "optional": true,
+            "type": "string",
+          },
+          {
             "name": "keysSuggestionError",
             "optional": true,
             "type": "string",
           },
           {
             "name": "keysSuggestionLoading",
-            "optional": true,
-            "type": "string",
-          },
-          {
-            "name": "keySuggestion",
             "optional": true,
             "type": "string",
           },
@@ -18246,22 +17470,22 @@ character validation. You should use this property only when absolutely necessar
           {
             "name": "removeButtonAriaLabel",
             "optional": true,
-            "type": "((item: TagEditorProps.Tag) => string)",
+            "type": "(item: TagEditorProps.Tag) => string",
           },
           {
             "name": "tagLimit",
             "optional": true,
-            "type": "((availableTags: number, tagLimit: number) => string)",
+            "type": "(availableTags: number, tagLimit: number) => string",
           },
           {
             "name": "tagLimitExceeded",
             "optional": true,
-            "type": "((tagLimit: number) => string)",
+            "type": "(tagLimit: number) => string",
           },
           {
             "name": "tagLimitReached",
             "optional": true,
-            "type": "((tagLimit: number) => string)",
+            "type": "(tagLimit: number) => string",
           },
           {
             "name": "tooManyKeysSuggestion",
@@ -18294,17 +17518,17 @@ character validation. You should use this property only when absolutely necessar
             "type": "string",
           },
           {
+            "name": "valueSuggestion",
+            "optional": true,
+            "type": "string",
+          },
+          {
             "name": "valuesSuggestionError",
             "optional": true,
             "type": "string",
           },
           {
             "name": "valuesSuggestionLoading",
-            "optional": true,
-            "type": "string",
-          },
-          {
-            "name": "valueSuggestion",
             "optional": true,
             "type": "string",
           },
@@ -18328,37 +17552,23 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "description": "Specifies a function that returns all the keys for a resource.
 The expected return type of the function should be a promise that
 resolves to a list of strings of all the keys (for example, \`['key1', 'key2']\`).",
-      "inlineType": {
-        "name": "(key: string) => Promise<ReadonlyArray<string>>",
-        "parameters": [
-          {
-            "name": "key",
-            "type": "string",
-          },
-        ],
-        "returnType": "Promise<ReadonlyArray<string>>",
-        "type": "function",
-      },
       "name": "keysRequest",
       "optional": true,
-      "type": "((key: string) => Promise<ReadonlyArray<string>>)",
+      "type": "(key: string) => Promise<ReadonlyArray<string>>",
     },
     {
-      "defaultValue": "false",
       "description": "Renders the component in a loading state.",
       "name": "loading",
       "optional": true,
       "type": "boolean",
     },
     {
-      "defaultValue": "50",
       "description": "Specifies the maximum number of tags that a customer can add.",
       "name": "tagLimit",
       "optional": true,
       "type": "number",
     },
     {
-      "defaultValue": "[]",
       "description": "Specifies an array of tags that are displayed to the user. Each tag item has the following properties:
 - \`key\` (string) - The key of the tag that's displayed in the corresponding key field.
 - \`value\` (string) - The value of the tag that's displayed in the corresponding value field.
@@ -18377,26 +17587,11 @@ resolves to a list of strings of all the keys (for example, \`['key1', 'key2']\`
       "description": "Specifies a function that returns all the values for a specified key
 of a resource. The expected return type of the function should be a promise
 that resolves to a list of strings of all the values (for example, \`['value1', 'value2']\`).
-
-You should return a rejected promise when the \`key\` parameter is an empty string.",
-      "inlineType": {
-        "name": "(key: string, value: string) => Promise<ReadonlyArray<string>>",
-        "parameters": [
-          {
-            "name": "key",
-            "type": "string",
-          },
-          {
-            "name": "value",
-            "type": "string",
-          },
-        ],
-        "returnType": "Promise<ReadonlyArray<string>>",
-        "type": "function",
-      },
+You should return a rejected promise when the \`key\` parameter is an empty string.
+",
       "name": "valuesRequest",
       "optional": true,
-      "type": "((key: string, value: string) => Promise<ReadonlyArray<string>>)",
+      "type": "(key: string, value: string) => Promise<ReadonlyArray<string>>",
     },
   ],
   "regions": [],
@@ -18491,12 +17686,12 @@ period of time. If you want a delayed handler to invoke a filtering API call, yo
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -18504,11 +17699,11 @@ and set the property to a string of each ID separated by spaces (for example, \`
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -18523,9 +17718,9 @@ To use it correctly, define an ID for the element you want to use as label and s
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -18534,9 +17729,9 @@ is provided by its parent form field component.",
       "description": "Accepts a human-readable, localized string that indicates the number of results. For example, "1 match" or "165 matches."
 If the total number of results is unknown, also include an indication that there may be more results than
 the number listed. For example, "25+ matches."
-
 The count text is only displayed when \`filteringText\` isn't empty.
-When the \`countText\` or \`filteringText\` changes, it will be announced to assistive technologies.",
+When the \`countText\` or \`filteringText\` changes, it will be announced to assistive technologies.
+",
       "name": "countText",
       "optional": true,
       "type": "string",
@@ -18611,6 +17806,7 @@ exports[`Documenter definition for textarea matches the snapshot: textarea 1`] =
     {
       "cancelable": false,
       "description": "Called when input focus is removed from the UI control.",
+      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -18618,7 +17814,7 @@ exports[`Documenter definition for textarea matches the snapshot: textarea 1`] =
       "description": "Called whenever a user changes the input value (by typing or pasting).
 The event \`detail\` contains the current value of the field.",
       "detailInlineType": {
-        "name": "BaseChangeDetail",
+        "name": "InputProps.ChangeDetail",
         "properties": [
           {
             "name": "value",
@@ -18628,12 +17824,13 @@ The event \`detail\` contains the current value of the field.",
         ],
         "type": "object",
       },
-      "detailType": "BaseChangeDetail",
+      "detailType": "InputProps.ChangeDetail",
       "name": "onChange",
     },
     {
       "cancelable": false,
       "description": "Called when input focus is moved to the UI control.",
+      "detailType": "null",
       "name": "onFocus",
     },
     {
@@ -18642,7 +17839,7 @@ The event \`detail\` contains the current value of the field.",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "BaseKeyDetail",
+        "name": "InputProps.KeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -18682,7 +17879,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "BaseKeyDetail",
+      "detailType": "InputProps.KeyDetail",
       "name": "onKeyDown",
     },
     {
@@ -18691,7 +17888,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
 The event \`detail\` contains the \`keyCode\` and information
 about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
       "detailInlineType": {
-        "name": "BaseKeyDetail",
+        "name": "InputProps.KeyDetail",
         "properties": [
           {
             "name": "altKey",
@@ -18731,7 +17928,7 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
         ],
         "type": "object",
       },
-      "detailType": "BaseKeyDetail",
+      "detailType": "InputProps.KeyDetail",
       "name": "onKeyUp",
     },
   ],
@@ -18748,20 +17945,20 @@ about modifiers (that is, CTRL, ALT, SHIFT, META, etc.).",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-
-Use this if you don't have a visible label for this control.",
+Use this if you don't have a visible label for this control.
+",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -18769,11 +17966,11 @@ Use this if you don't have a visible label for this control.",
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -18789,21 +17986,12 @@ To use it correctly, define an ID for the element you want to use as label and s
       "description": "Specifies whether to enable a browser's autocomplete functionality for this input.
 In some cases it might be appropriate to disable autocomplete (for example, for security-sensitive fields).
 To use it correctly, set the \`name\` property.
-
 You can either provide a boolean value to set the property to "on" or "off", or specify a string value
-for the [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.",
-      "inlineType": {
-        "name": "string | boolean",
-        "type": "union",
-        "values": [
-          "string",
-          "false",
-          "true",
-        ],
-      },
+for the [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.
+",
       "name": "autoComplete",
       "optional": true,
-      "type": "string | boolean",
+      "type": "boolean | string",
     },
     {
       "description": "Indicates whether the control should be focused as
@@ -18825,9 +18013,9 @@ scrolled out of the viewport.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -18897,8 +18085,8 @@ single form field.",
       "description": "Specifies if the control is read-only, which prevents the
 user from modifying the value but includes it in a form
 submission. A read-only control can receive focus.
-
-Don't use read-only inputs outside a form.",
+Don't use read-only inputs outside a form.
+",
       "name": "readOnly",
       "optional": true,
       "type": "boolean",
@@ -18914,10 +18102,10 @@ Don't use read-only inputs outside a form.",
 This value controls the native browser capability to check for spelling/grammar errors.
 If not set, the browser default behavior is to perform spellchecking.
 For more details, check the [spellcheck MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck).
-
 Enhanced spellchecking features of your browser and/or operating system may send input values to external parties.
 Make sure it’s deactivated for fields with sensitive information to prevent
-inadvertently sending data (such as user passwords) to third parties.",
+inadvertently sending data (such as user passwords) to third parties.
+",
       "name": "spellcheck",
       "optional": true,
       "type": "boolean",
@@ -18988,12 +18176,12 @@ If the component controls any secondary content (for example, another form field
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
@@ -19008,11 +18196,11 @@ because the form field component automatically sets the correct labels to make t
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -19041,9 +18229,9 @@ It is set to 2 if 4 or 8 items are supplied in order to optimize the layout.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -19059,14 +18247,14 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "List of tile definitions. Each tile has the following properties:
-
 - \`value\` [string] - The value that will be associated with the tile. This is the value the tiles will get when the radio button is selected.
 - \`label\` [ReactNode] - A short description for the option the tile represents.
 - \`description\` [ReactNode] - (Optional) Further explanatory guidance on the tile option, shown below the \`label\`.
 - \`image\` [ReactNode] - (Optional) Visually distinctive image for the tile option, shown below the \`description\`.
 - \`disabled\` [boolean] - (Optional) Specifies whether the tile is disabled. Users can't select disabled tiles.
 - \`controlId\` [string] - (Optional) The ID of the internal input. You can use this to relate a label element's \`for\` attribute to this control.
-           We recommend that you don't set this property because it's automatically set by the tiles component.",
+           We recommend that you don't set this property because it's automatically set by the tiles component.
+",
       "name": "items",
       "optional": true,
       "type": "ReadonlyArray<TilesProps.TilesDefinition>",
@@ -19090,7 +18278,7 @@ being included in a form submission. A read-only control is still focusable.",
 If you want to clear the selection, use \`null\`.",
       "name": "value",
       "optional": false,
-      "type": "string | null",
+      "type": "null | string",
     },
   ],
   "regions": [],
@@ -19104,6 +18292,7 @@ exports[`Documenter definition for time-input matches the snapshot: time-input 1
     {
       "cancelable": false,
       "description": "Called when input focus is removed from the UI control.",
+      "detailType": "null",
       "name": "onBlur",
     },
     {
@@ -19111,7 +18300,7 @@ exports[`Documenter definition for time-input matches the snapshot: time-input 1
       "description": "Called whenever a user changes the input value (by typing or pasting).
 The event \`detail\` contains the current value of the field.",
       "detailInlineType": {
-        "name": "BaseChangeDetail",
+        "name": "InputProps.ChangeDetail",
         "properties": [
           {
             "name": "value",
@@ -19121,12 +18310,13 @@ The event \`detail\` contains the current value of the field.",
         ],
         "type": "object",
       },
-      "detailType": "BaseChangeDetail",
+      "detailType": "InputProps.ChangeDetail",
       "name": "onChange",
     },
     {
       "cancelable": false,
       "description": "Called when input focus is moved to the UI control.",
+      "detailType": "null",
       "name": "onFocus",
     },
   ],
@@ -19143,20 +18333,20 @@ The event \`detail\` contains the current value of the field.",
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-
-Use this if you don't have a visible label for this control.",
+Use this if you don't have a visible label for this control.
+",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -19164,11 +18354,11 @@ Use this if you don't have a visible label for this control.",
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -19208,9 +18398,9 @@ scrolled out of the viewport.",
     {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
-
 It defaults to an automatically generated ID that
-is provided by its parent form field component.",
+is provided by its parent form field component.
+",
       "name": "controlId",
       "optional": true,
       "type": "string",
@@ -19237,8 +18427,8 @@ receive focus.",
     {
       "defaultValue": "'hh:mm:ss'",
       "description": "Specifies the format of the time input.
-
-Use it to restrict the granularity of time that the user can enter.",
+Use it to restrict the granularity of time that the user can enter.
+",
       "inlineType": {
         "name": "TimeInputProps.Format",
         "type": "union",
@@ -19287,8 +18477,8 @@ single form field.",
       "description": "Specifies if the control is read-only, which prevents the
 user from modifying the value but includes it in a form
 submission. A read-only control can receive focus.
-
-Don't use read-only inputs outside a form.",
+Don't use read-only inputs outside a form.
+",
       "name": "readOnly",
       "optional": true,
       "type": "boolean",
@@ -19376,20 +18566,20 @@ If the component controls any secondary content (for example, another form field
     {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
 To use it correctly, define an ID for each element that you want to use as a description
-and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).",
+and set the property to a string of each ID separated by spaces (for example, \`"id1 id2 id3"\`).
+",
       "name": "ariaDescribedby",
       "optional": true,
       "type": "string",
     },
     {
       "description": "Adds an \`aria-label\` to the native control.
-
-Use this if you don't have a visible label for this control.",
+Use this if you don't have a visible label for this control.
+",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -19397,11 +18587,11 @@ Use this if you don't have a visible label for this control.",
     {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
-
 Use this property if the component isn't surrounded by a form field, or you want to override the value
 automatically set by the form field (for example, if you have two components within a single form field).
 
-To use it correctly, define an ID for the element you want to use as label and set the property to that ID.",
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
       "name": "ariaLabelledby",
       "optional": true,
       "type": "string",
@@ -19564,7 +18754,6 @@ If an href is provided, it opens the link in a new tab.",
     },
     {
       "description": "An object containing all the necessary localized strings required by the component. The object should contain:
-
 * \`externalIconAriaLabel\` - (optional) Specifies the aria-label for the external icon when \`external\` is set to \`true\`.",
       "i18nTag": true,
       "inlineType": {
@@ -19588,29 +18777,6 @@ If an href is provided, it opens the link in a new tab.",
         "name": "IconProps.Name",
         "type": "union",
         "values": [
-          "search",
-          "map",
-          "filter",
-          "key",
-          "file",
-          "pause",
-          "play",
-          "remove",
-          "copy",
-          "menu",
-          "script",
-          "close",
-          "status-pending",
-          "refresh",
-          "external",
-          "group",
-          "calendar",
-          "ellipsis",
-          "zoom-in",
-          "zoom-out",
-          "download",
-          "security",
-          "edit",
           "add-plus",
           "anchor-link",
           "angle-left-double",
@@ -19629,6 +18795,7 @@ If an href is provided, it opens the link in a new tab.",
           "backward-10-seconds",
           "bug",
           "call",
+          "calendar",
           "caret-down-filled",
           "caret-down",
           "caret-left-filled",
@@ -19637,14 +18804,20 @@ If an href is provided, it opens the link in a new tab.",
           "caret-up",
           "check",
           "contact",
+          "close",
           "closed-caption",
           "closed-caption-unavailable",
+          "copy",
           "command-prompt",
           "delete-marker",
+          "download",
           "drag-indicator",
+          "edit",
+          "ellipsis",
           "envelope",
           "exit-full-screen",
           "expand",
+          "external",
           "face-happy",
           "face-happy-filled",
           "face-neutral",
@@ -19652,6 +18825,8 @@ If an href is provided, it opens the link in a new tab.",
           "face-sad",
           "face-sad-filled",
           "file-open",
+          "file",
+          "filter",
           "flag",
           "folder-open",
           "folder",
@@ -19661,20 +18836,31 @@ If an href is provided, it opens the link in a new tab.",
           "globe",
           "grid-view",
           "group-active",
+          "group",
           "heart",
           "heart-filled",
           "insert-row",
+          "key",
           "keyboard",
           "list-view",
           "location-pin",
           "lock-private",
+          "map",
+          "menu",
           "microphone",
           "microphone-off",
           "mini-player",
           "multiscreen",
           "notification",
+          "pause",
+          "play",
           "redo",
+          "refresh",
+          "remove",
           "resize-area",
+          "script",
+          "search",
+          "security",
           "settings",
           "send",
           "share",
@@ -19685,6 +18871,7 @@ If an href is provided, it opens the link in a new tab.",
           "status-in-progress",
           "status-info",
           "status-negative",
+          "status-pending",
           "status-positive",
           "status-stopped",
           "status-warning",
@@ -19714,6 +18901,8 @@ If an href is provided, it opens the link in a new tab.",
           "view-full",
           "view-horizontal",
           "view-vertical",
+          "zoom-in",
+          "zoom-out",
           "zoom-to-fit",
         ],
       },
@@ -19723,8 +18912,8 @@ If an href is provided, it opens the link in a new tab.",
     },
     {
       "description": "Specifies the URL of a custom icon. Use this property if the icon you want isn't available.
-
-If you set both \`iconUrl\` and \`iconSvg\`, \`iconSvg\` will take precedence.",
+If you set both \`iconUrl\` and \`iconSvg\`, \`iconSvg\` will take precedence.
+",
       "name": "iconUrl",
       "optional": true,
       "type": "string",
@@ -19765,29 +18954,6 @@ It prevents users from clicking the button, but it can still be focused.",
         "name": "IconProps.Name",
         "type": "union",
         "values": [
-          "search",
-          "map",
-          "filter",
-          "key",
-          "file",
-          "pause",
-          "play",
-          "remove",
-          "copy",
-          "menu",
-          "script",
-          "close",
-          "status-pending",
-          "refresh",
-          "external",
-          "group",
-          "calendar",
-          "ellipsis",
-          "zoom-in",
-          "zoom-out",
-          "download",
-          "security",
-          "edit",
           "add-plus",
           "anchor-link",
           "angle-left-double",
@@ -19806,6 +18972,7 @@ It prevents users from clicking the button, but it can still be focused.",
           "backward-10-seconds",
           "bug",
           "call",
+          "calendar",
           "caret-down-filled",
           "caret-down",
           "caret-left-filled",
@@ -19814,14 +18981,20 @@ It prevents users from clicking the button, but it can still be focused.",
           "caret-up",
           "check",
           "contact",
+          "close",
           "closed-caption",
           "closed-caption-unavailable",
+          "copy",
           "command-prompt",
           "delete-marker",
+          "download",
           "drag-indicator",
+          "edit",
+          "ellipsis",
           "envelope",
           "exit-full-screen",
           "expand",
+          "external",
           "face-happy",
           "face-happy-filled",
           "face-neutral",
@@ -19829,6 +19002,8 @@ It prevents users from clicking the button, but it can still be focused.",
           "face-sad",
           "face-sad-filled",
           "file-open",
+          "file",
+          "filter",
           "flag",
           "folder-open",
           "folder",
@@ -19838,20 +19013,31 @@ It prevents users from clicking the button, but it can still be focused.",
           "globe",
           "grid-view",
           "group-active",
+          "group",
           "heart",
           "heart-filled",
           "insert-row",
+          "key",
           "keyboard",
           "list-view",
           "location-pin",
           "lock-private",
+          "map",
+          "menu",
           "microphone",
           "microphone-off",
           "mini-player",
           "multiscreen",
           "notification",
+          "pause",
+          "play",
           "redo",
+          "refresh",
+          "remove",
           "resize-area",
+          "script",
+          "search",
+          "security",
           "settings",
           "send",
           "share",
@@ -19862,6 +19048,7 @@ It prevents users from clicking the button, but it can still be focused.",
           "status-in-progress",
           "status-info",
           "status-negative",
+          "status-pending",
           "status-positive",
           "status-stopped",
           "status-warning",
@@ -19891,6 +19078,8 @@ It prevents users from clicking the button, but it can still be focused.",
           "view-full",
           "view-horizontal",
           "view-vertical",
+          "zoom-in",
+          "zoom-out",
           "zoom-to-fit",
         ],
       },
@@ -19900,8 +19089,8 @@ It prevents users from clicking the button, but it can still be focused.",
     },
     {
       "description": "Specifies the URL of a custom icon in pressed state. Use this property if the icon needed for your use case isn't available.
-
-\`pressedIconSvg\` will take precedence if you set both \`pressedIconUrl\` and \`pressedIconSvg\`.",
+\`pressedIconSvg\` will take precedence if you set both \`pressedIconUrl\` and \`pressedIconSvg\`.
+",
       "name": "pressedIconUrl",
       "optional": true,
       "type": "string",
@@ -19911,8 +19100,8 @@ It prevents users from clicking the button, but it can still be focused.",
       "description": "Determines the general styling of the toggle button as follows:
 * \`normal\` for secondary buttons.
 * \`icon\` to display an icon only (no text).
-
-Defaults to \`normal\` if not specified.",
+Defaults to \`normal\` if not specified.
+",
       "inlineType": {
         "name": "ToggleButtonProps.Variant",
         "type": "union",
@@ -19942,7 +19131,6 @@ Defaults to \`normal\` if not specified.",
     },
     {
       "description": "Specifies the SVG of a custom icon.
-
 Use this property if you want your custom icon to inherit colors dictated by variant or hover states.
 When this property is set, the component will be decorated with \`aria-hidden="true"\`. Ensure that the \`svg\` element:
 - has attribute \`focusable="false"\`.
@@ -19959,13 +19147,13 @@ You can still set the stroke to \`currentColor\` to inherit the color of the sur
 If you set both \`iconUrl\` and \`iconSvg\`, \`iconSvg\` will take precedence.
 
 *Note:* Remember to remove any additional elements (for example: \`defs\`) and related CSS classes from SVG files exported from design software.
-In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.",
+In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.
+",
       "isDefault": false,
       "name": "iconSvg",
     },
     {
       "description": "Specifies the SVG of a custom icon in pressed state.
-
 Use this property if you want your custom icon to inherit colors dictated by variant or hover states.
 When this property is set, the component will be decorated with \`aria-hidden="true"\`. Ensure that the \`svg\` element:
 - has attribute \`focusable="false"\`
@@ -19982,7 +19170,8 @@ You can still set the stroke to \`currentColor\` to inherit the color of the sur
 If you set both \`pressedIconUrl\` and \`pressedIconSvg\`, \`pressedIconSvg\` will take precedence.
 
 *Note:* Remember to remove any additional elements (for example: \`defs\`) and related CSS classes from SVG files exported from design software.
-In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.",
+In most cases, they aren't needed, as the \`svg\` element inherits styles from the icon component.
+",
       "isDefault": false,
       "name": "pressedIconSvg",
     },
@@ -19996,8 +19185,8 @@ exports[`Documenter definition for token-group matches the snapshot: token-group
   "events": [
     {
       "cancelable": false,
-      "description": "Called when the user clicks on the dismiss button. The token won't be automatically removed.
-Make sure that you add a listener to this event to update your application state.",
+      "description": " Called when the user clicks on the dismiss button. The token won't be automatically removed.
+ Make sure that you add a listener to this event to update your application state.",
       "detailInlineType": {
         "name": "TokenGroupProps.DismissDetail",
         "properties": [
@@ -20017,7 +19206,7 @@ Make sure that you add a listener to this event to update your application state
   "name": "TokenGroup",
   "properties": [
     {
-      "defaultValue": "'horizontal'",
+      "defaultValue": ""horizontal"",
       "description": "Specifies the direction in which tokens are aligned (\`horizontal | vertical\`).",
       "inlineType": {
         "name": "TokenGroupProps.Alignment",
@@ -20079,9 +19268,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "defaultValue": "[]",
-      "description": "
-An array of objects representing token items. Each token has the following properties:
-
+      "description": "An array of objects representing token items. Each token has the following properties:
 - \`label\` (string) - Title text of the token.
 - \`description\` (string) - (Optional) Further information about the token that appears below the label.
 - \`disabled\` [boolean] - (Optional) Determines whether the token is disabled.
@@ -20091,7 +19278,8 @@ An array of objects representing token items. Each token has the following prope
 - \`iconName\` (string) - (Optional) Specifies the name of an [icon](/components/icon/) to display in the token.
 - \`iconAlt\` (string) - (Optional) Specifies alternate text for a custom icon, for use with \`iconUrl\`.
 - \`iconUrl\` (string) - (Optional) URL of a custom icon.
-- \`iconSvg\` (ReactNode) - (Optional) Custom SVG icon. Equivalent to the \`svg\` slot of the [icon component](/components/icon/).",
+- \`iconSvg\` (ReactNode) - (Optional) Custom SVG icon. Equivalent to the \`svg\` slot of the [icon component](/components/icon/).
+",
       "name": "items",
       "optional": true,
       "type": "ReadonlyArray<TokenGroupProps.Item>",
@@ -20196,11 +19384,11 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
     {
       "description": "Properties describing the product identity. They are as follows:
-
 * \`title\` (string) - Specifies the title text.
 * \`logo\` ({ src: string, alt: string }) - Specifies the logo for the product. Use fixed width and height for SVG images to ensure proper rendering.
 * \`href\` (string) - Specifies the \`href\` that the header links to.
-* \`onFollow\` (() => void) - Specifies the event handler called when the identity is clicked without any modifier keys.",
+* \`onFollow\` (() => void) - Specifies the event handler called when the identity is clicked without any modifier keys.
+",
       "inlineType": {
         "name": "TopNavigationProps.Identity",
         "properties": [
@@ -20217,7 +19405,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
           {
             "name": "onFollow",
             "optional": true,
-            "type": "CancelableEventHandler<{}>",
+            "type": "CancelableEventHandler",
           },
           {
             "name": "title",
@@ -20235,7 +19423,6 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "defaultValue": "[]",
       "description": "A list of utility navigation elements.
 The supported utility types are: \`button\` and \`menu-dropdown\`.
-
 The following properties are supported across all utility types:
 
 * \`type\` (string) - The type of the utility. Can be \`button\` or \`menu-dropdown\`.
@@ -20267,7 +19454,8 @@ The following properties are supported across all utility types:
 * \`items\` (ButtonDropdownProps.Items) - An array of dropdown items. This follows the same structure as the \`items\` property of the [button dropdown component](/components/button-dropdown), with the exception of the checkbox item type.
 * \`onItemClick\` (NonCancelableEventHandler<ButtonDropdownProps.ItemClickDetails>) - Specifies the event handler called when a dropdown item is selected.
 * \`onItemFollow\` (NonCancelableEventHandler<ButtonDropdownProps.ItemClickDetails>) - Specifies the event handler called when a dropdown item is selected without pressing modifier keys, and the item has an \`href\` set.
-* \`expandableGroups\` (boolean) - Controls expandability of the item groups.",
+* \`expandableGroups\` (boolean) - Controls expandability of the item groups.
+",
       "name": "utilities",
       "optional": true,
       "type": "ReadonlyArray<TopNavigationProps.Utility>",
@@ -20357,11 +19545,6 @@ exports[`Documenter definition for tutorial-panel matches the snapshot: tutorial
             "type": "string",
           },
           {
-            "name": "labelsTaskStatus",
-            "optional": false,
-            "type": "{ pending: string; 'in-progress': string; success: string; }",
-          },
-          {
             "name": "labelTotalSteps",
             "optional": false,
             "type": "(totalStepCount: number) => string",
@@ -20370,6 +19553,11 @@ exports[`Documenter definition for tutorial-panel matches the snapshot: tutorial
             "name": "labelTutorialListDownloadLink",
             "optional": true,
             "type": "string",
+          },
+          {
+            "name": "labelsTaskStatus",
+            "optional": false,
+            "type": "unknown",
           },
           {
             "name": "learnMoreLinkText",
@@ -20408,7 +19596,7 @@ exports[`Documenter definition for tutorial-panel matches the snapshot: tutorial
           },
           {
             "name": "tutorialListDescription",
-            "optional": true,
+            "optional": false,
             "type": "React.ReactNode",
           },
           {
@@ -20447,7 +19635,6 @@ specified in the \`i18nStrings\` property.",
     },
     {
       "description": "List of all available tutorials. An array of objects with the following properties:
-
 * \`title\` (string) - Name of the tutorial
 
 * \`description\` (ReactNode) - Short description of the tutorial's content.
@@ -20485,7 +19672,8 @@ specified in the \`i18nStrings\` property.",
 
   If this property is set to \`true\`, the tutorial list will show a status indicator underneath the tutorial title with
   a message that indicates that this tutorial has already been completed by the user (e.g. "Tutorial completed"), and
-  the "Start tutorial" button will be replaced by a "Restart tutorial" button.",
+  the "Start tutorial" button will be replaced by a "Restart tutorial" button.
+",
       "name": "tutorials",
       "optional": false,
       "type": "ReadonlyArray<TutorialPanelProps.Tutorial>",
@@ -20508,12 +19696,12 @@ If a user has entered data in the form, you should prompt the user with a modal 
     {
       "cancelable": false,
       "description": "Called when a user clicks the *next* button, the *previous* button, or an enabled step link in the navigation pane.
-
 The event \`detail\` includes the following:
 - \`requestedStepIndex\` - The index of the requested step.
 - \`reason\` - The user action that triggered the navigation event. It can be \`next\` (when the user clicks the *next* button),
 \`previous\` (when the user clicks the *previous* button), \`step\` (an enabled step link in the navigation pane),
-or \`skip\` (when navigated using navigation pane or the *skip-to* button to the previously unvisited step).",
+or \`skip\` (when navigated using navigation pane or the *skip-to* button to the previously unvisited step).
+",
       "detailInlineType": {
         "name": "WizardProps.NavigateDetail",
         "properties": [
@@ -20544,14 +19732,14 @@ or \`skip\` (when navigated using navigation pane or the *skip-to* button to the
   "properties": [
     {
       "description": "Index of the step that's currently displayed. The first step has an index of zero (0).
-
 If you don't set this property, the component starts on the first step and switches step automatically
 when a user navigates using the buttons or an enabled step link in the navigation pane (that is, uncontrolled behavior).
 
 If you provide a value for this property, you must also set an \`onNavigate\` listener to update the property when
 a user navigates (that is, controlled behavior).
 
-If you set it to a value that exceeds the maximum value (that is, the number of steps minus 1), its value is ignored and the component uses the maximum value.",
+If you set it to a value that exceeds the maximum value (that is, the number of steps minus 1), its value is ignored and the component uses the maximum value.
+",
       "name": "activeStepIndex",
       "optional": true,
       "type": "number",
@@ -20560,13 +19748,13 @@ If you set it to a value that exceeds the maximum value (that is, the number of 
       "defaultValue": "false",
       "description": "When set to \`false\`, the *skip-to* button is never shown.
 When set to \`true\`, the *skip-to* button may appear to offer faster navigation for the user.
-
 The *skip-to* button only allows to skip optional steps. It is shown when there is one or more optional
 steps ahead having no required steps in-between.
 
 Note: the *skip-to* button requires the function i18nStrings.skipToButtonLabel to be defined.
 
-Defaults to \`false\`.",
+Defaults to \`false\`.
+",
       "name": "allowSkipTo",
       "optional": true,
       "type": "boolean",
@@ -20611,7 +19799,6 @@ Defaults to \`false\`.",
     },
     {
       "description": "An object containing all the necessary localized strings required by the component.
-
 - \`stepNumberLabel\` ((stepNumber: number) => string) - A function that accepts a number (1-based indexing),
    and returns a human-readable, localized string displaying the step number in the navigation pane. For example, "Step 1" or "Step 2".
 - \`collapsedStepsLabel\` ((stepNumber: number, stepsCount: number) => string) - A function that accepts two number parameters (1-based indexing),
@@ -20636,11 +19823,6 @@ Defaults to \`false\`.",
             "name": "cancelButton",
             "optional": true,
             "type": "string",
-          },
-          {
-            "name": "collapsedStepsLabel",
-            "optional": true,
-            "type": "((stepNumber: number, stepsCount: number) => string)",
           },
           {
             "name": "errorIconAriaLabel",
@@ -20673,16 +19855,6 @@ Defaults to \`false\`.",
             "type": "string",
           },
           {
-            "name": "skipToButtonLabel",
-            "optional": true,
-            "type": "((targetStep: WizardProps.Step, targetStepNumber: number) => string)",
-          },
-          {
-            "name": "stepNumberLabel",
-            "optional": true,
-            "type": "((stepNumber: number) => string)",
-          },
-          {
             "name": "submitButton",
             "optional": true,
             "type": "string",
@@ -20691,6 +19863,21 @@ Defaults to \`false\`.",
             "name": "submitButtonLoadingAnnouncement",
             "optional": true,
             "type": "string",
+          },
+          {
+            "name": "collapsedStepsLabel",
+            "optional": true,
+            "type": "(stepNumber: number, stepsCount: number) => string",
+          },
+          {
+            "name": "skipToButtonLabel",
+            "optional": true,
+            "type": "(targetStep: WizardProps.Step, targetStepNumber: number) => string",
+          },
+          {
+            "name": "stepNumberLabel",
+            "optional": true,
+            "type": "(stepNumber: number) => string",
           },
         ],
         "type": "object",
@@ -20711,8 +19898,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     {
       "defaultValue": "false",
       "description": "Renders the *next* or *submit* button in a loading state.
-
-Use this if you need to wait for a response from the server before the user can proceed to the next step, such as during server-side validation or retrieving the next step's information.",
+Use this if you need to wait for a response from the server before the user can proceed to the next step, such as during server-side validation or retrieving the next step's information.
+",
       "name": "isLoadingNextStep",
       "optional": true,
       "type": "boolean",
@@ -20720,7 +19907,6 @@ Use this if you need to wait for a response from the server before the user can 
     {
       "analyticsTag": "",
       "description": "Array of step objects. Each object represents a step in the wizard with the following properties:
-
 - \`title\` (string) - Text that's displayed as the title in the navigation pane and form header.
 - \`info\` (ReactNode) - (Optional) Area for a page level info link that's displayed in the form header.
    The page level info link should trigger the default help panel content for the step. Use the [link component](/components/link/) to display the link.

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -7107,7 +7107,7 @@ exports[`Documenter definition for copy-to-clipboard matches the snapshot: copy-
       "type": "string",
     },
     {
-      "description": "The content to display for next to the copy button when \`variant="inline"\`. If not provided, \`textToCopy\` will be displayed instead.",
+      "description": "The content to display next to the copy button when \`variant="inline"\`. If not provided, \`textToCopy\` will be displayed instead.",
       "name": "content",
       "optional": true,
       "type": "string",

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -7107,6 +7107,12 @@ exports[`Documenter definition for copy-to-clipboard matches the snapshot: copy-
       "type": "string",
     },
     {
+      "description": "The content to display for next to the copy button when \`variant="inline"\`. If not provided, \`textToCopy\` will be displayed instead.",
+      "name": "content",
+      "optional": true,
+      "type": "string",
+    },
+    {
       "description": "Adds \`aria-label\` to the copy button. Use this to provide an accessible name for buttons that don't have visible text,
 and to distinguish between multiple buttons with identical visible text. The text will also be added to the \`title\` attribute of the button.",
       "name": "copyButtonAriaLabel",
@@ -7152,7 +7158,7 @@ Enable this setting if you need the popover to ignore its parent stacking contex
       "type": "boolean",
     },
     {
-      "description": "The text content to be copied. It is displayed next to the copy button when \`variant="inline"\`, and is not shown otherwise.",
+      "description": "The text content to be copied. It is displayed next to the copy button when \`variant="inline"\` unless when \`content\` is specified, and is not shown otherwise.",
       "name": "textToCopy",
       "optional": false,
       "type": "string",

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -7107,12 +7107,6 @@ exports[`Documenter definition for copy-to-clipboard matches the snapshot: copy-
       "type": "string",
     },
     {
-      "description": "The content to display next to the copy button when \`variant="inline"\`. If not provided, \`textToCopy\` will be displayed instead.",
-      "name": "content",
-      "optional": true,
-      "type": "string",
-    },
-    {
       "description": "Adds \`aria-label\` to the copy button. Use this to provide an accessible name for buttons that don't have visible text,
 and to distinguish between multiple buttons with identical visible text. The text will also be added to the \`title\` attribute of the button.",
       "name": "copyButtonAriaLabel",
@@ -7164,7 +7158,13 @@ Enable this setting if you need the popover to ignore its parent stacking contex
       "type": "string",
     },
     {
-      "defaultValue": "'button'",
+      "description": "The text content to display next to the copy button when \`variant="inline"\`. If not provided, \`textToCopy\` will be displayed instead.",
+      "name": "textToDisplay",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "defaultValue": ""button"",
       "description": "Determines the general styling of the copy button as follows:
 
 * \`button\` to display a standalone secondary button with an icon, and \`copyButtonText\` as text.

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -200,8 +200,9 @@ exports[`test-utils selectors 1`] = `
     "awsui_secondary-header_64tge",
   ],
   "copy-to-clipboard": [
-    "awsui_content_ljpwc",
     "awsui_root_ljpwc",
+    "awsui_text-to-copy_ljpwc",
+    "awsui_text-to-display_ljpwc",
   ],
   "date-input": [
     "awsui_root_yodkx",

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -200,8 +200,8 @@ exports[`test-utils selectors 1`] = `
     "awsui_secondary-header_64tge",
   ],
   "copy-to-clipboard": [
+    "awsui_content_ljpwc",
     "awsui_root_ljpwc",
-    "awsui_text-to-copy_ljpwc",
   ],
   "date-input": [
     "awsui_root_yodkx",

--- a/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
+++ b/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
@@ -87,10 +87,8 @@ describe('CopyToClipboard', () => {
     expect(wrapper.findTextToCopy()!.getElement().textContent).toBe('Copy test content');
 
     // Assert content written to the clipboard
-    act(() => wrapper.findCopyButton().click());
+    wrapper.findCopyButton().click();
     expect(mockedWriteText).toHaveBeenCalledWith('Text to copy');
-
-    jest.resetAllMocks();
   });
 
   describe.each([false, true])('popoverRenderWithPortal set to %s', (popoverRenderWithPortal: boolean) => {

--- a/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
+++ b/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 
 import CopyToClipboard from '../../../lib/components/copy-to-clipboard';
 import createWrapper from '../../../lib/components/test-utils/dom';
@@ -68,6 +68,29 @@ describe('CopyToClipboard', () => {
     expect(wrapper.findCopyButton().getElement().textContent).toBe('');
     expect(wrapper.findCopyButton().getElement()).toHaveAccessibleName('Copy');
     expect(wrapper.findTextToCopy()!.getElement().textContent).toBe('Text to copy');
+  });
+
+  test('renders an inline button with custom content and separate text to copy', () => {
+    const mockedWriteText = jest.fn().mockResolvedValue(act(() => new Promise(() => {}))); // The act here is just to prevent console warnings when tests run
+
+    Object.assign(global.navigator, {
+      clipboard: {
+        writeText: mockedWriteText,
+      },
+    });
+
+    const { container } = render(<CopyToClipboard {...defaultProps} variant="inline" content="Copy test content" />);
+    const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+    expect(wrapper.findCopyButton().getElement().textContent).toBe('');
+    expect(wrapper.findCopyButton().getElement()).toHaveAccessibleName('Copy');
+    expect(wrapper.findTextToCopy()!.getElement().textContent).toBe('Copy test content');
+
+    // Assert content written to the clipboard
+    act(() => wrapper.findCopyButton().click());
+    expect(mockedWriteText).toHaveBeenCalledWith('Text to copy');
+
+    jest.resetAllMocks();
   });
 
   describe.each([false, true])('popoverRenderWithPortal set to %s', (popoverRenderWithPortal: boolean) => {

--- a/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
+++ b/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
@@ -70,7 +70,7 @@ describe('CopyToClipboard', () => {
     expect(wrapper.findTextToCopy()!.getElement().textContent).toBe('Text to copy');
   });
 
-  test('renders an inline button with custom content and separate text to copy', () => {
+  test('renders an inline button with custom text to display and separate text to copy', () => {
     const mockedWriteText = jest.fn().mockResolvedValue(act(() => new Promise(() => {}))); // The act here is just to prevent console warnings when tests run
 
     Object.assign(global.navigator, {
@@ -79,12 +79,14 @@ describe('CopyToClipboard', () => {
       },
     });
 
-    const { container } = render(<CopyToClipboard {...defaultProps} variant="inline" content="Copy test content" />);
+    const { container } = render(
+      <CopyToClipboard {...defaultProps} variant="inline" textToDisplay="Copy test content" />
+    );
     const wrapper = createWrapper(container).findCopyToClipboard()!;
 
     expect(wrapper.findCopyButton().getElement().textContent).toBe('');
     expect(wrapper.findCopyButton().getElement()).toHaveAccessibleName('Copy');
-    expect(wrapper.findTextToCopy()!.getElement().textContent).toBe('Copy test content');
+    expect(wrapper.findTextToDisplay()!.getElement().textContent).toBe('Copy test content');
 
     // Assert content written to the clipboard
     wrapper.findCopyButton().click();

--- a/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
+++ b/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
@@ -86,7 +86,7 @@ describe('CopyToClipboard', () => {
 
     expect(wrapper.findCopyButton().getElement().textContent).toBe('');
     expect(wrapper.findCopyButton().getElement()).toHaveAccessibleName('Copy');
-    expect(wrapper.findTextToDisplay()!.getElement().textContent).toBe('Copy test content');
+    expect(wrapper.findDisplayedText()!.getElement().textContent).toBe('Copy test content');
 
     // Assert content written to the clipboard
     wrapper.findCopyButton().click();

--- a/src/copy-to-clipboard/interfaces.ts
+++ b/src/copy-to-clipboard/interfaces.ts
@@ -31,6 +31,11 @@ export interface CopyToClipboardProps extends BaseComponentProps {
   textToCopy: string;
 
   /**
+   * The text content to display next to the copy button when `variant="inline"`. If not provided, `textToCopy` will be displayed instead.
+   */
+  textToDisplay?: string;
+
+  /**
    * The message shown when the text is copied successfully.
    */
   copySuccessText: string;
@@ -48,11 +53,6 @@ export interface CopyToClipboardProps extends BaseComponentProps {
    * Enable this setting if you need the popover to ignore its parent stacking context.
    */
   popoverRenderWithPortal?: boolean;
-
-  /**
-   * The content to display next to the copy button when `variant="inline"`. If not provided, `textToCopy` will be displayed instead.
-   */
-  content?: string;
 }
 
 export namespace CopyToClipboardProps {

--- a/src/copy-to-clipboard/interfaces.ts
+++ b/src/copy-to-clipboard/interfaces.ts
@@ -26,7 +26,7 @@ export interface CopyToClipboardProps extends BaseComponentProps {
   copyButtonAriaLabel?: string;
 
   /**
-   * The text content to be copied. It is displayed next to the copy button when `variant="inline"`, and is not shown otherwise.
+   * The text content to be copied. It is displayed next to the copy button when `variant="inline"` unless when `content` is specified, and is not shown otherwise.
    */
   textToCopy: string;
 
@@ -48,6 +48,11 @@ export interface CopyToClipboardProps extends BaseComponentProps {
    * Enable this setting if you need the popover to ignore its parent stacking context.
    */
   popoverRenderWithPortal?: boolean;
+
+  /**
+   * The content to display for next to the copy button when `variant="inline"`. If not provided, `textToCopy` will be displayed instead.
+   */
+  content?: string;
 }
 
 export namespace CopyToClipboardProps {

--- a/src/copy-to-clipboard/interfaces.ts
+++ b/src/copy-to-clipboard/interfaces.ts
@@ -50,7 +50,7 @@ export interface CopyToClipboardProps extends BaseComponentProps {
   popoverRenderWithPortal?: boolean;
 
   /**
-   * The content to display for next to the copy button when `variant="inline"`. If not provided, `textToCopy` will be displayed instead.
+   * The content to display next to the copy button when `variant="inline"`. If not provided, `textToCopy` will be displayed instead.
    */
   content?: string;
 }

--- a/src/copy-to-clipboard/internal.tsx
+++ b/src/copy-to-clipboard/internal.tsx
@@ -90,7 +90,7 @@ export default function InternalCopyToClipboard({
       {isInline ? (
         <span className={styles['inline-container']}>
           <span className={styles['inline-container-trigger']}>{trigger}</span>
-          <span className={testStyles['text-to-copy']}>{content ?? textToCopy}</span>
+          <span className={testStyles.content}>{content ?? textToCopy}</span>
         </span>
       ) : (
         trigger

--- a/src/copy-to-clipboard/internal.tsx
+++ b/src/copy-to-clipboard/internal.tsx
@@ -23,6 +23,7 @@ export default function InternalCopyToClipboard({
   copyErrorText,
   textToCopy,
   popoverRenderWithPortal,
+  content,
   __internalRootRef = null,
   ...restProps
 }: InternalCopyToClipboardProps) {
@@ -89,7 +90,7 @@ export default function InternalCopyToClipboard({
       {isInline ? (
         <span className={styles['inline-container']}>
           <span className={styles['inline-container-trigger']}>{trigger}</span>
-          <span className={testStyles['text-to-copy']}>{textToCopy}</span>
+          <span className={testStyles['text-to-copy']}>{content ?? textToCopy}</span>
         </span>
       ) : (
         trigger

--- a/src/copy-to-clipboard/internal.tsx
+++ b/src/copy-to-clipboard/internal.tsx
@@ -22,8 +22,8 @@ export default function InternalCopyToClipboard({
   copySuccessText,
   copyErrorText,
   textToCopy,
+  textToDisplay,
   popoverRenderWithPortal,
-  content,
   __internalRootRef = null,
   ...restProps
 }: InternalCopyToClipboardProps) {
@@ -90,7 +90,9 @@ export default function InternalCopyToClipboard({
       {isInline ? (
         <span className={styles['inline-container']}>
           <span className={styles['inline-container-trigger']}>{trigger}</span>
-          <span className={testStyles.content}>{content ?? textToCopy}</span>
+          <span className={clsx(testStyles['text-to-display'], testStyles['text-to-copy'])}>
+            {textToDisplay ?? textToCopy}
+          </span>
         </span>
       ) : (
         trigger

--- a/src/copy-to-clipboard/test-classes/styles.scss
+++ b/src/copy-to-clipboard/test-classes/styles.scss
@@ -6,6 +6,6 @@
 .root {
   /* used in test-utils */
 }
-.text-to-copy {
+.content {
   /* used in test-utils */
 }

--- a/src/copy-to-clipboard/test-classes/styles.scss
+++ b/src/copy-to-clipboard/test-classes/styles.scss
@@ -6,6 +6,9 @@
 .root {
   /* used in test-utils */
 }
-.content {
+.text-to-copy {
+  /* used in test-utils */
+}
+.text-to-display {
   /* used in test-utils */
 }

--- a/src/test-utils/dom/copy-to-clipboard/index.ts
+++ b/src/test-utils/dom/copy-to-clipboard/index.ts
@@ -21,7 +21,7 @@ export default class CopyToClipboardWrapper extends ComponentWrapper {
   }
 
   /**
-   * @deprecated Use `findTextToDisplay` instead.
+   * @deprecated Use `findDisplayedText` instead.
    */
   findTextToCopy(): null | ElementWrapper {
     return this.findByClassName(testStyles['text-to-copy']);

--- a/src/test-utils/dom/copy-to-clipboard/index.ts
+++ b/src/test-utils/dom/copy-to-clipboard/index.ts
@@ -21,6 +21,6 @@ export default class CopyToClipboardWrapper extends ComponentWrapper {
   }
 
   findTextToCopy(): null | ElementWrapper {
-    return this.findByClassName(testStyles['text-to-copy']);
+    return this.findByClassName(testStyles.content);
   }
 }

--- a/src/test-utils/dom/copy-to-clipboard/index.ts
+++ b/src/test-utils/dom/copy-to-clipboard/index.ts
@@ -20,7 +20,14 @@ export default class CopyToClipboardWrapper extends ComponentWrapper {
     });
   }
 
+  /**
+   * @deprecated Use `findTextToDisplay` instead.
+   */
   findTextToCopy(): null | ElementWrapper {
-    return this.findByClassName(testStyles.content);
+    return this.findByClassName(testStyles['text-to-copy']);
+  }
+
+  findTextToDisplay(): null | ElementWrapper {
+    return this.findByClassName(testStyles['text-to-display']);
   }
 }

--- a/src/test-utils/dom/copy-to-clipboard/index.ts
+++ b/src/test-utils/dom/copy-to-clipboard/index.ts
@@ -27,7 +27,11 @@ export default class CopyToClipboardWrapper extends ComponentWrapper {
     return this.findByClassName(testStyles['text-to-copy']);
   }
 
-  findTextToDisplay(): null | ElementWrapper {
+  /**
+   * Used to get the text displayed next to the copy icon button when `variant='inline'`.
+   * Returns either the `textToCopy` value or the `textToDisplay` value if it has been set.
+   */
+  findDisplayedText(): null | ElementWrapper {
     return this.findByClassName(testStyles['text-to-display']);
   }
 }


### PR DESCRIPTION
### Description

**Original customer ask:**
> As of now, when `CopyToClipboard` uses `inline` variant, it will ignore `copyButtonText` and use `textToCopy` for both display and copy value.
Make `inline` variant to have different `copyButtonText` and `textToCopy` values like `button` variant.


**Customer usecase:**
> When you want to display a date with `CopyToClipboard`, you may want to display the date in localized, readable format but allow copying in language agnostic, timezone agnostic way, for example, UTC format.
It's a problem because as shown in the screenshot, different variants have different icon color and hurts visual uniformity without good reasons.


**Main problem:**
With any custom implementation, i.e. combining `SpaceBetween` using the `variant="icon"` and a string, it will result in a grey icon, this is particularly a problem when used in conjunction with regular inline `CopyToClipboard` which has a blue icon like inside a `SplitPanel` with `KeyValuePairs`.

**Solution:**
Adds a new property: `textToDisplay` which allows for specifying a separate display value from the copy value for `variant="inline"`.

This is achieved by assigning a `string` to `textToDisplay` and a separate `string` to `textToCopy`.
- e.g. a Human readable date/time to display but a timestamp to copy

If `content` has no value then `textToCopy` will be displayed instead.

Related links, issue #, if available: n/a
`AWSUI-45434`
`65TZAG3kNuqE`

### How has this been tested?
- Manual
- Unit

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
