### PR TITLE
chore: Disable error overlay

### DIFF
--- a/pages/webpack.config.base.cjs
+++ b/pages/webpack.config.base.cjs
@@ -136,6 +136,13 @@ module.exports = ({
       ...(moduleReplacements || []).map(({ from, to }) => replaceModule(from, to)),
     ],
     devServer: {
+      client: {
+        overlay: {
+          errors: true,
+          warnings: true,
+          runtimeErrors: false,
+        },
+      },
       devMiddleware: {
         publicPath: '/',
       },


### PR DESCRIPTION
### Description

Hide overlay, because it prints not real errors

<img width="1237" height="359" alt="image" src="https://github.com/user-attachments/assets/8af9071b-bb56-4761-b46e-07c62fcb5f49" />


Related links, issue #, if available: n/a

### How has this been tested?

The error does not get printed anymore

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
