### PR TITLE
fix: Add backward compatibility for expandable table test util

### DIFF
--- a/src/test-utils/dom/table/index.ts
+++ b/src/test-utils/dom/table/index.ts
@@ -178,7 +178,7 @@ export default class TableWrapper extends ComponentWrapper {
    */
   findExpandToggle(rowIndex: number): ElementWrapper | null {
     // the file was moved, which changed the hash, so we cannot use old test class anymore.
-    const oldSelector = `tbody tr:nth-child(${rowIndex}) .awsui_expand-toggle_1ss49`;
+    const oldSelector = `tbody tr:nth-child(${rowIndex}) .awsui_expand-toggle_1ss49_1w02f_153`;
     const newSelector = `tbody tr:nth-child(${rowIndex}) .${expandToggleStyles['expand-toggle']}`;
     return this.findNativeTable().findAny(oldSelector, newSelector);
   }

--- a/src/test-utils/dom/table/index.ts
+++ b/src/test-utils/dom/table/index.ts
@@ -177,7 +177,10 @@ export default class TableWrapper extends ComponentWrapper {
    * @param rowIndex 1-based index of the row.
    */
   findExpandToggle(rowIndex: number): ElementWrapper | null {
-    return this.findNativeTable().find(`tbody tr:nth-child(${rowIndex}) .${expandToggleStyles['expand-toggle']}`);
+    // the file was moved, which changed the hash, so we cannot use old test class anymore.
+    const oldSelector = `tbody tr:nth-child(${rowIndex}) .awsui_expand-toggle_1ss49`;
+    const newSelector = `tbody tr:nth-child(${rowIndex}) .${expandToggleStyles['expand-toggle']}`;
+    return this.findNativeTable().findAny(oldSelector, newSelector);
   }
 
   /**


### PR DESCRIPTION
### Description

in #3477 we moved styles file that was used in test utils, which led to regenerated hashes, which led to customers' integration test failing because of mismatched versions.

We discussed that using both old and new selector could be a solution if we absolutely have to change the selector.
Because there is no "old" selector anymore (we moved the file), I just copied the exact class name from the snapshot. Messy, but..

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
