### PR TITLE
chore: Prevent callback re-processing loop in useInternalDragHandleInteractionState

### DIFF
--- a/pages/drag-handle/drag-handle-interaction-state-hook.page.tsx
+++ b/pages/drag-handle/drag-handle-interaction-state-hook.page.tsx
@@ -26,6 +26,7 @@ type PageContext = React.Context<
 const TestBoardItemButton: React.FC = () => {
   const { urlParams, setUrlParams } = useContext(AppContext as PageContext);
   const [renderInPortal, setRenderInPortal] = useState(false);
+  const [, setInteractionTriggeredState] = useState(0);
 
   interface TestMetadata {
     operation: 'drag' | 'resize';
@@ -34,18 +35,23 @@ const TestBoardItemButton: React.FC = () => {
   const hookProps: UseDragHandleInteractionStateProps<TestMetadata> = {
     onDndStartAction: (event, metadata) => {
       console.log('onDndStartAction triggered', event.clientX, event.clientY, metadata);
+      setInteractionTriggeredState(s => s + 1);
     },
     onDndActiveAction: event => {
       console.log('onDndActiveAction triggered', event.clientX, event.clientY);
+      setInteractionTriggeredState(s => s + 1);
     },
     onDndEndAction: () => {
       console.log('onDndEndAction triggered');
+      setInteractionTriggeredState(s => s + 1);
     },
     onUapActionStartAction: metadata => {
       console.log('onKeyboardStartAction triggered', metadata);
+      setInteractionTriggeredState(s => s + 1);
     },
     onUapActionEndAction: () => {
       console.log('onKeyboardEndAction triggered');
+      setInteractionTriggeredState(s => s + 1);
     },
   };
 

--- a/src/internal/components/drag-handle/hooks/use-drag-handle-interaction-state.ts
+++ b/src/internal/components/drag-handle/hooks/use-drag-handle-interaction-state.ts
@@ -163,6 +163,13 @@ function interactionReducer<T = void>(
   state: DragHandleInteractionState<T>,
   action: Action<T>
 ): DragHandleInteractionState<T> {
+  if (action.type === 'CLEAR_CALLBACKS') {
+    return {
+      ...state,
+      transitionCallbacks: undefined,
+    };
+  }
+
   const nextState = calculateNextState(state, action);
 
   // Special handling for POINTER_MOVE to always trigger onDndActive callback
@@ -242,6 +249,9 @@ function useCallbackHandler<T = void>(
           break;
       }
     });
+
+    // Clean up callbacks to prevent re-execution on subsequent re-renders.
+    dispatch({ type: 'CLEAR_CALLBACKS' });
   }, [pendingCallbacks, props, dispatch]);
 }
 


### PR DESCRIPTION
### Description

Clicking a drag handle managed by `useInternalDragHandleInteractionState` could cause a an endless loop ("Maximum update depth exceeded"). It occurred because callbacks triggered by the hook would cause the consuming component to re-render. This re-render, in turn, re-triggered the hook's effect handler, which then re-processed the same (stale) callbacks because they weren't cleared from the hook's internal state, leading to an infinite loop.

This change adds the clear its internal `transitionCallbacks` immediately after they are processed. A new `CLEAR_CALLBACKS` action is dispatched within the `useCallbackHandler`'s effect post-execution, ensuring callbacks are only invoked once per state transition.

This fix eliminates the infinite loop, making drag handle interactions more stable and predictable, especially when consuming components re-render in response to hook-triggered actions.

Related links, issue #, if available: n/a

### How has this been tested?

1. Added additional unit test for this edge case
2. Updated the demo page

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
