### PR TITLE
chore: Add test for InternalDragHandle ariaDescribedby

### DIFF
--- a/src/internal/components/drag-handle/__tests__/drag-handle.test.tsx
+++ b/src/internal/components/drag-handle/__tests__/drag-handle.test.tsx
@@ -19,3 +19,15 @@ test('passes ariaLabelledBy to DragHandleButton', () => {
   expect(document.querySelector(`.${styles.handle}`)).toHaveAttribute('aria-labelledby', 'label-element');
   expect(document.querySelector(`.${styles.handle}`)).toHaveAccessibleName('custom label');
 });
+
+test('passes ariaDescribedby to DragHandleButton', () => {
+  render(
+    <div>
+      <div id="describe-element">describe label</div>
+      <InternalDragHandle ariaDescribedby="describe-element" />
+    </div>
+  );
+
+  expect(document.querySelector(`.${styles.handle}`)).toHaveAttribute('aria-describedby', 'describe-element');
+  expect(document.querySelector(`.${styles.handle}`)).toHaveAccessibleDescription('describe label');
+});


### PR DESCRIPTION
### Description

The property was introduced in #3431. Adding this test has been missed.

Related links, issue #, if available: `AWSUI-60240`

### How has this been tested?

- updated existing unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
