### PR TITLE
chore: Refine exit motion for global drawer

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
@@ -75,7 +75,7 @@ function AppLayoutGlobalDrawerImplementation({
     (wasExpanded && !isExpanded);
 
   return (
-    <Transition nodeRef={drawerRef} in={show || isExpanded} appear={show || isExpanded} timeout={0}>
+    <Transition nodeRef={drawerRef} in={show || isExpanded} appear={show || isExpanded} timeout={60}>
       {state => {
         return (
           <aside
@@ -89,7 +89,7 @@ function AppLayoutGlobalDrawerImplementation({
               !animationDisabled && sharedStyles['with-motion-horizontal'],
               !animationDisabled && isExpanded && styles['with-expanded-motion'],
               {
-                [styles['drawer-hidden']]: !show,
+                [styles['drawer-hidden']]: !show && state === 'exited',
                 [styles['last-opened']]: lastOpenedDrawerId === activeDrawerId || isExpanded,
                 [testutilStyles['active-drawer']]: show,
                 [styles['drawer-expanded']]: isExpanded,

--- a/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
@@ -64,6 +64,15 @@ $drawer-resize-handle-size: awsui.$space-m;
 
     @include desktop-only {
       inline-size: var(#{custom-props.$drawerSize});
+      &.exiting {
+        display: block;
+        border-inline-start: none;
+        > .global-drawer-wrapper {
+          opacity: 0;
+          // When multiple drawers are open and one of them is being closed, an unwanted width-changing transition appears.
+          // To avoid this, we set opacity to 0 to make the unwanted transition invisible.
+        }
+      }
     }
 
     @include mobile-only {

--- a/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useRef } from 'react';
+import { Transition } from 'react-transition-group';
 import clsx from 'clsx';
 
 import VisualContext from '../../../internal/components/visual-context';
@@ -80,6 +81,7 @@ export const SkeletonLayout = React.forwardRef<HTMLDivElement, SkeletonLayoutPro
     const isMobile = useMobile();
     const isMaxWidth = maxContentWidth === Number.MAX_VALUE || maxContentWidth === Number.MAX_SAFE_INTEGER;
     const anyPanelOpen = navigationOpen || toolsOpen;
+    const drawerRef = useRef<HTMLDivElement>(null);
     return (
       <VisualContext contextName="app-layout-toolbar">
         <div
@@ -162,7 +164,19 @@ export const SkeletonLayout = React.forwardRef<HTMLDivElement, SkeletonLayoutPro
           >
             {tools}
           </div>
-          <div className={clsx(styles['global-tools'], !globalToolsOpen && styles['panel-hidden'])}>{globalTools}</div>
+          <Transition nodeRef={drawerRef} in={globalToolsOpen} timeout={60}>
+            {state => (
+              <div
+                ref={drawerRef}
+                className={clsx(
+                  styles['global-tools'],
+                  !globalToolsOpen && state === 'exited' && styles['panel-hidden']
+                )}
+              >
+                {globalTools}
+              </div>
+            )}
+          </Transition>
         </div>
       </VisualContext>
     );


### PR DESCRIPTION
### Description
This PR fixes an animation issue for global-drawer.
We would like to have a smooth transition when a drawer is being closed.

Before this change, the style drawer-hidden was added immediately when a close button is clicked, which was one of the two reasons for the unwanted sudden closing behavior. To address this, an additional condition has been added to make sure only after the Transition's component state becomes exited.:
`[styles['drawer-hidden']]: !show && state === 'exited'`
And I updated relevant styles accordingly.

Additionally, I've added Transition component to the `global-tools` in the skeleton to ensure only after it gets the `panel-hidden` style.


<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
