### PR TITLE
fix: Drawer loading paddings

### DIFF
--- a/pages/drawer/permutations.page.tsx
+++ b/pages/drawer/permutations.page.tsx
@@ -11,6 +11,7 @@ import ScreenshotArea from '../utils/screenshot-area';
 
 const permutations = createPermutations<DrawerProps>([
   {
+    loading: [false, true],
     disableContentPaddings: [true, false],
     header: [null, <h2 key="header">Header</h2>],
     children: [null, <>Dummy content</>],
@@ -21,7 +22,7 @@ export default function () {
   return (
     <>
       <h1>Drawer permutations</h1>
-      <ScreenshotArea>
+      <ScreenshotArea disableAnimations={true}>
         <PermutationsView
           permutations={permutations}
           render={permutation => (

--- a/src/drawer/implementation.tsx
+++ b/src/drawer/implementation.tsx
@@ -33,7 +33,11 @@ export function DrawerImplementation({
     className: clsx(baseProps.className, styles.drawer, isToolbar && styles['with-toolbar']),
   };
   return loading ? (
-    <div {...containerProps} ref={__internalRootRef}>
+    <div
+      {...containerProps}
+      className={clsx(containerProps.className, styles['content-with-paddings'])}
+      ref={__internalRootRef}
+    >
       <InternalStatusIndicator type="loading">
         <InternalLiveRegion tagName="span">
           {i18n('i18nStrings.loadingText', i18nStrings?.loadingText)}


### PR DESCRIPTION
### Description

This PR addresses the issue with drawer paddings described here: https://github.com/cloudscape-design/components/issues/3466

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
