### PR TITLE
fix: Fix info link alignment in KeyValuePairs

### DIFF
--- a/src/key-value-pairs/styles.scss
+++ b/src/key-value-pairs/styles.scss
@@ -27,12 +27,12 @@
 
 .term {
   @include styles.font-label;
-  display: inline-flex;
   color: awsui.$color-text-label;
   margin-block-end: awsui.$space-key-value-gap;
 }
 
 .key-label {
+  display: inline-flex;
   @include styles.info-link-spacing;
 }
 


### PR DESCRIPTION
### Description

After a previous PR that changed the `label` prop into a `ReactNode` the alignment of the info icon was changed.
This PR fixes that by moving the `display: inline-flex` style to the `key-label` instead of the whole label including the info link.

Before:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/c3f6931b-e3fe-4680-8658-0f24248c4b81" />

After:
<img width="186" alt="image" src="https://github.com/user-attachments/assets/02457a9a-0e6a-4175-b210-7d1029bd7d8c" />

### How has this been tested?

Manual, error brought up via screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
