### PR TITLE
fix: Add group role to element referenced by the alert focus ref

### DIFF
--- a/src/alert/__tests__/alert.test.tsx
+++ b/src/alert/__tests__/alert.test.tsx
@@ -160,6 +160,15 @@ describe('Alert Component', () => {
     await expect(container).toValidateA11y();
   });
 
+  describe('a11y', () => {
+    it('has role group on the element referenced by the focus ref', () => {
+      let ref: AlertProps.Ref | null = null;
+      render(<Alert header="Important" ref={element => (ref = element)} />);
+      ref!.focus();
+      expect(document.activeElement).toHaveAttribute('role', 'group');
+    });
+  });
+
   describe('analytics', () => {
     test(`adds ${DATA_ATTR_ANALYTICS_ALERT} attribute with the alert type`, () => {
       const { container } = renderAlert({

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -134,7 +134,7 @@ const InternalAlert = React.forwardRef(
               )}
             >
               <div className={styles['alert-wrapper']}>
-                <div className={styles['alert-focus-wrapper']} tabIndex={-1} ref={focusRef}>
+                <div className={styles['alert-focus-wrapper']} tabIndex={-1} ref={focusRef} role="group">
                   <div className={clsx(styles.icon, styles.text)}>
                     <InternalIcon name={typeToIcon[type]} size={size} ariaLabel={statusIconAriaLabel} />
                   </div>


### PR DESCRIPTION
### Description

This PR add `role="group"` to the element that gets focused when focus is called on the component (the element that has the 'focusRef' ref.

Element that receive focus should not be generic elements, adding `role="group"` resolves this.

Related links, issue #, if available: n/a

### How has this been tested?

Tested manually in browser and added a corresponding test to `src/alert/__tests__/alert.test.tsx`

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- X Changes include appropriate documentation updates._
- X Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- X Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- X Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

N/A

#### Testing

-  X Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
