### PR TITLE
chore: ButtonDropdown main action with external link opens link in a new tab

### DIFF
--- a/src/button-dropdown/__tests__/button-dropdown.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown.test.tsx
@@ -241,6 +241,16 @@ describe('with main action', () => {
     expect(onFollow).not.toHaveBeenCalled();
   });
 
+  test('main action with external link opens link in a new tab', () => {
+    const wrapper = renderSplitButtonDropdown({
+      mainAction: { text: 'Main', href: 'https://external.com', external: true },
+    });
+
+    const mainActionElement = wrapper.findMainAction()!.getElement();
+    expect(mainActionElement).toHaveAttribute('target', '_blank');
+    expect(mainActionElement).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
   test('main action onFollow is triggered', () => {
     const onClick = jest.fn();
     const onFollow = jest.fn();

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -221,7 +221,7 @@ const InternalButtonDropdown = React.forwardRef(
       const { text, iconName, iconAlt, iconSvg, iconUrl, external, externalIconAriaLabel, ...mainActionProps } =
         mainAction;
       const mainActionIconProps = external
-        ? ({ iconName: 'external', iconAlign: 'right' } as const)
+        ? ({ iconName: 'external', iconAlign: 'right', target: '_blank', rel: 'noopener noreferrer' } as const)
         : ({ iconName, iconAlt, iconSvg, iconUrl } as const);
       const mainActionAriaLabel = externalIconAriaLabel
         ? `${mainAction.ariaLabel ?? mainAction.text} ${mainAction.externalIconAriaLabel}`


### PR DESCRIPTION
### Description

Before this change, builders needed to provide the `target` and the `rel` properties to open the link in a new tab, even marked as `external`.

With this change, the two properties are added when the main action is marked as external.

Why not just setting `external=true` on the `InternalButton`? This results in a more compact arrangement of the external icon and button text.

Related links, issue #, if available: `AWSUI-60663`

### How has this been tested?

- added additional unit tests.
- manually tested by adding an external link to to main action in `pages/button-dropdown/main-action.page.tsx`

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
