### PR TITLE
fix: Add LiveRegion to non-dismissible Popover

### DIFF
--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -279,9 +279,12 @@ describe('ARIA labels', () => {
   });
 
   it('uses aria-live if dismissButton is false', () => {
-    const wrapper = renderPopover({ children: 'Trigger', content: 'Popover', dismissButton: false });
+    const wrapper = renderPopover({ children: 'Trigger', content: 'Popover content', dismissButton: false });
     wrapper.findTrigger().click();
-    expect(wrapper.find('[aria-live="polite"]')).toBeTruthy();
+
+    const liveRegion = createWrapper().findLiveRegion()!;
+    expect(liveRegion).toBeDefined();
+    expect(liveRegion.getElement()).toHaveTextContent('Popover content');
   });
 
   it('does not pass the dismissAriaLabel to the dismiss button if not defined', () => {
@@ -308,15 +311,39 @@ describe('ARIA labels', () => {
     expect(wrapper.findBody()!.getElement()).not.toHaveAttribute('role', 'dialog');
   });
 
-  it('accessibility validation basic popover', async () => {
-    const wrapper = renderPopover({
-      children: 'Trigger',
-      content: 'Popover',
-      dismissButton: false,
-      renderWithPortal: true,
+  describe('live region', () => {
+    it('do not render live region when closed', () => {
+      renderPopover({
+        children: 'Trigger',
+        content: 'Popover',
+        dismissButton: false,
+        renderWithPortal: true,
+      });
+      expect(createWrapper().findLiveRegion()).toBeNull();
     });
-    wrapper.findTrigger().click();
-    await expect(document.body).toValidateA11y();
+
+    it('render live region when opened and dismissButton = false', () => {
+      const wrapper = renderPopover({
+        children: 'Trigger',
+        content: 'Popover',
+        dismissButton: false,
+        renderWithPortal: true,
+      });
+      wrapper.findTrigger().click();
+      const liveRegion = createWrapper().findLiveRegion()!.getElement()!;
+      expect(liveRegion).toHaveTextContent('Popover');
+    });
+
+    it('do not render live region when opened and dismissButton = true', () => {
+      const wrapper = renderPopover({
+        children: 'Trigger',
+        content: 'Popover',
+        dismissButton: true,
+        renderWithPortal: true,
+      });
+      wrapper.findTrigger().click();
+      expect(createWrapper().findLiveRegion()).toBeNull();
+    });
   });
 
   it('accessibility validation for popover with dismiss button and header', async () => {

--- a/src/popover/conditional-live-region.tsx
+++ b/src/popover/conditional-live-region.tsx
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { ReactNode } from 'react';
+
+import InternalLiveRegion from '../live-region/internal';
+
+interface ConditionalLiveRegionProps {
+  condition: boolean;
+  children: ReactNode;
+}
+
+const ConditionalLiveRegion = ({ condition, children }: ConditionalLiveRegionProps) => {
+  if (condition) {
+    return <InternalLiveRegion>{children}</InternalLiveRegion>;
+  }
+  return <>{children}</>;
+};
+
+export default ConditionalLiveRegion;

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -17,6 +17,7 @@ import { usePortalModeClasses } from '../internal/hooks/use-portal-mode-classes'
 import { KeyCode } from '../internal/keycode';
 import Arrow from './arrow';
 import PopoverBody from './body';
+import ConditionalLiveRegion from './conditional-live-region';
 import PopoverContainer from './container';
 import { PopoverProps } from './interfaces';
 
@@ -144,8 +145,6 @@ function InternalPopover(
 
   const popoverContent = (
     <div
-      aria-live={dismissButton ? undefined : 'polite'}
-      aria-atomic={dismissButton ? undefined : true}
       className={clsx(popoverClasses, !renderWithPortal && styles['popover-inline-content'])}
       data-awsui-referrer-id={referrerId}
     >
@@ -167,7 +166,7 @@ function InternalPopover(
             overflowVisible="both"
             closeAnalyticsAction={__closeAnalyticsAction}
           >
-            {content}
+            <ConditionalLiveRegion condition={!dismissButton}>{content}</ConditionalLiveRegion>
           </PopoverBody>
         </LinkDefaultVariantContext.Provider>
       </PopoverContainer>


### PR DESCRIPTION
### Description

Previously, `aria-live` and `aria-atomic` attributes on the popover content weren't effectively announcing content to screen readers.

Implements LiveRegion component to properly announce non-dismissible popover content to screen readers.

Note: This change only affects non-dismissible popovers since:
- Dismissible popovers receive focus and are naturally navigable by screen reader users
- Non-dismissible popovers lack focus management, requiring content to be announced via live regions

Related links, issue #, if available: `AWSUI-60746`

### How has this been tested?

- update / add existing unit tests
- green dry run

How can reviewers test these changes efficiently?
- Open the popup examples with a screen reader turned on
- Navigate via keyboard to the popover trigger and press enter
- The popover content is live announced.
- Close the popover and re-open it. Live announcement is happening again.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
