### PR TITLE
fix: Analytics label for icon buttons with children

### DIFF
--- a/src/button/__tests__/analytics-metadata.test.tsx
+++ b/src/button/__tests__/analytics-metadata.test.tsx
@@ -75,6 +75,15 @@ describe('Button renders correct analytics metadata', () => {
     validateComponentNameAndLabels(wrapper.getElement(), labels);
     expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual(getMetadata('button text aria', 'inline-icon'));
   });
+  test('when it has icon variant and children', () => {
+    const wrapper = renderButton({
+      ariaLabel: 'button text aria',
+      variant: 'inline-icon',
+      children: 'invisible but there',
+    });
+    validateComponentNameAndLabels(wrapper.getElement(), labels);
+    expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual(getMetadata('button text aria', 'inline-icon'));
+  });
 });
 describe('Internal Button', () => {
   test('does not render "component" metadata', () => {

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -222,7 +222,7 @@ export const InternalButton = React.forwardRef(
       onClick: handleClick,
       [DATA_ATTR_FUNNEL_VALUE]: uniqueId,
       ...getAnalyticsMetadataAttribute(analyticsMetadata),
-      ...getAnalyticsLabelAttribute(children ? `.${analyticsSelectors.label}` : ''),
+      ...getAnalyticsLabelAttribute(shouldHaveContent ? `.${analyticsSelectors.label}` : ''),
     } as const;
 
     const iconProps: ButtonIconProps = {


### PR DESCRIPTION
### Description

Needed to instrument button-group

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
