### PR TITLE
feat: Update analytics metadata expand and showMore event treatment f…

### DIFF
--- a/src/internal/components/button-trigger/analytics-metadata/interfaces.ts
+++ b/src/internal/components/button-trigger/analytics-metadata/interfaces.ts
@@ -6,7 +6,13 @@ import { LabelIdentifier } from '@cloudscape-design/component-toolkit/internal/a
 export interface GeneratedAnalyticsMetadataButtonTriggerExpand {
   action: 'expand';
   detail: {
-    label: LabelIdentifier;
-    expanded: string;
+    label: string | LabelIdentifier;
+  };
+}
+
+export interface GeneratedAnalyticsMetadataButtonTriggerCollapse {
+  action: 'collapse';
+  detail: {
+    label: string | LabelIdentifier;
   };
 }

--- a/src/internal/components/button-trigger/index.tsx
+++ b/src/internal/components/button-trigger/index.tsx
@@ -8,7 +8,10 @@ import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-tool
 import InternalIcon from '../../../icon/internal';
 import { BaseComponentProps, getBaseProps } from '../../base-component';
 import { BaseKeyDetail, CancelableEventHandler, fireCancelableEvent, fireKeyboardEvent } from '../../events';
-import { GeneratedAnalyticsMetadataButtonTriggerExpand } from './analytics-metadata/interfaces';
+import {
+  GeneratedAnalyticsMetadataButtonTriggerCollapse,
+  GeneratedAnalyticsMetadataButtonTriggerExpand,
+} from './analytics-metadata/interfaces';
 
 import analyticsSelectors from './analytics-metadata/styles.css.js';
 import styles from './styles.css.js';
@@ -109,11 +112,12 @@ const ButtonTrigger = (
     attributes['aria-invalid'] = invalid;
   }
 
-  const analyticsMetadata: GeneratedAnalyticsMetadataButtonTriggerExpand = {
-    action: 'expand',
+  const analyticsMetadata:
+    | GeneratedAnalyticsMetadataButtonTriggerExpand
+    | GeneratedAnalyticsMetadataButtonTriggerCollapse = {
+    action: !pressed ? 'expand' : 'collapse',
     detail: {
       label: { root: 'self' },
-      expanded: `${!pressed}`,
     },
   };
 

--- a/src/internal/components/selectable-item/analytics-metadata/interfaces.ts
+++ b/src/internal/components/selectable-item/analytics-metadata/interfaces.ts
@@ -5,9 +5,9 @@ import { LabelIdentifier } from '@cloudscape-design/component-toolkit/internal/a
 export interface GeneratedAnalyticsMetadataSelectableItemSelect {
   action: 'select';
   detail: {
-    label: LabelIdentifier;
+    label: string | LabelIdentifier;
     position?: string;
     value?: string;
-    groupLabel?: LabelIdentifier;
+    groupLabel?: string | LabelIdentifier;
   };
 }

--- a/src/internal/components/token-list/analytics-metadata/interfaces.ts
+++ b/src/internal/components/token-list/analytics-metadata/interfaces.ts
@@ -5,7 +5,13 @@ import { LabelIdentifier } from '@cloudscape-design/component-toolkit/internal/a
 export interface GeneratedAnalyticsMetadataTokenListShowMore {
   action: 'showMore';
   detail: {
-    label: LabelIdentifier;
-    expanded: string;
+    label: string | LabelIdentifier;
+  };
+}
+
+export interface GeneratedAnalyticsMetadataTokenListShowLess {
+  action: 'showLess';
+  detail: {
+    label: string | LabelIdentifier;
   };
 }

--- a/src/internal/components/token-list/token-limit-toggle.tsx
+++ b/src/internal/components/token-list/token-limit-toggle.tsx
@@ -8,7 +8,10 @@ import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-tool
 import { useInternalI18n } from '../../../i18n/context';
 import InternalIcon from '../../../icon/internal';
 import { fireNonCancelableEvent, NonCancelableEventHandler } from '../../events';
-import { GeneratedAnalyticsMetadataTokenListShowMore } from './analytics-metadata/interfaces';
+import {
+  GeneratedAnalyticsMetadataTokenListShowLess,
+  GeneratedAnalyticsMetadataTokenListShowMore,
+} from './analytics-metadata/interfaces';
 import { I18nStrings } from './interfaces';
 
 import styles from './styles.css.js';
@@ -45,11 +48,10 @@ export default function TokenLimitToggle({
     fireNonCancelableEvent(onClick, null);
   }, [onClick]);
 
-  const analyticsMetadata: GeneratedAnalyticsMetadataTokenListShowMore = {
-    action: 'showMore',
+  const analyticsMetadata: GeneratedAnalyticsMetadataTokenListShowMore | GeneratedAnalyticsMetadataTokenListShowLess = {
+    action: !expanded ? 'showMore' : 'showLess',
     detail: {
       label: { root: 'self' },
-      expanded: `${!expanded}`,
     },
   };
 

--- a/src/multiselect/__tests__/analytics-metadata.test.tsx
+++ b/src/multiselect/__tests__/analytics-metadata.test.tsx
@@ -11,6 +11,12 @@ import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-tool
 
 import FormField from '../../../lib/components/form-field';
 import Multiselect, { MultiselectProps } from '../../../lib/components/multiselect';
+import {
+  GeneratedAnalyticsMetadataMultiselectCollapse,
+  GeneratedAnalyticsMetadataMultiselectExpand,
+  GeneratedAnalyticsMetadataMultiselectShowLess,
+  GeneratedAnalyticsMetadataMultiselectShowMore,
+} from '../../../lib/components/multiselect/analytics-metadata/interfaces';
 import InternalMultiselect from '../../../lib/components/multiselect/internal';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { validateComponentNameAndLabels } from '../../internal/__tests__/analytics-metadata-test-utils';
@@ -118,24 +124,28 @@ describe('Multiselect renders correct analytics metadata', () => {
     const wrapper = renderMultiselect({});
     let trigger = wrapper.findTrigger()!.getElement();
     validateComponentNameAndLabels(trigger, labels);
-    expect(getGeneratedAnalyticsMetadata(trigger)).toEqual({
+    const expandMetadata: GeneratedAnalyticsMetadataMultiselectExpand = {
       action: 'expand',
       detail: {
         label: 'multiselect with metadata',
-        expanded: 'true',
       },
+    };
+    expect(getGeneratedAnalyticsMetadata(trigger)).toEqual({
+      ...expandMetadata,
       ...getMetadataContexts(),
     });
 
     wrapper.openDropdown();
     trigger = wrapper.findTrigger()!.getElement();
     validateComponentNameAndLabels(trigger, labels);
-    expect(getGeneratedAnalyticsMetadata(trigger)).toEqual({
-      action: 'expand',
+    const collapseMetadata: GeneratedAnalyticsMetadataMultiselectCollapse = {
+      action: 'collapse',
       detail: {
         label: 'multiselect with metadata',
-        expanded: 'false',
       },
+    };
+    expect(getGeneratedAnalyticsMetadata(trigger)).toEqual({
+      ...collapseMetadata,
       ...getMetadataContexts(),
     });
   });
@@ -277,22 +287,26 @@ describe('Multiselect renders correct analytics metadata', () => {
       });
 
       const tokenToggle = wrapper.findTokenToggle()!.getElement();
-      expect(getGeneratedAnalyticsMetadata(tokenToggle)).toEqual({
+      const showMoreMetadata: GeneratedAnalyticsMetadataMultiselectShowMore = {
         action: 'showMore',
         detail: {
           label: 'show more',
-          expanded: 'true',
         },
+      };
+      expect(getGeneratedAnalyticsMetadata(tokenToggle)).toEqual({
+        ...showMoreMetadata,
         ...getMetadataContexts(5),
       });
 
       wrapper.findTokenToggle()!.click();
-      expect(getGeneratedAnalyticsMetadata(wrapper.findTokenToggle()!.getElement())).toEqual({
-        action: 'showMore',
+      const showLessMetadata: GeneratedAnalyticsMetadataMultiselectShowLess = {
+        action: 'showLess',
         detail: {
           label: 'show less',
-          expanded: 'false',
         },
+      };
+      expect(getGeneratedAnalyticsMetadata(wrapper.findTokenToggle()!.getElement())).toEqual({
+        ...showLessMetadata,
         ...getMetadataContexts(5),
       });
     });

--- a/src/multiselect/analytics-metadata/interfaces.ts
+++ b/src/multiselect/analytics-metadata/interfaces.ts
@@ -1,6 +1,24 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+  GeneratedAnalyticsMetadataButtonTriggerCollapse,
+  GeneratedAnalyticsMetadataButtonTriggerExpand,
+} from '../../internal/components/button-trigger/analytics-metadata/interfaces';
+import { GeneratedAnalyticsMetadataSelectableItemSelect } from '../../internal/components/selectable-item/analytics-metadata/interfaces';
+import {
+  GeneratedAnalyticsMetadataTokenListShowLess,
+  GeneratedAnalyticsMetadataTokenListShowMore,
+} from '../../internal/components/token-list/analytics-metadata/interfaces';
+
+export type GeneratedAnalyticsMetadataMultiselectSelect = GeneratedAnalyticsMetadataSelectableItemSelect;
+
+export type GeneratedAnalyticsMetadataMultiselectExpand = GeneratedAnalyticsMetadataButtonTriggerExpand;
+export type GeneratedAnalyticsMetadataMultiselectCollapse = GeneratedAnalyticsMetadataButtonTriggerCollapse;
+
+export type GeneratedAnalyticsMetadataMultiselectShowMore = GeneratedAnalyticsMetadataTokenListShowMore;
+export type GeneratedAnalyticsMetadataMultiselectShowLess = GeneratedAnalyticsMetadataTokenListShowLess;
+
 export interface GeneratedAnalyticsMetadataMultiselectComponent {
   name: 'awsui.Multiselect';
   label: string;

--- a/src/property-filter/__tests__/analytics-metadata.test.tsx
+++ b/src/property-filter/__tests__/analytics-metadata.test.tsx
@@ -10,6 +10,15 @@ import {
 import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata/utils';
 
 import PropertyFilter, { PropertyFilterProps } from '../../../lib/components/property-filter';
+import {
+  GeneratedAnalyticsMetadataPropertyEditClose,
+  GeneratedAnalyticsMetadataPropertyFilterCollapse,
+  GeneratedAnalyticsMetadataPropertyFilterDismiss,
+  GeneratedAnalyticsMetadataPropertyFilterExpand,
+  GeneratedAnalyticsMetadataPropertyFilterSelect,
+  GeneratedAnalyticsMetadataPropertyShowLess,
+  GeneratedAnalyticsMetadataPropertyShowMore,
+} from '../../../lib/components/property-filter/analytics-metadata/interfaces';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { validateComponentNameAndLabels } from '../../internal/__tests__/analytics-metadata-test-utils';
 import { createDefaultProps } from './common';
@@ -151,7 +160,7 @@ describe('PropertyFilter renders correct analytics metadata', () => {
     act(() => wrapper.findNativeInput()!.focus());
     const propertiesItem = wrapper.findDropdown({ expandToViewport })!.findOptions()![0].getElement();
     validateComponentNameAndLabels(propertiesItem, labels);
-    expect(getGeneratedAnalyticsMetadata(propertiesItem)).toEqual({
+    const selectMetadata: GeneratedAnalyticsMetadataPropertyFilterSelect = {
       action: 'select',
       detail: {
         label: 'Instance ID',
@@ -159,6 +168,9 @@ describe('PropertyFilter renders correct analytics metadata', () => {
         value: 'Instance ID',
         groupLabel: 'Properties',
       },
+    };
+    expect(getGeneratedAnalyticsMetadata(propertiesItem)).toEqual({
+      ...selectMetadata,
       ...getMetadataContexts(),
     });
 
@@ -210,12 +222,15 @@ describe('PropertyFilter renders correct analytics metadata', () => {
 
       const dismissButton = wrapper.findTokens()[1]!.findRemoveButton()!.getElement();
       validateComponentNameAndLabels(dismissButton, labels);
-      expect(getGeneratedAnalyticsMetadata(dismissButton)).toEqual({
+      const dismissMetadata: GeneratedAnalyticsMetadataPropertyFilterDismiss = {
         action: 'dismiss',
         detail: {
           tokenLabel: 'Instance type != t3.small',
           tokenPosition: '2',
         },
+      };
+      expect(getGeneratedAnalyticsMetadata(dismissButton)).toEqual({
+        ...dismissMetadata,
         ...getMetadataContexts(4),
       });
     });
@@ -224,14 +239,16 @@ describe('PropertyFilter renders correct analytics metadata', () => {
 
       let operationSelectTrigger = wrapper.findTokens()[2]!.findTokenOperation()!.findTrigger()!.getElement();
       validateComponentNameAndLabels(operationSelectTrigger, labels);
-      expect(getGeneratedAnalyticsMetadata(operationSelectTrigger)).toEqual({
+      const expandMetadata: GeneratedAnalyticsMetadataPropertyFilterExpand = {
         action: 'expand',
         detail: {
           tokenLabel: 'Average latency > 981',
           tokenPosition: '3',
-          expanded: 'true',
           label: 'Boolean Operator',
         },
+      };
+      expect(getGeneratedAnalyticsMetadata(operationSelectTrigger)).toEqual({
+        ...expandMetadata,
         ...getMetadataContexts(4),
       });
 
@@ -239,14 +256,17 @@ describe('PropertyFilter renders correct analytics metadata', () => {
 
       operationSelectTrigger = wrapper.findTokens()[2]!.findTokenOperation()!.findTrigger()!.getElement();
       validateComponentNameAndLabels(operationSelectTrigger, labels);
-      expect(getGeneratedAnalyticsMetadata(operationSelectTrigger)).toEqual({
-        action: 'expand',
+
+      const collapseMetadata: GeneratedAnalyticsMetadataPropertyFilterCollapse = {
+        action: 'collapse',
         detail: {
           tokenLabel: 'Average latency > 981',
           tokenPosition: '3',
-          expanded: 'false',
           label: 'Boolean Operator',
         },
+      };
+      expect(getGeneratedAnalyticsMetadata(operationSelectTrigger)).toEqual({
+        ...collapseMetadata,
         ...getMetadataContexts(4),
       });
 
@@ -313,13 +333,16 @@ describe('PropertyFilter renders correct analytics metadata', () => {
 
       const closeButton = editPopoverWrapper.findDismissButton().getElement();
       validateComponentNameAndLabels(closeButton, labels);
-      expect(getGeneratedAnalyticsMetadata(closeButton)).toEqual({
+      const editCloseMetadata: GeneratedAnalyticsMetadataPropertyEditClose = {
         action: 'editClose',
         detail: {
           tokenLabel: 'Average latency > 981',
           tokenPosition: '3',
           label: 'Dismiss',
         },
+      };
+      expect(getGeneratedAnalyticsMetadata(closeButton)).toEqual({
+        ...editCloseMetadata,
         ...getMetadataContexts(4),
       });
     });
@@ -333,22 +356,26 @@ describe('PropertyFilter renders correct analytics metadata', () => {
       });
 
       const tokenToggle = wrapper.findTokenToggle()!.getElement();
-      expect(getGeneratedAnalyticsMetadata(tokenToggle)).toEqual({
+      const showMoreMetadata: GeneratedAnalyticsMetadataPropertyShowMore = {
         action: 'showMore',
         detail: {
           label: 'show more',
-          expanded: 'true',
         },
+      };
+      expect(getGeneratedAnalyticsMetadata(tokenToggle)).toEqual({
+        ...showMoreMetadata,
         ...getMetadataContexts(4),
       });
 
       wrapper.findTokenToggle()!.click();
-      expect(getGeneratedAnalyticsMetadata(wrapper.findTokenToggle()!.getElement())).toEqual({
-        action: 'showMore',
+      const showLessMetadata: GeneratedAnalyticsMetadataPropertyShowLess = {
+        action: 'showLess',
         detail: {
           label: 'show less',
-          expanded: 'false',
         },
+      };
+      expect(getGeneratedAnalyticsMetadata(wrapper.findTokenToggle()!.getElement())).toEqual({
+        ...showLessMetadata,
         ...getMetadataContexts(4),
       });
     });

--- a/src/property-filter/analytics-metadata/interfaces.ts
+++ b/src/property-filter/analytics-metadata/interfaces.ts
@@ -1,12 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { GeneratedAnalyticsMetadataSelectableItemSelect } from '../../internal/components/selectable-item/analytics-metadata/interfaces';
+import {
+  GeneratedAnalyticsMetadataTokenListShowLess,
+  GeneratedAnalyticsMetadataTokenListShowMore,
+} from '../../internal/components/token-list/analytics-metadata/interfaces';
+
 export interface GeneratedAnalyticsMetadataPropertyFilterClearFilters {
   action: 'clearFilters';
   detail: {
     label: string;
   };
 }
+
+export type GeneratedAnalyticsMetadataPropertyFilterSelect = GeneratedAnalyticsMetadataSelectableItemSelect;
 
 interface TokenAction {
   detail: {
@@ -16,8 +24,23 @@ interface TokenAction {
   };
 }
 
+export interface GeneratedAnalyticsMetadataPropertyFilterExpand extends TokenAction {
+  action: 'expand';
+}
+
+export interface GeneratedAnalyticsMetadataPropertyFilterCollapse extends TokenAction {
+  action: 'collapse';
+}
+export interface GeneratedAnalyticsMetadataPropertyFilterDismiss extends TokenAction {
+  action: 'dismiss';
+}
+
 export interface GeneratedAnalyticsMetadataPropertyEditStart extends TokenAction {
   action: 'editStart';
+}
+
+export interface GeneratedAnalyticsMetadataPropertyEditClose extends TokenAction {
+  action: 'editClose';
 }
 
 export interface GeneratedAnalyticsMetadataPropertyEditCancel extends TokenAction {
@@ -27,6 +50,9 @@ export interface GeneratedAnalyticsMetadataPropertyEditCancel extends TokenActio
 export interface GeneratedAnalyticsMetadataPropertyEditConfirm extends TokenAction {
   action: 'editConfirm';
 }
+
+export type GeneratedAnalyticsMetadataPropertyShowMore = GeneratedAnalyticsMetadataTokenListShowMore;
+export type GeneratedAnalyticsMetadataPropertyShowLess = GeneratedAnalyticsMetadataTokenListShowLess;
 
 export interface GeneratedAnalyticsMetadataPropertyFilterComponent {
   name: 'awsui.PropertyFilter';

--- a/src/select/__tests__/analytics-metadata.test.tsx
+++ b/src/select/__tests__/analytics-metadata.test.tsx
@@ -11,6 +11,10 @@ import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-tool
 
 import FormField from '../../../lib/components/form-field';
 import Select, { SelectProps } from '../../../lib/components/select';
+import {
+  GeneratedAnalyticsMetadataSelectCollapse,
+  GeneratedAnalyticsMetadataSelectExpand,
+} from '../../../lib/components/select/analytics-metadata/interfaces';
 import InternalSelect from '../../../lib/components/select/internal';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { validateComponentNameAndLabels } from '../../internal/__tests__/analytics-metadata-test-utils';
@@ -89,24 +93,28 @@ describe('Select renders correct analytics metadata', () => {
     const wrapper = renderSelect({});
     let trigger = wrapper.findTrigger()!.getElement();
     validateComponentNameAndLabels(trigger, labels);
-    expect(getGeneratedAnalyticsMetadata(trigger)).toEqual({
+    const expandMetadata: GeneratedAnalyticsMetadataSelectExpand = {
       action: 'expand',
       detail: {
         label: 'select with metadata',
-        expanded: 'true',
       },
+    };
+    expect(getGeneratedAnalyticsMetadata(trigger)).toEqual({
+      ...expandMetadata,
       ...getMetadataContexts(),
     });
 
     wrapper.openDropdown();
     trigger = wrapper.findTrigger()!.getElement();
     validateComponentNameAndLabels(trigger, labels);
-    expect(getGeneratedAnalyticsMetadata(trigger)).toEqual({
-      action: 'expand',
+    const collapseMetadata: GeneratedAnalyticsMetadataSelectCollapse = {
+      action: 'collapse',
       detail: {
         label: 'select with metadata',
-        expanded: 'false',
       },
+    };
+    expect(getGeneratedAnalyticsMetadata(trigger)).toEqual({
+      ...collapseMetadata,
       ...getMetadataContexts(),
     });
   });

--- a/src/select/analytics-metadata/interfaces.ts
+++ b/src/select/analytics-metadata/interfaces.ts
@@ -1,6 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+  GeneratedAnalyticsMetadataButtonTriggerCollapse,
+  GeneratedAnalyticsMetadataButtonTriggerExpand,
+} from '../../internal/components/button-trigger/analytics-metadata/interfaces';
+import { GeneratedAnalyticsMetadataSelectableItemSelect } from '../../internal/components/selectable-item/analytics-metadata/interfaces';
+
+export type GeneratedAnalyticsMetadataSelectSelect = GeneratedAnalyticsMetadataSelectableItemSelect;
+
+export type GeneratedAnalyticsMetadataSelectExpand = GeneratedAnalyticsMetadataButtonTriggerExpand;
+export type GeneratedAnalyticsMetadataSelectCollapse = GeneratedAnalyticsMetadataButtonTriggerCollapse;
+
 export interface GeneratedAnalyticsMetadataSelectComponent {
   name: 'awsui.Select';
   label: string;

--- a/src/token-group/__tests__/analytics-metadata.test.tsx
+++ b/src/token-group/__tests__/analytics-metadata.test.tsx
@@ -11,6 +11,10 @@ import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-tool
 
 import createWrapper from '../../../lib/components/test-utils/dom';
 import TokenGroup, { TokenGroupProps } from '../../../lib/components/token-group';
+import {
+  GeneratedAnalyticsMetadataTokenGroupShowLess,
+  GeneratedAnalyticsMetadataTokenGroupShowMore,
+} from '../../../lib/components/token-group/analytics-metadata/interfaces';
 import InternalTokenGroup from '../../../lib/components/token-group/internal';
 
 function renderTokenGroup(props: TokenGroupProps) {
@@ -106,22 +110,26 @@ describe('Token Group renders correct analytics metadata', () => {
     });
 
     const tokenToggle = wrapper.findTokenToggle()!.getElement();
-    expect(getGeneratedAnalyticsMetadata(tokenToggle)).toEqual({
+    const showMoreMetadata: GeneratedAnalyticsMetadataTokenGroupShowMore = {
       action: 'showMore',
       detail: {
         label: 'show more',
-        expanded: 'true',
       },
+    };
+    expect(getGeneratedAnalyticsMetadata(tokenToggle)).toEqual({
+      ...showMoreMetadata,
       ...getMetadataContexts(),
     });
 
     wrapper.findTokenToggle()!.click();
-    expect(getGeneratedAnalyticsMetadata(wrapper.findTokenToggle()!.getElement())).toEqual({
-      action: 'showMore',
+    const showLessMetadata: GeneratedAnalyticsMetadataTokenGroupShowLess = {
+      action: 'showLess',
       detail: {
         label: 'show less',
-        expanded: 'false',
       },
+    };
+    expect(getGeneratedAnalyticsMetadata(wrapper.findTokenToggle()!.getElement())).toEqual({
+      ...showLessMetadata,
       ...getMetadataContexts(),
     });
   });

--- a/src/token-group/analytics-metadata/interfaces.ts
+++ b/src/token-group/analytics-metadata/interfaces.ts
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { LabelIdentifier } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
+import {
+  GeneratedAnalyticsMetadataTokenListShowLess,
+  GeneratedAnalyticsMetadataTokenListShowMore,
+} from '../../internal/components/token-list/analytics-metadata/interfaces';
+
 export interface GeneratedAnalyticsMetadataTokenGroupDismiss {
   action: 'dismiss';
   detail: {
@@ -9,6 +14,9 @@ export interface GeneratedAnalyticsMetadataTokenGroupDismiss {
     position?: string;
   };
 }
+
+export type GeneratedAnalyticsMetadataTokenGroupShowMore = GeneratedAnalyticsMetadataTokenListShowMore;
+export type GeneratedAnalyticsMetadataTokenGroupShowLess = GeneratedAnalyticsMetadataTokenListShowLess;
 
 export interface GeneratedAnalyticsMetadataTokenGroupComponent {
   name: 'awsui.TokenGroup';


### PR DESCRIPTION
…or various components

### Description

Currently `expand` (and similar) events are being post-processed by the analytics team to rename them to `collapse` if `expanded=false`. This saves storage for events database tables.

Changing this will align with the actual usage.

### How has this been tested?

Updated unit tests, and added more

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ Yes, the Analytics team logic already supports the new native format.
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ N/A
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes
- _Changes are covered with new/existing integration tests?_ N/A
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
