### PR TITLE
chore: Introduce focus behavior when flash items gets dismissed

### DIFF
--- a/src/flashbar/__integ__/focus-interactions.test.ts
+++ b/src/flashbar/__integ__/focus-interactions.test.ts
@@ -73,3 +73,49 @@ test(
     return expect(page.isFlashFocused(initialCount + 1)).resolves.toBe(true);
   })
 );
+
+test(
+  'dismissing flash item moves focus to next item',
+  setupTest(async page => {
+    await page.addSequentialErrorFlashes();
+    await page.pause(FOCUS_THROTTLE_DELAY);
+
+    await page.dismissFirstItem();
+    await page.pause(FOCUS_THROTTLE_DELAY);
+
+    return expect(await page.isFlashFocused(1)).toBe(true);
+  })
+);
+
+test(
+  'dismissing flash in expanded collapsible state moves focus to next item',
+  setupTest(async page => {
+    await page.removeAll();
+    await page.toggleStackingFeature();
+    await page.addSequentialErrorFlashes();
+    await page.toggleCollapsedState();
+    await page.pause(FOCUS_THROTTLE_DELAY);
+
+    await page.dismissFirstItem();
+    await page.pause(FOCUS_THROTTLE_DELAY);
+
+    return expect(await page.isFlashFocused(1)).toBe(true);
+  })
+);
+
+test(
+  'dismissing flash in collapsed state moves focus to notification bar',
+  setupTest(async page => {
+    await page.removeAll();
+    await page.toggleStackingFeature();
+    await page.addSequentialErrorFlashes();
+    await page.pause(FOCUS_THROTTLE_DELAY);
+
+    await page.dismissFirstItem();
+    await page.pause(FOCUS_THROTTLE_DELAY);
+
+    const isDismissButtonFocused = await page.isDismissButtonFocused();
+
+    return expect(isDismissButtonFocused).toBe(true);
+  })
+);

--- a/src/flashbar/__integ__/pages/base.ts
+++ b/src/flashbar/__integ__/pages/base.ts
@@ -30,9 +30,21 @@ export class FlashbarBasePage extends BasePageObject {
     return createWrapper().findFlashbar().findByClassName(selectors['dismiss-button']).toSelector();
   }
 
-  isFlashFocused(index: number) {
-    return this.isFocused(
-      flashbar.findItems().get(index).findByClassName(selectors['flash-focus-container']).toSelector()
-    );
+  isDismissButtonFocused() {
+    const dismissButton = this.getDismissButton();
+    return this.isFocused(dismissButton);
+  }
+
+  isFlashDismissButtonFocused(index: number) {
+    const dismissButton = flashbar.findItems().get(index).findDismissButton().toSelector();
+    return this.isFocused(dismissButton);
+  }
+
+  async isFlashFocused(index: number) {
+    const flash = flashbar.findItems().get(index);
+    const container = flash.findByClassName(selectors['flash-focus-container']).toSelector();
+    const containerFocused = await this.isFocused(container);
+    const dismissButtonFocused = await this.isFlashDismissButtonFocused(index);
+    return containerFocused || dismissButtonFocused;
   }
 }

--- a/src/flashbar/__integ__/pages/interactive-page.ts
+++ b/src/flashbar/__integ__/pages/interactive-page.ts
@@ -37,6 +37,9 @@ export class FlashbarInteractivePage extends FlashbarBasePage {
   async removeAll() {
     await this.click('[data-id="remove-all"]');
   }
+  getBrowser() {
+    return this.browser;
+  }
 }
 
 export const setupTest = (testFn: (page: FlashbarInteractivePage) => Promise<void>) => {

--- a/src/flashbar/__integ__/pages/interactive-page.ts
+++ b/src/flashbar/__integ__/pages/interactive-page.ts
@@ -37,9 +37,6 @@ export class FlashbarInteractivePage extends FlashbarBasePage {
   async removeAll() {
     await this.click('[data-id="remove-all"]');
   }
-  getBrowser() {
-    return this.browser;
-  }
 }
 
 export const setupTest = (testFn: (page: FlashbarInteractivePage) => Promise<void>) => {

--- a/src/flashbar/__tests__/common.test.tsx
+++ b/src/flashbar/__tests__/common.test.tsx
@@ -1,0 +1,249 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { handleFlashDismissedInternal } from '../../../lib/components/flashbar/common';
+import { FlashbarProps } from '../../../lib/components/flashbar/interfaces';
+
+// Mock the focus utility function
+jest.mock('../../../lib/components/flashbar/flash', () => ({
+  ...jest.requireActual('../../../lib/components/flashbar/flash'),
+  focusFlashFocusableArea: jest.fn(),
+}));
+
+import { focusFlashFocusableArea } from '../../../lib/components/flashbar/flash';
+const mockFocusFlashFocusableArea = focusFlashFocusableArea as jest.MockedFunction<typeof focusFlashFocusableArea>;
+
+import styles from '../../../lib/components/flashbar/styles.css.js';
+
+describe('handleFlashDismissedInternal', () => {
+  let mockMainElement: HTMLElement;
+  let originalQuerySelector: typeof document.querySelector;
+  let originalSetTimeout: typeof setTimeout;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockMainElement = document.createElement('main');
+    mockMainElement.focus = jest.fn();
+
+    originalQuerySelector = document.querySelector;
+    document.querySelector = jest.fn(selector => {
+      if (selector === 'main' || selector === '[role="main"]') {
+        return mockMainElement;
+      }
+      return null;
+    });
+
+    originalSetTimeout = global.setTimeout;
+    global.setTimeout = jest.fn((callback: any) => {
+      callback();
+      return 0 as any;
+    }) as any;
+  });
+
+  afterEach(() => {
+    document.querySelector = originalQuerySelector;
+    global.setTimeout = originalSetTimeout;
+  });
+
+  const createTestItems = (count: number): FlashbarProps.MessageDefinition[] => {
+    return Array.from({ length: count }, (_, i) => ({
+      id: `item-${i}`,
+      type: 'info' as const,
+      header: `Item ${i}`,
+      content: `Content ${i}`,
+      dismissible: true,
+    }));
+  };
+
+  test('does nothing when items is undefined', () => {
+    const mockRef = document.createElement('div');
+    const flashRefs = {};
+
+    handleFlashDismissedInternal('item-1', undefined, mockRef, flashRefs);
+
+    expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
+    expect(mockMainElement.focus).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when dismissedId is undefined', () => {
+    const items = createTestItems(2);
+    const mockRef = document.createElement('div');
+    const flashRefs = {};
+
+    handleFlashDismissedInternal(undefined, items, mockRef, flashRefs);
+
+    expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
+    expect(mockMainElement.focus).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when refCurrent is null', () => {
+    const items = createTestItems(2);
+    const flashRefs = {};
+
+    handleFlashDismissedInternal('item-1', items, null, flashRefs);
+
+    expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
+    expect(mockMainElement.focus).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when dismissed item is not found', () => {
+    const items = createTestItems(2);
+    const mockRef = document.createElement('div');
+    const flashRefs = {};
+
+    handleFlashDismissedInternal('non-existent-item', items, mockRef, flashRefs);
+
+    expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
+    expect(mockMainElement.focus).not.toHaveBeenCalled();
+  });
+
+  test('focuses on next item when dismissing first item', () => {
+    const items = createTestItems(3);
+    const mockRef = document.createElement('div');
+    const mockNextElement = document.createElement('div');
+    const flashRefs = {
+      'item-1': mockNextElement,
+    };
+
+    handleFlashDismissedInternal('item-0', items, mockRef, flashRefs);
+
+    expect(mockFocusFlashFocusableArea).toHaveBeenCalledWith(mockNextElement);
+    expect(mockMainElement.focus).not.toHaveBeenCalled();
+  });
+
+  test('focuses on previous item when dismissing last item', () => {
+    const items = createTestItems(3);
+    const mockRef = document.createElement('div');
+    const mockPrevElement = document.createElement('div');
+    const flashRefs = {
+      'item-1': mockPrevElement,
+    };
+
+    handleFlashDismissedInternal('item-2', items, mockRef, flashRefs);
+
+    expect(mockFocusFlashFocusableArea).toHaveBeenCalledWith(mockPrevElement);
+    expect(mockMainElement.focus).not.toHaveBeenCalled();
+  });
+
+  test('focuses on main element when dismissing only item', () => {
+    const items = createTestItems(1);
+    const mockRef = document.createElement('div');
+    const flashRefs = {};
+
+    handleFlashDismissedInternal('item-0', items, mockRef, flashRefs);
+
+    expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
+    expect(mockMainElement.focus).toHaveBeenCalled();
+  });
+
+  test('focuses on notification bar button when next flash element is not available', () => {
+    const items = createTestItems(2);
+    const mockRef = document.createElement('div');
+    const mockNotificationButton = document.createElement('button');
+    mockNotificationButton.focus = jest.fn();
+    mockNotificationButton.className = styles.button;
+
+    mockRef.querySelector = jest.fn(selector => {
+      if (selector === `.${styles.button}`) {
+        return mockNotificationButton;
+      }
+      return null;
+    });
+
+    const flashRefs = {};
+
+    handleFlashDismissedInternal('item-0', items, mockRef, flashRefs);
+
+    expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
+    expect(mockNotificationButton.focus).toHaveBeenCalled();
+    expect(mockMainElement.focus).not.toHaveBeenCalled();
+  });
+
+  test('falls back to main element when neither next flash element nor notification button is available', () => {
+    const items = createTestItems(2);
+    const mockRef = document.createElement('div');
+
+    mockRef.querySelector = jest.fn(() => null);
+
+    const flashRefs = {};
+
+    handleFlashDismissedInternal('item-0', items, mockRef, flashRefs);
+
+    expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
+    expect(mockMainElement.focus).toHaveBeenCalled();
+  });
+
+  test('focuses on middle item correctly', () => {
+    const items = createTestItems(5);
+    const mockRef = document.createElement('div');
+    const mockNextElement = document.createElement('div');
+    const flashRefs = {
+      'item-3': mockNextElement,
+    };
+
+    handleFlashDismissedInternal('item-2', items, mockRef, flashRefs);
+
+    expect(mockFocusFlashFocusableArea).toHaveBeenCalledWith(mockNextElement);
+  });
+
+  test('setTimeout is called to defer focus operation', () => {
+    const items = createTestItems(2);
+    const mockRef = document.createElement('div');
+    const mockNextElement = document.createElement('div');
+    const flashRefs = {
+      'item-1': mockNextElement,
+    };
+
+    handleFlashDismissedInternal('item-0', items, mockRef, flashRefs);
+
+    expect(global.setTimeout).toHaveBeenCalledTimes(1);
+    expect(global.setTimeout).toHaveBeenCalledWith(expect.any(Function), 0);
+  });
+
+  test('handles empty items array', () => {
+    const items: FlashbarProps.MessageDefinition[] = [];
+    const mockRef = document.createElement('div');
+    const flashRefs = {};
+
+    handleFlashDismissedInternal('item-0', items, mockRef, flashRefs);
+
+    expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
+    expect(mockMainElement.focus).not.toHaveBeenCalled();
+  });
+
+  test('handles dismissing item at various positions', () => {
+    const items = createTestItems(4);
+    const mockRef = document.createElement('div');
+
+    const mockNextElement = document.createElement('div');
+    const flashRefs = { 'item-2': mockNextElement };
+
+    handleFlashDismissedInternal('item-1', items, mockRef, flashRefs);
+
+    expect(mockFocusFlashFocusableArea).toHaveBeenCalledWith(mockNextElement);
+  });
+
+  test('handles notification button fallback with role="main"', () => {
+    const items = createTestItems(1);
+    const mockRef = document.createElement('div');
+    const flashRefs = {};
+
+    const mockRoleMainElement = document.createElement('div');
+    mockRoleMainElement.setAttribute('role', 'main');
+    mockRoleMainElement.focus = jest.fn();
+
+    document.querySelector = jest.fn(selector => {
+      if (selector === 'main') {
+        return null;
+      }
+      if (selector === '[role="main"]') {
+        return mockRoleMainElement;
+      }
+      return null;
+    });
+
+    handleFlashDismissedInternal('item-0', items, mockRef, flashRefs);
+
+    expect(mockRoleMainElement.focus).toHaveBeenCalled();
+  });
+});

--- a/src/flashbar/__tests__/flash-utils.test.tsx
+++ b/src/flashbar/__tests__/flash-utils.test.tsx
@@ -1,0 +1,81 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { focusFlashById, focusFlashFocusableArea } from '../../../lib/components/flashbar/flash';
+
+import styles from '../../../lib/components/flashbar/styles.css.js';
+
+describe('Flash utility functions', () => {
+  describe('focusFlashFocusableArea', () => {
+    test('does nothing when flash element is null', () => {
+      expect(() => focusFlashFocusableArea(null)).not.toThrow();
+    });
+
+    test('focuses on dismiss button when available', () => {
+      const flashElement = document.createElement('div');
+      const dismissButton = document.createElement('button');
+      dismissButton.className = styles['dismiss-button'];
+      dismissButton.focus = jest.fn();
+
+      const focusContainer = document.createElement('div');
+      focusContainer.className = styles['flash-focus-container'];
+      focusContainer.focus = jest.fn();
+
+      flashElement.appendChild(dismissButton);
+      flashElement.appendChild(focusContainer);
+
+      focusFlashFocusableArea(flashElement);
+
+      expect(dismissButton.focus).toHaveBeenCalled();
+      expect(focusContainer.focus).not.toHaveBeenCalled();
+    });
+
+    test('focuses on focus container when dismiss button is not available', () => {
+      const flashElement = document.createElement('div');
+      const focusContainer = document.createElement('div');
+      focusContainer.className = styles['flash-focus-container'];
+      focusContainer.focus = jest.fn();
+
+      flashElement.appendChild(focusContainer);
+
+      focusFlashFocusableArea(flashElement);
+
+      expect(focusContainer.focus).toHaveBeenCalled();
+    });
+
+    test('does nothing when neither dismiss button nor focus container is available', () => {
+      const flashElement = document.createElement('div');
+
+      expect(() => focusFlashFocusableArea(flashElement)).not.toThrow();
+    });
+  });
+
+  describe('focusFlashById', () => {
+    test('does nothing when element is null', () => {
+      expect(() => focusFlashById(null, 'test-id')).not.toThrow();
+    });
+
+    test('does nothing when flash element with itemId is not found', () => {
+      const container = document.createElement('div');
+
+      focusFlashById(container, 'non-existent-id');
+
+      expect(container.querySelector).toBeTruthy();
+    });
+
+    test('does nothing when flash element has no focus container', () => {
+      const container = document.createElement('div');
+      const flashElement = document.createElement('div');
+      flashElement.setAttribute('data-itemid', 'test-id');
+
+      container.appendChild(flashElement);
+
+      expect(() => focusFlashById(container, 'test-id')).not.toThrow();
+    });
+
+    test('function exists and is callable', () => {
+      expect(typeof focusFlashById).toBe('function');
+      expect(() => focusFlashById(null, 'test')).not.toThrow();
+    });
+  });
+});

--- a/src/flashbar/__tests__/flashbar.test.tsx
+++ b/src/flashbar/__tests__/flashbar.test.tsx
@@ -31,7 +31,7 @@ mockInnerText();
 
 const noop = () => void 0;
 
-let consoleWarnSpy: jest.SpyInstance;
+let consoleWarnSpy: jest.SpyInstance | undefined;
 afterEach(() => {
   consoleWarnSpy?.mockRestore();
 });

--- a/src/flashbar/__tests__/focus-handling.test.tsx
+++ b/src/flashbar/__tests__/focus-handling.test.tsx
@@ -1,0 +1,285 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+
+import Flashbar, { FlashbarProps } from '../../../lib/components/flashbar';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+describe('Flashbar focus handling on dismiss', () => {
+  let mockMainElement: HTMLElement;
+  let originalQuerySelector: typeof document.querySelector;
+
+  beforeEach(() => {
+    // Mock main element
+    mockMainElement = document.createElement('main');
+    mockMainElement.focus = jest.fn();
+    document.body.appendChild(mockMainElement);
+
+    // Mock document.querySelector for main element fallback
+    originalQuerySelector = document.querySelector;
+    document.querySelector = jest.fn(selector => {
+      if (selector === 'main' || selector === '[role="main"]') {
+        return mockMainElement;
+      }
+      return originalQuerySelector.call(document, selector);
+    });
+  });
+
+  afterEach(() => {
+    document.querySelector = originalQuerySelector;
+    if (document.body.contains(mockMainElement)) {
+      document.body.removeChild(mockMainElement);
+    }
+  });
+
+  const createTestItems = (count: number): FlashbarProps.MessageDefinition[] => {
+    return Array.from({ length: count }, (_, i) => ({
+      id: `item-${i}`,
+      type: 'info' as const,
+      header: `Item ${i}`,
+      content: `Content ${i}`,
+      dismissible: true,
+    }));
+  };
+
+  const createDismissibleFlashbar = (items: FlashbarProps.MessageDefinition[]) => {
+    const TestComponent = () => {
+      const [flashItems, setFlashItems] = React.useState(items);
+
+      const itemsWithHandlers = flashItems.map(item => ({
+        ...item,
+        onDismiss: () => {
+          setFlashItems(prev => prev.filter(prevItem => prevItem.id !== item.id));
+        },
+      }));
+
+      return <Flashbar items={itemsWithHandlers} />;
+    };
+
+    return TestComponent;
+  };
+
+  test('dismiss functionality works correctly', () => {
+    const items = createTestItems(3);
+    const TestComponent = createDismissibleFlashbar(items);
+    const { container } = render(<TestComponent />);
+
+    const wrapper = createWrapper(container).findFlashbar()!;
+
+    expect(wrapper.findItems()).toHaveLength(3);
+    wrapper.findItems()[0].findDismissButton()!.click();
+
+    expect(wrapper.findItems()).toHaveLength(2);
+
+    expect(wrapper.findItems()[0].getElement()).toHaveTextContent('Item 1');
+  });
+
+  test('dismissing middle item works correctly', () => {
+    const items = createTestItems(5);
+    const TestComponent = createDismissibleFlashbar(items);
+    const { container } = render(<TestComponent />);
+
+    const wrapper = createWrapper(container).findFlashbar()!;
+
+    // Initially should have 5 items
+    expect(wrapper.findItems()).toHaveLength(5);
+
+    // Dismiss middle item (index 2)
+    wrapper.findItems()[2].findDismissButton()!.click();
+
+    // Should have 4 items remaining
+    expect(wrapper.findItems()).toHaveLength(4);
+
+    // Items should be reordered correctly
+    const remainingItems = wrapper.findItems();
+    expect(remainingItems[0].getElement()).toHaveTextContent('Item 0');
+    expect(remainingItems[1].getElement()).toHaveTextContent('Item 1');
+    expect(remainingItems[2].getElement()).toHaveTextContent('Item 3'); // Item 2 was removed
+    expect(remainingItems[3].getElement()).toHaveTextContent('Item 4');
+  });
+
+  test('dismissing last item works correctly', () => {
+    const items = createTestItems(3);
+    const TestComponent = createDismissibleFlashbar(items);
+    const { container } = render(<TestComponent />);
+
+    const wrapper = createWrapper(container).findFlashbar()!;
+
+    // Dismiss last item
+    const flashItems = wrapper.findItems();
+    flashItems[flashItems.length - 1].findDismissButton()!.click();
+
+    // Should have 2 items remaining
+    expect(wrapper.findItems()).toHaveLength(2);
+
+    // Last item should now be Item 1
+    const remainingItems = wrapper.findItems();
+    expect(remainingItems[remainingItems.length - 1].getElement()).toHaveTextContent('Item 1');
+  });
+
+  test('dismissing all items works correctly', () => {
+    const items = createTestItems(3);
+    const TestComponent = createDismissibleFlashbar(items);
+    const { container } = render(<TestComponent />);
+
+    const wrapper = createWrapper(container).findFlashbar()!;
+
+    // Dismiss items one by one
+    for (let i = 0; i < 3; i++) {
+      const flashItems = wrapper.findItems();
+      if (flashItems.length > 0) {
+        flashItems[0].findDismissButton()!.click();
+      }
+    }
+
+    // Should have no items remaining
+    expect(wrapper.findItems()).toHaveLength(0);
+  });
+
+  test('stackItems prop works correctly with dismissal', async () => {
+    const items = createTestItems(5);
+    const TestComponent = () => {
+      const [flashItems, setFlashItems] = React.useState(items);
+
+      const itemsWithHandlers = flashItems.map(item => ({
+        ...item,
+        onDismiss: () => {
+          setFlashItems(prev => prev.filter(prevItem => prevItem.id !== item.id));
+        },
+      }));
+
+      return <Flashbar items={itemsWithHandlers} stackItems={true} />;
+    };
+
+    const { container } = render(<TestComponent />);
+    const wrapper = createWrapper(container).findFlashbar()!;
+
+    // In stacked mode, should only show one item
+    expect(wrapper.findItems()).toHaveLength(1);
+
+    // Dismiss the visible item
+    wrapper.findItems()[0].findDismissButton()!.click();
+
+    await waitFor(() => {
+      expect(wrapper.findItems()).toHaveLength(1);
+    });
+
+    // Content should have changed to the next item
+    expect(wrapper.findItems()[0].getElement()).toHaveTextContent('Item 1');
+  });
+
+  test('handles items without IDs gracefully', () => {
+    const items: FlashbarProps.MessageDefinition[] = [
+      {
+        type: 'info',
+        header: 'Item without ID 1',
+        content: 'Content 1',
+        dismissible: true,
+      },
+      {
+        type: 'info',
+        header: 'Item without ID 2',
+        content: 'Content 2',
+        dismissible: true,
+      },
+    ];
+
+    const TestComponent = () => {
+      const [flashItems, setFlashItems] = React.useState(items);
+
+      const itemsWithHandlers = flashItems.map((item, index) => ({
+        ...item,
+        onDismiss: () => {
+          setFlashItems(prev => prev.filter((_, i) => i !== index));
+        },
+      }));
+
+      return <Flashbar items={itemsWithHandlers} />;
+    };
+
+    const { container } = render(<TestComponent />);
+    const wrapper = createWrapper(container).findFlashbar()!;
+
+    // Should render both items
+    expect(wrapper.findItems()).toHaveLength(2);
+
+    // Should be able to dismiss items without errors
+    wrapper.findItems()[0].findDismissButton()!.click();
+
+    expect(wrapper.findItems()).toHaveLength(1);
+
+    expect(wrapper.findItems()[0].getElement()).toHaveTextContent('Item without ID 2');
+  });
+
+  test('rapid dismissals work correctly', () => {
+    const items = createTestItems(5);
+    const TestComponent = createDismissibleFlashbar(items);
+    const { container } = render(<TestComponent />);
+
+    const wrapper = createWrapper(container).findFlashbar()!;
+
+    // Dismiss first item
+    wrapper.findItems()[0].findDismissButton()!.click();
+
+    expect(wrapper.findItems()).toHaveLength(4);
+
+    // Dismiss another item (was second, now first)
+    wrapper.findItems()[0].findDismissButton()!.click();
+
+    expect(wrapper.findItems()).toHaveLength(3);
+
+    // Dismiss another item (was third, now first)
+    wrapper.findItems()[0].findDismissButton()!.click();
+
+    // Should have 2 items remaining
+    expect(wrapper.findItems()).toHaveLength(2);
+
+    // Remaining items should be Item 3 and Item 4
+    const remainingItems = wrapper.findItems();
+    expect(remainingItems[0].getElement()).toHaveTextContent('Item 3');
+    expect(remainingItems[1].getElement()).toHaveTextContent('Item 4');
+  });
+
+  test('dismiss buttons are properly accessible', () => {
+    const items = createTestItems(2).map(item => ({
+      ...item,
+      dismissLabel: `Dismiss ${item.header}`,
+    }));
+    const TestComponent = createDismissibleFlashbar(items);
+    const { container } = render(<TestComponent />);
+
+    const wrapper = createWrapper(container).findFlashbar()!;
+    const flashItems = wrapper.findItems();
+
+    // Each dismiss button should be accessible
+    flashItems.forEach(item => {
+      const dismissButton = item.findDismissButton();
+      expect(dismissButton).toBeTruthy();
+      expect(dismissButton!.getElement()).toBeInTheDocument();
+      // The dismiss button should have either aria-label or aria-labelledby
+      const element = dismissButton!.getElement();
+      const hasAriaLabel = element.hasAttribute('aria-label');
+      const hasAriaLabelledBy = element.hasAttribute('aria-labelledby');
+      expect(hasAriaLabel || hasAriaLabelledBy).toBe(true);
+    });
+  });
+
+  test('focus behavior does not cause errors when main element is not present', () => {
+    // Remove the mocked main element
+    document.querySelector = jest.fn(() => null);
+
+    const items = createTestItems(1);
+    const TestComponent = createDismissibleFlashbar(items);
+    const { container } = render(<TestComponent />);
+
+    const wrapper = createWrapper(container).findFlashbar()!;
+
+    // Should not throw when dismissing the only item (even with no main element)
+    expect(() => {
+      wrapper.findItems()[0].findDismissButton()!.click();
+    }).not.toThrow();
+
+    expect(wrapper.findItems()).toHaveLength(0);
+  });
+});

--- a/src/flashbar/non-collapsible-flashbar.tsx
+++ b/src/flashbar/non-collapsible-flashbar.tsx
@@ -17,10 +17,11 @@ import { FlashbarProps } from './interfaces';
 import styles from './styles.css.js';
 
 export default function NonCollapsibleFlashbar({ items, i18nStrings, style, ...restProps }: FlashbarProps) {
-  const { allItemsHaveId, baseProps, isReducedMotion, isVisualRefresh, mergedRef } = useFlashbar({
-    items,
-    ...restProps,
-  });
+  const { allItemsHaveId, baseProps, isReducedMotion, isVisualRefresh, mergedRef, flashRefs, handleFlashDismissed } =
+    useFlashbar({
+      items,
+      ...restProps,
+    });
 
   const i18n = useInternalI18n('flashbar');
   const ariaLabel = i18n('i18nStrings.ariaLabel', i18nStrings?.ariaLabel);
@@ -113,14 +114,29 @@ export default function NonCollapsibleFlashbar({ items, i18nStrings, style, ...r
       <Flash
         className={clsx(animateFlash && styles['flash-with-motion'], isVisualRefresh && styles['flash-refresh'])}
         key={key}
-        ref={transitionRootElement}
+        ref={el => {
+          flashRefs.current[key] = el;
+          // If there's a transition root element ref, update it too
+          if (transitionRootElement && typeof transitionRootElement === 'function') {
+            transitionRootElement(el);
+          } else if (
+            transitionRootElement &&
+            typeof transitionRootElement === 'object' &&
+            'current' in transitionRootElement
+          ) {
+            (transitionRootElement as React.MutableRefObject<HTMLDivElement | null>).current = el;
+          }
+        }}
         transitionState={transitionState}
         i18nStrings={iconAriaLabels}
         style={style}
+        onDismissed={handleFlashDismissed}
         {...item}
       />
     );
   }
+
+  // The handleFlashDismissed function is now provided by the useFlashbar hook
 
   return (
     <div {...baseProps} className={clsx(baseProps.className, styles.flashbar)} ref={mergedRef}>


### PR DESCRIPTION
### Description

This introduces focus logic whenever a flash item gets dismissed, it works in both the collapsible and non-collapsible versions of the flashbar.

The idea works as the following:
- for each flash item we attach a ref
- when a flash item gets dismissed, we call a onDissmied callback that figures out the next flash item to focus and focues it
- if no flash items are remianing, we focus the main element (or an element with role="main")
- we prioritise focusing the dismiss button in case a flash is dismissed, otherwise we focus the focus invisible container of the flash item

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a
AWSUI-60902

### How has this been tested?
Added integration tests to it

<!-- How did you test to verify your changes? -->
Tested it locally as well in the flashbar interactive page

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
