### PR TITLE
fix: Properly handle app layout suspended state

### DIFF
--- a/src/internal/plugins/controllers/app-layout-widget.ts
+++ b/src/internal/plugins/controllers/app-layout-widget.ts
@@ -12,7 +12,14 @@ interface SecondaryRegistration<Props> {
   update: (props: Props) => void;
 }
 
-export type RegistrationState<Props> = PrimaryRegistration<Props> | SecondaryRegistration<Props>;
+interface SuspendedRegistration {
+  type: 'suspended';
+}
+
+export type RegistrationState<Props> =
+  | PrimaryRegistration<Props>
+  | SecondaryRegistration<Props>
+  | SuspendedRegistration;
 type RegistrationType = RegistrationState<unknown>['type'];
 
 type RegistrationChangeHandler<Props> = (


### PR DESCRIPTION
### Description

When app layout is suspended (e.g. intersection observer reported it is not intersecting), the inner app layout state still shows it is in "secondary" mode, which might be unexpected

Related links, issue #, if available: n/a

### How has this been tested?

n/a, I did not find any real manifestations of this bug

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
