### PR TITLE
fix: Use role="application" for two-dimensional drag handles

### DIFF
--- a/src/internal/components/drag-handle/__tests__/drag-handle-button.test.tsx
+++ b/src/internal/components/drag-handle/__tests__/drag-handle-button.test.tsx
@@ -53,10 +53,10 @@ test('assigns aria-labelledby attribute', () => {
   expect(document.querySelector(`.${styles.handle}`)).toHaveAccessibleName('custom label');
 });
 
-test('has role="button" by default', () => {
+test('has role="application" if no ariaValue is provided', () => {
   render(<DragHandleButton ariaLabel="drag handle" />);
 
-  expect(screen.getByRole('button')).toHaveAccessibleName('drag handle');
+  expect(screen.getByRole('application')).toHaveAccessibleName('drag handle');
 });
 
 test('has role="slider" and aria-value attributes when ariaValue is set', () => {

--- a/src/internal/components/drag-handle/button.tsx
+++ b/src/internal/components/drag-handle/button.tsx
@@ -53,7 +53,7 @@ const DragHandleButton = forwardRef(
       // when it is being dragged.
       <div
         ref={useMergeRefs(ref, dragHandleRefObject)}
-        role={ariaValue ? 'slider' : 'button'}
+        role={ariaValue ? 'slider' : 'application'}
         tabIndex={0}
         className={clsx(
           className,


### PR DESCRIPTION
### Description

NVDA just skips past buttons if you use arrow keys on them while they're focused. Because pressing arrow keys on a button shouldn't do anything. The thing is, we don't have a role we could could for something like this, which means we fall back to our "I give up" ("application") role.

Related links, issue #, if available: AWSUI-60203

### How has this been tested?

Modified a unit test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
