### PR TITLE
chore: Add more tests on app layout state management

### DIFF
--- a/src/app-layout/__tests__/state.test.tsx
+++ b/src/app-layout/__tests__/state.test.tsx
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { act } from '@testing-library/react';
+
+import AppLayout from '../../../lib/components/app-layout';
+import { forceMobileModeSymbol } from '../../../lib/components/internal/hooks/use-mobile';
+import { describeEachAppLayout, renderComponent } from './utils';
+
+describeEachAppLayout({ themes: ['refresh-toolbar'] }, () => {
+  test('content dom reference is preserved when changing state', () => {
+    const refSpy = jest.fn();
+    const { rerender, wrapper } = renderComponent(
+      <AppLayout navigation="testing" content={<div ref={refSpy}>content</div>} />
+    );
+
+    expect(refSpy).toHaveBeenCalledTimes(1);
+    expect(refSpy).toHaveBeenCalledWith(expect.any(HTMLElement));
+    expect(wrapper.findContentRegion().getElement()).toHaveTextContent('content');
+
+    refSpy.mockClear();
+    rerender(<AppLayout navigationHide={true} navigation="testing" content={<div ref={refSpy}>content</div>} />);
+    expect(refSpy).toHaveBeenCalledTimes(0);
+    expect(wrapper.findContentRegion().getElement()).toHaveTextContent('content');
+
+    rerender(<></>);
+    expect(refSpy).toHaveBeenCalledTimes(1);
+    expect(refSpy).toHaveBeenCalledWith(null);
+  });
+
+  // does not work without this fix: https://github.com/cloudscape-design/component-toolkit/pull/151
+  test.skip('content dom reference is preserved when changing switching between desktop and mobile', () => {
+    const refSpy = jest.fn();
+    renderComponent(<AppLayout content={<div ref={refSpy}>content</div>} />);
+
+    expect(refSpy).toHaveBeenCalledTimes(1);
+    expect(refSpy).toHaveBeenCalledWith(expect.any(HTMLElement));
+
+    refSpy.mockClear();
+    const globalWithFlags = globalThis as any;
+    globalWithFlags[forceMobileModeSymbol] = !globalWithFlags[forceMobileModeSymbol];
+    act(() => {
+      window.dispatchEvent(new CustomEvent('resize'));
+    });
+    expect(refSpy).toHaveBeenCalledTimes(0);
+
+    globalWithFlags[forceMobileModeSymbol] = !globalWithFlags[forceMobileModeSymbol];
+    act(() => {
+      window.dispatchEvent(new CustomEvent('resize'));
+    });
+    expect(refSpy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/app-layout/__tests__/utils.tsx
+++ b/src/app-layout/__tests__/utils.tsx
@@ -10,9 +10,9 @@ import { ComponentWrapper } from '@cloudscape-design/test-utils-core/dom';
 
 import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
 import customCssProps from '../../../lib/components/internal/generated/custom-css-properties';
+import { forceMobileModeSymbol } from '../../../lib/components/internal/hooks/use-mobile';
 import { SplitPanelProps } from '../../../lib/components/split-panel';
 import createWrapper, { AppLayoutWrapper, ElementWrapper } from '../../../lib/components/test-utils/dom';
-import { forceMobileModeSymbol } from '../../internal/hooks/use-mobile';
 
 import testutilStyles from '../../../lib/components/app-layout/test-classes/styles.css.js';
 import visualRefreshStyles from '../../../lib/components/app-layout/visual-refresh/styles.css.js';


### PR DESCRIPTION
### Description

Make sure we do not unmount main node when app layout state changes

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
