### PR TITLE
chore: Upgrade react typings and related dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,12 +51,12 @@
         "@types/jest": "^29.5.13",
         "@types/lodash": "^4.14.176",
         "@types/node": "^20.17.14",
-        "@types/react": "^16.14.20",
-        "@types/react-dom": "^16.9.14",
-        "@types/react-router": "^5.1.18",
-        "@types/react-router-dom": "^5.3.2",
+        "@types/react": "^16.14.65",
+        "@types/react-dom": "^16.9.25",
+        "@types/react-router": "^5.1.20",
+        "@types/react-router-dom": "^5.3.3",
         "@types/react-test-renderer": "^16.9.12",
-        "@types/react-transition-group": "^4.4.4",
+        "@types/react-transition-group": "^4.4.12",
         "@types/webpack-env": "^1.16.3",
         "@typescript-eslint/eslint-plugin": "^8.24.1",
         "@typescript-eslint/parser": "^8.24.1",
@@ -124,6 +124,7 @@
         "webpack-dev-server": "^5.2.1"
       },
       "peerDependencies": {
+        "@types/react": ">=16.14.41",
         "react": ">=16.8.0"
       }
     },
@@ -3627,21 +3628,25 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "16.14.34",
+      "version": "16.14.65",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.65.tgz",
+      "integrity": "sha512-Guc3kE+W8LrQB9I3bF3blvNH15dXFIVIHIJTqrF8cp5XI/3IJcHGo4C3sJNPb8Zx49aofXKnAGIKyonE4f7XWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
+        "@types/scheduler": "^0.16",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "16.9.17",
+      "version": "16.9.25",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.25.tgz",
+      "integrity": "sha512-ZK//eAPhwft9Ul2/Zj+6O11YR6L4JX0J2sVeBC9Ft7x7HFN7xk7yUV/zDxqV6rjvqgl6r8Dq7oQImxtyf/Mzcw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/react": "^16"
+      "peerDependencies": {
+        "@types/react": "^16.0.0"
       }
     },
     "node_modules/@types/react-router": {
@@ -3672,10 +3677,12 @@
       }
     },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.5",
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@types/react": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "weekstart": "^1.1.0"
   },
   "peerDependencies": {
+    "@types/react": ">=16.14.41",
     "react": ">=16.8.0"
   },
   "devDependencies": {
@@ -71,12 +72,12 @@
     "@types/jest": "^29.5.13",
     "@types/lodash": "^4.14.176",
     "@types/node": "^20.17.14",
-    "@types/react": "^16.14.20",
-    "@types/react-dom": "^16.9.14",
-    "@types/react-router": "^5.1.18",
-    "@types/react-router-dom": "^5.3.2",
+    "@types/react": "^16.14.65",
+    "@types/react-dom": "^16.9.25",
+    "@types/react-router": "^5.1.20",
+    "@types/react-router-dom": "^5.3.3",
     "@types/react-test-renderer": "^16.9.12",
-    "@types/react-transition-group": "^4.4.4",
+    "@types/react-transition-group": "^4.4.12",
     "@types/webpack-env": "^1.16.3",
     "@typescript-eslint/eslint-plugin": "^8.24.1",
     "@typescript-eslint/parser": "^8.24.1",


### PR DESCRIPTION
### Description

Catch up `@types/react` and related packages to latest compatible minors

Related links, issue #, if available: n/a

### How has this been tested?

Typings only change, dry-run will be enough


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
