### PR TITLE
fix: prevent double discovered breadcrumbs

### DIFF
--- a/pages/app-layout/global-breadcrumbs.page.tsx
+++ b/pages/app-layout/global-breadcrumbs.page.tsx
@@ -16,7 +16,7 @@ type DemoContext = React.Context<
 >;
 
 export default function () {
-  const { urlParams } = useContext(AppContext as DemoContext);
+  const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
   const [extraBreadcrumb, setExtraBreadcrumb] = useState(false);
 
   return (
@@ -45,9 +45,19 @@ export default function () {
             <input
               type="checkbox"
               data-testid="toggle-extra-breadcrumb"
+              checked={extraBreadcrumb}
               onChange={event => setExtraBreadcrumb(event.target.checked)}
             />{' '}
             Extra breadcrumb
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              data-testid="toggle-own-breadcrumb"
+              checked={urlParams.hasOwnBreadcrumbs || false}
+              onChange={event => setUrlParams({ hasOwnBreadcrumbs: event.target.checked || undefined })}
+            />{' '}
+            Own breadcrumb
           </label>
           {extraBreadcrumb && (
             <BreadcrumbGroup

--- a/src/app-layout/visual-refresh-toolbar/skeleton/breadcrumbs/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/breadcrumbs/index.tsx
@@ -6,6 +6,8 @@ import { BreadcrumbGroupImplementation } from '../../../../breadcrumb-group/impl
 import { BreadcrumbGroupProps } from '../../../../breadcrumb-group/interfaces';
 import { BreadcrumbsSlotContext } from '../../contexts';
 
+import styles from './styles.css.js';
+
 interface BreadcrumbsSlotProps {
   ownBreadcrumbs: React.ReactNode;
   discoveredBreadcrumbs: BreadcrumbGroupProps | null;
@@ -14,13 +16,15 @@ interface BreadcrumbsSlotProps {
 export function BreadcrumbsSlot({ ownBreadcrumbs, discoveredBreadcrumbs }: BreadcrumbsSlotProps) {
   return (
     <BreadcrumbsSlotContext.Provider value={{ isInToolbar: true }}>
-      {ownBreadcrumbs}
+      <div className={styles['breadcrumbs-own']}>{ownBreadcrumbs}</div>
       {discoveredBreadcrumbs && (
-        <BreadcrumbGroupImplementation
-          {...discoveredBreadcrumbs}
-          data-awsui-discovered-breadcrumbs={true}
-          __injectAnalyticsComponentMetadata={true}
-        />
+        <div className={styles['breadcrumbs-discovered']}>
+          <BreadcrumbGroupImplementation
+            {...discoveredBreadcrumbs}
+            data-awsui-discovered-breadcrumbs={true}
+            __injectAnalyticsComponentMetadata={true}
+          />
+        </div>
       )}
     </BreadcrumbsSlotContext.Provider>
   );

--- a/src/app-layout/visual-refresh-toolbar/skeleton/breadcrumbs/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/breadcrumbs/styles.scss
@@ -1,0 +1,9 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+// backward compatibility before this commit: TODO_REPLACE_ME
+.breadcrumbs-own:not(:empty) + .breadcrumbs-discovered {
+  display: none;
+}

--- a/src/internal/plugins/helpers/use-global-breadcrumbs.ts
+++ b/src/internal/plugins/helpers/use-global-breadcrumbs.ts
@@ -60,9 +60,13 @@ export function useGetGlobalBreadcrumbs(enabled: boolean) {
     if (!enabled) {
       return;
     }
-    return awsuiPluginsInternal.breadcrumbs.registerAppLayout(breadcrumbs => {
+    const unregisterAppLayout = awsuiPluginsInternal.breadcrumbs.registerAppLayout(breadcrumbs => {
       setDiscoveredBreadcrumbs(breadcrumbs);
     });
+    return () => {
+      unregisterAppLayout?.();
+      setDiscoveredBreadcrumbs(null);
+    };
   }, [enabled]);
 
   return discoveredBreadcrumbs;


### PR DESCRIPTION
### Description


Revert this PR: https://github.com/cloudscape-design/components/pull/3704, and also add some extra fixes and tests

Apparently these styles served extra purpose, not only backward compatibility

Related links, issue #, if available: V1881484904

### How has this been tested?

Added a regression test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
