### PR TITLE
chore: Applayout manages the global scroll-padding-top

### DIFF
--- a/pages/app-layout/global-scroll-padding.page.tsx
+++ b/pages/app-layout/global-scroll-padding.page.tsx
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import AppLayout from '~components/app-layout';
+import Button from '~components/button';
+import Header from '~components/header';
+import SpaceBetween from '~components/space-between';
+
+import ScreenshotArea from '../utils/screenshot-area';
+import ariaLabels from './utils/labels';
+
+export default function () {
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        ariaLabels={ariaLabels}
+        navigationHide={true}
+        content={
+          <div style={{ height: '200vh', border: '1px solid red' }}>
+            <div style={{ marginBlockEnd: '1rem' }}>
+              <Header data-testid="header" variant="h1">
+                Focusable components
+              </Header>
+            </div>
+            <SpaceBetween direction="vertical" size="xxl">
+              <Button data-testid="button-1" ariaLabel="Button 1">
+                Button 1
+              </Button>
+              <Button data-testid="button-2" ariaLabel="Button 2">
+                Button 2
+              </Button>
+            </SpaceBetween>
+          </div>
+        }
+      />
+    </ScreenshotArea>
+  );
+}

--- a/src/app-layout/__tests__/main.test.tsx
+++ b/src/app-layout/__tests__/main.test.tsx
@@ -117,6 +117,21 @@ describeEachAppLayout({ themes: ['classic', 'refresh-toolbar'], sizes: ['desktop
       await waitFor(() => expect(wrapper.getElement()).toHaveStyle({ minBlockSize: 'calc(100vh - 75px)' }));
     });
 
+    (theme !== 'classic' ? test : test.skip)('should set the header height to the scrolling element', () => {
+      Object.defineProperty(document, 'scrollingElement', { value: document.body });
+      renderComponent(
+        <div id="b">
+          <div style={{ height: 40 }} id="h" />
+          <AppLayout />
+        </div>
+      );
+
+      // Note: The toolbar height in jsdom environment is calculated as `0`.
+      // For this reason both `refresh` and `refresh-toolbar` only consider the height of `#h` element which is `40px`.
+      // We have covered this case with real values in integration tests.
+      expect(document.scrollingElement).toHaveStyle('scroll-padding-block-start: 40px');
+    });
+
     test('should use alternative header and footer selector', async () => {
       const { wrapper } = renderComponent(
         <>

--- a/src/app-layout/utils/use-global-scroll-padding.ts
+++ b/src/app-layout/utils/use-global-scroll-padding.ts
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { useEffect } from 'react';
+
+// Sets scroll padding to the scrolling element (`html` or `body`).
+// This prevents the focused element to be hidden under the sticky headers.
+export function useGlobalScrollPadding(headerHeight: number) {
+  useEffect(() => {
+    const scrollingElement = document.scrollingElement;
+    if (scrollingElement instanceof HTMLElement) {
+      scrollingElement.style.scrollPaddingBlockStart = `${headerHeight}px`;
+    }
+  }, [headerHeight]);
+}

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -17,6 +17,7 @@ import { AppLayoutProps } from '../interfaces';
 import { SplitPanelProviderProps } from '../split-panel';
 import { MIN_DRAWER_SIZE, OnChangeParams, useDrawers } from '../utils/use-drawers';
 import { useFocusControl, useMultipleFocusControl } from '../utils/use-focus-control';
+import { useGlobalScrollPadding } from '../utils/use-global-scroll-padding';
 import { useSplitPanelFocusControl } from '../utils/use-split-panel-focus-control';
 import { ActiveDrawersContext } from '../utils/visibility-context';
 import {
@@ -312,6 +313,8 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       toolbarHeight: toolbarHeight ?? 0,
       stickyNotifications: resolvedStickyNotifications,
     });
+
+    useGlobalScrollPadding(verticalOffsets.header);
 
     const appLayoutInternals: AppLayoutInternals = {
       ariaLabels: ariaLabelsWithDrawers,

--- a/src/app-layout/visual-refresh/layout.tsx
+++ b/src/app-layout/visual-refresh/layout.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import clsx from 'clsx';
 
 import customCssProps from '../../internal/generated/custom-css-properties';
+import { useGlobalScrollPadding } from '../utils/use-global-scroll-padding';
 import { useAppLayoutInternals } from './context';
 
 import testutilStyles from '../test-classes/styles.css.js';
@@ -45,6 +46,8 @@ export default function Layout({ children }: LayoutProps) {
     splitPanelPosition,
     splitPanelDisplayed,
   } = useAppLayoutInternals();
+
+  useGlobalScrollPadding(headerHeight);
 
   // Determine the first content child so the gap will vertically align with the trigger buttons
   const contentFirstChild = getContentFirstChild(breadcrumbs, contentHeader, hasNotificationsContent, isMobile);


### PR DESCRIPTION
### Description

Adds `useGlobalScrollPadding` hook used in both `<AppLayout />` and `<AppLayoutToolbar />` components.
This sets a `scroll-padding-block-start` to the scrolling element (`html` or `body`) so that the elements don't stay hidden under the sticky header, when they are focused.

Related links, issue #, if available: AWSUI-61007

### How has this been tested?

Added a new page and integration test for it.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
