### PR TITLE
fix: AnnotationContext popover position not recalculating onClick

### DIFF
--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -162,7 +162,7 @@ export default function PopoverContainer({
     const updatePositionOnResize = () => requestAnimationFrame(() => updatePositionHandler());
     const refreshPosition = () => requestAnimationFrame(() => positionHandlerRef.current());
 
-    window.addEventListener('click', onClick, { signal: controller.signal });
+    window.addEventListener('click', onClick, { capture: true, signal: controller.signal });
     window.addEventListener('resize', updatePositionOnResize, { signal: controller.signal });
     window.addEventListener('scroll', refreshPosition, { capture: true, signal: controller.signal });
 


### PR DESCRIPTION
### Description

Simple fix using window [capture](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#capture) to pick up on click events regardless of `stopPropagation` being set on buttons. This allows the [tool toggle button](https://github.com/cloudscape-design/components/blob/dev-v3-ernstka-annotation-context-fix/src/app-layout/visual-refresh-toolbar/toolbar/trigger-button/index.tsx#L98) to maintain its current behaviour as `stopPropagation` was added to it for its own reasons, but enables the popover to recalculate its position when a click event happens.

Related links, issue #, if available:
`AWSUI-60630`

### How has this been tested?

Manually verified

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
