### PR TITLE
chore: Add i18n translations for tree view and date range picker

### DIFF
--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -192,6 +192,12 @@ export interface I18nFormatArgTypes {
     "i18nStrings.endTimeLabel": never;
     "i18nStrings.dateTimeConstraintText": never;
     "i18nStrings.dateConstraintText": never;
+    "i18nStrings.slashedDateTimeConstraintText": never;
+    "i18nStrings.isoDateTimeConstraintText": never;
+    "i18nStrings.slashedDateConstraintText": never;
+    "i18nStrings.isoDateConstraintText": never;
+    "i18nStrings.slashedMonthConstraintText": never;
+    "i18nStrings.isoMonthConstraintText": never;
     "i18nStrings.monthConstraintText": never;
     "i18nStrings.errorIconAriaLabel": never;
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": {
@@ -513,6 +519,10 @@ export interface I18nFormatArgTypes {
     "i18nStrings.overflowMenuDismissIconAriaLabel": never;
     "i18nStrings.overflowMenuBackIconAriaLabel": never;
     "i18nStrings.overflowMenuTitleText": never;
+  }
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": never;
+    "i18nStrings.collapseButtonLabel": never;
   }
   "tutorial-panel": {
     "i18nStrings.loadingText": never;

--- a/src/i18n/messages/all.ar.json
+++ b/src/i18n/messages/all.ar.json
@@ -156,6 +156,12 @@
     "i18nStrings.endTimeLabel": "وقت الانتهاء",
     "i18nStrings.dateTimeConstraintText": "استخدم الصيغة YYYY/MM/DD للتاريخ، وصيغة 24 ساعة للوقت.",
     "i18nStrings.dateConstraintText": "للحصول على التاريخ، استخدم الصيغة YYYY/MM/DD.",
+    "i18nStrings.slashedDateTimeConstraintText": "استخدم الصيغة YYYY/MM/DD للتاريخ، وصيغة 24 ساعة للوقت.",
+    "i18nStrings.isoDateTimeConstraintText": "استخدم الصيغة YYYY-MM-DD للتاريخ، وصيغة 24 ساعة للوقت.",
+    "i18nStrings.slashedDateConstraintText": "للحصول على التاريخ، استخدم الصيغة YYYY/MM/DD.",
+    "i18nStrings.isoDateConstraintText": "للحصول على التاريخ، استخدم الصيغة YYYY-MM-DD.",
+    "i18nStrings.slashedMonthConstraintText": "للحصول على الشهر، استخدم الصيغة YYYY/MM.",
+    "i18nStrings.isoMonthConstraintText": "للحصول على الشهر، استخدم الصيغة YYYY-MM.",
     "i18nStrings.monthConstraintText": "للحصول على الشهر، استخدم الصيغة YYYY/MM.",
     "i18nStrings.errorIconAriaLabel": "خطأ",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "النطاق المحدد من {startDate} إلى {endDate}",
@@ -403,6 +409,10 @@
     "i18nStrings.overflowMenuDismissIconAriaLabel": "إغلاق القائمة",
     "i18nStrings.overflowMenuBackIconAriaLabel": "العودة إلى الصفحة السابقة",
     "i18nStrings.overflowMenuTitleText": "الكل"
+  },
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": "توسيع",
+    "i18nStrings.collapseButtonLabel": "تحجيم"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "جار التحميل",

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -93,7 +93,7 @@
     "i18nStrings.resizeHandleTooltipText": "Zum Ändern der Größe ziehen oder auswählen"
   },
   "collection-preferences": {
-    "title": "Präferenzen",
+    "title": "Einstellungen",
     "confirmLabel": "Bestätigen",
     "cancelLabel": "Abbrechen",
     "pageSizePreference.title": "Seitengröße",
@@ -156,6 +156,12 @@
     "i18nStrings.endTimeLabel": "Endzeit",
     "i18nStrings.dateTimeConstraintText": "Verwenden Sie für Datum JJJJ/MM/TT. Verwenden Sie für die Zeit das 24-Stunden-Format.",
     "i18nStrings.dateConstraintText": "Verwenden Sie für Datum JJJJ/MM/TT.",
+    "i18nStrings.slashedDateTimeConstraintText": "Verwenden Sie für das Datum das Format JJJJ/MM/TT. Verwenden Sie für die Zeit das 24-Stunden-Format.",
+    "i18nStrings.isoDateTimeConstraintText": "Verwenden Sie für das Datum das Format JJJJ-MM-TT. Verwenden Sie für die Zeit das 24-Stunden-Format.",
+    "i18nStrings.slashedDateConstraintText": "Verwenden Sie für das Datum das Format JJJJ/MM/TT.",
+    "i18nStrings.isoDateConstraintText": "Verwenden Sie für das Datum das Format JJJJ-MM-TT.",
+    "i18nStrings.slashedMonthConstraintText": "Verwenden Sie für den Monat das Format JJJJ/MM.",
+    "i18nStrings.isoMonthConstraintText": "Verwenden Sie für den Monat das Format JJJJ-MM.",
     "i18nStrings.monthConstraintText": "Verwenden Sie für Monat JJJJ/MM.",
     "i18nStrings.errorIconAriaLabel": "Fehler",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Bereich ausgewählt von {startDate} bis {endDate}",
@@ -403,6 +409,10 @@
     "i18nStrings.overflowMenuDismissIconAriaLabel": "Menü schließen",
     "i18nStrings.overflowMenuBackIconAriaLabel": "Zurück",
     "i18nStrings.overflowMenuTitleText": "Alle"
+  },
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": "Erweitern",
+    "i18nStrings.collapseButtonLabel": "Minimieren"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "Wird geladen",

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -156,6 +156,12 @@
     "i18nStrings.endTimeLabel": "End time",
     "i18nStrings.dateTimeConstraintText": "For date, use DD/MM/YYYY. For time, use 24-hr format.",
     "i18nStrings.dateConstraintText": "For date, use YYYY/MM/DD.",
+    "i18nStrings.slashedDateTimeConstraintText": "For date, use DD/MM/YYYY. For time, use 24-hr format.",
+    "i18nStrings.isoDateTimeConstraintText": "For date, use DD/MM/YYYY. For time, use 24-hr format.",
+    "i18nStrings.slashedDateConstraintText": "For date, use DD/MM/YYYY.",
+    "i18nStrings.isoDateConstraintText": "For date, use DD/MM/YYYY.",
+    "i18nStrings.slashedMonthConstraintText": "For month, use MM/YYYY.",
+    "i18nStrings.isoMonthConstraintText": "For month, use MM/YYYY.",
     "i18nStrings.monthConstraintText": "For month, use YYYY/MM.",
     "i18nStrings.errorIconAriaLabel": "Error",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Range selected from {startDate} to {endDate}",
@@ -403,6 +409,10 @@
     "i18nStrings.overflowMenuDismissIconAriaLabel": "Close menu",
     "i18nStrings.overflowMenuBackIconAriaLabel": "Back",
     "i18nStrings.overflowMenuTitleText": "All"
+  },
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": "Expand",
+    "i18nStrings.collapseButtonLabel": "Collapse"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "Loading",

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -156,6 +156,12 @@
     "i18nStrings.endTimeLabel": "End time",
     "i18nStrings.dateTimeConstraintText": "For date, use YYYY/MM/DD. For time, use 24 hr format.",
     "i18nStrings.dateConstraintText": "For date, use YYYY/MM/DD.",
+    "i18nStrings.slashedDateTimeConstraintText": "For date, use YYYY/MM/DD. For time, use 24 hr format.",
+    "i18nStrings.isoDateTimeConstraintText": "For date, use YYYY-MM-DD. For time, use 24 hr format.",
+    "i18nStrings.slashedDateConstraintText": "For date, use YYYY/MM/DD.",
+    "i18nStrings.isoDateConstraintText": "For date, use YYYY-MM-DD.",
+    "i18nStrings.slashedMonthConstraintText": "For month, use YYYY/MM.",
+    "i18nStrings.isoMonthConstraintText": "For month, use YYYY-MM.",
     "i18nStrings.monthConstraintText": "For month, use YYYY/MM.",
     "i18nStrings.errorIconAriaLabel": "Error",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Range selected from {startDate} to {endDate}",
@@ -403,6 +409,10 @@
     "i18nStrings.overflowMenuDismissIconAriaLabel": "Close menu",
     "i18nStrings.overflowMenuBackIconAriaLabel": "Back",
     "i18nStrings.overflowMenuTitleText": "All"
+  },
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": "Expand",
+    "i18nStrings.collapseButtonLabel": "Collapse"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "Loading",

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -156,6 +156,12 @@
     "i18nStrings.endTimeLabel": "Hora de finalización",
     "i18nStrings.dateTimeConstraintText": "Para la fecha, utilice AAAA/MM/DD. Para la hora, utilice el formato de 24 horas.",
     "i18nStrings.dateConstraintText": "Para la fecha, use el formato AAAA/MM/DD.",
+    "i18nStrings.slashedDateTimeConstraintText": "Para la fecha, use AAAA/MM/DD. Para la hora, use el formato de 24 horas.",
+    "i18nStrings.isoDateTimeConstraintText": "Para la fecha, use AAAA-MM-DD. Para la hora, use el formato de 24 horas.",
+    "i18nStrings.slashedDateConstraintText": "Para la fecha, use el formato AAAA/MM/DD.",
+    "i18nStrings.isoDateConstraintText": "Para la fecha, use el formato AAAA-MM-DD.",
+    "i18nStrings.slashedMonthConstraintText": "Para el mes, use el formato AAAA/MM.",
+    "i18nStrings.isoMonthConstraintText": "Para el mes, use el formato AAAA-MM.",
     "i18nStrings.monthConstraintText": "Para el mes, use el formato AAAA/MM.",
     "i18nStrings.errorIconAriaLabel": "Error",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Rango seleccionado de {startDate} a {endDate}",
@@ -403,6 +409,10 @@
     "i18nStrings.overflowMenuDismissIconAriaLabel": "Cerrar menú",
     "i18nStrings.overflowMenuBackIconAriaLabel": "Volver",
     "i18nStrings.overflowMenuTitleText": "Todos"
+  },
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": "Ampliar",
+    "i18nStrings.collapseButtonLabel": "Contraer"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "Cargando",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -66,7 +66,7 @@
     "i18nStrings.currentMonthAriaLabel": "Mois en cours"
   },
   "cards": {
-    "ariaLabels.selectionGroupLabel": "Sélection de l'élément"
+    "ariaLabels.selectionGroupLabel": "Sélection de l’élément"
   },
   "code-editor": {
     "i18nStrings.loadingState": "Chargement de l'éditeur de code en cours",
@@ -156,6 +156,12 @@
     "i18nStrings.endTimeLabel": "Heure de fin",
     "i18nStrings.dateTimeConstraintText": "Pour la date, utilisez le format AAAA/MM/JJ. Pour l'heure, utilisez le format 24 heures.",
     "i18nStrings.dateConstraintText": "Pour la date, utilisez le format AAAA/MM/JJ.",
+    "i18nStrings.slashedDateTimeConstraintText": "Pour la date, utilisez le format JJ/MM/AAAA. Pour l’heure, utilisez le format 24 heures.",
+    "i18nStrings.isoDateTimeConstraintText": "Pour la date, utilisez le format JJ/MM/AAAA. Pour l’heure, utilisez le format 24 heures.",
+    "i18nStrings.slashedDateConstraintText": "Pour la date, utilisez le format JJ/MM/AAAA.",
+    "i18nStrings.isoDateConstraintText": "Pour la date, utilisez le format JJ/MM/AAAA.",
+    "i18nStrings.slashedMonthConstraintText": "Pour le mois, utilisez le format MM/AAAA.",
+    "i18nStrings.isoMonthConstraintText": "Pour le mois, utilisez le format MM/AAAA.",
     "i18nStrings.monthConstraintText": "Pour le mois, utilisez le format AAAA/MM.",
     "i18nStrings.errorIconAriaLabel": "Erreur",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Plage sélectionnée de {startDate} à {endDate}",
@@ -403,6 +409,10 @@
     "i18nStrings.overflowMenuDismissIconAriaLabel": "Fermer le menu",
     "i18nStrings.overflowMenuBackIconAriaLabel": "Retour",
     "i18nStrings.overflowMenuTitleText": "Tous"
+  },
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": "Élargir",
+    "i18nStrings.collapseButtonLabel": "Réduire"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "Chargement en cours",

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -156,6 +156,12 @@
     "i18nStrings.endTimeLabel": "Waktu berakhir",
     "i18nStrings.dateTimeConstraintText": "Untuk tanggal, gunakan HH/BB/TTTT. Untuk waktu, gunakan format 24 jam.",
     "i18nStrings.dateConstraintText": "Untuk tanggal, gunakan HH/BB/TTTT.",
+    "i18nStrings.slashedDateTimeConstraintText": "Untuk tanggal, gunakan HH/BB/TTTT. Untuk waktu, gunakan format 24 jam.",
+    "i18nStrings.isoDateTimeConstraintText": "Untuk tanggal, gunakan HH-BB-TTTT. Untuk waktu, gunakan format 24 jam.",
+    "i18nStrings.slashedDateConstraintText": "Untuk tanggal, gunakan HH/BB/TTTT.",
+    "i18nStrings.isoDateConstraintText": "Untuk tanggal, gunakan HH-BB-TTTT.",
+    "i18nStrings.slashedMonthConstraintText": "Untuk bulan, gunakan BB/TTTT.",
+    "i18nStrings.isoMonthConstraintText": "Untuk bulan, gunakan BB-TTTT.",
     "i18nStrings.monthConstraintText": "Untuk bulan, gunakan BB/TTTT.",
     "i18nStrings.errorIconAriaLabel": "Kesalahan",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Rentang dipilih dari {startDate} hingga {endDate}",
@@ -403,6 +409,10 @@
     "i18nStrings.overflowMenuDismissIconAriaLabel": "Tutup menu",
     "i18nStrings.overflowMenuBackIconAriaLabel": "Kembali",
     "i18nStrings.overflowMenuTitleText": "Semua"
+  },
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": "Luaskan",
+    "i18nStrings.collapseButtonLabel": "Ciutkan"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "Memuat",

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -156,6 +156,12 @@
     "i18nStrings.endTimeLabel": "Ora di fine",
     "i18nStrings.dateTimeConstraintText": "Per la data, utilizza il formato GG/MM/AAAA. Per l'ora, usa il formato 24 ore.",
     "i18nStrings.dateConstraintText": "Per la data, utilizza il formato GG/MM/AAAA.",
+    "i18nStrings.slashedDateTimeConstraintText": "Per la data, utilizza il formato GG/MM/AAAA. Per l'ora, utilizza il formato 24 ore.",
+    "i18nStrings.isoDateTimeConstraintText": "Per la data, utilizza il formato GG-MM-AAAA. Per l'ora, usa il formato 24 ore.",
+    "i18nStrings.slashedDateConstraintText": "Per la data, utilizza il formato GG/MM/AAAA.",
+    "i18nStrings.isoDateConstraintText": "Per la data, utilizza il formato GG-MM-AAAA.",
+    "i18nStrings.slashedMonthConstraintText": "Per il mese, utilizza il formato MM/AAAA.",
+    "i18nStrings.isoMonthConstraintText": "Per il mese, utilizza il formato MM-AAAA.",
     "i18nStrings.monthConstraintText": "Per il mese, utilizza il formato MM/AAAA.",
     "i18nStrings.errorIconAriaLabel": "Errore",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Intervallo selezionato da {startDate} a {endDate}",
@@ -403,6 +409,10 @@
     "i18nStrings.overflowMenuDismissIconAriaLabel": "Chiudi menu",
     "i18nStrings.overflowMenuBackIconAriaLabel": "Indietro",
     "i18nStrings.overflowMenuTitleText": "Tutti"
+  },
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": "Espandi",
+    "i18nStrings.collapseButtonLabel": "Comprimi"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "Caricamento in corso",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -156,6 +156,12 @@
     "i18nStrings.endTimeLabel": "終了時刻",
     "i18nStrings.dateTimeConstraintText": "日付には YYYY/MM/DD を使用します。時刻には 24 時間形式を使用します。",
     "i18nStrings.dateConstraintText": "日付には YYYY/MM/DD を使用してください。",
+    "i18nStrings.slashedDateTimeConstraintText": "日付には YYYY/MM/DD を使用します。時刻には 24 時間形式を使用します。",
+    "i18nStrings.isoDateTimeConstraintText": "日付には YYYY-MM-DD を使用します。時刻には 24 時間形式を使用します。",
+    "i18nStrings.slashedDateConstraintText": "日付には YYYY/MM/DD を使用してください。",
+    "i18nStrings.isoDateConstraintText": "日付には YYYY-MM-DD を使用してください。",
+    "i18nStrings.slashedMonthConstraintText": "月には YYYY/MM を使用してください。",
+    "i18nStrings.isoMonthConstraintText": "月には YYYY-MM を使用してください。",
     "i18nStrings.monthConstraintText": "月には YYYY/MM を使用してください。",
     "i18nStrings.errorIconAriaLabel": "エラー",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "{startDate} から {endDate} で選択された範囲",
@@ -403,6 +409,10 @@
     "i18nStrings.overflowMenuDismissIconAriaLabel": "メニューを閉じる",
     "i18nStrings.overflowMenuBackIconAriaLabel": "戻る",
     "i18nStrings.overflowMenuTitleText": "すべて"
+  },
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": "展開する",
+    "i18nStrings.collapseButtonLabel": "折りたたむ"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "ロード中",

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -156,6 +156,12 @@
     "i18nStrings.endTimeLabel": "종료 시간",
     "i18nStrings.dateTimeConstraintText": "날짜에는 YYYY/MM/DD를 사용합니다. 시간에는 24시간 형식을 사용합니다.",
     "i18nStrings.dateConstraintText": "날짜에는 YYYY/MM/DD를 사용합니다.",
+    "i18nStrings.slashedDateTimeConstraintText": "날짜에는 YYYY/MM/DD를 사용합니다. 시간에는 24시간 형식을 사용합니다.",
+    "i18nStrings.isoDateTimeConstraintText": "날짜에는 YYYY-MM-DD를 사용합니다. 시간에는 24시간 형식을 사용합니다.",
+    "i18nStrings.slashedDateConstraintText": "날짜에는 YYYY/MM/DD를 사용합니다.",
+    "i18nStrings.isoDateConstraintText": "날짜에는 YYYY-MM-DD를 사용합니다.",
+    "i18nStrings.slashedMonthConstraintText": "월에는 YYYY/MM을 사용합니다.",
+    "i18nStrings.isoMonthConstraintText": "월에는 YYYY-MM을 사용합니다.",
     "i18nStrings.monthConstraintText": "월에는 YYYY/MM을 사용합니다.",
     "i18nStrings.errorIconAriaLabel": "오류",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "{startDate}~{endDate}에서 선택한 범위",
@@ -403,6 +409,10 @@
     "i18nStrings.overflowMenuDismissIconAriaLabel": "메뉴 닫기",
     "i18nStrings.overflowMenuBackIconAriaLabel": "뒤로",
     "i18nStrings.overflowMenuTitleText": "모두"
+  },
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": "확장",
+    "i18nStrings.collapseButtonLabel": "축소"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "로드 중",

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -156,6 +156,12 @@
     "i18nStrings.endTimeLabel": "Horário de término",
     "i18nStrings.dateTimeConstraintText": "Para a data, use o formato AAAA/MM/DD. Para o horário, use o formato de 24 horas.",
     "i18nStrings.dateConstraintText": "Para data, use AAAA/MM/DD.",
+    "i18nStrings.slashedDateTimeConstraintText": "Para a data, use o formato AAAA/MM/DD. Para o horário, use o formato de 24 horas.",
+    "i18nStrings.isoDateTimeConstraintText": "Para a data, use o formato AAAA/MM/DD. Para o horário, use o formato de 24 horas.",
+    "i18nStrings.slashedDateConstraintText": "Para data, use AAAA/MM/DD.",
+    "i18nStrings.isoDateConstraintText": "Para data, use AAAA/MM/DD.",
+    "i18nStrings.slashedMonthConstraintText": "Para mês, use AAAA/MM.",
+    "i18nStrings.isoMonthConstraintText": "Para mês, use AAAA/MM.",
     "i18nStrings.monthConstraintText": "Para mês, use AAAA/MM.",
     "i18nStrings.errorIconAriaLabel": "Erro",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Intervalo selecionado de {startDate} a {endDate}",
@@ -403,6 +409,10 @@
     "i18nStrings.overflowMenuDismissIconAriaLabel": "Fechar menu",
     "i18nStrings.overflowMenuBackIconAriaLabel": "Voltar",
     "i18nStrings.overflowMenuTitleText": "Todos"
+  },
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": "Expandir",
+    "i18nStrings.collapseButtonLabel": "Recolher"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "Carregando",

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -156,6 +156,12 @@
     "i18nStrings.endTimeLabel": "Bitiş zamanı",
     "i18nStrings.dateTimeConstraintText": "Tarih için YYYY/AA/GG kullanın. Zaman için 24 saat biçimini kullanın.",
     "i18nStrings.dateConstraintText": "Tarih için YYYYY/AA/GG kullanın.",
+    "i18nStrings.slashedDateTimeConstraintText": "Tarih için YYYY/AA/GG kullanın. Zaman için 24 saat biçimini kullanın.",
+    "i18nStrings.isoDateTimeConstraintText": "Tarih için YYYY-AA-GG kullanın. Zaman için 24 saat biçimini kullanın.",
+    "i18nStrings.slashedDateConstraintText": "Tarih için YYYYY/AA/GG kullanın.",
+    "i18nStrings.isoDateConstraintText": "Tarih için YYYYY-AA-GG kullanın.",
+    "i18nStrings.slashedMonthConstraintText": "Ay için YYYY/AA kullanın.",
+    "i18nStrings.isoMonthConstraintText": "Ay için YYYY-AA kullanın.",
     "i18nStrings.monthConstraintText": "Ay için YYYY/AA kullanın.",
     "i18nStrings.errorIconAriaLabel": "Hata",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "{startDate}-{endDate} aralığı seçildi",
@@ -403,6 +409,10 @@
     "i18nStrings.overflowMenuDismissIconAriaLabel": "Menüyü kapat",
     "i18nStrings.overflowMenuBackIconAriaLabel": "Geri",
     "i18nStrings.overflowMenuTitleText": "Tümü"
+  },
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": "Genişlet",
+    "i18nStrings.collapseButtonLabel": "Daralt"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "Yükleniyor",

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -156,6 +156,12 @@
     "i18nStrings.endTimeLabel": "结束时间",
     "i18nStrings.dateTimeConstraintText": "对于日期，请使用 YYYY/MM/DD。对于时间，请使用 24 小时格式。",
     "i18nStrings.dateConstraintText": "对于日期，使用 YYYY/MM/DD。",
+    "i18nStrings.slashedDateTimeConstraintText": "对于日期，请使用 YYYY/MM/DD。对于时间，请使用 24 小时格式。",
+    "i18nStrings.isoDateTimeConstraintText": "对于日期，请使用 YYYY-MM-DD。对于时间，请使用 24 小时格式。",
+    "i18nStrings.slashedDateConstraintText": "对于日期，使用 YYYY/MM/DD。",
+    "i18nStrings.isoDateConstraintText": "对于日期，使用 YYYY-MM-DD。",
+    "i18nStrings.slashedMonthConstraintText": "对于月份，使用 YYYY/MM。",
+    "i18nStrings.isoMonthConstraintText": "对于月份，使用 YYYY-MM。",
     "i18nStrings.monthConstraintText": "对于月份，使用 YYYY/MM。",
     "i18nStrings.errorIconAriaLabel": "错误",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "选定范围从 {startDate} 到 {endDate}",
@@ -403,6 +409,10 @@
     "i18nStrings.overflowMenuDismissIconAriaLabel": "关闭菜单",
     "i18nStrings.overflowMenuBackIconAriaLabel": "返回",
     "i18nStrings.overflowMenuTitleText": "全部"
+  },
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": "展开",
+    "i18nStrings.collapseButtonLabel": "折叠"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "正在加载",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -156,6 +156,12 @@
     "i18nStrings.endTimeLabel": "結束時間",
     "i18nStrings.dateTimeConstraintText": "日期請使用 YYYY/MM/DD 格式。時間請使用 24 小時格式。",
     "i18nStrings.dateConstraintText": "對於日期，請使用 YYYY/MM/DD。",
+    "i18nStrings.slashedDateTimeConstraintText": "日期請使用 YYYY/MM/DD 格式。時間請使用 24 小時格式。",
+    "i18nStrings.isoDateTimeConstraintText": "日期請使用 YYYY-MM-DD 格式。時間請使用 24 小時格式。",
+    "i18nStrings.slashedDateConstraintText": "日期請使用 YYYY/MM/DD 格式。",
+    "i18nStrings.isoDateConstraintText": "日期請使用 YYYY-MM-DD 格式。",
+    "i18nStrings.slashedMonthConstraintText": "月份請使用 YYYY/MM 格式。",
+    "i18nStrings.isoMonthConstraintText": "月份請使用 YYYY-MM 格式。",
     "i18nStrings.monthConstraintText": "對於月份，請使用 YYYY/MM。",
     "i18nStrings.errorIconAriaLabel": "錯誤",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "已選取從 {startDate} 到 {endDate} 的範圍",
@@ -403,6 +409,10 @@
     "i18nStrings.overflowMenuDismissIconAriaLabel": "關閉選單",
     "i18nStrings.overflowMenuBackIconAriaLabel": "返回",
     "i18nStrings.overflowMenuTitleText": "全部"
+  },
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": "展開",
+    "i18nStrings.collapseButtonLabel": "收合"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "正在載入",


### PR DESCRIPTION
### Description
Added i18n translations

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
