### PR TITLE
feat: Update analytics metadata expand event treatment for button dro…

### DIFF
--- a/src/breadcrumb-group/__tests__/analytics-metadata.test.tsx
+++ b/src/breadcrumb-group/__tests__/analytics-metadata.test.tsx
@@ -7,6 +7,10 @@ import { activateAnalyticsMetadata } from '@cloudscape-design/component-toolkit/
 import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata/utils';
 
 import BreadcrumbGroup from '../../../lib/components/breadcrumb-group';
+import {
+  GeneratedAnalyticsMetadataBreadcrumbGroupCollapse,
+  GeneratedAnalyticsMetadataBreadcrumbGroupExpand,
+} from '../../../lib/components/breadcrumb-group/analytics-metadata/interfaces';
 import { getItemsDisplayProperties } from '../../../lib/components/breadcrumb-group/utils';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { validateComponentNameAndLabels } from '../../internal/__tests__/analytics-metadata-test-utils';
@@ -98,22 +102,26 @@ describe('BreadcrumbGroup renders correct analytics metadata', () => {
     });
     const triggerButton = wrapper.findDropdown()!.findTriggerButton()!;
     validateComponentNameAndLabels(triggerButton.getElement(), labels);
-    expect(getGeneratedAnalyticsMetadata(triggerButton.getElement())).toEqual({
+    const expectedExpandMetadata: GeneratedAnalyticsMetadataBreadcrumbGroupExpand = {
       action: 'expand',
       detail: {
         label: '...',
-        expanded: 'true',
       },
+    };
+    expect(getGeneratedAnalyticsMetadata(triggerButton.getElement())).toEqual({
+      ...expectedExpandMetadata,
       contexts,
     });
 
     triggerButton.click();
-    expect(getGeneratedAnalyticsMetadata(triggerButton.getElement())).toEqual({
-      action: 'expand',
+    const expectedCollapseMetadata: GeneratedAnalyticsMetadataBreadcrumbGroupCollapse = {
+      action: 'collapse',
       detail: {
         label: '...',
-        expanded: 'false',
       },
+    };
+    expect(getGeneratedAnalyticsMetadata(triggerButton.getElement())).toEqual({
+      ...expectedCollapseMetadata,
       contexts,
     });
 

--- a/src/breadcrumb-group/analytics-metadata/interfaces.ts
+++ b/src/breadcrumb-group/analytics-metadata/interfaces.ts
@@ -12,6 +12,20 @@ export interface GeneratedAnalyticsMetadataBreadcrumbGroupClick {
   };
 }
 
+export interface GeneratedAnalyticsMetadataBreadcrumbGroupExpand {
+  action: 'expand';
+  detail: {
+    label: string;
+  };
+}
+
+export interface GeneratedAnalyticsMetadataBreadcrumbGroupCollapse {
+  action: 'collapse';
+  detail: {
+    label: string;
+  };
+}
+
 export interface GeneratedAnalyticsMetadataBreadcrumbGroupComponent {
   name: 'awsui.BreadcrumbGroup';
   label: string | LabelIdentifier;

--- a/src/button-dropdown/__tests__/analytics-metadata.test.tsx
+++ b/src/button-dropdown/__tests__/analytics-metadata.test.tsx
@@ -74,7 +74,22 @@ describe('Button Dropdown renders correct analytics metadata', () => {
       validateComponentNameAndLabels(nativeButton, labels);
       expect(getGeneratedAnalyticsMetadata(nativeButton)).toEqual({
         action: 'expand',
-        detail: { expanded: 'true', label },
+        detail: { label },
+        ...getMetadataContexts(label, 'normal'),
+      });
+    });
+    test('when expanded', () => {
+      const label = 'Action text';
+      const wrapper = renderButtonDropdown({
+        items,
+        children: label,
+      });
+      wrapper.findTriggerButton()?.click();
+      const nativeButton = wrapper.findTriggerButton()!.getElement();
+      validateComponentNameAndLabels(nativeButton, labels);
+      expect(getGeneratedAnalyticsMetadata(nativeButton)).toEqual({
+        action: 'collapse',
+        detail: { label },
         ...getMetadataContexts(label, 'normal'),
       });
     });
@@ -100,7 +115,7 @@ describe('Button Dropdown renders correct analytics metadata', () => {
       validateComponentNameAndLabels(nativeButton, labels);
       expect(getGeneratedAnalyticsMetadata(nativeButton)).toEqual({
         action: 'expand',
-        detail: { expanded: 'true', label },
+        detail: { label },
         ...getMetadataContexts(label, 'icon'),
       });
     });
@@ -115,7 +130,7 @@ describe('Button Dropdown renders correct analytics metadata', () => {
       validateComponentNameAndLabels(nativeButton, labels);
       expect(getGeneratedAnalyticsMetadata(nativeButton)).toEqual({
         action: 'expand',
-        detail: { expanded: 'true', label },
+        detail: { label },
         ...getMetadataContexts(label, 'primary'),
       });
     });
@@ -131,7 +146,7 @@ describe('Button Dropdown renders correct analytics metadata', () => {
       validateComponentNameAndLabels(nativeButton, labels);
       expect(getGeneratedAnalyticsMetadata(nativeButton)).toEqual({
         action: 'expand',
-        detail: { expanded: 'true', label },
+        detail: { label },
         ...getMetadataContexts(label, 'primary'),
       });
       const mainAction = wrapper.findMainAction()!.getElement();
@@ -215,7 +230,14 @@ describe('Button Dropdown renders correct analytics metadata', () => {
       validateComponentNameAndLabels(enabledCategory, labels);
       expect(getGeneratedAnalyticsMetadata(enabledCategory)).toEqual({
         action: 'expand',
-        detail: { label: 'Instances', id: 'instances', position: '3', expanded: 'true' },
+        detail: { label: 'Instances', id: 'instances', position: '3' },
+        ...getMetadataContexts(label, 'normal'),
+      });
+
+      wrapper.findExpandableCategoryById('instances')?.click();
+      expect(getGeneratedAnalyticsMetadata(enabledCategory)).toEqual({
+        action: 'collapse',
+        detail: { label: 'Instances', id: 'instances', position: '3' },
         ...getMetadataContexts(label, 'normal'),
       });
 
@@ -255,7 +277,6 @@ describe('Internal Button Dropdown', () => {
       action: 'expand',
       detail: {
         label: 'Action text',
-        expanded: 'true',
       },
     });
   });

--- a/src/button-dropdown/analytics-metadata/interfaces.ts
+++ b/src/button-dropdown/analytics-metadata/interfaces.ts
@@ -17,7 +17,15 @@ export interface GeneratedAnalyticsMetadataButtonDropdownExpand {
   action: 'expand';
   detail: {
     label: string | LabelIdentifier;
-    expanded: string;
+    position?: string;
+    id?: string;
+  };
+}
+
+export interface GeneratedAnalyticsMetadataButtonDropdownCollapse {
+  action: 'collapse';
+  detail: {
+    label: string | LabelIdentifier;
     position?: string;
     id?: string;
   };

--- a/src/button-dropdown/category-elements/expandable-category-element.tsx
+++ b/src/button-dropdown/category-elements/expandable-category-element.tsx
@@ -8,7 +8,10 @@ import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-tool
 import InternalIcon from '../../icon/internal';
 import Dropdown from '../../internal/components/dropdown';
 import useHiddenDescription from '../../internal/hooks/use-hidden-description';
-import { GeneratedAnalyticsMetadataButtonDropdownExpand } from '../analytics-metadata/interfaces.js';
+import {
+  GeneratedAnalyticsMetadataButtonDropdownCollapse,
+  GeneratedAnalyticsMetadataButtonDropdownExpand,
+} from '../analytics-metadata/interfaces.js';
 import { CategoryProps } from '../interfaces';
 import ItemsList from '../items-list';
 import Tooltip from '../tooltip.js';
@@ -75,14 +78,13 @@ const ExpandableCategoryElement = ({
         disabled
           ? {}
           : ({
-              action: 'expand',
+              action: !expanded ? 'expand' : 'collapse',
               detail: {
                 position: position || '0',
                 label: { root: 'self' },
                 id: item.id || '',
-                expanded: `${!expanded}`,
               },
-            } as GeneratedAnalyticsMetadataButtonDropdownExpand)
+            } as GeneratedAnalyticsMetadataButtonDropdownExpand | GeneratedAnalyticsMetadataButtonDropdownCollapse)
       )}
     >
       {item.text}

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -19,7 +19,10 @@ import { useVisualRefresh } from '../internal/hooks/use-visual-mode/index.js';
 import { isDevelopment } from '../internal/is-development';
 import { spinWhenOpen } from '../internal/styles/motion/utils';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
-import { GeneratedAnalyticsMetadataButtonDropdownExpand } from './analytics-metadata/interfaces.js';
+import {
+  GeneratedAnalyticsMetadataButtonDropdownCollapse,
+  GeneratedAnalyticsMetadataButtonDropdownExpand,
+} from './analytics-metadata/interfaces.js';
 import { ButtonDropdownProps, InternalButtonDropdownProps } from './interfaces';
 import ItemsList from './items-list';
 import { useButtonDropdown } from './utils/use-button-dropdown';
@@ -192,12 +195,14 @@ const InternalButtonDropdown = React.forwardRef(
 
     let trigger: React.ReactNode = null;
 
-    const analyticsMetadata: GeneratedAnalyticsMetadataButtonDropdownExpand | Record<string, never> = disabled
+    const analyticsMetadata:
+      | GeneratedAnalyticsMetadataButtonDropdownExpand
+      | GeneratedAnalyticsMetadataButtonDropdownCollapse
+      | Record<string, never> = disabled
       ? {}
       : {
-          action: 'expand',
+          action: !isOpen ? 'expand' : 'collapse',
           detail: {
-            expanded: `${!isOpen}`,
             label: `.${analyticsSelectors['trigger-label']}`,
           },
         };

--- a/src/tabs/__tests__/analytics-metadata.test.tsx
+++ b/src/tabs/__tests__/analytics-metadata.test.tsx
@@ -168,7 +168,6 @@ describe('Tabs renders correct analytics metadata', () => {
     expect(getGeneratedAnalyticsMetadata(firstActions)).toEqual({
       action: 'expand',
       detail: {
-        expanded: 'true',
         label: 'Query actions for first tab',
       },
       contexts: [
@@ -214,7 +213,6 @@ describe('Tabs renders correct analytics metadata', () => {
     expect(getGeneratedAnalyticsMetadata(secondActions)).toEqual({
       action: 'expand',
       detail: {
-        expanded: 'true',
         label: 'Query actions for second tab',
       },
       contexts: [


### PR DESCRIPTION
…pdown

### Description

Currently `expand` events are being post-processed by the analytics team to rename them to `collapse` if `expanded=false`. This saves storage for events database tables.

Changing this will align with the actual usage.

### How has this been tested?

Updated unit tests, and added more

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ Yes, the Analytics team logic already supports the new native format.
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ N/A
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes
- _Changes are covered with new/existing integration tests?_ N/A
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
