### PR TITLE
chore: Isolate documenter snapshot from the rest of tests

### DIFF
--- a/src/__tests__/snapshot-tests/documenter.test.ts
+++ b/src/__tests__/snapshot-tests/documenter.test.ts
@@ -1,6 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { getAllComponents, requireComponentDefinition } from '../utils';
+import definitions from '../../../lib/components-definitions/components';
+import { getAllComponents } from '../utils';
+
+function requireComponentDefinition(componentName: string) {
+  return definitions[componentName];
+}
 
 describe('Documenter', () => {
   test.each<string>(getAllComponents())(`definition for %s matches the snapshot`, (componentName: string) => {

--- a/src/__tests__/utils.tsx
+++ b/src/__tests__/utils.tsx
@@ -5,7 +5,6 @@ import fs from 'fs';
 import path from 'path';
 
 import { SplitPanelContextProvider } from '../../lib/components/internal/context/split-panel-context';
-import definitions from '../../lib/components-definitions/components';
 import { defaultSplitPanelContextProps } from './required-props-for-components';
 
 const componentsDir = path.resolve(__dirname, '../../lib/components');
@@ -66,10 +65,6 @@ export function requireComponent(componentName: string): any {
   }
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   return require(path.join(componentsDir, componentName));
-}
-
-export function requireComponentDefinition(componentName: string) {
-  return definitions[componentName];
 }
 
 export function requireDesignTokensFile(fileName: string): any {


### PR DESCRIPTION
### Description

Small quality of life improvement

Make this work

```
npm run quick-build && npx jest -c jest.unit.config.js src/path/to/test/file
```

Previously it failed on missing definitions, which `npm run quick-build` does not generate

```
    src/__tests__/utils.tsx:8:25 - error TS2307: Cannot find module '../../lib/components-definitions/components' or its corresponding type declarations.
```

Now you can use `quick-build` to run any tests, except the documenter ones

### How has this been tested?

PR build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
