### PR TITLE
feat: Expose disableFooterPaddings on container

### DIFF
--- a/pages/container/simple.page.tsx
+++ b/pages/container/simple.page.tsx
@@ -85,6 +85,10 @@ export default function SimpleContainers() {
             Lorem ipsum dolor sit amet, consectetur adipisicing elit. Phasellus tincidunt suscipit varius. Nullam dui
             tortor, mollis vitae molestie sed, malesuada.
           </Container>
+          <Container disableFooterPaddings={true} footer="Spaceless container footer">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Phasellus tincidunt suscipit varius. Nullam dui
+            tortor, mollis vitae molestie sed, malesuada.
+          </Container>
           <div>
             <Container variant="stacked" header="Stacked Container 1">
               Lorem ipsum dolor sit amet, consectetur adipisicing elit. Phasellus tincidunt suscipit varius. Nullam dui

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -6905,7 +6905,6 @@ exports[`Documenter definition for container matches the snapshot: container 1`]
       "type": "boolean",
     },
     {
-      "defaultValue": "false",
       "description": "Determines whether the container footer has padding. If \`true\`, removes the default padding from the footer.",
       "name": "disableFooterPaddings",
       "optional": true,

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -6906,6 +6906,16 @@ exports[`Documenter definition for container matches the snapshot: container 1`]
     },
     {
       "defaultValue": "false",
+      "description": "Determines whether the container footer has padding. If \`true\`, removes the default padding from the footer.",
+      "name": "disableFooterPaddings",
+      "optional": true,
+      "systemTags": [
+        "core",
+      ],
+      "type": "boolean",
+    },
+    {
+      "defaultValue": "false",
       "description": "Determines whether the container header has padding. If \`true\`, removes the default padding from the header.",
       "name": "disableHeaderPaddings",
       "optional": true,

--- a/src/container/index.tsx
+++ b/src/container/index.tsx
@@ -19,6 +19,7 @@ export default function Container({
   variant = 'default',
   disableHeaderPaddings = false,
   disableContentPaddings = false,
+  disableFooterPaddings = false,
   fitHeight = false,
   ...props
 }: ContainerProps) {
@@ -54,6 +55,7 @@ export default function Container({
         variant={variant}
         disableContentPaddings={disableContentPaddings}
         disableHeaderPaddings={disableHeaderPaddings}
+        disableFooterPaddings={disableFooterPaddings}
         fitHeight={fitHeight}
         {...props}
         {...externalProps}

--- a/src/container/index.tsx
+++ b/src/container/index.tsx
@@ -19,7 +19,6 @@ export default function Container({
   variant = 'default',
   disableHeaderPaddings = false,
   disableContentPaddings = false,
-  disableFooterPaddings = false,
   fitHeight = false,
   ...props
 }: ContainerProps) {
@@ -55,7 +54,6 @@ export default function Container({
         variant={variant}
         disableContentPaddings={disableContentPaddings}
         disableHeaderPaddings={disableHeaderPaddings}
-        disableFooterPaddings={disableFooterPaddings}
         fitHeight={fitHeight}
         {...props}
         {...externalProps}

--- a/src/container/interfaces.ts
+++ b/src/container/interfaces.ts
@@ -68,6 +68,12 @@ export interface ContainerProps extends BaseComponentProps {
   footer?: React.ReactNode;
 
   /**
+   * Determines whether the container footer has padding. If `true`, removes the default padding from the footer.
+   * @awsuiSystem core
+   */
+  disableFooterPaddings?: boolean;
+
+  /**
    * Specify a container variant with one of the following:
    * * `default` - Use this variant in standalone context.
    * * `stacked` - Use this variant adjacent to other stacked containers (such as a container,

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -22,11 +22,11 @@ import styles from './styles.css.js';
 import testStyles from './test-classes/styles.css.js';
 
 export interface InternalContainerProps extends Omit<ContainerProps, 'variant'>, InternalBaseComponentProps {
+  disableFooterPaddings?: boolean;
   __stickyHeader?: boolean;
   __stickyOffset?: number;
   __mobileStickyOffset?: number;
   __disableFooterDivider?: boolean;
-  __disableFooterPaddings?: boolean;
   __hiddenContent?: boolean;
   __headerRef?: React.RefObject<HTMLDivElement>;
   __fullPage?: boolean;
@@ -63,6 +63,7 @@ export default function InternalContainer({
   variant = 'default',
   disableHeaderPaddings = false,
   disableContentPaddings = false,
+  disableFooterPaddings = false,
   fitHeight,
   media,
   __stickyOffset,
@@ -70,7 +71,6 @@ export default function InternalContainer({
   __stickyHeader = false,
   __internalRootRef = null,
   __disableFooterDivider = false,
-  __disableFooterPaddings = false,
   __hiddenContent = false,
   __headerRef,
   __fullPage = false,
@@ -181,7 +181,7 @@ export default function InternalContainer({
           <div
             className={clsx(styles.footer, {
               [styles['with-divider']]: !__disableFooterDivider,
-              [styles['with-paddings']]: !__disableFooterPaddings,
+              [styles['with-paddings']]: !disableFooterPaddings,
             })}
           >
             {footer}

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -481,8 +481,8 @@ const InternalTable = React.forwardRef(
               }
               disableHeaderPaddings={true}
               disableContentPaddings={true}
+              disableFooterPaddings={true}
               variant={toContainerVariant(computedVariant)}
-              __disableFooterPaddings={true}
               __disableFooterDivider={true}
               __disableStickyMobile={false}
               footer={


### PR DESCRIPTION
### Description

Expose disableFooterPaddings property on container (core only), for added consistency with other container slots.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
