### PR TITLE
feat: Add uapTriggerMode property to InternalDragHandle component

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     {
       "path": "lib/components/internal/widget-exports.js",
       "brotli": false,
-      "limit": "775 kB",
+      "limit": "776 kB",
       "ignore": "react-dom"
     }
   ],

--- a/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
+++ b/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
@@ -30,7 +30,7 @@ function getDirectionButton(direction: Direction) {
 }
 
 function expectDirectionButtonHidden(direction: Direction) {
-  // This kicks off an exit transition which doesn't end in JSDOM, so we just listen
+  // Direction buttons get hidden via transition which doesn't end in JSDOM, so we just listen
   // for the exiting classname instead.
   const motionExitingClass = styles['direction-button-wrapper-motion-exiting'];
   expect(getDirectionButton(direction)?.parentElement).toHaveClass(motionExitingClass);

--- a/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
+++ b/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
@@ -143,7 +143,7 @@ test("doesn't show direction buttons by default", () => {
   expect(getDirectionButton('block-end')).not.toBeInTheDocument();
 });
 
-describe('interactionMode = focus (default)', () => {
+describe('uapTriggerMode = focus (default)', () => {
   test('shows direction buttons when focus enters the button', () => {
     const { dragHandle } = renderDragHandle({
       directions: { 'block-start': 'active', 'block-end': 'active' },
@@ -174,11 +174,11 @@ describe('interactionMode = focus (default)', () => {
   });
 });
 
-describe('interactionMode = controlled', () => {
+describe('uapTriggerMode = enter', () => {
   test('does not show direction buttons when focus enters the button', () => {
     const { dragHandle } = renderDragHandle({
       directions: { 'block-start': 'active', 'block-end': 'active' },
-      interactionMode: 'controlled',
+      uapTriggerMode: 'enter',
     });
 
     document.body.dataset.awsuiFocusVisible = 'true';
@@ -192,7 +192,7 @@ describe('interactionMode = controlled', () => {
   test('show direction buttons when enter is pressed on the focused button', () => {
     const { dragHandle } = renderDragHandle({
       directions: { 'block-start': 'active', 'block-end': 'active' },
-      interactionMode: 'controlled',
+      uapTriggerMode: 'enter',
     });
 
     document.body.dataset.awsuiFocusVisible = 'true';
@@ -213,7 +213,7 @@ describe('interactionMode = controlled', () => {
   test('hides direction buttons when focus leaves the button', () => {
     const { dragHandle } = renderDragHandle({
       directions: { 'block-start': 'active', 'block-end': 'active' },
-      interactionMode: 'controlled',
+      uapTriggerMode: 'enter',
     });
 
     document.body.dataset.awsuiFocusVisible = 'true';
@@ -233,7 +233,7 @@ describe('interactionMode = controlled', () => {
   test('hides direction buttons when toggling enter key', () => {
     const { dragHandle } = renderDragHandle({
       directions: { 'block-start': 'active', 'block-end': 'active' },
-      interactionMode: 'controlled',
+      uapTriggerMode: 'enter',
     });
 
     document.body.dataset.awsuiFocusVisible = 'true';

--- a/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
+++ b/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
@@ -23,6 +23,19 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
+function getDirectionButton(direction: Direction) {
+  return document.querySelector<HTMLButtonElement>(
+    `.${styles[`direction-button-wrapper-${direction}`]} .${styles['direction-button']}`
+  );
+}
+
+function expectDirectionButtonHidden(direction: Direction) {
+  // This kicks off an exit transition which doesn't end in JSDOM, so we just listen
+  // for the exiting classname instead.
+  const motionExitingClass = styles['direction-button-wrapper-motion-exiting'];
+  expect(getDirectionButton(direction)?.parentElement).toHaveClass(motionExitingClass);
+}
+
 function renderDragHandle(props: Omit<DragHandleWrapperProps, 'children'>) {
   const { container } = render(
     <DragHandleWrapper {...props}>
@@ -39,11 +52,6 @@ function renderDragHandle(props: Omit<DragHandleWrapperProps, 'children'>) {
       container.querySelector<HTMLButtonElement>('#drag-button')!.focus();
     },
     getTooltip: () => document.querySelector(`.${tooltipStyles.root}`),
-    getDirectionButton: (direction: Direction) => {
-      return document.querySelector<HTMLButtonElement>(
-        `.${styles[`direction-button-wrapper-${direction}`]} .${styles['direction-button']}`
-      );
-    },
   };
 }
 
@@ -127,43 +135,125 @@ test('hides tooltip on Escape', () => {
 });
 
 test("doesn't show direction buttons by default", () => {
-  const { getDirectionButton } = renderDragHandle({
+  renderDragHandle({
     directions: { 'block-start': 'active' },
-    tooltipText: 'Click me!',
   });
 
   expect(getDirectionButton('block-start')).not.toBeInTheDocument();
   expect(getDirectionButton('block-end')).not.toBeInTheDocument();
 });
 
-test('shows direction buttons when focus enters the button as result of a key input', () => {
-  const { dragHandle, getDirectionButton } = renderDragHandle({
-    directions: { 'block-start': 'active', 'block-end': 'active' },
-    tooltipText: 'Click me!',
+describe('interactionMode = focus (default)', () => {
+  test('shows direction buttons when focus enters the button', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+    });
+
+    document.body.dataset.awsuiFocusVisible = 'true';
+    dragHandle.focus();
+    expect(getDirectionButton('block-start')).toBeVisible();
+    expect(getDirectionButton('block-end')).toBeVisible();
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
   });
 
-  document.body.dataset.awsuiFocusVisible = 'true';
-  dragHandle.focus();
-  expect(getDirectionButton('block-start')).toBeVisible();
-  expect(getDirectionButton('block-end')).toBeVisible();
-  expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+  test('hides direction buttons when focus leaves the button', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      tooltipText: 'Click me!',
+    });
+
+    document.body.dataset.awsuiFocusVisible = 'true';
+    dragHandle.focus();
+
+    expect(getDirectionButton('block-start')).toBeInTheDocument();
+    expect(getDirectionButton('block-end')).toBeInTheDocument();
+
+    fireEvent.blur(dragHandle);
+    expectDirectionButtonHidden('block-start');
+    expectDirectionButtonHidden('block-end');
+  });
 });
 
-test('hides direction buttons when focus leaves the button', () => {
-  const { dragHandle, getDirectionButton } = renderDragHandle({
-    directions: { 'block-start': 'active', 'block-end': 'active' },
-    tooltipText: 'Click me!',
+describe('interactionMode = controlled', () => {
+  test('does not show direction buttons when focus enters the button', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      interactionMode: 'controlled',
+    });
+
+    document.body.dataset.awsuiFocusVisible = 'true';
+    dragHandle.focus();
+    expect(getDirectionButton('block-start')).toBeNull();
+    expect(getDirectionButton('block-end')).toBeNull();
+    expect(getDirectionButton('inline-start')).toBeNull();
+    expect(getDirectionButton('inline-end')).toBeNull();
   });
 
-  document.body.dataset.awsuiFocusVisible = 'true';
-  fireEvent.focusIn(dragHandle, { relatedElement: document.body });
-  fireEvent.focusOut(dragHandle, { relatedElement: document.body });
-  expect(getDirectionButton('block-start')).not.toBeInTheDocument();
-  expect(getDirectionButton('block-end')).not.toBeInTheDocument();
+  test('show direction buttons when enter is pressed on the focused button', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      interactionMode: 'controlled',
+    });
+
+    document.body.dataset.awsuiFocusVisible = 'true';
+    dragHandle.focus();
+    expect(getDirectionButton('block-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('block-end')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(dragHandle, { key: 'Enter' });
+
+    expect(getDirectionButton('block-start')).toBeInTheDocument();
+    expect(getDirectionButton('block-end')).toBeInTheDocument();
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+  });
+
+  test('hides direction buttons when focus leaves the button', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      interactionMode: 'controlled',
+    });
+
+    document.body.dataset.awsuiFocusVisible = 'true';
+
+    dragHandle.focus();
+    fireEvent.keyDown(dragHandle, { key: 'Enter' });
+    expect(getDirectionButton('block-start')).toBeInTheDocument();
+    expect(getDirectionButton('block-end')).toBeInTheDocument();
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+
+    fireEvent.blur(dragHandle);
+    expectDirectionButtonHidden('block-start');
+    expectDirectionButtonHidden('block-end');
+  });
+
+  test('hides direction buttons when toggling enter key', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      interactionMode: 'controlled',
+    });
+
+    document.body.dataset.awsuiFocusVisible = 'true';
+
+    fireEvent.keyDown(dragHandle, { key: 'Enter' });
+
+    expect(getDirectionButton('block-start')).toBeInTheDocument();
+    expect(getDirectionButton('block-end')).toBeInTheDocument();
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(dragHandle, { key: 'Enter' });
+
+    expectDirectionButtonHidden('block-start');
+    expectDirectionButtonHidden('block-end');
+  });
 });
 
 test('shows direction buttons when clicked', () => {
-  const { dragHandle, getDirectionButton } = renderDragHandle({
+  const { dragHandle } = renderDragHandle({
     directions: { 'block-start': 'active' },
     tooltipText: 'Click me!',
   });
@@ -174,7 +264,7 @@ test('shows direction buttons when clicked', () => {
 });
 
 test(`doesn't show direction buttons when drag is "cancelled"`, () => {
-  const { dragHandle, getDirectionButton } = renderDragHandle({
+  const { dragHandle } = renderDragHandle({
     directions: { 'block-start': 'active' },
     tooltipText: 'Click me!',
   });
@@ -185,7 +275,7 @@ test(`doesn't show direction buttons when drag is "cancelled"`, () => {
 });
 
 test('shows direction buttons when dragged 2 pixels', () => {
-  const { dragHandle, getDirectionButton } = renderDragHandle({
+  const { dragHandle } = renderDragHandle({
     directions: { 'block-start': 'active' },
     tooltipText: 'Click me!',
   });
@@ -197,7 +287,7 @@ test('shows direction buttons when dragged 2 pixels', () => {
 });
 
 test("doesn't show direction buttons when dragged more than 3 pixels", () => {
-  const { dragHandle, getDirectionButton } = renderDragHandle({
+  const { dragHandle } = renderDragHandle({
     directions: { 'block-start': 'active' },
     tooltipText: 'Click me!',
   });
@@ -209,21 +299,18 @@ test("doesn't show direction buttons when dragged more than 3 pixels", () => {
 });
 
 test('hides direction buttons on Escape keypress', () => {
-  const { dragHandle, showButtons, getDirectionButton } = renderDragHandle({
+  const { dragHandle, showButtons } = renderDragHandle({
     directions: { 'block-start': 'active' },
     tooltipText: 'Click me!',
   });
 
   showButtons();
   fireEvent.keyDown(dragHandle, { key: 'Escape' });
-  // This kicks off an exit transition which doesn't end in JSDOM, so we just listen
-  // for the exiting classname instead.
-  const transitionWrapper = getDirectionButton('block-start')?.parentElement;
-  expect(transitionWrapper).toHaveClass(styles['direction-button-wrapper-motion-exiting']);
+  expectDirectionButtonHidden('block-start');
 });
 
 test('renders disabled direction buttons', () => {
-  const { showButtons, getDirectionButton } = renderDragHandle({
+  const { showButtons } = renderDragHandle({
     directions: { 'block-start': 'active' },
     tooltipText: 'Click me!',
   });
@@ -233,7 +320,7 @@ test('renders disabled direction buttons', () => {
 });
 
 test("doesn't render direction buttons if value for direction is undefined", () => {
-  const { showButtons, getDirectionButton } = renderDragHandle({
+  const { showButtons } = renderDragHandle({
     directions: { 'block-start': 'active', 'inline-start': undefined },
     tooltipText: 'Click me!',
   });
@@ -244,7 +331,7 @@ test("doesn't render direction buttons if value for direction is undefined", () 
 });
 
 test('focus returns to drag button after direction button is clicked', () => {
-  const { dragHandle, showButtons, getDirectionButton } = renderDragHandle({
+  const { dragHandle, showButtons } = renderDragHandle({
     directions: { 'block-start': 'active', 'inline-start': undefined },
     tooltipText: 'Click me!',
   });
@@ -257,7 +344,7 @@ test('focus returns to drag button after direction button is clicked', () => {
 
 test('calls onDirectionClick when direction button is pressed', () => {
   const onDirectionClick = jest.fn();
-  const { showButtons, getDirectionButton } = renderDragHandle({
+  const { showButtons } = renderDragHandle({
     directions: { 'block-start': 'active', 'block-end': 'active', 'inline-start': 'active', 'inline-end': 'active' },
     tooltipText: 'Click me!',
     onDirectionClick,
@@ -282,7 +369,7 @@ test('calls onDirectionClick when direction button is pressed', () => {
 
 test("doesn't call onDirectionClick when disabled direction button is pressed", () => {
   const onDirectionClick = jest.fn();
-  const { showButtons, getDirectionButton } = renderDragHandle({
+  const { showButtons } = renderDragHandle({
     directions: { 'block-start': 'disabled' },
     tooltipText: 'Click me!',
     onDirectionClick,

--- a/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
+++ b/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
@@ -143,7 +143,7 @@ test("doesn't show direction buttons by default", () => {
   expect(getDirectionButton('block-end')).not.toBeInTheDocument();
 });
 
-describe('uapTriggerMode = focus (default)', () => {
+describe('triggerMode = focus (default)', () => {
   test('shows direction buttons when focus enters the button', () => {
     const { dragHandle } = renderDragHandle({
       directions: { 'block-start': 'active', 'block-end': 'active' },
@@ -174,11 +174,11 @@ describe('uapTriggerMode = focus (default)', () => {
   });
 });
 
-describe('uapTriggerMode = enter', () => {
+describe('triggerMode = keyboard-activate', () => {
   test('does not show direction buttons when focus enters the button', () => {
     const { dragHandle } = renderDragHandle({
       directions: { 'block-start': 'active', 'block-end': 'active' },
-      uapTriggerMode: 'enter',
+      triggerMode: 'keyboard-activate',
     });
 
     document.body.dataset.awsuiFocusVisible = 'true';
@@ -189,10 +189,10 @@ describe('uapTriggerMode = enter', () => {
     expect(getDirectionButton('inline-end')).toBeNull();
   });
 
-  test('show direction buttons when enter is pressed on the focused button', () => {
+  test.each(['Enter', ' '])('show direction buttons when "%s" key is pressed on the focused button', key => {
     const { dragHandle } = renderDragHandle({
       directions: { 'block-start': 'active', 'block-end': 'active' },
-      uapTriggerMode: 'enter',
+      triggerMode: 'keyboard-activate',
     });
 
     document.body.dataset.awsuiFocusVisible = 'true';
@@ -202,7 +202,7 @@ describe('uapTriggerMode = enter', () => {
     expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
     expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
 
-    fireEvent.keyDown(dragHandle, { key: 'Enter' });
+    fireEvent.keyDown(dragHandle, { key });
 
     expect(getDirectionButton('block-start')).toBeInTheDocument();
     expect(getDirectionButton('block-end')).toBeInTheDocument();
@@ -213,7 +213,7 @@ describe('uapTriggerMode = enter', () => {
   test('hides direction buttons when focus leaves the button', () => {
     const { dragHandle } = renderDragHandle({
       directions: { 'block-start': 'active', 'block-end': 'active' },
-      uapTriggerMode: 'enter',
+      triggerMode: 'keyboard-activate',
     });
 
     document.body.dataset.awsuiFocusVisible = 'true';
@@ -230,22 +230,22 @@ describe('uapTriggerMode = enter', () => {
     expectDirectionButtonHidden('block-end');
   });
 
-  test('hides direction buttons when toggling enter key', () => {
+  test.each(['Enter', ' '])('hides direction buttons when toggling "%s" key', key => {
     const { dragHandle } = renderDragHandle({
       directions: { 'block-start': 'active', 'block-end': 'active' },
-      uapTriggerMode: 'enter',
+      triggerMode: 'keyboard-activate',
     });
 
     document.body.dataset.awsuiFocusVisible = 'true';
 
-    fireEvent.keyDown(dragHandle, { key: 'Enter' });
+    fireEvent.keyDown(dragHandle, { key });
 
     expect(getDirectionButton('block-start')).toBeInTheDocument();
     expect(getDirectionButton('block-end')).toBeInTheDocument();
     expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
     expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
 
-    fireEvent.keyDown(dragHandle, { key: 'Enter' });
+    fireEvent.keyDown(dragHandle, { key });
 
     expectDirectionButtonHidden('block-start');
     expectDirectionButtonHidden('block-end');

--- a/src/internal/components/drag-handle-wrapper/index.tsx
+++ b/src/internal/components/drag-handle-wrapper/index.tsx
@@ -25,7 +25,7 @@ export default function DragHandleWrapper({
   tooltipText,
   children,
   onDirectionClick,
-  interactionMode = 'focus',
+  uapTriggerMode = 'focus',
 }: DragHandleWrapperProps) {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const dragHandleRef = useRef<HTMLDivElement | null>(null);
@@ -50,7 +50,7 @@ export default function DragHandleWrapper({
     // if the action that triggered the focus move was the result of a keypress.
     if (document.body.dataset.awsuiFocusVisible && !nodeContains(wrapperRef.current, event.relatedTarget)) {
       setShowTooltip(false);
-      if (interactionMode === 'focus') {
+      if (uapTriggerMode === 'focus') {
         setShowButtons(true);
       }
     }
@@ -154,7 +154,7 @@ export default function DragHandleWrapper({
     // the floating controls.
     if (event.key === 'Escape') {
       setShowButtons(false);
-    } else if (interactionMode === 'controlled' && event.key === 'Enter') {
+    } else if (uapTriggerMode === 'enter' && event.key === 'Enter') {
       // toggle buttons when Enter is pressed in controlled mode
       setShowButtons(prevShowButtons => !prevShowButtons);
     } else if (event.key !== 'Alt' && event.key !== 'Control' && event.key !== 'Meta' && event.key !== 'Shift') {

--- a/src/internal/components/drag-handle-wrapper/index.tsx
+++ b/src/internal/components/drag-handle-wrapper/index.tsx
@@ -25,6 +25,7 @@ export default function DragHandleWrapper({
   tooltipText,
   children,
   onDirectionClick,
+  interactionMode = 'focus',
 }: DragHandleWrapperProps) {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const dragHandleRef = useRef<HTMLDivElement | null>(null);
@@ -49,7 +50,9 @@ export default function DragHandleWrapper({
     // if the action that triggered the focus move was the result of a keypress.
     if (document.body.dataset.awsuiFocusVisible && !nodeContains(wrapperRef.current, event.relatedTarget)) {
       setShowTooltip(false);
-      setShowButtons(true);
+      if (interactionMode === 'focus') {
+        setShowButtons(true);
+      }
     }
   };
 
@@ -151,6 +154,9 @@ export default function DragHandleWrapper({
     // the floating controls.
     if (event.key === 'Escape') {
       setShowButtons(false);
+    } else if (interactionMode === 'controlled' && event.key === 'Enter') {
+      // toggle buttons when Enter is pressed in controlled mode
+      setShowButtons(prevShowButtons => !prevShowButtons);
     } else if (event.key !== 'Alt' && event.key !== 'Control' && event.key !== 'Meta' && event.key !== 'Shift') {
       // Pressing any other key will display the focus-visible ring around the
       // drag handle if it's in focus, so we should also show the buttons now.

--- a/src/internal/components/drag-handle-wrapper/index.tsx
+++ b/src/internal/components/drag-handle-wrapper/index.tsx
@@ -25,7 +25,7 @@ export default function DragHandleWrapper({
   tooltipText,
   children,
   onDirectionClick,
-  uapTriggerMode = 'focus',
+  triggerMode = 'focus',
 }: DragHandleWrapperProps) {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const dragHandleRef = useRef<HTMLDivElement | null>(null);
@@ -50,7 +50,7 @@ export default function DragHandleWrapper({
     // if the action that triggered the focus move was the result of a keypress.
     if (document.body.dataset.awsuiFocusVisible && !nodeContains(wrapperRef.current, event.relatedTarget)) {
       setShowTooltip(false);
-      if (uapTriggerMode === 'focus') {
+      if (triggerMode === 'focus') {
         setShowButtons(true);
       }
     }
@@ -154,8 +154,8 @@ export default function DragHandleWrapper({
     // the floating controls.
     if (event.key === 'Escape') {
       setShowButtons(false);
-    } else if (uapTriggerMode === 'enter' && event.key === 'Enter') {
-      // toggle buttons when Enter is pressed in controlled mode
+    } else if (triggerMode === 'keyboard-activate' && (event.key === 'Enter' || event.key === ' ')) {
+      // toggle buttons when Enter or space is pressed in 'keyboard-activate' triggerMode
       setShowButtons(prevShowButtons => !prevShowButtons);
     } else if (event.key !== 'Alt' && event.key !== 'Control' && event.key !== 'Meta' && event.key !== 'Shift') {
       // Pressing any other key will display the focus-visible ring around the

--- a/src/internal/components/drag-handle-wrapper/interfaces.ts
+++ b/src/internal/components/drag-handle-wrapper/interfaces.ts
@@ -3,12 +3,12 @@
 
 export type Direction = 'block-start' | 'block-end' | 'inline-start' | 'inline-end';
 export type DirectionState = 'active' | 'disabled';
-export type InteractionMode = 'focus' | 'controlled';
+export type UapTriggerMode = 'focus' | 'enter';
 
 export interface DragHandleWrapperProps {
   directions: Partial<Record<Direction, DirectionState>>;
   onDirectionClick?: (direction: Direction) => void;
   tooltipText?: string;
   children: React.ReactNode;
-  interactionMode?: InteractionMode;
+  uapTriggerMode?: UapTriggerMode;
 }

--- a/src/internal/components/drag-handle-wrapper/interfaces.ts
+++ b/src/internal/components/drag-handle-wrapper/interfaces.ts
@@ -3,10 +3,12 @@
 
 export type Direction = 'block-start' | 'block-end' | 'inline-start' | 'inline-end';
 export type DirectionState = 'active' | 'disabled';
+export type InteractionMode = 'focus' | 'controlled';
 
 export interface DragHandleWrapperProps {
   directions: Partial<Record<Direction, DirectionState>>;
   onDirectionClick?: (direction: Direction) => void;
   tooltipText?: string;
   children: React.ReactNode;
+  interactionMode?: InteractionMode;
 }

--- a/src/internal/components/drag-handle-wrapper/interfaces.ts
+++ b/src/internal/components/drag-handle-wrapper/interfaces.ts
@@ -3,12 +3,12 @@
 
 export type Direction = 'block-start' | 'block-end' | 'inline-start' | 'inline-end';
 export type DirectionState = 'active' | 'disabled';
-export type UapTriggerMode = 'focus' | 'enter';
+export type TriggerMode = 'focus' | 'keyboard-activate';
 
 export interface DragHandleWrapperProps {
   directions: Partial<Record<Direction, DirectionState>>;
   onDirectionClick?: (direction: Direction) => void;
   tooltipText?: string;
   children: React.ReactNode;
-  uapTriggerMode?: UapTriggerMode;
+  triggerMode?: TriggerMode;
 }

--- a/src/internal/components/drag-handle/index.tsx
+++ b/src/internal/components/drag-handle/index.tsx
@@ -24,6 +24,7 @@ const InternalDragHandle = forwardRef(
       onPointerDown,
       onKeyDown,
       onDirectionClick,
+      interactionMode,
       ...rest
     }: DragHandleProps,
     ref: React.Ref<Element>
@@ -35,6 +36,7 @@ const InternalDragHandle = forwardRef(
         directions={!disabled ? directions : {}}
         tooltipText={tooltipText}
         onDirectionClick={onDirectionClick}
+        interactionMode={interactionMode}
       >
         <DragHandleButton
           ref={ref}

--- a/src/internal/components/drag-handle/index.tsx
+++ b/src/internal/components/drag-handle/index.tsx
@@ -24,7 +24,7 @@ const InternalDragHandle = forwardRef(
       onPointerDown,
       onKeyDown,
       onDirectionClick,
-      uapTriggerMode,
+      triggerMode,
       ...rest
     }: DragHandleProps,
     ref: React.Ref<Element>
@@ -36,7 +36,7 @@ const InternalDragHandle = forwardRef(
         directions={!disabled ? directions : {}}
         tooltipText={tooltipText}
         onDirectionClick={onDirectionClick}
-        uapTriggerMode={uapTriggerMode}
+        triggerMode={triggerMode}
       >
         <DragHandleButton
           ref={ref}

--- a/src/internal/components/drag-handle/index.tsx
+++ b/src/internal/components/drag-handle/index.tsx
@@ -24,7 +24,7 @@ const InternalDragHandle = forwardRef(
       onPointerDown,
       onKeyDown,
       onDirectionClick,
-      interactionMode,
+      uapTriggerMode,
       ...rest
     }: DragHandleProps,
     ref: React.Ref<Element>
@@ -36,7 +36,7 @@ const InternalDragHandle = forwardRef(
         directions={!disabled ? directions : {}}
         tooltipText={tooltipText}
         onDirectionClick={onDirectionClick}
-        interactionMode={interactionMode}
+        uapTriggerMode={uapTriggerMode}
       >
         <DragHandleButton
           ref={ref}

--- a/src/internal/components/drag-handle/interfaces.ts
+++ b/src/internal/components/drag-handle/interfaces.ts
@@ -4,7 +4,7 @@
 import {
   Direction as WrapperDirection,
   DirectionState as WrapperDirectionState,
-  InteractionMode as WrapperInteractionMode,
+  UapTriggerMode,
 } from '../drag-handle-wrapper/interfaces';
 
 export interface DragHandleProps {
@@ -22,7 +22,7 @@ export interface DragHandleProps {
   tooltipText?: string;
   directions?: Partial<Record<DragHandleProps.Direction, DragHandleProps.DirectionState>>;
   onDirectionClick?: (direction: DragHandleProps.Direction) => void;
-  interactionMode?: WrapperInteractionMode;
+  uapTriggerMode?: UapTriggerMode;
 }
 
 export namespace DragHandleProps {

--- a/src/internal/components/drag-handle/interfaces.ts
+++ b/src/internal/components/drag-handle/interfaces.ts
@@ -4,6 +4,7 @@
 import {
   Direction as WrapperDirection,
   DirectionState as WrapperDirectionState,
+  InteractionMode as WrapperInteractionMode,
 } from '../drag-handle-wrapper/interfaces';
 
 export interface DragHandleProps {
@@ -21,6 +22,7 @@ export interface DragHandleProps {
   tooltipText?: string;
   directions?: Partial<Record<DragHandleProps.Direction, DragHandleProps.DirectionState>>;
   onDirectionClick?: (direction: DragHandleProps.Direction) => void;
+  interactionMode?: WrapperInteractionMode;
 }
 
 export namespace DragHandleProps {

--- a/src/internal/components/drag-handle/interfaces.ts
+++ b/src/internal/components/drag-handle/interfaces.ts
@@ -4,7 +4,7 @@
 import {
   Direction as WrapperDirection,
   DirectionState as WrapperDirectionState,
-  UapTriggerMode,
+  TriggerMode,
 } from '../drag-handle-wrapper/interfaces';
 
 export interface DragHandleProps {
@@ -22,7 +22,7 @@ export interface DragHandleProps {
   tooltipText?: string;
   directions?: Partial<Record<DragHandleProps.Direction, DragHandleProps.DirectionState>>;
   onDirectionClick?: (direction: DragHandleProps.Direction) => void;
-  uapTriggerMode?: UapTriggerMode;
+  triggerMode?: TriggerMode;
 }
 
 export namespace DragHandleProps {


### PR DESCRIPTION
### Description

This mode allows the builder to decide when UAP action buttons are shown.

Use-case: On board items the UAP action buttons should be shown on key `Enter` press instead of `onFocus`. When using `onFocus` to show them, tabbing through a board with many board items gets visually noisy.

(This is a preparation for adding the InternalDragHandle to board-items)

Related links, issue #, if available: `AWSUI-60240`

### How has this been tested?

- added additional unit tests for the new interaction mode

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
