### PR TITLE
fix: Add missing navigation aria-label to mobile nav

### DIFF
--- a/src/app-layout/__tests__/mobile.test.tsx
+++ b/src/app-layout/__tests__/mobile.test.tsx
@@ -604,4 +604,13 @@ describeEachAppLayout({ sizes: ['mobile'] }, ({ theme }) => {
     const drawersToolbar = findDrawersContainer(wrapper)!.getElement();
     expect(drawersToolbar).toHaveAttribute('role', 'toolbar');
   });
+
+  test('side navigation toggle button renders aria label on closed side navigation', () => {
+    const { wrapper } = renderComponent(
+      <AppLayout navigationOpen={false} onNavigationChange={() => {}} ariaLabels={{ navigation: 'Navigation Label' }} />
+    );
+    const toolbar = findMobileToolbar(wrapper)!.getElement();
+    const toggleButton = toolbar.querySelector('nav');
+    expect(toggleButton).toHaveAttribute('aria-label', 'Navigation Label');
+  });
 });

--- a/src/app-layout/visual-refresh/mobile-toolbar.tsx
+++ b/src/app-layout/visual-refresh/mobile-toolbar.tsx
@@ -55,6 +55,7 @@ export default function MobileToolbar() {
       {!navigationHide && (
         <nav
           aria-hidden={navigationOpen}
+          aria-label={ariaLabels?.navigation ?? undefined}
           aria-orientation="horizontal"
           className={clsx(styles['mobile-toolbar-nav'], { [testutilStyles['drawer-closed']]: !navigationOpen })}
         >


### PR DESCRIPTION
### Description

The mobile navigation region has no accessible name. With this change, I'm adding the missing `aria-label` to the nav element to provide a short description of the navigation region's purpose.

Related links, issue #, if available: AWSUI-60249

### How has this been tested?

- added unit tests to ensure the label is present across all `AppLayout` variants.
- verified manually in the browser.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
