### PR TITLE
chore: Show buttons on any other key in DragHandle only in focus trigger mode

### DIFF
--- a/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
+++ b/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
@@ -168,8 +168,30 @@ describe('triggerMode = focus (default)', () => {
 
     document.body.dataset.awsuiFocusVisible = 'true';
     dragHandle.focus();
-    expect(getDirectionButton('block-start')).toBeVisible();
-    expect(getDirectionButton('block-end')).toBeVisible();
+    expectDirectionButtonToBeVisible('block-start');
+    expectDirectionButtonToBeVisible('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+  });
+
+  test('after focused and Esc key pressed, any other button press should show the direction buttons ', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+    });
+
+    document.body.dataset.awsuiFocusVisible = 'true';
+    dragHandle.focus();
+    expectDirectionButtonToBeVisible('block-start');
+    expectDirectionButtonToBeVisible('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(dragHandle, { key: 'Escape' });
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(dragHandle, { key: 'A' });
+    expectDirectionButtonToBeVisible('block-start');
+    expectDirectionButtonToBeVisible('block-end');
     expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
   });
 
@@ -225,6 +247,24 @@ describe('triggerMode = keyboard-activate', () => {
     expect(getDirectionButton('block-end')).toBeInTheDocument();
     expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
     expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+  });
+
+  test('when focused and other key is pressed, it should not show the direction buttons ', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      triggerMode: 'keyboard-activate',
+    });
+
+    document.body.dataset.awsuiFocusVisible = 'true';
+    dragHandle.focus();
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(dragHandle, { key: 'A' });
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
   });
 
   test('hides direction buttons when focus leaves the button', () => {

--- a/src/internal/components/drag-handle-wrapper/index.tsx
+++ b/src/internal/components/drag-handle-wrapper/index.tsx
@@ -151,14 +151,19 @@ export default function DragHandleWrapper({
   };
 
   const onDragHandleKeyDown: React.KeyboardEventHandler = event => {
-    // For accessibility reasons, pressing escape should should always close
-    // the floating controls.
+    // For accessibility reasons, pressing escape should always close the floating controls.
     if (event.key === 'Escape') {
       setShowButtons(false);
     } else if (triggerMode === 'keyboard-activate' && (event.key === 'Enter' || event.key === ' ')) {
       // toggle buttons when Enter or space is pressed in 'keyboard-activate' triggerMode
       setShowButtons(prevshowButtons => !prevshowButtons);
-    } else if (event.key !== 'Alt' && event.key !== 'Control' && event.key !== 'Meta' && event.key !== 'Shift') {
+    } else if (
+      event.key !== 'Alt' &&
+      event.key !== 'Control' &&
+      event.key !== 'Meta' &&
+      event.key !== 'Shift' &&
+      triggerMode !== 'keyboard-activate'
+    ) {
       // Pressing any other key will display the focus-visible ring around the
       // drag handle if it's in focus, so we should also show the buttons now.
       setShowButtons(true);


### PR DESCRIPTION
### Description

Before this change, in keyboard-activate mode:
- when focusing the drag handle and Tab away, it showed the buttons.

After this change, in keyboard-activate mode:
- when focusing the drag handle and Tab away, it won't show the buttons.

Related links, issue #, if available: n/a

### How has this been tested?

- add aditional unit test for this change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
