### PR TITLE
fix: Fix table header background for resizable columns in classic

### DIFF
--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -78,10 +78,9 @@ export function Resizer({
 
     const updateTrackerPosition = (newOffset: number) => {
       const { insetInlineStart: scrollParentInsetInlineStart } = getLogicalBoundingClientRect(elements.table);
-      const classicOffset = isVisualRefresh ? 0 : 12; // space-xl / 2
       elements.tracker.style.insetBlockStart = getLogicalBoundingClientRect(elements.header).blockSize + 'px';
       // minus one pixel to offset the cell border
-      elements.tracker.style.insetInlineStart = newOffset - scrollParentInsetInlineStart - classicOffset - 1 + 'px';
+      elements.tracker.style.insetInlineStart = newOffset - scrollParentInsetInlineStart - 1 + 'px';
     };
 
     const updateColumnWidth = (newWidth: number) => {
@@ -189,7 +188,7 @@ export function Resizer({
       document.body.classList.remove(styles['resize-active-with-focus']);
       controller.abort();
     };
-  }, [minWidth, isDragging, isKeyboardDragging, resizerHasFocus, onWidthUpdate, onWidthUpdateCommit, isVisualRefresh]);
+  }, [minWidth, isDragging, isKeyboardDragging, resizerHasFocus, onWidthUpdate, onWidthUpdateCommit]);
 
   const { tabIndex: resizerTabIndex } = useSingleTabStopNavigation(resizerToggleRef, { tabIndex });
 

--- a/src/table/resizer/styles.scss
+++ b/src/table/resizer/styles.scss
@@ -41,7 +41,7 @@ th:not(:last-child) > .divider,
   }
 }
 
-.divider-interactive:not(.is-visual-refresh) {
+th:last-child > .divider-interactive:not(.is-visual-refresh) {
   inset-inline-end: calc(#{$handle-width} / 2);
 }
 
@@ -75,10 +75,10 @@ th:not(:last-child) > .divider,
       }
     }
   }
+}
 
-  &:not(.is-visual-refresh) {
-    inset-inline-end: 0;
-  }
+th:last-child > .resizer:not(.is-visual-refresh) {
+  inset-inline-end: 0;
 }
 
 .tracker {


### PR DESCRIPTION
### Description

#3635 introduced a small visual regression in classic: unwanted space to the right of the table.
After the discussion with Visual design, we decided it should be fixed.

<img width="742" height="263" alt="Screenshot 2025-07-14 at 16 04 46" src="https://github.com/user-attachments/assets/a7b4ae3b-3fc5-4f61-a69a-554821f61f2b" />


Related links, issue #, if available: n/a

### How has this been tested?

- manually
- ⏳ running in my pipeline rn

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
