### PR TITLE
chore: Dummy tree view component

### DIFF
--- a/build-tools/utils/pluralize.js
+++ b/build-tools/utils/pluralize.js
@@ -79,6 +79,7 @@ const pluralizationMap = {
   ToggleButton: 'ToggleButtons',
   TokenGroup: 'TokenGroups',
   TopNavigation: 'TopNavigations',
+  TreeView: 'TreeViews',
   TutorialPanel: 'TutorialPanels',
   Wizard: 'Wizards',
 };

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -20278,6 +20278,27 @@ The following properties are supported across all utility types:
 }
 `;
 
+exports[`Documenter definition for tree-view matches the snapshot: tree-view 1`] = `
+{
+  "events": [],
+  "functions": [],
+  "name": "TreeView",
+  "properties": [
+    {
+      "defaultValue": "[]",
+      "name": "items",
+      "optional": false,
+      "type": "Array<{ text: string; }>",
+    },
+  ],
+  "regions": [],
+  "releaseStatus": "stable",
+  "systemTags": [
+    "core",
+  ],
+}
+`;
+
 exports[`Documenter definition for tutorial-panel matches the snapshot: tutorial-panel 1`] = `
 {
   "events": [

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -653,6 +653,9 @@ exports[`test-utils selectors 1`] = `
     "awsui_utility-wrapper_1ca1i",
     "awsui_utility-wrapper_k5dlb",
   ],
+  "tree-view": [
+    "awsui_root_1js4f",
+  ],
   "tutorial-panel": [
     "awsui_collapse-button_ig8mp",
     "awsui_completed_ig8mp",

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-wrappers.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-wrappers.test.tsx.snap
@@ -87,6 +87,7 @@ import ToggleWrapper from './toggle';
 import ToggleButtonWrapper from './toggle-button';
 import TokenGroupWrapper from './token-group';
 import TopNavigationWrapper from './top-navigation';
+import TreeViewWrapper from './tree-view';
 import TutorialPanelWrapper from './tutorial-panel';
 import WizardWrapper from './wizard';
 
@@ -169,6 +170,7 @@ export { ToggleWrapper };
 export { ToggleButtonWrapper };
 export { TokenGroupWrapper };
 export { TopNavigationWrapper };
+export { TreeViewWrapper };
 export { TutorialPanelWrapper };
 export { WizardWrapper };
 
@@ -1658,6 +1660,25 @@ findTopNavigation(selector?: string): TopNavigationWrapper | null;
  */
 findAllTopNavigations(selector?: string): Array<TopNavigationWrapper>;
 /**
+ * Returns the wrapper of the first TreeView that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first TreeView.
+ * If no matching TreeView is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TreeViewWrapper | null}
+ */
+findTreeView(selector?: string): TreeViewWrapper | null;
+
+/**
+ * Returns an array of TreeView wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the TreeViews inside the current wrapper.
+ * If no matching TreeView is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<TreeViewWrapper>}
+ */
+findAllTreeViews(selector?: string): Array<TreeViewWrapper>;
+/**
  * Returns the wrapper of the first TutorialPanel that matches the specified CSS selector.
  * If no CSS selector is specified, returns the wrapper of the first TutorialPanel.
  * If no matching TutorialPanel is found, returns \`null\`.
@@ -2479,6 +2500,16 @@ ElementWrapper.prototype.findTopNavigation = function(selector) {
 ElementWrapper.prototype.findAllTopNavigations = function(selector) {
   return this.findAllComponents(TopNavigationWrapper, selector);
 };
+ElementWrapper.prototype.findTreeView = function(selector) {
+  const rootSelector = \`.\${TreeViewWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TreeViewWrapper);
+};
+
+ElementWrapper.prototype.findAllTreeViews = function(selector) {
+  return this.findAllComponents(TreeViewWrapper, selector);
+};
 ElementWrapper.prototype.findTutorialPanel = function(selector) {
   const rootSelector = \`.\${TutorialPanelWrapper.rootSelector}\`;
   // casting to 'any' is needed to avoid this issue with generics
@@ -2597,6 +2628,7 @@ import ToggleWrapper from './toggle';
 import ToggleButtonWrapper from './toggle-button';
 import TokenGroupWrapper from './token-group';
 import TopNavigationWrapper from './top-navigation';
+import TreeViewWrapper from './tree-view';
 import TutorialPanelWrapper from './tutorial-panel';
 import WizardWrapper from './wizard';
 
@@ -2679,6 +2711,7 @@ export { ToggleWrapper };
 export { ToggleButtonWrapper };
 export { TokenGroupWrapper };
 export { TopNavigationWrapper };
+export { TreeViewWrapper };
 export { TutorialPanelWrapper };
 export { WizardWrapper };
 
@@ -4012,6 +4045,23 @@ findTopNavigation(selector?: string): TopNavigationWrapper;
  */
 findAllTopNavigations(selector?: string): MultiElementWrapper<TopNavigationWrapper>;
 /**
+ * Returns a wrapper that matches the TreeViews with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches TreeViews.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TreeViewWrapper}
+ */
+findTreeView(selector?: string): TreeViewWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches TreeViews with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches TreeViews.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<TreeViewWrapper>}
+ */
+findAllTreeViews(selector?: string): MultiElementWrapper<TreeViewWrapper>;
+/**
  * Returns a wrapper that matches the TutorialPanels with the specified CSS selector.
  * If no CSS selector is specified, returns a wrapper that matches TutorialPanels.
  *
@@ -4828,6 +4878,16 @@ ElementWrapper.prototype.findTopNavigation = function(selector) {
 
 ElementWrapper.prototype.findAllTopNavigations = function(selector) {
   return this.findAllComponents(TopNavigationWrapper, selector);
+};
+ElementWrapper.prototype.findTreeView = function(selector) {
+  const rootSelector = \`.\${TreeViewWrapper.rootSelector}\`;
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TreeViewWrapper);
+};
+
+ElementWrapper.prototype.findAllTreeViews = function(selector) {
+  return this.findAllComponents(TreeViewWrapper, selector);
 };
 ElementWrapper.prototype.findTutorialPanel = function(selector) {
   const rootSelector = \`.\${TutorialPanelWrapper.rootSelector}\`;

--- a/src/test-utils/dom/tree-view/index.ts
+++ b/src/test-utils/dom/tree-view/index.ts
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ComponentWrapper } from '@cloudscape-design/test-utils-core/dom';
+
+import testClasses from '../../../tree-view/test-classes/styles.selectors.js';
+
+export default class TreeViewWrapper extends ComponentWrapper {
+  static rootSelector: string = testClasses.root;
+}

--- a/src/tree-view/__tests__/tree-view.test.tsx
+++ b/src/tree-view/__tests__/tree-view.test.tsx
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import createWrapper from '../../../lib/components/test-utils/dom';
+import TreeView from '../../../lib/components/tree-view';
+
+test('renders items', () => {
+  const { container } = render(<TreeView items={[{ text: 'one' }, { text: 'two' }]} />);
+  const wrapper = createWrapper(container).findTreeView()!;
+  expect(wrapper.findAll('li')).toHaveLength(2);
+});

--- a/src/tree-view/index.tsx
+++ b/src/tree-view/index.tsx
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+
+import { getBaseProps } from '../internal/base-component';
+import useBaseComponent from '../internal/hooks/use-base-component';
+import { applyDisplayName } from '../internal/utils/apply-display-name';
+import { TreeViewProps } from './interfaces';
+
+import testClasses from './test-classes/styles.css.js';
+
+export { TreeViewProps };
+
+/**
+ * @awsuiSystem core
+ */
+export default function TreeView({ items = [], ...rest }: TreeViewProps) {
+  const { __internalRootRef } = useBaseComponent('TreeView');
+  const baseProps = getBaseProps(rest);
+
+  return (
+    <div ref={__internalRootRef} {...baseProps} className={clsx(baseProps.className, testClasses.root)}>
+      <p>tree view component mock</p>
+      <ul>
+        {items.map((item, index) => (
+          <li key={index}>{item.text}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+applyDisplayName(TreeView, 'TreeView');

--- a/src/tree-view/interfaces.ts
+++ b/src/tree-view/interfaces.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export interface TreeViewProps {
+  items: Array<{ text: string }>;
+}

--- a/src/tree-view/test-classes/styles.scss
+++ b/src/tree-view/test-classes/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.root {
+  /* used in test-utils */
+}


### PR DESCRIPTION
### Description

Added a dummy component to test `@awsuiSystem` declaration tag end-to-end

Related links, issue #, if available: n/a

### How has this been tested?

Build in my dev-pipeline: TBD

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
