### PR TITLE
fix: Prevent drag handle arrow button flicker on exit animation

### DIFF
--- a/src/internal/components/drag-handle-wrapper/motion.scss
+++ b/src/internal/components/drag-handle-wrapper/motion.scss
@@ -56,8 +56,8 @@
     &-motion-exiting {
       @include styles.with-motion {
         animation:
-          drag-handle-exit awsui.$motion-duration-complex awsui.$motion-easing-responsive,
-          awsui-motion-fade-out-0 awsui.$motion-duration-complex awsui.$motion-easing-responsive;
+          drag-handle-exit awsui.$motion-duration-complex awsui.$motion-easing-responsive forwards,
+          awsui-motion-fade-out-0 awsui.$motion-duration-complex awsui.$motion-easing-responsive forwards;
       }
     }
   }


### PR DESCRIPTION
### Description

This change addresses a UX issue where buttons briefly reappeared after their exit animation, causing an unwanted flicker effect (reported in https://github.com/cloudscape-design/board-components/pull/356#issuecomment-2913112051). By retaining the final keyframe state, we create a smoother transition without disrupting the intended hide behavior.

Before this change: When the exit animation completes, the element briefly reverts to its original state before being hidden. This happens because by default, CSS animations reset to their pre-animation state once completed ([see MDN docs for animation-fill-mode](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-fill-mode)). The specific animation sequence behavior before this change:

1. Initial state (buttons visible)
1. Exit animation runs (fade out + transform)
1. Animation completes
1. **Element briefly reverts to original state (visible)**
1. Element is finally hidden

https://github.com/user-attachments/assets/be3f5c36-4ed2-4251-bfb1-bac18f9a9a84

The animation sequence after this change: 

1. Initial state (buttons visible)
1. Exit animation runs (fade out + transform)
1. Animation completes
1. **Final keyframe state is retained (faded out + transformed)**
1. Element is finally hidden

https://github.com/user-attachments/assets/f0a3131b-4857-4b60-a4bd-d1d7f97c2c5d




Related links, issue #, if available: `AWSUI-60240`

### How has this been tested?

- Tested on FF, Safari and Chrome on the board component.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.