### PR TITLE
chore: Add dnd drag buttons to list

### DIFF
--- a/pages/list/sortable-permutations.page.tsx
+++ b/pages/list/sortable-permutations.page.tsx
@@ -25,6 +25,11 @@ const items: Item[] = [
   { content: 'Item 4', description: 'Description', timestamp: 'January 1 2025' },
 ];
 
+const ControlledList = (props: ListProps<Item>) => {
+  const [items, setItems] = React.useState(props.items);
+  return <List {...props} items={items} onSortingChange={e => setItems(e.detail.items)} />;
+};
+
 const permutations = createPermutations<ListProps<Item> & { viewportWidth: number; _sortable: boolean | 'disabled' }>([
   {
     viewportWidth: [200, 400],
@@ -57,7 +62,7 @@ export default function ListItemPermutations() {
           permutations={permutations}
           render={({ viewportWidth, _sortable, ...permutation }) => (
             <div style={{ width: viewportWidth, borderRight: '1px solid red', padding: '4px', overflow: 'hidden' }}>
-              <List {...permutation} sortable={!!_sortable} sortDisabled={_sortable === 'disabled'} />
+              <ControlledList {...permutation} sortable={!!_sortable} sortDisabled={_sortable === 'disabled'} />
             </div>
           )}
         />

--- a/src/collection-preferences/content-display/__integ__/pages/content-display-page.ts
+++ b/src/collection-preferences/content-display/__integ__/pages/content-display-page.ts
@@ -6,7 +6,13 @@ import CollectionPreferencesPageObject from '../../../__integ__/pages/collection
 export default class ContentDisplayPageObject extends CollectionPreferencesPageObject {
   async containsOptionsInOrder(options: string[]) {
     const texts = await this.getElementsText(this.findOptions().toSelector());
-    return texts.join(`\n`).includes(options.join('\n'));
+    const result = texts.join(`\n`).includes(options.join('\n'));
+    if (!result) {
+      throw new Error(`Options are not in the expected order:
+        Expected: ${options.join(', ')}
+        Found: ${texts.join(', ')}`);
+    }
+    return true;
   }
 
   async expectAnnouncement(announcement: string) {

--- a/src/collection-preferences/content-display/__integ__/pages/dnd-page-object.ts
+++ b/src/collection-preferences/content-display/__integ__/pages/dnd-page-object.ts
@@ -27,7 +27,8 @@ export default class DndPageObject extends BasePageObject {
         id: 'event',
         parameters: { pointerType: 'mouse' },
         actions: [
-          { type: 'pointerMove', duration: 100, origin: 'pointer', x: xOffset, y: yOffset },
+          { type: 'pointerMove', duration: 100, origin: 'pointer', x: xOffset / 2, y: yOffset / 2 },
+          { type: 'pointerMove', duration: 100, origin: 'pointer', x: xOffset / 2, y: yOffset / 2 },
           { type: 'pause', duration: 150 },
         ],
       },

--- a/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
+++ b/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
@@ -315,6 +315,118 @@ describe('triggerMode = keyboard-activate', () => {
   });
 });
 
+describe('triggerMode = controlled', () => {
+  test('shows direction buttons when specified', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      triggerMode: 'controlled',
+      controlledShowButtons: true,
+    });
+
+    document.body.dataset.awsuiFocusVisible = 'true';
+    dragHandle.focus();
+    expect(getDirectionButton('block-start')).toBeInTheDocument();
+    expect(getDirectionButton('block-end')).toBeInTheDocument();
+    expect(getDirectionButton('inline-start')).toBeNull();
+    expect(getDirectionButton('inline-end')).toBeNull();
+  });
+
+  test('does not show direction buttons when focus enters the button', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      triggerMode: 'controlled',
+    });
+
+    document.body.dataset.awsuiFocusVisible = 'true';
+    dragHandle.focus();
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
+    expect(getDirectionButton('inline-start')).toBeNull();
+    expect(getDirectionButton('inline-end')).toBeNull();
+  });
+
+  test.each(['Enter', ' '])('does not show direction buttons when "%s" key is pressed on the focused button', key => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      triggerMode: 'controlled',
+    });
+
+    document.body.dataset.awsuiFocusVisible = 'true';
+    dragHandle.focus();
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(dragHandle, { key });
+
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+  });
+
+  test('when focused and other key is pressed, it should not show the direction buttons', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      triggerMode: 'controlled',
+    });
+
+    document.body.dataset.awsuiFocusVisible = 'true';
+    dragHandle.focus();
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(dragHandle, { key: 'A' });
+    expectDirectionButtonToBeHidden('block-start');
+    expectDirectionButtonToBeHidden('block-end');
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+  });
+
+  test('does not hide direction buttons when focus leaves the button', () => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      triggerMode: 'controlled',
+      controlledShowButtons: true,
+    });
+
+    document.body.dataset.awsuiFocusVisible = 'true';
+
+    dragHandle.focus();
+    expect(getDirectionButton('block-start')).toBeInTheDocument();
+    expect(getDirectionButton('block-end')).toBeInTheDocument();
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+
+    fireEvent.blur(dragHandle);
+    expect(getDirectionButton('block-start')).toBeInTheDocument();
+    expect(getDirectionButton('block-end')).toBeInTheDocument();
+  });
+
+  test.each(['Enter', ' '])('does not hide direction buttons when toggling "%s" key', key => {
+    const { dragHandle } = renderDragHandle({
+      directions: { 'block-start': 'active', 'block-end': 'active' },
+      triggerMode: 'controlled',
+      controlledShowButtons: true,
+    });
+
+    document.body.dataset.awsuiFocusVisible = 'true';
+
+    fireEvent.keyDown(dragHandle, { key });
+
+    expect(getDirectionButton('block-start')).toBeInTheDocument();
+    expect(getDirectionButton('block-end')).toBeInTheDocument();
+    expect(getDirectionButton('inline-start')).not.toBeInTheDocument();
+    expect(getDirectionButton('inline-end')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(dragHandle, { key });
+
+    expect(getDirectionButton('block-start')).toBeInTheDocument();
+    expect(getDirectionButton('block-end')).toBeInTheDocument();
+  });
+});
+
 test('shows direction buttons when clicked', () => {
   const { dragHandle } = renderDragHandle({
     directions: { 'block-start': 'active' },

--- a/src/internal/components/drag-handle-wrapper/index.tsx
+++ b/src/internal/components/drag-handle-wrapper/index.tsx
@@ -21,6 +21,7 @@ export default function DragHandleWrapper({
   onDirectionClick,
   triggerMode = 'focus',
   initialShowButtons = false,
+  controlledShowButtons = false,
   hideButtonsOnDrag,
   clickDragThreshold,
 }: DragHandleWrapperProps) {
@@ -161,7 +162,7 @@ export default function DragHandleWrapper({
       event.key !== 'Control' &&
       event.key !== 'Meta' &&
       event.key !== 'Shift' &&
-      triggerMode !== 'keyboard-activate'
+      triggerMode === 'focus'
     ) {
       // Pressing any other key will display the focus-visible ring around the
       // drag handle if it's in focus, so we should also show the buttons now.
@@ -179,9 +180,11 @@ export default function DragHandleWrapper({
     onDirectionClick?.(direction);
   };
 
+  const _showButtons = triggerMode === 'controlled' ? controlledShowButtons : showButtons;
+
   return (
     <div
-      className={clsx(styles['drag-handle-wrapper'], showButtons && styles['drag-handle-wrapper-open'])}
+      className={clsx(styles['drag-handle-wrapper'], _showButtons && styles['drag-handle-wrapper-open'])}
       ref={wrapperRef}
       onFocus={onWrapperFocusIn}
       onBlur={onWrapperFocusOut}
@@ -196,15 +199,15 @@ export default function DragHandleWrapper({
           {children}
         </div>
 
-        {!isDisabled && !showButtons && showTooltip && tooltipText && (
+        {!isDisabled && !_showButtons && showTooltip && tooltipText && (
           <Tooltip trackRef={dragHandleRef} value={tooltipText} onDismiss={() => setShowTooltip(false)} />
         )}
       </div>
 
-      <PortalOverlay track={dragHandleRef} isDisabled={!showButtons}>
+      <PortalOverlay track={dragHandleRef} isDisabled={!_showButtons}>
         {directions['block-start'] && (
           <DirectionButton
-            show={!isDisabled && showButtons}
+            show={!isDisabled && _showButtons}
             direction="block-start"
             state={directions['block-start']}
             onClick={() => onInternalDirectionClick('block-start')}
@@ -212,7 +215,7 @@ export default function DragHandleWrapper({
         )}
         {directions['block-end'] && (
           <DirectionButton
-            show={!isDisabled && showButtons}
+            show={!isDisabled && _showButtons}
             direction="block-end"
             state={directions['block-end']}
             onClick={() => onInternalDirectionClick('block-end')}
@@ -220,7 +223,7 @@ export default function DragHandleWrapper({
         )}
         {directions['inline-start'] && (
           <DirectionButton
-            show={!isDisabled && showButtons}
+            show={!isDisabled && _showButtons}
             direction="inline-start"
             state={directions['inline-start']}
             onClick={() => onInternalDirectionClick('inline-start')}
@@ -228,7 +231,7 @@ export default function DragHandleWrapper({
         )}
         {directions['inline-end'] && (
           <DirectionButton
-            show={!isDisabled && showButtons}
+            show={!isDisabled && _showButtons}
             direction="inline-end"
             state={directions['inline-end']}
             onClick={() => onInternalDirectionClick('inline-end')}

--- a/src/internal/components/drag-handle-wrapper/interfaces.ts
+++ b/src/internal/components/drag-handle-wrapper/interfaces.ts
@@ -3,7 +3,7 @@
 
 export type Direction = 'block-start' | 'block-end' | 'inline-start' | 'inline-end';
 export type DirectionState = 'active' | 'disabled';
-export type TriggerMode = 'focus' | 'keyboard-activate';
+export type TriggerMode = 'focus' | 'keyboard-activate' | 'controlled';
 
 export interface DragHandleWrapperProps {
   directions: Partial<Record<Direction, DirectionState>>;
@@ -12,6 +12,7 @@ export interface DragHandleWrapperProps {
   children: React.ReactNode;
   triggerMode?: TriggerMode;
   initialShowButtons?: boolean;
+  controlledShowButtons?: boolean;
   hideButtonsOnDrag: boolean;
   clickDragThreshold: number;
 }

--- a/src/internal/components/drag-handle/button.tsx
+++ b/src/internal/components/drag-handle/button.tsx
@@ -26,6 +26,7 @@ const DragHandleButton = forwardRef(
       ariaValue,
       disabled,
       onPointerDown,
+      onClick,
       onKeyDown,
     }: DragHandleProps,
     ref: React.Ref<Element>
@@ -33,7 +34,10 @@ const DragHandleButton = forwardRef(
     const dragHandleRefObject = useRef<HTMLDivElement>(null);
 
     const iconProps: IconProps = (() => {
-      const shared = { variant: disabled ? ('disabled' as const) : undefined, size };
+      const shared = {
+        variant: disabled ? ('disabled' as const) : undefined,
+        size,
+      };
       switch (variant) {
         case 'drag-indicator':
           return { ...shared, name: 'drag-indicator' };
@@ -73,9 +77,13 @@ const DragHandleButton = forwardRef(
         aria-valuemin={ariaValue?.valueMin}
         aria-valuenow={ariaValue?.valueNow}
         onPointerDown={onPointerDown}
+        onClick={onClick}
         onKeyDown={onKeyDown}
       >
-        <InternalIcon {...iconProps} />
+        {/* ensure that events happen on the parent div, not the icon */}
+        <div className={styles['prevent-pointer']}>
+          <InternalIcon {...iconProps} />
+        </div>
       </div>
     );
   }

--- a/src/internal/components/drag-handle/index.tsx
+++ b/src/internal/components/drag-handle/index.tsx
@@ -22,10 +22,12 @@ const InternalDragHandle = forwardRef(
       disabled,
       directions = {},
       onPointerDown,
+      onClick,
       onKeyDown,
       onDirectionClick,
       triggerMode,
       initialShowButtons,
+      controlledShowButtons,
       hideButtonsOnDrag = false,
       clickDragThreshold = 3,
       active,
@@ -42,6 +44,7 @@ const InternalDragHandle = forwardRef(
         onDirectionClick={onDirectionClick}
         triggerMode={triggerMode}
         initialShowButtons={initialShowButtons}
+        controlledShowButtons={controlledShowButtons}
         hideButtonsOnDrag={hideButtonsOnDrag}
         clickDragThreshold={clickDragThreshold}
       >
@@ -57,6 +60,7 @@ const InternalDragHandle = forwardRef(
           disabled={disabled}
           active={active}
           onPointerDown={onPointerDown}
+          onClick={onClick}
           onKeyDown={onKeyDown}
         />
       </DragHandleWrapper>

--- a/src/internal/components/drag-handle/interfaces.ts
+++ b/src/internal/components/drag-handle/interfaces.ts
@@ -19,12 +19,14 @@ export interface DragHandleProps {
   className?: string;
   onPointerDown?: React.PointerEventHandler;
   onKeyDown?: React.KeyboardEventHandler;
+  onClick?: React.MouseEventHandler;
 
   tooltipText?: string;
   directions?: Partial<Record<DragHandleProps.Direction, DragHandleProps.DirectionState>>;
   onDirectionClick?: (direction: DragHandleProps.Direction) => void;
   triggerMode?: TriggerMode;
   initialShowButtons?: boolean;
+  controlledShowButtons?: boolean;
   /**
    * Hide the UAP buttons when dragging is active.
    */
@@ -34,6 +36,7 @@ export interface DragHandleProps {
    * a drag. Small threshold needed for usability.
    */
   clickDragThreshold?: number;
+  ref?: React.RefObject<HTMLElement>;
 }
 
 export namespace DragHandleProps {

--- a/src/internal/components/drag-handle/styles.scss
+++ b/src/internal/components/drag-handle/styles.scss
@@ -85,3 +85,7 @@
     transform: rotate(90deg);
   }
 }
+
+.prevent-pointer {
+  pointer-events: none;
+}

--- a/src/internal/components/sortable-area/__tests__/sortable-area.test.tsx
+++ b/src/internal/components/sortable-area/__tests__/sortable-area.test.tsx
@@ -45,6 +45,12 @@ test('renders all items with correct attributes', () => {
           disabled: false,
           onPointerDown: expect.anything(),
           onKeyDown: expect.anything(),
+          onDirectionClick: expect.anything(),
+          onClick: expect.anything(),
+          triggerMode: 'controlled',
+          controlledShowButtons: false,
+          ref: expect.anything(),
+          directions: undefined,
         },
       })
     );

--- a/src/internal/components/sortable-area/keyboard-sensor/index.ts
+++ b/src/internal/components/sortable-area/keyboard-sensor/index.ts
@@ -31,7 +31,7 @@ export type KeyboardAndUAPCoordinateGetter = (
 ) => Coordinates | void;
 
 type KeyboardAndUAPSensorOptions = KeyboardSensorOptions & {
-  coordinateGetter?: KeyboardAndUAPCoordinateGetter;
+  coordinateGetter: KeyboardAndUAPCoordinateGetter;
   onActivation?({ event }: { event: KeyboardEvent | MouseEvent }): void;
 };
 
@@ -129,10 +129,6 @@ export class KeyboardAndUAPSensor implements SensorInstance {
 
     if (!this.referenceCoordinates) {
       this.referenceCoordinates = currentCoordinates;
-    }
-
-    if (!coordinateGetter) {
-      return;
     }
 
     const newCoordinates = coordinateGetter(event, {

--- a/src/internal/components/sortable-area/keyboard-sensor/utilities/__tests__/scroll.test.ts
+++ b/src/internal/components/sortable-area/keyboard-sensor/utilities/__tests__/scroll.test.ts
@@ -25,14 +25,14 @@ describe('applyScroll', () => {
   const newCoordinates = { x: 0, y: 10 };
 
   it('returns true if scroll was applied', () => {
-    expect(
-      applyScroll({ currentCoordinates, direction: 'ArrowDown', newCoordinates, scrollableAncestors: [element] })
-    ).toBe(true);
+    expect(applyScroll({ currentCoordinates, direction: 'down', newCoordinates, scrollableAncestors: [element] })).toBe(
+      true
+    );
   });
 
   it('returns false if scroll was not applied', () => {
-    expect(
-      applyScroll({ currentCoordinates, direction: 'ArrowUp', newCoordinates, scrollableAncestors: [element] })
-    ).toBe(false);
+    expect(applyScroll({ currentCoordinates, direction: 'up', newCoordinates, scrollableAncestors: [element] })).toBe(
+      false
+    );
   });
 });

--- a/src/internal/components/sortable-area/keyboard-sensor/utilities/events.ts
+++ b/src/internal/components/sortable-area/keyboard-sensor/utilities/events.ts
@@ -5,4 +5,6 @@ export enum EventName {
   Keydown = 'keydown',
   Resize = 'resize',
   VisibilityChange = 'visibilitychange',
+  CustomDown = 'custom-movedown',
+  CustomUp = 'custom-moveup',
 }

--- a/src/internal/components/sortable-area/keyboard-sensor/utilities/scroll.ts
+++ b/src/internal/components/sortable-area/keyboard-sensor/utilities/scroll.ts
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { KeyboardCode } from '@dnd-kit/core';
 import { canUseDOM, Coordinates, subtract as getCoordinatesDelta } from '@dnd-kit/utilities';
 
 function isDocumentScrollingElement(element: Element | null) {
@@ -78,7 +77,7 @@ export function applyScroll({
   scrollableAncestors,
 }: {
   currentCoordinates: Coordinates;
-  direction: string;
+  direction: 'up' | 'down';
   newCoordinates: Coordinates;
   scrollableAncestors: Element[];
 }) {
@@ -89,25 +88,21 @@ export function applyScroll({
 
     const clampedCoordinates = {
       y: Math.min(
-        direction === KeyboardCode.Down
-          ? scrollElementRect.bottom - scrollElementRect.height / 2
-          : scrollElementRect.bottom,
+        direction === 'down' ? scrollElementRect.bottom - scrollElementRect.height / 2 : scrollElementRect.bottom,
         Math.max(
-          direction === KeyboardCode.Down
-            ? scrollElementRect.top
-            : scrollElementRect.top + scrollElementRect.height / 2,
+          direction === 'down' ? scrollElementRect.top : scrollElementRect.top + scrollElementRect.height / 2,
           newCoordinates.y
         )
       ),
     };
 
-    const canScrollY = (direction === KeyboardCode.Down && !isBottom) || (direction === KeyboardCode.Up && !isTop);
+    const canScrollY = (direction === 'down' && !isBottom) || (direction === 'up' && !isTop);
 
     if (canScrollY && clampedCoordinates.y !== newCoordinates.y) {
       const newScrollCoordinates = scrollContainer.scrollTop + coordinatesDelta.y;
       const canScrollToNewCoordinates =
-        (direction === KeyboardCode.Down && newScrollCoordinates <= maxScroll.y) ||
-        (direction === KeyboardCode.Up && newScrollCoordinates >= minScroll.y);
+        (direction === 'down' && newScrollCoordinates <= maxScroll.y) ||
+        (direction === 'up' && newScrollCoordinates >= minScroll.y);
 
       if (canScrollToNewCoordinates) {
         // We don't need to update coordinates, the scroll adjustment alone will trigger

--- a/src/internal/components/sortable-area/styles.scss
+++ b/src/internal/components/sortable-area/styles.scss
@@ -19,9 +19,7 @@
   border-end-start-radius: $border-radius;
   border-end-end-radius: $border-radius;
 
-  @include focus-visible.when-visible-unfocused {
-    @include styles.focus-highlight(0px, $border-radius);
-  }
+  @include styles.focus-highlight(0px, $border-radius);
 }
 
 .drag-overlay {

--- a/src/list/__tests__/list-sortable.test.tsx
+++ b/src/list/__tests__/list-sortable.test.tsx
@@ -135,6 +135,17 @@ describe('List - Sortable', () => {
     await expectAnnouncement('Item moved from position 1 to position 2 of 3');
   });
 
+  test('ignores other keys', async () => {
+    const { wrapper } = renderSortableList();
+    const dragHandle = wrapper.findItemByIndex(1)!.findDragHandle()!.getElement();
+    pressKey(dragHandle, 'Space');
+    await expectAnnouncement('Picked up item at position 1 of 3');
+    pressKey(dragHandle, 'D');
+    pressKey(dragHandle, 'Space');
+    expect(wrapper.findItemByIndex(1)!.getElement()).toHaveTextContent('Item 1');
+    expect(wrapper.findItemByIndex(2)!.getElement()).toHaveTextContent('Item 2');
+  });
+
   test('can move an item with UAP buttons', async () => {
     const { wrapper } = renderSortableList();
     const dragHandle = wrapper.findItemByIndex(1)!.findDragHandle()!.getElement();
@@ -156,5 +167,15 @@ describe('List - Sortable', () => {
     expect(wrapper.findItemByIndex(1)!.getElement()).toHaveTextContent('Item 2');
     expect(wrapper.findItemByIndex(2)!.getElement()).toHaveTextContent('Item 1');
     await expectAnnouncement('Item moved from position 1 to position 2 of 3');
+  });
+
+  test('non-primary pointer events do not activate UAP', () => {
+    const { wrapper } = renderSortableList();
+    const dragHandle = wrapper.findItemByIndex(1)!.findDragHandle()!;
+    const dragWrapper = new InternalDragHandleWrapper(document.body);
+    expect(dragWrapper.findVisibleDirectionButtonBlockEnd()).toBeFalsy();
+
+    dragHandle.click({ button: 1 });
+    expect(dragWrapper.findVisibleDirectionButtonBlockEnd()).toBeFalsy();
   });
 });

--- a/src/list/__tests__/list-sortable.test.tsx
+++ b/src/list/__tests__/list-sortable.test.tsx
@@ -6,6 +6,7 @@ import { fireEvent, render } from '@testing-library/react';
 import TestI18nProvider from '../../../lib/components/i18n/testing';
 import List, { ListProps } from '../../../lib/components/list';
 import createWrapper from '../../../lib/components/test-utils/dom';
+import InternalDragHandleWrapper from '../../../lib/components/test-utils/dom/internal/drag-handle';
 
 interface Item {
   id: string;
@@ -129,6 +130,29 @@ describe('List - Sortable', () => {
     pressKey(dragHandle, 'ArrowDown');
     await expectAnnouncement('Moving item to position 2 of 3');
     pressKey(dragHandle, 'Space');
+    expect(wrapper.findItemByIndex(1)!.getElement()).toHaveTextContent('Item 2');
+    expect(wrapper.findItemByIndex(2)!.getElement()).toHaveTextContent('Item 1');
+    await expectAnnouncement('Item moved from position 1 to position 2 of 3');
+  });
+
+  test('can move an item with UAP buttons', async () => {
+    const { wrapper } = renderSortableList();
+    const dragHandle = wrapper.findItemByIndex(1)!.findDragHandle()!.getElement();
+    const dragWrapper = new InternalDragHandleWrapper(document.body);
+    expect(dragWrapper.findVisibleDirectionButtonBlockEnd()).toBeFalsy();
+
+    dragHandle.click();
+    expect(dragWrapper.findVisibleDirectionButtonBlockEnd()).toBeTruthy();
+    await expectAnnouncement('Picked up item at position 1 of 3');
+
+    dragWrapper.findVisibleDirectionButtonBlockEnd()!.click();
+    await expectAnnouncement('Moving item to position 2 of 3');
+    dragWrapper.findVisibleDirectionButtonBlockEnd()!.click();
+    await expectAnnouncement('Moving item to position 3 of 3');
+    dragWrapper.findVisibleDirectionButtonBlockStart()!.click();
+    await expectAnnouncement('Moving item to position 2 of 3');
+
+    pressKey(dragHandle, 'Enter');
     expect(wrapper.findItemByIndex(1)!.getElement()).toHaveTextContent('Item 2');
     expect(wrapper.findItemByIndex(2)!.getElement()).toHaveTextContent('Item 1');
     await expectAnnouncement('Item moved from position 1 to position 2 of 3');


### PR DESCRIPTION
### Description

Add pointer-only/"UAP" buttons to sortable list

Related links, issue #, if available: AWSUI-61051

### How has this been tested?

New unit and integ tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
