### PR TITLE
chore: Add hideButtonsOnDrag and clickDragThreshold property to InternalDragHandle

### DIFF
--- a/src/internal/components/drag-handle-wrapper/interfaces.ts
+++ b/src/internal/components/drag-handle-wrapper/interfaces.ts
@@ -12,4 +12,6 @@ export interface DragHandleWrapperProps {
   children: React.ReactNode;
   triggerMode?: TriggerMode;
   initialShowButtons?: boolean;
+  hideButtonsOnDrag: boolean;
+  clickDragThreshold: number;
 }

--- a/src/internal/components/drag-handle/index.tsx
+++ b/src/internal/components/drag-handle/index.tsx
@@ -26,6 +26,8 @@ const InternalDragHandle = forwardRef(
       onDirectionClick,
       triggerMode,
       initialShowButtons,
+      hideButtonsOnDrag = false,
+      clickDragThreshold = 3,
       ...rest
     }: DragHandleProps,
     ref: React.Ref<Element>
@@ -39,6 +41,8 @@ const InternalDragHandle = forwardRef(
         onDirectionClick={onDirectionClick}
         triggerMode={triggerMode}
         initialShowButtons={initialShowButtons}
+        hideButtonsOnDrag={hideButtonsOnDrag}
+        clickDragThreshold={clickDragThreshold}
       >
         <DragHandleButton
           ref={ref}

--- a/src/internal/components/drag-handle/interfaces.ts
+++ b/src/internal/components/drag-handle/interfaces.ts
@@ -24,6 +24,15 @@ export interface DragHandleProps {
   onDirectionClick?: (direction: DragHandleProps.Direction) => void;
   triggerMode?: TriggerMode;
   initialShowButtons?: boolean;
+  /**
+   * Hide the UAP buttons when dragging is active.
+   */
+  hideButtonsOnDrag?: boolean;
+  /**
+   * Max cursor movement (in pixels) that still counts as a press rather than
+   * a drag. Small threshold needed for usability.
+   */
+  clickDragThreshold?: number;
 }
 
 export namespace DragHandleProps {


### PR DESCRIPTION
### Description

Both options are used to allow more flexibility. Use cases:
- `hideButtonsOnDrag`: When using the UAP handles on board-items they're activated once clicked the handle. While dragging is active, the buttons, if visible, should be hidden. This helps to distinguish in between the pointer and step interaction modes.
- `clickDragThreshold`: A "click" happens when a "pointerdown" is followed by a "pointerup" with no "pointermove" between the two.
However, it would be a poor usability experience if a "click" isn't registered because, while pressing my mouse, I moved it by just one pixel, making it a "drag" instead. So we allow the pointer to move by `clickDragThreshold` to count as click instead of a move.

Related links, issue #, if available: https://github.com/cloudscape-design/board-components/pull/356#issuecomment-2913095025

### How has this been tested?

- added additional unit tests.
- manually verified in supported browsers.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
