### PR TITLE
feat: Allow custom primary actions in prompt input

### DIFF
--- a/pages/prompt-input/permutations.page.tsx
+++ b/pages/prompt-input/permutations.page.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import { Button } from '~components';
 import PromptInput, { PromptInputProps } from '~components/prompt-input';
 
 import img from '../icon/custom-icon.png';
@@ -76,7 +77,10 @@ const permutations = createPermutations<PromptInputProps>([
   {
     value: ['Short value for custom primary actions'],
     actionButtonIconName: [undefined, 'send'],
-    customPrimaryAction: [undefined, 'Custom primary'],
+    customPrimaryAction: [
+      undefined,
+      <Button variant="icon" iconName="add-plus" ariaLabel="Custom action" key="button" />,
+    ],
     secondaryActions: [undefined, 'secondary actions'],
     disableSecondaryActionsPaddings: [false, true],
   },

--- a/pages/prompt-input/permutations.page.tsx
+++ b/pages/prompt-input/permutations.page.tsx
@@ -76,7 +76,7 @@ const permutations = createPermutations<PromptInputProps>([
   {
     value: ['Short value for custom primary actions'],
     actionButtonIconName: [undefined, 'send'],
-    primaryAction: [undefined, 'Custom primary'],
+    customPrimaryAction: [undefined, 'Custom primary'],
     secondaryActions: [undefined, 'secondary actions'],
     disableSecondaryActionsPaddings: [false, true],
   },

--- a/pages/prompt-input/permutations.page.tsx
+++ b/pages/prompt-input/permutations.page.tsx
@@ -73,6 +73,13 @@ const permutations = createPermutations<PromptInputProps>([
     disableSecondaryActionsPaddings: [false, true],
     disableSecondaryContentPaddings: [false, true],
   },
+  {
+    value: ['Short value for custom primary actions'],
+    actionButtonIconName: [undefined, 'send'],
+    primaryAction: [undefined, 'Custom primary'],
+    secondaryActions: [undefined, 'secondary actions'],
+    disableSecondaryActionsPaddings: [false, true],
+  },
 ]);
 
 export default function PromptInputPermutations() {

--- a/pages/prompt-input/simple.page.tsx
+++ b/pages/prompt-input/simple.page.tsx
@@ -205,27 +205,25 @@ export default function PromptInputPage() {
                   disableSecondaryActionsPaddings={true}
                   customPrimaryAction={
                     hasPrimaryActions ? (
-                      <Box padding={{ right: 'xxs', top: 'xs' }}>
-                        <ButtonGroup
-                          variant="icon"
-                          items={[
-                            {
-                              type: 'icon-button',
-                              id: 'record',
-                              text: 'Record',
-                              iconName: 'microphone',
-                              disabled: isDisabled || isReadOnly,
-                            },
-                            {
-                              type: 'icon-button',
-                              id: 'submit',
-                              text: 'Submit',
-                              iconName: 'send',
-                              disabled: isDisabled || isReadOnly,
-                            },
-                          ]}
-                        />
-                      </Box>
+                      <ButtonGroup
+                        variant="icon"
+                        items={[
+                          {
+                            type: 'icon-button',
+                            id: 'record',
+                            text: 'Record',
+                            iconName: 'microphone',
+                            disabled: isDisabled || isReadOnly,
+                          },
+                          {
+                            type: 'icon-button',
+                            id: 'submit',
+                            text: 'Submit',
+                            iconName: 'send',
+                            disabled: isDisabled || isReadOnly,
+                          },
+                        ]}
+                      />
                     ) : undefined
                   }
                   secondaryActions={

--- a/pages/prompt-input/simple.page.tsx
+++ b/pages/prompt-input/simple.page.tsx
@@ -203,7 +203,7 @@ export default function PromptInputPage() {
                   warning={hasWarning}
                   ref={ref}
                   disableSecondaryActionsPaddings={true}
-                  primaryAction={
+                  customPrimaryAction={
                     hasPrimaryActions ? (
                       <Box padding={{ right: 'xxs', top: 'xs' }}>
                         <ButtonGroup

--- a/pages/prompt-input/simple.page.tsx
+++ b/pages/prompt-input/simple.page.tsx
@@ -31,6 +31,7 @@ type DemoContext = React.Context<
     hasText: boolean;
     hasSecondaryContent: boolean;
     hasSecondaryActions: boolean;
+    hasPrimaryActions: boolean;
     hasInfiniteMaxRows: boolean;
   }>
 >;
@@ -52,6 +53,7 @@ export default function PromptInputPage() {
     hasText,
     hasSecondaryActions,
     hasSecondaryContent,
+    hasPrimaryActions,
     hasInfiniteMaxRows,
   } = urlParams;
 
@@ -142,6 +144,16 @@ export default function PromptInputPage() {
                 Secondary actions
               </Checkbox>
               <Checkbox
+                checked={hasPrimaryActions}
+                onChange={() =>
+                  setUrlParams({
+                    hasPrimaryActions: !hasPrimaryActions,
+                  })
+                }
+              >
+                Custom primary actions
+              </Checkbox>
+              <Checkbox
                 checked={hasInfiniteMaxRows}
                 onChange={() =>
                   setUrlParams({
@@ -191,6 +203,31 @@ export default function PromptInputPage() {
                   warning={hasWarning}
                   ref={ref}
                   disableSecondaryActionsPaddings={true}
+                  primaryAction={
+                    hasPrimaryActions ? (
+                      <Box padding={{ right: 'xxs', top: 'xs' }}>
+                        <ButtonGroup
+                          variant="icon"
+                          items={[
+                            {
+                              type: 'icon-button',
+                              id: 'record',
+                              text: 'Record',
+                              iconName: 'microphone',
+                              disabled: isDisabled || isReadOnly,
+                            },
+                            {
+                              type: 'icon-button',
+                              id: 'submit',
+                              text: 'Submit',
+                              iconName: 'send',
+                              disabled: isDisabled || isReadOnly,
+                            },
+                          ]}
+                        />
+                      </Box>
+                    ) : undefined
+                  }
                   secondaryActions={
                     hasSecondaryActions ? (
                       <Box padding={{ left: 'xxs', top: 'xs' }}>

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -478,6 +478,7 @@ exports[`test-utils selectors 1`] = `
   ],
   "prompt-input": [
     "awsui_action-button_nr3gs",
+    "awsui_primary-action_nr3gs",
     "awsui_root_nr3gs",
     "awsui_secondary-actions_nr3gs",
     "awsui_secondary-content_nr3gs",

--- a/src/prompt-input/__tests__/prompt-input.test.tsx
+++ b/src/prompt-input/__tests__/prompt-input.test.tsx
@@ -136,7 +136,7 @@ describe('action button', () => {
     expect(wrapper.findActionButton().getElement()).toBeInTheDocument();
   });
 
-  test('should render action button inside secondary actions container when secondary actions are present', () => {
+  test('should not find primary button within secondaryActions', () => {
     const { wrapper } = renderPromptInput({
       value: '',
       minRows: 4,
@@ -145,9 +145,9 @@ describe('action button', () => {
     });
 
     const secondaryActionsContainer = wrapper.findSecondaryActions()!.getElement();
-    const actionButton = within(secondaryActionsContainer).getByRole('button');
+    const actionButton = within(secondaryActionsContainer).queryByRole('button');
 
-    expect(actionButton).toBeInTheDocument();
+    expect(actionButton).toBeFalsy();
   });
 
   test('disabled when in disabled state', () => {
@@ -168,6 +168,30 @@ describe('action button', () => {
 
     expect(wrapper.findActionButton().getElement()).toHaveAttribute('aria-disabled', 'true');
     expect(wrapper.findActionButton().getElement()).not.toHaveAttribute('disabled');
+  });
+});
+
+describe('custom primary action', () => {
+  test('custom primaryAction can be provided', () => {
+    const { wrapper } = renderPromptInput({
+      value: '',
+      actionButtonIconName: 'send',
+      primaryAction: (
+        <>
+          <button>One</button>
+          <button>Two</button>
+        </>
+      ),
+    });
+    expect(wrapper.findPrimaryActionSlot()!.getElement().querySelectorAll('button').length).toBe(2);
+  });
+  test('default primary action is removed if custom primaryAction provided', () => {
+    const { wrapper } = renderPromptInput({
+      value: '',
+      actionButtonIconName: 'send',
+      primaryAction: 'custom content',
+    });
+    expect(wrapper.findActionButton()).toBeFalsy();
   });
 });
 

--- a/src/prompt-input/__tests__/prompt-input.test.tsx
+++ b/src/prompt-input/__tests__/prompt-input.test.tsx
@@ -183,7 +183,7 @@ describe('custom primary action', () => {
         </>
       ),
     });
-    expect(wrapper.findPrimaryActionSlot()!.getElement().querySelectorAll('button').length).toBe(2);
+    expect(wrapper.findCustomPrimaryAction()!.getElement().querySelectorAll('button').length).toBe(2);
   });
   test('default primary action is removed if custom primaryAction provided', () => {
     const { wrapper } = renderPromptInput({

--- a/src/prompt-input/__tests__/prompt-input.test.tsx
+++ b/src/prompt-input/__tests__/prompt-input.test.tsx
@@ -172,11 +172,11 @@ describe('action button', () => {
 });
 
 describe('custom primary action', () => {
-  test('custom primaryAction can be provided', () => {
+  test('customPrimaryAction can be provided', () => {
     const { wrapper } = renderPromptInput({
       value: '',
       actionButtonIconName: 'send',
-      primaryAction: (
+      customPrimaryAction: (
         <>
           <button>One</button>
           <button>Two</button>
@@ -189,7 +189,7 @@ describe('custom primary action', () => {
     const { wrapper } = renderPromptInput({
       value: '',
       actionButtonIconName: 'send',
-      primaryAction: 'custom content',
+      customPrimaryAction: 'custom content',
     });
     expect(wrapper.findActionButton()).toBeFalsy();
   });

--- a/src/prompt-input/interfaces.ts
+++ b/src/prompt-input/interfaces.ts
@@ -86,6 +86,15 @@ export interface PromptInputProps
   maxRows?: number;
 
   /**
+   * Use this to replace the primary action.
+   * If this is provided then any other `actionButton*` properties will be ignored.
+   * Note that you should still provide an `onAction` function in order to handle keyboard submission.
+   *
+   * @awsuiSystem core
+   */
+  primaryAction?: React.ReactNode;
+
+  /**
    * Use this slot to add secondary actions to the prompt input.
    */
   secondaryActions?: React.ReactNode;

--- a/src/prompt-input/interfaces.ts
+++ b/src/prompt-input/interfaces.ts
@@ -92,7 +92,7 @@ export interface PromptInputProps
    *
    * @awsuiSystem core
    */
-  primaryAction?: React.ReactNode;
+  customPrimaryAction?: React.ReactNode;
 
   /**
    * Use this slot to add secondary actions to the prompt input.

--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -50,6 +50,7 @@ const InternalPromptInput = React.forwardRef(
       placeholder,
       readOnly,
       spellcheck,
+      primaryAction,
       secondaryActions,
       secondaryContent,
       disableSecondaryActionsPaddings,
@@ -105,7 +106,7 @@ const InternalPromptInput = React.forwardRef(
       adjustTextareaHeight();
     };
 
-    const hasActionButton = actionButtonIconName || actionButtonIconSvg || actionButtonIconUrl;
+    const hasActionButton = actionButtonIconName || actionButtonIconSvg || actionButtonIconUrl || primaryAction;
 
     const adjustTextareaHeight = useCallback(() => {
       if (textareaRef.current) {
@@ -173,19 +174,21 @@ const InternalPromptInput = React.forwardRef(
     }
 
     const action = (
-      <div className={styles.button}>
-        <InternalButton
-          className={clsx(styles['action-button'], testutilStyles['action-button'])}
-          ariaLabel={actionButtonAriaLabel}
-          disabled={disabled || readOnly || disableActionButton}
-          __focusable={readOnly}
-          iconName={actionButtonIconName}
-          iconUrl={actionButtonIconUrl}
-          iconSvg={actionButtonIconSvg}
-          iconAlt={actionButtonIconAlt}
-          onClick={() => fireNonCancelableEvent(onAction, { value })}
-          variant="icon"
-        />
+      <div className={clsx(styles['primary-action'], testutilStyles['primary-action'])}>
+        {primaryAction ?? (
+          <InternalButton
+            className={clsx(styles['action-button'], testutilStyles['action-button'])}
+            ariaLabel={actionButtonAriaLabel}
+            disabled={disabled || readOnly || disableActionButton}
+            __focusable={readOnly}
+            iconName={actionButtonIconName}
+            iconUrl={actionButtonIconUrl}
+            iconSvg={actionButtonIconSvg}
+            iconAlt={actionButtonIconAlt}
+            onClick={() => fireNonCancelableEvent(onAction, { value })}
+            variant="icon"
+          />
+        )}
       </div>
     );
 
@@ -219,13 +222,18 @@ const InternalPromptInput = React.forwardRef(
         </div>
         {secondaryActions && (
           <div
-            className={clsx(styles['secondary-actions'], testutilStyles['secondary-actions'], {
-              [styles['with-paddings']]: !disableSecondaryActionsPaddings,
+            className={clsx(styles['action-stripe'], {
               [styles.invalid]: invalid,
               [styles.warning]: warning,
             })}
           >
-            {secondaryActions}
+            <div
+              className={clsx(styles['secondary-actions'], testutilStyles['secondary-actions'], {
+                [styles['with-paddings']]: !disableSecondaryActionsPaddings,
+              })}
+            >
+              {secondaryActions}
+            </div>
             <div className={styles.buffer} onClick={() => textareaRef.current?.focus()} />
             {hasActionButton && action}
           </div>

--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -50,7 +50,7 @@ const InternalPromptInput = React.forwardRef(
       placeholder,
       readOnly,
       spellcheck,
-      primaryAction,
+      customPrimaryAction,
       secondaryActions,
       secondaryContent,
       disableSecondaryActionsPaddings,
@@ -106,7 +106,7 @@ const InternalPromptInput = React.forwardRef(
       adjustTextareaHeight();
     };
 
-    const hasActionButton = actionButtonIconName || actionButtonIconSvg || actionButtonIconUrl || primaryAction;
+    const hasActionButton = actionButtonIconName || actionButtonIconSvg || actionButtonIconUrl || customPrimaryAction;
 
     const adjustTextareaHeight = useCallback(() => {
       if (textareaRef.current) {
@@ -175,7 +175,7 @@ const InternalPromptInput = React.forwardRef(
 
     const action = (
       <div className={clsx(styles['primary-action'], testutilStyles['primary-action'])}>
-        {primaryAction ?? (
+        {customPrimaryAction ?? (
           <InternalButton
             className={clsx(styles['action-button'], testutilStyles['action-button'])}
             ariaLabel={actionButtonAriaLabel}

--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -230,6 +230,8 @@ const InternalPromptInput = React.forwardRef(
             <div
               className={clsx(styles['secondary-actions'], testutilStyles['secondary-actions'], {
                 [styles['with-paddings']]: !disableSecondaryActionsPaddings,
+                [styles.invalid]: invalid,
+                [styles.warning]: warning,
               })}
             >
               {secondaryActions}

--- a/src/prompt-input/styles.scss
+++ b/src/prompt-input/styles.scss
@@ -140,20 +140,13 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
   align-self: flex-end;
   flex-shrink: 0;
   padding-inline-start: calc(styles.$control-padding-horizontal / 2);
+  
+  .textarea-wrapper > & {
+    padding-inline-end: calc(styles.$control-padding-horizontal / 2);
 
-  > .action-button {
-    padding: 0;
-    margin-block-end: awsui.$space-scaled-xxxs;
-    margin-inline-end: calc(styles.$control-padding-horizontal / 2);
-
-    // offset the focus ring by 1px per side so it doesn't blend into the textarea border
-    @include focus-visible.when-visible {
-      @include styles.focus-highlight(
-        (
-          'vertical': calc((-1 * #{awsui.$space-xxxs}) - 1px),
-          'horizontal': calc((#{awsui.$space-xxxs}) - 1px),
-        )
-      );
+    > .action-button {
+      margin-block-end: awsui.$space-scaled-xxxs;
+      padding: 0;
     }
   }
 }
@@ -181,9 +174,6 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  >.primary-action>.action-button {
-    margin-block-end: awsui.$space-scaled-xxs;
-  }
 }
 
 .secondary-actions {

--- a/src/prompt-input/styles.scss
+++ b/src/prompt-input/styles.scss
@@ -136,13 +136,15 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
   }
 }
 
-.button {
+.primary-action {
   align-self: flex-end;
-  padding-inline: calc(styles.$control-padding-horizontal / 2);
-  padding-block-end: awsui.$space-scaled-xxxs;
+  flex-shrink: 0;
+  padding-inline-start: calc(styles.$control-padding-horizontal / 2);
 
   > .action-button {
     padding: 0;
+    margin-block-end: awsui.$space-scaled-xxxs;
+    margin-inline-end: calc(styles.$control-padding-horizontal / 2);
 
     // offset the focus ring by 1px per side so it doesn't blend into the textarea border
     @include focus-visible.when-visible {
@@ -173,13 +175,18 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
   }
 }
 
-.secondary-actions {
+.action-stripe {
   @include styles.styles-reset;
   @include styles.control-border-radius-full();
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
+  >.primary-action>.action-button {
+    margin-block-end: awsui.$space-scaled-xxs;
+  }
+}
 
+.secondary-actions {
   &.with-paddings {
     padding-inline-start: styles.$control-padding-horizontal;
     padding-block-start: awsui.$space-scaled-s;
@@ -189,14 +196,6 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
     &.warning {
       padding-inline-start: $invalid-border-offset;
     }
-
-    > .button {
-      padding-block-end: 0;
-    }
-  }
-
-  > .button {
-    padding-block-end: awsui.$space-scaled-xxs;
   }
 }
 

--- a/src/prompt-input/test-classes/styles.scss
+++ b/src/prompt-input/test-classes/styles.scss
@@ -14,6 +14,10 @@
   /* used in test-utils */
 }
 
+.primary-action {
+  /* used in test-utils */
+}
+
 .secondary-actions {
   /* used in test-utils */
 }

--- a/src/test-utils/dom/prompt-input/index.ts
+++ b/src/test-utils/dom/prompt-input/index.ts
@@ -14,8 +14,7 @@ export default class PromptInputWrapper extends ComponentWrapper {
   }
 
   /**
-   * Finds the primary action button. Note that if you provide `primaryAction`
-   * then this will return null, you should use `findPrimaryActionSlot` instead.
+   * Finds the action button. Note that, despite its typings, this may return null.
    */
   findActionButton(): ElementWrapper<HTMLButtonElement> {
     return this.findByClassName<HTMLButtonElement>(testutilStyles['action-button'])!;

--- a/src/test-utils/dom/prompt-input/index.ts
+++ b/src/test-utils/dom/prompt-input/index.ts
@@ -13,16 +13,27 @@ export default class PromptInputWrapper extends ComponentWrapper {
     return this.findByClassName<HTMLTextAreaElement>(testutilStyles.textarea)!;
   }
 
+  /**
+   * Finds the primary action button. Note that if you provide `primaryAction`
+   * then this will return null, you should use `findPrimaryActionSlot` instead.
+   */
   findActionButton(): ElementWrapper<HTMLButtonElement> {
     return this.findByClassName<HTMLButtonElement>(testutilStyles['action-button'])!;
   }
 
+  /**
+   * Finds the secondary actions slot. Note that, despite its typings, this may return null.
+   */
   findSecondaryActions(): ElementWrapper<HTMLDivElement> {
     return this.findByClassName<HTMLDivElement>(testutilStyles['secondary-actions'])!;
   }
 
-  findSecondaryContent(): ElementWrapper<HTMLDivElement> {
-    return this.findByClassName<HTMLDivElement>(testutilStyles['secondary-content'])!;
+  findSecondaryContent(): ElementWrapper<HTMLDivElement> | null {
+    return this.findByClassName<HTMLDivElement>(testutilStyles['secondary-content']);
+  }
+
+  findPrimaryActionSlot(): ElementWrapper<HTMLDivElement> | null {
+    return this.findByClassName<HTMLDivElement>(testutilStyles['primary-action']);
   }
 
   /**

--- a/src/test-utils/dom/prompt-input/index.ts
+++ b/src/test-utils/dom/prompt-input/index.ts
@@ -31,7 +31,7 @@ export default class PromptInputWrapper extends ComponentWrapper {
     return this.findByClassName<HTMLDivElement>(testutilStyles['secondary-content']);
   }
 
-  findPrimaryActionSlot(): ElementWrapper<HTMLDivElement> | null {
+  findCustomPrimaryAction(): ElementWrapper<HTMLDivElement> | null {
     return this.findByClassName<HTMLDivElement>(testutilStyles['primary-action']);
   }
 


### PR DESCRIPTION
### Description

Allow custom primary actions. For example, to replace the default single action with multiple action buttons.

Related links, issue #, if available: AWSUI-60922

### How has this been tested?

Updated unit tests and permutations

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
