### PR TITLE
fix: Ensure portal ref exists and is in DOM before use in DragHandle arrow overlay

### DIFF
--- a/src/internal/components/drag-handle-wrapper/portal-overlay.tsx
+++ b/src/internal/components/drag-handle-wrapper/portal-overlay.tsx
@@ -33,7 +33,8 @@ export default function PortalOverlay({
     let lastInlineSize: number | undefined;
     let lastBlockSize: number | undefined;
     const updateElement = () => {
-      if (ref.current) {
+      // It could be that the portal hasn't been attached to the DOM yet - ensure the ref exists and is attached DOM tree.
+      if (ref.current && document.body.contains(ref.current)) {
         const isRtl = getIsRtl(ref.current);
         const { insetInlineStart, insetBlockStart, inlineSize, blockSize } = getLogicalBoundingClientRect(track);
         // For simplicity, we just make all our calculations independent of


### PR DESCRIPTION
It could be that the portal hasn't been attached to the DOM yet. With this change it ensures the ref exists and is attached to the DOM tree.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
