### PR TITLE
fix: Fix font smoothing on top navigation link utilities

### DIFF
--- a/src/link/styles.scss
+++ b/src/link/styles.scss
@@ -17,7 +17,7 @@
 
   @each $variant in map.keys(constants.$link-variants) {
     &.variant-#{$variant} {
-      @if $variant == 'info' {
+      @if $variant == 'info' or $variant == 'top-navigation' {
         @include styles.font-smoothing;
       }
       @if $variant == 'secondary' {


### PR DESCRIPTION
### Description

Bold text in general should have the `font-smoothing` mixin applied. The "top-navigation" variant of the link component is niche enough that we missed it at some point. See the subtle boldness difference between "Link" and "Customer Name" [here](https://cloudscape.design/components/top-navigation/?tabId=playground).

Related links, issue #, if available: AWSUI-60745

### How has this been tested?

Screenshot tests, though I'm curious if this is subtle enough to end up getting picked up.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
