### PR TITLE
feat: Accept position in internal ButtonDropdown for analytics purposes

### DIFF
--- a/src/button-dropdown/__tests__/analytics-metadata.test.tsx
+++ b/src/button-dropdown/__tests__/analytics-metadata.test.tsx
@@ -300,4 +300,18 @@ describe('Internal Button Dropdown', () => {
       detail: { label: 'Delete', position: '1', href: '#' },
     });
   });
+  test('accepts position', () => {
+    const renderResult = render(
+      <InternalButtonDropdown position="4" items={items}>
+        Action text
+      </InternalButtonDropdown>
+    );
+    const wrapper = createWrapper(renderResult.container).findButtonDropdown()!;
+    wrapper.openDropdown();
+    const enabledSimpleItem = wrapper.findItemById('rm')!.getElement();
+    expect(getGeneratedAnalyticsMetadata(enabledSimpleItem)).toEqual({
+      action: 'click',
+      detail: { label: 'Delete', position: '4,1', href: '#', id: 'rm' },
+    });
+  });
 });

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -327,6 +327,11 @@ export interface InternalButtonDropdownProps
   fullWidth?: boolean;
 
   analyticsMetadataTransformer?: (input: GeneratedAnalyticsMetadataFragment) => GeneratedAnalyticsMetadataFragment;
+
+  /**
+   * Position of the button dropdown inside a list of elements, for example a button group
+   */
+  position?: string;
 }
 
 export interface CustomTriggerProps {

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -56,6 +56,7 @@ const InternalButtonDropdown = React.forwardRef(
       analyticsMetadataTransformer,
       linkStyle,
       fullWidth,
+      position,
       ...props
     }: InternalButtonDropdownProps,
     ref: React.Ref<ButtonDropdownProps.Ref>
@@ -409,6 +410,7 @@ const InternalButtonDropdown = React.forwardRef(
               variant={variant}
               analyticsMetadataTransformer={analyticsMetadataTransformer}
               linkStyle={linkStyle}
+              position={position}
             />
           </OptionsList>
         </Dropdown>


### PR DESCRIPTION
### Description

Needed to instrument button-group

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
