### PR TITLE
revert: Popover is positioned incorrectly when the layout changes (#3427)

### DIFF
--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -116,11 +116,11 @@ export default function PopoverContainer({
     /*
     This is a heuristic. Some layout changes are caused by user clicks (e.g. toggling the tools panel, submitting a form),
     and by tracking the click event we can adapt the popover's position to the new layout.
+
+    TODO: extend this to Enter and Spacebar?
     */
 
-    const controller = new AbortController();
-
-    const onClick = async (event: UIEvent | KeyboardEvent) => {
+    const onClick = (event: UIEvent | KeyboardEvent) => {
       if (
         // Do not update position if keepPosition is true.
         keepPosition ||
@@ -131,29 +131,14 @@ export default function PopoverContainer({
         return;
       }
 
-      // Continuously update the popover position for one second to account for any layout changes
-      // and animations. On browsers where `requestIdleCallback` is supported,
-      // this runs only while the CPU is otherwise idle. In other browsers (mainly Safari), we call it
-      // with a low frequency.
-      const targetTime = performance.now() + 1_000;
-
-      while (performance.now() < targetTime) {
-        if (controller.signal.aborted) {
-          break;
-        }
-
+      requestAnimationFrame(() => {
         updatePositionHandler();
-
-        if (typeof requestIdleCallback !== 'undefined') {
-          await new Promise(r => requestIdleCallback(r));
-        } else {
-          await new Promise(r => setTimeout(r, 50));
-        }
-      }
+      });
     };
 
     const updatePositionOnResize = () => requestAnimationFrame(() => updatePositionHandler());
     const refreshPosition = () => requestAnimationFrame(() => positionHandlerRef.current());
+    const controller = new AbortController();
 
     window.addEventListener('click', onClick, { signal: controller.signal });
     window.addEventListener('resize', updatePositionOnResize, { signal: controller.signal });


### PR DESCRIPTION
### Description

This reverts commit 62b757d1f7ef697b128f880a8e578a073efb1e66.

This introduced a regression: AWSUI-60831

Related links, issue #, if available: n/a

### How has this been tested?

Checked locally, the regression does not happen after this

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
