### PR TITLE
revert: Migrate to new test-utils documenter (#3693)

### DIFF
--- a/build-tools/tasks/docs.js
+++ b/build-tools/tasks/docs.js
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 const path = require('path');
-const { writeComponentsDocumentation, writeTestUtilsDocumentation } = require('@cloudscape-design/documenter');
+const { writeComponentsDocumentation, documentTestUtils } = require('@cloudscape-design/documenter');
+const { writeFile } = require('../utils/files');
 const workspace = require('../utils/workspace');
 
 module.exports = function docs() {
@@ -14,17 +15,27 @@ module.exports = function docs() {
       TagEditor: ['getTagsDiff'],
     },
   });
-  writeTestUtilsDocumentation({
-    outDir: path.join(workspace.apiDocsPath, 'test-utils-doc'),
-    tsconfigPath: require.resolve('../../src/test-utils/tsconfig.json'),
-    domUtils: {
-      root: 'src/test-utils/dom/index.ts',
-      extraExports: ['default', 'ElementWrapper'],
-    },
-    selectorsUtils: {
-      root: 'src/test-utils/selectors/index.ts',
-      extraExports: ['default', 'ElementWrapper'],
-    },
-  });
+  testUtilDocs();
   return Promise.resolve();
 };
+
+function testUtilDocs() {
+  ['dom', 'selectors'].forEach(testUtilType => {
+    const baseWrapperDefinitions = require(`@cloudscape-design/test-utils-core/test-utils-doc/${testUtilType}`);
+    const componentWrapperDefinitions = documentTestUtils(
+      {
+        tsconfig: require.resolve('../../src/test-utils/tsconfig.json'),
+      },
+      `**/{${testUtilType},types}/**/*`
+    );
+
+    const definitions = [...baseWrapperDefinitions, ...componentWrapperDefinitions];
+    const indexContent = `module.exports = {
+      classes: ${JSON.stringify(definitions)}
+    }
+    `;
+
+    const outPath = path.join(workspace.apiDocsPath, 'test-utils-doc', `${testUtilType}.js`);
+    writeFile(outPath, indexContent);
+  });
+}

--- a/src/__tests__/snapshot-tests/documenter.test.ts
+++ b/src/__tests__/snapshot-tests/documenter.test.ts
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import definitions from '../../../lib/components-definitions/components';
+// @ts-expect-error no typings
 import testUtilDomDefinitions from '../../../lib/components-definitions/test-utils-doc/dom';
+// @ts-expect-error no typings
 import testUtilSelectorsDefinitions from '../../../lib/components-definitions/test-utils-doc/selectors';
 import { getAllComponents } from '../utils';
 


### PR DESCRIPTION


### Description

This reverts commit 0cea5f4b36814ef901cbf7df401a320775d37133.

The new format is not fully compatible with the new

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
