### PR TITLE
fix: LiveRegion text extraction

### DIFF
--- a/src/live-region/__integ__/live-region.test.ts
+++ b/src/live-region/__integ__/live-region.test.ts
@@ -26,7 +26,7 @@ describe('Live region', () => {
     setupTest(async page => {
       // Wait for live region to debounce after page load
       await new Promise(resolve => setTimeout(resolve, 2000));
-      await expect(page.getInnerHTML('[aria-live]')).resolves.toBe('&lt;p&gt;Testing&lt;/p&gt;Testing');
+      await expect(page.getInnerHTML('[aria-live]')).resolves.toBe('&lt;p&gt;Testing&lt;/p&gt; Testing');
     })
   );
 });

--- a/src/live-region/__tests__/live-region.test.tsx
+++ b/src/live-region/__tests__/live-region.test.tsx
@@ -138,6 +138,12 @@ describe('text extractor', () => {
     expect(extractTextContent(el)).toBe('');
   });
 
+  it('extracts text from an empty element with a comment', () => {
+    const el = document.createElement('div');
+    el.innerHTML = '<!-- comment -->';
+    expect(extractTextContent(el)).toBe('');
+  });
+
   it('extracts text from a single element', () => {
     const el = document.createElement('div');
     el.textContent = 'Hello';

--- a/src/live-region/__tests__/live-region.test.tsx
+++ b/src/live-region/__tests__/live-region.test.tsx
@@ -3,7 +3,10 @@
 import React, { createRef } from 'react';
 import { render, waitFor } from '@testing-library/react';
 
-import InternalLiveRegion, { InternalLiveRegionRef } from '../../../lib/components/live-region/internal.js';
+import InternalLiveRegion, {
+  extractTextContent,
+  InternalLiveRegionRef,
+} from '../../../lib/components/live-region/internal.js';
 
 import styles from '../../../lib/components/live-region/test-classes/styles.css.js';
 
@@ -126,5 +129,24 @@ describe('LiveRegion', () => {
 
     ref.current?.reannounce();
     expect(politeRegion).toHaveTextContent('Announcement');
+  });
+});
+
+describe('text extractor', () => {
+  it('extracts text from a single element', () => {
+    const el = document.createElement('div');
+    el.textContent = 'Hello';
+    expect(extractTextContent(el)).toBe('Hello');
+  });
+
+  it('extracts text from nested elements', () => {
+    const el = document.createElement('article');
+    el.innerHTML = `
+        <h1>Hello</h1>
+        <p>World</p>
+        <span>inline</span>
+        <span>content</span>
+    `;
+    expect(extractTextContent(el)).toBe('Hello World inline content');
   });
 });

--- a/src/live-region/__tests__/live-region.test.tsx
+++ b/src/live-region/__tests__/live-region.test.tsx
@@ -133,6 +133,11 @@ describe('LiveRegion', () => {
 });
 
 describe('text extractor', () => {
+  it('extracts text from an empty element', () => {
+    const el = document.createElement('div');
+    expect(extractTextContent(el)).toBe('');
+  });
+
   it('extracts text from a single element', () => {
     const el = document.createElement('div');
     el.textContent = 'Hello';
@@ -146,6 +151,7 @@ describe('text extractor', () => {
         <p>World</p>
         <span>inline</span>
         <span>content</span>
+        <span></span>
     `;
     expect(extractTextContent(el)).toBe('Hello World inline content');
   });

--- a/src/live-region/internal.tsx
+++ b/src/live-region/internal.tsx
@@ -137,7 +137,7 @@ export function extractTextContent(node: HTMLElement): string {
     return '';
   }
 
-  return Array.from(node.childNodes).map(processNode).join(' ').replace(/\s+/g, ' ').trim();
+  return Array.from(node.childNodes, processNode).join(' ').replace(/\s+/g, ' ').trim();
 }
 
 function getSourceContent(source: ReadonlyArray<string | React.RefObject<HTMLElement> | undefined>): string {

--- a/src/live-region/internal.tsx
+++ b/src/live-region/internal.tsx
@@ -116,12 +116,28 @@ export default React.forwardRef(function InternalLiveRegion(
   );
 });
 
-function extractTextContent(node: HTMLElement): string {
+const processNode = (childNode: Node): string => {
+  if (childNode.nodeType === Node.TEXT_NODE) {
+    return childNode.textContent || '';
+  }
+
+  if (childNode.nodeType === Node.ELEMENT_NODE) {
+    return extractTextContent(childNode as HTMLElement);
+  }
+
+  return '';
+};
+
+export function extractTextContent(node: HTMLElement): string {
   // We use the text content of the node as the announcement text.
   // This only extracts text content from the node including all its children which is enough for now.
   // To make it more powerful, it is possible to create a more sophisticated extractor with respect to
   // ARIA properties to ignore aria-hidden nodes and read ARIA labels from the live content.
-  return (node.textContent || '').replace(/\s+/g, ' ').trim();
+  if (!node || !node.childNodes) {
+    return '';
+  }
+
+  return Array.from(node.childNodes).map(processNode).join(' ').replace(/\s+/g, ' ').trim();
 }
 
 function getSourceContent(source: ReadonlyArray<string | React.RefObject<HTMLElement> | undefined>): string {

--- a/src/live-region/internal.tsx
+++ b/src/live-region/internal.tsx
@@ -133,7 +133,7 @@ export function extractTextContent(node: HTMLElement): string {
   // This only extracts text content from the node including all its children which is enough for now.
   // To make it more powerful, it is possible to create a more sophisticated extractor with respect to
   // ARIA properties to ignore aria-hidden nodes and read ARIA labels from the live content.
-  if (!node || !node.childNodes) {
+  if (!node || !node?.childNodes?.length) {
     return '';
   }
 


### PR DESCRIPTION
### Description

AWSUI-60601
Fixed text extraction logic in a way that does not concatenate words coming from dom nodes without spaces between them. 

Reproduction Steps:

Create a ⁠LiveRegion component.
Place two or more inline elements (e.g., ⁠<span>, ⁠<a>, ⁠<strong>) as direct children of the ⁠LiveRegion.
<LiveRegion>
<span>Documentation</span>
<span>Something</span>
</LiveRegion>
Ensure that the inline elements contain text content.
Use a screen reader to listen to the announcement of the ⁠LiveRegion's content.
Expected Behavior:

The screen reader should announce the text content of each inline element with a space separating them. For example, if the ⁠LiveRegion contains ⁠<span>Documentation</span><span>Something</span>, the screen reader should announce "Documentation Something".

Actual Behavior:

The screen reader announces the text content of the inline elements without spaces. For example, if the ⁠LiveRegion contains ⁠<span>Documentation</span><span>Something</span>, the screen reader announces "DocumentationSomething".

### How has this been tested?

Manually and via u tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
