### PR TITLE
fix: Drawer gutter with iframe content

### DIFF
--- a/pages/app-layout/utils/external-widget.tsx
+++ b/pages/app-layout/utils/external-widget.tsx
@@ -8,6 +8,7 @@ import ButtonDropdown from '~components/button-dropdown';
 import Drawer from '~components/drawer';
 import awsuiPlugins from '~components/internal/plugins';
 
+import { IframeWrapper } from '../../utils/iframe-wrapper';
 import { Counter, CustomDrawerContent } from './content-blocks';
 
 const searchParams = new URL(location.hash.substring(1), location.href).searchParams;
@@ -239,10 +240,15 @@ awsuiPlugins.appLayout.registerDrawer({
 
   mountContent: container => {
     ReactDOM.render(
-      <>
-        <Counter id="circle3-global" />
-        global widget content circle 3
-      </>,
+      <IframeWrapper
+        id="circle3-global"
+        AppComponent={() => (
+          <>
+            <Counter id="circle3-global" />
+            global widget content circle 3
+          </>
+        )}
+      />,
       container
     );
   },

--- a/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
@@ -178,6 +178,7 @@ $drawer-resize-handle-size: awsui.$space-m;
       inline-size: $global-drawer-gap-size;
       background: awsui.$color-gap-global-drawer;
       border-inline-end: awsui.$border-divider-section-width solid awsui.$color-border-layout;
+      box-sizing: border-box;
     }
 
     > .drawer-slider {


### PR DESCRIPTION
### Description

This PR addressed a visual issue with showing a grey gutter in global drawers when the content inside of it is rendered within iframe, which is a use-case for Amazon Q.

Before:
![image](https://github.com/user-attachments/assets/98df350f-dde0-4b57-98ba-de4dff8ef142)

After: 
![image](https://github.com/user-attachments/assets/105e4870-19c9-4d3e-8674-fb85dd04c364)


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
