### PR TITLE
chore: Increase font size of h3 header description text

### DIFF
--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -204,8 +204,9 @@
     }
   }
   &-variant-h3 {
-    @include styles.font-body-s;
+    @include styles.font-body-m;
     &:not(.refresh) {
+      @include styles.font-body-s;
       padding-block-end: awsui.$space-scaled-xxs;
     }
   }


### PR DESCRIPTION
### Description
We are increasing the font size of the description text in Header to be consistent across all header levels.
Before, the description text for h3 was smaller, but now it's the same size for h1, h2, and h3.

Related links, issue #, if available: AWSUI-60895

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
