### PR TITLE
chore: Remove `selectionGroupLabel` from table's selection controls

### DIFF
--- a/src/table/__tests__/selection.test.tsx
+++ b/src/table/__tests__/selection.test.tsx
@@ -83,10 +83,7 @@ describe('Selection controls` labelling', () => {
 
   test('puts selectionGroupLabel and allItemsSelectionLabel on selectAll checkbox', () => {
     tableWrapper = renderTable({ selectionType: 'multi', selectedItems: [items[0]], ariaLabels }).wrapper;
-    expect(tableWrapper.findSelectAllTrigger()?.getElement()).toHaveAttribute(
-      'aria-label',
-      'group label 1 item selected'
-    );
+    expect(tableWrapper.findSelectAllTrigger()?.getElement()).toHaveAttribute('aria-label', '1 item selected');
   });
 
   test('puts selectionGroupLabel on single selection column header', () => {
@@ -108,15 +105,12 @@ describe('Selection controls` labelling', () => {
       tableWrapper = renderTable({ selectionType, ariaLabels, selectedItems: [items[1]] }).wrapper;
       expect(tableWrapper.findRowSelectionArea(1)?.getElement()).toHaveAttribute(
         'aria-label',
-        'group label Apples is not selected'
+        'Apples is not selected'
       );
-      expect(tableWrapper.findRowSelectionArea(2)?.getElement()).toHaveAttribute(
-        'aria-label',
-        'group label Oranges is selected'
-      );
+      expect(tableWrapper.findRowSelectionArea(2)?.getElement()).toHaveAttribute('aria-label', 'Oranges is selected');
       expect(tableWrapper.findRowSelectionArea(3)?.getElement()).toHaveAttribute(
         'aria-label',
-        'group label Bananas is not selected'
+        'Bananas is not selected'
       );
     });
   });

--- a/src/table/selection/use-selection.ts
+++ b/src/table/selection/use-selection.ts
@@ -4,7 +4,6 @@ import { useState } from 'react';
 
 import { fireNonCancelableEvent } from '../../internal/events';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
-import { joinStrings } from '../../internal/utils/strings';
 import { TableProps } from '../interfaces';
 import { getTrackableValue } from '../utils';
 import { SelectionProps } from './interfaces';
@@ -65,10 +64,7 @@ function useSingleSelection<T>({
       disabled: isItemDisabled(item),
       checked: isItemSelected(item),
       onChange: () => handleToggleItem(item),
-      ariaLabel: joinStrings(
-        ariaLabels?.selectionGroupLabel,
-        ariaLabels?.itemSelectionLabel?.({ selectedItems }, item)
-      ),
+      ariaLabel: ariaLabels?.itemSelectionLabel?.({ selectedItems }, item),
     }),
   };
 }
@@ -171,7 +167,7 @@ function useMultiSelection<T>({
       checked: allItemsCheckboxSelected,
       indeterminate: allItemsCheckboxIndeterminate,
       onChange: handleToggleAll,
-      ariaLabel: joinStrings(ariaLabels?.selectionGroupLabel, ariaLabels?.allItemsSelectionLabel?.({ selectedItems })),
+      ariaLabel: ariaLabels?.allItemsSelectionLabel?.({ selectedItems }),
       selectionGroupLabel: ariaLabels?.selectionGroupLabel,
     }),
     getItemSelectionProps: (item: T): SelectionProps => ({
@@ -181,10 +177,7 @@ function useMultiSelection<T>({
       checked: isItemSelected(item),
       onChange: () => handleToggleItem(item),
       onShiftToggle: (value: boolean) => setShiftPressed(value),
-      ariaLabel: joinStrings(
-        ariaLabels?.selectionGroupLabel,
-        ariaLabels?.itemSelectionLabel?.({ selectedItems }, item)
-      ),
+      ariaLabel: ariaLabels?.itemSelectionLabel?.({ selectedItems }, item),
     }),
   };
 }


### PR DESCRIPTION
The `selectionGroupLabel` property is already part of the table column header and considered while navigating through the table via screen readers. It's not necessary.

Resolves #3459

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
