### PR TITLE
fix: Ensure runtime actions cause re-calculation of alert/flash wrapping

### DIFF
--- a/src/alert/actions-wrapper/index.tsx
+++ b/src/alert/actions-wrapper/index.tsx
@@ -60,12 +60,21 @@ export const ActionsWrapper = ({
     if (!ref.current || !containerWidth || !wrappedClass) {
       return;
     }
-    const isRtl = getIsRtl(ref.current);
-    const { offsetWidth, offsetLeft } = ref.current;
-    const start = isRtl ? containerWidth - offsetWidth - offsetLeft : offsetLeft;
-    // if the action slot is towards the left (right in RTL) of its container
-    setWrapped(start < 100);
-  }, [containerWidth, wrappedClass]);
+    function check() {
+      const isRtl = getIsRtl(ref.current);
+      const { offsetWidth, offsetLeft } = ref.current!;
+      const start = isRtl ? containerWidth! - offsetWidth - offsetLeft : offsetLeft;
+      // if the action slot is towards the left (right in RTL) of its container
+      setWrapped(start < 100);
+    }
+
+    // Discovered actions are rendered by their plugin, so don't cause a
+    // re-render of our React tree. So we observe for changes.
+    const observer = new MutationObserver(check);
+    observer.observe(ref.current, { attributes: false, childList: true, subtree: true });
+    check();
+    return () => observer.disconnect();
+  });
   const actionButton = createActionButton(testUtilClasses, action, buttonText, onButtonClick);
   if (!actionButton && discoveredActions.length === 0) {
     return null;


### PR DESCRIPTION
### Description

Prevent the case where dynamically-injected runtime action causes actions slot to wrap without triggering the addition of the "wrapped" class.

Related links, issue #, if available: #3338

### How has this been tested?

Tested locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
