### PR TITLE
feat: Allow table inline editing to be rendered without a wrapping <form>

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -17528,6 +17528,9 @@ To target individual cells use \`columnDefinitions.verticalAlign\`, that takes p
        The \`cellContext\` object contains the following properties:
     * \`cellContext.currentValue\` - State to keep track of a value in input fields while editing.
     * \`cellContext.setValue\` - Function to update \`currentValue\`. This should be called when the value in input field changes.
+    * \`cellContext.submitValue\` - Function to submit the \`currentValue\`.
+  * \`editConfig.disableNativeForm\` (boolean) - Disables the use of a \`<form>\` element to capture submissions inside the inline editor.
+       If enabled, ensure that any text inputs in the editing cell submit the cell value when the Enter key is pressed, using \`cellContext.submitValue\`.
 * \`isRowHeader\` (boolean) - Specifies that cells in this column should be used as row headers.
 * \`hasDynamicContent\` (boolean) - Specifies that cells in this column may have dynamic content. The contents will then be observed to update calculated column widths.
    This may have a negative performance impact, so should be used only if necessary. It has no effect if \`resizableColumns\` is set to \`true\`.

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -116,6 +116,9 @@ export interface TableProps<T = any> extends BaseComponentProps {
    *        The `cellContext` object contains the following properties:
    *     * `cellContext.currentValue` - State to keep track of a value in input fields while editing.
    *     * `cellContext.setValue` - Function to update `currentValue`. This should be called when the value in input field changes.
+   *     * `cellContext.submitValue` - Function to submit the `currentValue`.
+   *   * `editConfig.disableNativeForm` (boolean) - Disables the use of a `<form>` element to capture submissions inside the inline editor.
+   *        If enabled, ensure that any text inputs in the editing cell submit the cell value when the Enter key is pressed, using `cellContext.submitValue`.
    * * `isRowHeader` (boolean) - Specifies that cells in this column should be used as row headers.
    * * `hasDynamicContent` (boolean) - Specifies that cells in this column may have dynamic content. The contents will then be observed to update calculated column widths.
    *    This may have a negative performance impact, so should be used only if necessary. It has no effect if `resizableColumns` is set to `true`.
@@ -413,6 +416,7 @@ export namespace TableProps {
   export interface CellContext<V> {
     currentValue: Optional<V>;
     setValue: (value: V | undefined) => void;
+    submitValue: () => void;
   }
 
   export interface EditConfig<T, V = any> {
@@ -452,6 +456,13 @@ export namespace TableProps {
      * Determines whether inline edit for certain items is disabled, and provides a reason why.
      */
     disabledReason?: (item: T) => string | undefined;
+
+    /**
+     * Disables the use of a `<form>` element to capture submissions inside the inline editor.
+     * If enabled, ensure that any text inputs in the editing cell submit the cell value when
+     * the Enter key is pressed, using `cellContext.submitValue`.
+     */
+    disableNativeForm?: boolean;
   }
 
   export type ColumnDefinition<ItemType> = {


### PR DESCRIPTION
### Description

See 8vYGAsYRWx2h for API proposal.

Related links, issue #, if available: AWSUI-60735

### How has this been tested?

Unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
