### PR TITLE
chore: Update selection events analytics metadata

### DIFF
--- a/src/checkbox/__tests__/analytics-metadata.test.tsx
+++ b/src/checkbox/__tests__/analytics-metadata.test.tsx
@@ -10,6 +10,10 @@ import {
 import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata/utils';
 
 import Checkbox, { CheckboxProps } from '../../../lib/components/checkbox';
+import {
+  GeneratedAnalyticsMetadataCheckboxDeselect,
+  GeneratedAnalyticsMetadataCheckboxSelect,
+} from '../../../lib/components/checkbox/analytics-metadata/interfaces';
 import InternalCheckbox from '../../../lib/components/checkbox/internal';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { validateComponentNameAndLabels } from '../../internal/__tests__/analytics-metadata-test-utils';
@@ -22,11 +26,10 @@ function renderCheckbox(props: CheckboxProps) {
 }
 
 const getMetadata = (label: string, checked: boolean, disabled?: boolean) => {
-  const eventMetadata = {
-    action: 'select',
+  const eventMetadata: GeneratedAnalyticsMetadataCheckboxSelect | GeneratedAnalyticsMetadataCheckboxDeselect = {
+    action: checked ? 'deselect' : 'select',
     detail: {
       label,
-      selected: `${!checked}`,
     },
   };
 
@@ -78,9 +81,9 @@ test('Internal Checkbox does not render "component" metadata', () => {
   const element = createWrapper(renderResult.container).findCheckbox()!.findNativeInput()!.getElement();
   validateComponentNameAndLabels(element, labels);
   expect(getGeneratedAnalyticsMetadata(element)).toEqual({
-    action: 'select',
+    action: 'deselect',
     detail: {
-      selected: 'false',
+      label: '',
     },
   });
 });

--- a/src/checkbox/analytics-metadata/interfaces.ts
+++ b/src/checkbox/analytics-metadata/interfaces.ts
@@ -7,7 +7,12 @@ export interface GeneratedAnalyticsMetadataCheckboxSelect {
   action: 'select';
   detail: {
     label: string;
-    selected: string;
+  };
+}
+export interface GeneratedAnalyticsMetadataCheckboxDeselect {
+  action: 'deselect';
+  detail: {
+    label: string;
   };
 }
 

--- a/src/checkbox/internal.tsx
+++ b/src/checkbox/internal.tsx
@@ -16,10 +16,7 @@ import { useSingleTabStopNavigation } from '../internal/context/single-tab-stop-
 import { fireNonCancelableEvent } from '../internal/events';
 import useForwardFocus from '../internal/hooks/forward-focus';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
-import {
-  GeneratedAnalyticsMetadataCheckboxComponent,
-  GeneratedAnalyticsMetadataCheckboxSelect,
-} from './analytics-metadata/interfaces';
+import { GeneratedAnalyticsMetadataCheckboxComponent } from './analytics-metadata/interfaces';
 import { CheckboxProps } from './interfaces';
 
 import styles from './styles.css.js';
@@ -76,9 +73,7 @@ const InternalCheckbox = React.forwardRef<CheckboxProps.Ref, InternalProps>(
       analyticsMetadata.component = analyticsComponentMetadata;
     }
     if (!disabled && !readOnly) {
-      analyticsMetadata.detail = {
-        selected: `${!checked}`,
-      } as Partial<GeneratedAnalyticsMetadataCheckboxSelect['detail']>;
+      analyticsMetadata.action = !checked ? 'select' : 'deselect';
     }
 
     return (

--- a/src/collection-preferences/__tests__/analytics-metadata.test.tsx
+++ b/src/collection-preferences/__tests__/analytics-metadata.test.tsx
@@ -237,7 +237,6 @@ describe('CollectionPreferences renders correct analytics metadata', () => {
         action: 'select',
         detail: {
           label: 'Wrap lines label',
-          selected: 'true',
         },
         ...getMetadata({}, 'wrapLines'),
       });
@@ -254,7 +253,6 @@ describe('CollectionPreferences renders correct analytics metadata', () => {
         action: 'select',
         detail: {
           label: 'Striped rows label',
-          selected: 'true',
         },
         ...getMetadata({}, 'stripedRows'),
       });
@@ -271,7 +269,6 @@ describe('CollectionPreferences renders correct analytics metadata', () => {
         action: 'select',
         detail: {
           label: 'Compact mode',
-          selected: 'true',
         },
         ...getMetadata({}, 'contentDensity'),
       });

--- a/src/table/__tests__/analytics-metadata.test.tsx
+++ b/src/table/__tests__/analytics-metadata.test.tsx
@@ -13,6 +13,12 @@ import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-tool
 import ButtonDropdown from '../../../lib/components/button-dropdown';
 import Header from '../../../lib/components/header';
 import Table, { TableProps } from '../../../lib/components/table';
+import {
+  GeneratedAnalyticsMetadataTableDeselect,
+  GeneratedAnalyticsMetadataTableDeselectAll,
+  GeneratedAnalyticsMetadataTableSelect,
+  GeneratedAnalyticsMetadataTableSelectAll,
+} from '../../../lib/components/table/analytics-metadata/interfaces';
 import InternalTable from '../../../lib/components/table/internal';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { validateComponentNameAndLabels } from '../../internal/__tests__/analytics-metadata-test-utils';
@@ -125,11 +131,12 @@ describe('Table renders correct analytics metadata', () => {
 
       const firstSelectionArea = wrapper.findRowSelectionArea(1)!.find('input')!.getElement();
       validateComponentNameAndLabels(firstSelectionArea, labels);
+      const selectEvent: GeneratedAnalyticsMetadataTableSelect = {
+        action: 'select',
+        detail: { position: '1', item: 'first' },
+      };
       expect(getGeneratedAnalyticsMetadata(firstSelectionArea)).toEqual(
-        getMetadata({ selectedItemsCount: '1', selectionType: 'multi', variant: 'full-page' }, undefined, {
-          action: 'select',
-          detail: { position: '1', item: 'first', selected: 'true' },
-        })
+        getMetadata({ selectedItemsCount: '1', selectionType: 'multi', variant: 'full-page' }, undefined, selectEvent)
       );
 
       const disabledSelectionArea = wrapper.findRowSelectionArea(2)!.find('input')!.getElement();
@@ -140,20 +147,43 @@ describe('Table renders correct analytics metadata', () => {
 
       const thirdSelectionArea = wrapper.findRowSelectionArea(3)!.find('input')!.getElement();
       validateComponentNameAndLabels(thirdSelectionArea, labels);
+      const deselectEvent: GeneratedAnalyticsMetadataTableDeselect = {
+        action: 'deselect',
+        detail: { position: '3', item: 'third' },
+      };
       expect(getGeneratedAnalyticsMetadata(thirdSelectionArea)).toEqual(
-        getMetadata({ selectedItemsCount: '1', selectionType: 'multi', variant: 'full-page' }, undefined, {
-          action: 'select',
-          detail: { position: '3', item: 'third', selected: 'false' },
-        })
+        getMetadata({ selectedItemsCount: '1', selectionType: 'multi', variant: 'full-page' }, undefined, deselectEvent)
       );
 
       const selectAllArea = wrapper.findSelectAllTrigger()!.find('input')!.getElement();
       validateComponentNameAndLabels(selectAllArea, labels);
+      const selectAllEvent: GeneratedAnalyticsMetadataTableSelectAll = {
+        action: 'selectAll',
+        detail: { label: '' },
+      };
       expect(getGeneratedAnalyticsMetadata(selectAllArea)).toEqual(
-        getMetadata({ selectedItemsCount: '1', selectionType: 'multi', variant: 'full-page' }, undefined, {
-          action: 'selectAll',
-          detail: { selected: 'true' },
-        })
+        getMetadata(
+          { selectedItemsCount: '1', selectionType: 'multi', variant: 'full-page' },
+          undefined,
+          selectAllEvent
+        )
+      );
+    });
+    test('multiple with all items selected', () => {
+      const wrapper = renderTable({ selectionType: 'multi', selectedItems: items });
+
+      const selectAllArea = wrapper.findSelectAllTrigger()!.find('input')!.getElement();
+      validateComponentNameAndLabels(selectAllArea, labels);
+      const deselectAllEvent: GeneratedAnalyticsMetadataTableDeselectAll = {
+        action: 'deselectAll',
+        detail: { label: '' },
+      };
+      expect(getGeneratedAnalyticsMetadata(selectAllArea)).toEqual(
+        getMetadata(
+          { selectedItemsCount: '3', selectionType: 'multi', variant: 'container' },
+          undefined,
+          deselectAllEvent
+        )
       );
     });
     test('single', () => {

--- a/src/table/analytics-metadata/interfaces.ts
+++ b/src/table/analytics-metadata/interfaces.ts
@@ -6,8 +6,16 @@ import { LabelIdentifier } from '@cloudscape-design/component-toolkit/internal/a
 export interface GeneratedAnalyticsMetadataTableSelect {
   action: 'select';
   detail: {
-    label: string;
-    selected: string;
+    label?: string;
+    position: string;
+    item: string;
+  };
+}
+
+export interface GeneratedAnalyticsMetadataTableDeselect {
+  action: 'deselect';
+  detail: {
+    label?: string;
     position: string;
     item: string;
   };
@@ -17,7 +25,13 @@ export interface GeneratedAnalyticsMetadataTableSelectAll {
   action: 'selectAll';
   detail: {
     label: string;
-    selected: string;
+  };
+}
+
+export interface GeneratedAnalyticsMetadataTableDeselectAll {
+  action: 'deselectAll';
+  detail: {
+    label: string;
   };
 }
 

--- a/src/table/selection/selection-cell.tsx
+++ b/src/table/selection/selection-cell.tsx
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
+
 import ScreenreaderOnly from '../../internal/components/screenreader-only';
 import { TableTdElement, TableTdElementProps } from '../body-cell/td-element';
 import { TableThElement, TableThElementProps } from '../header-cell/th-element';
@@ -38,6 +40,9 @@ export function TableHeaderSelectionCell({
       colIndex={0}
       focusedComponent={focusedComponent}
       ariaLabel={selectAllProps?.selectionGroupLabel}
+      {...getAnalyticsMetadataAttribute({
+        action: selectAllProps?.checked ? 'deselectAll' : 'selectAll',
+      })}
     >
       {selectAllProps ? (
         <SelectionControl

--- a/src/table/selection/selection-control.tsx
+++ b/src/table/selection/selection-control.tsx
@@ -10,7 +10,6 @@ import { SingleTabStopNavigationContext } from '../../internal/context/single-ta
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { KeyCode } from '../../internal/keycode';
 import RadioButton from '../../radio-group/radio-button';
-import { GeneratedAnalyticsMetadataTableSelect } from '../analytics-metadata/interfaces';
 import { SelectionProps } from './interfaces';
 
 import styles from './styles.css.js';
@@ -113,7 +112,7 @@ export function SelectionControl({
                 position: `${rowIndex + 1}`,
                 item: itemKey || '',
               },
-            } as Partial<GeneratedAnalyticsMetadataTableSelect>)
+            })
           : {})}
       >
         {selector}

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -4,10 +4,8 @@ import React from 'react';
 import clsx from 'clsx';
 
 import { findUpUntil } from '@cloudscape-design/component-toolkit/dom';
-import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 import { fireNonCancelableEvent, NonCancelableEventHandler } from '../internal/events';
-import { GeneratedAnalyticsMetadataTableSelectAll } from './analytics-metadata/interfaces';
 import { TableHeaderCell } from './header-cell';
 import { TableProps } from './interfaces';
 import { focusMarkers, SelectionProps } from './selection';
@@ -112,9 +110,6 @@ const Thead = React.forwardRef(
               getSelectAllProps={getSelectAllProps}
               onFocusMove={onFocusMove}
               singleSelectionHeaderAriaLabel={singleSelectionHeaderAriaLabel}
-              {...getAnalyticsMetadataAttribute({
-                action: 'selectAll',
-              } as Partial<GeneratedAnalyticsMetadataTableSelectAll>)}
             />
           ) : null}
 

--- a/src/toggle/__tests__/analytics-metadata.test.tsx
+++ b/src/toggle/__tests__/analytics-metadata.test.tsx
@@ -11,6 +11,10 @@ import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-tool
 
 import createWrapper from '../../../lib/components/test-utils/dom';
 import Toggle, { ToggleProps } from '../../../lib/components/toggle';
+import {
+  GeneratedAnalyticsMetadataToggleDeselect,
+  GeneratedAnalyticsMetadataToggleSelect,
+} from '../../../lib/components/toggle/analytics-metadata/interfaces';
 import InternalToggle from '../../../lib/components/toggle/internal';
 import { validateComponentNameAndLabels } from '../../internal/__tests__/analytics-metadata-test-utils';
 
@@ -22,11 +26,10 @@ function renderToggle(props: ToggleProps) {
 }
 
 const getMetadata = (label: string, checked: boolean, disabled?: boolean) => {
-  const eventMetadata = {
-    action: 'select',
+  const eventMetadata: GeneratedAnalyticsMetadataToggleSelect | GeneratedAnalyticsMetadataToggleDeselect = {
+    action: !checked ? 'select' : 'deselect',
     detail: {
       label,
-      selected: `${!checked}`,
     },
   };
 
@@ -78,9 +81,8 @@ test('Internal Toggle does not render "component" metadata', () => {
   const element = createWrapper(renderResult.container).findToggle()!.findNativeInput()!.getElement();
   validateComponentNameAndLabels(element, labels);
   expect(getGeneratedAnalyticsMetadata(element)).toEqual({
-    action: 'select',
+    action: 'deselect',
     detail: {
-      selected: 'false',
       label: 'toggle label',
     },
   });

--- a/src/toggle/analytics-metadata/interfaces.ts
+++ b/src/toggle/analytics-metadata/interfaces.ts
@@ -7,7 +7,13 @@ export interface GeneratedAnalyticsMetadataToggleSelect {
   action: 'select';
   detail: {
     label: string;
-    selected: string;
+  };
+}
+
+export interface GeneratedAnalyticsMetadataToggleDeselect {
+  action: 'deselect';
+  detail: {
+    label: string;
   };
 }
 

--- a/src/toggle/internal.tsx
+++ b/src/toggle/internal.tsx
@@ -14,10 +14,7 @@ import { useFormFieldContext } from '../internal/context/form-field-context';
 import { fireNonCancelableEvent } from '../internal/events';
 import useForwardFocus from '../internal/hooks/forward-focus';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
-import {
-  GeneratedAnalyticsMetadataToggleComponent,
-  GeneratedAnalyticsMetadataToggleSelect,
-} from './analytics-metadata/interfaces';
+import { GeneratedAnalyticsMetadataToggleComponent } from './analytics-metadata/interfaces';
 import { ToggleProps } from './interfaces';
 
 import styles from './styles.css.js';
@@ -62,9 +59,7 @@ const InternalToggle = React.forwardRef<ToggleProps.Ref, InternalToggleProps>(
     }
 
     if (!disabled && !readOnly) {
-      analyticsMetadata.detail = {
-        selected: `${!checked}`,
-      } as Partial<GeneratedAnalyticsMetadataToggleSelect['detail']>;
+      analyticsMetadata.action = !checked ? 'select' : 'deselect';
     }
     useForwardFocus(ref, checkboxRef);
 


### PR DESCRIPTION
### Description

Currently `select` (and similar) events are being post-processed by the analytics team to rename them to `deselect` if `selected=false`. This saves storage for events database tables.

Changing this will align with the actual usage.

### How has this been tested?

Updated unit tests, and added more

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ Yes, the Analytics team logic already supports the new native format.
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ N/A
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes
- _Changes are covered with new/existing integration tests?_ N/A
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
