### PR TITLE
fix: Display property filter empty state as expected

### DIFF
--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -188,15 +188,6 @@ describe('property filter parts', () => {
       expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'false');
       expect(wrapper.findDropdown().findOpenDropdown()!.getElement()).toHaveTextContent('Use: "free-text"');
     });
-    it('when free text filtering is not allowed and no property is matched the dropdown is not shown and aria-expanded is false', () => {
-      const { propertyFilterWrapper: wrapper } = renderComponent({
-        disableFreeTextFiltering: true,
-        filteringProperties: [],
-      });
-      wrapper.setInputValue('free-text');
-      expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'false');
-      expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
-    });
     it('when free text filtering is allowed and no properties available the filtering-empty is shown', () => {
       const { propertyFilterWrapper: wrapper } = renderComponent({
         disableFreeTextFiltering: false,
@@ -206,12 +197,31 @@ describe('property filter parts', () => {
       expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'true');
       expect(wrapper.findDropdown().findOpenDropdown()!.getElement()).toHaveTextContent('Empty');
     });
+    it('when free text filtering is allowed and no properties available, with text entered, the use message is shown', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        disableFreeTextFiltering: false,
+        filteringProperties: [],
+      });
+      wrapper.focus();
+      wrapper.setInputValue('free-text');
+      expect(wrapper.findEnteredTextOption()!.getElement()).toHaveTextContent('Use: "free-text"');
+    });
     it('when free text filtering is not allowed and no properties available the filtering-empty is shown', () => {
       const { propertyFilterWrapper: wrapper } = renderComponent({
         disableFreeTextFiltering: true,
         filteringProperties: [],
       });
       wrapper.focus();
+      expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'true');
+      expect(wrapper.findDropdown().findOpenDropdown()!.getElement()).toHaveTextContent('Empty');
+    });
+    it('when free text filtering is not allowed and no properties available the filtering-empty is shown, also when text is entered', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        disableFreeTextFiltering: true,
+        filteringProperties: [],
+      });
+      wrapper.focus();
+      wrapper.setInputValue('free-text');
       expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'true');
       expect(wrapper.findDropdown().findOpenDropdown()!.getElement()).toHaveTextContent('Empty');
     });

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -158,7 +158,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
     const highlightedOptionIdSource = useUniqueId();
     const highlightedOptionId = autosuggestItemsState.highlightedOption ? highlightedOptionIdSource : undefined;
 
-    const isEmpty = !value && !autosuggestItemsState.items.length;
+    const isEmpty = !autosuggestItemsState.items.length;
     const dropdownStatus = useDropdownStatus({
       ...props,
       isEmpty,
@@ -173,7 +173,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
           {customForm.content}
         </div>
       );
-    } else if (autosuggestItemsState.items.length > 0) {
+    } else {
       content = (
         <AutosuggestOptionsList
           statusType={statusType}


### PR DESCRIPTION
### Description

Changes two things:
- Displays the empty state also when text is entered (if free text filtering is disabled)
- Ensures the empty state is styled correctly

Related links, issue #, if available: AWSUI-60979

### How has this been tested?

Tested locally & in dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
