### PR TITLE
chore: Use CSS-native :focus-visible to track visible focus state (batch 3)

### DIFF
--- a/src/app-layout/drawer/styles.scss
+++ b/src/app-layout/drawer/styles.scss
@@ -4,7 +4,6 @@
 */
 @use '../../internal/styles/tokens' as awsui;
 @use '../../internal/styles' as styles;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use '../constants' as constants;
 
 .toggle {

--- a/src/app-layout/toggles/styles.scss
+++ b/src/app-layout/toggles/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../internal/styles/tokens' as awsui;
 @use '../../internal/styles' as styles;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 .toggle-button {
   cursor: pointer;
@@ -22,7 +21,7 @@
     outline: none;
     text-decoration: none;
   }
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.focus-highlight(awsui.$space-button-inline-icon-focus-outline-gutter);
   }
 }

--- a/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../../../internal/styles' as styles;
 @use '../../../../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 .trigger {
   // reset native <button> tag styles

--- a/src/app-layout/visual-refresh/trigger-button.scss
+++ b/src/app-layout/visual-refresh/trigger-button.scss
@@ -5,7 +5,6 @@
 
 @use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 @mixin trigger-selected-styles {
   background: awsui.$color-background-layout-toggle-selected-default;
@@ -69,7 +68,7 @@ handleSplitPanelMaxWidth function in the context.
   pointer-events: auto;
   position: relative;
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.focus-highlight(3px);
   }
 

--- a/src/file-input/styles.scss
+++ b/src/file-input/styles.scss
@@ -4,7 +4,6 @@
 */
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/styles' as styles;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 .root,
 .file-input {
@@ -16,20 +15,19 @@
 }
 
 .file-input-button {
-  @include focus-visible.when-visible-unfocused {
-    &.force-focus-outline {
-      &-icon {
-        @include styles.focus-highlight(
-          (
-            'vertical': awsui.$space-button-icon-focus-outline-gutter-vertical,
-            'horizontal': awsui.$space-button-focus-outline-gutter,
-          )
-        );
-      }
+  // stylelint-disable-next-line selector-combinator-disallowed-list
+  body:has(:focus-visible) &.force-focus-outline {
+    &-icon {
+      @include styles.focus-highlight(
+        (
+          'vertical': awsui.$space-button-icon-focus-outline-gutter-vertical,
+          'horizontal': awsui.$space-button-focus-outline-gutter,
+        )
+      );
+    }
 
-      &-button {
-        @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
-      }
+    &-button {
+      @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
     }
   }
 }

--- a/src/internal/components/drag-handle-wrapper/index.tsx
+++ b/src/internal/components/drag-handle-wrapper/index.tsx
@@ -45,7 +45,7 @@ export default function DragHandleWrapper({
     // handled in the "pointerup" listener instead. In cases where focus is moved
     // to the button (by manually calling `.focus()`, the buttons should only appear)
     // if the action that triggered the focus move was the result of a keypress.
-    if (document.body.dataset.awsuiFocusVisible && !nodeContains(wrapperRef.current, event.relatedTarget)) {
+    if (document.body.matches('body:has(:focus-visible)') && !nodeContains(wrapperRef.current, event.relatedTarget)) {
       setShowTooltip(false);
       if (triggerMode === 'focus') {
         setShowButtons(true);

--- a/src/internal/components/drag-handle/__tests__/test-utils.test.tsx
+++ b/src/internal/components/drag-handle/__tests__/test-utils.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 import InternalDragHandle from '../../../../../lib/components/internal/components/drag-handle/index.js';
 import InternalDragHandleWrapper from '../../../../../lib/components/test-utils/dom/internal/drag-handle';
@@ -25,8 +25,8 @@ describe('test util selectors', () => {
     const handle = container.querySelector<HTMLButtonElement>(`.${InternalDragHandleWrapper.rootSelector}`)!;
 
     if (showUapActions) {
-      document.body.dataset.awsuiFocusVisible = 'true';
-      handle.focus();
+      fireEvent.pointerDown(handle);
+      fireEvent.pointerUp(handle);
     }
 
     return {

--- a/src/internal/components/drag-handle/styles.scss
+++ b/src/internal/components/drag-handle/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 .handle {
   appearance: none;
@@ -66,7 +65,7 @@
     text-decoration: none;
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     &:not(.hide-focus) {
       @include styles.focus-highlight(0px);
     }

--- a/src/internal/components/sortable-area/styles.scss
+++ b/src/internal/components/sortable-area/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 @mixin animated {
   @include styles.with-motion {
@@ -19,7 +18,8 @@
   border-end-start-radius: $border-radius;
   border-end-end-radius: $border-radius;
 
-  @include focus-visible.when-visible-unfocused {
+  // stylelint-disable-next-line selector-combinator-disallowed-list
+  body:has(:focus-visible) & {
     @include styles.focus-highlight(0px, $border-radius);
   }
 }

--- a/src/split-panel/styles.scss
+++ b/src/split-panel/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use '../app-layout/constants' as constants;
 
 $slider-width: 16px;

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 $cell-vertical-padding: awsui.$space-scaled-xs;
 // Calculate padding to prevent a shift in content after selection due to the difference
@@ -404,7 +403,7 @@ $cell-negative-space-vertical: 2px;
     }
 
     &-focusable {
-      @include focus-visible.when-visible {
+      &:focus-visible {
         // Making focus outline slightly smaller to not intersect with the success indicator.
         @include safe-focus-highlight(-1px);
       }
@@ -546,7 +545,7 @@ $cell-negative-space-vertical: 2px;
     }
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include cell-focus-outline;
   }
 }

--- a/src/table/expandable-rows/styles.scss
+++ b/src/table/expandable-rows/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../internal/styles/index' as styles;
 @use '../../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 @use './motion';
 
@@ -40,7 +39,7 @@
   outline: 0;
   color: awsui.$color-text-interactive-default;
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.focus-highlight(awsui.$space-button-inline-icon-focus-outline-gutter);
   }
 

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -3,20 +3,18 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use '../../internal/styles/tokens' as awsui;
 @use '../../internal/styles' as styles;
 
 $cell-horizontal-padding: awsui.$space-scaled-l;
 
 @mixin when-focus-visible-or-fake {
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @content;
   }
-  &.header-cell-fake-focus {
-    @include focus-visible.when-visible-unfocused {
-      @content;
-    }
+  // stylelint-disable-next-line selector-combinator-disallowed-list
+  body:has(:focus-visible) &.header-cell-fake-focus {
+    @content;
   }
 }
 

--- a/src/table/resizer/styles.scss
+++ b/src/table/resizer/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../internal/styles/index' as styles;
 @use '../../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 //stylelint-disable-next-line selector-combinator-disallowed-list,selector-max-universal
 .resize-active:not(.resize-active-with-focus) * {
@@ -66,12 +65,13 @@ th:not(:last-child) > .divider {
   &:hover + .divider {
     border-inline-start: $active-separator-width solid awsui.$color-border-divider-active;
   }
-  &.has-focus {
-    @include focus-visible.when-visible-unfocused {
-      @include styles.focus-highlight(calc(#{awsui.$space-table-header-focus-outline-gutter} - 2px));
-      & {
-        position: absolute;
-      }
+  // stylelint-disable-next-line selector-combinator-disallowed-list
+  body:has(:focus-visible) &.has-focus {
+    @include styles.focus-highlight(calc(#{awsui.$space-table-header-focus-outline-gutter} - 2px));
+    // Required to avoid SASS mixed declarations warning (https://sass-lang.com/d/mixed-decls)
+    // stylelint-disable-next-line no-duplicate-selectors
+    & {
+      position: absolute;
     }
   }
 }

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../internal/styles/index' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use '../container/shared' as container;
 
 .root {
@@ -87,7 +86,7 @@
     display: none; /* Hide scrollbar in Safari and Chrome */
   }
 
-  @include focus-visible.when-visible {
+  &:focus-visible {
     @include styles.container-focus();
   }
 }


### PR DESCRIPTION
### Description

Reducing the potential blast radius of a visual change that affects tons of components. I'll be removing the internal JS-based `focus-visible` solution in individual batches. This one contains all the weird interesting changes I've had to make, but it's the last one before I remove `useFocusVisible()` from the components package entirely.

See #3585 for the big original PR.

Related links, issue #, if available: AWSUI-60845

### How has this been tested?

Tested the whole big PR in my dev pipeline, and the individual changes just manually.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
