### PR TITLE
fix: Fix off-center popover flash when clicking CopyToClipboard

### DIFF
--- a/src/copy-to-clipboard/internal.tsx
+++ b/src/copy-to-clipboard/internal.tsx
@@ -70,7 +70,9 @@ export default function InternalCopyToClipboard({
       triggerType="custom"
       dismissButton={false}
       renderWithPortal={popoverRenderWithPortal}
-      content={<InternalStatusIndicator type={status}>{statusText}</InternalStatusIndicator>}
+      content={
+        status === 'pending' ? null : <InternalStatusIndicator type={status}>{statusText}</InternalStatusIndicator>
+      }
       __onOpen={onClick}
     >
       <InternalButton

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -153,6 +153,45 @@ describe('Dismiss button', () => {
       });
       expect(wrapper.findBody({ renderWithPortal })).toBeTruthy();
     });
+
+    it('does not render the popover body if content is null when a click is fired on the trigger', () => {
+      const wrapper = renderPopover({ children: 'Trigger', content: null, renderWithPortal });
+      wrapper.findTrigger().click();
+      act(() => {
+        wrapper
+          .findTrigger()
+          .getElement()
+          .dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      });
+      expect(wrapper.findBody({ renderWithPortal })).toBeNull();
+    });
+
+    it('renders the popover body if content becomes non-null after a click is fired on the trigger', () => {
+      const { container, rerender } = render(
+        <Popover content={null} renderWithPortal={renderWithPortal}>
+          Trigger
+        </Popover>
+      );
+      const wrapper = new PopoverInternalWrapper(container);
+
+      wrapper.findTrigger().click();
+      act(() => {
+        wrapper
+          .findTrigger()
+          .getElement()
+          .dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      });
+      expect(wrapper.findBody({ renderWithPortal })).toBeNull();
+
+      // Update the props with non-null content
+      rerender(
+        <Popover content="Popover Content" renderWithPortal={renderWithPortal}>
+          Trigger
+        </Popover>
+      );
+
+      expect(wrapper.findBody({ renderWithPortal })).toBeTruthy();
+    });
   });
 });
 

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -147,37 +147,38 @@ function InternalPopover(
 
   const referrerId = useUniqueId();
 
-  const popoverContent = (
-    <div
-      aria-live={dismissButton ? undefined : 'polite'}
-      aria-atomic={dismissButton ? undefined : true}
-      className={clsx(popoverClasses, !renderWithPortal && styles['popover-inline-content'])}
-      data-awsui-referrer-id={referrerId}
-    >
-      <PopoverContainer
-        size={size}
-        fixedWidth={fixedWidth}
-        position={position}
-        trackRef={triggerRef}
-        arrow={position => <Arrow position={position} />}
-        renderWithPortal={renderWithPortal}
-        zIndex={renderWithPortal ? 7000 : undefined}
+  const popoverContent =
+    content === null ? null : (
+      <div
+        aria-live={dismissButton ? undefined : 'polite'}
+        aria-atomic={dismissButton ? undefined : true}
+        className={clsx(popoverClasses, !renderWithPortal && styles['popover-inline-content'])}
+        data-awsui-referrer-id={referrerId}
       >
-        <LinkDefaultVariantContext.Provider value={{ defaultVariant: 'primary' }}>
-          <PopoverBody
-            dismissButton={dismissButton}
-            dismissAriaLabel={dismissAriaLabel}
-            header={header}
-            onDismiss={onDismiss}
-            overflowVisible="both"
-            closeAnalyticsAction={__closeAnalyticsAction}
-          >
-            {content}
-          </PopoverBody>
-        </LinkDefaultVariantContext.Provider>
-      </PopoverContainer>
-    </div>
-  );
+        <PopoverContainer
+          size={size}
+          fixedWidth={fixedWidth}
+          position={position}
+          trackRef={triggerRef}
+          arrow={position => <Arrow position={position} />}
+          renderWithPortal={renderWithPortal}
+          zIndex={renderWithPortal ? 7000 : undefined}
+        >
+          <LinkDefaultVariantContext.Provider value={{ defaultVariant: 'primary' }}>
+            <PopoverBody
+              dismissButton={dismissButton}
+              dismissAriaLabel={dismissAriaLabel}
+              header={header}
+              onDismiss={onDismiss}
+              overflowVisible="both"
+              closeAnalyticsAction={__closeAnalyticsAction}
+            >
+              {content}
+            </PopoverBody>
+          </LinkDefaultVariantContext.Provider>
+        </PopoverContainer>
+      </div>
+    );
 
   const mergedRef = useMergeRefs(popoverRef, __internalRootRef);
 
@@ -215,7 +216,7 @@ function InternalPopover(
           {children}
         </span>
       )}
-      {visible && (
+      {visible && popoverContent !== null && (
         <ResetContextsForModal>
           {renderWithPortal ? <Portal>{popoverContent}</Portal> : popoverContent}
         </ResetContextsForModal>


### PR DESCRIPTION
### Description

Because the clipboard API is async, the `CopyToClipboard` popover briefly renders in the "pending" state before rendering in the "success" or "error" state, which is perceived as a visual glitch.

The fix here is to wait to open the popover until we're out of the "pending" state. To achieve that, I've modified the `InternalPopover` API so that it doesn't render a popover if the given `content` is `null`, regardless of its internal `visible` state.

### How has this been tested?

You can replicate the bug and verify this fix in the local demo: Run `npm run start`, open the local URL, then go to any of the `CopyToClipboard` examples and click around.

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
