### PR TITLE
chore: Adds disabled state to file input and file token group components

### DIFF
--- a/pages/file-input/permutations.page.tsx
+++ b/pages/file-input/permutations.page.tsx
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import FileInput, { FileInputProps } from '~components/file-input';
+
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
+
+const permutations = createPermutations<FileInputProps>([
+  {
+    value: [[]],
+    onChange: [() => {}],
+    ariaLabel: ['prompt file input'],
+    variant: ['icon', 'button'],
+    children: ['Upload file'],
+    disabled: [false, true],
+  },
+  {
+    value: [[]],
+    onChange: [() => {}],
+    ariaLabel: ['prompt file input'],
+    variant: ['icon', 'button'],
+    children: ['Upload file'],
+    disabled: [true],
+    disabledReason: ["You don't have access to upload files."],
+  },
+]);
+
+export default function ExpandableSectionPermutations() {
+  return (
+    <>
+      <h1>File input permutations</h1>
+      <ScreenshotArea disableAnimations={true}>
+        <PermutationsView permutations={permutations} render={permutation => <FileInput {...permutation} />} />
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -8871,6 +8871,19 @@ is provided by its parent form field component.",
       "type": "string",
     },
     {
+      "description": "Renders the file input as disabled and file selection.",
+      "name": "disabled",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
+      "description": "Provides a reason why the file input is disabled (only when \`disabled\` is \`true\`).
+If provided, the file input becomes focusable.",
+      "name": "disabledReason",
+      "optional": true,
+      "type": "string",
+    },
+    {
       "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
 use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes). If you must
 use the \`id\` attribute, consider setting it on a parent element instead.",
@@ -8968,6 +8981,13 @@ Make sure that you add a listener to this event to update your application state
       "name": "className",
       "optional": true,
       "type": "string",
+    },
+    {
+      "description": "Specifies if the control is disabled.
+This prevents the user from modifying the value. A disabled control is not focusable.",
+      "name": "disabled",
+      "optional": true,
+      "type": "boolean",
     },
     {
       "description": "An object containing all the localized strings required by the component:

--- a/src/file-input/__tests__/file-input.test.tsx
+++ b/src/file-input/__tests__/file-input.test.tsx
@@ -133,6 +133,21 @@ describe('FileInput input', () => {
     expect((onChange as jest.Mock).mock.lastCall[0].detail.value[0]).toBe(file1);
     expect((onChange as jest.Mock).mock.lastCall[0].detail.value[1]).toBe(file2);
   });
+
+  test('disables the native input and the trigger button when `disabled` prop is assigned', () => {
+    const wrapper = render({ disabled: true });
+    const input = wrapper.findNativeInput().getElement();
+
+    expect(input).toBeDisabled();
+    expect(wrapper.findTrigger().isDisabled()).toBe(true);
+  });
+
+  test('shows the disabled upon focus when `disabledReason` prop is assigned', () => {
+    const wrapper = render({ disabled: true, disabledReason: 'Test disabled reason' });
+    wrapper.findTrigger().focus();
+
+    expect(wrapper.findTrigger().findDisabledReason()!.getElement()).toHaveTextContent('Test disabled reason');
+  });
 });
 
 describe('ref', () => {
@@ -171,5 +186,37 @@ describe('a11y', () => {
       value: [file1, file2],
     });
     await expect(wrapper.getElement()).toValidateA11y();
+  });
+
+  describe('when disabled', () => {
+    test('decorative button is not focusable by keyboard', () => {
+      const wrapper = render({ disabled: true });
+
+      expect(wrapper.findTrigger().getElement()).toHaveAttribute('disabled');
+      expect(wrapper.findTrigger().getElement()).toHaveAttribute('tabIndex', '-1');
+    });
+
+    test('native input is not focusable', () => {
+      const wrapper = render({ disabled: true });
+      wrapper.findNativeInput().focus();
+      expect(wrapper.findNativeInput().getElement()).not.toHaveFocus();
+    });
+  });
+
+  describe('when disabled with disabledReason', () => {
+    test('decorative button is focusable by keyboard', () => {
+      const wrapper = render({ disabled: true, disabledReason: 'Test disabled reason' });
+      wrapper.findTrigger().focus();
+      expect(wrapper.findTrigger().getElement()).toHaveFocus();
+
+      expect(wrapper.findTrigger().getElement()).not.toHaveAttribute('disabled');
+      expect(wrapper.findTrigger().getElement()).not.toHaveAttribute('tabIndex');
+    });
+
+    test('native input is not focusable', () => {
+      const wrapper = render({ disabled: true, disabledReason: 'Test disabled reason' });
+      wrapper.findNativeInput().focus();
+      expect(wrapper.findNativeInput().getElement()).not.toHaveFocus();
+    });
   });
 });

--- a/src/file-input/interfaces.ts
+++ b/src/file-input/interfaces.ts
@@ -48,6 +48,17 @@ export interface FileInputProps extends BaseComponentProps, FormFieldCommonValid
    * If you want to clear the selection, use empty array.
    */
   value: ReadonlyArray<File>;
+
+  /**
+   * Renders the file input as disabled and file selection.
+   */
+  disabled?: boolean;
+
+  /**
+   * Provides a reason why the file input is disabled (only when `disabled` is `true`).
+   * If provided, the file input becomes focusable.
+   */
+  disabledReason?: string;
 }
 
 export namespace FileInputProps {

--- a/src/file-input/internal.tsx
+++ b/src/file-input/internal.tsx
@@ -42,6 +42,8 @@ const InternalFileInput = React.forwardRef(
       onChange,
       variant = 'button',
       children,
+      disabled,
+      disabledReason,
       __internalRootRef = null,
       __inputClassName,
       __inputNativeAttributes,
@@ -76,10 +78,12 @@ const InternalFileInput = React.forwardRef(
 
     checkControlled('FileInput', 'value', value, 'onChange', onChange);
 
+    const shouldDecorativeButtonGetFocus = disabled && Boolean(disabledReason);
     const nativeAttributes: React.HTMLAttributes<HTMLInputElement> = {
       'aria-label': ariaLabel || children,
       'aria-labelledby': joinStrings(formFieldContext.ariaLabelledby, uploadButtonLabelId),
       'aria-describedby': formFieldContext.ariaDescribedby,
+      'aria-hidden': shouldDecorativeButtonGetFocus,
       ...__inputNativeAttributes,
     };
     if (formFieldContext.invalid) {
@@ -137,6 +141,7 @@ const InternalFileInput = React.forwardRef(
           hidden={false}
           multiple={multiple}
           accept={accept}
+          disabled={disabled}
           onChange={onUploadInputChange}
           onFocus={onUploadInputFocus}
           onBlur={onUploadInputBlur}
@@ -151,12 +156,15 @@ const InternalFileInput = React.forwardRef(
           iconName="upload"
           variant={variant === 'icon' ? 'icon' : undefined}
           formAction="none"
+          disabled={disabled}
+          ariaLabel={ariaLabel}
+          disabledReason={disabledReason}
           onClick={onUploadButtonClick}
           className={clsx(styles['file-input-button'], {
             [styles['force-focus-outline-button']]: isFocused && variant === 'button',
             [styles['force-focus-outline-icon']]: isFocused && variant === 'icon',
           })}
-          __nativeAttributes={{ tabIndex: -1, 'aria-hidden': true }}
+          __nativeAttributes={shouldDecorativeButtonGetFocus ? { tabIndex } : { tabIndex: -1, 'aria-hidden': true }}
         >
           {variant === 'button' && children}
         </InternalButton>

--- a/src/file-token-group/interfaces.ts
+++ b/src/file-token-group/interfaces.ts
@@ -59,6 +59,11 @@ export interface FileTokenGroupProps extends BaseComponentProps {
    */
   readOnly?: boolean;
   /**
+   * Specifies if the control is disabled.
+   * This prevents the user from modifying the value. A disabled control is not focusable.
+   */
+  disabled?: boolean;
+  /**
    * An object containing all the localized strings required by the component:
    * * `removeFileAriaLabel` (function): A function to render the ARIA label for file token remove button.
    * * `errorIconAriaLabel` (string): The ARIA label to be shown on the error file icon.


### PR DESCRIPTION
### Description

Adds `disabled` state to two components:
- File input
- File token group

**Note on file token group:** This component already has a similar property of `readOnly` which completely removes the dismiss button. The only difference between `readOnly` and `disabled` is that `disabled` keeps the dismiss button but disables it.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
