### PR TITLE
fix: Prevent page scroll when resizing code editor with keyboard

### DIFF
--- a/src/code-editor/resizable-box/__tests__/resizable-box.test.tsx
+++ b/src/code-editor/resizable-box/__tests__/resizable-box.test.tsx
@@ -58,24 +58,21 @@ test('Emits resize events on mouse resizing', () => {
   expect(onResize).toHaveBeenCalledWith(150);
 });
 
-test('Emits resize events on keyboard resizing', () => {
+test.each([
+  ['ArrowDown', 20],
+  ['ArrowRight', 20],
+  ['ArrowUp', -20],
+  ['ArrowLeft', -20],
+])('Emits resize events on keydown press: %s', (key, expectedChange) => {
+  const initialHeight = 100;
   const onResize = jest.fn();
-  render(<ResizableBox {...defaultProps} height={100} onResize={onResize} />);
-  // Arrow keys resize by 20px
-  fireEvent.keyDown(findHandle(), { key: 'ArrowDown' });
-  expect(onResize).toHaveBeenCalledWith(120);
 
-  onResize.mockClear();
-  fireEvent.keyDown(findHandle(), { key: 'ArrowRight' });
-  expect(onResize).toHaveBeenCalledWith(120);
+  render(<ResizableBox {...defaultProps} height={initialHeight} onResize={onResize} />);
 
-  onResize.mockClear();
-  fireEvent.keyDown(findHandle(), { key: 'ArrowUp' });
-  expect(onResize).toHaveBeenCalledWith(80);
-
-  onResize.mockClear();
-  fireEvent.keyDown(findHandle(), { key: 'ArrowLeft' });
-  expect(onResize).toHaveBeenCalledWith(80);
+  const keydownEvent = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  fireEvent(findHandle(), keydownEvent);
+  expect(keydownEvent.defaultPrevented).toBe(true);
+  expect(onResize).toHaveBeenCalledWith(initialHeight + expectedChange);
 });
 
 test('Emits resize events when direction buttons are pressed', () => {

--- a/src/code-editor/resizable-box/index.tsx
+++ b/src/code-editor/resizable-box/index.tsx
@@ -44,10 +44,12 @@ export function ResizableBox({
     switch (event.key) {
       case 'ArrowDown':
       case 'ArrowRight':
+        event.preventDefault(); // Prevent page scroll
         onResizeStable(height + KEYBOARD_STEP_SIZE);
         break;
       case 'ArrowUp':
       case 'ArrowLeft':
+        event.preventDefault(); // Prevent page scroll
         onResizeStable(Math.max(height - KEYBOARD_STEP_SIZE, minHeight));
         break;
     }


### PR DESCRIPTION
### Description

Noticed after the implementation shipped. Not a big deal, but still nice to fix.

Related links, issue #, if available: n/a

### How has this been tested?

Updated unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
