### PR TITLE
chore: Include viewport visibility in performance marks

### DIFF
--- a/pages/app/app-context.tsx
+++ b/pages/app/app-context.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { createContext } from 'react';
+import React, { createContext, useContext } from 'react';
 import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import mapValues from 'lodash/mapValues';
 
@@ -41,6 +41,10 @@ const appContextDefaults: AppContextType = {
 const AppContext = createContext<AppContextType>(appContextDefaults);
 
 export default AppContext;
+
+export function useAppContext<T extends keyof any>() {
+  return useContext(AppContext as React.Context<AppContextType<Record<T, string | boolean>>>);
+}
 
 export function parseQuery(query: string) {
   const queryParams: Record<string, any> = { ...appContextDefaults.urlParams };

--- a/pages/table/performance-marks.page.tsx
+++ b/pages/table/performance-marks.page.tsx
@@ -5,10 +5,15 @@ import React, { useState } from 'react';
 import { Button, Header, Link, Modal, SpaceBetween, Table, Tabs } from '~components';
 import Box from '~components/box';
 
+import { useAppContext } from '../app/app-context';
+
 const EVALUATE_COMPONENT_VISIBILITY_EVENT = 'awsui-evaluate-component-visibility';
 
 export default function TablePerformanceMarkPage() {
   const [loading, setLoading] = useState(true);
+
+  const { outsideOfViewport } = useAppContext<'outsideOfViewport'>().urlParams;
+
   const dispatchEvaluateVisibilityEvent = () => {
     const event = new CustomEvent(EVALUATE_COMPONENT_VISIBILITY_EVENT);
     setTimeout(() => {
@@ -29,6 +34,20 @@ export default function TablePerformanceMarkPage() {
             Dispatch EvaluateVisibility Event
           </Button>
         </label>
+
+        {outsideOfViewport && (
+          <div
+            style={{
+              margin: 3,
+              padding: 10,
+              border: '1px solid rgba(128 128 128 / 50%)',
+              background: 'rgba(128 128 128 / 10%)',
+              height: '100vh',
+            }}
+          >
+            The Table is rendered below the viewport
+          </div>
+        )}
 
         <Table
           items={[]}

--- a/src/button-dropdown/__integ__/performance-marks.test.ts
+++ b/src/button-dropdown/__integ__/performance-marks.test.ts
@@ -15,6 +15,7 @@ function setupTest(
     const page = new BasePageObject(browser);
     await browser.url(`#/light/button-dropdown/${pageName}`);
     const getMarks = async () => {
+      await new Promise(r => setTimeout(r, 200));
       const marks = await browser.execute(() => performance.getEntriesByType('mark') as PerformanceMark[]);
       return marks.filter(m => m.detail?.source === 'awsui');
     };
@@ -37,6 +38,7 @@ describe('ButtonDropdown', () => {
         instanceIdentifier: expect.any(String),
         loading: false,
         disabled: false,
+        inViewport: true,
         text: 'Launch instance',
       });
 

--- a/src/button/__integ__/performance-marks.test.ts
+++ b/src/button/__integ__/performance-marks.test.ts
@@ -15,6 +15,7 @@ function setupTest(
     const page = new BasePageObject(browser);
     await browser.url(`#/light/button/${pageName}`);
     const getMarks = async () => {
+      await new Promise(r => setTimeout(r, 200));
       const marks = await browser.execute(() => performance.getEntriesByType('mark') as PerformanceMark[]);
       return marks.filter(m => m.detail?.source === 'awsui');
     };
@@ -37,6 +38,7 @@ describe('Button', () => {
         instanceIdentifier: expect.any(String),
         loading: false,
         disabled: false,
+        inViewport: true,
         text: 'Primary button',
       });
 
@@ -57,6 +59,7 @@ describe('Button', () => {
         instanceIdentifier: marks[0].detail.instanceIdentifier,
         loading: false,
         disabled: false,
+        inViewport: true,
         text: 'Primary button',
       });
 
@@ -68,6 +71,7 @@ describe('Button', () => {
         instanceIdentifier: marks[1].detail.instanceIdentifier,
         loading: false,
         disabled: false,
+        inViewport: true,
         text: 'Primary button with loading and disabled props',
       });
 
@@ -109,6 +113,7 @@ describe('Button', () => {
         instanceIdentifier: marks[0].detail.instanceIdentifier,
         loading: false,
         disabled: false,
+        inViewport: true,
         text: 'Primary button',
       });
 
@@ -120,6 +125,7 @@ describe('Button', () => {
         instanceIdentifier: marks[1].detail.instanceIdentifier,
         loading: false,
         disabled: false,
+        inViewport: true,
         text: 'Primary button',
       });
 

--- a/src/internal/hooks/use-performance-marks/__tests__/is-in-viewport.test.tsx
+++ b/src/internal/hooks/use-performance-marks/__tests__/is-in-viewport.test.tsx
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { runAllIntersectionObservers } from '../../../utils/__tests__/mock-intersection-observer';
+
+jest.useFakeTimers();
+
+function isInViewport(element: Element, callback: (inViewport: boolean) => void) {
+  // We need to import the function dynamically so that it picks up the mocked IntersectionObserver.
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return jest.requireActual('../is-in-viewport').isInViewport(element, callback);
+}
+
+beforeEach(() => jest.resetAllMocks());
+
+describe('isInViewport', () => {
+  it('calls the callback with `true` if the element is visible', () => {
+    const callback = jest.fn();
+    const element = document.createElement('div');
+
+    isInViewport(element, callback);
+
+    runAllIntersectionObservers([{ target: element, isIntersecting: true }]);
+
+    jest.runAllTimers();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(true);
+  });
+
+  it('calls the callback with `false` if the element is not visible', () => {
+    const callback = jest.fn();
+    const element = document.createElement('div');
+
+    isInViewport(element, callback);
+
+    runAllIntersectionObservers([{ target: element, isIntersecting: false }]);
+
+    jest.runAllTimers();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(false);
+  });
+
+  it('calls the callback with `false` if the IntersectionObserver does not fire in reasonable time', () => {
+    const callback = jest.fn();
+    const element = document.createElement('div');
+
+    isInViewport(element, callback);
+
+    jest.runAllTimers();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(false);
+  });
+
+  it('calls the callback with a delay', () => {
+    const callback = jest.fn();
+    const element = document.createElement('div');
+
+    isInViewport(element, callback);
+
+    runAllIntersectionObservers([{ target: element, isIntersecting: false }]);
+
+    expect(callback).not.toHaveBeenCalled();
+
+    jest.runAllTimers();
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('calls different callbacks for different elements', () => {
+    const callback1 = jest.fn();
+    const element1 = document.createElement('div');
+    const callback2 = jest.fn();
+    const element2 = document.createElement('div');
+
+    isInViewport(element1, callback1);
+    isInViewport(element2, callback2);
+
+    runAllIntersectionObservers([
+      { target: element2, isIntersecting: false },
+      { target: element1, isIntersecting: true },
+    ]);
+
+    jest.runAllTimers();
+
+    expect(callback1).toHaveBeenCalledWith(true);
+    expect(callback2).toHaveBeenCalledWith(false);
+  });
+
+  it('does not call the callback if the cleanup function is run', () => {
+    const callback = jest.fn();
+    const element = document.createElement('div');
+
+    const cleanup = isInViewport(element, callback);
+
+    runAllIntersectionObservers([{ target: element, isIntersecting: false }]);
+
+    cleanup();
+
+    jest.runAllTimers();
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/src/internal/hooks/use-performance-marks/__tests__/is-in-viewport.test.tsx
+++ b/src/internal/hooks/use-performance-marks/__tests__/is-in-viewport.test.tsx
@@ -55,20 +55,6 @@ describe('isInViewport', () => {
     expect(callback).toHaveBeenCalledWith(false);
   });
 
-  it('calls the callback with a delay', () => {
-    const callback = jest.fn();
-    const element = document.createElement('div');
-
-    isInViewport(element, callback);
-
-    runAllIntersectionObservers([{ target: element, isIntersecting: false }]);
-
-    expect(callback).not.toHaveBeenCalled();
-
-    jest.runAllTimers();
-    expect(callback).toHaveBeenCalled();
-  });
-
   it('calls different callbacks for different elements', () => {
     const callback1 = jest.fn();
     const element1 = document.createElement('div');
@@ -95,9 +81,9 @@ describe('isInViewport', () => {
 
     const cleanup = isInViewport(element, callback);
 
-    runAllIntersectionObservers([{ target: element, isIntersecting: false }]);
-
     cleanup();
+
+    runAllIntersectionObservers([{ target: element, isIntersecting: false }]);
 
     jest.runAllTimers();
 

--- a/src/internal/hooks/use-performance-marks/is-in-viewport.ts
+++ b/src/internal/hooks/use-performance-marks/is-in-viewport.ts
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+type Callback = (inViewport: boolean) => void;
+let map = new WeakMap<Element, Callback>();
+
+const MAX_DELAY_MS = 1000;
+const MANUAL_TRIGGER_DELAY = 100;
+
+/**
+ * This function determines whether an element is in the viewport. The callback
+ * is batched with other elements that also use this function, in order to improve
+ * performance.
+ */
+export function isInViewport(element: Element, callback: Callback) {
+  const mapSnapshot = map;
+
+  let resolve = (value: boolean) => {
+    resolve = () => {}; // Prevent multiple execution
+    callback(value);
+  };
+
+  mapSnapshot.set(element, inViewport => resolve(inViewport));
+
+  /*
+	 If the IntersectionObserver does not fire in reasonable time (for example
+	 in a background page in Chrome), we need to call the callback manually.
+  
+	 See https://issues.chromium.org/issues/41383759
+	 */
+  const timeoutHandle = setTimeout(() => resolve(false), MANUAL_TRIGGER_DELAY);
+
+  observer.observe(element);
+
+  // Cleanup
+  return () => {
+    clearTimeout(timeoutHandle);
+    mapSnapshot.delete(element);
+    observer.unobserve(element);
+  };
+}
+
+function createIntersectionObserver(callback: IntersectionObserverCallback) {
+  if (typeof IntersectionObserver === 'undefined') {
+    return {
+      observe: () => {},
+      unobserve: () => {},
+    };
+  }
+  return new IntersectionObserver(callback);
+}
+
+const observer = createIntersectionObserver(function isInViewportObserver(entries) {
+  // This avoids interference when the IntersectionObserver is called again during the delay.
+  const mapSnapshot = map;
+  map = new Map();
+
+  // We only want the first run of the observer.
+  for (const entry of entries) {
+    observer.unobserve(entry.target);
+  }
+
+  // We yield the event loop, since these events are low priority and not time critical.
+  defer(() => {
+    for (const entry of entries) {
+      mapSnapshot.get(entry.target)?.(entry.isIntersecting);
+    }
+  }, MAX_DELAY_MS);
+});
+
+function defer(callback: () => void, maxDelayMs: number) {
+  if (typeof requestIdleCallback === 'function') {
+    requestIdleCallback(callback, { timeout: maxDelayMs });
+  } else {
+    // requestIdleCallback is not supported in Safari
+    setTimeout(callback, maxDelayMs);
+  }
+}

--- a/src/internal/utils/__tests__/mock-intersection-observer.test.ts
+++ b/src/internal/utils/__tests__/mock-intersection-observer.test.ts
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { runAllIntersectionObservers } from './mock-intersection-observer';
+
+describe('IntersectionObserver mock', () => {
+  it('runs the callback for observed elements', () => {
+    const callback = jest.fn();
+    const element1 = document.createElement('div');
+    const element2 = document.createElement('div');
+    const element3 = document.createElement('div');
+
+    const observer = new IntersectionObserver(callback);
+    observer.observe(element1);
+    observer.observe(element2);
+    observer.observe(element3);
+    observer.unobserve(element3);
+
+    runAllIntersectionObservers([
+      { target: element2, isIntersecting: true },
+      { target: element1, isIntersecting: false },
+      { target: element3, isIntersecting: true },
+      { target: document.createElement('div'), isIntersecting: false },
+    ]);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(
+      [
+        { target: element2, isIntersecting: true },
+        { target: element1, isIntersecting: false },
+      ],
+      expect.anything()
+    );
+  });
+
+  it('supports multiple instances', () => {
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+    const element1 = document.createElement('div');
+    const element2 = document.createElement('div');
+
+    const observer1 = new IntersectionObserver(callback1);
+    const observer2 = new IntersectionObserver(callback2);
+    observer1.observe(element1);
+    observer2.observe(element2);
+
+    runAllIntersectionObservers([
+      { target: element1, isIntersecting: true },
+      { target: element2, isIntersecting: true },
+    ]);
+
+    expect(callback1).toHaveBeenCalledTimes(1);
+    expect(callback2).toHaveBeenCalledTimes(1);
+    expect(callback1).toHaveBeenCalledWith([{ target: element1, isIntersecting: true }], expect.anything());
+    expect(callback2).toHaveBeenCalledWith([{ target: element2, isIntersecting: true }], expect.anything());
+  });
+});

--- a/src/internal/utils/__tests__/mock-intersection-observer.ts
+++ b/src/internal/utils/__tests__/mock-intersection-observer.ts
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ When this file is imported, it automatically mocks the global `IntersectionObserver` class.
+ The callbacks of all IntersectionObservers are only run when the `runAllIntersectionObservers`
+ function is called.
+*/
+
+const allCallbacks = new Set<(entries: IntersectionObserverEntry[]) => void>();
+
+global.IntersectionObserver = class IntersectionObserverMock {
+  private elements = new Set<Element>();
+
+  constructor(callback: IntersectionObserverCallback) {
+    allCallbacks.add(entries => {
+      const observedEntries = entries.filter(r => this.elements.has(r.target));
+
+      callback(observedEntries, this as unknown as IntersectionObserver);
+    });
+  }
+
+  observe(element: Element) {
+    this.elements.add(element);
+  }
+
+  unobserve(element: Element) {
+    this.elements.delete(element);
+  }
+} as unknown as typeof IntersectionObserver;
+
+/**
+ * Runs all registered IntersectionObserver callbacks.
+ * The callback will only contain entries for elements that are currently being observed.
+ * If an element is not being observed or not included in the `results` parameter, it
+ * will not be included in the callback.
+ */
+export function runAllIntersectionObservers(entries: Array<PartialEntry>) {
+  allCallbacks.forEach(callback => callback(entries as IntersectionObserverEntry[]));
+}
+
+interface PartialEntry extends Partial<IntersectionObserverEntry> {
+  target: Element;
+  isIntersecting: boolean;
+}


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

This PR updates our performance marks to include information about whether the component is inside the viewport or not.

Related links, issue #, if available: n/a

### How has this been tested?


Tested manually in the dev pages, added unit tests.
<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
