### PR TITLE
chore: Provide correct role and href for disabled link buttons

### DIFF
--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -116,6 +116,8 @@ describe('Button Component', () => {
       expect(wrapper.getElement()).toHaveClass(styles.disabled);
       expect(wrapper.getElement()).not.toHaveAttribute('disabled');
       expect(wrapper.getElement()).toHaveAttribute('aria-disabled');
+      expect(wrapper.getElement()).toHaveAttribute('role', 'link');
+      expect(wrapper.getElement()).not.toHaveAttribute('href');
       expect(wrapper.isDisabled()).toBe(true);
     });
 
@@ -552,6 +554,8 @@ describe('Button Component', () => {
     test('adds a tab index -1 to the link button', () => {
       const wrapper = renderButton({ loading: true, href: 'https://amazon.com' });
       expect(wrapper.getElement()).toHaveAttribute('tabIndex', '-1');
+      expect(wrapper.getElement()).not.toHaveAttribute('href');
+      expect(wrapper.getElement()).toHaveAttribute('role', 'link');
     });
   });
 
@@ -617,6 +621,18 @@ describe('Button Component', () => {
     test('mirrors the href property as href attribute', () => {
       const wrapper = renderButton({ href: 'https://amazon.com' });
       expect(wrapper.getElement()).toHaveAttribute('href', 'https://amazon.com');
+    });
+
+    test('removes href attribute and adds role="link" when button is disabled', () => {
+      const wrapper = renderButton({ href: 'https://amazon.com', disabled: true });
+      expect(wrapper.getElement()).not.toHaveAttribute('href');
+      expect(wrapper.getElement()).toHaveAttribute('role', 'link');
+    });
+
+    test('removes href attribute and adds role="link" when button is loading', () => {
+      const wrapper = renderButton({ href: 'https://amazon.com', loading: true });
+      expect(wrapper.getElement()).not.toHaveAttribute('href');
+      expect(wrapper.getElement()).toHaveAttribute('role', 'link');
     });
 
     test.each(buttonTargetExpectations)('"target" property %s', (props, expectation) => {

--- a/src/button/__tests__/internal.test.tsx
+++ b/src/button/__tests__/internal.test.tsx
@@ -80,6 +80,18 @@ describe('Analytics', () => {
     );
   });
 
+  test('does not send an externalLinkInteracted metric when button is disabled', () => {
+    const { container } = render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+        <Button iconName="external" href="https://example.com" disabled={true} />
+      </AnalyticsFunnel>
+    );
+    act(() => void jest.runAllTimers());
+    createWrapper(container).findButton()!.click();
+
+    expect(FunnelMetrics.externalLinkInteracted).not.toHaveBeenCalled();
+  });
+
   test('does not send an externalLinkInteracted metric when the button is not a link', () => {
     const onClick = jest.fn();
     const { container } = render(
@@ -113,6 +125,18 @@ describe('Analytics', () => {
         elementSelector: expect.any(String),
       })
     );
+  });
+
+  test('does not send an externalLinkInteracted metric when button with target=_blank is disabled', () => {
+    const { container } = render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+        <Button target="_blank" href="https://example.com" disabled={true} />
+      </AnalyticsFunnel>
+    );
+    act(() => void jest.runAllTimers());
+    createWrapper(container).findButton()!.click();
+
+    expect(FunnelMetrics.externalLinkInteracted).not.toHaveBeenCalled();
   });
 
   test('does not send an externalLinkInteracted metric for non-external links', () => {

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -330,11 +330,22 @@ export const InternalButton = React.forwardRef(
         : undefined;
 
     if (isAnchor) {
+      const getAnchorTabIndex = () => {
+        if (isNotInteractive) {
+          // If disabled with a reason, make it focusable so users can access the tooltip
+          // Otherwise, resolve to the default button props tabIndex.
+          return disabledReason ? 0 : buttonProps.tabIndex;
+        }
+        return buttonProps.tabIndex;
+      };
+
       return (
         <>
           <a
             {...buttonProps}
-            href={href}
+            href={isNotInteractive ? undefined : href}
+            role={isNotInteractive ? 'link' : undefined}
+            tabIndex={getAnchorTabIndex()}
             target={target}
             // security recommendation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target
             rel={rel ?? (target === '_blank' ? 'noopener noreferrer' : undefined)}


### PR DESCRIPTION
### Description

In case a button has an href, it is rendered as an anchor. When an anchor is disabled, it should not have both `aria-disabled` and `href`. We need to remove the `href` while adding a `role: "link"`.


Following this guideline: https://w3c.github.io/html-aria/?utm_source=chatgpt.com#:~:text=It%20is%20NOT%20RECOMMENDED%20to%20use%20aria%2Ddisabled%3D%22true%22%20on%20an%20a%20element%20with%20an%20href%20attribute.

<!-- Also include relevant motivation and context. -->

Related links:
archives/C01BMLAMF1P/p1753117381571299

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
