### PR TITLE
chore: Change aria role in AppLayout drawer's overflow menu items to menuitem

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     {
       "path": "lib/components/internal/widget-exports.js",
       "brotli": false,
-      "limit": "750 kB"
+      "limit": "751 kB"
     }
   ],
   "browserslist": [

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -82,6 +82,21 @@ describeEachAppLayout(({ size, theme }) => {
     );
   });
 
+  test('overflow menu item have aria-role set to `menuitem`', () => {
+    const { wrapper } = renderComponent(<AppLayout drawers={manyDrawers} />);
+    const buttonDropdown = wrapper.findDrawersOverflowTrigger();
+
+    buttonDropdown!.openDropdown();
+
+    const countItems = buttonDropdown!.findItems();
+    const countRoleMenuItemRole = buttonDropdown!
+      .findOpenDropdown()!
+      .find('[role="menu"]')!
+      .findAll('[role="menuitem"]');
+
+    expect(countItems.length).toBe(countRoleMenuItemRole.length);
+  });
+
   test('renders aria-labels', () => {
     const { wrapper } = renderComponent(<AppLayout drawers={[testDrawer]} />);
     expect(wrapper.findDrawerTriggerById('security')!.getElement()).toHaveAttribute(

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -1411,11 +1411,12 @@ describe('toolbar mode only features', () => {
 
         const menu = buttonDropdown!.findOpenDropdown()!.find('[role="menu"]')!;
         // Global drawers should have role=menuitemcheckbox
-        expect(menu.findAll('[role="menuitemcheckbox"]')).toHaveLength(2);
+        const menuItemCheckboxesLength = menu.findAll('[role="menuitemcheckbox"]').length;
+        expect(menuItemCheckboxesLength).toBe(2);
 
         // Regular drawers should have role=menuitem
-        const menuItems = menu.findAll('[role="menuitem"]');
-        expect(menuItems).toHaveLength(manyDrawers.length);
+        const menuItemsLength = menu.findAll('[role="menuitem"]').length;
+        expect(menuItemsLength).toBe(manyDrawers.length - menuItemCheckboxesLength);
       });
 
       test('assigns menuitemcheckbox role to global drawers in overflow menu', async () => {

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -1415,7 +1415,7 @@ describe('toolbar mode only features', () => {
 
         // Regular drawers should have role=menuitem
         const menuItems = menu.findAll('[role="menuitem"]');
-        expect(menuItems).toHaveLength(99);
+        expect(menuItems).toHaveLength(manyDrawers.length);
       });
 
       test('assigns menuitemcheckbox role to global drawers in overflow menu', async () => {

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -14,6 +14,7 @@ import {
   findActiveDrawerLandmark,
   getActiveDrawerWidth,
   getGlobalDrawersTestUtils,
+  manyDrawers,
   testDrawer,
 } from './utils';
 
@@ -1385,6 +1386,58 @@ describe('toolbar mode only features', () => {
       expect(onToggle).toHaveBeenCalledWith({ isOpen: true, initiatedByUserAction: true });
       globalDrawersWrapper.findCloseButtonByActiveDrawerId(drawerIdWithToggle)!.click();
       expect(onToggle).toHaveBeenCalledWith({ isOpen: false, initiatedByUserAction: true });
+    });
+
+    describe('global drawers aria role in overflow menu', () => {
+      const registerGlobalDrawers = (count: number) => {
+        for (let i = 1; i <= count; i++) {
+          awsuiPlugins.appLayout.registerDrawer({
+            ...drawerDefaults,
+            id: `global-drawer${i}`,
+            type: 'global',
+          });
+        }
+      };
+
+      test('assigns correct ARIA roles when mixing global and regular drawers', async () => {
+        registerGlobalDrawers(2);
+        const { wrapper } = await renderComponent(<AppLayout drawers={manyDrawers} />);
+        const buttonDropdown = wrapper.findDrawersOverflowTrigger();
+
+        buttonDropdown!.openDropdown();
+
+        expect(buttonDropdown!.findItemById('global-drawer1')).toBeTruthy();
+        expect(buttonDropdown!.findItemById('global-drawer2')).toBeTruthy();
+
+        const menu = buttonDropdown!.findOpenDropdown()!.find('[role="menu"]')!;
+        // Global drawers should have role=menuitemcheckbox
+        expect(menu.findAll('[role="menuitemcheckbox"]')).toHaveLength(2);
+
+        // Regular drawers should have role=menuitem
+        const menuItems = menu.findAll('[role="menuitem"]');
+        expect(menuItems).toHaveLength(99);
+      });
+
+      test('assigns menuitemcheckbox role to global drawers in overflow menu', async () => {
+        registerGlobalDrawers(3);
+
+        // In mobile view, two drawers are visible in the toolbar, the others are placed in the overflow menu
+        const { wrapper, globalDrawersWrapper } = await renderComponent(<AppLayout drawers={[testDrawer]} />);
+        const buttonDropdown = wrapper.findDrawersOverflowTrigger();
+
+        expect(globalDrawersWrapper.findDrawerById('global-drawer2')).toBeFalsy();
+        expect(globalDrawersWrapper.findDrawerById('global-drawer3')).toBeFalsy();
+
+        buttonDropdown!.openDropdown();
+
+        const menuItemCheckboxItemsLength = buttonDropdown!
+          .findOpenDropdown()!
+          .find('[role="menu"]')!
+          .findAll('[role="menuitemcheckbox"]').length;
+        expect(menuItemCheckboxItemsLength).toBe(2);
+        expect(buttonDropdown!.findItemById('global-drawer2')).toBeTruthy();
+        expect(buttonDropdown!.findItemById('global-drawer3')).toBeTruthy();
+      });
     });
   });
 });

--- a/src/app-layout/drawer/overflow-menu.tsx
+++ b/src/app-layout/drawer/overflow-menu.tsx
@@ -23,12 +23,13 @@ interface OverflowMenuProps {
   globalDrawersStartIndex?: number;
 }
 
-const mapDrawerToItem = (drawer: Drawer) => ({
+const mapDrawerToItem = (drawer: Drawer, isTypeCheckbox: boolean) => ({
   id: drawer.id,
   text: drawer.ariaLabels.drawerName,
   iconName: drawer.trigger!.iconName,
   iconSvg: drawer.trigger!.iconSvg,
   badge: drawer.badge,
+  itemType: isTypeCheckbox ? ('checkbox' as ButtonDropdownProps.ItemType) : undefined,
   checked: drawer.active,
 });
 
@@ -39,9 +40,12 @@ export default function OverflowMenu({
   ariaLabel,
   globalDrawersStartIndex,
 }: OverflowMenuProps) {
-  const itemsFlatList = drawers.map(mapDrawerToItem);
+  const hasGlobalDrawers = globalDrawersStartIndex !== undefined;
+  const itemsFlatList = drawers.map((item, index) =>
+    mapDrawerToItem(item, hasGlobalDrawers && index >= globalDrawersStartIndex)
+  );
   let items: ReadonlyArray<InternalItemOrGroup>;
-  if (globalDrawersStartIndex !== undefined && globalDrawersStartIndex > 0) {
+  if (hasGlobalDrawers) {
     items = [
       { items: itemsFlatList.slice(0, globalDrawersStartIndex) },
       { items: itemsFlatList.slice(globalDrawersStartIndex) },

--- a/src/app-layout/drawer/overflow-menu.tsx
+++ b/src/app-layout/drawer/overflow-menu.tsx
@@ -29,7 +29,6 @@ const mapDrawerToItem = (drawer: Drawer) => ({
   iconName: drawer.trigger!.iconName,
   iconSvg: drawer.trigger!.iconSvg,
   badge: drawer.badge,
-  itemType: 'checkbox' as ButtonDropdownProps.ItemType,
   checked: drawer.active,
 });
 


### PR DESCRIPTION
### Description

All drawer's shown in the overflow menu items are currently implemented with `role="menuitemcheckbox"` roles, but not all have have a visual checked/unchecked semantics. 

With this change:
- regular drawers (provided via AppLayout's `drawers` property get `role="menuitem"` because only one of them is selectable.
- golbal drawers (added via runtime API) get `role="menuitemcheckbox"` because multiple of them are selectable

Related links, issue #, if available: AWSUI-60248

### How has this been tested?

- verified manually in the browser in my local env
- build to live dry-run: 7312012546
- tested successfully in my dev pipeline

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
