### PR TITLE
chore: Update supported Safari versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,12 @@ We support
 
 ## Browsers support
 
-We support the latest 3 major versions of these browsers for desktop.
-
+We support the latest 3 *major* versions of these browsers for desktop:
 - Google Chrome
 - Mozilla Firefox
 - Microsoft Edge
-- Apple Safari for macOS
+
+and the latest three *minor* versions of Apple Safari for macOS for desktop.
 
 We do not support Microsoft Internet Explorer or mobile browsers. We support all viewport sizes across desktop browsers.
 

--- a/package.json
+++ b/package.json
@@ -172,6 +172,6 @@
     "last 3 Chrome major versions",
     "last 3 Firefox major versions",
     "last 3 Edge major versions",
-    "last 3 Safari major versions"
+    "last 3 Safari versions"
   ]
 }


### PR DESCRIPTION
### Description

Until recently, we supported the latest three major versions of Safari.
This has changed. We do now support the latest three minor versions of Safari for macOS. This aligns with https://repost.aws/knowledge-center/browsers-management-console



Related links, issue #, if available: `AWSUI-60833`

### How has this been tested?

- Reviewed manually.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
