### PR TITLE
chore: Adjust popover trigger styles

### DIFF
--- a/src/popover/styles.scss
+++ b/src/popover/styles.scss
@@ -39,6 +39,7 @@ $trigger-underline-offset: 0.25em;
 }
 
 .trigger-type-text-inline {
+  @include styles.default-text-style;
   border-block: 0;
   /*
     This transparent border is necessary to maintain space between the trigger and the bottom-positioned popover.


### PR DESCRIPTION
### Description

Applied default text styles to the popover trigger (`text-inline` type) to slightly increase the line height, based on a user request.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
