### PR TITLE
fix: Remove CSS syntax unsupported by some versions of SASS

### DIFF
--- a/src/alert/styles.scss
+++ b/src/alert/styles.scss
@@ -69,8 +69,7 @@
 
 .alert-focus-wrapper {
   flex: 1;
-  min-inline-size: 70%; // fallback for browsers that don't support calc-size
-  min-inline-size: calc-size(max-content, min(size, 70%));
+  min-inline-size: 70%;
   display: grid;
   grid-template-columns: min-content auto;
 

--- a/src/flashbar/styles.scss
+++ b/src/flashbar/styles.scss
@@ -71,8 +71,7 @@
 .flash-focus-container {
   display: flex;
   flex: 1;
-  min-inline-size: 70%; // fallback for browsers that don't support calc-size
-  min-inline-size: calc-size(max-content, min(size, 70%));
+  min-inline-size: 70%;
 
   &:focus {
     outline: none;


### PR DESCRIPTION
### Description

Some consuming teams' builds failed with this syntax, rolling it back for now. It is anyway only supported by Chrome, so for now we just revert behavior in Chrome to what it is in other browsers.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
