### PR TITLE
chore: Add additional testing for async table task flows

### DIFF
--- a/pages/funnel-analytics/with-async-table.page.tsx
+++ b/pages/funnel-analytics/with-async-table.page.tsx
@@ -1,0 +1,188 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useRef, useState } from 'react';
+
+import { useCollection } from '@cloudscape-design/collection-hooks';
+
+import {
+  Box,
+  Button,
+  CollectionPreferences,
+  CollectionPreferencesProps,
+  Header,
+  Pagination,
+  SpaceBetween,
+  Table,
+  TableProps,
+  TextFilter,
+} from '~components';
+import { setComponentMetrics } from '~components/internal/analytics';
+
+import { contentDisplayPreferenceI18nStrings } from '../common/i18n-strings';
+import { generateItems, Instance } from '../table/generate-data';
+import {
+  columnsConfig,
+  contentDisplayPreference,
+  defaultPreferences,
+  EmptyState,
+  getMatchesCountText,
+  pageSizeOptions,
+  paginationLabels,
+} from '../table/shared-configs';
+
+const componentMetricsLog: any[] = [];
+(window as any).__awsuiComponentlMetrics__ = componentMetricsLog;
+
+setComponentMetrics({
+  componentMounted: props => {
+    componentMetricsLog.push({ name: 'componentMounted', detail: { ...props } });
+    return props.taskInteractionId || 'mocked-task-interaction-id';
+  },
+  componentUpdated: props => {
+    componentMetricsLog.push({ name: 'componentUpdated', detail: { ...props } });
+  },
+});
+
+const allItems = generateItems();
+
+const MINIMUM_LOADING_TIME_MS = 500;
+const MAXIMUM_ADDITIONAL_LOADING_TIME_MS = 1000;
+
+function useLoading() {
+  const [loading, setLoading] = useState(false);
+  const loadingTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  return {
+    loading,
+    load: () => {
+      clearTimeout(loadingTimeoutRef.current);
+      loadingTimeoutRef.current = setTimeout(
+        () => setLoading(false),
+        MINIMUM_LOADING_TIME_MS + Math.random() * MAXIMUM_ADDITIONAL_LOADING_TIME_MS
+      );
+      setLoading(true);
+    },
+  };
+}
+
+export default function WithAsyncTablePage() {
+  const [selectedItems, setSelectedItems] = useState<TableProps['selectedItems']>([]);
+  const [preferences, setPreferences] = useState<CollectionPreferencesProps.Preferences>(defaultPreferences);
+  const { loading, load } = useLoading();
+
+  const { items, actions, filteredItemsCount, collectionProps, filterProps, paginationProps } = useCollection(
+    allItems,
+    {
+      filtering: {
+        empty: (
+          <EmptyState
+            title="No resources"
+            subtitle="No resources to display."
+            action={<Button>Create resource</Button>}
+          />
+        ),
+        noMatch: (
+          <EmptyState
+            title="No matches"
+            subtitle="We can’t find a match."
+            action={<Button onClick={() => actions.setFiltering('')}>Clear filter</Button>}
+          />
+        ),
+      },
+      pagination: { pageSize: preferences.pageSize },
+      sorting: {},
+    }
+  );
+
+  return (
+    <Box padding="l">
+      <SpaceBetween size="xxl">
+        <Button onClick={load} loading={loading} data-testid="refresh-table">
+          Refresh the table without user interaction
+        </Button>
+        <Table<Instance>
+          ariaLabels={{
+            selectionGroupLabel: 'selectionGroupLabel',
+            activateEditLabel: () => 'activateEditLabel',
+            cancelEditLabel: () => 'cancelEditLabel',
+            submitEditLabel: () => 'submitEditLabel',
+            allItemsSelectionLabel: () => 'allItemsSelectionLabel',
+            itemSelectionLabel: () => 'itemSelectionLabel',
+            tableLabel: 'tableLabel',
+            expandButtonLabel: () => 'expand row',
+            collapseButtonLabel: () => 'collapse row',
+          }}
+          {...collectionProps}
+          analyticsMetadata={{
+            instanceIdentifier: 'the-instances-table',
+            flowType: 'view-resource',
+            resourceType: 'table-resource-type',
+          }}
+          selectionType="single"
+          variant="full-page"
+          selectedItems={selectedItems}
+          onSortingChange={e => {
+            collectionProps.onSortingChange!(e);
+            load();
+          }}
+          header={
+            <Header headingTagOverride="h1" counter={`(${allItems.length})`}>
+              Instances
+            </Header>
+          }
+          loading={loading}
+          columnDefinitions={columnsConfig}
+          items={items}
+          pagination={
+            <Pagination
+              {...paginationProps}
+              onChange={e => {
+                paginationProps.onChange(e);
+                load();
+              }}
+              ariaLabels={paginationLabels}
+            />
+          }
+          filter={
+            <TextFilter
+              {...filterProps!}
+              countText={getMatchesCountText(filteredItemsCount!)}
+              onChange={e => {
+                filterProps!.onChange(e);
+                load();
+              }}
+              filteringAriaLabel="Filter instances"
+            />
+          }
+          columnDisplay={preferences.contentDisplay}
+          preferences={
+            <CollectionPreferences
+              title="Preferences"
+              confirmLabel="Confirm"
+              cancelLabel="Cancel"
+              onConfirm={({ detail }) => {
+                setPreferences(detail);
+                load();
+              }}
+              preferences={preferences}
+              pageSizePreference={{
+                title: 'Select page size',
+                options: pageSizeOptions,
+              }}
+              contentDisplayPreference={{
+                ...contentDisplayPreference,
+                ...contentDisplayPreferenceI18nStrings,
+              }}
+              wrapLinesPreference={{
+                label: 'Wrap lines',
+                description: 'Wrap lines description',
+              }}
+            />
+          }
+          stickyHeader={true}
+          onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+        />
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/src/table/__integ__/component-metrics.test.ts
+++ b/src/table/__integ__/component-metrics.test.ts
@@ -210,3 +210,43 @@ describe('preferences', () => {
     })
   );
 });
+
+describe('async loading', () => {
+  test(
+    'tracks component updates once table completes loading',
+    setupTest(async ({ page, wrapper }) => {
+      await page.click(wrapper.findPagination().findPageNumberByIndex(3).toSelector());
+      await page.waitForInteractionEvent('componentUpdated');
+      const componentsLog = await page.getComponentMetricsLog();
+      expect(componentsLog.length).toBe(2);
+      expect(componentsLog[1].name).toBe('componentUpdated');
+      expect(componentsLog[1].detail).toEqual({
+        taskInteractionId: expect.any(String),
+        componentName: 'table',
+        actionType: 'pagination',
+        componentConfiguration: {
+          ...baseComponentConfiguration,
+          instanceIdentifier: 'the-instances-table',
+          taskName: 'the-instances-table',
+          variant: 'full-page',
+          pagination: {
+            currentPageIndex: 3,
+            totalNumberOfPages: 200,
+            openEnd: false,
+          },
+        },
+      });
+    }, '#/light/funnel-analytics/with-async-table')
+  );
+
+  test(
+    'tracks component updates when the table refreshes for other reasons',
+    setupTest(async ({ page }) => {
+      await page.click('[data-testid=refresh-table]');
+      await page.waitForInteractionEvent('componentUpdated');
+      const componentsLog = await page.getComponentMetricsLog();
+      expect(componentsLog.length).toBe(2);
+      expect(componentsLog[1].name).toBe('componentUpdated');
+    }, '#/light/funnel-analytics/with-async-table')
+  );
+});


### PR DESCRIPTION
### Description

- Add additional testing for async based tables
- Add an additional test for sorting

For additional context you can look at this draft [PR](https://github.com/cloudscape-design/components/pull/3495) that includes all the relevant changes and shows the final state.

### How has this been tested?

- Tests pass

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
