### PR TITLE
feat: Add interaction state hook with DnD and keyboard support

### DIFF
--- a/build-tools/tasks/package-json.js
+++ b/build-tools/tasks/package-json.js
@@ -28,6 +28,7 @@ function getComponentsExports() {
     './internal/do-not-use/expandable-section': './internal/do-not-use/expandable-section.js',
     './internal/do-not-use/i18n': './internal/do-not-use/i18n.js',
     './internal/do-not-use/tooltip': './internal/do-not-use/tooltip.js',
+    './internal/do-not-use/drag-handle': './internal/do-not-use/drag-handle.js',
     './internal/widget-exports': './internal/widget-exports.js',
     './test-utils/dom/internal/tooltip': './test-utils/dom/internal/tooltip.js',
     './test-utils/selectors/internal/tooltip': './test-utils/selectors/internal/tooltip.js',

--- a/pages/drag-handle/drag-handle-interaction-state-hook.page.tsx
+++ b/pages/drag-handle/drag-handle-interaction-state-hook.page.tsx
@@ -1,15 +1,31 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import clsx from 'clsx';
 
-import InternalDragHandle from '~components/internal/components/drag-handle';
+import Box from '~components/box';
+import Checkbox from '~components/checkbox';
+import Container from '~components/container';
+import Header from '~components/header';
 import useDragHandleInteractionState, {
   UseDragHandleInteractionStateProps,
 } from '~components/internal/components/drag-handle/hooks/use-drag-handle-interaction-state';
+import SpaceBetween from '~components/space-between';
+
+import AppContext, { AppContextType } from '../app/app-context';
+
+import styles from './styles.scss';
+
+type PageContext = React.Context<
+  AppContextType<{
+    renderInPortal: boolean;
+  }>
+>;
 
 const TestBoardItemButton: React.FC = () => {
-  const [shouldRenderInPortal, setShouldRenderInPortal] = useState(true);
+  const { urlParams, setUrlParams } = useContext(AppContext as PageContext);
+  const [renderInPortal, setRenderInPortal] = useState(false);
 
   interface TestMetadata {
     operation: 'drag' | 'resize';
@@ -36,84 +52,79 @@ const TestBoardItemButton: React.FC = () => {
   const hook = useDragHandleInteractionState<TestMetadata>(hookProps);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
-  useEffect(() => {
-    const currentButton = buttonRef.current;
+  const handleGlobalPointerMove = (event: PointerEvent) => {
+    hook.processPointerMove(event);
+  };
 
-    const handleGlobalPointerMove = (event: PointerEvent) => {
-      hook.processPointerMove(event);
-    };
+  const handleGlobalPointerUp = (event: PointerEvent) => {
+    hook.processPointerUp(event);
+    // Clean up global listeners after interaction ends
+    window.removeEventListener('pointermove', handleGlobalPointerMove);
+    window.removeEventListener('pointerup', handleGlobalPointerUp);
+  };
 
-    const handleGlobalPointerUp = (event: PointerEvent) => {
-      hook.processPointerUp(event);
-      // Clean up global listeners after interaction ends
-      window.removeEventListener('pointermove', handleGlobalPointerMove);
-      window.removeEventListener('pointerup', handleGlobalPointerUp);
-    };
+  const handleOnPointerDown = (event: PointerEvent) => {
+    hook.processPointerDown(event, { operation: 'drag' });
+    if (urlParams.renderInPortal) {
+      setRenderInPortal(true);
+    }
 
-    const handleWindowPointerDown = (event: PointerEvent) => {
-      // Is the event originated from our button?
-      if (currentButton && currentButton.contains(event.target as Node)) {
-        hook.processPointerDown(event, { operation: 'drag' }); // event is already native PointerEvent from window listener
+    window.addEventListener('pointermove', handleGlobalPointerMove);
+    window.addEventListener('pointerup', handleGlobalPointerUp);
+  };
 
-        // Start listening for global move and up
-        window.addEventListener('pointermove', handleGlobalPointerMove);
-        window.addEventListener('pointerup', handleGlobalPointerUp);
-      }
-    };
-    window.addEventListener('pointerdown', handleWindowPointerDown);
-
-    return () => {
-      window.removeEventListener('pointerdown', handleWindowPointerDown);
-      window.removeEventListener('pointermove', handleGlobalPointerMove);
-      window.removeEventListener('pointerup', handleGlobalPointerUp);
-    };
-    // Depend on the specific (stable) hook properties, as the hook itself changes on every state change.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hook.processPointerDown, shouldRenderInPortal]);
-
+  // Using a native button for testing because the system's button does not expose all native properties
   const buttonComp = (
-    <>
-      <InternalDragHandle />
-      <button
-        ref={buttonRef}
-        onKeyDown={e => hook.processKeyDown(e, { operation: 'resize' })}
-        onFocus={hook.processFocus}
-        onBlur={hook.processBlur}
-        style={{
-          padding: '20px',
-          border: '2px solid blue',
-          touchAction: 'none',
-        }}
-        tabIndex={0}
-      >
-        Interact with Me (Global Pointer Listeners)
-      </button>
-    </>
+    <button
+      ref={buttonRef}
+      onPointerDown={e => handleOnPointerDown(e.nativeEvent)}
+      onKeyDown={e => hook.processKeyDown(e, { operation: 'resize' })}
+      onFocus={hook.processFocus}
+      onBlur={hook.processBlur}
+      className={clsx(styles['test-button'])}
+      tabIndex={0}
+    >
+      Test button to interact with
+    </button>
   );
 
   return (
-    <div>
-      <button onClick={() => setShouldRenderInPortal(prevState => !prevState)}>
-        RenderInPortal: {shouldRenderInPortal.toString()}
-      </button>
-      <hr />
-      <div style={{ marginTop: '20px', fontFamily: 'monospace' }}>
-        <p>Current State: {String(hook.interaction.state) || 'null'}</p>
-        <p>Metadata: {JSON.stringify(hook.interaction.metadata)}</p>
-        <p>
-          DnD Event Coords (last):{' '}
-          {hook.interaction.eventData ? (
-            <>
-              ({hook.interaction.eventData?.clientX}, {hook.interaction.eventData?.clientY})
-            </>
-          ) : (
-            '-'
-          )}
-        </p>
-      </div>
-      <hr />
-      {shouldRenderInPortal ? <div>{createPortal(buttonComp, document.body)}</div> : buttonComp}
-    </div>
+    <>
+      <Header
+        variant="h1"
+        description="Page to test the board-item behaviour which is rendered in a portal on onPointerDown when adding from the pallete to the board"
+      >
+        Drag handle hook
+      </Header>
+      <SpaceBetween size="m">
+        <Checkbox
+          checked={urlParams.renderInPortal}
+          onChange={event => {
+            setUrlParams({ renderInPortal: event.detail.checked });
+          }}
+        >
+          Render Test Button in a portal on click
+        </Checkbox>
+
+        <Container>
+          <Box variant="pre">
+            <p>Current State: {String(hook.interaction.state) || 'null'}</p>
+            <p>Metadata: {JSON.stringify(hook.interaction.metadata)}</p>
+            <p>
+              DnD Event Coords:{' '}
+              {hook.interaction.eventData ? (
+                <>
+                  ({hook.interaction.eventData?.clientX}, {hook.interaction.eventData?.clientY})
+                </>
+              ) : (
+                '-'
+              )}
+            </p>
+          </Box>
+        </Container>
+        {renderInPortal ? <div>{createPortal(buttonComp, document.body)}</div> : buttonComp}
+      </SpaceBetween>
+    </>
   );
 };
 

--- a/pages/drag-handle/drag-handle-interaction-state-hook.page.tsx
+++ b/pages/drag-handle/drag-handle-interaction-state-hook.page.tsx
@@ -63,6 +63,13 @@ const TestBoardItemButton: React.FC = () => {
     window.removeEventListener('pointerup', handleGlobalPointerUp);
   };
 
+  const handlePointerCancel = () => {
+    hook.processPointerCancel();
+    // Clean up global listeners after interaction ends
+    window.removeEventListener('pointermove', handleGlobalPointerMove);
+    window.removeEventListener('pointerup', handleGlobalPointerUp);
+  };
+
   const handleOnPointerDown = (event: PointerEvent) => {
     hook.processPointerDown(event, { operation: 'drag' });
     if (urlParams.renderInPortal) {
@@ -78,6 +85,7 @@ const TestBoardItemButton: React.FC = () => {
     <button
       ref={buttonRef}
       onPointerDown={e => handleOnPointerDown(e.nativeEvent)}
+      onPointerCancel={handlePointerCancel}
       onKeyDown={e => hook.processKeyDown(e, { operation: 'resize' })}
       onFocus={hook.processFocus}
       onBlur={hook.processBlur}
@@ -108,7 +116,7 @@ const TestBoardItemButton: React.FC = () => {
 
         <Container>
           <Box variant="pre">
-            <p>Current State: {String(hook.interaction.state) || 'null'}</p>
+            <p>Current State: {String(hook.interaction.value) || 'null'}</p>
             <p>Metadata: {JSON.stringify(hook.interaction.metadata)}</p>
             <p>
               DnD Event Coords:{' '}

--- a/pages/drag-handle/drag-handle-interaction-state-hook.page.tsx
+++ b/pages/drag-handle/drag-handle-interaction-state-hook.page.tsx
@@ -1,0 +1,120 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import InternalDragHandle from '~components/internal/components/drag-handle';
+import useDragHandleInteractionState, {
+  UseDragHandleInteractionStateProps,
+} from '~components/internal/components/drag-handle/hooks/use-drag-handle-interaction-state';
+
+const TestBoardItemButton: React.FC = () => {
+  const [shouldRenderInPortal, setShouldRenderInPortal] = useState(true);
+
+  interface TestMetadata {
+    operation: 'drag' | 'resize';
+  }
+
+  const hookProps: UseDragHandleInteractionStateProps<TestMetadata> = {
+    onDndStartAction: (event, metadata) => {
+      console.log('onDndStartAction triggered', event.clientX, event.clientY, metadata);
+    },
+    onDndActiveAction: event => {
+      console.log('onDndActiveAction triggered', event.clientX, event.clientY);
+    },
+    onDndEndAction: () => {
+      console.log('onDndEndAction triggered');
+    },
+    onUapActionStartAction: metadata => {
+      console.log('onKeyboardStartAction triggered', metadata);
+    },
+    onUapActionEndAction: () => {
+      console.log('onKeyboardEndAction triggered');
+    },
+  };
+
+  const hook = useDragHandleInteractionState<TestMetadata>(hookProps);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const currentButton = buttonRef.current;
+
+    const handleGlobalPointerMove = (event: PointerEvent) => {
+      hook.processPointerMove(event);
+    };
+
+    const handleGlobalPointerUp = (event: PointerEvent) => {
+      hook.processPointerUp(event);
+      // Clean up global listeners after interaction ends
+      window.removeEventListener('pointermove', handleGlobalPointerMove);
+      window.removeEventListener('pointerup', handleGlobalPointerUp);
+    };
+
+    const handleWindowPointerDown = (event: PointerEvent) => {
+      // Is the event originated from our button?
+      if (currentButton && currentButton.contains(event.target as Node)) {
+        hook.processPointerDown(event, { operation: 'drag' }); // event is already native PointerEvent from window listener
+
+        // Start listening for global move and up
+        window.addEventListener('pointermove', handleGlobalPointerMove);
+        window.addEventListener('pointerup', handleGlobalPointerUp);
+      }
+    };
+    window.addEventListener('pointerdown', handleWindowPointerDown);
+
+    return () => {
+      window.removeEventListener('pointerdown', handleWindowPointerDown);
+      window.removeEventListener('pointermove', handleGlobalPointerMove);
+      window.removeEventListener('pointerup', handleGlobalPointerUp);
+    };
+    // Depend on the specific (stable) hook properties, as the hook itself changes on every state change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hook.processPointerDown, shouldRenderInPortal]);
+
+  const buttonComp = (
+    <>
+      <InternalDragHandle />
+      <button
+        ref={buttonRef}
+        onKeyDown={e => hook.processKeyDown(e, { operation: 'resize' })}
+        onFocus={hook.processFocus}
+        onBlur={hook.processBlur}
+        style={{
+          padding: '20px',
+          border: '2px solid blue',
+          touchAction: 'none',
+        }}
+        tabIndex={0}
+      >
+        Interact with Me (Global Pointer Listeners)
+      </button>
+    </>
+  );
+
+  return (
+    <div>
+      <button onClick={() => setShouldRenderInPortal(prevState => !prevState)}>
+        RenderInPortal: {shouldRenderInPortal.toString()}
+      </button>
+      <hr />
+      <div style={{ marginTop: '20px', fontFamily: 'monospace' }}>
+        <p>Current State: {String(hook.interaction.state) || 'null'}</p>
+        <p>Metadata: {JSON.stringify(hook.interaction.metadata)}</p>
+        <p>
+          DnD Event Coords (last):{' '}
+          {hook.interaction.eventData ? (
+            <>
+              ({hook.interaction.eventData?.clientX}, {hook.interaction.eventData?.clientY})
+            </>
+          ) : (
+            '-'
+          )}
+        </p>
+      </div>
+      <hr />
+      {shouldRenderInPortal ? <div>{createPortal(buttonComp, document.body)}</div> : buttonComp}
+    </div>
+  );
+};
+
+export default TestBoardItemButton;

--- a/pages/drag-handle/styles.scss
+++ b/pages/drag-handle/styles.scss
@@ -1,0 +1,20 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '~design-tokens' as awsui;
+
+.test-button {
+  background: awsui.$color-background-button-normal-default;
+  padding-block: awsui.$space-scaled-xxl;
+  padding-inline: awsui.$space-scaled-xxl;
+
+  &:hover {
+    background: awsui.$color-background-button-normal-hover;
+  }
+
+  &:focus {
+    background: awsui.$color-background-button-normal-active;
+  }
+}

--- a/src/internal/components/drag-handle/hooks/__tests__/use-drag-handle-interaction-state.test.tsx
+++ b/src/internal/components/drag-handle/hooks/__tests__/use-drag-handle-interaction-state.test.tsx
@@ -107,6 +107,8 @@ function createPointerEvent(type: string, overrides: Partial<any> = {}): any {
   });
 }
 
+const KEY_CODES_TO_TOGGLE_UAP_ACTION = ['Enter', ' '];
+
 describe('Drag Handle Hooks', () => {
   describe('Helper Functions', () => {
     describe('calculateNextState', () => {
@@ -186,27 +188,33 @@ describe('Drag Handle Hooks', () => {
         expect(nextState.eventData).toBe(mockPointerEvent);
       });
 
-      test('should transition to uap-action-start on Enter key press from idle', () => {
-        const state: DragHandleInteractionState = { state: null };
-        const action: Action = {
-          type: 'KEY_DOWN',
-          payload: { key: 'Enter' },
-        };
+      test.each(KEY_CODES_TO_TOGGLE_UAP_ACTION)(
+        'should transition to uap-action-start on "%s" key press from idle',
+        key => {
+          const state: DragHandleInteractionState = { state: null };
+          const action: Action = {
+            type: 'KEY_DOWN',
+            payload: { key },
+          };
 
-        const nextState = calculateNextState(state, action);
-        expect(nextState.state).toBe('uap-action-start');
-      });
+          const nextState = calculateNextState(state, action);
+          expect(nextState.state).toBe('uap-action-start');
+        }
+      );
 
-      test('should transition from uap-action-start to uap-action-end on Enter key press', () => {
-        const state: DragHandleInteractionState = { state: 'uap-action-start' };
-        const action: Action = {
-          type: 'KEY_DOWN',
-          payload: { key: 'Enter' },
-        };
+      test.each(KEY_CODES_TO_TOGGLE_UAP_ACTION)(
+        'should transition from uap-action-start to uap-action-end on "%s" key press',
+        key => {
+          const state: DragHandleInteractionState = { state: 'uap-action-start' };
+          const action: Action = {
+            type: 'KEY_DOWN',
+            payload: { key },
+          };
 
-        const nextState = calculateNextState(state, action);
-        expect(nextState.state).toBe('uap-action-end');
-      });
+          const nextState = calculateNextState(state, action);
+          expect(nextState.state).toBe('uap-action-end');
+        }
+      );
 
       test('should transition from uap-action-start to uap-action-end on Escape key press', () => {
         const state: DragHandleInteractionState = { state: 'uap-action-start' };
@@ -286,27 +294,33 @@ describe('Drag Handle Hooks', () => {
         expect(nextState).toBe(state);
       });
 
-      test('should transition from dnd-start to uap-action-start on Enter key press', () => {
-        const state: DragHandleInteractionState = { state: 'dnd-start' };
-        const action: Action = {
-          type: 'KEY_DOWN',
-          payload: { key: 'Enter' },
-        };
+      test.each(KEY_CODES_TO_TOGGLE_UAP_ACTION)(
+        'should transition from dnd-start to uap-action-start on "%s" key press',
+        key => {
+          const state: DragHandleInteractionState = { state: 'dnd-start' };
+          const action: Action = {
+            type: 'KEY_DOWN',
+            payload: { key },
+          };
 
-        const nextState = calculateNextState(state, action);
-        expect(nextState.state).toBe('uap-action-start');
-      });
+          const nextState = calculateNextState(state, action);
+          expect(nextState.state).toBe('uap-action-start');
+        }
+      );
 
-      test('should transition from dnd-active to uap-action-start on Enter key press', () => {
-        const state: DragHandleInteractionState = { state: 'dnd-active' };
-        const action: Action = {
-          type: 'KEY_DOWN',
-          payload: { key: 'Enter' },
-        };
+      test.each(KEY_CODES_TO_TOGGLE_UAP_ACTION)(
+        'should transition from dnd-active to uap-action-start on "%s" key press',
+        key => {
+          const state: DragHandleInteractionState = { state: 'dnd-active' };
+          const action: Action = {
+            type: 'KEY_DOWN',
+            payload: { key },
+          };
 
-        const nextState = calculateNextState(state, action);
-        expect(nextState.state).toBe('uap-action-start');
-      });
+          const nextState = calculateNextState(state, action);
+          expect(nextState.state).toBe('uap-action-start');
+        }
+      );
 
       test('should not change state on non-Enter/non-Escape key press in uap-action-end state', () => {
         const state: DragHandleInteractionState = { state: 'uap-action-end' };
@@ -498,26 +512,29 @@ describe('Drag Handle Hooks', () => {
         expect(ref.current?.interaction.state).toBe('dnd-end');
       });
 
-      test('should handle Enter key press', () => {
+      test.each(KEY_CODES_TO_TOGGLE_UAP_ACTION)('should handle "%s" key press', key => {
         const ref = React.createRef<TestComponentRef>();
         const { getByTestId } = render(<TestComponent ref={ref} />);
         const element = getByTestId('drag-handle');
 
-        fireEvent.keyDown(element, { key: 'Enter' });
+        fireEvent.keyDown(element, { key });
         expect(ref.current?.interaction.state).toBe('uap-action-start');
       });
 
-      test('should handle Enter key press toggle in uap-action-start state', () => {
-        const ref = React.createRef<TestComponentRef>();
-        const { getByTestId } = render(<TestComponent ref={ref} />);
-        const element = getByTestId('drag-handle');
+      test.each(KEY_CODES_TO_TOGGLE_UAP_ACTION)(
+        'should handle "%s" key press toggle in uap-action-start state',
+        key => {
+          const ref = React.createRef<TestComponentRef>();
+          const { getByTestId } = render(<TestComponent ref={ref} />);
+          const element = getByTestId('drag-handle');
 
-        fireEvent.keyDown(element, { key: 'Enter' });
-        expect(ref.current?.interaction.state).toBe('uap-action-start');
+          fireEvent.keyDown(element, { key: key });
+          expect(ref.current?.interaction.state).toBe('uap-action-start');
 
-        fireEvent.keyDown(element, { key: 'Enter' });
-        expect(ref.current?.interaction.state).toBe('uap-action-end');
-      });
+          fireEvent.keyDown(element, { key: key });
+          expect(ref.current?.interaction.state).toBe('uap-action-end');
+        }
+      );
 
       test('should handle Escape key press in uap-action-start state', () => {
         const ref = React.createRef<TestComponentRef>();

--- a/src/internal/components/drag-handle/hooks/__tests__/use-drag-handle-interaction-state.test.tsx
+++ b/src/internal/components/drag-handle/hooks/__tests__/use-drag-handle-interaction-state.test.tsx
@@ -54,8 +54,6 @@ const TestComponent = React.forwardRef((props: TestComponentProps, ref: React.Re
         case 'BLUR':
           processBlur();
           break;
-        case 'RESET_TO_IDLE': // Handled by the reducer directly
-          break;
       }
     },
   }));
@@ -235,41 +233,6 @@ describe('Drag Handle Hooks', () => {
         expect(nextState.value).toBe('uap-action-end');
       });
 
-      test('should reset to idle on RESET_TO_IDLE from uap-action-end', () => {
-        const state: DragHandleInteractionState = { value: 'uap-action-end' };
-        const action: Action = { type: 'RESET_TO_IDLE' };
-
-        const nextState = calculateNextState(state, action);
-        expect(nextState.value).toBe(null);
-      });
-
-      test('should reset to idle on RESET_TO_IDLE from dnd-end', () => {
-        const state: DragHandleInteractionState = { value: 'dnd-end' };
-        const action: Action = { type: 'RESET_TO_IDLE' };
-
-        const nextState = calculateNextState(state, action);
-        expect(nextState.value).toBe(null);
-      });
-
-      test('should not reset to idle on RESET_TO_IDLE from active states', () => {
-        const dndStartState: DragHandleInteractionState = { value: 'dnd-start' };
-        const dndActiveState: DragHandleInteractionState = { value: 'dnd-active' };
-        const uapActionStartState: DragHandleInteractionState = { value: 'uap-action-start' };
-        const action: Action = { type: 'RESET_TO_IDLE' };
-
-        expect(calculateNextState(dndStartState, action)).toBe(dndStartState);
-        expect(calculateNextState(dndActiveState, action)).toBe(dndActiveState);
-        expect(calculateNextState(uapActionStartState, action)).toBe(uapActionStartState);
-      });
-
-      test('should stay in idle on RESET_TO_IDLE', () => {
-        const idleState: DragHandleInteractionState = { value: null };
-        const action: Action = { type: 'RESET_TO_IDLE' };
-
-        const nextState = calculateNextState(idleState, action);
-        expect(nextState.value).toBeNull();
-      });
-
       test('should return state on FOCUS action', () => {
         const state: DragHandleInteractionState = { value: 'uap-action-start' };
         const action: Action = { type: 'FOCUS' };
@@ -290,8 +253,10 @@ describe('Drag Handle Hooks', () => {
         const state: DragHandleInteractionState = { value: 'uap-action-start' };
         const action: Action = { type: 'UNKNOWN' as any };
 
-        const nextState = calculateNextState(state, action);
-        expect(nextState).toBe(state);
+        const nextState = () => {
+          calculateNextState(state, action);
+        };
+        expect(nextState).toThrow('The given action type [UNKNOWN] is not supported.');
       });
 
       test.each(KEY_CODES_TO_TOGGLE_UAP_ACTION)(
@@ -833,13 +798,6 @@ describe('Drag Handle Hooks', () => {
         });
         // State should remain unchanged
         expect(ref.current?.interaction.value).toBe('dnd-start');
-      });
-
-      test('should handle RESET_TO_IDLE action directly', () => {
-        const state: DragHandleInteractionState = { value: 'uap-action-end' };
-        const action: Action = { type: 'RESET_TO_IDLE' };
-        const nextState = calculateNextState(state, action);
-        expect(nextState.value).toBeNull();
       });
     });
 

--- a/src/internal/components/drag-handle/hooks/__tests__/use-drag-handle-interaction-state.test.tsx
+++ b/src/internal/components/drag-handle/hooks/__tests__/use-drag-handle-interaction-state.test.tsx
@@ -1,0 +1,874 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useImperativeHandle } from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+
+import type { Action, DragHandleInteractionState, UseDragHandleInteractionStateProps } from '../interfaces';
+import useDragHandleInteractionState, {
+  calculateNextState,
+  getCallbacksForTransition,
+} from '../use-drag-handle-interaction-state';
+
+interface TestComponentProps extends UseDragHandleInteractionStateProps {
+  debug?: boolean;
+}
+
+interface TestComponentRef {
+  interaction: DragHandleInteractionState;
+  dispatchAction: (action: Action) => void;
+}
+
+const TestComponent = React.forwardRef((props: TestComponentProps, ref: React.Ref<TestComponentRef>) => {
+  const { debug, ...hookProps } = props;
+  const {
+    interaction,
+    processPointerDown,
+    processPointerMove,
+    processPointerUp,
+    processKeyDown,
+    processFocus,
+    processBlur,
+  } = useDragHandleInteractionState(hookProps, { debug: debug || false });
+
+  // Exposed for testing
+  useImperativeHandle(ref, () => ({
+    interaction,
+    dispatchAction: (action: Action) => {
+      switch (action.type) {
+        case 'POINTER_DOWN':
+          processPointerDown(action.payload.nativeEvent, action.payload.metadata);
+          break;
+        case 'POINTER_MOVE':
+          processPointerMove(action.payload.nativeEvent);
+          break;
+        case 'POINTER_UP':
+          processPointerUp(action.payload.nativeEvent);
+          break;
+        case 'KEY_DOWN':
+          processKeyDown({ key: action.payload.key } as React.KeyboardEvent, action.payload.metadata);
+          break;
+        case 'FOCUS':
+          processFocus();
+          break;
+        case 'BLUR':
+          processBlur();
+          break;
+        case 'RESET_TO_IDLE': // Handled by the reducer directly
+          break;
+      }
+    },
+  }));
+
+  return (
+    <div
+      data-testid="drag-handle"
+      tabIndex={0}
+      onPointerDown={e => processPointerDown(e.nativeEvent, undefined)}
+      onPointerMove={e => processPointerMove(e.nativeEvent)}
+      onPointerUp={e => processPointerUp(e.nativeEvent)}
+      onKeyDown={processKeyDown}
+      onFocus={processFocus}
+      onBlur={processBlur}
+    >
+      Drag Handle
+    </div>
+  );
+});
+
+// PointerEvent is not available in JSDOM env
+class MockPointerEvent {
+  type: string;
+  bubbles: boolean;
+  cancelable: boolean;
+  button: number;
+
+  [key: string]: any;
+
+  constructor(type: string, init: any = {}) {
+    this.type = type;
+    this.bubbles = init.bubbles || false;
+    this.cancelable = init.cancelable || false;
+    this.button = init.button !== undefined ? init.button : 0;
+
+    Object.keys(init).forEach(key => {
+      if (!['type', 'bubbles', 'cancelable', 'button'].includes(key)) {
+        this[key] = init[key];
+      }
+    });
+  }
+}
+
+function createPointerEvent(type: string, overrides: Partial<any> = {}): any {
+  return new MockPointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    ...overrides,
+  });
+}
+
+describe('Drag Handle Hooks', () => {
+  describe('Helper Functions', () => {
+    describe('calculateNextState', () => {
+      const mockPointerEvent = createPointerEvent('pointerdown');
+
+      test('should transition from idle to dnd-start on POINTER_DOWN', () => {
+        const state: DragHandleInteractionState = { state: null };
+        const action: Action = {
+          type: 'POINTER_DOWN',
+          payload: { nativeEvent: mockPointerEvent },
+        };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState.state).toBe('dnd-start');
+        expect(nextState.eventData).toBe(mockPointerEvent);
+      });
+
+      test('should transition from dnd-start to dnd-active on POINTER_MOVE', () => {
+        const state: DragHandleInteractionState = {
+          state: 'dnd-start',
+          eventData: mockPointerEvent,
+        };
+        const moveEvent = createPointerEvent('pointermove');
+        const action: Action = {
+          type: 'POINTER_MOVE',
+          payload: { nativeEvent: moveEvent },
+        };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState.state).toBe('dnd-active');
+        expect(nextState.eventData).toBe(moveEvent);
+      });
+
+      test('should stay in dnd-active on POINTER_MOVE', () => {
+        const state: DragHandleInteractionState = {
+          state: 'dnd-active',
+          eventData: mockPointerEvent,
+        };
+        const moveEvent = createPointerEvent('pointermove');
+        const action: Action = {
+          type: 'POINTER_MOVE',
+          payload: { nativeEvent: moveEvent },
+        };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState.state).toBe('dnd-active');
+        expect(nextState.eventData).toBe(moveEvent);
+      });
+
+      test('should transition from dnd-start to uap-action-start on POINTER_UP', () => {
+        const state: DragHandleInteractionState = {
+          state: 'dnd-start',
+          eventData: mockPointerEvent,
+        };
+        const action: Action = {
+          type: 'POINTER_UP',
+          payload: { nativeEvent: createPointerEvent('pointerup') },
+        };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState.state).toBe('uap-action-start');
+        expect(nextState.eventData).toBeUndefined();
+      });
+
+      test('should transition from dnd-active to dnd-end on POINTER_UP', () => {
+        const state: DragHandleInteractionState = {
+          state: 'dnd-active',
+          eventData: mockPointerEvent,
+        };
+        const action: Action = {
+          type: 'POINTER_UP',
+          payload: { nativeEvent: createPointerEvent('pointerup') },
+        };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState.state).toBe('dnd-end');
+        expect(nextState.eventData).toBe(mockPointerEvent);
+      });
+
+      test('should transition to uap-action-start on Enter key press from idle', () => {
+        const state: DragHandleInteractionState = { state: null };
+        const action: Action = {
+          type: 'KEY_DOWN',
+          payload: { key: 'Enter' },
+        };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState.state).toBe('uap-action-start');
+      });
+
+      test('should transition from uap-action-start to uap-action-end on Enter key press', () => {
+        const state: DragHandleInteractionState = { state: 'uap-action-start' };
+        const action: Action = {
+          type: 'KEY_DOWN',
+          payload: { key: 'Enter' },
+        };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState.state).toBe('uap-action-end');
+      });
+
+      test('should transition from uap-action-start to uap-action-end on Escape key press', () => {
+        const state: DragHandleInteractionState = { state: 'uap-action-start' };
+        const action: Action = {
+          type: 'KEY_DOWN',
+          payload: { key: 'Escape' },
+        };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState.state).toBe('uap-action-end');
+      });
+
+      test('should transition from uap-action-start to uap-action-end on BLUR', () => {
+        const state: DragHandleInteractionState = { state: 'uap-action-start' };
+        const action: Action = { type: 'BLUR' };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState.state).toBe('uap-action-end');
+      });
+
+      test('should reset to idle on RESET_TO_IDLE from uap-action-end', () => {
+        const state: DragHandleInteractionState = { state: 'uap-action-end' };
+        const action: Action = { type: 'RESET_TO_IDLE' };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState.state).toBe(null);
+      });
+
+      test('should reset to idle on RESET_TO_IDLE from dnd-end', () => {
+        const state: DragHandleInteractionState = { state: 'dnd-end' };
+        const action: Action = { type: 'RESET_TO_IDLE' };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState.state).toBe(null);
+      });
+
+      test('should not reset to idle on RESET_TO_IDLE from active states', () => {
+        const dndStartState: DragHandleInteractionState = { state: 'dnd-start' };
+        const dndActiveState: DragHandleInteractionState = { state: 'dnd-active' };
+        const uapActionStartState: DragHandleInteractionState = { state: 'uap-action-start' };
+        const action: Action = { type: 'RESET_TO_IDLE' };
+
+        expect(calculateNextState(dndStartState, action)).toBe(dndStartState);
+        expect(calculateNextState(dndActiveState, action)).toBe(dndActiveState);
+        expect(calculateNextState(uapActionStartState, action)).toBe(uapActionStartState);
+      });
+
+      test('should stay in idle on RESET_TO_IDLE', () => {
+        const idleState: DragHandleInteractionState = { state: null };
+        const action: Action = { type: 'RESET_TO_IDLE' };
+
+        const nextState = calculateNextState(idleState, action);
+        expect(nextState.state).toBeNull();
+      });
+
+      test('should return state on FOCUS action', () => {
+        const state: DragHandleInteractionState = { state: 'uap-action-start' };
+        const action: Action = { type: 'FOCUS' };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState).toBe(state);
+      });
+
+      test('should return state on FOCUS action with null state', () => {
+        const state: DragHandleInteractionState = { state: null };
+        const action: Action = { type: 'FOCUS' };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState).toBe(state);
+      });
+
+      test('should return state on unknown action type', () => {
+        const state: DragHandleInteractionState = { state: 'uap-action-start' };
+        const action: Action = { type: 'UNKNOWN' as any };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState).toBe(state);
+      });
+
+      test('should transition from dnd-start to uap-action-start on Enter key press', () => {
+        const state: DragHandleInteractionState = { state: 'dnd-start' };
+        const action: Action = {
+          type: 'KEY_DOWN',
+          payload: { key: 'Enter' },
+        };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState.state).toBe('uap-action-start');
+      });
+
+      test('should transition from dnd-active to uap-action-start on Enter key press', () => {
+        const state: DragHandleInteractionState = { state: 'dnd-active' };
+        const action: Action = {
+          type: 'KEY_DOWN',
+          payload: { key: 'Enter' },
+        };
+
+        const nextState = calculateNextState(state, action);
+        expect(nextState.state).toBe('uap-action-start');
+      });
+    });
+
+    describe('getCallbacksForTransition', () => {
+      const mockPointerEvent = createPointerEvent('pointerdown');
+
+      test('should generate onDndStart callback for transition to dnd-start', () => {
+        const prevState: DragHandleInteractionState = { state: null };
+        const nextState: DragHandleInteractionState = {
+          state: 'dnd-start',
+          eventData: mockPointerEvent,
+        };
+
+        const callbacks = getCallbacksForTransition(prevState, nextState);
+        expect(callbacks).toHaveLength(1);
+        expect(callbacks[0]).toEqual({
+          type: 'onDndStart',
+          payload: mockPointerEvent,
+        });
+      });
+
+      test('should generate onDndActive callback for transition to dnd-active', () => {
+        const prevState: DragHandleInteractionState = {
+          state: 'dnd-start',
+          eventData: mockPointerEvent,
+        };
+        const nextState: DragHandleInteractionState = {
+          state: 'dnd-active',
+          eventData: mockPointerEvent,
+        };
+
+        const callbacks = getCallbacksForTransition(prevState, nextState);
+        expect(callbacks).toHaveLength(1);
+        expect(callbacks[0]).toEqual({
+          type: 'onDndActive',
+          payload: mockPointerEvent,
+        });
+      });
+
+      test('should generate onDndEnd callback for transition from dnd-active to dnd-end', () => {
+        const prevState: DragHandleInteractionState = {
+          state: 'dnd-active',
+          eventData: mockPointerEvent,
+        };
+        const nextState: DragHandleInteractionState = {
+          state: 'dnd-end',
+          eventData: mockPointerEvent,
+        };
+
+        const callbacks = getCallbacksForTransition(prevState, nextState);
+        expect(callbacks).toHaveLength(1);
+        expect(callbacks[0]).toEqual({ type: 'onDndEnd' });
+      });
+
+      test('should generate onUapActionStart callback for transition to uap-action-start', () => {
+        const prevState: DragHandleInteractionState = { state: null };
+        const nextState: DragHandleInteractionState = { state: 'uap-action-start' };
+
+        const callbacks = getCallbacksForTransition(prevState, nextState);
+        expect(callbacks).toHaveLength(1);
+        expect(callbacks[0]).toEqual({ type: 'onUapActionStart' });
+      });
+
+      test('should generate onUapActionEnd callback for transition from uap-action-start to uap-action-end', () => {
+        const prevState: DragHandleInteractionState = { state: 'uap-action-start' };
+        const nextState: DragHandleInteractionState = { state: 'uap-action-end' };
+
+        const callbacks = getCallbacksForTransition(prevState, nextState);
+        expect(callbacks).toHaveLength(1);
+        expect(callbacks[0]).toEqual({ type: 'onUapActionEnd' });
+      });
+
+      test('should generate multiple callbacks for complex transitions', () => {
+        const prevState: DragHandleInteractionState = {
+          state: 'dnd-start',
+          eventData: mockPointerEvent,
+        };
+        const nextState: DragHandleInteractionState = { state: 'uap-action-start' };
+
+        const callbacks = getCallbacksForTransition(prevState, nextState);
+        expect(callbacks).toHaveLength(2);
+        expect(callbacks).toContainEqual({ type: 'onDndEnd' });
+        expect(callbacks).toContainEqual({ type: 'onUapActionStart' });
+      });
+    });
+  });
+
+  describe('useDragHandleInteractionState hook', () => {
+    describe('Initial State', () => {
+      test('should initialize with idle state', () => {
+        const ref = React.createRef<TestComponentRef>();
+        render(<TestComponent ref={ref} />);
+        expect(ref.current?.interaction.state).toBeNull();
+      });
+    });
+
+    describe('Event Handlers', () => {
+      test('should handle pointer down event', () => {
+        const ref = React.createRef<TestComponentRef>();
+        render(<TestComponent ref={ref} />);
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_DOWN',
+            payload: { nativeEvent: createPointerEvent('pointerdown') },
+          });
+        });
+        expect(ref.current?.interaction.state).toBe('dnd-start');
+      });
+
+      test('should handle pointer move event after pointer down', () => {
+        const ref = React.createRef<TestComponentRef>();
+        render(<TestComponent ref={ref} />);
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_DOWN',
+            payload: { nativeEvent: createPointerEvent('pointerdown') },
+          });
+        });
+        expect(ref.current?.interaction.state).toBe('dnd-start');
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_MOVE',
+            payload: { nativeEvent: createPointerEvent('pointermove') },
+          });
+        });
+        expect(ref.current?.interaction.state).toBe('dnd-active');
+      });
+
+      test('should handle pointer up event after pointer down', () => {
+        const ref = React.createRef<TestComponentRef>();
+        render(<TestComponent ref={ref} />);
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_DOWN',
+            payload: { nativeEvent: createPointerEvent('pointerdown') },
+          });
+        });
+        expect(ref.current?.interaction.state).toBe('dnd-start');
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_UP',
+            payload: { nativeEvent: createPointerEvent('pointerup') },
+          });
+        });
+        expect(ref.current?.interaction.state).toBe('uap-action-start');
+      });
+
+      test('should handle pointer up event after pointer move', () => {
+        const ref = React.createRef<TestComponentRef>();
+        render(<TestComponent ref={ref} />);
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_DOWN',
+            payload: { nativeEvent: createPointerEvent('pointerdown') },
+          });
+        });
+        expect(ref.current?.interaction.state).toBe('dnd-start');
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_MOVE',
+            payload: { nativeEvent: createPointerEvent('pointermove') },
+          });
+        });
+        expect(ref.current?.interaction.state).toBe('dnd-active');
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_UP',
+            payload: { nativeEvent: createPointerEvent('pointerup') },
+          });
+        });
+        expect(ref.current?.interaction.state).toBe('dnd-end');
+      });
+
+      test('should handle Enter key press', () => {
+        const ref = React.createRef<TestComponentRef>();
+        const { getByTestId } = render(<TestComponent ref={ref} />);
+        const element = getByTestId('drag-handle');
+
+        fireEvent.keyDown(element, { key: 'Enter' });
+        expect(ref.current?.interaction.state).toBe('uap-action-start');
+      });
+
+      test('should handle Enter key press toggle in uap-action-start state', () => {
+        const ref = React.createRef<TestComponentRef>();
+        const { getByTestId } = render(<TestComponent ref={ref} />);
+        const element = getByTestId('drag-handle');
+
+        fireEvent.keyDown(element, { key: 'Enter' });
+        expect(ref.current?.interaction.state).toBe('uap-action-start');
+
+        fireEvent.keyDown(element, { key: 'Enter' });
+        expect(ref.current?.interaction.state).toBe('uap-action-end');
+      });
+
+      test('should handle Escape key press in uap-action-start state', () => {
+        const ref = React.createRef<TestComponentRef>();
+        const { getByTestId } = render(<TestComponent ref={ref} />);
+        const element = getByTestId('drag-handle');
+
+        fireEvent.keyDown(element, { key: 'Enter' });
+        expect(ref.current?.interaction.state).toBe('uap-action-start');
+
+        fireEvent.keyDown(element, { key: 'Escape' });
+        expect(ref.current?.interaction.state).toBe('uap-action-end');
+      });
+
+      test('should handle blur event in uap-action-start state', () => {
+        const ref = React.createRef<TestComponentRef>();
+        const { getByTestId } = render(<TestComponent ref={ref} />);
+        const element = getByTestId('drag-handle');
+
+        fireEvent.keyDown(element, { key: 'Enter' });
+        expect(ref.current?.interaction.state).toBe('uap-action-start');
+
+        fireEvent.blur(element);
+        expect(ref.current?.interaction.state).toBe('uap-action-end');
+      });
+
+      test('should handle focus event', () => {
+        const ref = React.createRef<TestComponentRef>();
+        const { getByTestId } = render(<TestComponent ref={ref} />);
+        const element = getByTestId('drag-handle');
+
+        fireEvent.focus(element);
+        expect(ref.current?.interaction.state).toBeNull();
+      });
+    });
+
+    describe('Callbacks', () => {
+      test('should call onDndStartAction on dnd-start', () => {
+        const onDndStartAction = jest.fn();
+        const ref = React.createRef<TestComponentRef>();
+        render(<TestComponent ref={ref} onDndStartAction={onDndStartAction} />);
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_DOWN',
+            payload: { nativeEvent: createPointerEvent('pointerdown') },
+          });
+        });
+        expect(onDndStartAction).toHaveBeenCalledTimes(1);
+        expect(onDndStartAction).toHaveBeenCalledWith(expect.any(MockPointerEvent), undefined);
+      });
+
+      test('should pass metadata to onDndStartAction', () => {
+        interface TestMetadata {
+          id: string;
+        }
+
+        const TestComponentWithMetadata = React.forwardRef(
+          (
+            props: {
+              onDndStartAction?: (event: PointerEvent, metadata?: TestMetadata) => void;
+            },
+            ref: React.Ref<any>
+          ) => {
+            const { processPointerDown } = useDragHandleInteractionState<TestMetadata>({
+              onDndStartAction: props.onDndStartAction,
+            });
+            useImperativeHandle(ref, () => ({
+              processPointerDown,
+            }));
+            return <div data-testid="typed-drag-handle" />;
+          }
+        );
+
+        const onDndStartAction = jest.fn();
+        const ref = React.createRef<{ processPointerDown: (event: PointerEvent, metadata?: TestMetadata) => void }>();
+        render(<TestComponentWithMetadata ref={ref} onDndStartAction={onDndStartAction} />);
+
+        const metadata: TestMetadata = { id: 'test-metadata' };
+        const event = createPointerEvent('pointerdown');
+
+        act(() => {
+          ref.current?.processPointerDown(event, metadata);
+        });
+        expect(onDndStartAction).toHaveBeenCalledTimes(1);
+        expect(onDndStartAction).toHaveBeenCalledWith(expect.any(MockPointerEvent), metadata);
+      });
+
+      test('should call onDndActiveAction on dnd-active', () => {
+        const onDndActiveAction = jest.fn();
+        const ref = React.createRef<TestComponentRef>();
+        render(<TestComponent ref={ref} onDndActiveAction={onDndActiveAction} />);
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_DOWN',
+            payload: { nativeEvent: createPointerEvent('pointerdown') },
+          });
+        });
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_MOVE',
+            payload: { nativeEvent: createPointerEvent('pointermove') },
+          });
+        });
+        expect(onDndActiveAction).toHaveBeenCalledTimes(1);
+        expect(onDndActiveAction).toHaveBeenCalledWith(expect.any(MockPointerEvent));
+      });
+
+      test('should call onDndEndAction on dnd-end', () => {
+        const onDndEndAction = jest.fn();
+        const ref = React.createRef<TestComponentRef>();
+        render(<TestComponent ref={ref} onDndEndAction={onDndEndAction} />);
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_DOWN',
+            payload: { nativeEvent: createPointerEvent('pointerdown') },
+          });
+        });
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_MOVE',
+            payload: { nativeEvent: createPointerEvent('pointermove') },
+          });
+        });
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_UP',
+            payload: { nativeEvent: createPointerEvent('pointerup') },
+          });
+        });
+        expect(onDndEndAction).toHaveBeenCalledTimes(1);
+      });
+
+      test('should call onUapActionStartAction on uap-action-start', () => {
+        const onUapActionStartAction = jest.fn();
+        const ref = React.createRef<TestComponentRef>();
+        const { getByTestId } = render(<TestComponent ref={ref} onUapActionStartAction={onUapActionStartAction} />);
+        const element = getByTestId('drag-handle');
+
+        fireEvent.keyDown(element, { key: 'Enter' });
+        expect(onUapActionStartAction).toHaveBeenCalledTimes(1);
+        expect(onUapActionStartAction).toHaveBeenCalledWith(undefined);
+      });
+
+      test('should pass metadata to onUapActionStartAction when transitioning from dnd-start', () => {
+        interface TestMetadata {
+          id: string;
+        }
+
+        const TestComponentWithMetadata = React.forwardRef(
+          (props: { onUapActionStartAction?: (metadata?: TestMetadata) => void }, ref: React.Ref<any>) => {
+            const { processPointerDown, processPointerUp } = useDragHandleInteractionState<TestMetadata>({
+              onUapActionStartAction: props.onUapActionStartAction,
+            });
+            useImperativeHandle(ref, () => ({
+              processPointerDown,
+              processPointerUp,
+            }));
+            return <div data-testid="typed-drag-handle" />;
+          }
+        );
+
+        const onUapActionStartAction = jest.fn();
+        const ref = React.createRef<{
+          processPointerDown: (event: PointerEvent, metadata?: TestMetadata) => void;
+          processPointerUp: (event: PointerEvent) => void;
+        }>();
+
+        render(<TestComponentWithMetadata ref={ref} onUapActionStartAction={onUapActionStartAction} />);
+        const metadata: TestMetadata = { id: 'test-metadata' };
+
+        act(() => {
+          ref.current?.processPointerDown(createPointerEvent('pointerdown'), metadata);
+          ref.current?.processPointerUp(createPointerEvent('pointerup'));
+        });
+        expect(onUapActionStartAction).toHaveBeenCalledTimes(1);
+        expect(onUapActionStartAction).toHaveBeenCalledWith(metadata);
+      });
+
+      test('should call onUapActionEndAction on uap-action-end', () => {
+        const onUapActionEndAction = jest.fn();
+        const ref = React.createRef<TestComponentRef>();
+        const { getByTestId } = render(<TestComponent ref={ref} onUapActionEndAction={onUapActionEndAction} />);
+        const element = getByTestId('drag-handle');
+
+        fireEvent.keyDown(element, { key: 'Enter' });
+        fireEvent.keyDown(element, { key: 'Enter' });
+        expect(onUapActionEndAction).toHaveBeenCalledTimes(1);
+      });
+
+      test('should call multiple callbacks for complex transitions', () => {
+        const onDndStartAction = jest.fn();
+        const onDndEndAction = jest.fn();
+        const onUapActionStartAction = jest.fn();
+        const ref = React.createRef<TestComponentRef>();
+
+        render(
+          <TestComponent
+            ref={ref}
+            onDndStartAction={onDndStartAction}
+            onDndEndAction={onDndEndAction}
+            onUapActionStartAction={onUapActionStartAction}
+          />
+        );
+
+        // dnd-start -> uap-action-start transition
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_DOWN',
+            payload: { nativeEvent: createPointerEvent('pointerdown') },
+          });
+        });
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_UP',
+            payload: { nativeEvent: createPointerEvent('pointerup') },
+          });
+        });
+        expect(onDndStartAction).toHaveBeenCalledTimes(1);
+        expect(onDndEndAction).toHaveBeenCalledTimes(1);
+        expect(onUapActionStartAction).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('Edge Cases', () => {
+      test('should ignore pointer move when not in dnd state', () => {
+        const ref = React.createRef<TestComponentRef>();
+        const { getByTestId } = render(<TestComponent ref={ref} />);
+        const element = getByTestId('drag-handle');
+
+        fireEvent.pointerMove(element);
+        expect(ref.current?.interaction.state).toBeNull();
+      });
+
+      test('should ignore pointer up when not in dnd state', () => {
+        const ref = React.createRef<TestComponentRef>();
+        const { getByTestId } = render(<TestComponent ref={ref} />);
+        const element = getByTestId('drag-handle');
+
+        fireEvent.pointerUp(element);
+        expect(ref.current?.interaction.state).toBeNull();
+      });
+
+      test('should ignore non-Enter/Escape key presses', () => {
+        const ref = React.createRef<TestComponentRef>();
+        const { getByTestId } = render(<TestComponent ref={ref} />);
+        const element = getByTestId('drag-handle');
+
+        fireEvent.keyDown(element, { key: 'A' });
+        expect(ref.current?.interaction.state).toBeNull();
+      });
+
+      test('should handle RESET_TO_IDLE action directly', () => {
+        const state: DragHandleInteractionState = { state: 'uap-action-end' };
+        const action: Action = { type: 'RESET_TO_IDLE' };
+        const nextState = calculateNextState(state, action);
+        expect(nextState.state).toBeNull();
+      });
+    });
+
+    describe('Direct Action Dispatch', () => {
+      test('should handle direct action dispatch', () => {
+        const ref = React.createRef<TestComponentRef>();
+        render(<TestComponent ref={ref} />);
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_DOWN',
+            payload: {
+              nativeEvent: createPointerEvent('pointerdown'),
+            },
+          });
+        });
+        expect(ref.current?.interaction.state).toBe('dnd-start');
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_MOVE',
+            payload: {
+              nativeEvent: createPointerEvent('pointermove'),
+            },
+          });
+        });
+        expect(ref.current?.interaction.state).toBe('dnd-active');
+      });
+
+      test('should update event data without changing state', () => {
+        const ref = React.createRef<TestComponentRef>();
+        render(<TestComponent ref={ref} />);
+
+        // First set state to dnd-active
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_DOWN',
+            payload: {
+              nativeEvent: createPointerEvent('pointerdown'),
+            },
+          });
+        });
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_MOVE',
+            payload: {
+              nativeEvent: createPointerEvent('pointermove'),
+            },
+          });
+        });
+
+        // Then dispatch another POINTER_MOVE with different event data
+        const initialEventData = ref.current?.interaction.eventData;
+        const newEventData = createPointerEvent('pointermove', { clientX: 100, clientY: 100 });
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_MOVE',
+            payload: {
+              nativeEvent: newEventData,
+            },
+          });
+        });
+        // State should still be dnd-active and event data should be updated
+        expect(ref.current?.interaction.state).toBe('dnd-active');
+        expect(ref.current?.interaction.eventData).not.toBe(initialEventData);
+        expect(ref.current?.interaction.eventData).toBe(newEventData);
+      });
+    });
+
+    describe('Debug Option', () => {
+      test('should enable debug logging when debug option set to true', () => {
+        const consoleSpy = jest.spyOn(console, 'log');
+        const ref = React.createRef<TestComponentRef>();
+
+        render(<TestComponent ref={ref} debug={true} />);
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_DOWN',
+            payload: {
+              nativeEvent: createPointerEvent('pointerdown'),
+            },
+          });
+        });
+        expect(consoleSpy).toHaveBeenCalledWith('State transition: null -> dnd-start', expect.any(Object));
+        consoleSpy.mockReset();
+
+        act(() => {
+          ref.current?.dispatchAction({
+            type: 'POINTER_UP',
+            payload: {
+              nativeEvent: createPointerEvent('pointerdown'),
+            },
+          });
+        });
+        expect(consoleSpy).toHaveBeenCalledWith('State transition: dnd-start -> uap-action-start', expect.any(Object));
+        consoleSpy.mockRestore();
+      });
+    });
+  });
+});

--- a/src/internal/components/drag-handle/hooks/__tests__/use-drag-handle-interaction-state.test.tsx
+++ b/src/internal/components/drag-handle/hooks/__tests__/use-drag-handle-interaction-state.test.tsx
@@ -115,20 +115,20 @@ describe('Drag Handle Hooks', () => {
       const mockPointerEvent = createPointerEvent('pointerdown');
 
       test('should transition from idle to dnd-start on POINTER_DOWN', () => {
-        const state: DragHandleInteractionState = { state: null };
+        const state: DragHandleInteractionState = { value: null };
         const action: Action = {
           type: 'POINTER_DOWN',
           payload: { nativeEvent: mockPointerEvent },
         };
 
         const nextState = calculateNextState(state, action);
-        expect(nextState.state).toBe('dnd-start');
+        expect(nextState.value).toBe('dnd-start');
         expect(nextState.eventData).toBe(mockPointerEvent);
       });
 
       test('should transition from dnd-start to dnd-active on POINTER_MOVE', () => {
         const state: DragHandleInteractionState = {
-          state: 'dnd-start',
+          value: 'dnd-start',
           eventData: mockPointerEvent,
         };
         const moveEvent = createPointerEvent('pointermove');
@@ -138,13 +138,13 @@ describe('Drag Handle Hooks', () => {
         };
 
         const nextState = calculateNextState(state, action);
-        expect(nextState.state).toBe('dnd-active');
+        expect(nextState.value).toBe('dnd-active');
         expect(nextState.eventData).toBe(moveEvent);
       });
 
       test('should stay in dnd-active on POINTER_MOVE', () => {
         const state: DragHandleInteractionState = {
-          state: 'dnd-active',
+          value: 'dnd-active',
           eventData: mockPointerEvent,
         };
         const moveEvent = createPointerEvent('pointermove');
@@ -154,13 +154,13 @@ describe('Drag Handle Hooks', () => {
         };
 
         const nextState = calculateNextState(state, action);
-        expect(nextState.state).toBe('dnd-active');
+        expect(nextState.value).toBe('dnd-active');
         expect(nextState.eventData).toBe(moveEvent);
       });
 
       test('should transition from dnd-start to uap-action-start on POINTER_UP', () => {
         const state: DragHandleInteractionState = {
-          state: 'dnd-start',
+          value: 'dnd-start',
           eventData: mockPointerEvent,
         };
         const action: Action = {
@@ -169,13 +169,13 @@ describe('Drag Handle Hooks', () => {
         };
 
         const nextState = calculateNextState(state, action);
-        expect(nextState.state).toBe('uap-action-start');
+        expect(nextState.value).toBe('uap-action-start');
         expect(nextState.eventData).toBeUndefined();
       });
 
       test('should transition from dnd-active to dnd-end on POINTER_UP', () => {
         const state: DragHandleInteractionState = {
-          state: 'dnd-active',
+          value: 'dnd-active',
           eventData: mockPointerEvent,
         };
         const action: Action = {
@@ -184,77 +184,77 @@ describe('Drag Handle Hooks', () => {
         };
 
         const nextState = calculateNextState(state, action);
-        expect(nextState.state).toBe('dnd-end');
+        expect(nextState.value).toBe('dnd-end');
         expect(nextState.eventData).toBe(mockPointerEvent);
       });
 
       test.each(KEY_CODES_TO_TOGGLE_UAP_ACTION)(
         'should transition to uap-action-start on "%s" key press from idle',
         key => {
-          const state: DragHandleInteractionState = { state: null };
+          const state: DragHandleInteractionState = { value: null };
           const action: Action = {
             type: 'KEY_DOWN',
             payload: { key },
           };
 
           const nextState = calculateNextState(state, action);
-          expect(nextState.state).toBe('uap-action-start');
+          expect(nextState.value).toBe('uap-action-start');
         }
       );
 
       test.each(KEY_CODES_TO_TOGGLE_UAP_ACTION)(
         'should transition from uap-action-start to uap-action-end on "%s" key press',
         key => {
-          const state: DragHandleInteractionState = { state: 'uap-action-start' };
+          const state: DragHandleInteractionState = { value: 'uap-action-start' };
           const action: Action = {
             type: 'KEY_DOWN',
             payload: { key },
           };
 
           const nextState = calculateNextState(state, action);
-          expect(nextState.state).toBe('uap-action-end');
+          expect(nextState.value).toBe('uap-action-end');
         }
       );
 
       test('should transition from uap-action-start to uap-action-end on Escape key press', () => {
-        const state: DragHandleInteractionState = { state: 'uap-action-start' };
+        const state: DragHandleInteractionState = { value: 'uap-action-start' };
         const action: Action = {
           type: 'KEY_DOWN',
           payload: { key: 'Escape' },
         };
 
         const nextState = calculateNextState(state, action);
-        expect(nextState.state).toBe('uap-action-end');
+        expect(nextState.value).toBe('uap-action-end');
       });
 
       test('should transition from uap-action-start to uap-action-end on BLUR', () => {
-        const state: DragHandleInteractionState = { state: 'uap-action-start' };
+        const state: DragHandleInteractionState = { value: 'uap-action-start' };
         const action: Action = { type: 'BLUR' };
 
         const nextState = calculateNextState(state, action);
-        expect(nextState.state).toBe('uap-action-end');
+        expect(nextState.value).toBe('uap-action-end');
       });
 
       test('should reset to idle on RESET_TO_IDLE from uap-action-end', () => {
-        const state: DragHandleInteractionState = { state: 'uap-action-end' };
+        const state: DragHandleInteractionState = { value: 'uap-action-end' };
         const action: Action = { type: 'RESET_TO_IDLE' };
 
         const nextState = calculateNextState(state, action);
-        expect(nextState.state).toBe(null);
+        expect(nextState.value).toBe(null);
       });
 
       test('should reset to idle on RESET_TO_IDLE from dnd-end', () => {
-        const state: DragHandleInteractionState = { state: 'dnd-end' };
+        const state: DragHandleInteractionState = { value: 'dnd-end' };
         const action: Action = { type: 'RESET_TO_IDLE' };
 
         const nextState = calculateNextState(state, action);
-        expect(nextState.state).toBe(null);
+        expect(nextState.value).toBe(null);
       });
 
       test('should not reset to idle on RESET_TO_IDLE from active states', () => {
-        const dndStartState: DragHandleInteractionState = { state: 'dnd-start' };
-        const dndActiveState: DragHandleInteractionState = { state: 'dnd-active' };
-        const uapActionStartState: DragHandleInteractionState = { state: 'uap-action-start' };
+        const dndStartState: DragHandleInteractionState = { value: 'dnd-start' };
+        const dndActiveState: DragHandleInteractionState = { value: 'dnd-active' };
+        const uapActionStartState: DragHandleInteractionState = { value: 'uap-action-start' };
         const action: Action = { type: 'RESET_TO_IDLE' };
 
         expect(calculateNextState(dndStartState, action)).toBe(dndStartState);
@@ -263,15 +263,15 @@ describe('Drag Handle Hooks', () => {
       });
 
       test('should stay in idle on RESET_TO_IDLE', () => {
-        const idleState: DragHandleInteractionState = { state: null };
+        const idleState: DragHandleInteractionState = { value: null };
         const action: Action = { type: 'RESET_TO_IDLE' };
 
         const nextState = calculateNextState(idleState, action);
-        expect(nextState.state).toBeNull();
+        expect(nextState.value).toBeNull();
       });
 
       test('should return state on FOCUS action', () => {
-        const state: DragHandleInteractionState = { state: 'uap-action-start' };
+        const state: DragHandleInteractionState = { value: 'uap-action-start' };
         const action: Action = { type: 'FOCUS' };
 
         const nextState = calculateNextState(state, action);
@@ -279,7 +279,7 @@ describe('Drag Handle Hooks', () => {
       });
 
       test('should return state on FOCUS action with null state', () => {
-        const state: DragHandleInteractionState = { state: null };
+        const state: DragHandleInteractionState = { value: null };
         const action: Action = { type: 'FOCUS' };
 
         const nextState = calculateNextState(state, action);
@@ -287,7 +287,7 @@ describe('Drag Handle Hooks', () => {
       });
 
       test('should return state on unknown action type', () => {
-        const state: DragHandleInteractionState = { state: 'uap-action-start' };
+        const state: DragHandleInteractionState = { value: 'uap-action-start' };
         const action: Action = { type: 'UNKNOWN' as any };
 
         const nextState = calculateNextState(state, action);
@@ -297,33 +297,33 @@ describe('Drag Handle Hooks', () => {
       test.each(KEY_CODES_TO_TOGGLE_UAP_ACTION)(
         'should transition from dnd-start to uap-action-start on "%s" key press',
         key => {
-          const state: DragHandleInteractionState = { state: 'dnd-start' };
+          const state: DragHandleInteractionState = { value: 'dnd-start' };
           const action: Action = {
             type: 'KEY_DOWN',
             payload: { key },
           };
 
           const nextState = calculateNextState(state, action);
-          expect(nextState.state).toBe('uap-action-start');
+          expect(nextState.value).toBe('uap-action-start');
         }
       );
 
       test.each(KEY_CODES_TO_TOGGLE_UAP_ACTION)(
         'should transition from dnd-active to uap-action-start on "%s" key press',
         key => {
-          const state: DragHandleInteractionState = { state: 'dnd-active' };
+          const state: DragHandleInteractionState = { value: 'dnd-active' };
           const action: Action = {
             type: 'KEY_DOWN',
             payload: { key },
           };
 
           const nextState = calculateNextState(state, action);
-          expect(nextState.state).toBe('uap-action-start');
+          expect(nextState.value).toBe('uap-action-start');
         }
       );
 
       test('should not change state on non-Enter/non-Escape key press in uap-action-end state', () => {
-        const state: DragHandleInteractionState = { state: 'uap-action-end' };
+        const state: DragHandleInteractionState = { value: 'uap-action-end' };
         const action: Action = {
           type: 'KEY_DOWN',
           payload: { key: 'A' },
@@ -338,9 +338,9 @@ describe('Drag Handle Hooks', () => {
       const mockPointerEvent = createPointerEvent('pointerdown');
 
       test('should generate onDndStart callback for transition to dnd-start', () => {
-        const prevState: DragHandleInteractionState = { state: null };
+        const prevState: DragHandleInteractionState = { value: null };
         const nextState: DragHandleInteractionState = {
-          state: 'dnd-start',
+          value: 'dnd-start',
           eventData: mockPointerEvent,
         };
 
@@ -354,11 +354,11 @@ describe('Drag Handle Hooks', () => {
 
       test('should generate onDndActive callback for transition to dnd-active', () => {
         const prevState: DragHandleInteractionState = {
-          state: 'dnd-start',
+          value: 'dnd-start',
           eventData: mockPointerEvent,
         };
         const nextState: DragHandleInteractionState = {
-          state: 'dnd-active',
+          value: 'dnd-active',
           eventData: mockPointerEvent,
         };
 
@@ -372,11 +372,11 @@ describe('Drag Handle Hooks', () => {
 
       test('should generate onDndEnd callback for transition from dnd-active to dnd-end', () => {
         const prevState: DragHandleInteractionState = {
-          state: 'dnd-active',
+          value: 'dnd-active',
           eventData: mockPointerEvent,
         };
         const nextState: DragHandleInteractionState = {
-          state: 'dnd-end',
+          value: 'dnd-end',
           eventData: mockPointerEvent,
         };
 
@@ -386,8 +386,8 @@ describe('Drag Handle Hooks', () => {
       });
 
       test('should generate onUapActionStart callback for transition to uap-action-start', () => {
-        const prevState: DragHandleInteractionState = { state: null };
-        const nextState: DragHandleInteractionState = { state: 'uap-action-start' };
+        const prevState: DragHandleInteractionState = { value: null };
+        const nextState: DragHandleInteractionState = { value: 'uap-action-start' };
 
         const callbacks = getCallbacksForTransition(prevState, nextState);
         expect(callbacks).toHaveLength(1);
@@ -395,8 +395,8 @@ describe('Drag Handle Hooks', () => {
       });
 
       test('should generate onUapActionEnd callback for transition from uap-action-start to uap-action-end', () => {
-        const prevState: DragHandleInteractionState = { state: 'uap-action-start' };
-        const nextState: DragHandleInteractionState = { state: 'uap-action-end' };
+        const prevState: DragHandleInteractionState = { value: 'uap-action-start' };
+        const nextState: DragHandleInteractionState = { value: 'uap-action-end' };
 
         const callbacks = getCallbacksForTransition(prevState, nextState);
         expect(callbacks).toHaveLength(1);
@@ -405,10 +405,10 @@ describe('Drag Handle Hooks', () => {
 
       test('should generate multiple callbacks for complex transitions', () => {
         const prevState: DragHandleInteractionState = {
-          state: 'dnd-start',
+          value: 'dnd-start',
           eventData: mockPointerEvent,
         };
-        const nextState: DragHandleInteractionState = { state: 'uap-action-start' };
+        const nextState: DragHandleInteractionState = { value: 'uap-action-start' };
 
         const callbacks = getCallbacksForTransition(prevState, nextState);
         expect(callbacks).toHaveLength(2);
@@ -423,7 +423,7 @@ describe('Drag Handle Hooks', () => {
       test('should initialize with idle state', () => {
         const ref = React.createRef<TestComponentRef>();
         render(<TestComponent ref={ref} />);
-        expect(ref.current?.interaction.state).toBeNull();
+        expect(ref.current?.interaction.value).toBeNull();
       });
     });
 
@@ -438,7 +438,7 @@ describe('Drag Handle Hooks', () => {
             payload: { nativeEvent: createPointerEvent('pointerdown') },
           });
         });
-        expect(ref.current?.interaction.state).toBe('dnd-start');
+        expect(ref.current?.interaction.value).toBe('dnd-start');
       });
 
       test('should handle pointer move event after pointer down', () => {
@@ -451,7 +451,7 @@ describe('Drag Handle Hooks', () => {
             payload: { nativeEvent: createPointerEvent('pointerdown') },
           });
         });
-        expect(ref.current?.interaction.state).toBe('dnd-start');
+        expect(ref.current?.interaction.value).toBe('dnd-start');
 
         act(() => {
           ref.current?.dispatchAction({
@@ -459,7 +459,7 @@ describe('Drag Handle Hooks', () => {
             payload: { nativeEvent: createPointerEvent('pointermove') },
           });
         });
-        expect(ref.current?.interaction.state).toBe('dnd-active');
+        expect(ref.current?.interaction.value).toBe('dnd-active');
       });
 
       test('should handle pointer up event after pointer down', () => {
@@ -472,7 +472,7 @@ describe('Drag Handle Hooks', () => {
             payload: { nativeEvent: createPointerEvent('pointerdown') },
           });
         });
-        expect(ref.current?.interaction.state).toBe('dnd-start');
+        expect(ref.current?.interaction.value).toBe('dnd-start');
 
         act(() => {
           ref.current?.dispatchAction({
@@ -480,7 +480,7 @@ describe('Drag Handle Hooks', () => {
             payload: { nativeEvent: createPointerEvent('pointerup') },
           });
         });
-        expect(ref.current?.interaction.state).toBe('uap-action-start');
+        expect(ref.current?.interaction.value).toBe('uap-action-start');
       });
 
       test('should handle pointer up event after pointer move', () => {
@@ -493,7 +493,7 @@ describe('Drag Handle Hooks', () => {
             payload: { nativeEvent: createPointerEvent('pointerdown') },
           });
         });
-        expect(ref.current?.interaction.state).toBe('dnd-start');
+        expect(ref.current?.interaction.value).toBe('dnd-start');
 
         act(() => {
           ref.current?.dispatchAction({
@@ -501,7 +501,7 @@ describe('Drag Handle Hooks', () => {
             payload: { nativeEvent: createPointerEvent('pointermove') },
           });
         });
-        expect(ref.current?.interaction.state).toBe('dnd-active');
+        expect(ref.current?.interaction.value).toBe('dnd-active');
 
         act(() => {
           ref.current?.dispatchAction({
@@ -509,7 +509,7 @@ describe('Drag Handle Hooks', () => {
             payload: { nativeEvent: createPointerEvent('pointerup') },
           });
         });
-        expect(ref.current?.interaction.state).toBe('dnd-end');
+        expect(ref.current?.interaction.value).toBe('dnd-end');
       });
 
       test.each(KEY_CODES_TO_TOGGLE_UAP_ACTION)('should handle "%s" key press', key => {
@@ -518,7 +518,7 @@ describe('Drag Handle Hooks', () => {
         const element = getByTestId('drag-handle');
 
         fireEvent.keyDown(element, { key });
-        expect(ref.current?.interaction.state).toBe('uap-action-start');
+        expect(ref.current?.interaction.value).toBe('uap-action-start');
       });
 
       test.each(KEY_CODES_TO_TOGGLE_UAP_ACTION)(
@@ -529,10 +529,10 @@ describe('Drag Handle Hooks', () => {
           const element = getByTestId('drag-handle');
 
           fireEvent.keyDown(element, { key: key });
-          expect(ref.current?.interaction.state).toBe('uap-action-start');
+          expect(ref.current?.interaction.value).toBe('uap-action-start');
 
           fireEvent.keyDown(element, { key: key });
-          expect(ref.current?.interaction.state).toBe('uap-action-end');
+          expect(ref.current?.interaction.value).toBe('uap-action-end');
         }
       );
 
@@ -542,10 +542,10 @@ describe('Drag Handle Hooks', () => {
         const element = getByTestId('drag-handle');
 
         fireEvent.keyDown(element, { key: 'Enter' });
-        expect(ref.current?.interaction.state).toBe('uap-action-start');
+        expect(ref.current?.interaction.value).toBe('uap-action-start');
 
         fireEvent.keyDown(element, { key: 'Escape' });
-        expect(ref.current?.interaction.state).toBe('uap-action-end');
+        expect(ref.current?.interaction.value).toBe('uap-action-end');
       });
 
       test('should handle blur event in uap-action-start state', () => {
@@ -554,10 +554,10 @@ describe('Drag Handle Hooks', () => {
         const element = getByTestId('drag-handle');
 
         fireEvent.keyDown(element, { key: 'Enter' });
-        expect(ref.current?.interaction.state).toBe('uap-action-start');
+        expect(ref.current?.interaction.value).toBe('uap-action-start');
 
         fireEvent.blur(element);
-        expect(ref.current?.interaction.state).toBe('uap-action-end');
+        expect(ref.current?.interaction.value).toBe('uap-action-end');
       });
 
       test('should handle focus event', () => {
@@ -566,7 +566,7 @@ describe('Drag Handle Hooks', () => {
         const element = getByTestId('drag-handle');
 
         fireEvent.focus(element);
-        expect(ref.current?.interaction.state).toBeNull();
+        expect(ref.current?.interaction.value).toBeNull();
       });
     });
 
@@ -771,7 +771,7 @@ describe('Drag Handle Hooks', () => {
         const element = getByTestId('drag-handle');
 
         fireEvent.pointerMove(element);
-        expect(ref.current?.interaction.state).toBeNull();
+        expect(ref.current?.interaction.value).toBeNull();
       });
 
       test('should ignore pointer up when not in dnd state', () => {
@@ -780,7 +780,7 @@ describe('Drag Handle Hooks', () => {
         const element = getByTestId('drag-handle');
 
         fireEvent.pointerUp(element);
-        expect(ref.current?.interaction.state).toBeNull();
+        expect(ref.current?.interaction.value).toBeNull();
       });
 
       test('should ignore non-Enter/Escape key presses', () => {
@@ -789,7 +789,7 @@ describe('Drag Handle Hooks', () => {
         const element = getByTestId('drag-handle');
 
         fireEvent.keyDown(element, { key: 'A' });
-        expect(ref.current?.interaction.state).toBeNull();
+        expect(ref.current?.interaction.value).toBeNull();
       });
 
       test('should ignore non-Enter/Escape key presses in a non-null state', () => {
@@ -802,7 +802,7 @@ describe('Drag Handle Hooks', () => {
             payload: { nativeEvent: createPointerEvent('pointerdown') },
           });
         });
-        expect(ref.current?.interaction.state).toBe('dnd-start');
+        expect(ref.current?.interaction.value).toBe('dnd-start');
 
         // Dispatch a non-Enter/Escape key press
         act(() => {
@@ -811,7 +811,7 @@ describe('Drag Handle Hooks', () => {
             payload: { key: 'A' },
           });
         });
-        expect(ref.current?.interaction.state).toBe('dnd-start');
+        expect(ref.current?.interaction.value).toBe('dnd-start');
       });
 
       test('should ignore blur event in non-uap-action-start state', () => {
@@ -825,21 +825,21 @@ describe('Drag Handle Hooks', () => {
             payload: { nativeEvent: createPointerEvent('pointerdown') },
           });
         });
-        expect(ref.current?.interaction.state).toBe('dnd-start');
+        expect(ref.current?.interaction.value).toBe('dnd-start');
 
         // Then dispatch a blur event
         act(() => {
           ref.current?.dispatchAction({ type: 'BLUR' });
         });
         // State should remain unchanged
-        expect(ref.current?.interaction.state).toBe('dnd-start');
+        expect(ref.current?.interaction.value).toBe('dnd-start');
       });
 
       test('should handle RESET_TO_IDLE action directly', () => {
-        const state: DragHandleInteractionState = { state: 'uap-action-end' };
+        const state: DragHandleInteractionState = { value: 'uap-action-end' };
         const action: Action = { type: 'RESET_TO_IDLE' };
         const nextState = calculateNextState(state, action);
-        expect(nextState.state).toBeNull();
+        expect(nextState.value).toBeNull();
       });
     });
 
@@ -856,7 +856,7 @@ describe('Drag Handle Hooks', () => {
             },
           });
         });
-        expect(ref.current?.interaction.state).toBe('dnd-start');
+        expect(ref.current?.interaction.value).toBe('dnd-start');
 
         act(() => {
           ref.current?.dispatchAction({
@@ -866,7 +866,7 @@ describe('Drag Handle Hooks', () => {
             },
           });
         });
-        expect(ref.current?.interaction.state).toBe('dnd-active');
+        expect(ref.current?.interaction.value).toBe('dnd-active');
       });
 
       test('should update event data without changing state', () => {
@@ -905,7 +905,7 @@ describe('Drag Handle Hooks', () => {
           });
         });
         // State should still be dnd-active and event data should be updated
-        expect(ref.current?.interaction.state).toBe('dnd-active');
+        expect(ref.current?.interaction.value).toBe('dnd-active');
         expect(ref.current?.interaction.eventData).not.toBe(initialEventData);
         expect(ref.current?.interaction.eventData).toBe(newEventData);
       });
@@ -913,7 +913,7 @@ describe('Drag Handle Hooks', () => {
       test('should not update state when event data is the same', () => {
         const mockEvent = createPointerEvent('pointermove');
         const state: DragHandleInteractionState = {
-          state: 'dnd-active',
+          value: 'dnd-active',
           eventData: mockEvent,
         };
 
@@ -921,7 +921,7 @@ describe('Drag Handle Hooks', () => {
           type: 'POINTER_MOVE',
           payload: { nativeEvent: mockEvent },
         });
-        expect(result.state).toBe('dnd-active');
+        expect(result.value).toBe('dnd-active');
         expect(result.eventData).toBe(mockEvent);
       });
     });

--- a/src/internal/components/drag-handle/hooks/interfaces.ts
+++ b/src/internal/components/drag-handle/hooks/interfaces.ts
@@ -44,6 +44,7 @@ export type Action<T = void> =
   | { type: 'POINTER_DOWN'; payload: PointerDownActionPayload<T> }
   | { type: 'POINTER_MOVE'; payload: DefaultActionPayload }
   | { type: 'POINTER_UP'; payload: DefaultActionPayload }
+  | { type: 'POINTER_CANCEL' }
   | { type: 'KEY_DOWN'; payload: KeyDownActionPayload<T> }
   | { type: 'FOCUS' }
   | { type: 'BLUR' }

--- a/src/internal/components/drag-handle/hooks/interfaces.ts
+++ b/src/internal/components/drag-handle/hooks/interfaces.ts
@@ -13,7 +13,7 @@ export type StateTransitionCallbacks<T = void> =
   | { type: 'onUapActionEnd' };
 
 export interface DragHandleInteractionState<T = void> {
-  state: InteractionState;
+  value: InteractionState;
   eventData?: PointerEvent; // Only relevant for dnd states
   metadata?: T;
   transitionCallbacks?: StateTransitionCallbacks<T>[];

--- a/src/internal/components/drag-handle/hooks/interfaces.ts
+++ b/src/internal/components/drag-handle/hooks/interfaces.ts
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export type UapActionInteractionStateValue = 'uap-action-start' | 'uap-action-end';
+export type DndInteractionStateValue = 'dnd-start' | 'dnd-active' | 'dnd-end';
+export type InteractionState = null | UapActionInteractionStateValue | DndInteractionStateValue;
+
+export type StateTransitionCallbacks<T = void> =
+  | { type: 'onDndStart'; payload: PointerEvent; metadata?: T }
+  | { type: 'onDndActive'; payload: PointerEvent }
+  | { type: 'onDndEnd' }
+  | { type: 'onUapActionStart'; metadata?: T }
+  | { type: 'onUapActionEnd' };
+
+export interface DragHandleInteractionState<T = void> {
+  state: InteractionState;
+  eventData?: PointerEvent; // Only relevant for dnd states
+  metadata?: T;
+  pendingCallbacks?: StateTransitionCallbacks<T>[];
+}
+
+export interface UseDragHandleInteractionStateProps<T = void> {
+  onDndStartAction?: (event: PointerEvent, metadata?: T) => void;
+  onDndActiveAction?: (event: PointerEvent) => void;
+  onDndEndAction?: () => void;
+  onUapActionStartAction?: (metadata?: T) => void;
+  onUapActionEndAction?: () => void;
+}
+
+interface DefaultActionPayload {
+  nativeEvent: PointerEvent;
+}
+
+interface PointerDownActionPayload<T = void> extends DefaultActionPayload {
+  metadata?: T;
+}
+
+interface KeyDownActionPayload<T = void> {
+  key: string;
+  metadata?: T;
+}
+
+export type Action<T = void> =
+  | { type: 'POINTER_DOWN'; payload: PointerDownActionPayload<T> }
+  | { type: 'POINTER_MOVE'; payload: DefaultActionPayload }
+  | { type: 'POINTER_UP'; payload: DefaultActionPayload }
+  | { type: 'KEY_DOWN'; payload: KeyDownActionPayload<T> }
+  | { type: 'FOCUS' }
+  | { type: 'BLUR' }
+  | { type: 'RESET_TO_IDLE' }
+  | { type: 'CLEAR_CALLBACKS' };

--- a/src/internal/components/drag-handle/hooks/interfaces.ts
+++ b/src/internal/components/drag-handle/hooks/interfaces.ts
@@ -16,7 +16,7 @@ export interface DragHandleInteractionState<T = void> {
   state: InteractionState;
   eventData?: PointerEvent; // Only relevant for dnd states
   metadata?: T;
-  pendingCallbacks?: StateTransitionCallbacks<T>[];
+  transitionCallbacks?: StateTransitionCallbacks<T>[];
 }
 
 export interface UseDragHandleInteractionStateProps<T = void> {

--- a/src/internal/components/drag-handle/hooks/use-drag-handle-interaction-state.ts
+++ b/src/internal/components/drag-handle/hooks/use-drag-handle-interaction-state.ts
@@ -1,0 +1,344 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+
+import type {
+  Action,
+  DragHandleInteractionState,
+  StateTransitionCallbacks,
+  UseDragHandleInteractionStateProps,
+} from './interfaces';
+
+export { UseDragHandleInteractionStateProps };
+
+export function calculateNextState<T = void>(
+  state: DragHandleInteractionState<T>,
+  action: Action<T>
+): DragHandleInteractionState<T> {
+  switch (action.type) {
+    case 'POINTER_DOWN': {
+      const { nativeEvent, metadata } = action.payload;
+      return {
+        state: 'dnd-start',
+        eventData: nativeEvent,
+        metadata,
+      };
+    }
+
+    case 'POINTER_MOVE': {
+      const { nativeEvent } = action.payload;
+      if (state.state === 'dnd-start' || state.state === 'dnd-active') {
+        return {
+          ...state,
+          state: 'dnd-active',
+          eventData: nativeEvent,
+        };
+      }
+      return state;
+    }
+
+    case 'POINTER_UP': {
+      if (state.state === 'dnd-start' || state.state === 'dnd-active') {
+        const dndSubStateBeforeUp = state.state;
+        if (dndSubStateBeforeUp === 'dnd-start') {
+          return {
+            state: 'uap-action-start',
+            metadata: state.metadata, // Preserve metadata when transitioning from dnd-start to uap-action-start
+          };
+        } else {
+          return {
+            state: 'dnd-end',
+            eventData: state.eventData,
+          };
+        }
+      }
+      return state;
+    }
+
+    case 'KEY_DOWN': {
+      const { key, metadata } = action.payload;
+
+      if (key === 'Enter') {
+        if (state.state === null || state.state === 'uap-action-end' || state.state === 'dnd-end') {
+          return {
+            state: 'uap-action-start',
+            metadata,
+          };
+        } else if (state.state === 'uap-action-start') {
+          return {
+            state: 'uap-action-end',
+          };
+        } else if (state.state === 'dnd-start' || state.state === 'dnd-active') {
+          return {
+            state: 'uap-action-start',
+            metadata,
+          };
+        }
+      } else if (key === 'Escape') {
+        if (state.state === 'uap-action-start') {
+          return {
+            state: 'uap-action-end',
+          };
+        }
+      }
+      return state;
+    }
+
+    case 'FOCUS':
+      return state;
+
+    case 'BLUR':
+      if (state.state === 'uap-action-start') {
+        return {
+          state: 'uap-action-end',
+        };
+      }
+      return state;
+
+    case 'RESET_TO_IDLE':
+      if (state.state === 'uap-action-end' || state.state === 'dnd-end' || state.state === null) {
+        return {
+          state: null,
+        };
+      }
+      return state;
+
+    default:
+      return state;
+  }
+}
+
+export function getCallbacksForTransition<T = void>(
+  prevState: DragHandleInteractionState<T>,
+  nextState: DragHandleInteractionState<T>
+): StateTransitionCallbacks<T>[] {
+  const callbacks: StateTransitionCallbacks<T>[] = [];
+
+  // Transitions from dnd-start or dnd-active to any other state
+  if (
+    (prevState.state === 'dnd-start' || prevState.state === 'dnd-active') &&
+    nextState.state !== 'dnd-start' &&
+    nextState.state !== 'dnd-active'
+  ) {
+    callbacks.push({ type: 'onDndEnd' });
+  }
+
+  // From uap-action-start to uap-action-end directly
+  if (prevState.state === 'uap-action-start' && nextState.state === 'uap-action-end') {
+    callbacks.push({ type: 'onUapActionEnd' });
+  }
+
+  // Transitions to dnd-start
+  if (nextState.state === 'dnd-start') {
+    callbacks.push({
+      type: 'onDndStart',
+      payload: nextState.eventData!,
+      metadata: nextState.metadata,
+    });
+  }
+
+  // Transitions to dnd-active
+  if (nextState.state === 'dnd-active' && prevState.state === 'dnd-start') {
+    callbacks.push({
+      type: 'onDndActive',
+      payload: nextState.eventData!,
+    });
+  }
+
+  // Transitions to uap-action-start
+  if (nextState.state === 'uap-action-start') {
+    callbacks.push({
+      type: 'onUapActionStart',
+      metadata: nextState.metadata,
+    });
+  }
+
+  return callbacks;
+}
+
+function interactionReducer<T = void>(
+  state: DragHandleInteractionState<T>,
+  action: Action<T>
+): DragHandleInteractionState<T> {
+  if (action.type === 'CLEAR_CALLBACKS') {
+    return {
+      ...state,
+      pendingCallbacks: undefined,
+    };
+  }
+
+  const nextState = calculateNextState(state, action);
+
+  // Special handling for POINTER_MOVE to always trigger onDndActive callback
+  if (action.type === 'POINTER_MOVE' && action.payload.nativeEvent) {
+    const transitionCallbacks = getCallbacksForTransition(state, nextState);
+    // Check if there's already an onDndActive callback from the transition
+    const hasOnDndActiveCallback = transitionCallbacks.some(callback => callback.type === 'onDndActive');
+    const callbacks = hasOnDndActiveCallback
+      ? transitionCallbacks
+      : [...transitionCallbacks, { type: 'onDndActive' as const, payload: action.payload.nativeEvent }];
+
+    return {
+      ...nextState,
+      pendingCallbacks: callbacks,
+    };
+  }
+
+  // Return current state if state didn't change
+  const isDndState = (state: DragHandleInteractionState<T>) => {
+    return state.state === 'dnd-start' || state.state === 'dnd-active' || state.state === 'dnd-end';
+  };
+  if (nextState.state === state.state) {
+    if (isDndState(nextState) && isDndState(state)) {
+      if (nextState.eventData === state.eventData) {
+        return state;
+      }
+    } else {
+      return state;
+    }
+  }
+
+  const callbacks = getCallbacksForTransition(state, nextState);
+  return {
+    ...nextState,
+    pendingCallbacks: callbacks.length > 0 ? callbacks : undefined,
+  };
+}
+
+function useStateLogger<T = void>(state: DragHandleInteractionState<T>, isEnabled: boolean) {
+  const prevStateRef = useRef<DragHandleInteractionState<T>>(state);
+  useEffect(() => {
+    if (state.state !== prevStateRef.current.state && isEnabled) {
+      console.log(`State transition: ${prevStateRef.current.state} -> ${state.state}`, {
+        prevState: prevStateRef.current,
+        nextState: state,
+      });
+    }
+    prevStateRef.current = state;
+  }, [state, isEnabled]);
+}
+
+function useCallbackHandler<T = void>(
+  pendingCallbacks: StateTransitionCallbacks<T>[] | undefined,
+  props: UseDragHandleInteractionStateProps<T>,
+  dispatch: React.Dispatch<Action<T>>
+) {
+  useEffect(() => {
+    if (!pendingCallbacks?.length) {
+      return;
+    }
+    pendingCallbacks.forEach(callback => {
+      switch (callback.type) {
+        case 'onDndStart':
+          props.onDndStartAction?.(callback.payload, callback.metadata);
+          break;
+        case 'onDndActive':
+          props.onDndActiveAction?.(callback.payload);
+          break;
+        case 'onDndEnd':
+          props.onDndEndAction?.();
+          break;
+        case 'onUapActionStart':
+          props.onUapActionStartAction?.(callback.metadata);
+          break;
+        case 'onUapActionEnd':
+          props.onUapActionEndAction?.();
+          break;
+      }
+    });
+
+    dispatch({ type: 'CLEAR_CALLBACKS' });
+  }, [pendingCallbacks, props, dispatch]);
+}
+
+function useEventHandlers<T = void>(dispatchParam: React.Dispatch<Action<T>>) {
+  // Use ref to maintain stable dispatch reference to avoid recreation on every re-render
+  const dispatchRef = useRef(dispatchParam);
+  useEffect(() => {
+    dispatchRef.current = dispatchParam;
+  }, [dispatchParam]);
+
+  const processPointerDown = useCallback((event: PointerEvent, metadata?: T) => {
+    dispatchRef.current({
+      type: 'POINTER_DOWN',
+      payload: { nativeEvent: event, metadata },
+    });
+  }, []);
+
+  const processPointerMove = useCallback((event: PointerEvent) => {
+    dispatchRef.current({
+      type: 'POINTER_MOVE',
+      payload: { nativeEvent: event },
+    });
+  }, []);
+
+  const processPointerUp = useCallback((event: PointerEvent) => {
+    dispatchRef.current({
+      type: 'POINTER_UP',
+      payload: { nativeEvent: event },
+    });
+  }, []);
+
+  const processKeyDown = useCallback((event: React.KeyboardEvent<Element>, metadata?: T) => {
+    const key = event.key;
+    if (key === 'Enter' || key === 'Escape') {
+      dispatchRef.current({
+        type: 'KEY_DOWN',
+        payload: { key, metadata },
+      });
+    }
+  }, []);
+
+  const processFocus = useCallback(() => {
+    dispatchRef.current({ type: 'FOCUS' });
+  }, []);
+
+  const processBlur = useCallback(() => {
+    dispatchRef.current({ type: 'BLUR' });
+  }, []);
+
+  return {
+    processPointerDown,
+    processPointerMove,
+    processPointerUp,
+    processKeyDown,
+    processFocus,
+    processBlur,
+  };
+}
+
+/**
+ * Manages interaction states for drag handle components.
+ *
+ * The hook implements a state machine for drag handles that supports:
+ * - Pointer-based drag-and-drop (DnD) interactions
+ * - Keyboard-based universal access pattern (UAP) interactions
+ * - State transitions with appropriate callbacks
+ * - Metadata passing between states
+ *
+ * States:
+ * - null: Idle state with no active interaction
+ * - dnd-start: Initial pointer down, beginning of potential drag
+ * - dnd-active: Active dragging with pointer movement
+ * - dnd-end: Completed drag operation
+ * - uap-action-start: Keyboard/accessibility action initiated
+ * - uap-action-end: Keyboard/accessibility action completed
+ */
+export default function useDragHandleInteractionState<T = void>(
+  props: UseDragHandleInteractionStateProps<T> = {},
+  options = { debug: false }
+) {
+  const propsRef = useRef<UseDragHandleInteractionStateProps<T>>(props);
+  propsRef.current = props;
+
+  const [interaction, dispatch] = useReducer(interactionReducer<T>, { state: null } as DragHandleInteractionState<T>);
+  useStateLogger(interaction, options.debug);
+  useCallbackHandler(interaction.pendingCallbacks, propsRef.current, dispatch);
+  const eventHandlers = useEventHandlers(dispatch);
+  return {
+    interaction,
+    ...eventHandlers,
+  };
+}

--- a/src/internal/components/drag-handle/hooks/use-drag-handle-interaction-state.ts
+++ b/src/internal/components/drag-handle/hooks/use-drag-handle-interaction-state.ts
@@ -21,7 +21,7 @@ export function calculateNextState<T = void>(
     case 'POINTER_DOWN': {
       const { nativeEvent, metadata } = action.payload;
       return {
-        state: 'dnd-start',
+        value: 'dnd-start',
         eventData: nativeEvent,
         metadata,
       };
@@ -29,10 +29,10 @@ export function calculateNextState<T = void>(
 
     case 'POINTER_MOVE': {
       const { nativeEvent } = action.payload;
-      if (state.state === 'dnd-start' || state.state === 'dnd-active') {
+      if (state.value === 'dnd-start' || state.value === 'dnd-active') {
         return {
           ...state,
-          state: 'dnd-active',
+          value: 'dnd-active',
           eventData: nativeEvent,
         };
       }
@@ -40,16 +40,16 @@ export function calculateNextState<T = void>(
     }
 
     case 'POINTER_UP': {
-      if (state.state === 'dnd-start' || state.state === 'dnd-active') {
-        const dndSubStateBeforeUp = state.state;
+      if (state.value === 'dnd-start' || state.value === 'dnd-active') {
+        const dndSubStateBeforeUp = state.value;
         if (dndSubStateBeforeUp === 'dnd-start') {
           return {
-            state: 'uap-action-start',
+            value: 'uap-action-start',
             metadata: state.metadata, // Preserve metadata when transitioning from dnd-start to uap-action-start
           };
         } else {
           return {
-            state: 'dnd-end',
+            value: 'dnd-end',
             eventData: state.eventData,
           };
         }
@@ -61,25 +61,25 @@ export function calculateNextState<T = void>(
       const { key, metadata } = action.payload;
 
       if (key === 'Enter' || key === ' ') {
-        if (state.state === null || state.state === 'uap-action-end' || state.state === 'dnd-end') {
+        if (state.value === null || state.value === 'uap-action-end' || state.value === 'dnd-end') {
           return {
-            state: 'uap-action-start',
+            value: 'uap-action-start',
             metadata,
           };
-        } else if (state.state === 'uap-action-start') {
+        } else if (state.value === 'uap-action-start') {
           return {
-            state: 'uap-action-end',
+            value: 'uap-action-end',
           };
-        } else if (state.state === 'dnd-start' || state.state === 'dnd-active') {
+        } else if (state.value === 'dnd-start' || state.value === 'dnd-active') {
           return {
-            state: 'uap-action-start',
+            value: 'uap-action-start',
             metadata,
           };
         }
       } else if (key === 'Escape') {
-        if (state.state === 'uap-action-start') {
+        if (state.value === 'uap-action-start') {
           return {
-            state: 'uap-action-end',
+            value: 'uap-action-end',
           };
         }
       }
@@ -90,17 +90,17 @@ export function calculateNextState<T = void>(
       return state;
 
     case 'BLUR':
-      if (state.state === 'uap-action-start') {
+      if (state.value === 'uap-action-start') {
         return {
-          state: 'uap-action-end',
+          value: 'uap-action-end',
         };
       }
       return state;
 
     case 'RESET_TO_IDLE':
-      if (state.state === 'uap-action-end' || state.state === 'dnd-end' || state.state === null) {
+      if (state.value === 'uap-action-end' || state.value === 'dnd-end' || state.value === null) {
         return {
-          state: null,
+          value: null,
         };
       }
       return state;
@@ -118,20 +118,20 @@ export function getCallbacksForTransition<T = void>(
 
   // Transitions from dnd-start or dnd-active to any other state
   if (
-    (prevState.state === 'dnd-start' || prevState.state === 'dnd-active') &&
-    nextState.state !== 'dnd-start' &&
-    nextState.state !== 'dnd-active'
+    (prevState.value === 'dnd-start' || prevState.value === 'dnd-active') &&
+    nextState.value !== 'dnd-start' &&
+    nextState.value !== 'dnd-active'
   ) {
     callbacks.push({ type: 'onDndEnd' });
   }
 
   // From uap-action-start to uap-action-end directly
-  if (prevState.state === 'uap-action-start' && nextState.state === 'uap-action-end') {
+  if (prevState.value === 'uap-action-start' && nextState.value === 'uap-action-end') {
     callbacks.push({ type: 'onUapActionEnd' });
   }
 
   // Transitions to dnd-start
-  if (nextState.state === 'dnd-start') {
+  if (nextState.value === 'dnd-start') {
     callbacks.push({
       type: 'onDndStart',
       payload: nextState.eventData!,
@@ -140,7 +140,7 @@ export function getCallbacksForTransition<T = void>(
   }
 
   // Transitions to dnd-active
-  if (nextState.state === 'dnd-active' && prevState.state === 'dnd-start') {
+  if (nextState.value === 'dnd-active' && prevState.value === 'dnd-start') {
     callbacks.push({
       type: 'onDndActive',
       payload: nextState.eventData!,
@@ -148,7 +148,7 @@ export function getCallbacksForTransition<T = void>(
   }
 
   // Transitions to uap-action-start
-  if (nextState.state === 'uap-action-start') {
+  if (nextState.value === 'uap-action-start') {
     callbacks.push({
       type: 'onUapActionStart',
       metadata: nextState.metadata,
@@ -188,9 +188,9 @@ function interactionReducer<T = void>(
 
   // Return current state if state didn't change
   const isDndState = (state: DragHandleInteractionState<T>) => {
-    return state.state === 'dnd-start' || state.state === 'dnd-active' || state.state === 'dnd-end';
+    return state.value === 'dnd-start' || state.value === 'dnd-active' || state.value === 'dnd-end';
   };
-  if (nextState.state === state.state) {
+  if (nextState.value === state.value) {
     if (isDndState(nextState) && isDndState(state)) {
       if (nextState.eventData === state.eventData) {
         return state;
@@ -210,8 +210,8 @@ function interactionReducer<T = void>(
 function useStateLogger<T = void>(state: DragHandleInteractionState<T>, isEnabled: boolean) {
   const prevStateRef = useRef<DragHandleInteractionState<T>>(state);
   useEffect(() => {
-    if (state.state !== prevStateRef.current.state && isEnabled) {
-      console.log(`State transition: ${prevStateRef.current.state} -> ${state.state}`, {
+    if (state.value !== prevStateRef.current.value && isEnabled) {
+      console.log(`State transition: ${prevStateRef.current.value} -> ${state.value}`, {
         prevState: prevStateRef.current,
         nextState: state,
       });
@@ -277,7 +277,7 @@ export default function useDragHandleInteractionState<T = void>(
   const propsRef = useRef<UseDragHandleInteractionStateProps<T>>(props);
   propsRef.current = props;
 
-  const [interaction, dispatch] = useReducer(interactionReducer<T>, { state: null } as DragHandleInteractionState<T>);
+  const [interaction, dispatch] = useReducer(interactionReducer<T>, { value: null } as DragHandleInteractionState<T>);
   useStateLogger(interaction, options.debug);
   useCallbackHandler(interaction.transitionCallbacks, propsRef.current, dispatch);
   return {

--- a/src/internal/components/drag-handle/hooks/use-drag-handle-interaction-state.ts
+++ b/src/internal/components/drag-handle/hooks/use-drag-handle-interaction-state.ts
@@ -57,6 +57,15 @@ export function calculateNextState<T = void>(
       return state;
     }
 
+    case 'POINTER_CANCEL': {
+      if (state.value === 'dnd-start' || state.value === 'dnd-active') {
+        return {
+          value: 'dnd-end',
+        };
+      }
+      return state;
+    }
+
     case 'KEY_DOWN': {
       const { key, metadata } = action.payload;
 
@@ -290,6 +299,11 @@ export default function useDragHandleInteractionState<T = void>(
       dispatch({
         type: 'POINTER_UP',
         payload: { nativeEvent: event },
+      });
+    },
+    processPointerCancel: () => {
+      dispatch({
+        type: 'POINTER_CANCEL',
       });
     },
     processKeyDown: (event: React.KeyboardEvent<Element>, metadata?: T) => {

--- a/src/internal/components/drag-handle/hooks/use-drag-handle-interaction-state.ts
+++ b/src/internal/components/drag-handle/hooks/use-drag-handle-interaction-state.ts
@@ -163,13 +163,6 @@ function interactionReducer<T = void>(
   state: DragHandleInteractionState<T>,
   action: Action<T>
 ): DragHandleInteractionState<T> {
-  if (action.type === 'CLEAR_CALLBACKS') {
-    return {
-      ...state,
-      transitionCallbacks: undefined,
-    };
-  }
-
   const nextState = calculateNextState(state, action);
 
   // Special handling for POINTER_MOVE to always trigger onDndActive callback
@@ -249,8 +242,6 @@ function useCallbackHandler<T = void>(
           break;
       }
     });
-
-    dispatch({ type: 'CLEAR_CALLBACKS' });
   }, [pendingCallbacks, props, dispatch]);
 }
 

--- a/src/internal/components/drag-handle/hooks/use-drag-handle-interaction-state.ts
+++ b/src/internal/components/drag-handle/hooks/use-drag-handle-interaction-state.ts
@@ -97,16 +97,8 @@ export function calculateNextState<T = void>(
       }
       return state;
 
-    case 'RESET_TO_IDLE':
-      if (state.value === 'uap-action-end' || state.value === 'dnd-end' || state.value === null) {
-        return {
-          value: null,
-        };
-      }
-      return state;
-
     default:
-      return state;
+      throw new Error(`The given action type [${action.type}] is not supported.`);
   }
 }
 

--- a/src/internal/components/drag-handle/hooks/use-drag-handle-interaction-state.ts
+++ b/src/internal/components/drag-handle/hooks/use-drag-handle-interaction-state.ts
@@ -165,7 +165,7 @@ function interactionReducer<T = void>(
   if (action.type === 'CLEAR_CALLBACKS') {
     return {
       ...state,
-      pendingCallbacks: undefined,
+      transitionCallbacks: undefined,
     };
   }
 
@@ -182,7 +182,7 @@ function interactionReducer<T = void>(
 
     return {
       ...nextState,
-      pendingCallbacks: callbacks,
+      transitionCallbacks: callbacks,
     };
   }
 
@@ -203,7 +203,7 @@ function interactionReducer<T = void>(
   const callbacks = getCallbacksForTransition(state, nextState);
   return {
     ...nextState,
-    pendingCallbacks: callbacks.length > 0 ? callbacks : undefined,
+    transitionCallbacks: callbacks.length > 0 ? callbacks : undefined,
   };
 }
 
@@ -279,7 +279,7 @@ export default function useDragHandleInteractionState<T = void>(
 
   const [interaction, dispatch] = useReducer(interactionReducer<T>, { state: null } as DragHandleInteractionState<T>);
   useStateLogger(interaction, options.debug);
-  useCallbackHandler(interaction.pendingCallbacks, propsRef.current, dispatch);
+  useCallbackHandler(interaction.transitionCallbacks, propsRef.current, dispatch);
   return {
     interaction,
     processPointerDown: (event: PointerEvent, metadata?: T) => {

--- a/src/internal/do-not-use/drag-handle.ts
+++ b/src/internal/do-not-use/drag-handle.ts
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import useInternalDragHandleInteractionState, {
+  UseDragHandleInteractionStateProps as UseInternalDragHandleInteractionStateProps,
+} from '../components/drag-handle/hooks/use-drag-handle-interaction-state';
+import InternalDragHandle, { DragHandleProps as InternalDragHandleProps } from '../components/drag-handle/index.js';
+
+export type { InternalDragHandleProps, UseInternalDragHandleInteractionStateProps };
+export { InternalDragHandle, useInternalDragHandleInteractionState };


### PR DESCRIPTION
### Description

Add interaction state hook with DnD and keyboard support

Introduce useDragHandleInteractionState hook that implements a comprehensive state machine for drag handle components. The hook manages multiple interaction states:
- Pointer-based drag-and-drop (dnd-start, dnd-active, dnd-end)
- Keyboard-based universal access pattern (uap-action-start, uap-action-end)

The hook includes state transition logic, callback management, event handling, and metadata passing between states. 

Use-case: For complex drag/resize, the hook will trigger callbacks based on transition states. E.g. in the board components to put the board and board items into the different states based on the user interaction with the drag/resize handle.

Related links, issue #, if available: `AWSUI-60240`

### How has this been tested?

- added new unit tests
- tested locally by consuming the hook in the board components

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
