### PR TITLE
chore: Document options limit on segmented control

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -15737,7 +15737,8 @@ the label is visible and attached to the select component, unless \`ariaLabelled
       "type": "string",
     },
     {
-      "description": "An array of objects representing options. Each segment has the following properties:
+      "description": "An array of objects representing options. Only up to 6 options are supported.
+Each segment has the following properties:
 
 - \`id\` (string) - The ID of the segment.
 - \`disabled\` [boolean] - (Optional) Determines whether the segment is disabled, which prevents the user from selecting it.

--- a/src/segmented-control/interfaces.ts
+++ b/src/segmented-control/interfaces.ts
@@ -13,7 +13,8 @@ export interface SegmentedControlProps extends BaseComponentProps {
   selectedId: string | null;
 
   /**
-   * An array of objects representing options. Each segment has the following properties:
+   * An array of objects representing options. Only up to 6 options are supported.
+   * Each segment has the following properties:
    *
    * - `id` (string) - The ID of the segment.
    * - `disabled` [boolean] - (Optional) Determines whether the segment is disabled, which prevents the user from selecting it.


### PR DESCRIPTION
### Description
Add documentation on the maximum number of options for segmented control.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
