### PR TITLE
fix: Do not generate test utils for non-public components

### DIFF
--- a/build-tools/tasks/test-utils.js
+++ b/build-tools/tasks/test-utils.js
@@ -22,16 +22,22 @@ function compileTypescript(theme) {
 
 function generateTestUtilsForComponents(signalCompletion) {
   const componentNamesKebabCase = listPublicItems(path.join(testUtilsSrcDir, 'dom'));
+  const publicComponents = listPublicItems('src');
 
-  const components = componentNamesKebabCase.map(testUtilsFolderName => {
-    const name = pascalCase(testUtilsFolderName);
-    const pluralName = pluralizeComponentName(name);
-    return {
-      name,
-      pluralName,
-      testUtilsFolderName,
-    };
-  });
+  const isPublicComponent = name => publicComponents.includes(name);
+
+  const components = componentNamesKebabCase
+    .filter(component => isPublicComponent(component) || component === 'annotation')
+    // The test utils for the internal Annotation component have already been exposed. We need to keep them for backwards compatibility.
+    .map(testUtilsFolderName => {
+      const name = pascalCase(testUtilsFolderName);
+      const pluralName = pluralizeComponentName(name);
+      return {
+        name,
+        pluralName,
+        testUtilsFolderName,
+      };
+    });
 
   generateTestUtils({
     components,

--- a/src/test-utils/dom/hotspot/index.ts
+++ b/src/test-utils/dom/hotspot/index.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 
+import AnnotationWrapper from '../annotation';
 import createWrapper from '../index';
-import { AnnotationWrapper } from '../index.js';
 
 import annotationStyles from '../../../annotation-context/annotation/styles.selectors.js';
 import hotspotStyles from '../../../hotspot/styles.selectors.js';


### PR DESCRIPTION
### Description

Before this change, our build process would generate a `find` function for every folder/component in the `src/test-utils/dom` folder, even if that corresponding component is not public (such as the Annotation component). This can lead customers to use a test util function that was not expected to be exposed directly (i.e. `createWrapper().findAnnotation()`).

With this change, we only generate a `find` function if the component is public.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
