### PR TITLE
fix: OnNavigationChange callback

### DIFF
--- a/src/app-layout/__tests__/app-layout-navigation.test.tsx
+++ b/src/app-layout/__tests__/app-layout-navigation.test.tsx
@@ -52,10 +52,12 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop', 'mobile'
     expect(wrapper.findOpenNavigationPanel()).toBeTruthy();
     wrapper.findNavigationToggle().click();
     expect(mockOnNavigationChange).toHaveBeenCalledTimes(1);
+    expect(mockOnNavigationChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { open: false } }));
     expect(wrapper.findOpenNavigationPanel()).toBeFalsy();
 
     wrapper.findNavigationToggle().click();
     expect(mockOnNavigationChange).toHaveBeenCalledTimes(2);
+    expect(mockOnNavigationChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { open: true } }));
     expect(wrapper.findOpenNavigationPanel()).toBeTruthy();
   });
 });

--- a/src/app-layout/__tests__/app-layout-navigation.test.tsx
+++ b/src/app-layout/__tests__/app-layout-navigation.test.tsx
@@ -42,4 +42,20 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop', 'mobile'
     expect(wrapper.findNavigation()).toBeTruthy();
     expect(wrapper.findNavigationToggle()).toBeFalsy();
   });
+
+  (size === 'desktop' ? test : test.skip)('should call onNavigationToggle on open/close navigation', () => {
+    const mockOnNavigationChange = jest.fn();
+    const { wrapper } = renderComponent(
+      <AppLayout navigation={<>Mock Navigation</>} onNavigationChange={mockOnNavigationChange} content={<>Content</>} />
+    );
+
+    expect(wrapper.findOpenNavigationPanel()).toBeTruthy();
+    wrapper.findNavigationToggle().click();
+    expect(mockOnNavigationChange).toHaveBeenCalledTimes(1);
+    expect(wrapper.findOpenNavigationPanel()).toBeFalsy();
+
+    wrapper.findNavigationToggle().click();
+    expect(mockOnNavigationChange).toHaveBeenCalledTimes(2);
+    expect(wrapper.findOpenNavigationPanel()).toBeTruthy();
+  });
 });

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -171,7 +171,7 @@ export function AppLayoutToolbarImplementation({
                 if (setExpandedDrawerId) {
                   setExpandedDrawerId(null);
                 }
-                if (navigationOpen) {
+                if (navigationOpen && expandedDrawerId) {
                   return;
                 }
                 onNavigationToggle?.(!navigationOpen);


### PR DESCRIPTION
### Description

[This commit](https://github.com/cloudscape-design/components/commit/727c496d5df702d063f05f28aae92cc763d7c723) introduced a bug in the `AppLayout` component where the `onNavigationChange` callback is no longer triggered when the navigation panel is open.

Originally, this condition was added to prevent triggering the callback during the drawers’ expanded mode, in order to preserve the original state when exiting that mode. However, the issue is that the condition does not correctly check whether any drawer is currently in expanded state.

This PR fixes that logic and adds a corresponding test.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
