### PR TITLE
feat: Allow button native element attributes to be set

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -4217,6 +4217,50 @@ It prevents users from clicking the button, but it can still be focused.",
       "type": "string",
     },
     {
+      "description": "Attributes to add to the native \`a\` element (when \`href\` is provided).
+Some attributes will be automatically combined with Cloudscape-provided attribute values:
+- \`className\` will be appended.
+- Event handlers will be chained, unless the default is prevented.
+
+We do not support using this attribute to apply custom styling.",
+      "inlineType": {
+        "name": "Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "children"> & Record<\`data-\${string}\`, string>",
+        "type": "union",
+        "values": [
+          "Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "children">",
+          "Record<\`data-\${string}\`, string>",
+        ],
+      },
+      "name": "nativeAnchorAttributes",
+      "optional": true,
+      "systemTags": [
+        "core",
+      ],
+      "type": "Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "children"> & Record<\`data-\${string}\`, string>",
+    },
+    {
+      "description": "Attributes to add to the native \`button\` element.
+Some attributes will be automatically combined with Cloudscape-provided attribute values:
+- \`className\` will be appended.
+- Event handlers will be chained, unless the default is prevented.
+
+We do not support using this attribute to apply custom styling.",
+      "inlineType": {
+        "name": "Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "children"> & Record<\`data-\${string}\`, string>",
+        "type": "union",
+        "values": [
+          "Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "children">",
+          "Record<\`data-\${string}\`, string>",
+        ],
+      },
+      "name": "nativeButtonAttributes",
+      "optional": true,
+      "systemTags": [
+        "core",
+      ],
+      "type": "Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "children"> & Record<\`data-\${string}\`, string>",
+    },
+    {
       "description": "Adds a \`rel\` attribute to the link. By default, the component sets the \`rel\` attribute to "noopener noreferrer" when \`target\` is \`"_blank"\`.
 If the \`rel\` property is provided, it overrides the default behavior.",
       "name": "rel",
@@ -20164,6 +20208,50 @@ It prevents users from clicking the button, but it can still be focused.",
       "name": "loadingText",
       "optional": true,
       "type": "string",
+    },
+    {
+      "description": "Attributes to add to the native \`a\` element (when \`href\` is provided).
+Some attributes will be automatically combined with Cloudscape-provided attribute values:
+- \`className\` will be appended.
+- Event handlers will be chained, unless the default is prevented.
+
+We do not support using this attribute to apply custom styling.",
+      "inlineType": {
+        "name": "Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "children"> & Record<\`data-\${string}\`, string>",
+        "type": "union",
+        "values": [
+          "Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "children">",
+          "Record<\`data-\${string}\`, string>",
+        ],
+      },
+      "name": "nativeAnchorAttributes",
+      "optional": true,
+      "systemTags": [
+        "core",
+      ],
+      "type": "Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "children"> & Record<\`data-\${string}\`, string>",
+    },
+    {
+      "description": "Attributes to add to the native \`button\` element.
+Some attributes will be automatically combined with Cloudscape-provided attribute values:
+- \`className\` will be appended.
+- Event handlers will be chained, unless the default is prevented.
+
+We do not support using this attribute to apply custom styling.",
+      "inlineType": {
+        "name": "Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "children"> & Record<\`data-\${string}\`, string>",
+        "type": "union",
+        "values": [
+          "Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "children">",
+          "Record<\`data-\${string}\`, string>",
+        ],
+      },
+      "name": "nativeButtonAttributes",
+      "optional": true,
+      "systemTags": [
+        "core",
+      ],
+      "type": "Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "children"> & Record<\`data-\${string}\`, string>",
     },
     {
       "defaultValue": "false",

--- a/src/app-layout/visual-refresh/mobile-toolbar.tsx
+++ b/src/app-layout/visual-refresh/mobile-toolbar.tsx
@@ -69,7 +69,7 @@ export default function MobileToolbar() {
             className={testutilStyles['navigation-toggle']}
             ref={navigationRefs.toggle}
             disabled={hasDrawerViewportOverlay}
-            __nativeAttributes={{ 'aria-haspopup': navigationOpen ? undefined : true }}
+            nativeButtonAttributes={{ 'aria-haspopup': navigationOpen ? undefined : true }}
           />
         </nav>
       )}
@@ -97,7 +97,7 @@ export default function MobileToolbar() {
               onClick={() => handleToolsClick(true)}
               variant="icon"
               ref={toolsRefs.toggle}
-              __nativeAttributes={{ 'aria-haspopup': true }}
+              nativeButtonAttributes={{ 'aria-haspopup': true }}
             />
           </aside>
         )

--- a/src/app-layout/visual-refresh/trigger-button.tsx
+++ b/src/app-layout/visual-refresh/trigger-button.tsx
@@ -67,7 +67,7 @@ function TriggerButton(
           badge={badge}
           onClick={onClick}
           variant="icon"
-          __nativeAttributes={{
+          nativeButtonAttributes={{
             'aria-haspopup': true,
             ...(testId && {
               'data-testid': testId,

--- a/src/attribute-editor/internal.tsx
+++ b/src/attribute-editor/internal.tsx
@@ -152,7 +152,8 @@ const InternalAttributeEditor = React.forwardRef(
             // Using aria-disabled="true" and tabindex="-1" instead of "disabled"
             // because focus can be dynamically moved to this button by calling
             // `focusAddButton()` on the ref.
-            __nativeAttributes={disableAddButton ? { tabIndex: -1 } : {}}
+            nativeButtonAttributes={disableAddButton ? { tabIndex: -1 } : {}}
+            __skipNativeAttributesWarnings={true}
             __focusable={true}
             onClick={onAddButtonClick}
             formAction="none"

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -168,7 +168,7 @@ const InternalButtonDropdown = React.forwardRef(
       ariaLabel,
       ariaExpanded: canBeOpened && isOpen,
       formAction: 'none',
-      __nativeAttributes: {
+      nativeButtonAttributes: {
         'aria-haspopup': true,
       },
     };

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -814,8 +814,8 @@ describe('table grid navigation support', () => {
   test('does not override explicit tab index with 0', () => {
     const { setCurrentTarget } = renderWithSingleTabStopNavigation(
       <div>
-        <InternalButton id="button1" __nativeAttributes={{ tabIndex: -2 }} />
-        <InternalButton id="button2" __nativeAttributes={{ tabIndex: -2 }} />
+        <InternalButton id="button1" nativeButtonAttributes={{ tabIndex: -2 }} />
+        <InternalButton id="button2" nativeButtonAttributes={{ tabIndex: -2 }} />
       </div>
     );
     setCurrentTarget(getButton('#button1'));

--- a/src/button/__tests__/internal.test.tsx
+++ b/src/button/__tests__/internal.test.tsx
@@ -12,22 +12,8 @@ import { mockedFunnelInteractionId, mockFunnelMetrics } from '../../internal/ana
 
 import styles from '../../../lib/components/button/styles.css.js';
 
-test('specific properties take precedence over nativeAttributes', () => {
-  const { container } = render(
-    <InternalButton ariaLabel="property" __nativeAttributes={{ 'aria-label': 'native attribute' }} />
-  );
-  expect(container.querySelector('button')).toHaveAttribute('aria-label', 'property');
-});
-
-test('supports providing custom attributes', () => {
-  const { container } = render(<InternalButton __nativeAttributes={{ 'aria-hidden': 'true' }} />);
-  expect(container.querySelector('button')).toHaveAttribute('aria-hidden', 'true');
-});
-
 test('supports __iconClass property', () => {
-  const { container } = render(
-    <InternalButton __iconClass="example-class" iconName="settings" __nativeAttributes={{ 'aria-expanded': 'true' }} />
-  );
+  const { container } = render(<InternalButton __iconClass="example-class" iconName="settings" />);
   expect(container.querySelector(`button .${styles.icon}`)).toHaveClass('example-class');
 });
 

--- a/src/button/__tests__/native-attributes.test.tsx
+++ b/src/button/__tests__/native-attributes.test.tsx
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Button from '../../../lib/components/button';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+import styles from '../../../lib/components/button/styles.css.js';
+
+describe('Button native attributes', () => {
+  test('passes nativeAttributes to the button element', () => {
+    const { container } = render(
+      <Button
+        nativeButtonAttributes={{
+          'data-testid': 'test-button',
+          'aria-controls': 'controlled-element',
+        }}
+      >
+        Button text
+      </Button>
+    );
+    const wrapper = createWrapper(container).findButton()!;
+
+    expect(wrapper.getElement()).toHaveAttribute('data-testid', 'test-button');
+    expect(wrapper.getElement()).toHaveAttribute('aria-controls', 'controlled-element');
+  });
+
+  test('passes nativeAttributes to the anchor element when href is provided', () => {
+    const { container } = render(
+      <Button
+        href="https://example.com"
+        nativeAnchorAttributes={{
+          'data-testid': 'test-link',
+          'aria-controls': 'controlled-element',
+        }}
+      >
+        Link text
+      </Button>
+    );
+    const wrapper = createWrapper(container).findButton()!;
+
+    expect(wrapper.getElement()).toHaveAttribute('data-testid', 'test-link');
+    expect(wrapper.getElement()).toHaveAttribute('aria-controls', 'controlled-element');
+    expect(wrapper.getElement().tagName).toBe('A');
+  });
+
+  test('overrides built-in attributes with nativeAttributes', () => {
+    const { container } = render(
+      <Button
+        ariaLabel="Button label"
+        nativeButtonAttributes={{
+          'aria-label': 'Override label',
+        }}
+      >
+        Button text
+      </Button>
+    );
+    const wrapper = createWrapper(container).findButton()!;
+
+    expect(wrapper.getElement()).toHaveAccessibleName('Override label');
+  });
+
+  test('combines built-in className with any provided in nativeAttributes', () => {
+    const { container } = render(
+      <Button
+        ariaLabel="Button label"
+        nativeButtonAttributes={{
+          className: 'my-additional-class',
+        }}
+      >
+        Button text
+      </Button>
+    );
+    const wrapper = createWrapper(container).findButton()!;
+
+    expect(wrapper.getElement()).toHaveClass('my-additional-class');
+    expect(wrapper.getElement()).toHaveClass(styles.button);
+  });
+
+  test('events get chained', () => {
+    const mainClick = jest.fn();
+    const nativeClick = jest.fn();
+    const { container } = render(
+      <Button
+        ariaLabel="Button label"
+        onClick={mainClick}
+        nativeButtonAttributes={{
+          onClick: nativeClick,
+        }}
+      >
+        Button text
+      </Button>
+    );
+    const wrapper = createWrapper(container).findButton()!;
+    wrapper.click();
+    expect(mainClick).toHaveBeenCalled();
+    expect(nativeClick).toHaveBeenCalled();
+  });
+});

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -41,6 +41,8 @@ const Button = React.forwardRef(
       form,
       i18nStrings,
       style,
+      nativeButtonAttributes,
+      nativeAnchorAttributes,
       ...props
     }: ButtonProps,
     ref: React.Ref<ButtonProps.Ref>
@@ -82,6 +84,8 @@ const Button = React.forwardRef(
         form={form}
         i18nStrings={i18nStrings}
         style={style}
+        nativeButtonAttributes={nativeButtonAttributes}
+        nativeAnchorAttributes={nativeAnchorAttributes}
         __injectAnalyticsComponentMetadata={true}
       >
         {children}

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -5,6 +5,7 @@ import React from 'react';
 import { IconProps } from '../icon/interfaces';
 import { BaseComponentProps } from '../internal/base-component';
 import { BaseNavigationDetail, CancelableEventHandler, ClickDetail as _ClickDetail } from '../internal/events';
+import { NativeAttributes } from '../internal/utils/with-native-attributes';
 
 export interface BaseButtonProps {
   /**
@@ -100,6 +101,30 @@ export interface BaseButtonProps {
    * @i18n
    */
   i18nStrings?: ButtonProps.I18nStrings;
+
+  /**
+   * Attributes to add to the native `button` element.
+   * Some attributes will be automatically combined with Cloudscape-provided attribute values:
+   * - `className` will be appended.
+   * - Event handlers will be chained, unless the default is prevented.
+   *
+   * We do not support using this attribute to apply custom styling.
+   *
+   * @awsuiSystem core
+   */
+  nativeButtonAttributes?: NativeAttributes<React.ButtonHTMLAttributes<HTMLButtonElement>>;
+
+  /**
+   * Attributes to add to the native `a` element (when `href` is provided).
+   * Some attributes will be automatically combined with Cloudscape-provided attribute values:
+   * - `className` will be appended.
+   * - Event handlers will be chained, unless the default is prevented.
+   *
+   * We do not support using this attribute to apply custom styling.
+   *
+   * @awsuiSystem core
+   */
+  nativeAnchorAttributes?: NativeAttributes<React.AnchorHTMLAttributes<HTMLAnchorElement>>;
 }
 
 export interface ButtonProps extends BaseComponentProps, BaseButtonProps {

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -31,6 +31,7 @@ import useHiddenDescription from '../internal/hooks/use-hidden-description';
 import { useModalContextLoadingButtonComponent } from '../internal/hooks/use-modal-component-analytics';
 import { usePerformanceMarks } from '../internal/hooks/use-performance-marks';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
+import WithNativeAttributes from '../internal/utils/with-native-attributes';
 import InternalLiveRegion from '../live-region/internal';
 import { GeneratedAnalyticsMetadataButtonFragment } from './analytics-metadata/interfaces';
 import { ButtonIconProps, LeftIcon, RightIcon } from './icon-helper';
@@ -50,14 +51,12 @@ export type InternalButtonProps = Omit<ButtonProps, 'variant'> & {
     | 'inline-icon-pointer-target';
   badge?: boolean;
   analyticsAction?: string;
-  __nativeAttributes?:
-    | (React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>)
-    | Record<`data-${string}`, string>;
   __iconClass?: string;
   __focusable?: boolean;
   __injectAnalyticsComponentMetadata?: boolean;
   __title?: string;
   __emitPerformanceMarks?: boolean;
+  __skipNativeAttributesWarnings?: boolean;
 } & InternalBaseComponentProps<HTMLAnchorElement | HTMLButtonElement>;
 
 export const InternalButton = React.forwardRef(
@@ -92,12 +91,14 @@ export const InternalButton = React.forwardRef(
       badge,
       i18nStrings,
       style,
-      __nativeAttributes,
+      nativeButtonAttributes,
+      nativeAnchorAttributes,
       __internalRootRef = null,
       __focusable = false,
       __injectAnalyticsComponentMetadata = false,
       __title,
       __emitPerformanceMarks = true,
+      __skipNativeAttributesWarnings,
       analyticsAction = 'click',
       ...props
     }: InternalButtonProps,
@@ -187,8 +188,7 @@ export const InternalButton = React.forwardRef(
       [styles.link]: isAnchor,
     });
 
-    const explicitTabIndex =
-      __nativeAttributes && 'tabIndex' in __nativeAttributes ? __nativeAttributes.tabIndex : undefined;
+    const explicitTabIndex = nativeButtonAttributes?.tabIndex ?? nativeAnchorAttributes?.tabIndex;
     const { tabIndex } = useSingleTabStopNavigation(buttonRef, {
       tabIndex: isAnchor && isNotInteractive && !isDisabledWithReason ? -1 : explicitTabIndex,
     });
@@ -209,7 +209,6 @@ export const InternalButton = React.forwardRef(
 
     const buttonProps = {
       ...props,
-      ...__nativeAttributes,
       ...performanceMarkAttributes,
       tabIndex,
       // https://github.com/microsoft/TypeScript/issues/36659
@@ -332,7 +331,10 @@ export const InternalButton = React.forwardRef(
     if (isAnchor) {
       return (
         <>
-          <a
+          <WithNativeAttributes<HTMLAnchorElement, React.AnchorHTMLAttributes<HTMLAnchorElement>>
+            tag="a"
+            nativeAttributes={nativeAnchorAttributes}
+            skipWarnings={__skipNativeAttributesWarnings}
             {...buttonProps}
             href={href}
             target={target}
@@ -345,7 +347,7 @@ export const InternalButton = React.forwardRef(
           >
             {buttonContent}
             {isDisabledWithReason && disabledReasonContent}
-          </a>
+          </WithNativeAttributes>
           {loading && loadingText && (
             <InternalLiveRegion tagName="span" hidden={true}>
               {loadingText}
@@ -357,7 +359,10 @@ export const InternalButton = React.forwardRef(
 
     return (
       <>
-        <button
+        <WithNativeAttributes<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>
+          tag="button"
+          nativeAttributes={nativeButtonAttributes}
+          skipWarnings={__skipNativeAttributesWarnings}
           {...buttonProps}
           type={formAction === 'none' ? 'button' : 'submit'}
           disabled={disabled && !__focusable && !isDisabledWithReason}
@@ -367,7 +372,7 @@ export const InternalButton = React.forwardRef(
         >
           {buttonContent}
           {isDisabledWithReason && disabledReasonContent}
-        </button>
+        </WithNativeAttributes>
         {loading && loadingText && (
           <InternalLiveRegion tagName="span" hidden={true}>
             {loadingText}

--- a/src/code-editor/status-bar.tsx
+++ b/src/code-editor/status-bar.tsx
@@ -122,10 +122,11 @@ export function StatusBar({
             iconAlt="Settings"
             ariaLabel={i18n('i18nStrings.preferencesButtonAriaLabel', i18nStrings?.preferencesButtonAriaLabel)}
             onClick={onPreferencesOpen}
-            __nativeAttributes={{
+            nativeButtonAttributes={{
               tabIndex: paneStatus !== 'hidden' && isTabFocused ? -1 : undefined,
               'aria-hidden': paneStatus !== 'hidden' && isTabFocused ? true : undefined,
             }}
+            __skipNativeAttributesWarnings={true}
           />
         </div>
       </div>

--- a/src/file-input/internal.tsx
+++ b/src/file-input/internal.tsx
@@ -156,7 +156,8 @@ const InternalFileInput = React.forwardRef(
             [styles['force-focus-outline-button']]: isFocused && variant === 'button',
             [styles['force-focus-outline-icon']]: isFocused && variant === 'icon',
           })}
-          __nativeAttributes={{ tabIndex: -1, 'aria-hidden': true }}
+          nativeButtonAttributes={{ tabIndex: -1, 'aria-hidden': true }}
+          __skipNativeAttributesWarnings={true}
         >
           {variant === 'button' && children}
         </InternalButton>

--- a/src/internal/utils/__tests__/with-native-attributes.test.tsx
+++ b/src/internal/utils/__tests__/with-native-attributes.test.tsx
@@ -1,0 +1,164 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { HTMLAttributes, MouseEventHandler } from 'react';
+import { render } from '@testing-library/react';
+
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+
+import WithNativeAttributes from '../with-native-attributes';
+
+jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
+  warnOnce: jest.fn(),
+}));
+
+const mockedWarnOnce = warnOnce as jest.MockedFunction<typeof warnOnce>;
+
+describe('WithNativeAttributes', () => {
+  beforeEach(() => {
+    mockedWarnOnce.mockClear();
+  });
+
+  test('renders with basic props', () => {
+    const { container } = render(
+      <WithNativeAttributes tag="div" nativeAttributes={{}}>
+        Test content
+      </WithNativeAttributes>
+    );
+
+    expect(container.firstChild).toBeInTheDocument();
+    expect(container.firstChild?.nodeName).toBe('DIV');
+    expect(container.firstChild?.textContent).toBe('Test content');
+  });
+  test('works with different HTML tags', () => {
+    const { container: spanContainer } = render(
+      <WithNativeAttributes tag="span" nativeAttributes={{}}>
+        Span content
+      </WithNativeAttributes>
+    );
+
+    const { container: buttonContainer } = render(
+      <WithNativeAttributes tag="button" nativeAttributes={{}}>
+        Button content
+      </WithNativeAttributes>
+    );
+
+    expect(spanContainer.firstChild?.nodeName).toBe('SPAN');
+    expect(buttonContainer.firstChild?.nodeName).toBe('BUTTON');
+  });
+
+  test('handles empty nativeAttributes', () => {
+    const { container } = render(
+      <WithNativeAttributes<HTMLDivElement, HTMLAttributes<HTMLDivElement>>
+        tag="div"
+        className="test-class"
+        nativeAttributes={undefined}
+      >
+        Test content
+      </WithNativeAttributes>
+    );
+
+    const element = container.firstElementChild!;
+    expect(element).toHaveClass('test-class');
+    expect(element.textContent).toBe('Test content');
+  });
+
+  test('concatenates className from rest props and nativeAttributes', () => {
+    const { container } = render(
+      <WithNativeAttributes tag="div" className="base-class" nativeAttributes={{ className: 'native-class' }}>
+        Test content
+      </WithNativeAttributes>
+    );
+
+    const element = container.firstElementChild!;
+    expect(element).toHaveClass('base-class');
+    expect(element).toHaveClass('native-class');
+  });
+
+  test('merges style objects from rest props and nativeAttributes', () => {
+    const { container } = render(
+      <WithNativeAttributes
+        tag="div"
+        style={{ color: 'red', fontSize: '16px' }}
+        nativeAttributes={{ style: { backgroundColor: 'blue', fontSize: '18px' } }}
+      >
+        Test content
+      </WithNativeAttributes>
+    );
+
+    const element = container.firstChild as HTMLElement;
+    expect(element.style.color).toBe('red');
+    expect(element.style.backgroundColor).toBe('blue');
+    expect(element.style.fontSize).toBe('18px'); // nativeAttributes should override
+  });
+
+  test('chains event handlers', () => {
+    const nativeHandler = jest.fn();
+    const restHandler = jest.fn();
+
+    const { container } = render(
+      <WithNativeAttributes tag="button" onClick={restHandler} nativeAttributes={{ onClick: nativeHandler }}>
+        Click me
+      </WithNativeAttributes>
+    );
+
+    const button = container.firstChild as HTMLButtonElement;
+    button.click();
+
+    expect(nativeHandler).toHaveBeenCalled();
+    expect(restHandler).toHaveBeenCalled();
+  });
+
+  test('prevents rest handler execution when event is cancelled', () => {
+    const nativeHandler = jest.fn((event => event.preventDefault()) as MouseEventHandler);
+    const restHandler = jest.fn();
+
+    const { container } = render(
+      <WithNativeAttributes tag="button" onClick={restHandler} nativeAttributes={{ onClick: nativeHandler }}>
+        Click me
+      </WithNativeAttributes>
+    );
+
+    const button = container.firstChild as HTMLButtonElement;
+    button.click();
+
+    expect(nativeHandler).toHaveBeenCalled();
+    expect(restHandler).not.toHaveBeenCalled();
+  });
+
+  test('overrides other attributes and shows warning', () => {
+    const { container } = render(
+      <WithNativeAttributes tag="div" id="original-id" nativeAttributes={{ id: 'override-id' }}>
+        Test content
+      </WithNativeAttributes>
+    );
+
+    const element = container.firstElementChild!;
+    expect(element.id).toBe('override-id');
+    expect(mockedWarnOnce).toHaveBeenCalledWith(
+      'Button',
+      'Overriding native attribute [id] which has a Cloudscape-provided value'
+    );
+  });
+
+  test('passes through data attributes without warning', () => {
+    const { container } = render(
+      <WithNativeAttributes tag="div" nativeAttributes={{ 'data-testid': 'test-element' }}>
+        Test content
+      </WithNativeAttributes>
+    );
+
+    const element = container.firstElementChild!;
+    expect(element).toHaveAttribute('data-testid', 'test-element');
+    expect(mockedWarnOnce).not.toHaveBeenCalled();
+  });
+
+  test('does not allow children to be overrwitten', () => {
+    const { container } = render(
+      <WithNativeAttributes tag="div" nativeAttributes={{ children: 'Something custom' } as any}>
+        Test content
+      </WithNativeAttributes>
+    );
+
+    expect(container).toHaveTextContent('Test content');
+  });
+});

--- a/src/internal/utils/with-native-attributes.tsx
+++ b/src/internal/utils/with-native-attributes.tsx
@@ -1,0 +1,65 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { ReactNode } from 'react';
+import clsx from 'clsx';
+
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+
+export type NativeAttributes<T extends React.HTMLAttributes<HTMLElement>> =
+  | (Omit<T, 'children'> & Record<`data-${string}`, string>)
+  | undefined;
+
+type NativeAttributesProps<AT extends React.HTMLAttributes<HTMLElement>> = {
+  tag: string;
+  children?: ReactNode;
+  skipWarnings?: boolean;
+  nativeAttributes: NativeAttributes<AT>;
+} & NativeAttributes<AT>;
+interface ForwardRefType {
+  <ET extends HTMLElement, AT extends React.HTMLAttributes<ET>>(
+    props: NativeAttributesProps<AT> & { ref?: React.Ref<ET> }
+  ): JSX.Element;
+}
+
+export default React.forwardRef(
+  <ET extends HTMLElement, AT extends React.HTMLAttributes<ET>>(
+    { tag, nativeAttributes, children, skipWarnings, ...rest }: NativeAttributesProps<AT>,
+    ref: React.Ref<ET>
+  ) => {
+    const Tag = tag;
+
+    const processedAttributes = Object.entries(nativeAttributes || {}).reduce((acc, [key, value]) => {
+      // concatenate className
+      if (key === 'className') {
+        acc[key] = clsx(rest.className, value);
+
+        // merge style
+      } else if (key === 'style') {
+        acc[key] = { ...rest.style, ...value };
+
+        // chain event handlers
+      } else if (key.match(/^on[A-Z]/) && typeof value === 'function' && key in rest) {
+        acc[key] = (event: Event) => {
+          value(event);
+          if (!event.defaultPrevented) {
+            (rest as any)[key](event);
+          }
+        };
+
+        // override other attributes, warning if it already exists
+      } else {
+        if (key in rest && !skipWarnings) {
+          warnOnce('Button', `Overriding native attribute [${key}] which has a Cloudscape-provided value`);
+        }
+        acc[key] = value;
+      }
+      return acc;
+    }, {} as any);
+
+    return (
+      <Tag {...rest} {...processedAttributes} ref={ref}>
+        {children}
+      </Tag>
+    );
+  }
+) as ForwardRefType;

--- a/src/tutorial-panel/components/tutorial-list/index.tsx
+++ b/src/tutorial-panel/components/tutorial-list/index.tsx
@@ -129,7 +129,7 @@ function Tutorial({
               id={triggerControldId}
               variant="icon"
               ariaExpanded={expanded}
-              __nativeAttributes={{
+              nativeButtonAttributes={{
                 'aria-controls': controlId,
                 'aria-labelledby': headerId,
               }}


### PR DESCRIPTION
### Description

Allow button native attributes to be set.

Related links, issue #, if available: AWSUI-60858

### How has this been tested?

New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
