### PR TITLE
fix: Do not render "select all" when there are no options to select

### DIFF
--- a/src/multiselect/__tests__/select-all.test.tsx
+++ b/src/multiselect/__tests__/select-all.test.tsx
@@ -103,14 +103,17 @@ describe('Multiselect with "select all" control', () => {
     expect(dropdown.findOptionByValue('1')).toBeNull();
   });
 
-  test('is hidden when there are no options to select', () => {
-    const wrapper = renderMultiselectWithSelectAll({ options: [] });
-    wrapper.openDropdown();
-    const dropdown = wrapper.findDropdown();
-    const options = dropdown.findOptions();
-    expect(options.length).toBe(0);
-    expect(dropdown.findSelectAll()).toBe(null);
-  });
+  test.each([false, true])(
+    'is hidden when there are no options to select [virtuaScroll=%s]',
+    (virtualScroll: boolean) => {
+      const wrapper = renderMultiselectWithSelectAll({ options: [], virtualScroll });
+      wrapper.openDropdown();
+      const dropdown = wrapper.findDropdown();
+      const options = dropdown.findOptions();
+      expect(options.length).toBe(0);
+      expect(dropdown.findSelectAll()).toBe(null);
+    }
+  );
 
   describe('with filtering', () => {
     test('does not select non-visible options', () => {

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -141,6 +141,7 @@ const InternalMultiselect = React.forwardRef(
 
     const dropdownStatus = multiselectProps.dropdownStatus;
     const dropdownProps = multiselectProps.getDropdownProps();
+    const hasFilteredOptions = multiselectProps.filteredOptions.length > 0;
 
     return (
       <div
@@ -182,7 +183,7 @@ const InternalMultiselect = React.forwardRef(
             useInteractiveGroups={true}
             screenReaderContent={multiselectProps.announcement}
             highlightType={multiselectProps.highlightType}
-            firstOptionSticky={enableSelectAll}
+            firstOptionSticky={hasFilteredOptions && enableSelectAll}
           />
         </Dropdown>
 


### PR DESCRIPTION
### Description

Before: "Select all" appeared on empty virtualScroll multiselect causing a JS error.
After: "Select all" is not rendered when no options are available.

Fixes #3432

Related links, issue #, if available: `AWSUI-60656`

### How has this been tested?

- verified manually be recreating the failing scenario and test the changes.
- updated existing unit test to test test in both `virtualScroll` modes.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
