### PR TITLE
fix: Fix popover positioning inside query containers

### DIFF
--- a/pages/popover/scenarios.page.tsx
+++ b/pages/popover/scenarios.page.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useState } from 'react';
+import clsx from 'clsx';
 
 import { Select } from '~components';
 import Box from '~components/box';
@@ -122,6 +123,20 @@ export default function () {
               dismissAriaLabel="Close"
             >
               With select
+            </Popover>
+          </section>
+
+          <section id="scenario-in-containment" className={clsx(styles.scenario, styles['containing-block'])}>
+            <Popover
+              position="left"
+              size="medium"
+              fixedWidth={true}
+              header="Network interface eth0"
+              content={<KeyValuePair />}
+              dismissAriaLabel="Close"
+              renderWithPortal={renderWithPortal}
+            >
+              eth0
             </Popover>
           </section>
         </SpaceBetween>

--- a/pages/popover/scenarios.scss
+++ b/pages/popover/scenarios.scss
@@ -7,3 +7,7 @@
   padding-inline: 0;
   text-align: center;
 }
+
+.containing-block {
+  contain: layout;
+}

--- a/src/internal/utils/dom.ts
+++ b/src/internal/utils/dom.ts
@@ -10,7 +10,6 @@ export function isContainingBlock(element: HTMLElement): boolean {
   return (
     (!!computedStyle.transform && computedStyle.transform !== 'none') ||
     (!!computedStyle.perspective && computedStyle.perspective !== 'none') ||
-    (!!computedStyle.containerType && computedStyle.containerType !== 'normal') ||
     computedStyle.contain?.split(' ').some(s => ['layout', 'paint', 'strict', 'content'].includes(s))
   );
 }


### PR DESCRIPTION
### Description

Fixes #3356. There have been some developments since I made my comment ([link](https://github.com/cloudscape-design/components/issues/3356#issuecomment-2743106844)) about Safari - the developments being that [it's fixed in Safari 18.4](https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes), and we have new browser support policies regarding Safari.

Yes, this breaks popover positioning inside query containers for Safari <18.4 (mind you, Cloudscape itself doesn't use container queries... _yet?_), but it also unbreaks it for Chrome, Edge, Firefox, and Safari >18.4. Sooo.... yay simple fix! We can talk about the implications of this tomorrow, if we have to.

Related links, issue #, if available: AWSUI-60541

### How has this been tested?

Testing this inside JSDOM feels silly to me. Though, it's on me that the original PR that introduced didn't have a test because I thought this was trivial, so added a screenshot test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
