### PR TITLE
feat: Update analytics metadata expand event treatment for flashbar

### DIFF
--- a/src/flashbar/__tests__/analytics-metadata.test.tsx
+++ b/src/flashbar/__tests__/analytics-metadata.test.tsx
@@ -11,6 +11,7 @@ import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-tool
 
 import Button from '../../../lib/components/button';
 import Flashbar, { FlashbarProps } from '../../../lib/components/flashbar';
+import { GeneratedAnalyticsMetadataFlashbarButtonClick } from '../../../lib/components/flashbar/analytics-metadata/interfaces';
 import {
   DATA_ATTR_ANALYTICS_FLASHBAR,
   DATA_ATTR_ANALYTICS_SUPPRESS_FLOW_EVENTS,
@@ -137,11 +138,15 @@ describe('Flashbar renders correct analytics metadata', () => {
 
       const embeddedButton = wrapper.findItems()[2].findActionButton()!.getElement();
       validateComponentNameAndLabels(embeddedButton, labels);
-      expect(getGeneratedAnalyticsMetadata(embeddedButton)).toEqual({
+
+      const buttonClickMetadata: GeneratedAnalyticsMetadataFlashbarButtonClick = {
         action: 'buttonClick',
         detail: {
           label: 'click me',
         },
+      };
+      expect(getGeneratedAnalyticsMetadata(embeddedButton)).toEqual({
+        ...buttonClickMetadata,
         ...getMetadata(3, stackItems, true),
       });
     });
@@ -192,7 +197,6 @@ describe('Flashbar renders correct analytics metadata', () => {
       action: 'expand',
       detail: {
         label: 'Notifications bar',
-        expanded: 'true',
       },
       ...getMetadata(undefined, true, false),
     });
@@ -200,10 +204,9 @@ describe('Flashbar renders correct analytics metadata', () => {
     act(() => toggleButtonWrapper.click());
 
     expect(getGeneratedAnalyticsMetadata(toggleButtonWrapper.getElement())).toEqual({
-      action: 'expand',
+      action: 'collapse',
       detail: {
         label: 'Notifications bar',
-        expanded: 'false',
       },
       ...getMetadata(undefined, true, true),
     });

--- a/src/flashbar/analytics-metadata/interfaces.ts
+++ b/src/flashbar/analytics-metadata/interfaces.ts
@@ -10,11 +10,24 @@ export interface GeneratedAnalyticsMetadataFlashbarDismiss {
   };
 }
 
+export interface GeneratedAnalyticsMetadataFlashbarButtonClick {
+  action: 'buttonClick';
+  detail: {
+    label: string;
+  };
+}
+
 export interface GeneratedAnalyticsMetadataFlashbarExpand {
   action: 'expand';
   detail: {
     label: string;
-    expanded: string;
+  };
+}
+
+export interface GeneratedAnalyticsMetadataFlashbarCollapse {
+  action: 'collapse';
+  detail: {
+    label: string;
   };
 }
 

--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -18,7 +18,10 @@ import { useEffectOnUpdate } from '../internal/hooks/use-effect-on-update';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { scrollElementIntoView } from '../internal/utils/scrollable-containers';
 import { throttle } from '../internal/utils/throttle';
-import { GeneratedAnalyticsMetadataFlashbarExpand } from './analytics-metadata/interfaces';
+import {
+  GeneratedAnalyticsMetadataFlashbarCollapse,
+  GeneratedAnalyticsMetadataFlashbarExpand,
+} from './analytics-metadata/interfaces';
 import { getComponentsAnalyticsMetadata, getItemAnalyticsMetadata } from './analytics-metadata/utils';
 import { useFlashbar } from './common';
 import { Flash, focusFlashById } from './flash';
@@ -324,12 +327,11 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
           onClick={toggleCollapseExpand}
           ref={notificationBarRef}
           {...getAnalyticsMetadataAttribute({
-            action: 'expand',
+            action: !isFlashbarStackExpanded ? 'expand' : 'collapse',
             detail: {
               label: 'h2',
-              expanded: `${!isFlashbarStackExpanded}`,
             },
-          } as GeneratedAnalyticsMetadataFlashbarExpand)}
+          } as GeneratedAnalyticsMetadataFlashbarExpand | GeneratedAnalyticsMetadataFlashbarCollapse)}
         >
           <span aria-live="polite" className={styles.status} role="status" id={itemCountElementId}>
             {notificationBarText && <h2 className={styles.header}>{notificationBarText}</h2>}


### PR DESCRIPTION
### Description

Currently `expand` events are being post-processed by the analytics team to rename them to `collapse` if `expanded=false`. This saves storage for events database tables.

Changing this will align with the actual usage.

### How has this been tested?

Updated unit tests, and added more

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ Yes, the Analytics team logic already supports the new native format.
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ N/A
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes
- _Changes are covered with new/existing integration tests?_ N/A
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
