### PR TITLE
chore: Disabled animations in Button screenshot area

### DIFF
--- a/pages/button/style-custom-types.page.tsx
+++ b/pages/button/style-custom-types.page.tsx
@@ -11,7 +11,7 @@ import ScreenshotArea from '../utils/screenshot-area';
 
 export default function CustomButtonTypes() {
   return (
-    <ScreenshotArea>
+    <ScreenshotArea disableAnimations={true}>
       <h1>Custom Button Types</h1>
 
       <SpaceBetween direction="horizontal" size="m">


### PR DESCRIPTION
This PR disables animations in the screenshot are for the Button custom types demo page.