### PR TITLE
chore: Update PortalOverlay's position in DragHandleWrapper only when buttons are shown

### DIFF
--- a/src/internal/components/drag-handle-wrapper/__tests__/portal-overlay.test.tsx
+++ b/src/internal/components/drag-handle-wrapper/__tests__/portal-overlay.test.tsx
@@ -29,7 +29,7 @@ test('matches the position of the tracked element', async () => {
   const trackElement = document.createElement('span');
 
   render(
-    <PortalOverlay track={trackElement}>
+    <PortalOverlay track={trackElement} isDisabled={false}>
       <div id="overlay">Overlay</div>
     </PortalOverlay>
   );
@@ -47,12 +47,54 @@ test('matches the position of the tracked element in rtl', async () => {
   const trackElement = document.createElement('span');
 
   render(
-    <PortalOverlay track={trackElement}>
+    <PortalOverlay track={trackElement} isDisabled={false}>
       <div id="overlay">Overlay</div>
     </PortalOverlay>
   );
 
   const portalOverlay = document.querySelector<HTMLElement>(`.${styles['portal-overlay']}`)!;
+  await waitFor(() => {
+    expect(portalOverlay.style.translate).toBe('-2px 4px');
+    expect(portalOverlay.style.width).toBe('10px');
+    expect(portalOverlay.style.height).toBe('20px');
+  });
+});
+
+test('does not update position when disabled', async () => {
+  const trackElement = document.createElement('span');
+
+  render(
+    <PortalOverlay track={trackElement} isDisabled={true}>
+      <div id="overlay">Overlay</div>
+    </PortalOverlay>
+  );
+
+  const portalOverlay = document.querySelector<HTMLElement>(`.${styles['portal-overlay']}`)!;
+  await waitFor(() => {
+    expect(portalOverlay.style.translate).toBeUndefined();
+    expect(portalOverlay.style.width).toBe('');
+    expect(portalOverlay.style.height).toBe('');
+  });
+});
+
+test('resumes position updates when enabled after being disabled', async () => {
+  const trackElement = document.createElement('span');
+
+  const PortalOverlayWrapper = ({ isDisabled }: { isDisabled: boolean }) => (
+    <PortalOverlay track={trackElement} isDisabled={isDisabled}>
+      <div id="overlay">Overlay</div>
+    </PortalOverlay>
+  );
+
+  const { rerender } = render(<PortalOverlayWrapper isDisabled={true} />);
+  const portalOverlay = document.querySelector<HTMLElement>(`.${styles['portal-overlay']}`)!;
+  await waitFor(() => {
+    expect(portalOverlay.style.translate).toBeUndefined();
+    expect(portalOverlay.style.width).toBe('');
+    expect(portalOverlay.style.height).toBe('');
+  });
+
+  rerender(<PortalOverlayWrapper isDisabled={false} />);
   await waitFor(() => {
     expect(portalOverlay.style.translate).toBe('-2px 4px');
     expect(portalOverlay.style.width).toBe('10px');

--- a/src/internal/components/drag-handle-wrapper/__tests__/portal-overlay.test.tsx
+++ b/src/internal/components/drag-handle-wrapper/__tests__/portal-overlay.test.tsx
@@ -22,6 +22,7 @@ jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
 }));
 
 afterEach(() => {
+  isRtl = false;
   jest.restoreAllMocks();
 });
 
@@ -96,7 +97,7 @@ test('resumes position updates when enabled after being disabled', async () => {
 
   rerender(<PortalOverlayWrapper isDisabled={false} />);
   await waitFor(() => {
-    expect(portalOverlay.style.translate).toBe('-2px 4px');
+    expect(portalOverlay.style.translate).toBe('2px 4px');
     expect(portalOverlay.style.width).toBe('10px');
     expect(portalOverlay.style.height).toBe('20px');
   });

--- a/src/internal/components/drag-handle-wrapper/index.tsx
+++ b/src/internal/components/drag-handle-wrapper/index.tsx
@@ -189,7 +189,7 @@ export default function DragHandleWrapper({
         )}
       </div>
 
-      <PortalOverlay track={dragHandleRef.current}>
+      <PortalOverlay track={dragHandleRef.current} isDisabled={!showButtons}>
         {directions['block-start'] && (
           <DirectionButton
             show={!isDisabled && showButtons}

--- a/src/internal/components/drag-handle-wrapper/portal-overlay.tsx
+++ b/src/internal/components/drag-handle-wrapper/portal-overlay.tsx
@@ -12,11 +12,19 @@ import Portal from '../portal';
 
 import styles from './styles.css.js';
 
-export default function PortalOverlay({ track, children }: { track: HTMLElement | null; children: React.ReactNode }) {
+export default function PortalOverlay({
+  track,
+  isDisabled,
+  children,
+}: {
+  track: HTMLElement | null;
+  isDisabled: boolean;
+  children: React.ReactNode;
+}) {
   const ref = useRef<HTMLSpanElement | null>(null);
 
   useEffect(() => {
-    if (track === null) {
+    if (track === null || isDisabled) {
       return;
     }
 
@@ -56,7 +64,7 @@ export default function PortalOverlay({ track, children }: { track: HTMLElement 
     return () => {
       cleanedUp = true;
     };
-  }, [track]);
+  }, [isDisabled, track]);
 
   if (track === null) {
     return null;


### PR DESCRIPTION
### Description

Before this change, the update position effect has been run on every animation frame even though no position buttons have been shown.

With this change, the position calculation is only done when the position buttons are visible.

Related links, issue #, if available: AWSUI-60240

### How has this been tested?

- manually tested in supported browsers
- added additonal unit tests
- screenshot tests in my pipeline run green

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
