### PR TITLE
feat: KeyValuePairs update pair label to ReactNode

### DIFF
--- a/pages/key-value-pairs/permutations.page.tsx
+++ b/pages/key-value-pairs/permutations.page.tsx
@@ -3,8 +3,10 @@
 import React from 'react';
 
 import { CopyToClipboard, ProgressBar } from '~components';
+import Icon from '~components/icon';
 import KeyValuePairs, { KeyValuePairsProps } from '~components/key-value-pairs';
 import Link from '~components/link';
+import SpaceBetween from '~components/space-between';
 import StatusIndicator from '~components/status-indicator';
 
 import createPermutations from '../utils/permutations';
@@ -352,6 +354,41 @@ const permutations = createPermutations<KeyValuePairsProps>([
               Value with external link
             </Link>
           ),
+        },
+      ],
+    ],
+  },
+  {
+    columns: [3],
+    items: [
+      [
+        {
+          label: (
+            <SpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>
+              <Icon key={'icon'} name={'status-info'} />
+              <div key={'label'}>Label for key</div>
+            </SpaceBetween>
+          ),
+          value: 'Info icon at the start',
+        },
+        {
+          label: (
+            <SpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>
+              <div key={'label'}>Label for key</div>
+              <Icon key={'icon'} name={'external'} />
+            </SpaceBetween>
+          ),
+          value: 'External icon at the end',
+        },
+        {
+          label: (
+            <SpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>
+              <div key={'label'}>Label for key</div>
+              <Icon key={'icon'} name={'external'} />
+            </SpaceBetween>
+          ),
+          value: 'External icon at the end with info link',
+          info: <Link>Info</Link>,
         },
       ],
     ],

--- a/pages/key-value-pairs/simple.page.tsx
+++ b/pages/key-value-pairs/simple.page.tsx
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import Icon from '~components/icon';
 import KeyValuePairs from '~components/key-value-pairs';
-import Link from '~components/link';
-import SpaceBetween from '~components/space-between';
 
 import ScreenshotArea from '../utils/screenshot-area';
 
@@ -29,34 +26,6 @@ export default function () {
                 {
                   label: 'Label for key',
                   value: 'Value',
-                },
-                {
-                  label: (
-                    <SpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>
-                      <Icon key={'icon'} name={'status-info'} />
-                      <div key={'label'}>Label for key</div>
-                    </SpaceBetween>
-                  ),
-                  value: 'Info icon at the start',
-                },
-                {
-                  label: (
-                    <SpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>
-                      <div key={'label'}>Label for key</div>
-                      <Icon key={'icon'} name={'external'} />
-                    </SpaceBetween>
-                  ),
-                  value: 'External icon at the end',
-                },
-                {
-                  label: (
-                    <SpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>
-                      <div key={'label'}>Label for key</div>
-                      <Icon key={'icon'} name={'external'} />
-                    </SpaceBetween>
-                  ),
-                  value: 'External icon at the end with info link',
-                  info: <Link>Info</Link>,
                 },
               ],
             },

--- a/pages/key-value-pairs/simple.page.tsx
+++ b/pages/key-value-pairs/simple.page.tsx
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import Icon from '~components/icon';
 import KeyValuePairs from '~components/key-value-pairs';
+import Link from '~components/link';
+import SpaceBetween from '~components/space-between';
 
 import ScreenshotArea from '../utils/screenshot-area';
 
@@ -26,6 +29,34 @@ export default function () {
                 {
                   label: 'Label for key',
                   value: 'Value',
+                },
+                {
+                  label: (
+                    <SpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>
+                      <Icon key={'icon'} name={'status-info'} />
+                      <div key={'label'}>Label for key</div>
+                    </SpaceBetween>
+                  ),
+                  value: 'Info icon at the start',
+                },
+                {
+                  label: (
+                    <SpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>
+                      <div key={'label'}>Label for key</div>
+                      <Icon key={'icon'} name={'external'} />
+                    </SpaceBetween>
+                  ),
+                  value: 'External icon at the end',
+                },
+                {
+                  label: (
+                    <SpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>
+                      <div key={'label'}>Label for key</div>
+                      <Icon key={'icon'} name={'external'} />
+                    </SpaceBetween>
+                  ),
+                  value: 'External icon at the end with info link',
+                  info: <Link>Info</Link>,
                 },
               ],
             },

--- a/src/key-value-pairs/__tests__/key-value-pairs.test.tsx
+++ b/src/key-value-pairs/__tests__/key-value-pairs.test.tsx
@@ -3,9 +3,11 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 
+import Icon from '../../../lib/components/icon';
 import KeyValuePairs from '../../../lib/components/key-value-pairs';
 import Link from '../../../lib/components/link';
-import createWrapper from '../../../lib/components/test-utils/dom';
+import SpaceBetween from '../../../lib/components/space-between';
+import createWrapper, { IconWrapper } from '../../../lib/components/test-utils/dom';
 
 function renderKeyValuePairs(jsx: React.ReactElement) {
   const { container, ...rest } = render(jsx);
@@ -28,6 +30,43 @@ describe('KeyValuePairs', () => {
 
       expect(wrapper.findItems()[0]!.findLabel()!.getElement()).toHaveTextContent('Label for key');
       expect(wrapper.findItems()[0]!.findValue()!.getElement()).toHaveTextContent('Value');
+    });
+
+    test('renders correctly with ReactNode label', () => {
+      const { wrapper } = renderKeyValuePairs(
+        <KeyValuePairs
+          items={[
+            {
+              label: (
+                <SpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>
+                  <Icon name={'status-info'} />
+                  Label after icon
+                </SpaceBetween>
+              ),
+              value: 'Value',
+            },
+            {
+              label: (
+                <SpaceBetween size={'xxs'} direction={'horizontal'} alignItems={'center'}>
+                  Label before icon
+                  <Icon name={'external'} />
+                </SpaceBetween>
+              ),
+              value: 'Value',
+            },
+          ]}
+        />
+      );
+
+      const firstLabel = wrapper.findItems()[0]!.findLabel();
+      expect(firstLabel!.getElement().firstElementChild!.children).toHaveLength(2);
+      expect(firstLabel!.findIcon()).toBeInstanceOf(IconWrapper);
+      expect(firstLabel!.getElement()).toHaveTextContent('Label after icon');
+
+      const secondLabel = wrapper.findItems()[1]!.findLabel();
+      expect(secondLabel!.getElement().firstElementChild!.children).toHaveLength(2);
+      expect(secondLabel!.findIcon()).toBeInstanceOf(IconWrapper);
+      expect(secondLabel!.getElement()).toHaveTextContent('Label before icon');
     });
 
     test('renders label with info correctly', () => {

--- a/src/key-value-pairs/interfaces.ts
+++ b/src/key-value-pairs/interfaces.ts
@@ -61,7 +61,7 @@ export namespace KeyValuePairsProps {
 
   export interface Pair extends BaseComponentProps {
     type?: 'pair';
-    label: string;
+    label: React.ReactNode;
     value: React.ReactNode;
     info?: React.ReactNode;
   }

--- a/src/key-value-pairs/styles.scss
+++ b/src/key-value-pairs/styles.scss
@@ -27,6 +27,7 @@
 
 .term {
   @include styles.font-label;
+  display: inline-flex;
   color: awsui.$color-text-label;
   margin-block-end: awsui.$space-key-value-gap;
 }


### PR DESCRIPTION
### Description

Update the `label` property to support `ReactNode` for custom components such as adding icons to the labels.

<img width="289" alt="image" src="https://github.com/user-attachments/assets/e7b50d84-63a8-44da-b942-16d1a24d1927" />

Related links, issue #, if available: n/a
`AWSUI-55326`
`08LJAUcYhg64`

### How has this been tested?
Manual, unit

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
