### PR TITLE
Do not bail on calculating position of popover if its trigger is inside Shadow DOM

### DIFF
--- a/src/popover/use-popover-position.ts
+++ b/src/popover/use-popover-position.ts
@@ -63,10 +63,14 @@ export default function usePopoverPosition({
       const document = popover.ownerDocument;
       const track = trackRef.current;
 
+      const rootNode = popover.getRootNode();
+      const isInShadowDom = rootNode !== document && rootNode.nodeType === Node.DOCUMENT_FRAGMENT_NODE;
+
       // If the popover body isn't being rendered for whatever reason (e.g. "display: none" or JSDOM),
       // or track does not belong to the document - bail on calculating dimensions.
       const { offsetWidth, offsetHeight } = getOffsetDimensions(popover);
-      if (offsetWidth === 0 || offsetHeight === 0 || !nodeContains(document.body, track)) {
+
+      if (offsetWidth === 0 || offsetHeight === 0 || !nodeContains(isInShadowDom ? rootNode : document.body, track)) {
         return;
       }
 


### PR DESCRIPTION
### Description

This PR fixes a problem that prevents Popovers from working from inside Shadow DOM.

Currently, Popover bails on calculating dimensions of its body if its trigger does not belong to the document. This check is done using `nodeContains` utility. This is an optimization to prevent calculations from running in virtual environments where Popover wouldn't work anyway. However, this also prevents Popover from working from inside Shadow DOM, as the `nodeContains` doesn't work across the Shadow DOM boundary and the check fails.

This PR fixes this by checking if Popover is rendered inside Shadow DOM, and if so, checking that the trigger is contained inside it. 

With this change customers will be able to use Popover in applications that use Shadow DOM.

Related links, issue #, if available: related to AWSUI-60527.

### How has this been tested?

1. unit tests
2. I have built a small playground page with a webcomponent wrapped in Shadow DOM that contains a Popover. I have verified that the Popover does not work in the playground before the fix, and does work after

   | before | after |
   |--|--|
   |![before](https://github.com/user-attachments/assets/a2164253-d43d-4974-ba8b-90ceb810091f)|![after](https://github.com/user-attachments/assets/8528fc12-b72a-4743-849c-5ab0509a4bad)|

   I can include the playground code into this PR, but the code is a bit hacky.


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
