### PR TITLE
chore: Add missing await in inline editor tests

### DIFF
--- a/src/table/__tests__/inline-editor.test.tsx
+++ b/src/table/__tests__/inline-editor.test.tsx
@@ -8,9 +8,7 @@ import { InlineEditor } from '../../../lib/components/table/body-cell/inline-edi
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { TableProps } from '../interfaces';
 
-const handleSubmitEdit = jest.fn((): Promise<void> => {
-  return new Promise(resolve => setTimeout(resolve, 500));
-});
+const handleSubmitEdit = jest.fn();
 const handleEditEnd = jest.fn();
 
 let thereBeErrors = false;
@@ -41,7 +39,7 @@ const TestComponent = ({
         if (submitValueRef) {
           submitValueRef.current = submitValue;
         }
-        return <input value={currentValue ?? item.test} onChange={() => setValue('test')} />;
+        return <input value={currentValue ?? item.test} onChange={event => setValue(event.target.value)} />;
       },
     },
     cell: (item: any) => <span>{item.test}</span>,
@@ -87,11 +85,11 @@ describe('InlineEditor', () => {
 
   it('should show error', () => {
     thereBeErrors = true;
-    const changeEvent = new Event('change', { bubbles: true });
     const { wrapper } = renderComponent(<TestComponent />);
     const input = wrapper.find('input')!.getElement();
     fireEvent.click(input);
-    fireEvent(input, changeEvent);
+    fireEvent.change(input, { target: { value: 'new value' } });
+
     expect(wrapper.find('[aria-label="error-icon"]')?.getElement()).toBeInTheDocument();
   });
 
@@ -99,35 +97,32 @@ describe('InlineEditor', () => {
     'should submit edit when submit button is pressed (disableNativeForm=%s)',
     async disableNativeForm => {
       thereBeErrors = false;
-      const changeEvent = new Event('change', { bubbles: true });
       const { wrapper } = renderComponent(<TestComponent disableNativeForm={disableNativeForm} />);
       const input = wrapper.find('input')!.getElement();
 
       fireEvent.click(input);
+      fireEvent.change(input, { target: { value: 'new value' } });
 
-      fireEvent(input, changeEvent);
       expect(wrapper.find('[aria-label="error-icon"]')?.getElement()).toBeUndefined();
 
       fireEvent.click(wrapper.getElement().querySelector('[aria-label="save edit"]')!);
       await waitFor(() => {
         expect(handleSubmitEdit).toHaveBeenCalled();
         expect(handleSubmitEdit.mock.lastCall!.length).toBe(3);
+        expect(handleEditEnd).toHaveBeenCalled();
       });
-
-      expect(handleEditEnd).toHaveBeenCalled();
     }
   );
 
   it('should submit edit when submitValue is called', async () => {
     thereBeErrors = false;
     const submitValueRef = React.createRef<TableProps.CellContext<string>['submitValue'] | null>();
-    const changeEvent = new Event('change', { bubbles: true });
     const { wrapper } = renderComponent(<TestComponent submitValueRef={submitValueRef} />);
     const input = wrapper.find('input')!.getElement();
 
     fireEvent.click(input);
+    fireEvent.change(input, { target: { value: 'new value' } });
 
-    fireEvent(input, changeEvent);
     expect(wrapper.find('[aria-label="error-icon"]')?.getElement()).toBeUndefined();
 
     act(() => {
@@ -136,9 +131,8 @@ describe('InlineEditor', () => {
     await waitFor(() => {
       expect(handleSubmitEdit).toHaveBeenCalled();
       expect(handleSubmitEdit.mock.lastCall!.length).toBe(3);
+      expect(handleEditEnd).toHaveBeenCalled();
     });
-
-    expect(handleEditEnd).toHaveBeenCalled();
   });
 
   it('should not render a form element if disableNativeForm is set', () => {
@@ -153,7 +147,6 @@ describe('InlineEditor', () => {
 
   it('should not submit any wrapping forms', async () => {
     thereBeErrors = false;
-    const changeEvent = new Event('change', { bubbles: true });
     const onSubmitSpy = jest.fn();
     const { wrapper } = renderComponent(
       <form onSubmit={onSubmitSpy}>
@@ -163,8 +156,8 @@ describe('InlineEditor', () => {
 
     const input = wrapper.find('input')!.getElement();
     fireEvent.click(input);
+    fireEvent.change(input, { target: { value: 'new value' } });
 
-    fireEvent(input, changeEvent);
     fireEvent.click(wrapper.getElement().querySelector('[aria-label="save edit"]')!);
 
     await waitFor(() => {
@@ -177,12 +170,11 @@ describe('InlineEditor', () => {
 
   it('should handle failed submission', async () => {
     thereBeErrors = false;
-    const changeEvent = new Event('change', { bubbles: true });
     const { wrapper } = renderComponent(<TestComponent />);
     const input = wrapper.find('input')!.getElement();
 
     fireEvent.click(input);
-    fireEvent(input, changeEvent);
+    fireEvent.change(input, { target: { value: 'new value' } });
 
     // eslint-disable-next-line require-await
     handleSubmitEdit.mockImplementation(() => Promise.reject(new Error('test error')));
@@ -205,22 +197,28 @@ describe('InlineEditor', () => {
   // useless test but need the coverage
   it('should render spinner while submitting', async () => {
     thereBeErrors = false;
-    const changeEvent = new Event('change', { bubbles: true });
     const { wrapper } = renderComponent(<TestComponent />);
+    let resolveSubmit = () => {};
+    handleSubmitEdit.mockImplementationOnce(() => {
+      return new Promise<void>(resolve => {
+        resolveSubmit = resolve;
+      });
+    });
 
     const input = wrapper.find('input')!.getElement();
     fireEvent.click(input);
-    fireEvent(input, changeEvent);
+    fireEvent.change(input, { target: { value: 'new value' } });
 
     const button = wrapper.findButton('[aria-label="save edit"]')!;
     fireEvent.click(button.getElement());
     await waitFor(() => {
       expect(button.findLoadingIndicator()).not.toBeNull();
-      expect(button).toHaveAttribute('disabled');
+      expect(button.getElement()).toHaveAttribute('aria-disabled');
     });
+    resolveSubmit();
     await waitFor(() => {
       expect(button.findLoadingIndicator()).toBeNull();
-      expect(button).not.toHaveAttribute('disabled');
+      expect(button.getElement()).not.toHaveAttribute('aria-disabled');
     });
   });
 

--- a/src/table/__tests__/inline-editor.test.tsx
+++ b/src/table/__tests__/inline-editor.test.tsx
@@ -97,7 +97,7 @@ describe('InlineEditor', () => {
 
   it.each([false, true])(
     'should submit edit when submit button is pressed (disableNativeForm=%s)',
-    disableNativeForm => {
+    async disableNativeForm => {
       thereBeErrors = false;
       const changeEvent = new Event('change', { bubbles: true });
       const { wrapper } = renderComponent(<TestComponent disableNativeForm={disableNativeForm} />);
@@ -109,7 +109,7 @@ describe('InlineEditor', () => {
       expect(wrapper.find('[aria-label="error-icon"]')?.getElement()).toBeUndefined();
 
       fireEvent.click(wrapper.getElement().querySelector('[aria-label="save edit"]')!);
-      waitFor(() => {
+      await waitFor(() => {
         expect(handleSubmitEdit).toHaveBeenCalled();
         expect(handleSubmitEdit.mock.lastCall!.length).toBe(3);
       });
@@ -118,7 +118,7 @@ describe('InlineEditor', () => {
     }
   );
 
-  it('should submit edit when submitValue is called', () => {
+  it('should submit edit when submitValue is called', async () => {
     thereBeErrors = false;
     const submitValueRef = React.createRef<TableProps.CellContext<string>['submitValue'] | null>();
     const changeEvent = new Event('change', { bubbles: true });
@@ -133,7 +133,7 @@ describe('InlineEditor', () => {
     act(() => {
       submitValueRef.current!();
     });
-    waitFor(() => {
+    await waitFor(() => {
       expect(handleSubmitEdit).toHaveBeenCalled();
       expect(handleSubmitEdit.mock.lastCall!.length).toBe(3);
     });
@@ -151,7 +151,7 @@ describe('InlineEditor', () => {
     expect(wrapper.find('button[type=submit]')).toBe(null);
   });
 
-  it('should not submit any wrapping forms', () => {
+  it('should not submit any wrapping forms', async () => {
     thereBeErrors = false;
     const changeEvent = new Event('change', { bubbles: true });
     const onSubmitSpy = jest.fn();
@@ -167,7 +167,7 @@ describe('InlineEditor', () => {
     fireEvent(input, changeEvent);
     fireEvent.click(wrapper.getElement().querySelector('[aria-label="save edit"]')!);
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(handleSubmitEdit).toHaveBeenCalled();
       expect(handleSubmitEdit.mock.lastCall!.length).toBe(3);
     });
@@ -175,7 +175,7 @@ describe('InlineEditor', () => {
     expect(onSubmitSpy).not.toHaveBeenCalled();
   });
 
-  it('should handle failed submission', () => {
+  it('should handle failed submission', async () => {
     thereBeErrors = false;
     const changeEvent = new Event('change', { bubbles: true });
     const { wrapper } = renderComponent(<TestComponent />);
@@ -188,7 +188,7 @@ describe('InlineEditor', () => {
     handleSubmitEdit.mockImplementation(() => Promise.reject(new Error('test error')));
 
     fireEvent.click(wrapper.getElement().querySelector('[aria-label="save edit"]')!);
-    waitFor(() => {
+    await waitFor(() => {
       expect(handleSubmitEdit).toHaveBeenCalled();
       expect(handleSubmitEdit.mock.lastCall!.length).toBe(3);
       expect(handleEditEnd).not.toHaveBeenCalled();
@@ -203,7 +203,7 @@ describe('InlineEditor', () => {
   });
 
   // useless test but need the coverage
-  it('should render spinner while submitting', () => {
+  it('should render spinner while submitting', async () => {
     thereBeErrors = false;
     const changeEvent = new Event('change', { bubbles: true });
     const { wrapper } = renderComponent(<TestComponent />);
@@ -214,11 +214,11 @@ describe('InlineEditor', () => {
 
     const button = wrapper.findButton('[aria-label="save edit"]')!;
     fireEvent.click(button.getElement());
-    waitFor(() => {
+    await waitFor(() => {
       expect(button.findLoadingIndicator()).not.toBeNull();
       expect(button).toHaveAttribute('disabled');
     });
-    waitFor(() => {
+    await waitFor(() => {
       expect(button.findLoadingIndicator()).toBeNull();
       expect(button).not.toHaveAttribute('disabled');
     });


### PR DESCRIPTION
### Description

Splitting #3624 into a PR someone else can approve/merge.

Related links, issue #, if available: n/a

### How has this been tested?

Fixing tests _is_ the PR. Maybe something broke during a version change, or maybe these tests didn't quite work as expected to begin with, but they're green again, and a little bit faster too.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
