### PR TITLE
feat: Add new color token for error bar markers in charts

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
@@ -825,6 +825,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#273ea5",
           },
         },
+        "color-charts-error-bar-marker": {
+          "$description": "Color for the error bar marker in charts.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#131920",
+          },
+        },
         "color-charts-green-1000": {
           "$description": "Color from the 'green' data visualization palette at a contrast ratio of 10:1",
           "$value": {
@@ -3395,6 +3402,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#c3d1ff",
             "light": "#273ea5",
+          },
+        },
+        "color-charts-error-bar-marker": {
+          "$description": "Color for the error bar marker in charts.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#131920",
           },
         },
         "color-charts-green-1000": {
@@ -5969,6 +5983,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#273ea5",
           },
         },
+        "color-charts-error-bar-marker": {
+          "$description": "Color for the error bar marker in charts.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#131920",
+          },
+        },
         "color-charts-green-1000": {
           "$description": "Color from the 'green' data visualization palette at a contrast ratio of 10:1",
           "$value": {
@@ -8539,6 +8560,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#c3d1ff",
             "light": "#273ea5",
+          },
+        },
+        "color-charts-error-bar-marker": {
+          "$description": "Color for the error bar marker in charts.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#131920",
           },
         },
         "color-charts-green-1000": {
@@ -11113,6 +11141,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#273ea5",
           },
         },
+        "color-charts-error-bar-marker": {
+          "$description": "Color for the error bar marker in charts.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#131920",
+          },
+        },
         "color-charts-green-1000": {
           "$description": "Color from the 'green' data visualization palette at a contrast ratio of 10:1",
           "$value": {
@@ -13685,6 +13720,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#273ea5",
           },
         },
+        "color-charts-error-bar-marker": {
+          "$description": "Color for the error bar marker in charts.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#131920",
+          },
+        },
         "color-charts-green-1000": {
           "$description": "Color from the 'green' data visualization palette at a contrast ratio of 10:1",
           "$value": {
@@ -16255,6 +16297,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
       "$value": {
         "dark": "#c3d1ff",
         "light": "#273ea5",
+      },
+    },
+    "color-charts-error-bar-marker": {
+      "$description": "Color for the error bar marker in charts.",
+      "$value": {
+        "dark": "#ffffff",
+        "light": "#131920",
       },
     },
     "color-charts-green-1000": {
@@ -18834,6 +18883,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#273ea5",
           },
         },
+        "color-charts-error-bar-marker": {
+          "$description": "Color for the error bar marker in charts.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#131920",
+          },
+        },
         "color-charts-green-1000": {
           "$description": "Color from the 'green' data visualization palette at a contrast ratio of 10:1",
           "$value": {
@@ -21404,6 +21460,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#c3d1ff",
             "light": "#273ea5",
+          },
+        },
+        "color-charts-error-bar-marker": {
+          "$description": "Color for the error bar marker in charts.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#131920",
           },
         },
         "color-charts-green-1000": {
@@ -23978,6 +24041,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#273ea5",
           },
         },
+        "color-charts-error-bar-marker": {
+          "$description": "Color for the error bar marker in charts.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#131920",
+          },
+        },
         "color-charts-green-1000": {
           "$description": "Color from the 'green' data visualization palette at a contrast ratio of 10:1",
           "$value": {
@@ -26548,6 +26618,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#c3d1ff",
             "light": "#273ea5",
+          },
+        },
+        "color-charts-error-bar-marker": {
+          "$description": "Color for the error bar marker in charts.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#131920",
           },
         },
         "color-charts-green-1000": {
@@ -29122,6 +29199,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#273ea5",
           },
         },
+        "color-charts-error-bar-marker": {
+          "$description": "Color for the error bar marker in charts.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#131920",
+          },
+        },
         "color-charts-green-1000": {
           "$description": "Color from the 'green' data visualization palette at a contrast ratio of 10:1",
           "$value": {
@@ -31692,6 +31776,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#c3d1ff",
             "light": "#273ea5",
+          },
+        },
+        "color-charts-error-bar-marker": {
+          "$description": "Color for the error bar marker in charts.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#131920",
           },
         },
         "color-charts-green-1000": {
@@ -34266,6 +34357,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#273ea5",
           },
         },
+        "color-charts-error-bar-marker": {
+          "$description": "Color for the error bar marker in charts.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#131920",
+          },
+        },
         "color-charts-green-1000": {
           "$description": "Color from the 'green' data visualization palette at a contrast ratio of 10:1",
           "$value": {
@@ -36838,6 +36936,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#273ea5",
           },
         },
+        "color-charts-error-bar-marker": {
+          "$description": "Color for the error bar marker in charts.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#131920",
+          },
+        },
         "color-charts-green-1000": {
           "$description": "Color from the 'green' data visualization palette at a contrast ratio of 10:1",
           "$value": {
@@ -39408,6 +39513,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
       "$value": {
         "dark": "#c3d1ff",
         "light": "#273ea5",
+      },
+    },
+    "color-charts-error-bar-marker": {
+      "$description": "Color for the error bar marker in charts.",
+      "$value": {
+        "dark": "#ffffff",
+        "light": "#131920",
       },
     },
     "color-charts-green-1000": {

--- a/style-dictionary/utils/token-names.ts
+++ b/style-dictionary/utils/token-names.ts
@@ -392,7 +392,8 @@ export type ColorChartsTokenName =
   | 'colorChartsPaletteCategorical47'
   | 'colorChartsPaletteCategorical48'
   | 'colorChartsPaletteCategorical49'
-  | 'colorChartsPaletteCategorical50';
+  | 'colorChartsPaletteCategorical50'
+  | 'colorChartsErrorBarMarker';
 export type ColorSeverityTokenName =
   | 'colorSeverityDarkRed'
   | 'colorSeverityRed'

--- a/style-dictionary/visual-refresh/color-charts.ts
+++ b/style-dictionary/visual-refresh/color-charts.ts
@@ -158,6 +158,7 @@ const tokens: StyleDictionary.ColorChartsDictionary = {
   colorChartsPaletteCategorical48: '{colorChartsTeal1000}',
   colorChartsPaletteCategorical49: '{colorChartsPurple1200}',
   colorChartsPaletteCategorical50: '{colorChartsOrange1000}',
+  colorChartsErrorBarMarker: { light: '{colorGrey900}', dark: '{colorWhite}' },
 };
 
 const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = expandColorDictionary(tokens);

--- a/style-dictionary/visual-refresh/metadata/color-charts.ts
+++ b/style-dictionary/visual-refresh/metadata/color-charts.ts
@@ -703,6 +703,11 @@ const metadata: StyleDictionary.MetadataIndex = {
     public: true,
     themeable: true,
   },
+  colorChartsErrorBarMarker: {
+    description: 'Color for the error bar marker in charts.',
+    public: true,
+    themeable: true,
+  },
 };
 
 export default metadata;


### PR DESCRIPTION
### Description

For proper contrast, error bar markers in the new charts should have the following colors:

- Light mode: grey-900 (`#131920`)
- Dark mode: white (`#ffffff`)

The alternative is to use the component toolkit internal API to detect light and dark mode, but even the `grey-900` and `color-white` tokens are not public tokens, so creating this new token seems a better approach.

Related doc: `JaIkAMOgChPb`

### How has this been tested?

Ran the design tokens unit test to update the design tokens snapshot as expected.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
