### PR TITLE
chore: Use CSS-native :focus-visible to track visible focus state (batch 2)

### DIFF
--- a/src/internal/components/abstract-switch/styles.scss
+++ b/src/internal/components/abstract-switch/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 .content,
 .description,
@@ -21,14 +20,6 @@
   display: none;
   &.show-outline {
     display: block;
-  }
-}
-
-.native-input {
-  @include focus-visible.when-visible {
-    & + .outline {
-      display: block;
-    }
   }
 }
 
@@ -86,4 +77,8 @@
     margin-inline: 0;
   }
   /* stylelint-enable selector-max-type */
+}
+
+.native-input:focus-visible + .outline {
+  display: block;
 }

--- a/src/internal/components/button-trigger/styles.scss
+++ b/src/internal/components/button-trigger/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use '../../../token-group/constants' as tokenGroup;
 
 @use './motion';
@@ -46,7 +45,7 @@ $padding-block-inner-filtering-token: 0px;
     block-size: 100%;
     min-block-size: unset;
 
-    @include focus-visible.when-visible {
+    &:focus-visible {
       @include styles.focus-highlight(awsui.$space-filtering-token-operation-select-focus-outline-gutter);
     }
   }
@@ -111,7 +110,7 @@ $padding-block-inner-filtering-token: 0px;
   }
 
   &:not(.in-filtering-token) {
-    @include focus-visible.when-visible {
+    &:focus-visible {
       @include styles.form-focus-element();
     }
 

--- a/src/internal/components/chart-legend/styles.scss
+++ b/src/internal/components/chart-legend/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use './motion';
 
 .root {
@@ -46,7 +45,7 @@
     outline: none;
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.focus-highlight(2px);
   }
 

--- a/src/internal/components/menu-dropdown/styles.scss
+++ b/src/internal/components/menu-dropdown/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 .button {
   @include styles.styles-reset;
@@ -59,7 +58,7 @@
     margin-inline-end: awsui.$space-xl;
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     // -1px because the button touches the edges of the top navigation.
     @include styles.focus-highlight(-1px);
   }

--- a/src/internal/components/panel-resize-handle/styles.scss
+++ b/src/internal/components/panel-resize-handle/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 .slider {
   padding-block: 0;
@@ -22,7 +21,7 @@
     outline: none;
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.focus-highlight(0px);
   }
 }

--- a/src/internal/components/token-list/styles.scss
+++ b/src/internal/components/token-list/styles.scss
@@ -6,7 +6,6 @@
 @use '../../styles/tokens' as awsui;
 @use '../../styles' as styles;
 @use '../../../file-token-group/constants' as constants;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 .root {
   gap: awsui.$space-scaled-xs;
@@ -94,7 +93,7 @@
     text-decoration-color: transparent;
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.focus-element-without-border(awsui.$border-radius-control-default-focus-ring);
   }
 

--- a/src/internal/styles/links.scss
+++ b/src/internal/styles/links.scss
@@ -8,7 +8,6 @@
 @use './motion' as styles;
 @use './typography/' as typography;
 @use './forms/' as mixins;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use '../../link/constants.scss' as constants;
 
 @mixin link-variant-style($variant) {

--- a/src/link/styles.scss
+++ b/src/link/styles.scss
@@ -6,7 +6,6 @@
 @use 'sass:map';
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use './constants' as constants;
 
 .link {
@@ -44,7 +43,7 @@
     }
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.link-focus;
   }
 

--- a/src/pagination/styles.scss
+++ b/src/pagination/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../internal/styles/index' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 .root {
   @include styles.styles-reset;
@@ -40,7 +39,7 @@
     outline: none;
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.focus-element-without-border(awsui.$border-radius-control-default-focus-ring);
   }
 

--- a/src/popover/styles.scss
+++ b/src/popover/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 @import './arrow';
 @import './body';
@@ -77,7 +76,7 @@ $trigger-underline-offset: 0.25em;
     outline: none;
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.focus-highlight(1px);
   }
 }

--- a/src/prompt-input/styles.scss
+++ b/src/prompt-input/styles.scss
@@ -8,7 +8,6 @@
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/styles/foundation/' as foundation;
 @use '../internal/styles/forms/constants' as constants;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 $send-icon-right-spacing: awsui.$space-static-xxs;
 $invalid-border-offset: constants.$invalid-control-left-padding;
@@ -145,7 +144,7 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
     padding: 0;
 
     // offset the focus ring by 1px per side so it doesn't blend into the textarea border
-    @include focus-visible.when-visible {
+    &:focus-visible {
       @include styles.focus-highlight(
         (
           'vertical': calc((-1 * #{awsui.$space-xxxs}) - 1px),

--- a/src/property-filter/filtering-token/styles.scss
+++ b/src/property-filter/filtering-token/styles.scss
@@ -3,7 +3,6 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;
 @use '../../token-group/constants' as constants;
@@ -118,7 +117,7 @@ $border-radius-inner-token: calc(#{awsui.$border-radius-token} / 2);
   background-color: transparent;
   border-inline-start: awsui.$border-width-button solid constants.$token-border-color;
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.focus-highlight(awsui.$space-filtering-token-dismiss-button-focus-outline-gutter);
   }
 

--- a/src/radio-group/styles.scss
+++ b/src/radio-group/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 $radio-size: awsui.$size-control;
 

--- a/src/segmented-control/segment.scss
+++ b/src/segmented-control/segment.scss
@@ -7,7 +7,6 @@
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/styles' as styles;
 @use '../button/constants' as constants;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 $segment-properties: (
   'default-background': awsui.$color-background-segment-default,
@@ -74,7 +73,7 @@ $segment-divider-width: 1px;
     color: $disabled-color;
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.focus-highlight(awsui.$space-segmented-control-focus-outline-gutter);
   }
 

--- a/src/select/parts/styles.scss
+++ b/src/select/parts/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 .placeholder {
   @include styles.form-placeholder;

--- a/src/side-navigation/styles.scss
+++ b/src/side-navigation/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 .root {
   @include styles.styles-reset;
@@ -177,7 +176,7 @@
     text-decoration: none;
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.link-focus;
   }
 }

--- a/src/tabs/styles.scss
+++ b/src/tabs/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 @import './tab-header-bar';
 
@@ -32,7 +31,7 @@
 .tabs-content-active {
   display: block;
   flex: 1;
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.container-focus();
   }
 }

--- a/src/tabs/tab-header-bar.scss
+++ b/src/tabs/tab-header-bar.scss
@@ -6,7 +6,6 @@
 /* stylelint-disable selector-max-type */
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 $separator-color: awsui.$color-border-tabs-divider;
 $label-horizontal-spacing: awsui.$space-xs;
@@ -213,7 +212,7 @@ $label-horizontal-spacing: awsui.$space-xs;
     outline: none;
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     z-index: 1;
     border-inline-end-color: transparent;
     @include styles.focus-highlight(awsui.$space-tabs-focus-outline-gutter);

--- a/src/tag-editor/styles.scss
+++ b/src/tag-editor/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 .root {
   /* used in test utils */
@@ -18,7 +17,7 @@
 .undo-button {
   @include styles.link-recovery('body-m');
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.link-focus;
   }
 }

--- a/src/toggle/styles.scss
+++ b/src/toggle/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 $toggle-width: 2.4 * styles.$base-size;
 $toggle-height: 1.6 * styles.$base-size;

--- a/src/token-group/styles.scss
+++ b/src/token-group/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use './constants' as constants;
 @use './mixins.scss' as mixins;
 
@@ -29,7 +28,7 @@
   color: awsui.$color-text-button-inline-icon-default;
   background-color: transparent;
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.focus-highlight(0px);
   }
 

--- a/src/top-navigation/1.0-beta/styles.scss
+++ b/src/top-navigation/1.0-beta/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 .top-navigation {
   @include styles.styles-reset;
@@ -61,7 +60,7 @@
     &:hover {
       color: awsui.$color-text-accent;
     }
-    @include focus-visible.when-visible {
+    &:focus-visible {
       @include styles.link-focus;
     }
   }

--- a/src/top-navigation/styles.scss
+++ b/src/top-navigation/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 .top-navigation {
   @include styles.styles-reset;
@@ -68,7 +67,7 @@
       color: awsui.$color-text-accent;
     }
 
-    @include focus-visible.when-visible {
+    &:focus-visible {
       @include styles.link-focus;
     }
   }
@@ -292,7 +291,7 @@
     }
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
   }
 }

--- a/src/tutorial-panel/components/tutorial-list/styles.scss
+++ b/src/tutorial-panel/components/tutorial-list/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../../internal/styles/tokens' as awsui;
 @use '../../../internal/styles' as styles;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 @use './motion';
 
@@ -110,7 +109,7 @@
     text-decoration-color: currentColor;
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.link-focus;
   }
 }

--- a/src/wizard/styles.scss
+++ b/src/wizard/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use '../internal/generated/custom-css-properties/index.scss' as custom-props;
 
 .root {
@@ -96,7 +95,7 @@
           grid-column: 2;
         }
 
-        @include focus-visible.when-visible {
+        &:focus-visible {
           @include styles.link-focus;
         }
       }
@@ -272,7 +271,7 @@
 .form-header-component {
   &-wrapper {
     outline: none;
-    @include focus-visible.when-visible {
+    &:focus-visible {
       @include styles.link-focus;
     }
   }


### PR DESCRIPTION
### Description

Reducing the potential blast radius of a visual change that affects tons of components. I'll be removing the internal JS-based `focus-visible` solution in individual batches. This one is just the second half alphabetically, excluding any weird ones that made me have to adjust tests.

See #3585 for the big original PR.

Related links, issue #, if available: AWSUI-60845

### How has this been tested?

Tested the whole big PR in my dev pipeline, and the individual changes just manually.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
