### PR TITLE
chore: Warn when columns exceed max value in Key-Value pairs component

### DIFF
--- a/src/key-value-pairs/internal.tsx
+++ b/src/key-value-pairs/internal.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import clsx from 'clsx';
 
-import { useUniqueId } from '@cloudscape-design/component-toolkit/internal';
+import { useUniqueId, warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 import Box from '../box/internal';
 import ColumnLayout from '../column-layout/internal';
@@ -51,6 +51,15 @@ const InternalKeyValuePairs = React.forwardRef(
     }: KeyValuePairsProps & Required<Pick<KeyValuePairsProps, 'columns'>>,
     ref: React.Ref<HTMLDivElement>
   ) => {
+    const MAX_COLUMNS = 4;
+
+    if (columns > MAX_COLUMNS) {
+      warnOnce(
+        'Key-value pairs',
+        `\`columns\` (${columns}) must be <= ${MAX_COLUMNS}. Using ${MAX_COLUMNS} as default.`
+      );
+    }
+
     return (
       <LinkDefaultVariantContext.Provider value={{ defaultVariant: 'primary' }}>
         <div
@@ -66,7 +75,7 @@ const InternalKeyValuePairs = React.forwardRef(
         */}
           <ColumnLayout
             __tagOverride="dl"
-            columns={Math.min(columns, 4)}
+            columns={Math.min(columns, MAX_COLUMNS)}
             variant="text-grid"
             minColumnWidth={minColumnWidth}
           >


### PR DESCRIPTION
### Description

Add dev warning in case the `columns` property exceeds the max column value to create awareness about.

Before this change, devs did not get feedback about, with that change, there will be a console warning in dev envs.

Related links, issue #, if available: `AWSUI-60981`

### How has this been tested?

- add additional unit tests
- green dry-run

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
