### PR TITLE
chore: refactor drawer permutation page

### DIFF
--- a/pages/drawer/permutations.page.tsx
+++ b/pages/drawer/permutations.page.tsx
@@ -11,11 +11,11 @@ import ScreenshotArea from '../utils/screenshot-area';
 
 const permutations = createPermutations<DrawerProps>([
   {
-    loading: [false, true],
     disableContentPaddings: [true, false],
     header: [null, <h2 key="header">Header</h2>],
     children: [null, <>Dummy content</>],
   },
+  { loading: [true], i18nStrings: [{ loadingText: 'Loading' }, {}] },
 ]);
 
 export default function () {
@@ -26,10 +26,13 @@ export default function () {
         <PermutationsView
           permutations={permutations}
           render={permutation => (
-            // add visible border to capture component paddings
-            <div style={{ border: '1px solid red' }}>
-              <Drawer {...permutation} />
-            </div>
+            <>
+              {!permutation.header && !permutation.children && !permutation.loading && <p>(empty permutation)</p>}
+              {/* add visible border to capture component paddings */}
+              <div style={{ border: '1px solid red' }}>
+                <Drawer {...permutation} />
+              </div>
+            </>
           )}
         />
       </ScreenshotArea>


### PR DESCRIPTION
### Description

1. Remove duplicated combinations of loading state
2. Added random text to the empty `<Drawer />` case to make sure this permutation does not collapse to an empty div

Related links, issue #, if available: n/a

### How has this been tested?

Reviewed locally. Now this page is good for testing CR-194096177

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
