### PR TITLE
feat: Support icons in KeyValuePairs labels

### DIFF
--- a/pages/key-value-pairs/simple.page.tsx
+++ b/pages/key-value-pairs/simple.page.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 
 import KeyValuePairs from '~components/key-value-pairs';
+import Link from '~components/link';
 
 import ScreenshotArea from '../utils/screenshot-area';
 
@@ -26,6 +27,24 @@ export default function () {
                 {
                   label: 'Label for key',
                   value: 'Value',
+                },
+                {
+                  label: 'Label for key',
+                  value: 'Value',
+                  iconName: 'status-info',
+                },
+                {
+                  label: 'Label for key',
+                  value: 'Value',
+                  iconName: 'external',
+                  iconAlign: 'end',
+                },
+                {
+                  label: 'Label for key',
+                  value: 'Value',
+                  iconName: 'external',
+                  iconAlign: 'end',
+                  info: <Link>Info</Link>,
                 },
               ],
             },

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -398,6 +398,7 @@ exports[`test-utils selectors 1`] = `
   "key-value-pairs": [
     "awsui_detail_1y9fy",
     "awsui_group-list-item_1y9fy",
+    "awsui_icon_1y9fy",
     "awsui_info_1y9fy",
     "awsui_key-label_1y9fy",
     "awsui_key-value-pairs_1y9fy",

--- a/src/key-value-pairs/__tests__/key-value-pairs.test.tsx
+++ b/src/key-value-pairs/__tests__/key-value-pairs.test.tsx
@@ -7,6 +7,8 @@ import KeyValuePairs from '../../../lib/components/key-value-pairs';
 import Link from '../../../lib/components/link';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
+import styles from '../../../lib/components/key-value-pairs/styles.css.js';
+
 function renderKeyValuePairs(jsx: React.ReactElement) {
   const { container, ...rest } = render(jsx);
   return { wrapper: createWrapper(container).findKeyValuePairs()!, ...rest };
@@ -53,6 +55,38 @@ describe('KeyValuePairs', () => {
         labelId
       );
       expect(wrapper.findItems()[0]!.findInfo()!.getElement()).toHaveTextContent('Info');
+    });
+
+    test('renders label with icons correctly', () => {
+      const { wrapper } = renderKeyValuePairs(
+        <KeyValuePairs
+          items={[
+            {
+              label: 'Label for key',
+              value: 'Value',
+              iconName: 'status-info',
+              iconAlign: 'start',
+              iconAriaLabel: 'info icon at the start',
+            },
+            {
+              label: 'Label for key',
+              value: 'Value',
+              iconName: 'external',
+              iconAlign: 'end',
+              iconAriaLabel: 'external icon at the end',
+            },
+          ]}
+        />
+      );
+
+      expect(wrapper.findItems()[0]!.findIcon()?.getElement()).toHaveClass(styles['icon-start']);
+      expect(wrapper.findItems()[0]!.findIcon()?.getElement()).toHaveAttribute('aria-label', 'info icon at the start');
+
+      expect(wrapper.findItems()[1]!.findIcon()?.getElement()).toHaveClass(styles['icon-end']);
+      expect(wrapper.findItems()[1]!.findIcon()?.getElement()).toHaveAttribute(
+        'aria-label',
+        'external icon at the end'
+      );
     });
   });
 

--- a/src/key-value-pairs/__tests__/key-value-pairs.test.tsx
+++ b/src/key-value-pairs/__tests__/key-value-pairs.test.tsx
@@ -66,26 +66,59 @@ describe('KeyValuePairs', () => {
               value: 'Value',
               iconName: 'status-info',
               iconAlign: 'start',
-              iconAriaLabel: 'info icon at the start',
+              iconAriaLabel: 'info icon on the left',
             },
             {
               label: 'Label for key',
               value: 'Value',
               iconName: 'external',
               iconAlign: 'end',
-              iconAriaLabel: 'external icon at the end',
+              iconAriaLabel: 'external icon on the right',
             },
           ]}
         />
       );
 
       expect(wrapper.findItems()[0]!.findIcon()?.getElement()).toHaveClass(styles['icon-start']);
-      expect(wrapper.findItems()[0]!.findIcon()?.getElement()).toHaveAttribute('aria-label', 'info icon at the start');
+      expect(wrapper.findItems()[0]!.findIcon()?.getElement()).toHaveAttribute('aria-label', 'info icon on the left');
 
       expect(wrapper.findItems()[1]!.findIcon()?.getElement()).toHaveClass(styles['icon-end']);
       expect(wrapper.findItems()[1]!.findIcon()?.getElement()).toHaveAttribute(
         'aria-label',
-        'external icon at the end'
+        'external icon on the right'
+      );
+    });
+
+    test('renders label with icons correctly, rtl', () => {
+      document.body.style.direction = 'rtl';
+      const { wrapper } = renderKeyValuePairs(
+        <KeyValuePairs
+          items={[
+            {
+              label: 'Label for key',
+              value: 'Value',
+              iconName: 'status-info',
+              iconAlign: 'start',
+              iconAriaLabel: 'info icon on the right',
+            },
+            {
+              label: 'Label for key',
+              value: 'Value',
+              iconName: 'external',
+              iconAlign: 'end',
+              iconAriaLabel: 'external icon on the left',
+            },
+          ]}
+        />
+      );
+
+      expect(wrapper.findItems()[0]!.findIcon()?.getElement()).toHaveClass(styles['icon-end']);
+      expect(wrapper.findItems()[0]!.findIcon()?.getElement()).toHaveAttribute('aria-label', 'info icon on the right');
+
+      expect(wrapper.findItems()[1]!.findIcon()?.getElement()).toHaveClass(styles['icon-start']);
+      expect(wrapper.findItems()[1]!.findIcon()?.getElement()).toHaveAttribute(
+        'aria-label',
+        'external icon on the left'
       );
     });
   });

--- a/src/key-value-pairs/__tests__/key-value-pairs.test.tsx
+++ b/src/key-value-pairs/__tests__/key-value-pairs.test.tsx
@@ -7,8 +7,6 @@ import KeyValuePairs from '../../../lib/components/key-value-pairs';
 import Link from '../../../lib/components/link';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
-import styles from '../../../lib/components/key-value-pairs/styles.css.js';
-
 function renderKeyValuePairs(jsx: React.ReactElement) {
   const { container, ...rest } = render(jsx);
   return { wrapper: createWrapper(container).findKeyValuePairs()!, ...rest };
@@ -57,70 +55,48 @@ describe('KeyValuePairs', () => {
       expect(wrapper.findItems()[0]!.findInfo()!.getElement()).toHaveTextContent('Info');
     });
 
-    test('renders label with icons correctly', () => {
-      const { wrapper } = renderKeyValuePairs(
-        <KeyValuePairs
-          items={[
-            {
-              label: 'Label for key',
-              value: 'Value',
-              iconName: 'status-info',
-              iconAlign: 'start',
-              iconAriaLabel: 'info icon on the left',
-            },
-            {
-              label: 'Label for key',
-              value: 'Value',
-              iconName: 'external',
-              iconAlign: 'end',
-              iconAriaLabel: 'external icon on the right',
-            },
-          ]}
-        />
-      );
+    it.each<string>(['ltr', 'rtl'])(
+      'renders label with icons correctly, maintaining logical order, %s',
+      (direction: string) => {
+        document.body.style.direction = direction;
+        const { wrapper } = renderKeyValuePairs(
+          <KeyValuePairs
+            items={[
+              {
+                label: 'Label at the end',
+                value: 'Value',
+                iconName: 'status-info',
+                iconAlign: 'start',
+                iconAriaLabel: 'info icon at the start',
+              },
+              {
+                label: 'Label at the start',
+                value: 'Value',
+                iconName: 'external',
+                iconAlign: 'end',
+                iconAriaLabel: 'external icon at the end',
+              },
+            ]}
+          />
+        );
 
-      expect(wrapper.findItems()[0]!.findIcon()?.getElement()).toHaveClass(styles['icon-start']);
-      expect(wrapper.findItems()[0]!.findIcon()?.getElement()).toHaveAttribute('aria-label', 'info icon on the left');
+        const nextSibling = wrapper.findItems()[0]!.findIcon()?.getElement().parentElement?.nextElementSibling;
+        expect(nextSibling?.firstChild).toBeInstanceOf(HTMLLabelElement);
+        expect(nextSibling?.textContent).toBe('Label at the end');
+        expect(wrapper.findItems()[0]!.findIcon()?.getElement()).toHaveAttribute(
+          'aria-label',
+          'info icon at the start'
+        );
 
-      expect(wrapper.findItems()[1]!.findIcon()?.getElement()).toHaveClass(styles['icon-end']);
-      expect(wrapper.findItems()[1]!.findIcon()?.getElement()).toHaveAttribute(
-        'aria-label',
-        'external icon on the right'
-      );
-    });
-
-    test('renders label with icons correctly, rtl', () => {
-      document.body.style.direction = 'rtl';
-      const { wrapper } = renderKeyValuePairs(
-        <KeyValuePairs
-          items={[
-            {
-              label: 'Label for key',
-              value: 'Value',
-              iconName: 'status-info',
-              iconAlign: 'start',
-              iconAriaLabel: 'info icon on the right',
-            },
-            {
-              label: 'Label for key',
-              value: 'Value',
-              iconName: 'external',
-              iconAlign: 'end',
-              iconAriaLabel: 'external icon on the left',
-            },
-          ]}
-        />
-      );
-
-      expect(wrapper.findItems()[0]!.findIcon()?.getElement()).toHaveClass(styles['icon-end']);
-      expect(wrapper.findItems()[0]!.findIcon()?.getElement()).toHaveAttribute('aria-label', 'info icon on the right');
-
-      expect(wrapper.findItems()[1]!.findIcon()?.getElement()).toHaveClass(styles['icon-start']);
-      expect(wrapper.findItems()[1]!.findIcon()?.getElement()).toHaveAttribute(
-        'aria-label',
-        'external icon on the left'
-      );
-    });
+        const previousSibling = wrapper.findItems()[1]!.findIcon()?.getElement().parentElement?.previousElementSibling;
+        expect(previousSibling?.firstChild).toBeInstanceOf(HTMLLabelElement);
+        expect(previousSibling?.textContent).toBe('Label at the start');
+        expect(wrapper.findItems()[1]!.findIcon()?.getElement()).toHaveAttribute(
+          'aria-label',
+          'external icon at the end'
+        );
+      }
+    );
   });
 
   describe('column layout', () => {

--- a/src/key-value-pairs/interfaces.ts
+++ b/src/key-value-pairs/interfaces.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import { IconProps } from '../icon/interfaces';
 import { BaseComponentProps } from '../internal/base-component';
 
 export interface KeyValuePairsProps extends BaseComponentProps {
@@ -52,6 +53,7 @@ export interface KeyValuePairsProps extends BaseComponentProps {
 
 export namespace KeyValuePairsProps {
   export type Item = Group | Pair;
+  export type IconAlign = 'start' | 'end';
 
   export interface Group {
     type: 'group';
@@ -64,5 +66,8 @@ export namespace KeyValuePairsProps {
     label: string;
     value: React.ReactNode;
     info?: React.ReactNode;
+    iconName?: IconProps.Name;
+    iconAlign?: KeyValuePairsProps.IconAlign;
+    iconAlt?: string;
   }
 }

--- a/src/key-value-pairs/interfaces.ts
+++ b/src/key-value-pairs/interfaces.ts
@@ -68,6 +68,6 @@ export namespace KeyValuePairsProps {
     info?: React.ReactNode;
     iconName?: IconProps.Name;
     iconAlign?: KeyValuePairsProps.IconAlign;
-    iconAlt?: string;
+    iconAriaLabel?: string;
   }
 }

--- a/src/key-value-pairs/internal.tsx
+++ b/src/key-value-pairs/internal.tsx
@@ -22,14 +22,23 @@ const InternalKeyValuePair = ({
   value,
   iconName,
   iconAlign = 'start',
-  iconAlt,
+  iconAriaLabel,
   id,
 }: KeyValuePairsProps.Pair) => {
   const kvPairId = useUniqueId('kv-pair-');
 
   const getLabelWithIcon = () => {
+    let rtlIconAlign = iconAlign;
+    if (getIsRtl(document.body)) {
+      rtlIconAlign = iconAlign === 'start' ? 'end' : 'start';
+    }
+
     const icon = iconName && (
-      <InternalIcon alt={iconAlt} name={iconName} className={clsx(styles.icon, styles[`icon-${iconAlign}`])} />
+      <InternalIcon
+        ariaLabel={iconAriaLabel}
+        name={iconName}
+        className={clsx(styles.icon, styles[`icon-${rtlIconAlign}`])}
+      />
     );
     const labelComponent = (
       <label className={styles['key-label']} id={id || kvPairId}>
@@ -37,12 +46,7 @@ const InternalKeyValuePair = ({
       </label>
     );
 
-    let iconAndLabelPair: React.ReactNode[] = [];
-    if (getIsRtl(document.body)) {
-      iconAndLabelPair = iconAlign === 'start' ? [labelComponent, icon] : [icon, labelComponent];
-    } else {
-      iconAndLabelPair = iconAlign === 'start' ? [icon, labelComponent] : [labelComponent, icon];
-    }
+    const iconAndLabelPair = rtlIconAlign === 'start' ? [icon, labelComponent] : [labelComponent, icon];
 
     return (
       <InternalSpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>

--- a/src/key-value-pairs/internal.tsx
+++ b/src/key-value-pairs/internal.tsx
@@ -3,28 +3,60 @@
 import React from 'react';
 import clsx from 'clsx';
 
+import { getIsRtl } from '@cloudscape-design/component-toolkit/internal';
+
 import Box from '../box/internal';
 import ColumnLayout from '../column-layout/internal';
+import InternalIcon from '../icon/internal';
 import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
 import { LinkDefaultVariantContext } from '../internal/context/link-default-variant-context';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
+import InternalSpaceBetween from '../space-between/internal';
 import { KeyValuePairsProps } from './interfaces';
 
 import styles from './styles.css.js';
 
-const InternalKeyValuePair = ({ label, info, value, id }: KeyValuePairsProps.Pair) => {
+const InternalKeyValuePair = ({
+  label,
+  info,
+  value,
+  iconName,
+  iconAlign = 'start',
+  iconAlt,
+  id,
+}: KeyValuePairsProps.Pair) => {
   const kvPairId = useUniqueId('kv-pair-');
 
-  return (
-    <>
-      <dt className={styles.term}>
-        <label className={styles['key-label']} id={id || kvPairId}>
-          {label}
-        </label>
+  const getLabelWithIcon = () => {
+    const icon = iconName && (
+      <InternalIcon alt={iconAlt} name={iconName} className={clsx(styles.icon, styles[`icon-${iconAlign}`])} />
+    );
+    const labelComponent = (
+      <label className={styles['key-label']} id={id || kvPairId}>
+        {label}
+      </label>
+    );
+
+    let iconAndLabelPair: React.ReactNode[] = [];
+    if (getIsRtl(document.body)) {
+      iconAndLabelPair = iconAlign === 'start' ? [labelComponent, icon] : [icon, labelComponent];
+    } else {
+      iconAndLabelPair = iconAlign === 'start' ? [icon, labelComponent] : [labelComponent, icon];
+    }
+
+    return (
+      <InternalSpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>
+        {iconAndLabelPair}
         <InfoLinkLabelContext.Provider value={id || kvPairId}>
           {info && <span className={styles.info}>{info}</span>}
         </InfoLinkLabelContext.Provider>
-      </dt>
+      </InternalSpaceBetween>
+    );
+  };
+
+  return (
+    <>
+      <dt className={styles.term}>{getLabelWithIcon()}</dt>
       <dd className={styles.detail}>{value}</dd>
     </>
   );

--- a/src/key-value-pairs/internal.tsx
+++ b/src/key-value-pairs/internal.tsx
@@ -3,8 +3,6 @@
 import React from 'react';
 import clsx from 'clsx';
 
-import { getIsRtl } from '@cloudscape-design/component-toolkit/internal';
-
 import Box from '../box/internal';
 import ColumnLayout from '../column-layout/internal';
 import InternalIcon from '../icon/internal';
@@ -28,25 +26,15 @@ const InternalKeyValuePair = ({
   const kvPairId = useUniqueId('kv-pair-');
 
   const getLabelWithIcon = () => {
-    let rtlIconAlign = iconAlign;
-    if (getIsRtl(document.body)) {
-      rtlIconAlign = iconAlign === 'start' ? 'end' : 'start';
-    }
-
-    const icon = iconName && (
-      <InternalIcon
-        ariaLabel={iconAriaLabel}
-        name={iconName}
-        className={clsx(styles.icon, styles[`icon-${rtlIconAlign}`])}
-      />
-    );
+    const icon = iconName && <InternalIcon ariaLabel={iconAriaLabel} name={iconName} className={styles.icon} />;
     const labelComponent = (
       <label className={styles['key-label']} id={id || kvPairId}>
         {label}
       </label>
     );
 
-    const iconAndLabelPair = rtlIconAlign === 'start' ? [icon, labelComponent] : [labelComponent, icon];
+    // Order the icon and label according to alignment
+    const iconAndLabelPair = iconAlign === 'start' ? [icon, labelComponent] : [labelComponent, icon];
 
     return (
       <InternalSpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>

--- a/src/key-value-pairs/internal.tsx
+++ b/src/key-value-pairs/internal.tsx
@@ -26,9 +26,11 @@ const InternalKeyValuePair = ({
   const kvPairId = useUniqueId('kv-pair-');
 
   const getLabelWithIcon = () => {
-    const icon = iconName && <InternalIcon ariaLabel={iconAriaLabel} name={iconName} className={styles.icon} />;
+    const icon = iconName && (
+      <InternalIcon key={`${label}-icon`} ariaLabel={iconAriaLabel} name={iconName} className={styles.icon} />
+    );
     const labelComponent = (
-      <label className={styles['key-label']} id={id || kvPairId}>
+      <label key={`${label}-label`} className={styles['key-label']} id={id || kvPairId}>
         {label}
       </label>
     );
@@ -39,7 +41,7 @@ const InternalKeyValuePair = ({
     return (
       <InternalSpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>
         {iconAndLabelPair}
-        <InfoLinkLabelContext.Provider value={id || kvPairId}>
+        <InfoLinkLabelContext.Provider key={`${label}-info-link`} value={id || kvPairId}>
           {info && <span className={styles.info}>{info}</span>}
         </InfoLinkLabelContext.Provider>
       </InternalSpaceBetween>

--- a/src/key-value-pairs/styles.scss
+++ b/src/key-value-pairs/styles.scss
@@ -34,14 +34,14 @@
 .key-label {
   @include styles.info-link-spacing;
 
-  > .icon-left {
+  > .icon-start {
     position: relative;
     // margin-left was breaking layout on firefox
     inset-inline-start: calc(-1 * #{awsui.$space-xxs});
     margin-inline-end: awsui.$space-xxs;
   }
 
-  > .icon-right {
+  > .icon-end {
     position: relative;
     // margin-right was breaking layout on firefox
     inset-inline-end: calc(-1 * #{awsui.$space-xxs});

--- a/src/key-value-pairs/styles.scss
+++ b/src/key-value-pairs/styles.scss
@@ -33,20 +33,6 @@
 
 .key-label {
   @include styles.info-link-spacing;
-
-  > .icon-start {
-    position: relative;
-    // margin-left was breaking layout on firefox
-    inset-inline-start: calc(-1 * #{awsui.$space-xxs});
-    margin-inline-end: awsui.$space-xxs;
-  }
-
-  > .icon-end {
-    position: relative;
-    // margin-right was breaking layout on firefox
-    inset-inline-end: calc(-1 * #{awsui.$space-xxs});
-    margin-inline-start: awsui.$space-xxs;
-  }
 }
 
 .detail {
@@ -63,7 +49,5 @@
 }
 
 .icon {
-  margin-inline-start: auto;
-  margin-inline-end: auto;
-  inset-inline: 0;
+  /*  used in test-utils */
 }

--- a/src/key-value-pairs/styles.scss
+++ b/src/key-value-pairs/styles.scss
@@ -33,6 +33,20 @@
 
 .key-label {
   @include styles.info-link-spacing;
+
+  > .icon-left {
+    position: relative;
+    // margin-left was breaking layout on firefox
+    inset-inline-start: calc(-1 * #{awsui.$space-xxs});
+    margin-inline-end: awsui.$space-xxs;
+  }
+
+  > .icon-right {
+    position: relative;
+    // margin-right was breaking layout on firefox
+    inset-inline-end: calc(-1 * #{awsui.$space-xxs});
+    margin-inline-start: awsui.$space-xxs;
+  }
 }
 
 .detail {
@@ -46,4 +60,10 @@
   display: inline-flex;
   padding-inline-start: awsui.$space-xs;
   border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+}
+
+.icon {
+  margin-inline-start: auto;
+  margin-inline-end: auto;
+  inset-inline: 0;
 }

--- a/src/test-utils/dom/key-value-pairs/index.ts
+++ b/src/test-utils/dom/key-value-pairs/index.ts
@@ -19,6 +19,10 @@ class KeyValuePairsPairWrapper extends ComponentWrapper {
   findInfo(): ElementWrapper | null {
     return this.findByClassName(styles.info);
   }
+
+  findIcon(): ElementWrapper | null {
+    return this.findByClassName(styles.icon);
+  }
 }
 
 class KeyValuePairsItemWrapper extends KeyValuePairsPairWrapper {


### PR DESCRIPTION
### Description

Adds 3 new props to support icons either infront or behind labels in `KeyValuePairs`:
- `iconName`
- `iconAlign`
- `iconAriaLabel`

Icon name follows the standard icon name options.
Icon align will allow control for `start` or `end` options, and maintains logical order when RTL is enabled.
Icon aria-label will set the underlying aria for the icon

Related links, issue #, if available:
`AWSUI-55326`

### How has this been tested?
Manual, unit (ltr, rtl)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
