### PR TITLE
chore: Add ariaLabelledBy to InternalDragHandle component

### DIFF
--- a/src/internal/components/drag-handle/__tests__/drag-handle-button.test.tsx
+++ b/src/internal/components/drag-handle/__tests__/drag-handle-button.test.tsx
@@ -42,6 +42,17 @@ test('assigns aria label and aria description', () => {
   expect(document.querySelector(`.${styles.handle}`)).toHaveAccessibleDescription('handle');
 });
 
+test('assigns aria-labelledby attribute', () => {
+  render(
+    <div>
+      <div id="label-element">custom label</div>
+      <DragHandleButton ariaLabelledBy="label-element" />
+    </div>
+  );
+  expect(document.querySelector(`.${styles.handle}`)).toHaveAttribute('aria-labelledby', 'label-element');
+  expect(document.querySelector(`.${styles.handle}`)).toHaveAccessibleName('custom label');
+});
+
 test('has role="button" by default', () => {
   render(<DragHandleButton ariaLabel="drag handle" />);
 

--- a/src/internal/components/drag-handle/__tests__/drag-handle.test.tsx
+++ b/src/internal/components/drag-handle/__tests__/drag-handle.test.tsx
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import InternalDragHandle from '../../../../../lib/components/internal/components/drag-handle/index.js';
+
+import styles from '../../../../../lib/components/internal/components/drag-handle/styles.css.js';
+
+test('passes ariaLabelledBy to DragHandleButton', () => {
+  render(
+    <div>
+      <div id="label-element">custom label</div>
+      <InternalDragHandle ariaLabelledBy="label-element" />
+    </div>
+  );
+
+  expect(document.querySelector(`.${styles.handle}`)).toHaveAttribute('aria-labelledby', 'label-element');
+  expect(document.querySelector(`.${styles.handle}`)).toHaveAccessibleName('custom label');
+});

--- a/src/internal/components/drag-handle/button.tsx
+++ b/src/internal/components/drag-handle/button.tsx
@@ -18,6 +18,7 @@ const DragHandleButton = forwardRef(
       size = 'normal',
       className,
       ariaLabel,
+      ariaLabelledBy,
       ariaDescribedby,
       ariaValue,
       disabled,
@@ -62,6 +63,7 @@ const DragHandleButton = forwardRef(
           disabled && styles['handle-disabled']
         )}
         aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
         aria-describedby={ariaDescribedby}
         aria-disabled={disabled}
         aria-valuemax={ariaValue?.valueMax}

--- a/src/internal/components/drag-handle/index.tsx
+++ b/src/internal/components/drag-handle/index.tsx
@@ -15,6 +15,7 @@ const InternalDragHandle = forwardRef(
       variant,
       size,
       ariaLabel,
+      ariaLabelledBy,
       ariaDescribedby,
       tooltipText,
       ariaValue,
@@ -41,6 +42,7 @@ const InternalDragHandle = forwardRef(
           variant={variant}
           size={size}
           ariaLabel={ariaLabel}
+          ariaLabelledBy={ariaLabelledBy}
           ariaDescribedby={ariaDescribedby}
           ariaValue={ariaValue}
           disabled={disabled}

--- a/src/internal/components/drag-handle/interfaces.ts
+++ b/src/internal/components/drag-handle/interfaces.ts
@@ -10,6 +10,7 @@ export interface DragHandleProps {
   variant?: DragHandleProps.Variant;
   size?: DragHandleProps.Size;
   ariaLabel?: string;
+  ariaLabelledBy?: string;
   ariaDescribedby?: string;
   ariaValue?: DragHandleProps.AriaValue;
   disabled?: boolean;


### PR DESCRIPTION
### Description

This is needed for using the DragHandle component in the board components where we make use of ariaLabelledBy to reference multiple DragHandle's to one label.

Related links, issue #, if available: AWSUI-60240

### How has this been tested?

- added additional unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
