### PR TITLE
fix: Replaces the logical scroll padding with physical

### DIFF
--- a/src/app-layout/__tests__/main.test.tsx
+++ b/src/app-layout/__tests__/main.test.tsx
@@ -129,7 +129,7 @@ describeEachAppLayout({ themes: ['classic', 'refresh-toolbar'], sizes: ['desktop
       // Note: The toolbar height in jsdom environment is calculated as `0`.
       // For this reason both `refresh` and `refresh-toolbar` only consider the height of `#h` element which is `40px`.
       // We have covered this case with real values in integration tests.
-      expect(document.scrollingElement).toHaveStyle('scroll-padding-block-start: 40px');
+      expect(document.scrollingElement).toHaveStyle('scroll-padding-top: 40px');
     });
 
     test('should use alternative header and footer selector', async () => {

--- a/src/app-layout/utils/use-global-scroll-padding.ts
+++ b/src/app-layout/utils/use-global-scroll-padding.ts
@@ -8,7 +8,7 @@ export function useGlobalScrollPadding(headerHeight: number) {
   useEffect(() => {
     const scrollingElement = document.scrollingElement;
     if (scrollingElement instanceof HTMLElement) {
-      scrollingElement.style.scrollPaddingBlockStart = `${headerHeight}px`;
+      scrollingElement.style.scrollPaddingTop = `${headerHeight}px`;
     }
   }, [headerHeight]);
 }


### PR DESCRIPTION
### Description

Follow-up to this PR: https://github.com/cloudscape-design/test-utils/pull/94

We used logical spacing according to our established standard, but then I realized it actually doesn't make sense to change the scroll-padding based on the text direction as regardless of the text direction, the header will be on the top and the padding is needed where the header is located.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
