### PR TITLE
chore: Improve Table task flow preferences capture

### DIFF
--- a/src/collection-preferences/index.tsx
+++ b/src/collection-preferences/index.tsx
@@ -12,6 +12,7 @@ import { InternalButton } from '../button/internal';
 import { useInternalI18n } from '../i18n/context';
 import { getBaseProps } from '../internal/base-component';
 import { CollectionPreferencesMetadata } from '../internal/context/collection-preferences-metadata-context';
+import { useTableComponentsContext } from '../internal/context/table-component-context';
 import { fireNonCancelableEvent } from '../internal/events';
 import checkControlled from '../internal/hooks/check-controlled';
 import useBaseComponent from '../internal/hooks/use-base-component';
@@ -126,6 +127,19 @@ export default function CollectionPreferences({
   }
 
   const referrerId = useUniqueId();
+  const tableComponentContext = useTableComponentsContext();
+  if (tableComponentContext?.preferencesRef?.current) {
+    tableComponentContext.preferencesRef.current.pageSize = preferences?.pageSize;
+
+    // When both are used contentDisplayPreference takes preference and so we always prefer to use this as our visible columns if available
+    if (preferences?.contentDisplay) {
+      tableComponentContext.preferencesRef.current.visibleColumns = preferences?.contentDisplay
+        .filter(column => column.visible)
+        .map(column => column.id);
+    } else if (preferences?.visibleContent) {
+      tableComponentContext.preferencesRef.current.visibleColumns = [...preferences.visibleContent];
+    }
+  }
 
   return (
     <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>

--- a/src/collection-preferences/index.tsx
+++ b/src/collection-preferences/index.tsx
@@ -128,18 +128,31 @@ export default function CollectionPreferences({
 
   const referrerId = useUniqueId();
   const tableComponentContext = useTableComponentsContext();
-  if (tableComponentContext?.preferencesRef?.current) {
-    tableComponentContext.preferencesRef.current.pageSize = preferences?.pageSize;
 
-    // When both are used contentDisplayPreference takes preference and so we always prefer to use this as our visible columns if available
-    if (preferences?.contentDisplay) {
-      tableComponentContext.preferencesRef.current.visibleColumns = preferences?.contentDisplay
-        .filter(column => column.visible)
-        .map(column => column.id);
-    } else if (preferences?.visibleContent) {
-      tableComponentContext.preferencesRef.current.visibleColumns = [...preferences.visibleContent];
+  useEffect(() => {
+    if (tableComponentContext?.preferencesRef?.current) {
+      tableComponentContext.preferencesRef.current.pageSize = preferences?.pageSize;
+
+      // When both are used contentDisplayPreference takes preference and so we always prefer to use this as our visible columns if available
+      if (preferences?.contentDisplay) {
+        tableComponentContext.preferencesRef.current.visibleColumns = preferences?.contentDisplay
+          .filter(column => column.visible)
+          .map(column => column.id);
+      } else if (preferences?.visibleContent) {
+        tableComponentContext.preferencesRef.current.visibleColumns = [...preferences.visibleContent];
+      }
+
+      return () => {
+        delete tableComponentContext.preferencesRef.current?.pageSize;
+        delete tableComponentContext.preferencesRef.current?.visibleColumns;
+      };
     }
-  }
+  }, [
+    tableComponentContext?.preferencesRef,
+    preferences?.contentDisplay,
+    preferences?.visibleContent,
+    preferences?.pageSize,
+  ]);
 
   return (
     <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>

--- a/src/internal/analytics/interfaces.ts
+++ b/src/internal/analytics/interfaces.ts
@@ -211,7 +211,7 @@ export interface IPerformanceMetrics {
 
 type JSONValue = string | number | boolean | null | undefined;
 export interface JSONObject {
-  [key: string]: JSONObject | JSONValue;
+  [key: string]: JSONObject | JSONValue | JSONObject[] | JSONValue[];
 }
 
 interface ComponentMountedProps {

--- a/src/internal/context/__tests__/table-component-context.test.tsx
+++ b/src/internal/context/__tests__/table-component-context.test.tsx
@@ -14,6 +14,10 @@ describe('Verify TableComponentsContext', () => {
           <div data-testid="filterText">{tableComponentsContext?.filterRef?.current?.filterText}</div>
           <div data-testid="totalPageCount">{tableComponentsContext?.paginationRef?.current?.totalPageCount}</div>
           <div data-testid="currentPageIndex">{tableComponentsContext?.paginationRef?.current?.currentPageIndex}</div>
+          <div data-testid="pageSize">{tableComponentsContext?.preferencesRef?.current?.pageSize}</div>
+          <div data-testid="visibleColumns">
+            {tableComponentsContext?.preferencesRef?.current?.visibleColumns?.join(',')}
+          </div>
         </div>
       );
     };
@@ -24,6 +28,7 @@ describe('Verify TableComponentsContext', () => {
             current: { totalPageCount: 10, currentPageIndex: 1 },
           },
           filterRef: { current: { filterText: 'test' } },
+          preferencesRef: { current: { pageSize: 20, visibleColumns: ['id'] } },
         }}
       >
         <ChildComponent />
@@ -32,24 +37,38 @@ describe('Verify TableComponentsContext', () => {
     expect(getByTestId('filterText')).toHaveTextContent('test');
     expect(getByTestId('totalPageCount')).toHaveTextContent('10');
     expect(getByTestId('currentPageIndex')).toHaveTextContent('1');
+    expect(getByTestId('pageSize')).toHaveTextContent('20');
+    expect(getByTestId('visibleColumns')).toHaveTextContent('id');
   });
 
   test('child component is able to update the tableComponentsContext context value', () => {
     const updatedFilterText = 'updatedText';
     const updatedCurrentPage = 20;
     const updatedTotalPageCount = 100;
+    const updatedPageSize = 50;
+    const updatedVisibleColumns = ['id', 'name'];
     const ChildComponent = () => {
       const tableComponentsContext = useTableComponentsContext();
-      if (tableComponentsContext?.filterRef.current && tableComponentsContext?.paginationRef.current) {
+      if (
+        tableComponentsContext?.filterRef.current &&
+        tableComponentsContext?.paginationRef.current &&
+        tableComponentsContext?.preferencesRef.current
+      ) {
         tableComponentsContext.filterRef.current.filterText = updatedFilterText;
         tableComponentsContext.paginationRef.current.currentPageIndex = updatedCurrentPage;
         tableComponentsContext.paginationRef.current.totalPageCount = updatedTotalPageCount;
+        tableComponentsContext.preferencesRef.current.pageSize = updatedPageSize;
+        tableComponentsContext.preferencesRef.current.visibleColumns = updatedVisibleColumns;
       }
       return (
         <div>
           <div data-testid="filterText">{tableComponentsContext?.filterRef?.current?.filterText}</div>
           <div data-testid="totalPageCount">{tableComponentsContext?.paginationRef?.current?.totalPageCount}</div>
           <div data-testid="currentPageIndex">{tableComponentsContext?.paginationRef?.current?.currentPageIndex}</div>
+          <div data-testid="pageSize">{tableComponentsContext?.preferencesRef?.current?.pageSize}</div>
+          <div data-testid="visibleColumns">
+            {tableComponentsContext?.preferencesRef?.current?.visibleColumns?.join(',')}
+          </div>
         </div>
       );
     };
@@ -60,6 +79,7 @@ describe('Verify TableComponentsContext', () => {
             current: { totalPageCount: 10, currentPageIndex: 1 },
           },
           filterRef: { current: { filterText: 'test' } },
+          preferencesRef: { current: { pageSize: 20, visibleColumns: ['id'] } },
         }}
       >
         <ChildComponent />
@@ -68,5 +88,7 @@ describe('Verify TableComponentsContext', () => {
     expect(getByTestId('filterText')).toHaveTextContent(updatedFilterText);
     expect(getByTestId('totalPageCount')).toHaveTextContent(`${updatedTotalPageCount}`);
     expect(getByTestId('currentPageIndex')).toHaveTextContent(`${updatedCurrentPage}`);
+    expect(getByTestId('pageSize')).toHaveTextContent(`${updatedPageSize}`);
+    expect(getByTestId('visibleColumns')).toHaveTextContent(updatedVisibleColumns.join(','));
   });
 });

--- a/src/internal/context/table-component-context.ts
+++ b/src/internal/context/table-component-context.ts
@@ -12,9 +12,16 @@ export interface PaginationRef {
   totalPageCount?: number;
   openEnd?: boolean;
 }
+
+export interface PreferencesRef {
+  pageSize?: number;
+  visibleColumns?: string[];
+}
+
 interface TableComponentsContextProps {
   filterRef: RefObject<FilterRef>;
   paginationRef: RefObject<PaginationRef>;
+  preferencesRef: RefObject<PreferencesRef>;
 }
 
 const TableComponentsContext = createContext<TableComponentsContextProps | null>(null);

--- a/src/table/__integ__/component-metrics.test.ts
+++ b/src/table/__integ__/component-metrics.test.ts
@@ -46,9 +46,12 @@ const baseComponentConfiguration = {
     columnId: null,
     sortingOrder: null,
   },
+  tablePreferences: {
+    visibleColumns: ['id', 'type', 'dnsName', 'state'],
+    resourcesPerPage: 20,
+  },
   filtered: false,
   totalNumberOfResources: 200,
-  resourcesPerPage: 20,
   pagination: {
     currentPageIndex: 1,
     totalNumberOfPages: 200,
@@ -130,6 +133,78 @@ describe('selection', () => {
         componentConfiguration: {
           ...baseComponentConfiguration,
           resourcesSelected: true,
+        },
+      });
+    })
+  );
+});
+
+describe('preferences', () => {
+  test(
+    'tracks component changes when visible content preference is changed',
+    setupTest(async ({ page, wrapper }) => {
+      await page.click(wrapper.findCollectionPreferences().findTriggerButton().toSelector());
+      await page.waitForVisible(wrapper.findCollectionPreferences().findModal().toSelector());
+      await page.click(
+        wrapper.findCollectionPreferences().findModal().findContentDisplayPreference().findOptionByIndex(2).toSelector()
+      );
+      await page.click(wrapper.findCollectionPreferences().findModal().findConfirmButton().toSelector());
+      await page.waitForInteractionEvent('componentUpdated');
+      const componentsLog = await page.getComponentMetricsLog();
+      expect(componentsLog.length).toBe(2);
+      expect(componentsLog[1].name).toBe('componentUpdated');
+      expect(componentsLog[1].detail).toEqual({
+        taskInteractionId: expect.any(String),
+        componentName: 'table',
+        actionType: 'preferences',
+        componentConfiguration: {
+          ...baseComponentConfiguration,
+          tablePreferences: {
+            visibleColumns: ['id', 'dnsName', 'state'],
+            resourcesPerPage: 20,
+          },
+        },
+      });
+    })
+  );
+
+  test(
+    'tracks component changes when page size is changed',
+    setupTest(async ({ page, wrapper }) => {
+      await page.click(wrapper.findCollectionPreferences().findTriggerButton().toSelector());
+      await page.waitForVisible(wrapper.findCollectionPreferences().findModal().toSelector());
+      await page.click(
+        wrapper
+          .findCollectionPreferences()
+          .findModal()
+          .findPageSizePreference()
+          .findOptions()
+          .get(2)
+          .findNativeInput()
+          .toSelector()
+      );
+
+      await page.click(wrapper.findCollectionPreferences().findModal().findConfirmButton().toSelector());
+      await page.waitForInteractionEvent('componentUpdated');
+      const componentsLog = await page.getComponentMetricsLog();
+      expect(componentsLog.length).toBe(2);
+      expect(componentsLog[1].name).toBe('componentUpdated');
+      expect(componentsLog[1].detail).toEqual({
+        taskInteractionId: expect.any(String),
+        componentName: 'table',
+        actionType: 'preferences',
+        componentConfiguration: {
+          ...baseComponentConfiguration,
+          totalNumberOfResources: 80, // TODO: Remove after filtering PR is merged
+          pagination: {
+            currentPageIndex: 1,
+            totalNumberOfPages: 80,
+            openEnd: false,
+          },
+          tablePreferences: {
+            visibleColumns: ['id', 'type', 'dnsName', 'state'],
+            resourcesPerPage: 50,
+          },
         },
       });
     })

--- a/src/table/__tests__/component-metrics.test.tsx
+++ b/src/table/__tests__/component-metrics.test.tsx
@@ -3,17 +3,179 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 
+import CollectionPreferences, { CollectionPreferencesProps } from '../../../lib/components/collection-preferences';
+import { ComponentMetrics } from '../../../lib/components/internal/analytics';
 import Table from '../../../lib/components/table';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { mockComponentMetrics } from '../../internal/analytics/__tests__/mocks';
 
 beforeEach(() => {
+  jest.useFakeTimers();
   jest.resetAllMocks();
   mockComponentMetrics();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
 });
 
 test('should add data-analytics-task-interaction-id to root of Table component', () => {
   const { container } = render(<Table items={[]} columnDefinitions={[]} />);
   const tableElement = createWrapper(container).findTable()!.getElement();
   expect(tableElement).toHaveAttribute('data-analytics-task-interaction-id');
+});
+
+describe('preferences', () => {
+  const createDefaultProps = (): CollectionPreferencesProps => ({
+    preferences: {
+      pageSize: 10,
+    },
+    pageSizePreference: {
+      options: [
+        { value: 10, label: '10 resources' },
+        { value: 20, label: '20 resources' },
+      ],
+    },
+    contentDisplayPreference: {
+      options: [
+        {
+          id: 'id',
+          label: 'ID',
+          alwaysVisible: true,
+        },
+        {
+          id: 'name',
+          label: 'Name',
+        },
+      ],
+    },
+    onConfirm: () => {},
+  });
+
+  const setupPreferenceChangeTest = (
+    initialProps: CollectionPreferencesProps,
+    updatedPreferences: Partial<CollectionPreferencesProps['preferences']>
+  ) => {
+    const { container, rerender } = render(
+      <Table items={[]} columnDefinitions={[]} preferences={<CollectionPreferences {...initialProps} />} />
+    );
+
+    const preferencesWrapper = createWrapper(container).findCollectionPreferences()!;
+    preferencesWrapper.findTriggerButton()!.click();
+    preferencesWrapper.findModal()!.findConfirmButton()!.click();
+
+    rerender(
+      <Table
+        items={[]}
+        columnDefinitions={[]}
+        preferences={
+          <CollectionPreferences
+            {...initialProps}
+            preferences={{
+              ...initialProps.preferences,
+              ...updatedPreferences,
+            }}
+          />
+        }
+      />
+    );
+
+    jest.runAllTimers();
+
+    return { container };
+  };
+
+  test('should track changes in pageSize through preferences', () => {
+    const defaultProps = createDefaultProps();
+
+    setupPreferenceChangeTest(defaultProps, { pageSize: 20 });
+
+    expect(ComponentMetrics.componentUpdated).toHaveBeenCalledTimes(1);
+    expect(ComponentMetrics.componentUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskInteractionId: expect.any(String),
+        componentName: 'table',
+        actionType: 'preferences',
+        componentConfiguration: expect.objectContaining({
+          tablePreferences: {
+            visibleColumns: [],
+            resourcesPerPage: 20,
+          },
+        }),
+      })
+    );
+  });
+
+  test('should track changes in visibleContent through preferences', () => {
+    const defaultProps = createDefaultProps();
+
+    setupPreferenceChangeTest(defaultProps, { visibleContent: ['id'] });
+
+    expect(ComponentMetrics.componentUpdated).toHaveBeenCalledTimes(1);
+    expect(ComponentMetrics.componentUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskInteractionId: expect.any(String),
+        componentName: 'table',
+        actionType: 'preferences',
+        componentConfiguration: expect.objectContaining({
+          tablePreferences: {
+            visibleColumns: ['id'],
+            resourcesPerPage: 10,
+          },
+        }),
+      })
+    );
+  });
+
+  test('should track changes in contentDisplay through preferences', () => {
+    const defaultProps = createDefaultProps();
+    const updatedContentDisplay = [
+      { id: 'id', visible: true },
+      { id: 'name', visible: false },
+    ];
+
+    setupPreferenceChangeTest(defaultProps, { contentDisplay: updatedContentDisplay });
+
+    expect(ComponentMetrics.componentUpdated).toHaveBeenCalledTimes(1);
+    expect(ComponentMetrics.componentUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskInteractionId: expect.any(String),
+        componentName: 'table',
+        actionType: 'preferences',
+        componentConfiguration: expect.objectContaining({
+          tablePreferences: {
+            visibleColumns: ['id'],
+            resourcesPerPage: 10,
+          },
+        }),
+      })
+    );
+  });
+
+  test('should prefer contentDisplay if both visibleContent and contentDisplay are provided', () => {
+    const defaultProps = createDefaultProps();
+
+    setupPreferenceChangeTest(defaultProps, {
+      visibleContent: ['name'],
+      contentDisplay: [
+        { id: 'id', visible: true },
+        { id: 'name', visible: false },
+      ],
+    });
+
+    expect(ComponentMetrics.componentUpdated).toHaveBeenCalledTimes(1);
+    expect(ComponentMetrics.componentUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskInteractionId: expect.any(String),
+        componentName: 'table',
+        actionType: 'preferences',
+        componentConfiguration: expect.objectContaining({
+          tablePreferences: {
+            visibleColumns: ['id'],
+            resourcesPerPage: 10,
+          },
+        }),
+      })
+    );
+  });
 });

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -16,7 +16,12 @@ import { getAnalyticsMetadataProps, getBaseProps } from '../internal/base-compon
 import { getVisualContextClassname } from '../internal/components/visual-context';
 import { CollectionLabelContext } from '../internal/context/collection-label-context';
 import { LinkDefaultVariantContext } from '../internal/context/link-default-variant-context';
-import { FilterRef, PaginationRef, TableComponentsContextProvider } from '../internal/context/table-component-context';
+import {
+  FilterRef,
+  PaginationRef,
+  PreferencesRef,
+  TableComponentsContextProvider,
+} from '../internal/context/table-component-context';
 import { fireNonCancelableEvent } from '../internal/events';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
@@ -188,6 +193,7 @@ const InternalTable = React.forwardRef(
     const { cancelEdit, ...cellEditing } = useCellEditing({ onCancel: onEditCancel, onSubmit: submitEdit });
     const paginationRef = useRef<PaginationRef>({});
     const filterRef = useRef<FilterRef>({});
+    const preferencesRef = useRef<PreferencesRef>({});
     /* istanbul ignore next: performance marks do not work in JSDOM */
     const getHeaderText = () =>
       toolsHeaderPerformanceMarkRef.current?.querySelector<HTMLElement>(`.${headerStyles['heading-text']}`)
@@ -229,6 +235,7 @@ const InternalTable = React.forwardRef(
     const getComponentConfiguration = () => {
       const filterData = filterRef.current;
       const paginationData = paginationRef.current;
+      const preferencesData = preferencesRef.current;
 
       return {
         variant,
@@ -243,7 +250,10 @@ const InternalTable = React.forwardRef(
         },
         filtered: Boolean(filterData?.filterText),
         totalNumberOfResources: paginationData.totalPageCount,
-        resourcesPerPage: allRows?.length || 0,
+        tablePreferences: {
+          visibleColumns: preferencesData?.visibleColumns ?? [],
+          resourcesPerPage: preferencesData?.pageSize ?? null,
+        },
         pagination: {
           currentPageIndex: paginationData?.currentPageIndex ?? 0,
           totalNumberOfPages: paginationData?.openEnd ? null : paginationData?.totalPageCount ?? null,
@@ -418,7 +428,7 @@ const InternalTable = React.forwardRef(
 
     return (
       <LinkDefaultVariantContext.Provider value={{ defaultVariant: 'primary' }}>
-        <TableComponentsContextProvider value={{ paginationRef, filterRef }}>
+        <TableComponentsContextProvider value={{ paginationRef, filterRef, preferencesRef }}>
           <ColumnWidthsProvider
             visibleColumns={visibleColumnWidthsWithSelection}
             resizableColumns={resizableColumns}


### PR DESCRIPTION
### Description

- Capture table preference changes in existing componentUpdated event

For additional context you can look at this draft [PR](https://github.com/cloudscape-design/components/pull/3495) that includes all the relevant changes and shows the final state.

### How has this been tested?

- Added additional integ and unit test

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
