### PR TITLE
feat: Show resizer for last table column

### DIFF
--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -128,6 +128,7 @@ export function TableHeaderCell<ItemType>({
       focusedComponent={focusedComponent}
       stuck={stuck}
       sticky={sticky}
+      resizable={resizableColumns}
       hidden={hidden}
       stripedRows={stripedRows}
       colIndex={colIndex}

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -224,7 +224,7 @@ settings icon in the pagination slot.
     @include cell-offset(awsui.$space-xxs);
   }
 
-  &:last-child.header-cell-sortable {
+  &:last-child.header-cell-sortable:not(.header-cell-resizable) {
     padding-inline-end: awsui.$space-xxxs;
   }
 

--- a/src/table/header-cell/th-element.tsx
+++ b/src/table/header-cell/th-element.tsx
@@ -25,6 +25,7 @@ export interface TableThElementProps {
   focusedComponent?: null | string;
   stuck?: boolean;
   sticky?: boolean;
+  resizable?: boolean;
   hidden?: boolean;
   stripedRows?: boolean;
   isSelection?: boolean;
@@ -46,6 +47,7 @@ export function TableThElement({
   focusedComponent,
   stuck,
   sticky,
+  resizable,
   hidden,
   stripedRows,
   isSelection,
@@ -79,6 +81,7 @@ export function TableThElement({
         styles['header-cell'],
         styles[`header-cell-variant-${variant}`],
         sticky && styles['header-cell-sticky'],
+        resizable && styles['header-cell-resizable'],
         stuck && styles['header-cell-stuck'],
         stripedRows && styles['has-striped-rows'],
         isVisualRefresh && styles['is-visual-refresh'],

--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -231,7 +231,7 @@ export function Resizer({
         data-focus-id={focusId}
       />
       <span
-        className={clsx(styles.divider, isDragging && styles['divider-active'])}
+        className={clsx(styles['divider-interactive'], isDragging && styles['divider-active'])}
         data-awsui-table-suppress-navigation={true}
         ref={resizerSeparatorRef}
         id={separatorId}

--- a/src/table/resizer/styles.scss
+++ b/src/table/resizer/styles.scss
@@ -16,7 +16,8 @@
 $handle-width: awsui.$space-xl;
 $active-separator-width: 2px;
 
-th:not(:last-child) > .divider {
+th:not(:last-child) > .divider,
+.divider-interactive {
   $gap: calc(2 * #{awsui.$space-xs} + #{awsui.$space-xxxs});
 
   position: absolute;
@@ -58,10 +59,6 @@ th:not(:last-child) > .divider {
   //stylelint-disable-next-line selector-combinator-disallowed-list
   .resize-active & {
     pointer-events: none;
-  }
-  th:last-child > & {
-    inline-size: calc(#{$handle-width} / 2);
-    inset-inline-end: 0;
   }
   &:hover + .divider {
     border-inline-start: $active-separator-width solid awsui.$color-border-divider-active;


### PR DESCRIPTION
### Description

We've received a report that hovering over last column's resizer causes layout shifts in Firefox & Safari.
While we could fix that, the question is: why do we have a non-visible interactive element in the first place? It's there, it receives focus and shows focus ring, but you need to know it exists to interact with it.

So, let's make it simple 

Related links, issue #, if available: AWSUI-60946

Before (with focus ring):
![image](https://github.com/user-attachments/assets/a5d13f61-d001-4a65-b7bd-39df81ca9e0d)

After:
![image](https://github.com/user-attachments/assets/18d4c3a5-360d-4acb-b83d-4d41a84dc488)

### How has this been tested?

- ✅ RUN through my dev pipeline to check screenshots 
- checked with visual design

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
