### PR TITLE
chore: Handle undefined values when validating props

### DIFF
--- a/src/internal/base-component/__tests__/validate-props-production.test.ts
+++ b/src/internal/base-component/__tests__/validate-props-production.test.ts
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { validateProps } from '../../../../lib/components/internal/base-component';
+import { isDevelopment } from '../../../../lib/components/internal/is-development';
+
+jest.mock('../../../../lib/components/internal/is-development', () => ({ isDevelopment: false }));
+
+test('does nothing in production builds', () => {
+  expect(isDevelopment).toBe(false);
+  expect(() => validateProps('TestComponent', { variant: 'foo' }, ['variant'], {})).not.toThrow();
+});

--- a/src/internal/base-component/__tests__/validate-props.test.ts
+++ b/src/internal/base-component/__tests__/validate-props.test.ts
@@ -5,6 +5,7 @@ import { validateProps } from '../../../../lib/components/internal/base-componen
 test('should pass validation', () => {
   expect(() => validateProps('TestComponent', {}, [], {})).not.toThrow();
   expect(() => validateProps('TestComponent', { variant: 'foo' }, ['bar'], { variant: ['foo'] })).not.toThrow();
+  expect(() => validateProps('TestComponent', { variant: undefined }, ['bar'], { variant: ['foo'] })).not.toThrow();
 });
 
 test('should throw error when excluded prop is used', () => {

--- a/src/internal/base-component/index.ts
+++ b/src/internal/base-component/index.ts
@@ -5,6 +5,7 @@ import { initAwsUiVersions } from '@cloudscape-design/component-toolkit/internal
 
 import { AnalyticsMetadata } from '../analytics/interfaces';
 import { PACKAGE_SOURCE, PACKAGE_VERSION, THEME } from '../environment';
+import { isDevelopment } from '../is-development';
 
 // these styles needed to be imported for every public component
 import './styles.css.js';
@@ -45,11 +46,14 @@ export function validateProps(
   excludedProps: Array<string>,
   allowedEnums: Record<string, Array<string>>
 ) {
+  if (!isDevelopment) {
+    return;
+  }
   for (const [prop, value] of Object.entries(props)) {
     if (excludedProps.includes(prop)) {
       throw new Error(`${componentName} does not support "${prop}" property when used in ${THEME} theme`);
     }
-    if (allowedEnums[prop] && !allowedEnums[prop].includes(value)) {
+    if (value && allowedEnums[prop] && !allowedEnums[prop].includes(value)) {
       throw new Error(`${componentName} does not support "${prop}" with value "${value}" when used in ${THEME} theme`);
     }
   }


### PR DESCRIPTION
### Description

We have a new function to validate in runtime if there is a property from an unsupported system.

Two fixes in this PR

1. Do not throw in this use-case `<Button variant={undefined}>`
2. Add `isDevelopment` condition to remove this code from production builds

Related links, issue #, if available: n/a

### How has this been tested?

Updated unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
