### PR TITLE
chore: Remove backward compatibility for old code

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/skeleton/breadcrumbs/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/breadcrumbs/index.tsx
@@ -6,8 +6,6 @@ import { BreadcrumbGroupImplementation } from '../../../../breadcrumb-group/impl
 import { BreadcrumbGroupProps } from '../../../../breadcrumb-group/interfaces';
 import { BreadcrumbsSlotContext } from '../../contexts';
 
-import styles from './styles.css.js';
-
 interface BreadcrumbsSlotProps {
   ownBreadcrumbs: React.ReactNode;
   discoveredBreadcrumbs: BreadcrumbGroupProps | null;
@@ -16,15 +14,13 @@ interface BreadcrumbsSlotProps {
 export function BreadcrumbsSlot({ ownBreadcrumbs, discoveredBreadcrumbs }: BreadcrumbsSlotProps) {
   return (
     <BreadcrumbsSlotContext.Provider value={{ isInToolbar: true }}>
-      <div className={styles['breadcrumbs-own']}>{ownBreadcrumbs}</div>
+      {ownBreadcrumbs}
       {discoveredBreadcrumbs && (
-        <div className={styles['breadcrumbs-discovered']}>
-          <BreadcrumbGroupImplementation
-            {...discoveredBreadcrumbs}
-            data-awsui-discovered-breadcrumbs={true}
-            __injectAnalyticsComponentMetadata={true}
-          />
-        </div>
+        <BreadcrumbGroupImplementation
+          {...discoveredBreadcrumbs}
+          data-awsui-discovered-breadcrumbs={true}
+          __injectAnalyticsComponentMetadata={true}
+        />
       )}
     </BreadcrumbsSlotContext.Provider>
   );

--- a/src/app-layout/visual-refresh-toolbar/skeleton/breadcrumbs/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/breadcrumbs/styles.scss
@@ -1,9 +1,0 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
-
-// backward compatibility before this commit: 7a4b7b3e3b1d50830383805a8f4ab6cd93c9701f
-.breadcrumbs-own:not(:empty) + .breadcrumbs-discovered {
-  display: none;
-}


### PR DESCRIPTION
### Description

Undo compatibility for this commit: https://github.com/cloudscape-design/components/commit/7a4b7b3e3b1d50830383805a8f4ab6cd93c9701f

it is now released everywhere

Related links, issue #, if available: n/a

### How has this been tested?

PR build + manual testing

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
