### PR TITLE
chore: Move tsbuildinfo from test-utils to lib

### DIFF
--- a/build-tools/tasks/test-utils.js
+++ b/build-tools/tasks/test-utils.js
@@ -16,7 +16,19 @@ function compileTypescript(theme) {
   return task(`typescript:test-utils:${theme.name}`, async () => {
     const config = path.resolve(testUtilsSrcDir, 'tsconfig.json');
     const outDir = path.join(theme.outputPath, 'test-utils');
-    await execa('tsc', ['-p', config, '--outDir', outDir, '--sourceMap'], { stdio: 'inherit' });
+    await execa(
+      'tsc',
+      [
+        '-p',
+        config,
+        '--outDir',
+        outDir,
+        '--tsBuildInfoFile',
+        `./lib/${theme.name}-test-utils.tsbuildinfo`,
+        '--sourceMap',
+      ],
+      { stdio: 'inherit' }
+    );
   });
 }
 


### PR DESCRIPTION
### Description

Currently the tsbuildinfo file for test-utils is building to `/lib/components/test-utils/tsconfig.tsbuildinfo` which results in it being included in the published npm artifact. This change sets the output of this file to `/lib/{theme-name}-test-utils.tsbuildinfo` to maintain incremental typescript but remove it from the npm artifact.

### How has this been tested?

Manually verified the file has moved and all checks still pass.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
