### PR TITLE
feat: Allow button-dropdown native attributes to be set

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -4655,6 +4655,44 @@ The main action also supports the following properties of the [button](/componen
       "type": "ButtonDropdownProps.MainAction",
     },
     {
+      "description": "Attributes to add to the native \`button\` element.
+
+It is not supported to use this attribute to apply custom styling.",
+      "inlineType": {
+        "name": "(React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>) | Record<\`data-\${string}\`, string>",
+        "type": "union",
+        "values": [
+          "React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>",
+          "Record<\`data-\${string}\`, string>",
+        ],
+      },
+      "name": "nativeButtonAttributes",
+      "optional": true,
+      "systemTags": [
+        "core",
+      ],
+      "type": "(React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>) | Record<\`data-\${string}\`, string>",
+    },
+    {
+      "description": "Attributes to add to the native  \`button\` element of the \`mainAction\`.
+
+It is not supported to use this attribute to apply custom styling.",
+      "inlineType": {
+        "name": "(React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>) | Record<\`data-\${string}\`, string>",
+        "type": "union",
+        "values": [
+          "React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>",
+          "Record<\`data-\${string}\`, string>",
+        ],
+      },
+      "name": "nativeMainActionButtonAttributes",
+      "optional": true,
+      "systemTags": [
+        "core",
+      ],
+      "type": "(React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>) | Record<\`data-\${string}\`, string>",
+    },
+    {
       "defaultValue": "'normal'",
       "description": "Determines the general styling of the button dropdown.
 * \`primary\` for primary buttons

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -4216,6 +4216,25 @@ It prevents users from clicking the button, but it can still be focused.",
       "type": "string",
     },
     {
+      "description": "Attributes to add to the native \`button\` element.
+
+It is not supported to use this attribute to apply custom styling.",
+      "inlineType": {
+        "name": "(React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>) | Record<\`data-\${string}\`, string>",
+        "type": "union",
+        "values": [
+          "React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>",
+          "Record<\`data-\${string}\`, string>",
+        ],
+      },
+      "name": "nativeAttributes",
+      "optional": true,
+      "systemTags": [
+        "core",
+      ],
+      "type": "(React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>) | Record<\`data-\${string}\`, string>",
+    },
+    {
       "description": "Adds a \`rel\` attribute to the link. By default, the component sets the \`rel\` attribute to "noopener noreferrer" when \`target\` is \`"_blank"\`.
 If the \`rel\` property is provided, it overrides the default behavior.",
       "name": "rel",
@@ -19907,6 +19926,25 @@ It prevents users from clicking the button, but it can still be focused.",
       "name": "loadingText",
       "optional": true,
       "type": "string",
+    },
+    {
+      "description": "Attributes to add to the native \`button\` element.
+
+It is not supported to use this attribute to apply custom styling.",
+      "inlineType": {
+        "name": "(React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>) | Record<\`data-\${string}\`, string>",
+        "type": "union",
+        "values": [
+          "React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>",
+          "Record<\`data-\${string}\`, string>",
+        ],
+      },
+      "name": "nativeAttributes",
+      "optional": true,
+      "systemTags": [
+        "core",
+      ],
+      "type": "(React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>) | Record<\`data-\${string}\`, string>",
     },
     {
       "defaultValue": "false",

--- a/src/app-layout/visual-refresh/mobile-toolbar.tsx
+++ b/src/app-layout/visual-refresh/mobile-toolbar.tsx
@@ -69,7 +69,7 @@ export default function MobileToolbar() {
             className={testutilStyles['navigation-toggle']}
             ref={navigationRefs.toggle}
             disabled={hasDrawerViewportOverlay}
-            __nativeAttributes={{ 'aria-haspopup': navigationOpen ? undefined : true }}
+            nativeAttributes={{ 'aria-haspopup': navigationOpen ? undefined : true }}
           />
         </nav>
       )}
@@ -97,7 +97,7 @@ export default function MobileToolbar() {
               onClick={() => handleToolsClick(true)}
               variant="icon"
               ref={toolsRefs.toggle}
-              __nativeAttributes={{ 'aria-haspopup': true }}
+              nativeAttributes={{ 'aria-haspopup': true }}
             />
           </aside>
         )

--- a/src/app-layout/visual-refresh/trigger-button.tsx
+++ b/src/app-layout/visual-refresh/trigger-button.tsx
@@ -67,7 +67,7 @@ function TriggerButton(
           badge={badge}
           onClick={onClick}
           variant="icon"
-          __nativeAttributes={{
+          nativeAttributes={{
             'aria-haspopup': true,
             ...(testId && {
               'data-testid': testId,

--- a/src/attribute-editor/internal.tsx
+++ b/src/attribute-editor/internal.tsx
@@ -153,7 +153,7 @@ const InternalAttributeEditor = React.forwardRef(
             // Using aria-disabled="true" and tabindex="-1" instead of "disabled"
             // because focus can be dynamically moved to this button by calling
             // `focusAddButton()` on the ref.
-            __nativeAttributes={disableAddButton ? { tabIndex: -1 } : {}}
+            nativeAttributes={disableAddButton ? { tabIndex: -1 } : {}}
             __focusable={true}
             onClick={onAddButtonClick}
             formAction="none"

--- a/src/button-dropdown/__tests__/native-attributes.test.tsx
+++ b/src/button-dropdown/__tests__/native-attributes.test.tsx
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import ButtonDropdown from '../../../lib/components/button-dropdown';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+describe('ButtonDropdown native attributes', () => {
+  const items = [{ id: 'item1', text: 'Item 1' }];
+
+  test('passes nativeButtonAttributes to the dropdown trigger button', () => {
+    const { container } = render(
+      <ButtonDropdown
+        items={items}
+        nativeButtonAttributes={{
+          'data-testid': 'dropdown-trigger',
+          'aria-controls': 'controlled-element',
+        }}
+      />
+    );
+    const wrapper = createWrapper(container).findButtonDropdown()!;
+    const triggerButton = wrapper.findNativeButton().getElement();
+
+    expect(triggerButton).toHaveAttribute('data-testid', 'dropdown-trigger');
+    expect(triggerButton).toHaveAttribute('aria-controls', 'controlled-element');
+  });
+
+  test('passes nativeMainActionButtonAttributes to the main action button', () => {
+    const { container } = render(
+      <ButtonDropdown
+        items={items}
+        variant="primary"
+        mainAction={{ text: 'Main action' }}
+        nativeMainActionButtonAttributes={{
+          'data-testid': 'main-action',
+          'aria-controls': 'another-element',
+        }}
+      />
+    );
+    const wrapper = createWrapper(container).findButtonDropdown()!;
+    const mainActionButton = wrapper.findMainAction()!.getElement();
+
+    expect(mainActionButton).toHaveAttribute('data-testid', 'main-action');
+    expect(mainActionButton).toHaveAttribute('aria-controls', 'another-element');
+  });
+
+  test('does not apply nativeMainActionButtonAttributes when no main action is present', () => {
+    const { container } = render(
+      <ButtonDropdown
+        items={items}
+        nativeMainActionButtonAttributes={{
+          'data-testid': 'main-action',
+        }}
+      />
+    );
+    const wrapper = createWrapper(container).findButtonDropdown()!;
+
+    expect(wrapper.findMainAction()).toBeNull();
+    expect(container.querySelector('[data-testid="main-action"]')).toBeNull();
+  });
+
+  test('applies both nativeButtonAttributes and nativeMainActionButtonAttributes to respective buttons', () => {
+    const { container } = render(
+      <ButtonDropdown
+        items={items}
+        variant="primary"
+        mainAction={{ text: 'Main action' }}
+        nativeButtonAttributes={{
+          'data-testid': 'dropdown-trigger',
+        }}
+        nativeMainActionButtonAttributes={{
+          'data-testid': 'main-action',
+        }}
+      />
+    );
+    const wrapper = createWrapper(container).findButtonDropdown()!;
+
+    expect(wrapper.findNativeButton().getElement()).toHaveAttribute('data-testid', 'dropdown-trigger');
+    expect(wrapper.findMainAction()!.getElement()).toHaveAttribute('data-testid', 'main-action');
+  });
+});

--- a/src/button-dropdown/__tests__/native-attributes.test.tsx
+++ b/src/button-dropdown/__tests__/native-attributes.test.tsx
@@ -9,11 +9,11 @@ import createWrapper from '../../../lib/components/test-utils/dom';
 describe('ButtonDropdown native attributes', () => {
   const items = [{ id: 'item1', text: 'Item 1' }];
 
-  test('passes nativeButtonAttributes to the dropdown trigger button', () => {
+  test('passes nativeTriggerAttributes to the dropdown trigger button', () => {
     const { container } = render(
       <ButtonDropdown
         items={items}
-        nativeButtonAttributes={{
+        nativeTriggerAttributes={{
           'data-testid': 'dropdown-trigger',
           'aria-controls': 'controlled-element',
         }}
@@ -60,13 +60,13 @@ describe('ButtonDropdown native attributes', () => {
     expect(container.querySelector('[data-testid="main-action"]')).toBeNull();
   });
 
-  test('applies both nativeButtonAttributes and nativeMainActionButtonAttributes to respective buttons', () => {
+  test('applies both nativeTriggerAttributes and nativeMainActionButtonAttributes to respective buttons', () => {
     const { container } = render(
       <ButtonDropdown
         items={items}
         variant="primary"
         mainAction={{ text: 'Main action' }}
-        nativeButtonAttributes={{
+        nativeTriggerAttributes={{
           'data-testid': 'dropdown-trigger',
         }}
         nativeMainActionButtonAttributes={{

--- a/src/button-dropdown/index.tsx
+++ b/src/button-dropdown/index.tsx
@@ -33,7 +33,7 @@ const ButtonDropdown = React.forwardRef(
       onItemFollow,
       mainAction,
       fullWidth,
-      nativeButtonAttributes,
+      nativeTriggerAttributes,
       nativeMainActionButtonAttributes,
       ...props
     }: ButtonDropdownProps,
@@ -74,7 +74,7 @@ const ButtonDropdown = React.forwardRef(
         onItemFollow={onItemFollow}
         mainAction={mainAction}
         fullWidth={fullWidth}
-        nativeButtonAttributes={nativeButtonAttributes}
+        nativeTriggerAttributes={nativeTriggerAttributes}
         nativeMainActionButtonAttributes={nativeMainActionButtonAttributes}
         {...getAnalyticsMetadataAttribute({
           component: analyticsComponentMetadata,

--- a/src/button-dropdown/index.tsx
+++ b/src/button-dropdown/index.tsx
@@ -33,6 +33,8 @@ const ButtonDropdown = React.forwardRef(
       onItemFollow,
       mainAction,
       fullWidth,
+      nativeButtonAttributes,
+      nativeMainActionButtonAttributes,
       ...props
     }: ButtonDropdownProps,
     ref: React.Ref<ButtonDropdownProps.Ref>
@@ -72,6 +74,8 @@ const ButtonDropdown = React.forwardRef(
         onItemFollow={onItemFollow}
         mainAction={mainAction}
         fullWidth={fullWidth}
+        nativeButtonAttributes={nativeButtonAttributes}
+        nativeMainActionButtonAttributes={nativeMainActionButtonAttributes}
         {...getAnalyticsMetadataAttribute({
           component: analyticsComponentMetadata,
         })}

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -127,10 +127,10 @@ export interface ButtonDropdownProps extends BaseComponentProps, ExpandToViewpor
    *
    * @awsuiSystem core
    */
-  nativeButtonAttributes?: ButtonProps['nativeAttributes'];
+  nativeTriggerAttributes?: ButtonProps['nativeAttributes'];
 
   /**
-   * Attributes to add to the native  `button` element of the `mainAction`.
+   * Attributes to add to the native `button` element of the `mainAction`.
    *
    * It is not supported to use this attribute to apply custom styling.
    *

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -119,6 +119,24 @@ export interface ButtonDropdownProps extends BaseComponentProps, ExpandToViewpor
    * Sets the button width to be 100% of the parent container width. Button content is centered.
    */
   fullWidth?: boolean;
+
+  /**
+   * Attributes to add to the native `button` element.
+   *
+   * It is not supported to use this attribute to apply custom styling.
+   *
+   * @awsuiSystem core
+   */
+  nativeButtonAttributes?: ButtonProps['nativeAttributes'];
+
+  /**
+   * Attributes to add to the native  `button` element of the `mainAction`.
+   *
+   * It is not supported to use this attribute to apply custom styling.
+   *
+   * @awsuiSystem core
+   */
+  nativeMainActionButtonAttributes?: ButtonProps['nativeAttributes'];
 }
 
 export namespace ButtonDropdownProps {

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -168,7 +168,7 @@ const InternalButtonDropdown = React.forwardRef(
       ariaLabel,
       ariaExpanded: canBeOpened && isOpen,
       formAction: 'none',
-      __nativeAttributes: {
+      nativeAttributes: {
         'aria-haspopup': true,
       },
     };

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -56,7 +56,7 @@ const InternalButtonDropdown = React.forwardRef(
       analyticsMetadataTransformer,
       linkStyle,
       fullWidth,
-      nativeButtonAttributes,
+      nativeTriggerAttributes,
       nativeMainActionButtonAttributes,
       ...props
     }: InternalButtonDropdownProps,
@@ -293,7 +293,7 @@ const InternalButtonDropdown = React.forwardRef(
               <InternalButton
                 ref={triggerRef}
                 {...baseTriggerProps}
-                nativeAttributes={{ ...baseTriggerProps.nativeAttributes, ...nativeButtonAttributes }}
+                nativeAttributes={{ ...baseTriggerProps.nativeAttributes, ...nativeTriggerAttributes }}
                 className={clsx(baseTriggerProps.className, {
                   [styles['main-action-trigger-full-width']]: canBeFullWidth,
                 })}
@@ -312,7 +312,7 @@ const InternalButtonDropdown = React.forwardRef(
             ref={triggerRef}
             id={triggerId}
             {...baseTriggerProps}
-            nativeAttributes={{ ...baseTriggerProps.nativeAttributes, ...nativeButtonAttributes }}
+            nativeAttributes={{ ...baseTriggerProps.nativeAttributes, ...nativeTriggerAttributes }}
             className={clsx(baseTriggerProps.className, {
               [styles['full-width']]: canBeFullWidth,
               [styles.loading]: canBeFullWidth && !!loading,

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -56,6 +56,8 @@ const InternalButtonDropdown = React.forwardRef(
       analyticsMetadataTransformer,
       linkStyle,
       fullWidth,
+      nativeButtonAttributes,
+      nativeMainActionButtonAttributes,
       ...props
     }: InternalButtonDropdownProps,
     ref: React.Ref<ButtonDropdownProps.Ref>
@@ -237,6 +239,7 @@ const InternalButtonDropdown = React.forwardRef(
           ref={mainActionRef}
           {...mainActionProps}
           {...mainActionIconProps}
+          nativeAttributes={nativeMainActionButtonAttributes}
           fullWidth={canBeFullWidth}
           className={clsx(
             styles['trigger-button'],
@@ -290,6 +293,7 @@ const InternalButtonDropdown = React.forwardRef(
               <InternalButton
                 ref={triggerRef}
                 {...baseTriggerProps}
+                nativeAttributes={{ ...baseTriggerProps.nativeAttributes, ...nativeButtonAttributes }}
                 className={clsx(baseTriggerProps.className, {
                   [styles['main-action-trigger-full-width']]: canBeFullWidth,
                 })}
@@ -308,6 +312,7 @@ const InternalButtonDropdown = React.forwardRef(
             ref={triggerRef}
             id={triggerId}
             {...baseTriggerProps}
+            nativeAttributes={{ ...baseTriggerProps.nativeAttributes, ...nativeButtonAttributes }}
             className={clsx(baseTriggerProps.className, {
               [styles['full-width']]: canBeFullWidth,
               [styles.loading]: canBeFullWidth && !!loading,

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -813,8 +813,8 @@ describe('table grid navigation support', () => {
   test('does not override explicit tab index with 0', () => {
     const { setCurrentTarget } = renderWithSingleTabStopNavigation(
       <div>
-        <InternalButton id="button1" __nativeAttributes={{ tabIndex: -2 }} />
-        <InternalButton id="button2" __nativeAttributes={{ tabIndex: -2 }} />
+        <InternalButton id="button1" nativeAttributes={{ tabIndex: -2 }} />
+        <InternalButton id="button2" nativeAttributes={{ tabIndex: -2 }} />
       </div>
     );
     setCurrentTarget(getButton('#button1'));

--- a/src/button/__tests__/internal.test.tsx
+++ b/src/button/__tests__/internal.test.tsx
@@ -12,21 +12,9 @@ import { mockedFunnelInteractionId, mockFunnelMetrics } from '../../internal/ana
 
 import styles from '../../../lib/components/button/styles.css.js';
 
-test('specific properties take precedence over nativeAttributes', () => {
-  const { container } = render(
-    <InternalButton ariaLabel="property" __nativeAttributes={{ 'aria-label': 'native attribute' }} />
-  );
-  expect(container.querySelector('button')).toHaveAttribute('aria-label', 'property');
-});
-
-test('supports providing custom attributes', () => {
-  const { container } = render(<InternalButton __nativeAttributes={{ 'aria-hidden': 'true' }} />);
-  expect(container.querySelector('button')).toHaveAttribute('aria-hidden', 'true');
-});
-
 test('supports __iconClass property', () => {
   const { container } = render(
-    <InternalButton __iconClass="example-class" iconName="settings" __nativeAttributes={{ 'aria-expanded': 'true' }} />
+    <InternalButton __iconClass="example-class" iconName="settings" nativeAttributes={{ 'aria-expanded': 'true' }} />
   );
   expect(container.querySelector(`button .${styles.icon}`)).toHaveClass('example-class');
 });

--- a/src/button/__tests__/native-attributes.test.tsx
+++ b/src/button/__tests__/native-attributes.test.tsx
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Button from '../../../lib/components/button';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+describe('Button native attributes', () => {
+  test('passes nativeAttributes to the button element', () => {
+    const { container } = render(
+      <Button
+        nativeAttributes={{
+          'data-testid': 'test-button',
+          'aria-controls': 'controlled-element',
+        }}
+      >
+        Button text
+      </Button>
+    );
+    const wrapper = createWrapper(container).findButton()!;
+
+    expect(wrapper.getElement()).toHaveAttribute('data-testid', 'test-button');
+    expect(wrapper.getElement()).toHaveAttribute('aria-controls', 'controlled-element');
+  });
+
+  test('passes nativeAttributes to the anchor element when href is provided', () => {
+    const { container } = render(
+      <Button
+        href="https://example.com"
+        nativeAttributes={{
+          'data-testid': 'test-link',
+          'aria-controls': 'controlled-element',
+        }}
+      >
+        Link text
+      </Button>
+    );
+    const wrapper = createWrapper(container).findButton()!;
+
+    expect(wrapper.getElement()).toHaveAttribute('data-testid', 'test-link');
+    expect(wrapper.getElement()).toHaveAttribute('aria-controls', 'controlled-element');
+    expect(wrapper.getElement().tagName).toBe('A');
+  });
+
+  test('overrides built-in attributes with nativeAttributes', () => {
+    const { container } = render(
+      <Button
+        ariaLabel="Button label"
+        nativeAttributes={{
+          'aria-label': 'Override label',
+        }}
+      >
+        Button text
+      </Button>
+    );
+    const wrapper = createWrapper(container).findButton()!;
+
+    expect(wrapper.getElement()).toHaveAccessibleName('Override label');
+  });
+});

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -40,6 +40,7 @@ const Button = React.forwardRef(
       fullWidth,
       form,
       i18nStrings,
+      nativeAttributes,
       ...props
     }: ButtonProps,
     ref: React.Ref<ButtonProps.Ref>
@@ -80,6 +81,7 @@ const Button = React.forwardRef(
         fullWidth={fullWidth}
         form={form}
         i18nStrings={i18nStrings}
+        nativeAttributes={nativeAttributes}
         __injectAnalyticsComponentMetadata={true}
       >
         {children}

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -100,6 +100,17 @@ export interface BaseButtonProps {
    * @i18n
    */
   i18nStrings?: ButtonProps.I18nStrings;
+
+  /**
+   * Attributes to add to the native `button` element.
+   *
+   * It is not supported to use this attribute to apply custom styling.
+   *
+   * @awsuiSystem core
+   */
+  nativeAttributes?:
+    | (React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>)
+    | Record<`data-${string}`, string>;
 }
 
 export interface ButtonProps extends BaseComponentProps, BaseButtonProps {

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -49,9 +49,6 @@ export type InternalButtonProps = Omit<ButtonProps, 'variant'> & {
     | 'inline-icon-pointer-target';
   badge?: boolean;
   analyticsAction?: string;
-  __nativeAttributes?:
-    | (React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>)
-    | Record<`data-${string}`, string>;
   __iconClass?: string;
   __focusable?: boolean;
   __injectAnalyticsComponentMetadata?: boolean;
@@ -90,7 +87,7 @@ export const InternalButton = React.forwardRef(
       fullWidth,
       badge,
       i18nStrings,
-      __nativeAttributes,
+      nativeAttributes = {},
       __internalRootRef = null,
       __focusable = false,
       __injectAnalyticsComponentMetadata = false,
@@ -185,8 +182,7 @@ export const InternalButton = React.forwardRef(
       [styles.link]: isAnchor,
     });
 
-    const explicitTabIndex =
-      __nativeAttributes && 'tabIndex' in __nativeAttributes ? __nativeAttributes.tabIndex : undefined;
+    const explicitTabIndex = 'tabIndex' in nativeAttributes ? nativeAttributes.tabIndex : undefined;
     const { tabIndex } = useSingleTabStopNavigation(buttonRef, {
       tabIndex: isAnchor && isNotInteractive && !isDisabledWithReason ? -1 : explicitTabIndex,
     });
@@ -207,7 +203,6 @@ export const InternalButton = React.forwardRef(
 
     const buttonProps = {
       ...props,
-      ...__nativeAttributes,
       ...performanceMarkAttributes,
       tabIndex,
       // https://github.com/microsoft/TypeScript/issues/36659
@@ -305,6 +300,7 @@ export const InternalButton = React.forwardRef(
             aria-disabled={isNotInteractive ? true : undefined}
             download={download}
             {...disabledReasonProps}
+            {...nativeAttributes}
           >
             {buttonContent}
             {isDisabledWithReason && disabledReasonContent}
@@ -326,6 +322,7 @@ export const InternalButton = React.forwardRef(
           disabled={disabled && !__focusable && !isDisabledWithReason}
           aria-disabled={hasAriaDisabled ? true : undefined}
           {...disabledReasonProps}
+          {...nativeAttributes}
         >
           {buttonContent}
           {isDisabledWithReason && disabledReasonContent}

--- a/src/code-editor/status-bar.tsx
+++ b/src/code-editor/status-bar.tsx
@@ -122,7 +122,7 @@ export function StatusBar({
             iconAlt="Settings"
             ariaLabel={i18n('i18nStrings.preferencesButtonAriaLabel', i18nStrings?.preferencesButtonAriaLabel)}
             onClick={onPreferencesOpen}
-            __nativeAttributes={{
+            nativeAttributes={{
               tabIndex: paneStatus !== 'hidden' && isTabFocused ? -1 : undefined,
               'aria-hidden': paneStatus !== 'hidden' && isTabFocused ? true : undefined,
             }}

--- a/src/file-input/internal.tsx
+++ b/src/file-input/internal.tsx
@@ -134,7 +134,7 @@ const InternalFileInput = React.forwardRef(
             [styles['force-focus-outline-button']]: isFocused && variant === 'button',
             [styles['force-focus-outline-icon']]: isFocused && variant === 'icon',
           })}
-          __nativeAttributes={{ tabIndex: -1, 'aria-hidden': true }}
+          nativeAttributes={{ tabIndex: -1, 'aria-hidden': true }}
         >
           {variant === 'button' && children}
         </InternalButton>

--- a/src/tutorial-panel/components/tutorial-list/index.tsx
+++ b/src/tutorial-panel/components/tutorial-list/index.tsx
@@ -128,7 +128,7 @@ function Tutorial({
               id={triggerControldId}
               variant="icon"
               ariaExpanded={expanded}
-              __nativeAttributes={{
+              nativeAttributes={{
                 'aria-controls': controlId,
                 'aria-labelledby': headerId,
               }}


### PR DESCRIPTION
### Description

Allow button native attributes to be set.

Related links, issue #, if available: AWSUI-60864

### How has this been tested?

New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
