### PR TITLE
feat: Add showButton property to InternalDragHandle

### DIFF
--- a/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
+++ b/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
@@ -29,11 +29,28 @@ function getDirectionButton(direction: Direction) {
   );
 }
 
-function expectDirectionButtonHidden(direction: Direction) {
-  // Direction buttons get hidden via transition which doesn't end in JSDOM, so we just listen
-  // for the exiting classname instead.
-  const motionExitingClass = styles['direction-button-wrapper-motion-exiting'];
-  expect(getDirectionButton(direction)?.parentElement).toHaveClass(motionExitingClass);
+// Direction buttons get hidden via transition which doesn't end in JSDOM, so we use
+// the "exiting", "exited" or "hidden" classname instead to verify it's hidden.
+const DIRECTION_BUTTON_HIDDEN_CLASSES = [
+  styles['direction-button-wrapper-motion-exiting'],
+  styles['direction-button-wrapper-motion-exited'],
+  styles['direction-button-wrapper-hidden'],
+];
+
+function expectDirectionButtonToBeHidden(direction: Direction) {
+  expect(
+    DIRECTION_BUTTON_HIDDEN_CLASSES.some(className =>
+      getDirectionButton(direction)!.parentElement!.classList.contains(className)
+    )
+  ).toBe(true);
+}
+
+function expectDirectionButtonToBeVisible(direction: Direction) {
+  expect(
+    !DIRECTION_BUTTON_HIDDEN_CLASSES.some(className =>
+      getDirectionButton(direction)!.parentElement!.classList.contains(className)
+    )
+  ).toBe(true);
 }
 
 function renderDragHandle(props: Omit<DragHandleWrapperProps, 'children'>) {
@@ -139,7 +156,7 @@ test("doesn't show direction buttons by default", () => {
     directions: { 'block-start': 'active' },
   });
 
-  expect(getDirectionButton('block-start')).not.toBeInTheDocument();
+  expectDirectionButtonToBeHidden('block-start');
   expect(getDirectionButton('block-end')).not.toBeInTheDocument();
 });
 
@@ -169,8 +186,8 @@ describe('triggerMode = focus (default)', () => {
     expect(getDirectionButton('block-end')).toBeInTheDocument();
 
     fireEvent.blur(dragHandle);
-    expectDirectionButtonHidden('block-start');
-    expectDirectionButtonHidden('block-end');
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
   });
 });
 
@@ -183,8 +200,8 @@ describe('triggerMode = keyboard-activate', () => {
 
     document.body.dataset.awsuiFocusVisible = 'true';
     dragHandle.focus();
-    expect(getDirectionButton('block-start')).toBeNull();
-    expect(getDirectionButton('block-end')).toBeNull();
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
     expect(getDirectionButton('inline-start')).toBeNull();
     expect(getDirectionButton('inline-end')).toBeNull();
   });
@@ -197,8 +214,8 @@ describe('triggerMode = keyboard-activate', () => {
 
     document.body.dataset.awsuiFocusVisible = 'true';
     dragHandle.focus();
-    expect(getDirectionButton('block-start')).not.toBeInTheDocument();
-    expect(getDirectionButton('block-end')).not.toBeInTheDocument();
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
     expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
     expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
 
@@ -226,8 +243,8 @@ describe('triggerMode = keyboard-activate', () => {
     expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
 
     fireEvent.blur(dragHandle);
-    expectDirectionButtonHidden('block-start');
-    expectDirectionButtonHidden('block-end');
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
   });
 
   test.each(['Enter', ' '])('hides direction buttons when toggling "%s" key', key => {
@@ -247,8 +264,8 @@ describe('triggerMode = keyboard-activate', () => {
 
     fireEvent.keyDown(dragHandle, { key });
 
-    expectDirectionButtonHidden('block-start');
-    expectDirectionButtonHidden('block-end');
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
   });
 });
 
@@ -271,7 +288,7 @@ test(`doesn't show direction buttons when drag is "cancelled"`, () => {
 
   fireEvent.pointerDown(dragHandle);
   fireEvent.pointerCancel(dragHandle);
-  expect(getDirectionButton('block-start')).not.toBeInTheDocument();
+  expectDirectionButtonToBeHidden('block-start');
 });
 
 test('shows direction buttons when dragged 2 pixels', () => {
@@ -295,7 +312,7 @@ test("doesn't show direction buttons when dragged more than 3 pixels", () => {
   fireEvent.pointerDown(dragHandle, { clientX: 50, clientY: 50 });
   fireEvent.pointerMove(dragHandle, { clientX: 55, clientY: 55 });
   fireEvent.pointerUp(dragHandle);
-  expect(getDirectionButton('block-start')).not.toBeInTheDocument();
+  expectDirectionButtonToBeHidden('block-start');
 });
 
 test('hides direction buttons on Escape keypress', () => {
@@ -306,7 +323,7 @@ test('hides direction buttons on Escape keypress', () => {
 
   showButtons();
   fireEvent.keyDown(dragHandle, { key: 'Escape' });
-  expectDirectionButtonHidden('block-start');
+  expectDirectionButtonToBeHidden('block-start');
 });
 
 test('renders disabled direction buttons', () => {
@@ -378,4 +395,110 @@ test("doesn't call onDirectionClick when disabled direction button is pressed", 
   showButtons();
   fireEvent.click(getDirectionButton('block-start')!);
   expect(onDirectionClick).not.toHaveBeenCalled();
+});
+
+describe('showButtons property', () => {
+  test('shows direction buttons initially when showButtons=true', () => {
+    renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      showButtons: true,
+    });
+    expectDirectionButtonToBeVisible('block-start');
+    expectDirectionButtonToBeVisible('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+  });
+
+  test('hides direction buttons initially when showButtons=false (default)', () => {
+    renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+    });
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+  });
+
+  test('hides direction buttons on Escape keypress when initially visible', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      showButtons: true,
+    });
+    expectDirectionButtonToBeVisible('block-start');
+    expectDirectionButtonToBeVisible('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(dragHandle, { key: 'Escape' });
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+  });
+
+  test('hides direction buttons when focus leaves the button when initially visible', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      showButtons: true,
+    });
+    expectDirectionButtonToBeVisible('block-start');
+    expectDirectionButtonToBeVisible('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+    dragHandle.focus();
+
+    fireEvent.blur(dragHandle);
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+  });
+
+  test('keeps direction buttons visible after click when initially visible', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active' },
+      showButtons: true,
+    });
+
+    expect(getDirectionButton('block-start')).toBeInTheDocument();
+
+    dragHandle.click();
+    expectDirectionButtonToBeVisible('block-start');
+    expect(getDirectionButton('block-end')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+  });
+
+  describe('interaction with triggerMode', () => {
+    test('shows direction buttons initially with showButtons=true and triggerMode=keyboard-activate', () => {
+      renderDragHandle({
+        directions: { 'block-start': 'active', 'block-end': 'active' },
+        triggerMode: 'keyboard-activate',
+        showButtons: true,
+      });
+
+      expectDirectionButtonToBeVisible('block-start');
+      expectDirectionButtonToBeVisible('block-end');
+      expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+      expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+    });
+
+    test.each(['Enter', ' '])('toggles direction buttons with "%s" key when initially visible', key => {
+      const { dragHandle } = renderDragHandle({
+        directions: { 'block-start': 'active', 'block-end': 'active' },
+        triggerMode: 'keyboard-activate',
+        showButtons: true,
+      });
+      expectDirectionButtonToBeVisible('block-start');
+      expectDirectionButtonToBeVisible('block-end');
+      expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+      expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+
+      fireEvent.keyDown(dragHandle, { key });
+      expectDirectionButtonToBeHidden('block-start');
+      expectDirectionButtonToBeHidden('block-end');
+      expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+      expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/internal/components/drag-handle-wrapper/__tests__/portal-overlay.test.tsx
+++ b/src/internal/components/drag-handle-wrapper/__tests__/portal-overlay.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { createRef } from 'react';
 import { render, waitFor } from '@testing-library/react';
 
 import PortalOverlay from '../../../../../lib/components/internal/components/drag-handle-wrapper/portal-overlay.js';
@@ -27,11 +27,17 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-test('matches the position of the tracked element', async () => {
-  const trackElement = document.createElement('span');
+function createMockRef() {
+  const ref = createRef<HTMLElement>();
+  render(<span ref={ref} />);
 
+  return ref;
+}
+
+test('matches the position of the tracked element', async () => {
+  const mockRef = createMockRef();
   render(
-    <PortalOverlay track={trackElement} isDisabled={false}>
+    <PortalOverlay track={mockRef} isDisabled={false}>
       <div id="overlay">Overlay</div>
     </PortalOverlay>
   );
@@ -46,10 +52,10 @@ test('matches the position of the tracked element', async () => {
 
 test('matches the position of the tracked element in rtl', async () => {
   isRtl = true;
-  const trackElement = document.createElement('span');
+  const mockRef = createMockRef();
 
   render(
-    <PortalOverlay track={trackElement} isDisabled={false}>
+    <PortalOverlay track={mockRef} isDisabled={false}>
       <div id="overlay">Overlay</div>
     </PortalOverlay>
   );
@@ -63,10 +69,10 @@ test('matches the position of the tracked element in rtl', async () => {
 });
 
 test('does not update position when disabled', async () => {
-  const trackElement = document.createElement('span');
+  const mockRef = createMockRef();
 
   render(
-    <PortalOverlay track={trackElement} isDisabled={true}>
+    <PortalOverlay track={mockRef} isDisabled={true}>
       <div id="overlay">Overlay</div>
     </PortalOverlay>
   );
@@ -80,10 +86,10 @@ test('does not update position when disabled', async () => {
 });
 
 test('resumes position updates when enabled after being disabled', async () => {
-  const trackElement = document.createElement('span');
+  const mockRef = createMockRef();
 
   const PortalOverlayWrapper = ({ isDisabled }: { isDisabled: boolean }) => (
-    <PortalOverlay track={trackElement} isDisabled={isDisabled}>
+    <PortalOverlay track={mockRef} isDisabled={isDisabled}>
       <div id="overlay">Overlay</div>
     </PortalOverlay>
   );

--- a/src/internal/components/drag-handle-wrapper/index.tsx
+++ b/src/internal/components/drag-handle-wrapper/index.tsx
@@ -26,11 +26,12 @@ export default function DragHandleWrapper({
   children,
   onDirectionClick,
   triggerMode = 'focus',
+  showButtons = false,
 }: DragHandleWrapperProps) {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const dragHandleRef = useRef<HTMLDivElement | null>(null);
   const [showTooltip, setShowTooltip] = useState(false);
-  const [showButtons, setShowButtons] = useState(false);
+  const [buttonVisibility, setButtonVisibility] = useState(showButtons);
 
   const isPointerDown = useRef(false);
   const initialPointerPosition = useRef<{ x: number; y: number } | undefined>();
@@ -51,7 +52,7 @@ export default function DragHandleWrapper({
     if (document.body.dataset.awsuiFocusVisible && !nodeContains(wrapperRef.current, event.relatedTarget)) {
       setShowTooltip(false);
       if (triggerMode === 'focus') {
-        setShowButtons(true);
+        setButtonVisibility(true);
       }
     }
   };
@@ -62,7 +63,7 @@ export default function DragHandleWrapper({
     // since it'll be returned when they switch back anyway, we exclude that
     // case by checking for `document.hasFocus()`.
     if (document.hasFocus() && !nodeContains(wrapperRef.current, event.relatedTarget)) {
-      setShowButtons(false);
+      setButtonVisibility(false);
     }
   };
 
@@ -114,7 +115,7 @@ export default function DragHandleWrapper({
         if (isPointerDown.current && !didPointerDrag.current) {
           // The cursor didn't move much between "pointerdown" and "pointerup".
           // Handle this as a "click" instead of a "drag".
-          setShowButtons(true);
+          setButtonVisibility(true);
         }
         resetPointerDownState();
       },
@@ -153,14 +154,14 @@ export default function DragHandleWrapper({
     // For accessibility reasons, pressing escape should should always close
     // the floating controls.
     if (event.key === 'Escape') {
-      setShowButtons(false);
+      setButtonVisibility(false);
     } else if (triggerMode === 'keyboard-activate' && (event.key === 'Enter' || event.key === ' ')) {
       // toggle buttons when Enter or space is pressed in 'keyboard-activate' triggerMode
-      setShowButtons(prevShowButtons => !prevShowButtons);
+      setButtonVisibility(prevButtonVisibility => !prevButtonVisibility);
     } else if (event.key !== 'Alt' && event.key !== 'Control' && event.key !== 'Meta' && event.key !== 'Shift') {
       // Pressing any other key will display the focus-visible ring around the
       // drag handle if it's in focus, so we should also show the buttons now.
-      setShowButtons(true);
+      setButtonVisibility(true);
     }
   };
 
@@ -176,7 +177,7 @@ export default function DragHandleWrapper({
 
   return (
     <div
-      className={clsx(styles['drag-handle-wrapper'], showButtons && styles['drag-handle-wrapper-open'])}
+      className={clsx(styles['drag-handle-wrapper'], buttonVisibility && styles['drag-handle-wrapper-open'])}
       ref={wrapperRef}
       onFocus={onWrapperFocusIn}
       onBlur={onWrapperFocusOut}
@@ -191,15 +192,15 @@ export default function DragHandleWrapper({
           {children}
         </div>
 
-        {!isDisabled && !showButtons && showTooltip && tooltipText && (
+        {!isDisabled && !buttonVisibility && showTooltip && tooltipText && (
           <Tooltip trackRef={dragHandleRef} value={tooltipText} onDismiss={() => setShowTooltip(false)} />
         )}
       </div>
 
-      <PortalOverlay track={dragHandleRef.current} isDisabled={!showButtons}>
+      <PortalOverlay track={dragHandleRef} isDisabled={!buttonVisibility}>
         {directions['block-start'] && (
           <DirectionButton
-            show={!isDisabled && showButtons}
+            show={!isDisabled && buttonVisibility}
             direction="block-start"
             state={directions['block-start']}
             onClick={() => onInternalDirectionClick('block-start')}
@@ -207,7 +208,7 @@ export default function DragHandleWrapper({
         )}
         {directions['block-end'] && (
           <DirectionButton
-            show={!isDisabled && showButtons}
+            show={!isDisabled && buttonVisibility}
             direction="block-end"
             state={directions['block-end']}
             onClick={() => onInternalDirectionClick('block-end')}
@@ -215,7 +216,7 @@ export default function DragHandleWrapper({
         )}
         {directions['inline-start'] && (
           <DirectionButton
-            show={!isDisabled && showButtons}
+            show={!isDisabled && buttonVisibility}
             direction="inline-start"
             state={directions['inline-start']}
             onClick={() => onInternalDirectionClick('inline-start')}
@@ -223,7 +224,7 @@ export default function DragHandleWrapper({
         )}
         {directions['inline-end'] && (
           <DirectionButton
-            show={!isDisabled && showButtons}
+            show={!isDisabled && buttonVisibility}
             direction="inline-end"
             state={directions['inline-end']}
             onClick={() => onInternalDirectionClick('inline-end')}

--- a/src/internal/components/drag-handle-wrapper/interfaces.ts
+++ b/src/internal/components/drag-handle-wrapper/interfaces.ts
@@ -11,4 +11,5 @@ export interface DragHandleWrapperProps {
   tooltipText?: string;
   children: React.ReactNode;
   triggerMode?: TriggerMode;
+  showButtons?: boolean;
 }

--- a/src/internal/components/drag-handle/index.tsx
+++ b/src/internal/components/drag-handle/index.tsx
@@ -25,6 +25,7 @@ const InternalDragHandle = forwardRef(
       onKeyDown,
       onDirectionClick,
       triggerMode,
+      showButtons,
       ...rest
     }: DragHandleProps,
     ref: React.Ref<Element>
@@ -37,6 +38,7 @@ const InternalDragHandle = forwardRef(
         tooltipText={tooltipText}
         onDirectionClick={onDirectionClick}
         triggerMode={triggerMode}
+        showButtons={showButtons}
       >
         <DragHandleButton
           ref={ref}

--- a/src/internal/components/drag-handle/interfaces.ts
+++ b/src/internal/components/drag-handle/interfaces.ts
@@ -23,6 +23,7 @@ export interface DragHandleProps {
   directions?: Partial<Record<DragHandleProps.Direction, DragHandleProps.DirectionState>>;
   onDirectionClick?: (direction: DragHandleProps.Direction) => void;
   triggerMode?: TriggerMode;
+  showButtons?: boolean;
 }
 
 export namespace DragHandleProps {


### PR DESCRIPTION
Use-case: This will be consumed in board components where we need to render the arrow icons under some conditions on the initial render.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
