### PR TITLE
chore: Updating Granularity type to that of CalendarProps

### DIFF
--- a/pages/date-range-picker/common.ts
+++ b/pages/date-range-picker/common.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { CalendarProps } from '~components/calendar';
 import { DateRangePickerProps } from '~components/date-range-picker';
 
 import { AppContextType } from '../app/app-context';
@@ -187,7 +188,7 @@ export function generateRelativeOptions(dateOnly: boolean, monthOnly: boolean) {
   return relativeOptions;
 }
 
-export const isValid = (granularity: DateRangePickerProps.Granularity) => {
+export const isValid = (granularity: CalendarProps.Granularity) => {
   const errorMessages = {
     durationBetweenOneAndTwenty: 'The amount part of the range needs to be between 1 and 20.',
     durationMissing: 'You need to provide a duration.',

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -7979,10 +7979,10 @@ Default: the user's current time offset as provided by the browser.",
     },
     {
       "defaultValue": "'day'",
-      "description": "Specifies the granularity at which users will be able to select a date range.
+      "description": "Specifies the granularity at which users will be able to select a date.
 Defaults to \`day\`.",
       "inlineType": {
-        "name": "DateRangePickerProps.Granularity",
+        "name": "CalendarProps.Granularity",
         "type": "union",
         "values": [
           "day",

--- a/src/date-range-picker/calendar/grids/index.tsx
+++ b/src/date-range-picker/calendar/grids/index.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { addMonths, addYears, isAfter, isBefore, isSameMonth, isSameYear, max, min } from 'date-fns';
 
+import { CalendarProps } from '../../../calendar/interfaces';
 import {
   getBaseDay,
   moveNextDay,
@@ -22,14 +23,13 @@ import { KeyCode } from '../../../internal/keycode';
 import handleKey from '../../../internal/utils/handle-key';
 import { hasValue } from '../../../internal/utils/has-value';
 import InternalSpaceBetween from '../../../space-between/internal';
-import { DateRangePickerProps } from '../../interfaces';
 import { findDateToFocus } from '../utils';
 import { Grid } from './grid';
 import { SelectGridProps } from './interfaces';
 
 import testutilStyles from '../../test-classes/styles.css.js';
 
-function isVisible(date: Date, baseDate: Date, isSingleGrid: boolean, granularity: DateRangePickerProps.Granularity) {
+function isVisible(date: Date, baseDate: Date, isSingleGrid: boolean, granularity: CalendarProps.Granularity) {
   const isSame = granularity === 'day' ? isSameMonth : isSameYear;
   const add = granularity === 'day' ? addMonths : addYears;
   if (isSingleGrid) {

--- a/src/date-range-picker/calendar/grids/interfaces.ts
+++ b/src/date-range-picker/calendar/grids/interfaces.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { CalendarProps } from '../../../calendar/interfaces';
 import { DateRangePickerProps, DayIndex } from '../../interfaces';
 
 export interface GridBaseProps {
@@ -33,10 +34,10 @@ export interface GridProps extends GridBaseProps {
   currentMonthAriaLabel?: string;
   startOfWeek?: DayIndex;
   todayAriaLabel?: string;
-  granularity: DateRangePickerProps.Granularity;
+  granularity: CalendarProps.Granularity;
 }
 
-export interface SelectGridProps extends GridBaseProps {
+export interface SelectGridProps extends GridBaseProps, Pick<CalendarProps, 'granularity'> {
   /**
    * changes the page/view of the calendar. Doing so will change to another month or year
    * @param date
@@ -51,7 +52,6 @@ export interface SelectGridProps extends GridBaseProps {
    * not needed for grids with a month granularity
    */
   startOfWeek?: DayIndex;
-  granularity?: DateRangePickerProps.Granularity;
   todayAriaLabel?: string;
   currentMonthAriaLabel?: string;
 }

--- a/src/date-range-picker/calendar/grids/interfaces.ts
+++ b/src/date-range-picker/calendar/grids/interfaces.ts
@@ -17,7 +17,7 @@ export interface GridBaseProps {
   locale: string;
 }
 
-export interface GridProps extends GridBaseProps {
+export interface GridProps extends GridBaseProps, Required<Pick<CalendarProps, 'granularity'>> {
   rangeStartDate: Date | null;
   rangeEndDate: Date | null;
   focusedDateRef: React.RefObject<HTMLTableCellElement>;
@@ -34,7 +34,6 @@ export interface GridProps extends GridBaseProps {
   currentMonthAriaLabel?: string;
   startOfWeek?: DayIndex;
   todayAriaLabel?: string;
-  granularity: CalendarProps.Granularity;
 }
 
 export interface SelectGridProps extends GridBaseProps, Pick<CalendarProps, 'granularity'> {

--- a/src/date-range-picker/calendar/header/header-button.tsx
+++ b/src/date-range-picker/calendar/header/header-button.tsx
@@ -4,14 +4,13 @@ import React from 'react';
 import clsx from 'clsx';
 
 import { InternalButton } from '../../../button/internal';
-import { DateRangePickerProps } from '../../interfaces';
+import { CalendarProps } from '../../../calendar/interfaces';
 
 import testutilStyles from '../../test-classes/styles.css.js';
 
-interface HeaderButtonProps {
+interface HeaderButtonProps extends Pick<CalendarProps, 'granularity'> {
   ariaLabel?: string;
   onChangePage: (n: number) => void;
-  granularity?: DateRangePickerProps.Granularity;
 }
 
 export function PrevPageButton({ ariaLabel, onChangePage }: HeaderButtonProps) {

--- a/src/date-range-picker/calendar/header/header-button.tsx
+++ b/src/date-range-picker/calendar/header/header-button.tsx
@@ -4,11 +4,10 @@ import React from 'react';
 import clsx from 'clsx';
 
 import { InternalButton } from '../../../button/internal';
-import { CalendarProps } from '../../../calendar/interfaces';
 
 import testutilStyles from '../../test-classes/styles.css.js';
 
-interface HeaderButtonProps extends Pick<CalendarProps, 'granularity'> {
+interface HeaderButtonProps {
   ariaLabel?: string;
   onChangePage: (n: number) => void;
 }

--- a/src/date-range-picker/calendar/header/index.tsx
+++ b/src/date-range-picker/calendar/header/index.tsx
@@ -4,16 +4,16 @@ import React from 'react';
 import clsx from 'clsx';
 import { add } from 'date-fns';
 
+import { CalendarProps } from '../../../calendar/interfaces';
 import { renderMonthAndYear, renderYear } from '../../../calendar/utils/intl';
 import { useInternalI18n } from '../../../i18n/context.js';
 import InternalLiveRegion from '../../../live-region/internal';
-import { DateRangePickerProps } from '../../interfaces';
 import { NextPageButton, PrevPageButton } from './header-button';
 
 import styles from '../../styles.css.js';
 import testutilStyles from '../../test-classes/styles.css.js';
 
-interface CalendarHeaderProps {
+interface CalendarHeaderProps extends Pick<CalendarProps, 'granularity'> {
   baseDate: Date;
   locale: string;
   onChangePage: (n: number) => void;
@@ -21,7 +21,6 @@ interface CalendarHeaderProps {
   nextPageLabel?: string;
   isSingleGrid: boolean;
   headingIdPrefix: string;
-  granularity?: DateRangePickerProps.Granularity;
 }
 
 export default function CalendarHeader({

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -16,6 +16,7 @@ import {
   startOfYear,
 } from 'date-fns';
 
+import { CalendarProps } from '../../calendar/interfaces';
 import { getDateLabel, renderTimeLabel } from '../../calendar/utils/intl';
 import { getBaseDay } from '../../calendar/utils/navigation-day';
 import { getBaseMonth } from '../../calendar/utils/navigation-month';
@@ -37,7 +38,7 @@ import { findDateToFocus, findMonthToDisplay, findMonthToFocus, findYearToDispla
 import styles from '../styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
 
-export interface DateRangePickerCalendarProps extends BaseComponentProps {
+export interface DateRangePickerCalendarProps extends BaseComponentProps, Pick<CalendarProps, 'granularity'> {
   value: DateRangePickerProps.PendingAbsoluteValue;
   setValue: React.Dispatch<React.SetStateAction<DateRangePickerProps.PendingAbsoluteValue>>;
   locale?: string;
@@ -48,7 +49,6 @@ export interface DateRangePickerCalendarProps extends BaseComponentProps {
   dateOnly?: boolean;
   timeInputFormat?: TimeInputProps.Format;
   customAbsoluteRangeControl: DateRangePickerProps.AbsoluteRangeControl | undefined;
-  granularity?: DateRangePickerProps.Granularity;
 }
 
 export default function DateRangePickerCalendar({

--- a/src/date-range-picker/calendar/range-inputs.tsx
+++ b/src/date-range-picker/calendar/range-inputs.tsx
@@ -4,13 +4,14 @@
 import React from 'react';
 import clsx from 'clsx';
 
+import { CalendarProps } from '../../calendar/interfaces';
 import InternalDateInput from '../../date-input/internal';
 import InternalFormField from '../../form-field/internal';
 import { useInternalI18n } from '../../i18n/context.js';
 import { BaseComponentProps } from '../../internal/base-component';
 import { TimeInputProps } from '../../time-input/interfaces';
 import InternalTimeInput from '../../time-input/internal';
-import { DateRangePickerProps, RangeCalendarI18nStrings } from '../interfaces';
+import { RangeCalendarI18nStrings } from '../interfaces';
 
 import styles from '../styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
@@ -28,7 +29,7 @@ type I18nStrings = Pick<
   | 'endTimeLabel'
 >;
 
-interface RangeInputsProps extends BaseComponentProps {
+interface RangeInputsProps extends BaseComponentProps, Pick<CalendarProps, 'granularity'> {
   startDate: string;
   onChangeStartDate: (value: string) => void;
   startTime: string;
@@ -40,7 +41,6 @@ interface RangeInputsProps extends BaseComponentProps {
   i18nStrings?: I18nStrings;
   dateOnly: boolean;
   timeInputFormat: TimeInputProps.Format;
-  granularity?: DateRangePickerProps.Granularity;
 }
 
 export default function RangeInputs({

--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -8,6 +8,7 @@ import InternalAlert from '../alert/internal';
 import InternalBox from '../box/internal';
 import { ButtonProps } from '../button/interfaces';
 import { InternalButton } from '../button/internal';
+import { CalendarProps } from '../calendar/interfaces';
 import { useInternalI18n } from '../i18n/context';
 import FocusLock from '../internal/components/focus-lock';
 import InternalLiveRegion, { InternalLiveRegionRef } from '../live-region/internal';
@@ -47,13 +48,13 @@ interface DateRangePickerDropdownProps
       | 'i18nStrings'
       | 'customRelativeRangeUnits'
       | 'dateDisabledReason'
-    > {
+    >,
+    Pick<CalendarProps, 'granularity'> {
   onClear: () => void;
   onApply: (value: null | DateRangePickerProps.Value) => DateRangePickerProps.ValidationResult;
   onDropdownClose: () => void;
   isSingleGrid: boolean;
   customAbsoluteRangeControl: DateRangePickerProps.AbsoluteRangeControl | undefined;
-  granularity?: DateRangePickerProps.Granularity;
 }
 
 export function DateRangePickerDropdown({

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import { CalendarProps } from '../calendar/interfaces';
 import { BaseComponentProps } from '../internal/base-component';
 import { ExpandToViewport } from '../internal/components/dropdown/interfaces';
 import { FormFieldValidationControlProps } from '../internal/context/form-field-context';
@@ -119,17 +120,13 @@ export interface DateRangePickerBaseProps {
    * Default: the user's current time offset as provided by the browser.
    */
   getTimeOffset?: DateRangePickerProps.GetTimeOffsetFunction;
-  /**
-   * Specifies the granularity at which users will be able to select a date range.
-   * Defaults to `day`.
-   */
-  granularity?: DateRangePickerProps.Granularity;
 }
 export interface DateRangePickerProps
   extends BaseComponentProps,
     FormFieldValidationControlProps,
     ExpandToViewport,
-    DateRangePickerBaseProps {
+    DateRangePickerBaseProps,
+    Pick<CalendarProps, 'granularity'> {
   /**
    * Specifies the placeholder text that is rendered when the value is empty.
    */
@@ -517,8 +514,6 @@ export namespace DateRangePickerProps {
   }
 
   export type AbsoluteFormat = 'iso' | 'long-localized';
-
-  export type Granularity = 'day' | 'month';
 }
 
 export type DayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;

--- a/src/date-range-picker/relative-range/index.tsx
+++ b/src/date-range-picker/relative-range/index.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 import InternalBox from '../../box/internal';
+import { CalendarProps } from '../../calendar/interfaces';
 import InternalFormField from '../../form-field/internal';
 import { useInternalI18n } from '../../i18n/context';
 import InternalInput from '../../input/internal';
@@ -18,7 +19,7 @@ import { DateRangePickerProps } from '../interfaces';
 import testutilStyles from '../test-classes/styles.css.js';
 import styles from './styles.css.js';
 
-interface RelativeRangePickerProps {
+interface RelativeRangePickerProps extends Pick<CalendarProps, 'granularity'> {
   dateOnly: boolean;
   options: ReadonlyArray<DateRangePickerProps.RelativeOption>;
   initialSelection: DateRangePickerProps.RelativeValue | null;
@@ -26,7 +27,6 @@ interface RelativeRangePickerProps {
   i18nStrings?: DateRangePickerProps.I18nStrings;
   isSingleGrid: boolean;
   customUnits?: DateRangePickerProps.TimeUnit[];
-  granularity?: DateRangePickerProps.Granularity;
 }
 
 interface UnitSelectOption {


### PR DESCRIPTION
### Description

Currently the DatePicker imports its Granularity from CalendarProps, so this will ensure the types are the same between DatePicker and DateRangePacker and the one source of truth for the Granularity type lives in the CalendarProps

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
