### PR TITLE
feat: Add support for download links in ButtonDropdown

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -5615,6 +5615,7 @@ The following properties are supported across all types:
 ### action
 
 - \`href\` (string) - (Optional) Defines the target URL of the menu item, turning it into a link.
+- \`download\` (boolean | string) - (Optional) Indicates that the link should be downloaded when clicked. Only works when \`href\` is also provided. If set to \`true\`, the browser will use the filename from the URL. If set to a string, that string will be used as the suggested filename.
 - \`external\` (boolean) - Marks a menu item as external by adding an icon after the menu item text. The link will open in a new tab when clicked. Note that this only works when \`href\` is also provided.
 - \`externalIconAriaLabel\` (string) - Adds an \`aria-label\` to the external icon.
 - \`iconName\` (string) - (Optional) Specifies the name of the icon, used with the [icon component](/components/icon/).

--- a/src/button-dropdown/__tests__/button-dropdown-items.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-items.test.tsx
@@ -499,3 +499,227 @@ describe('Internal ButtonDropdown badge property', () => {
     expect(wrapper.findAllByClassName(iconStyles.badge)?.map(item => item.getElement())).toHaveLength(2);
   });
 });
+
+describe('ButtonDropdown download property', () => {
+  const testProps = { expandToViewport: false };
+
+  it('should render download attribute with boolean true value', () => {
+    const items: ButtonDropdownProps.Items = [
+      {
+        id: 'download-item',
+        text: 'Download file',
+        href: 'https://example.com/file.pdf',
+        download: true,
+      },
+    ];
+    const wrapper = renderButtonDropdown({ ...testProps, items });
+    wrapper.openDropdown();
+
+    const anchor = wrapper.findItemById('download-item')!.find('a')!.getElement();
+    expect(anchor).toHaveAttribute('download', '');
+    expect(anchor).toHaveAttribute('href', 'https://example.com/file.pdf');
+  });
+
+  it('should render download attribute with string value', () => {
+    const items: ButtonDropdownProps.Items = [
+      {
+        id: 'download-item',
+        text: 'Download file',
+        href: 'https://example.com/file.pdf',
+        download: 'custom-filename.pdf',
+      },
+    ];
+    const wrapper = renderButtonDropdown({ ...testProps, items });
+    wrapper.openDropdown();
+
+    const anchor = wrapper.findItemById('download-item')!.find('a')!.getElement();
+    expect(anchor).toHaveAttribute('download', 'custom-filename.pdf');
+    expect(anchor).toHaveAttribute('href', 'https://example.com/file.pdf');
+  });
+
+  it('should not render download attribute when download is false', () => {
+    const items: ButtonDropdownProps.Items = [
+      {
+        id: 'no-download-item',
+        text: 'Regular link',
+        href: 'https://example.com/page',
+        download: false,
+      },
+    ];
+    const wrapper = renderButtonDropdown({ ...testProps, items });
+    wrapper.openDropdown();
+
+    const anchor = wrapper.findItemById('no-download-item')!.find('a')!.getElement();
+    expect(anchor).not.toHaveAttribute('download');
+    expect(anchor).toHaveAttribute('href', 'https://example.com/page');
+  });
+
+  it('should not render download attribute when download is not specified', () => {
+    const items: ButtonDropdownProps.Items = [
+      {
+        id: 'regular-item',
+        text: 'Regular link',
+        href: 'https://example.com/page',
+      },
+    ];
+    const wrapper = renderButtonDropdown({ ...testProps, items });
+    wrapper.openDropdown();
+
+    const anchor = wrapper.findItemById('regular-item')!.find('a')!.getElement();
+    expect(anchor).not.toHaveAttribute('download');
+    expect(anchor).toHaveAttribute('href', 'https://example.com/page');
+  });
+
+  it('should not render download attribute when href is not provided', () => {
+    const items: ButtonDropdownProps.Items = [
+      {
+        id: 'no-href-item',
+        text: 'Button item',
+        download: true,
+      },
+    ];
+    const wrapper = renderButtonDropdown({ ...testProps, items });
+    wrapper.openDropdown();
+
+    const item = wrapper.findItemById('no-href-item')!;
+    expect(item.find('a')).toBe(null);
+    expect(item.getElement()).toHaveTextContent('Button item');
+  });
+
+  it('should not render download attribute when item is disabled', () => {
+    const items: ButtonDropdownProps.Items = [
+      {
+        id: 'disabled-download-item',
+        text: 'Disabled download',
+        href: 'https://example.com/file.pdf',
+        download: 'filename.pdf',
+        disabled: true,
+      },
+    ];
+    const wrapper = renderButtonDropdown({ ...testProps, items });
+    wrapper.openDropdown();
+
+    const anchor = wrapper.findItemById('disabled-download-item')!.find('a')!.getElement();
+    expect(anchor).not.toHaveAttribute('download');
+    expect(anchor).not.toHaveAttribute('href');
+  });
+
+  it('should not render download attribute when parent category is disabled', () => {
+    const items: ButtonDropdownProps.Items = [
+      {
+        text: 'Disabled category',
+        disabled: true,
+        items: [
+          {
+            id: 'category-download-item',
+            text: 'Download in disabled category',
+            href: 'https://example.com/file.pdf',
+            download: true,
+          },
+        ],
+      },
+    ];
+    const wrapper = renderButtonDropdown({ ...testProps, items });
+    wrapper.openDropdown();
+
+    const anchor = wrapper.findItemById('category-download-item')!.find('a')!.getElement();
+    expect(anchor).not.toHaveAttribute('download');
+    expect(anchor).not.toHaveAttribute('href');
+  });
+
+  it('should render download attribute with external link', () => {
+    const items: ButtonDropdownProps.Items = [
+      {
+        id: 'external-download-item',
+        text: 'Download external file',
+        href: 'https://external.com/file.pdf',
+        download: 'external-file.pdf',
+        external: true,
+        externalIconAriaLabel: '(opens new tab)',
+      },
+    ];
+    const wrapper = renderButtonDropdown({ ...testProps, items });
+    wrapper.openDropdown();
+
+    const anchor = wrapper.findItemById('external-download-item')!.find('a')!.getElement();
+    expect(anchor).toHaveAttribute('download', 'external-file.pdf');
+    expect(anchor).toHaveAttribute('href', 'https://external.com/file.pdf');
+    expect(anchor).toHaveAttribute('target', '_blank');
+    expect(anchor).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('should render download attribute in nested category items', () => {
+    const items: ButtonDropdownProps.Items = [
+      {
+        text: 'Downloads',
+        items: [
+          {
+            id: 'nested-download-item',
+            text: 'Download nested file',
+            href: 'https://example.com/nested-file.pdf',
+            download: 'nested-filename.pdf',
+          },
+          {
+            id: 'nested-regular-item',
+            text: 'Regular nested link',
+            href: 'https://example.com/page',
+          },
+        ],
+      },
+    ];
+    const wrapper = renderButtonDropdown({ ...testProps, items });
+    wrapper.openDropdown();
+
+    const downloadAnchor = wrapper.findItemById('nested-download-item')!.find('a')!.getElement();
+    expect(downloadAnchor).toHaveAttribute('download', 'nested-filename.pdf');
+    expect(downloadAnchor).toHaveAttribute('href', 'https://example.com/nested-file.pdf');
+
+    const regularAnchor = wrapper.findItemById('nested-regular-item')!.find('a')!.getElement();
+    expect(regularAnchor).not.toHaveAttribute('download');
+    expect(regularAnchor).toHaveAttribute('href', 'https://example.com/page');
+  });
+
+  it('should handle mixed items with and without download', () => {
+    const items: ButtonDropdownProps.Items = [
+      {
+        id: 'download-boolean',
+        text: 'Download with boolean',
+        href: 'https://example.com/file1.pdf',
+        download: true,
+      },
+      {
+        id: 'download-string',
+        text: 'Download with string',
+        href: 'https://example.com/file2.pdf',
+        download: 'custom-name.pdf',
+      },
+      {
+        id: 'regular-link',
+        text: 'Regular link',
+        href: 'https://example.com/page',
+      },
+      {
+        id: 'button-item',
+        text: 'Button item',
+      },
+    ];
+    const wrapper = renderButtonDropdown({ ...testProps, items });
+    wrapper.openDropdown();
+
+    // Check download with boolean
+    const booleanAnchor = wrapper.findItemById('download-boolean')!.find('a')!.getElement();
+    expect(booleanAnchor).toHaveAttribute('download', '');
+
+    // Check download with string
+    const stringAnchor = wrapper.findItemById('download-string')!.find('a')!.getElement();
+    expect(stringAnchor).toHaveAttribute('download', 'custom-name.pdf');
+
+    // Check regular link
+    const regularAnchor = wrapper.findItemById('regular-link')!.find('a')!.getElement();
+    expect(regularAnchor).not.toHaveAttribute('download');
+
+    // Check button item (no anchor)
+    const buttonItem = wrapper.findItemById('button-item')!;
+    expect(buttonItem.find('a')).toBe(null);
+  });
+});

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -33,6 +33,7 @@ export interface ButtonDropdownProps extends BaseComponentProps, ExpandToViewpor
    * ### action
    *
    * - `href` (string) - (Optional) Defines the target URL of the menu item, turning it into a link.
+   * - `download` (boolean | string) - (Optional) Indicates that the link should be downloaded when clicked. Only works when `href` is also provided. If set to `true`, the browser will use the filename from the URL. If set to a string, that string will be used as the suggested filename.
    * - `external` (boolean) - Marks a menu item as external by adding an icon after the menu item text. The link will open in a new tab when clicked. Note that this only works when `href` is also provided.
    * - `externalIconAriaLabel` (string) - Adds an `aria-label` to the external icon.
    * - `iconName` (string) - (Optional) Specifies the name of the icon, used with the [icon component](/components/icon/).
@@ -190,6 +191,7 @@ export namespace ButtonDropdownProps {
     disabledReason?: string;
     description?: string;
     href?: string;
+    download?: boolean | string;
     external?: boolean;
     externalIconAriaLabel?: string;
     iconAlt?: string;
@@ -199,7 +201,7 @@ export namespace ButtonDropdownProps {
   }
 
   export interface CheckboxItem
-    extends Omit<ButtonDropdownProps.Item, 'href' | 'external' | 'externalIconAriaLabel' | 'itemType'> {
+    extends Omit<ButtonDropdownProps.Item, 'href' | 'download' | 'external' | 'externalIconAriaLabel' | 'itemType'> {
     itemType: 'checkbox';
     checked: boolean;
   }

--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -136,6 +136,7 @@ function MenuItem({ item, disabled, highlighted, linkStyle }: MenuItemProps) {
     <a
       {...menuItemProps}
       href={!disabled ? item.href : undefined}
+      download={!disabled && item.download ? item.download : undefined}
       target={getItemTarget(item)}
       rel={item.external ? 'noopener noreferrer' : undefined}
     >


### PR DESCRIPTION
This PR adds the ability to specify `download: true` for an item in a `ButtonDropdown`, in conjunction with an `href`, to get a download link instead of a normal link. This matches the behavior of the `download` prop on the `Button` component.

### How has this been tested?

I've added unit tests as part of this PR.

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
