### PR TITLE
fix: Skip popover position updates if it happened offscreen

### DIFF
--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -4,7 +4,7 @@ import React, { useLayoutEffect, useRef } from 'react';
 import clsx from 'clsx';
 
 import { nodeContains } from '@cloudscape-design/component-toolkit/dom';
-import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
+import { getLogicalBoundingClientRect, useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { InternalPosition, PopoverProps } from './interfaces';
@@ -18,7 +18,7 @@ interface PopoverContainerProps {
   getTrack?: () => null | HTMLElement | SVGElement;
   /**
     Used to update the container position in case track or track position changes:
-    
+
     const trackRef = useRef<Element>(null)
     return (<>
       <Track style={getPosition(selectedItemId)} ref={trackRef} />
@@ -128,6 +128,13 @@ export default function PopoverContainer({
         // so no need to update its position either in this case.
         nodeContains(getTrack.current(), event.target)
       ) {
+        return;
+      }
+
+      // Do not update position if popover moved offscreen
+      const popoverOffset = popoverRef.current && getLogicalBoundingClientRect(popoverRef.current);
+      // istanbul ignore if - tested via integration tests
+      if (!popoverOffset || popoverOffset.insetBlockStart < 0 || popoverOffset.insetBlockEnd > window.innerHeight) {
         return;
       }
 


### PR DESCRIPTION
### Description

Fixing this bug: AWSUI-60831

Related links, issue #, if available: n/a

### How has this been tested?

Added a new integration test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
