### PR TITLE
chore: Fix a space bug for VR improvements

### DIFF
--- a/src/flashbar/styles.scss
+++ b/src/flashbar/styles.scss
@@ -82,7 +82,7 @@
 }
 
 .flash-text {
-  margin-block: awsui.$space-xxxs;
+  margin-block: awsui.$border-item-width;
   margin-inline: 0;
   padding-block: awsui.$space-scaled-xxs;
   padding-inline: awsui.$space-xxs;


### PR DESCRIPTION
### Description

This PR fixes a bug that's been introduced in [this change](https://github.com/cloudscape-design/components/pull/3439/files#diff-830d2afec0c4339df425e599c2a7294f079d8350460fd6426562f3106993526c) for VR improvements.

The expected block margin size is 1px for classic and 2px for VR.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
