### PR TITLE
feat: resizeDrawer method for plugin api

### DIFF
--- a/pages/app-layout/runtime-drawers.page.tsx
+++ b/pages/app-layout/runtime-drawers.page.tsx
@@ -112,6 +112,19 @@ export default function WithDrawers() {
                 <Button onClick={() => awsuiPlugins.appLayout.closeDrawer('circle4-global')}>
                   Close a drawer without a trigger
                 </Button>
+
+                <Button
+                  onClick={() => awsuiPlugins.appLayout.resizeDrawer('circle-global', 400)}
+                  data-testid="button-circle-global-resize"
+                >
+                  Resize circle-global drawer to 400px
+                </Button>
+                <Button
+                  onClick={() => awsuiPlugins.appLayout.resizeDrawer('circle3-global', 500)}
+                  data-testid="button-circle3-global-resize"
+                >
+                  Resize circle3-global drawer to 500px
+                </Button>
               </SpaceBetween>
             </SpaceBetween>
           }

--- a/src/app-layout/__integ__/runtime-drawers.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers.test.ts
@@ -148,6 +148,12 @@ describe('Visual refresh toolbar only', () => {
     hasHorizontalScroll() {
       return this.browser.execute(() => document.body.scrollWidth - document.body.clientWidth > 0);
     }
+
+    async getDrawerWidth(drawerId: string) {
+      const { width } = await this.getBoundingBox(findDrawerById(wrapper, drawerId)!.toSelector());
+
+      return width;
+    }
   }
   function setupTest(testFn: (page: PageObject) => Promise<void>) {
     return useBrowser(async browser => {
@@ -360,6 +366,28 @@ describe('Visual refresh toolbar only', () => {
       await expect(page.isClickable(findDrawerById(wrapper, 'circle3-global')!.toSelector())).resolves.toBe(false);
       await expect(page.isClickable(findDrawerById(wrapper, 'circle')!.toSelector())).resolves.toBe(false);
       await expect(page.isClickable(wrapper.findOpenNavigationPanel().toSelector())).resolves.toBe(false);
+    })
+  );
+
+  test(
+    'should programmatically resize drawers',
+    setupTest(async page => {
+      await page.setWindowSize(viewports.desktopWide);
+      const drawerId1 = 'circle-global';
+      const drawerId2 = 'circle3-global';
+      await page.click(wrapper.findDrawerTriggerById(drawerId1).toSelector());
+      await page.click(wrapper.findDrawerTriggerById(drawerId2).toSelector());
+
+      await expect(page.getDrawerWidth(drawerId1)).resolves.toBe(351);
+      await expect(page.getDrawerWidth(drawerId2)).resolves.toBe(321);
+
+      await page.click(wrapper.find('[data-testid="button-circle-global-resize"]').toSelector());
+
+      await expect(page.getDrawerWidth(drawerId1)).resolves.toBe(401);
+
+      await page.click(wrapper.find('[data-testid="button-circle3-global-resize"]').toSelector());
+
+      await expect(page.getDrawerWidth(drawerId2)).resolves.toBe(501);
     })
   );
 });

--- a/src/app-layout/__integ__/runtime-drawers.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers.test.ts
@@ -378,16 +378,22 @@ describe('Visual refresh toolbar only', () => {
       await page.click(wrapper.findDrawerTriggerById(drawerId1).toSelector());
       await page.click(wrapper.findDrawerTriggerById(drawerId2).toSelector());
 
-      await expect(page.getDrawerWidth(drawerId1)).resolves.toBe(351);
-      await expect(page.getDrawerWidth(drawerId2)).resolves.toBe(321);
+      await page.waitForAssertion(async () => {
+        await expect(page.getDrawerWidth(drawerId1)).resolves.toBe(351);
+        await expect(page.getDrawerWidth(drawerId2)).resolves.toBe(321);
+      });
 
       await page.click(wrapper.find('[data-testid="button-circle-global-resize"]').toSelector());
 
-      await expect(page.getDrawerWidth(drawerId1)).resolves.toBe(401);
+      await page.waitForAssertion(async () => {
+        await expect(page.getDrawerWidth(drawerId1)).resolves.toBe(401);
+      });
 
       await page.click(wrapper.find('[data-testid="button-circle3-global-resize"]').toSelector());
 
-      await expect(page.getDrawerWidth(drawerId2)).resolves.toBe(501);
+      await page.waitForAssertion(async () => {
+        await expect(page.getDrawerWidth(drawerId2)).resolves.toBe(501);
+      });
     })
   );
 });

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -18,6 +18,7 @@ import {
   findActiveDrawerLandmark,
   getActiveDrawerWidth,
   getGlobalDrawersTestUtils,
+  getGlobalDrawerWidth,
   manyDrawers,
   testDrawer,
 } from './utils';
@@ -792,6 +793,30 @@ describeEachAppLayout(({ size }) => {
     await delay();
 
     expect(wrapper.findActiveDrawer()).toBeFalsy();
+  });
+
+  // skip these tests on mobile mode, because it only works for desktop view
+  (size === 'desktop' ? describe : describe.skip)('resizing', () => {
+    test('resizes a drawer when resizeDrawer is called', async () => {
+      awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
+
+      const { wrapper } = await renderComponent(<AppLayout drawers={[testDrawer]} />);
+
+      awsuiPlugins.appLayout.openDrawer('test');
+
+      await delay();
+
+      expect(wrapper.findActiveDrawer()!.getElement()).toHaveTextContent('runtime drawer content');
+      expect(getActiveDrawerWidth(wrapper)).toEqual('290px');
+
+      awsuiPlugins.appLayout.resizeDrawer('test', 800);
+
+      expect(getActiveDrawerWidth(wrapper)).toEqual('800px');
+
+      awsuiPlugins.appLayout.resizeDrawer('test', 300);
+
+      expect(getActiveDrawerWidth(wrapper)).toEqual('300px');
+    });
   });
 });
 
@@ -1645,6 +1670,33 @@ describe('toolbar mode only features', () => {
           );
         });
       });
+    });
+
+    test('resizes multiple global drawers when resizeDrawer is called', async () => {
+      awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, type: 'global' });
+      awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, type: 'global', id: 'test1' });
+
+      const { globalDrawersWrapper } = await renderComponent(<AppLayout />);
+
+      awsuiPlugins.appLayout.openDrawer('test');
+      awsuiPlugins.appLayout.openDrawer('test1');
+
+      await delay();
+
+      expect(globalDrawersWrapper.findDrawerById('test')!.getElement()).toHaveTextContent('runtime drawer content');
+      expect(globalDrawersWrapper.findDrawerById('test1')!.getElement()).toHaveTextContent('runtime drawer content');
+      expect(getGlobalDrawerWidth(globalDrawersWrapper, 'test')).toEqual('290px');
+      expect(getGlobalDrawerWidth(globalDrawersWrapper, 'test1')).toEqual('290px');
+
+      awsuiPlugins.appLayout.resizeDrawer('test', 800);
+
+      expect(getGlobalDrawerWidth(globalDrawersWrapper, 'test')).toEqual('800px');
+      expect(getGlobalDrawerWidth(globalDrawersWrapper, 'test1')).toEqual('290px');
+
+      awsuiPlugins.appLayout.resizeDrawer('test1', 801);
+
+      expect(getGlobalDrawerWidth(globalDrawersWrapper, 'test')).toEqual('800px');
+      expect(getGlobalDrawerWidth(globalDrawersWrapper, 'test1')).toEqual('801px');
     });
   });
 

--- a/src/app-layout/__tests__/utils.tsx
+++ b/src/app-layout/__tests__/utils.tsx
@@ -107,6 +107,15 @@ export function getActiveDrawerWidth(wrapper: AppLayoutWrapper): string {
   return drawerElement.style.width;
 }
 
+export function getGlobalDrawerWidth(
+  wrapper: ReturnType<typeof getGlobalDrawersTestUtils>,
+  drawerId: string
+): string | null {
+  const drawerElement = wrapper.findDrawerById(drawerId)!.getElement();
+  const value = drawerElement.style.getPropertyValue(customCssProps.drawerSize);
+  return value ?? null;
+}
+
 export const splitPanelI18nStrings: SplitPanelProps.I18nStrings = {
   closeButtonAriaLabel: 'Close panel',
   openButtonAriaLabel: 'Open panel',

--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -159,6 +159,23 @@ function useDrawerRuntimeOpenClose(
   }, [disableRuntimeDrawers, onDrawerClosed]);
 }
 
+function useDrawerRuntimeResize(
+  disableRuntimeDrawers: boolean | undefined,
+  onActiveDrawerResize: ({ id, size }: { id: string; size: number }) => void
+) {
+  const onRuntimeDrawerResize = useStableCallback((drawerId: string, size: number) => {
+    onActiveDrawerResize({ id: drawerId, size });
+  });
+
+  useEffect(() => {
+    if (disableRuntimeDrawers) {
+      return;
+    }
+
+    return awsuiPluginsInternal.appLayout.onDrawerResize(onRuntimeDrawerResize);
+  }, [disableRuntimeDrawers, onRuntimeDrawerResize]);
+}
+
 function applyToolsDrawer(toolsProps: ToolsProps, runtimeDrawers: DrawersLayout) {
   const drawers = [...runtimeDrawers.localBefore, ...runtimeDrawers.localAfter];
   if (drawers.length === 0 && toolsProps.disableDrawersMerge) {
@@ -296,6 +313,8 @@ export function useDrawers(
     activeGlobalDrawersIds,
     onActiveGlobalDrawersChange
   );
+
+  useDrawerRuntimeResize(disableRuntimeDrawers, onActiveDrawerResize);
 
   const activeDrawerSize = activeDrawerIdResolved
     ? (drawerSizes[activeDrawerIdResolved] ?? activeDrawer?.defaultSize ?? toolsProps.toolsWidth)


### PR DESCRIPTION
### Description

This PR introduces a new method `resizeDrawer(drawerId: string, size: number)` for Cloudscape plugin api to programmatically resize drawers declared within `AppLayout` component.

**Usage example:**

```javascript
awsuiPlugins.appLayout.resizeDrawer('circle-global', 400)
```

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
