### PR TITLE
chore: Migrate to the new documenter API

### DIFF
--- a/build-tools/tasks/docs.js
+++ b/build-tools/tasks/docs.js
@@ -1,29 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 const path = require('path');
-const { documentComponents, documentTestUtils } = require('@cloudscape-design/documenter');
+const { writeComponentsDocumentation, documentTestUtils } = require('@cloudscape-design/documenter');
 const { writeFile } = require('../utils/files');
-const { listPublicItems } = require('../utils/files');
 const workspace = require('../utils/workspace');
 
 module.exports = function docs() {
-  componentDocs();
-  testUtilDocs();
-  return Promise.resolve();
-};
-
-const publicDirs = listPublicItems('src');
-
-function validatePublicFiles(definitionFiles) {
-  for (const publicDir of publicDirs) {
-    if (!definitionFiles.includes(publicDir)) {
-      throw new Error(`Directory src/${publicDir} does not have a corresponding API definition`);
-    }
-  }
-}
-
-function componentDocs() {
-  const definitions = documentComponents({
+  writeComponentsDocumentation({
+    outDir: path.join(workspace.apiDocsPath, 'components'),
     tsconfigPath: require.resolve('../../tsconfig.json'),
     publicFilesGlob: 'src/*/index.tsx',
     extraExports: {
@@ -31,19 +15,9 @@ function componentDocs() {
       TagEditor: ['getTagsDiff'],
     },
   });
-  const outDir = path.join(workspace.apiDocsPath, 'components');
-  for (const definition of definitions) {
-    writeFile(
-      path.join(outDir, definition.dashCaseName + '.js'),
-      `module.exports = ${JSON.stringify(definition, null, 2)};`
-    );
-  }
-  const indexContent = `module.exports = {
-    ${definitions.map(definition => `${JSON.stringify(definition.dashCaseName)}:require('./${definition.dashCaseName}')`).join(',\n')}
-  }`;
-  writeFile(path.join(outDir, 'index.js'), indexContent);
-  validatePublicFiles(definitions.map(def => def.dashCaseName));
-}
+  testUtilDocs();
+  return Promise.resolve();
+};
 
 function testUtilDocs() {
   ['dom', 'selectors'].forEach(testUtilType => {

--- a/src/__tests__/utils.tsx
+++ b/src/__tests__/utils.tsx
@@ -5,10 +5,10 @@ import fs from 'fs';
 import path from 'path';
 
 import { SplitPanelContextProvider } from '../../lib/components/internal/context/split-panel-context';
+import definitions from '../../lib/components-definitions/components';
 import { defaultSplitPanelContextProps } from './required-props-for-components';
 
 const componentsDir = path.resolve(__dirname, '../../lib/components');
-const definitionsDir = path.resolve(__dirname, '../../lib/components-definitions/components');
 const designTokensDir = path.resolve(__dirname, '../../lib/design-tokens');
 
 export function getAllComponents(): string[] {
@@ -67,9 +67,8 @@ export function requireComponent(componentName: string): any {
   return require(path.join(componentsDir, componentName));
 }
 
-export function requireComponentDefinition(componentName: string): any {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  return require(path.join(definitionsDir, componentName));
+export function requireComponentDefinition(componentName: string) {
+  return definitions[componentName];
 }
 
 export function requireDesignTokensFile(fileName: string): any {


### PR DESCRIPTION
### Description

Support changes done in that PR: https://github.com/cloudscape-design/documenter/pull/67

Related links, issue #, if available: n/a

### How has this been tested?

* Inspected definitions directory locally, all files are expected
* Dry-run passes (eventually)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
