### PR TITLE
chore: Make color-background-button-link-* tokens public and themeable

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
@@ -111,6 +111,20 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-button-link-active": {
+          "$description": "The background color of link buttons in active state.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#eaeded",
+          },
+        },
+        "color-background-button-link-hover": {
+          "$description": "The background color of link buttons in hover state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#fafafa",
+          },
+        },
         "color-background-button-normal-active": {
           "$description": "The background color of normal buttons in active state.",
           "$value": {
@@ -2667,6 +2681,20 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
+          },
+        },
+        "color-background-button-link-active": {
+          "$description": "The background color of link buttons in active state.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#eaeded",
+          },
+        },
+        "color-background-button-link-hover": {
+          "$description": "The background color of link buttons in hover state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#fafafa",
           },
         },
         "color-background-button-normal-active": {
@@ -5227,6 +5255,20 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-button-link-active": {
+          "$description": "The background color of link buttons in active state.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#eaeded",
+          },
+        },
+        "color-background-button-link-hover": {
+          "$description": "The background color of link buttons in hover state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#fafafa",
+          },
+        },
         "color-background-button-normal-active": {
           "$description": "The background color of normal buttons in active state.",
           "$value": {
@@ -7783,6 +7825,20 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
+          },
+        },
+        "color-background-button-link-active": {
+          "$description": "The background color of link buttons in active state.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#eaeded",
+          },
+        },
+        "color-background-button-link-hover": {
+          "$description": "The background color of link buttons in hover state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#fafafa",
           },
         },
         "color-background-button-normal-active": {
@@ -10343,6 +10399,20 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-button-link-active": {
+          "$description": "The background color of link buttons in active state.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#eaeded",
+          },
+        },
+        "color-background-button-link-hover": {
+          "$description": "The background color of link buttons in hover state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#fafafa",
+          },
+        },
         "color-background-button-normal-active": {
           "$description": "The background color of normal buttons in active state.",
           "$value": {
@@ -12901,6 +12971,20 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-button-link-active": {
+          "$description": "The background color of link buttons in active state.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#16191f",
+          },
+        },
+        "color-background-button-link-hover": {
+          "$description": "The background color of link buttons in hover state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#21252c",
+          },
+        },
         "color-background-button-normal-active": {
           "$description": "The background color of normal buttons in active state.",
           "$value": {
@@ -15457,6 +15541,20 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
       "$value": {
         "dark": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
         "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
+      },
+    },
+    "color-background-button-link-active": {
+      "$description": "The background color of link buttons in active state.",
+      "$value": {
+        "dark": "#16191f",
+        "light": "#eaeded",
+      },
+    },
+    "color-background-button-link-hover": {
+      "$description": "The background color of link buttons in hover state.",
+      "$value": {
+        "dark": "#21252c",
+        "light": "#fafafa",
       },
     },
     "color-background-button-normal-active": {
@@ -18022,6 +18120,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-button-link-active": {
+          "$description": "The background color of link buttons in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-button-link-hover": {
+          "$description": "The background color of link buttons in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#f0fbff",
+          },
+        },
         "color-background-button-normal-active": {
           "$description": "The background color of normal buttons in active state.",
           "$value": {
@@ -20578,6 +20690,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
+          },
+        },
+        "color-background-button-link-active": {
+          "$description": "The background color of link buttons in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#333843",
+          },
+        },
+        "color-background-button-link-hover": {
+          "$description": "The background color of link buttons in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#1b232d",
           },
         },
         "color-background-button-normal-active": {
@@ -23138,6 +23264,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-button-link-active": {
+          "$description": "The background color of link buttons in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-button-link-hover": {
+          "$description": "The background color of link buttons in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#f0fbff",
+          },
+        },
         "color-background-button-normal-active": {
           "$description": "The background color of normal buttons in active state.",
           "$value": {
@@ -25694,6 +25834,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
+          },
+        },
+        "color-background-button-link-active": {
+          "$description": "The background color of link buttons in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-button-link-hover": {
+          "$description": "The background color of link buttons in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#f0fbff",
           },
         },
         "color-background-button-normal-active": {
@@ -28254,6 +28408,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-button-link-active": {
+          "$description": "The background color of link buttons in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-button-link-hover": {
+          "$description": "The background color of link buttons in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#f0fbff",
+          },
+        },
         "color-background-button-normal-active": {
           "$description": "The background color of normal buttons in active state.",
           "$value": {
@@ -30810,6 +30978,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
+          },
+        },
+        "color-background-button-link-active": {
+          "$description": "The background color of link buttons in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-button-link-hover": {
+          "$description": "The background color of link buttons in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#f0fbff",
           },
         },
         "color-background-button-normal-active": {
@@ -33370,6 +33552,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-button-link-active": {
+          "$description": "The background color of link buttons in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#333843",
+          },
+        },
+        "color-background-button-link-hover": {
+          "$description": "The background color of link buttons in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#1b232d",
+          },
+        },
         "color-background-button-normal-active": {
           "$description": "The background color of normal buttons in active state.",
           "$value": {
@@ -35928,6 +36124,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-button-link-active": {
+          "$description": "The background color of link buttons in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#333843",
+          },
+        },
+        "color-background-button-link-hover": {
+          "$description": "The background color of link buttons in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#1b232d",
+          },
+        },
         "color-background-button-normal-active": {
           "$description": "The background color of normal buttons in active state.",
           "$value": {
@@ -38484,6 +38694,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
       "$value": {
         "dark": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
         "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
+      },
+    },
+    "color-background-button-link-active": {
+      "$description": "The background color of link buttons in active state.",
+      "$value": {
+        "dark": "#333843",
+        "light": "#d1f1ff",
+      },
+    },
+    "color-background-button-link-hover": {
+      "$description": "The background color of link buttons in hover state.",
+      "$value": {
+        "dark": "#1b232d",
+        "light": "#f0fbff",
       },
     },
     "color-background-button-normal-active": {

--- a/style-dictionary/visual-refresh/metadata/colors.ts
+++ b/style-dictionary/visual-refresh/metadata/colors.ts
@@ -23,6 +23,16 @@ const metadata: StyleDictionary.MetadataIndex = {
     themeable: true,
     public: true,
   },
+  colorBackgroundButtonLinkActive: {
+    description: 'The background color of link buttons in active state.',
+    themeable: true,
+    public: true,
+  },
+  colorBackgroundButtonLinkHover: {
+    description: 'The background color of link buttons in hover state.',
+    themeable: true,
+    public: true,
+  },
   colorBackgroundToggleButtonNormalPressed: {
     description: 'The background color of normal toggle buttons in pressed state.',
     themeable: true,


### PR DESCRIPTION
### Description

The title explains it. We make the other button tokens themeable, no reason we can't allow customizing the link button variant.

Related links, issue #, if available: AWSUI-60747

### How has this been tested?

Updated the snapshot tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
