### PR TITLE
chore: Track table counter text from title as fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     {
       "path": "lib/components/internal/widget-exports.js",
       "brotli": false,
-      "limit": "786 kB",
+      "limit": "790 kB",
       "ignore": "react-dom"
     }
   ],

--- a/pages/funnel-analytics/with-table.page.tsx
+++ b/pages/funnel-analytics/with-table.page.tsx
@@ -91,7 +91,7 @@ export default function WithTablePage() {
         }}
         selectionType="multi"
         header={
-          <Header headingTagOverride="h1" counter={`(${allItems.length})`}>
+          <Header headingTagOverride="h1" counter={`(1/${allItems.length})`}>
             Table title
           </Header>
         }

--- a/src/header/analytics/use-table-integration.ts
+++ b/src/header/analytics/use-table-integration.ts
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { useEffect, useMemo } from 'react';
+
+import { parseCountValue } from '../../internal/analytics/utils/parse-count-text';
+import { useTableComponentsContext } from '../../internal/context/table-component-context';
+
+/**
+ * Custom hook that integrates table counter values with table component context.
+ *
+ * The extracted count value is automatically synchronized with the table header
+ * component through the table context, updating the countText property.
+ */
+export const useTableIntegration = (countText: string | undefined) => {
+  const tableComponentContext = useTableComponentsContext();
+  const countValue = useMemo(() => parseCountValue(countText), [countText]);
+
+  useEffect(() => {
+    if (tableComponentContext?.headerRef?.current && countValue !== undefined) {
+      tableComponentContext.headerRef.current.totalCount = countValue;
+
+      return () => {
+        delete tableComponentContext.headerRef.current?.totalCount;
+      };
+    }
+  }, [tableComponentContext?.headerRef, countValue]);
+};

--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -16,6 +16,7 @@ import { useMobile } from '../internal/hooks/use-mobile';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { SomeRequired } from '../internal/types';
+import { useTableIntegration } from './analytics/use-table-integration';
 import { HeaderProps } from './interfaces';
 
 import analyticsSelectors from './analytics-metadata/styles.css.js';
@@ -49,6 +50,9 @@ export default function InternalHeader({
   const assignHeaderId = useContext(CollectionLabelContext).assignId;
   const isInContainer = useContainerHeader();
   const headingId = useUniqueId('heading');
+
+  useTableIntegration(counter);
+
   if (assignHeaderId !== undefined) {
     assignHeaderId(headingId);
   }

--- a/src/internal/analytics/utils/__tests__/parse-count-text.test.ts
+++ b/src/internal/analytics/utils/__tests__/parse-count-text.test.ts
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { parseCountValue } from '../../../../../lib/components/internal/analytics/utils/parse-count-text.js';
+
+test('parses out only the number from a given countText', () => {
+  expect(parseCountValue('1 item')).toBe(1);
+});
+
+test('parses out the total number from a given countText', () => {
+  expect(parseCountValue('1/5')).toBe(5);
+});
+
+test('parse out the number on open ended counts', () => {
+  expect(parseCountValue('100+')).toBe(100);
+});
+
+test('returns undefined when no numbers found', () => {
+  expect(parseCountValue('No items')).toBeUndefined();
+  expect(parseCountValue('items only')).toBeUndefined();
+});
+
+// Format variations
+test('handles parentheses format', () => {
+  expect(parseCountValue('Items (25)')).toBe(25);
+  expect(parseCountValue('(100)')).toBe(100);
+});
+
+test('handles comma-separated numbers', () => {
+  expect(parseCountValue('1,234 items')).toBe(1234);
+  expect(parseCountValue('Total: 1,234')).toBe(1234);
+});
+
+test('handles strings with extra whitespace', () => {
+  expect(parseCountValue('  100  ')).toBe(100);
+  expect(parseCountValue('\t50\n')).toBe(50);
+});
+
+test('returns undefined for undefined input', () => {
+  expect(parseCountValue(undefined)).toBeUndefined();
+});
+
+test('returns undefined for empty string', () => {
+  expect(parseCountValue('')).toBeUndefined();
+});
+
+test('returns undefined for non-string input', () => {
+  expect(parseCountValue(123 as any)).toBeUndefined();
+  expect(parseCountValue(null as any)).toBeUndefined();
+});

--- a/src/internal/analytics/utils/__tests__/parse-count-text.test.ts
+++ b/src/internal/analytics/utils/__tests__/parse-count-text.test.ts
@@ -26,11 +26,6 @@ test('handles parentheses format', () => {
   expect(parseCountValue('(100)')).toBe(100);
 });
 
-test('handles comma-separated numbers', () => {
-  expect(parseCountValue('1,234 items')).toBe(1234);
-  expect(parseCountValue('Total: 1,234')).toBe(1234);
-});
-
 test('handles strings with extra whitespace', () => {
   expect(parseCountValue('  100  ')).toBe(100);
   expect(parseCountValue('\t50\n')).toBe(50);

--- a/src/internal/analytics/utils/parse-count-text.ts
+++ b/src/internal/analytics/utils/parse-count-text.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Extracts the count value from table header/filter text.
+ *
+ * Parses various counter string formats and extracts the relevant numeric value:
+ * - "Items (100)" - Extracts 100 (first number found)
+ * - "1/100" - Extracts 100 (denominator of fraction, representing total count)
+ * - "100+" - Extracts 100 (first number found)
+ * - "1,234 items" - Extracts 1234 (handles comma-separated numbers)
+ */
+export const parseCountValue = (countText: string | undefined): number | undefined => {
+  if (!countText || typeof countText !== 'string') {
+    return undefined;
+  }
+
+  const target = countText.includes('/') ? countText.split('/')[1] : countText;
+  const match = target.match(/\d[\d,]*/);
+  return match ? parseInt(match[0].replace(/,/g, ''), 10) : undefined;
+};

--- a/src/internal/analytics/utils/parse-count-text.ts
+++ b/src/internal/analytics/utils/parse-count-text.ts
@@ -8,7 +8,6 @@
  * - "Items (100)" - Extracts 100 (first number found)
  * - "1/100" - Extracts 100 (denominator of fraction, representing total count)
  * - "100+" - Extracts 100 (first number found)
- * - "1,234 items" - Extracts 1234 (handles comma-separated numbers)
  */
 export const parseCountValue = (countText: string | undefined): number | undefined => {
   if (!countText || typeof countText !== 'string') {
@@ -16,6 +15,6 @@ export const parseCountValue = (countText: string | undefined): number | undefin
   }
 
   const target = countText.includes('/') ? countText.split('/')[1] : countText;
-  const match = target.match(/\d[\d,]*/);
-  return match ? parseInt(match[0].replace(/,/g, ''), 10) : undefined;
+  const match = target.match(/\d+/);
+  return match ? parseInt(match[0], 10) : undefined;
 };

--- a/src/internal/context/__tests__/table-component-context.test.tsx
+++ b/src/internal/context/__tests__/table-component-context.test.tsx
@@ -31,6 +31,7 @@ describe('Verify TableComponentsContext', () => {
           },
           filterRef: { current: { filterText: 'test', filterCount: 10, filtered: true } },
           preferencesRef: { current: { pageSize: 20, visibleColumns: ['id'] } },
+          headerRef: { current: { totalCount: 10 } },
         }}
       >
         <ChildComponent />
@@ -90,6 +91,7 @@ describe('Verify TableComponentsContext', () => {
           },
           filterRef: { current: { filterText: 'test', filterCount: 10, filtered: true } },
           preferencesRef: { current: { pageSize: 20, visibleColumns: ['id'] } },
+          headerRef: { current: { totalCount: 10 } },
         }}
       >
         <ChildComponent />

--- a/src/internal/context/table-component-context.ts
+++ b/src/internal/context/table-component-context.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import { createContext, RefObject, useContext } from 'react';
 
+export interface HeaderRef {
+  totalCount?: number;
+}
+
 export interface FilterRef {
   filtered?: boolean;
   filterText?: string;
@@ -21,6 +25,7 @@ export interface PreferencesRef {
 }
 
 interface TableComponentsContextProps {
+  headerRef: RefObject<HeaderRef>;
   filterRef: RefObject<FilterRef>;
   paginationRef: RefObject<PaginationRef>;
   preferencesRef: RefObject<PreferencesRef>;

--- a/src/table/__integ__/component-metrics.test.ts
+++ b/src/table/__integ__/component-metrics.test.ts
@@ -53,6 +53,7 @@ const baseComponentConfiguration = {
   },
   filtered: false,
   filteredBy: [],
+  filteredCount: 4000,
   totalNumberOfResources: 4000,
   pagination: {
     currentPageIndex: 1,
@@ -80,6 +81,7 @@ const basePropertyFilterConfiguration = {
   },
   filtered: false,
   filteredBy: [],
+  filteredCount: 4000,
   totalNumberOfResources: 4000,
   pagination: {
     currentPageIndex: 1,
@@ -298,7 +300,7 @@ describe('filtering', () => {
         componentConfiguration: {
           ...baseComponentConfiguration,
           filtered: true,
-          totalNumberOfResources: 92,
+          filteredCount: 92,
           pagination: {
             currentPageIndex: 1,
             openEnd: false,
@@ -327,7 +329,7 @@ describe('filtering', () => {
           ...basePropertyFilterConfiguration,
           filtered: true,
           filteredBy: ['state'],
-          totalNumberOfResources: 852,
+          filteredCount: 852,
           pagination: {
             currentPageIndex: 1,
             openEnd: false,
@@ -356,7 +358,7 @@ describe('filtering', () => {
           ...basePropertyFilterConfiguration,
           filtered: true,
           filteredBy: [],
-          totalNumberOfResources: 852,
+          filteredCount: 852,
           pagination: {
             currentPageIndex: 1,
             openEnd: false,

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -18,6 +18,7 @@ import { CollectionLabelContext } from '../internal/context/collection-label-con
 import { LinkDefaultVariantContext } from '../internal/context/link-default-variant-context';
 import {
   FilterRef,
+  HeaderRef,
   PaginationRef,
   PreferencesRef,
   TableComponentsContextProvider,
@@ -193,6 +194,7 @@ const InternalTable = React.forwardRef(
     const paginationRef = useRef<PaginationRef>({});
     const filterRef = useRef<FilterRef>({});
     const preferencesRef = useRef<PreferencesRef>({});
+    const headerRef = useRef<HeaderRef>({});
     /* istanbul ignore next: performance marks do not work in JSDOM */
     const getHeaderText = () =>
       toolsHeaderPerformanceMarkRef.current?.querySelector<HTMLElement>(`.${headerStyles['heading-text']}`)
@@ -232,6 +234,7 @@ const InternalTable = React.forwardRef(
       });
     };
     const getComponentConfiguration = () => {
+      const headerData = headerRef.current;
       const filterData = filterRef.current;
       const paginationData = paginationRef.current;
       const preferencesData = preferencesRef.current;
@@ -248,9 +251,10 @@ const InternalTable = React.forwardRef(
           columnId: sortingColumn?.sortingField,
           sortingOrder: sortingColumn ? (sortingDescending ? 'desc' : 'asc') : undefined,
         },
-        filtered: Boolean(filterData.filtered),
+        filtered: filterData?.filtered ?? null,
         filteredBy: filterData?.filteredBy ?? [],
-        totalNumberOfResources: filterRef.current?.filterCount ?? null,
+        filteredCount: filterData?.filterCount ?? null,
+        totalNumberOfResources: headerData?.totalCount ?? null,
         tablePreferences: {
           visibleColumns: preferencesData?.visibleColumns ?? [],
           resourcesPerPage: preferencesData?.pageSize ?? null,
@@ -433,7 +437,7 @@ const InternalTable = React.forwardRef(
 
     return (
       <LinkDefaultVariantContext.Provider value={{ defaultVariant: 'primary' }}>
-        <TableComponentsContextProvider value={{ paginationRef, filterRef, preferencesRef }}>
+        <TableComponentsContextProvider value={{ paginationRef, filterRef, preferencesRef, headerRef }}>
           <ColumnWidthsProvider
             visibleColumns={visibleColumnWidthsWithSelection}
             resizableColumns={resizableColumns}

--- a/src/text-filter/analytics/use-table-integration.ts
+++ b/src/text-filter/analytics/use-table-integration.ts
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { useEffect, useMemo } from 'react';
+
+import { parseCountValue } from '../../internal/analytics/utils/parse-count-text';
+import { useTableComponentsContext } from '../../internal/context/table-component-context';
+
+/**
+ * Custom hook that integrates table counter values with table component context.
+ *
+ * The extracted count value is automatically synchronized with the table header
+ * component through the table context, updating the countText property.
+ */
+export const useTableIntegration = (filteringText: string | undefined, countText: string | undefined) => {
+  const tableComponentContext = useTableComponentsContext();
+  const countValue = useMemo(() => parseCountValue(countText), [countText]);
+
+  useEffect(() => {
+    if (tableComponentContext?.filterRef?.current) {
+      tableComponentContext.filterRef.current.filterText = filteringText;
+      tableComponentContext.filterRef.current.filterCount = countValue;
+      tableComponentContext.filterRef.current.filtered = !!filteringText;
+
+      return () => {
+        delete tableComponentContext.filterRef.current?.filterText;
+        delete tableComponentContext.filterRef.current?.filterCount;
+        delete tableComponentContext.filterRef.current?.filtered;
+      };
+    }
+  }, [tableComponentContext?.filterRef, countValue, filteringText]);
+};

--- a/src/text-filter/internal.tsx
+++ b/src/text-filter/internal.tsx
@@ -1,17 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useRef } from 'react';
 import clsx from 'clsx';
 
 import InternalInput from '../input/internal';
 import { getBaseProps } from '../internal/base-component';
-import { useTableComponentsContext } from '../internal/context/table-component-context';
 import { fireNonCancelableEvent } from '../internal/events';
 import useForwardFocus from '../internal/hooks/forward-focus';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { joinStrings } from '../internal/utils/strings';
 import { InternalLiveRegionRef } from '../live-region/internal';
+import { useTableIntegration } from './analytics/use-table-integration';
 import { TextFilterProps } from './interfaces';
 import { SearchResults } from './search-results';
 import useDebounceSearchResultCallback from './use-debounce-search-result-callback';
@@ -45,33 +45,10 @@ const InternalTextFilter = React.forwardRef(
     const inputRef = useRef<HTMLInputElement>(null);
     const searchResultsRef = useRef<InternalLiveRegionRef>(null);
     useForwardFocus(ref, inputRef);
-
-    const countValue = useMemo(() => {
-      if (!countText || typeof countText !== 'string') {
-        return undefined;
-      }
-
-      const m = countText.match(/\d+/);
-      return m ? parseInt(m[0]) : undefined;
-    }, [countText]);
+    useTableIntegration(filteringText, countText);
 
     const searchResultsId = useUniqueId('text-filter-search-results');
     const showResults = filteringText && countText && !disabled;
-    const tableComponentContext = useTableComponentsContext();
-
-    useEffect(() => {
-      if (tableComponentContext?.filterRef?.current) {
-        tableComponentContext.filterRef.current.filterText = filteringText;
-        tableComponentContext.filterRef.current.filterCount = countValue;
-        tableComponentContext.filterRef.current.filtered = !!filteringText;
-
-        return () => {
-          delete tableComponentContext.filterRef.current?.filterText;
-          delete tableComponentContext.filterRef.current?.filterCount;
-          delete tableComponentContext.filterRef.current?.filtered;
-        };
-      }
-    }, [tableComponentContext?.filterRef, countValue, filteringText]);
 
     useDebounceSearchResultCallback({
       searchQuery: filteringText,


### PR DESCRIPTION
### Description

Extracts count text from Table header as a fallback to the Filter count when a custom filter is used.

### How has this been tested?

- Added integ tests for the Table integration
- Added unit tests for the added utility method that does the parsing

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
