### PR TITLE
fix: Harmonize drawer headers' letter spacing with other headers

### DIFF
--- a/src/internal/styles/typography/mixins.scss
+++ b/src/internal/styles/typography/mixins.scss
@@ -105,6 +105,7 @@
 
 @mixin font-panel-header {
   font-size: awsui.$font-panel-header-size;
+  letter-spacing: awsui.$letter-spacing-heading-m;
   line-height: awsui.$font-panel-header-line-height;
   font-weight: awsui.$font-weight-heading-l;
   @include font-smoothing;

--- a/src/top-navigation/styles.scss
+++ b/src/top-navigation/styles.scss
@@ -230,23 +230,24 @@
   border-block-end: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
 
   &-text {
-    @include styles.font-panel-header;
     color: awsui.$color-text-heading-default;
     flex: 1;
     margin-block: 0;
     margin-inline: 0;
     text-align: center;
 
+    &--title {
+      /* used in test-utils */
+      @include styles.font-panel-header;
+    }
+
     &--secondary {
       font-size: awsui.$font-header-h2-description-size;
       line-height: awsui.$font-header-h2-description-line-height;
       font-weight: styles.$font-weight-normal;
+      @include styles.font-smoothing;
     }
   }
-}
-
-.overflow-menu-header-text--title {
-  /* used in test-utils */
 }
 
 .overflow-menu-back-button {


### PR DESCRIPTION
### Description

The letter spacing of headers of drawers and split panels are not consistent with our header styles, since they are styled like an h3 header except for the letter spacing.

(And we also save a few pixels).

As an example, the screenshot below shows a split panel header with a Box with `variant="h3"` and `margin="n"` in the split panel content.

<img width="1503" height="117" alt="Screenshot 2025-07-22 at 08 38 24" src="https://github.com/user-attachments/assets/b31d6b76-3dc6-4158-8cb7-8fa0a66fb019" />

This change is confirmed with Visual Design.

Related links, issue #, if available: n/a

### How has this been tested?

Tested in my pipeline, visual diffs are as expected.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
