### PR TITLE
fix: Prevent forms wrapping inline editing table from submitting

### DIFF
--- a/src/table/__tests__/inline-editor.test.tsx
+++ b/src/table/__tests__/inline-editor.test.tsx
@@ -105,6 +105,30 @@ describe('InlineEditor', () => {
     expect(handleEditEnd).toHaveBeenCalled();
   });
 
+  it('should not submit any wrapping forms', () => {
+    thereBeErrors = false;
+    const changeEvent = new Event('change', { bubbles: true });
+    const onSubmitSpy = jest.fn();
+    const { wrapper } = renderComponent(
+      <form onSubmit={onSubmitSpy}>
+        <TestComponent />
+      </form>
+    );
+
+    const input = wrapper.find('input')!.getElement();
+    fireEvent.click(input);
+
+    fireEvent(input, changeEvent);
+    fireEvent.click(wrapper.getElement().querySelector('[aria-label="save edit"]')!);
+
+    waitFor(() => {
+      expect(handleSubmitEdit).toHaveBeenCalled();
+      expect(handleSubmitEdit.mock.lastCall!.length).toBe(3);
+    });
+
+    expect(onSubmitSpy).not.toHaveBeenCalled();
+  });
+
   it('should handle failed submission', () => {
     thereBeErrors = false;
     const changeEvent = new Event('change', { bubbles: true });

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -58,7 +58,8 @@ export function InlineEditor<ItemType>({
   }
 
   async function onSubmitClick(evt: React.FormEvent) {
-    evt.preventDefault();
+    evt.preventDefault(); // Prevents the form from navigating away
+    evt.stopPropagation(); // Prevents any outer form elements from submitting
     if (currentEditValue === undefined) {
       finishEdit();
       return;


### PR DESCRIPTION
### Description

A quick fix for an issue when you put an inline editing table inside an "outer form" (well, technically, you shouldn't nest forms, but, well...)

Related links, issue #, if available: AWSUI-60735

### How has this been tested?

Added a unit test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
