### PR TITLE
fix: Re-announce dropdown footer message on dropdown toggle

### DIFF
--- a/src/autosuggest/__tests__/autosuggest-dropdown-states.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest-dropdown-states.test.tsx
@@ -62,7 +62,7 @@ function expectFooterContent(expectedText: string, expandToViewport = false) {
   expect(wrapper.findDropdown({ expandToViewport }).find('ul')!.getElement()).toHaveAccessibleDescription(expectedText);
 }
 
-function expectLiveAnnouncement(expectedText: string) {
+function expectLiveRegionText(expectedText: string) {
   const liveRegion = createWrapper().findLiveRegion()!.getElement();
   expect(liveRegion).toHaveTextContent(expectedText);
 }
@@ -140,7 +140,7 @@ describe.each([true, false])('footer live announcements [expandToViewport=%s]', 
     focusInput();
     expectDropdown(expandToViewport);
     expectFooterContent('error!', expandToViewport);
-    expectLiveAnnouncement('error!');
+    expectLiveRegionText('error!');
   });
 
   test('live announces error text on dropdown toggle', () => {
@@ -148,7 +148,7 @@ describe.each([true, false])('footer live announcements [expandToViewport=%s]', 
     focusInput();
     expectDropdown(expandToViewport);
     expectFooterContent('error!', expandToViewport);
-    expectLiveAnnouncement('error!');
+    expectLiveRegionText('error!');
 
     wrapper.findNativeInput().keydown(KeyCode.enter);
     expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
@@ -157,7 +157,7 @@ describe.each([true, false])('footer live announcements [expandToViewport=%s]', 
     wrapper.findNativeInput().keydown(KeyCode.down);
     expectDropdown(expandToViewport);
     expectFooterContent('error!', expandToViewport);
-    expectLiveAnnouncement('error!');
+    expectLiveRegionText('error!');
   });
 });
 

--- a/src/autosuggest/__tests__/autosuggest-dropdown-states.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest-dropdown-states.test.tsx
@@ -4,6 +4,8 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
+
 import '../../__a11y__/to-validate-a11y';
 import Autosuggest, { AutosuggestProps } from '../../../lib/components/autosuggest';
 import createWrapper from '../../../lib/components/test-utils/dom';
@@ -38,9 +40,9 @@ function focusInput() {
   createWrapper().findAutosuggest()!.focus();
 }
 
-function expectDropdown() {
+function expectDropdown(expandToViewport = false) {
   const wrapper = createWrapper().findAutosuggest()!;
-  expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+  expect(wrapper.findDropdown({ expandToViewport }).findOpenDropdown()).not.toBe(null);
   expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'true');
 }
 
@@ -53,11 +55,16 @@ function expectFooterSticky(isSticky: boolean) {
   expect(Boolean(dropdown.findByClassName(styles['list-bottom']))).toBe(!isSticky);
 }
 
-function expectFooterContent(expectedText: string) {
+function expectFooterContent(expectedText: string, expandToViewport = false) {
   const wrapper = createWrapper().findAutosuggest()!;
-  expect(wrapper.findDropdown().findFooterRegion()!).not.toBe(null);
-  expect(wrapper.findDropdown().findFooterRegion()!.getElement()).toHaveTextContent(expectedText);
-  expect(wrapper.findDropdown().find('ul')!.getElement()).toHaveAccessibleDescription(expectedText);
+  expect(wrapper.findDropdown({ expandToViewport }).findFooterRegion()!).not.toBe(null);
+  expect(wrapper.findDropdown({ expandToViewport }).findFooterRegion()!.getElement()).toHaveTextContent(expectedText);
+  expect(wrapper.findDropdown({ expandToViewport }).find('ul')!.getElement()).toHaveAccessibleDescription(expectedText);
+}
+
+function expectLiveAnnouncement(expectedText: string) {
+  const liveRegion = createWrapper().findLiveRegion()!.getElement();
+  expect(liveRegion).toHaveTextContent(expectedText);
 }
 
 function expectFooterImage(expectedText: string) {
@@ -124,6 +131,33 @@ describe('footer types', () => {
     expectFooterSticky(true);
     expectFooterContent('3 items');
     await expectA11y();
+  });
+});
+
+describe.each([true, false])('footer live announcements [expandToViewport=%s]', (expandToViewport: boolean) => {
+  test('live announces error text on initial dropdown render', () => {
+    renderAutosuggest({ statusType: 'error', expandToViewport });
+    focusInput();
+    expectDropdown(expandToViewport);
+    expectFooterContent('error!', expandToViewport);
+    expectLiveAnnouncement('error!');
+  });
+
+  test('live announces error text on dropdown toggle', () => {
+    const { wrapper } = renderAutosuggest({ statusType: 'error', expandToViewport });
+    focusInput();
+    expectDropdown(expandToViewport);
+    expectFooterContent('error!', expandToViewport);
+    expectLiveAnnouncement('error!');
+
+    wrapper.findNativeInput().keydown(KeyCode.enter);
+    expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
+    expect(createWrapper().findLiveRegion()).toBeNull();
+
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    expectDropdown(expandToViewport);
+    expectFooterContent('error!', expandToViewport);
+    expectLiveAnnouncement('error!');
   });
 });
 

--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -291,7 +291,7 @@ describe('Date range picker', () => {
 
         wrapper.findDropdown()!.findApplyButton().click();
         expect(wrapper.findDropdown()!.findValidationError()?.getElement()).toHaveTextContent('10 is not allowed.');
-        expect(createWrapper().findAll('[aria-live]')[1]!.getElement()).toHaveTextContent('10 is not allowed.');
+        expect(createWrapper().findLiveRegion()!.getElement()).toHaveTextContent('10 is not allowed.');
       });
 
       test('after rendering the error once, displays subsequent errors in real time', () => {
@@ -360,7 +360,7 @@ describe('Date range picker', () => {
         wrapper.findDropdown()?.findDateAt('left', 1, 1).click();
         wrapper.findDropdown()!.findApplyButton().click();
 
-        const liveRegion = document.querySelectorAll('[aria-live=polite]')![3];
+        const liveRegion = document.querySelectorAll('[aria-live=polite]')![2];
 
         // announces first validation error
         await waitFor(() => expect(liveRegion).toHaveTextContent('You must provide an end date'));
@@ -372,7 +372,7 @@ describe('Date range picker', () => {
 
         wrapper.findDropdown()!.findApplyButton().click();
 
-        // reannounces second validation error
+        // re-announces second validation error, indicated by the trailing dot.
         await waitFor(() => expect(liveRegion).toHaveTextContent('The range cannot start before 2020.'));
 
         Mockdate.reset();

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -286,7 +286,7 @@ const AutosuggestInput = React.forwardRef(
           footer={
             dropdownFooterRef && (
               <div ref={dropdownFooterRef} className={styles['dropdown-footer']}>
-                {dropdownFooter}
+                {open && dropdownFooter ? dropdownFooter : null}
               </div>
             )
           }

--- a/src/internal/components/dropdown-footer/__tests__/dropdown-footer.test.tsx
+++ b/src/internal/components/dropdown-footer/__tests__/dropdown-footer.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import DropdownFooter from '../../../../../lib/components/internal/components/dropdown-footer';
+import createWrapper from '../../../../../lib/components/test-utils/dom';
 import DropdownWrapper from '../../../../../lib/components/test-utils/dom/internal/dropdown';
 
 import dropdownFooterStyles from '../../../../../lib/components/internal/components/dropdown-footer/styles.css.js';
@@ -21,6 +22,7 @@ describe('Dropdown footer', () => {
     expect(element).toHaveTextContent('hello world');
     expect(element).toHaveClass(dropdownFooterStyles.root);
     expect(element).not.toHaveClass(dropdownFooterStyles.hidden);
+    expect(createWrapper().findLiveRegion()!.getElement()).toHaveTextContent('hello world');
   });
 
   test('adds hidden class when given content is null', () => {
@@ -28,5 +30,13 @@ describe('Dropdown footer', () => {
     const element = wrapper.find('div')!.getElement();
     expect(element).toHaveClass(dropdownFooterStyles.root);
     expect(element).toHaveClass(dropdownFooterStyles.hidden);
+  });
+
+  test('does not render live region when given content is null', () => {
+    const { wrapper } = renderComponent(<DropdownFooter content={null} />);
+    const element = wrapper.find('div')!.getElement();
+    expect(element).toHaveClass(dropdownFooterStyles.root);
+    expect(element).toHaveClass(dropdownFooterStyles.hidden);
+    expect(createWrapper().findLiveRegion()).toBeNull();
   });
 });

--- a/src/internal/components/dropdown-footer/index.tsx
+++ b/src/internal/components/dropdown-footer/index.tsx
@@ -16,7 +16,11 @@ interface DropdownFooter {
 
 const DropdownFooter: React.FC<DropdownFooter> = ({ content, id, hasItems = true }: DropdownFooter) => (
   <div className={clsx(styles.root, { [styles.hidden]: content === null, [styles['no-items']]: !hasItems })}>
-    <InternalLiveRegion id={id}>{content && <DropdownStatus>{content}</DropdownStatus>}</InternalLiveRegion>
+    {content && (
+      <InternalLiveRegion id={id}>
+        <DropdownStatus>{content}</DropdownStatus>
+      </InternalLiveRegion>
+    )}
   </div>
 );
 

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -459,6 +459,55 @@ describe('Dropdown states', () => {
   });
 });
 
+describe.each([true, false])('footer live announcements [expandToViewport=%s]', (expandToViewport: boolean) => {
+  test('live announces footer text on initial dropdown render', () => {
+    const { wrapper } = renderMultiselect(
+      <Multiselect
+        selectedOptions={[]}
+        options={defaultOptions}
+        statusType="error"
+        errorText="Test error text"
+        errorIconAriaLabel="Test error text"
+        recoveryText="Retry"
+        expandToViewport={expandToViewport}
+        keepOpen={false}
+      />
+    );
+    expect(createWrapper().findLiveRegion()).toBeNull();
+
+    wrapper.openDropdown();
+    expect(wrapper.findDropdown({ expandToViewport }).findFooterRegion()!.getElement()).toHaveTextContent(
+      'Test error text'
+    );
+    expect(createWrapper().findLiveRegion()!.getElement()).toHaveTextContent('Test error text');
+  });
+
+  test('live announce footer text on dropdown toggle', () => {
+    const { wrapper } = renderMultiselect(
+      <Multiselect
+        selectedOptions={[]}
+        options={defaultOptions}
+        statusType="error"
+        errorText="Test error text"
+        errorIconAriaLabel="Test error text"
+        recoveryText="Retry"
+        expandToViewport={expandToViewport}
+        keepOpen={false}
+      />
+    );
+    expect(createWrapper().findLiveRegion()).toBeNull();
+
+    wrapper.openDropdown();
+    expect(createWrapper().findLiveRegion()!.getElement()).toHaveTextContent('Test error text');
+
+    wrapper.closeDropdown({ expandToViewport });
+    expect(createWrapper().findLiveRegion()).toBeNull();
+
+    wrapper.openDropdown();
+    expect(createWrapper().findLiveRegion()!.getElement()).toHaveTextContent('Test error text');
+  });
+});
+
 test('fires a change event when user selects a group option from the dropdown', () => {
   const onChange = jest.fn();
   const { wrapper } = renderMultiselect(

--- a/src/select/__tests__/select-a11y.test.tsx
+++ b/src/select/__tests__/select-a11y.test.tsx
@@ -26,6 +26,11 @@ const defaultOptions: SelectProps.Options = [
   },
 ];
 
+function expectLiveRegionText(expectedText: string) {
+  const liveRegion = createWrapper().findLiveRegion()!.getElement();
+  expect(liveRegion).toHaveTextContent(expectedText);
+}
+
 describe.each([false, true])('expandToViewport=%s', expandToViewport => {
   const defaultProps = {
     options: defaultOptions,
@@ -77,5 +82,35 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
       .map(labelId => wrapper.getElement().querySelector(`#${labelId}`)!.textContent)
       .join(' ');
     expect(label).toBe('select First');
+  });
+
+  test('live announces footer text on initial dropdown render', () => {
+    const { wrapper } = renderSelect({
+      selectedOption: { label: 'First', value: '1' },
+      statusType: 'error',
+      errorText: 'Test error text',
+    });
+    expect(createWrapper().findLiveRegion()).toBeNull();
+
+    wrapper.openDropdown();
+    expectLiveRegionText('Test error text');
+  });
+
+  test('live announce footer text on dropdown toggle', () => {
+    const { wrapper } = renderSelect({
+      selectedOption: { label: 'First', value: '1' },
+      statusType: 'error',
+      errorText: 'Test error text',
+    });
+    expect(createWrapper().findLiveRegion()).toBeNull();
+
+    wrapper.openDropdown();
+    expectLiveRegionText('Test error text');
+
+    wrapper.closeDropdown({ expandToViewport });
+    expect(createWrapper().findLiveRegion()).toBeNull();
+
+    wrapper.openDropdown();
+    expectLiveRegionText('Test error text');
   });
 });


### PR DESCRIPTION
### Description

Before this change:
- The live announcement happened only on the initial dropdown open
- When re-opening the dropdown, no live announcement happened

With this change:
- The live announcement happens on every dropdown open

Related links, issue #, if available: AWSUI-60501

### How has this been tested?

- added unit test to ensure the changes.
- manually tested in the following components in in error state by opening and re-opening:
  - select
    - expandToViewport set to `true` and `false`
  - multislect
    - expandToViewport set to `true` and `false`
  - autosuggest
    - expandToViewport set to `true` and `false`
- successful dry-run live build: 7313587195
- screenshot tests passed in my dev pipeline

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
