### PR TITLE
feat: Update analytics metadata expand event treatment for expandable…

### DIFF
--- a/src/expandable-section/__tests__/analytics-metadata.test.tsx
+++ b/src/expandable-section/__tests__/analytics-metadata.test.tsx
@@ -44,9 +44,8 @@ const getContextsMetadata = (label: string, variant: string, expanded: boolean) 
 
 const getExpandMetadata = (label: string, variant: string, expanded: boolean) => ({
   ...getContextsMetadata(label, variant, expanded),
-  action: 'expand',
+  action: !expanded ? 'expand' : 'collapse',
   detail: {
-    expanded: `${!expanded}`,
     label,
   },
 });
@@ -139,7 +138,6 @@ test('Internal ExpandableSection does not render "component" metadata', () => {
     action: 'expand',
     detail: {
       label: 'whatever',
-      expanded: 'true',
     },
   });
 });

--- a/src/expandable-section/analytics-metadata/interfaces.ts
+++ b/src/expandable-section/analytics-metadata/interfaces.ts
@@ -6,8 +6,14 @@ import { LabelIdentifier } from '@cloudscape-design/component-toolkit/internal/a
 export interface GeneratedAnalyticsMetadataExpandableSectionExpand {
   action: 'expand';
   detail: {
-    label: LabelIdentifier;
-    expanded: string;
+    label: string | LabelIdentifier;
+  };
+}
+
+export interface GeneratedAnalyticsMetadataExpandableSectionCollapse {
+  action: 'collapse';
+  detail: {
+    label: string | LabelIdentifier;
   };
 }
 

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -9,7 +9,10 @@ import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-tool
 import InternalHeader, { Description as HeaderDescription } from '../header/internal';
 import InternalIcon from '../icon/internal';
 import { isDevelopment } from '../internal/is-development';
-import { GeneratedAnalyticsMetadataExpandableSectionExpand } from './analytics-metadata/interfaces';
+import {
+  GeneratedAnalyticsMetadataExpandableSectionCollapse,
+  GeneratedAnalyticsMetadataExpandableSectionExpand,
+} from './analytics-metadata/interfaces';
 import { ExpandableSectionProps, InternalVariant } from './interfaces';
 import {
   variantRequiresActionsDivider,
@@ -62,11 +65,12 @@ interface ExpandableSectionHeaderProps extends Omit<ExpandableDefaultHeaderProps
 }
 
 const getExpandActionAnalyticsMetadataAttribute = (expanded: boolean) => {
-  const metadata: GeneratedAnalyticsMetadataExpandableSectionExpand = {
-    action: 'expand',
+  const metadata:
+    | GeneratedAnalyticsMetadataExpandableSectionExpand
+    | GeneratedAnalyticsMetadataExpandableSectionCollapse = {
+    action: !expanded ? 'expand' : 'collapse',
     detail: {
       label: { rootSelector: `.${analyticsSelectors.root}` },
-      expanded: `${!expanded}`,
     },
   };
   return getAnalyticsMetadataAttribute(metadata);

--- a/src/side-navigation/__tests__/analytics-metadata.test.tsx
+++ b/src/side-navigation/__tests__/analytics-metadata.test.tsx
@@ -11,6 +11,10 @@ import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-tool
 
 import Badge from '../../../lib/components/badge';
 import SideNavigation, { SideNavigationProps } from '../../../lib/components/side-navigation';
+import {
+  GeneratedAnalyticsMetadataSideNavigationCollapse,
+  GeneratedAnalyticsMetadataSideNavigationExpand,
+} from '../../../lib/components/side-navigation/analytics-metadata/interfaces';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { validateComponentNameAndLabels } from '../../internal/__tests__/analytics-metadata-test-utils';
 
@@ -94,14 +98,21 @@ const getClickGeneratedMetadata = (label: string, position: string, href: string
   ...getMetadataContexts(),
 });
 
-const getExpandGeneratedMetadata = (label: string, expanded = 'false') => ({
-  action: 'expand',
-  detail: {
-    expanded,
-    label,
-  },
-  ...getMetadataContexts(),
-});
+const getExpandGeneratedMetadata = (label: string, expanded = false) => {
+  const partialMetadata:
+    | GeneratedAnalyticsMetadataSideNavigationExpand
+    | GeneratedAnalyticsMetadataSideNavigationCollapse = {
+    action: !expanded ? 'expand' : 'collapse',
+    detail: {
+      label,
+    },
+  };
+
+  return {
+    ...partialMetadata,
+    ...getMetadataContexts(),
+  };
+};
 
 beforeAll(() => {
   activateAnalyticsMetadata(true);
@@ -176,14 +187,14 @@ describe('Side Navigation renders correct analytics metadata', () => {
 
       const expandButton = wrapper.findItemByIndex(4)!.findSection()!.findExpandButton()!.getElement();
       validateComponentNameAndLabels(expandButton, labels);
-      expect(getGeneratedAnalyticsMetadata(expandButton)).toEqual(getExpandGeneratedMetadata('Section heading'));
+      expect(getGeneratedAnalyticsMetadata(expandButton)).toEqual(getExpandGeneratedMetadata('Section heading', true));
     });
     test('in expandable link group', () => {
       const wrapper = renderSideNavigation();
 
       const expandButton = wrapper.findItemByIndex(6)!.findExpandableLinkGroup()!.findExpandButton()!.getElement();
       validateComponentNameAndLabels(expandButton, labels);
-      expect(getGeneratedAnalyticsMetadata(expandButton)).toEqual(getExpandGeneratedMetadata('Parent page', 'true'));
+      expect(getGeneratedAnalyticsMetadata(expandButton)).toEqual(getExpandGeneratedMetadata('Parent page'));
     });
   });
 });

--- a/src/side-navigation/analytics-metadata/interfaces.ts
+++ b/src/side-navigation/analytics-metadata/interfaces.ts
@@ -1,6 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+  GeneratedAnalyticsMetadataExpandableSectionCollapse,
+  GeneratedAnalyticsMetadataExpandableSectionExpand,
+} from '../../expandable-section/analytics-metadata/interfaces';
+
 export interface GeneratedAnalyticsMetadataSideNavigationClick {
   action: 'click';
   detail: {
@@ -10,6 +15,9 @@ export interface GeneratedAnalyticsMetadataSideNavigationClick {
     external: string;
   };
 }
+
+export type GeneratedAnalyticsMetadataSideNavigationExpand = GeneratedAnalyticsMetadataExpandableSectionExpand;
+export type GeneratedAnalyticsMetadataSideNavigationCollapse = GeneratedAnalyticsMetadataExpandableSectionCollapse;
 
 export interface GeneratedAnalyticsMetadataSideNavigationComponent {
   name: 'awsui.SideNavigation';


### PR DESCRIPTION
… section

### Description

Currently `expand` events are being post-processed by the analytics team to rename them to `collapse` if `expanded=false`. This saves storage for events database tables.

Changing this will align with the actual usage.

### How has this been tested?

Updated unit tests, and added more

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ Yes, the Analytics team logic already supports the new native format.
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ N/A
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes
- _Changes are covered with new/existing integration tests?_ N/A
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
