### PR TITLE
fix: Restore reponsiveness inside prompt input secondary actions

### DIFF
--- a/pages/prompt-input/permutations.page.tsx
+++ b/pages/prompt-input/permutations.page.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import { Button } from '~components';
+import { Button, FileTokenGroup } from '~components';
 import PromptInput, { PromptInputProps } from '~components/prompt-input';
 
 import img from '../icon/custom-icon.png';
@@ -83,6 +83,37 @@ const permutations = createPermutations<PromptInputProps>([
     ],
     secondaryActions: [undefined, 'secondary actions'],
     disableSecondaryActionsPaddings: [false, true],
+  },
+  {
+    value: ['Short value for secondary action responsiveness'],
+    actionButtonIconName: [undefined, 'send'],
+    secondaryActions: [
+      'short',
+      'longer but breakable secondary action content',
+      'longerbutunbreakablesecondaryactioncontent',
+      <FileTokenGroup
+        key="file-token"
+        items={[
+          {
+            file: new File([new Blob(['Test content'])], 'test-for-venue-use-case.pdf', {
+              type: 'application/pdf',
+              lastModified: 1590962400000,
+            }),
+          },
+        ]}
+        onDismiss={() => {}}
+        showFileSize={true}
+        showFileLastModified={true}
+        showFileThumbnail={true}
+        i18nStrings={{
+          removeFileAriaLabel: () => 'Remove file',
+          limitShowFewer: 'Show fewer files',
+          limitShowMore: 'Show more files',
+          errorIconAriaLabel: 'Error',
+          warningIconAriaLabel: 'Warning',
+        }}
+      />,
+    ],
   },
 ]);
 

--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -230,6 +230,7 @@ const InternalPromptInput = React.forwardRef(
             <div
               className={clsx(styles['secondary-actions'], testutilStyles['secondary-actions'], {
                 [styles['with-paddings']]: !disableSecondaryActionsPaddings,
+                [styles['with-paddings-and-actions']]: !disableSecondaryActionsPaddings && hasActionButton,
                 [styles.invalid]: invalid,
                 [styles.warning]: warning,
               })}

--- a/src/prompt-input/styles.scss
+++ b/src/prompt-input/styles.scss
@@ -177,8 +177,13 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
 }
 
 .secondary-actions {
+  flex-basis: max-content;
+  flex-grow: 0;
+  flex-shrink: 1;
+  box-sizing: border-box;
+  @include styles.text-flex-wrapping;
   &.with-paddings {
-    padding-inline-start: styles.$control-padding-horizontal;
+    padding-inline: styles.$control-padding-horizontal;
     padding-block-start: awsui.$space-scaled-s;
     padding-block-end: styles.$control-padding-vertical;
 
@@ -186,6 +191,9 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
     &.warning {
       padding-inline-start: $invalid-border-offset;
     }
+  }
+  &.with-paddings-and-actions {
+    padding-inline-end: 0;
   }
 }
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
