### PR TITLE
fix: Wrap long key names in chart detail popovers

### DIFF
--- a/pages/common/popover-drilldown-sample-data.ts
+++ b/pages/common/popover-drilldown-sample-data.ts
@@ -31,6 +31,35 @@ export default [
     ],
   },
   {
+    title: 'AWS-MiscellaneousOverflowingStringNameService',
+    data: [
+      {
+        x: '2023-04-01',
+        y: 0,
+      },
+      {
+        x: '2023-05-01',
+        y: 12,
+      },
+      {
+        x: '2023-06-01',
+        y: 31,
+      },
+      {
+        x: '2023-07-01',
+        y: 52,
+      },
+      {
+        x: '2023-08-01',
+        y: 24,
+      },
+      {
+        x: '2023-09-01',
+        y: 4,
+      },
+    ],
+  },
+  {
     title: 'Amazon Relational Database Service',
     data: [
       {

--- a/src/internal/components/chart-series-details/styles.scss
+++ b/src/internal/components/chart-series-details/styles.scss
@@ -36,6 +36,7 @@ $font-weight-bold: awsui.$font-weight-heading-s;
   justify-content: space-between;
   inline-size: 100%;
   > .key {
+    @include styles.text-wrapping;
     display: inline-flex;
     color: awsui.$color-text-group-label;
   }

--- a/src/mixed-line-bar-chart/__integ__/announcements.test.ts
+++ b/src/mixed-line-bar-chart/__integ__/announcements.test.ts
@@ -8,11 +8,11 @@ describe('Popover content is announced as plain text on hover', () => {
     const alwaysVisibleTexts = [
       'Jun 2023',
       'Amazon Simple Storage Service $69.80',
-      'Amazon Relational Database Service $35.96',
-      'Group 1 $83.31',
-      'Group 2 $114.17',
+      'AWS-MiscellaneousOverflowingStringNameService $31.00',
+      'Group 1 $76.02',
+      'Group 2 $157.42',
     ];
-    const group1SubItemsTexts = ['AWS Config $40.06', 'AWS Key Management Service $43.25'];
+    const group1SubItemsTexts = ['Amazon Relational Database Service $35.96', 'AWS Config $40.06'];
 
     test(
       'without expandable sub-items',


### PR DESCRIPTION
### Description

Classic `min-width: 0` and `word-break: break-word`. Tried applying it to the value as well, but it then started breaking currency values at separators, which looked really bad. So just wrapping the keys.

Fun fact: `word-break: break-word` and `word-wrap: break-word` are both technically deprecated, so they're maybe worth fixing separately. Don't want to wrap it up in this PR — too risky.

Related links, issue #, if available: AWSUI-60885

### How has this been tested?

Made changes to screenshot-covered pages.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
