### PR TITLE
fix: Popover is positioned incorrectly when the layout changes

### DIFF
--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -115,7 +115,9 @@ export default function PopoverContainer({
       }
 
       // Continuously update the popover position for one second to account for any layout changes
-      // and animations. This runs only while the CPU is otherwise idle.
+      // and animations. On browsers where `requestIdleCallback` is supported,
+      // this runs only while the CPU is otherwise idle. In other browsers (mainly Safari), we call it
+      // with a low frequency.
       const targetTime = performance.now() + 1_000;
 
       while (performance.now() < targetTime) {
@@ -124,7 +126,12 @@ export default function PopoverContainer({
         }
 
         updatePositionHandler();
-        await new Promise(r => requestIdleCallback(r));
+
+        if (typeof requestIdleCallback !== 'undefined') {
+          await new Promise(r => requestIdleCallback(r));
+        } else {
+          await new Promise(r => setTimeout(r, 50));
+        }
       }
     };
 


### PR DESCRIPTION
### Description

When an Annotation Popover is open, and the user interacts with the page so that the layout changes (e.g. toggling the side navigation panel), the Popover needs to update its position. With the existing heuristic, the Popover recalculates whenever the user clicks on the page (or interacts with a button using the keyboard), but the current logic assumes that any layout update then happens in a single frame. In the case of the navigation panel opening, it slides in with an animation, so the Popover only adapts to the first frame.

With this change, the Popover continuously updates its position for one second after the user interacts with the page. This should give enough time for any layout-related animations to finish, and it smoothly updates the Popover's position while its trigger moves. Since we're using `requestIdleCallback`, the browser will only execute these updates if the CPU is otherwise idle.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: 
- AWSUI-60630

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
