### PR TITLE
chore: Add usage tracking for global breadcrumbs feature

### DIFF
--- a/src/internal/plugins/helpers/use-global-breadcrumbs.ts
+++ b/src/internal/plugins/helpers/use-global-breadcrumbs.ts
@@ -8,6 +8,7 @@ import {
   BreadcrumbsSlotContext,
 } from '../../../app-layout/visual-refresh-toolbar/contexts';
 import { BreadcrumbGroupProps } from '../../../breadcrumb-group/interfaces';
+import { metrics } from '../../metrics';
 import { awsuiPluginsInternal } from '../api';
 import { BreadcrumbsGlobalRegistration } from '../controllers/breadcrumbs';
 
@@ -24,9 +25,13 @@ function useSetGlobalBreadcrumbsImplementation({
     if (isInToolbar || __disableGlobalization || !isLayoutVisible) {
       return;
     }
-    const registration = awsuiPluginsInternal.breadcrumbs.registerBreadcrumbs(props, isRegistered =>
-      setRegistered(isRegistered ?? true)
-    );
+    const registration = awsuiPluginsInternal.breadcrumbs.registerBreadcrumbs(props, isRegistered => {
+      setRegistered(isRegistered ?? true);
+      if (isRegistered) {
+        const breadcrumbs = props.items.map(item => item.text).join(' > ');
+        metrics.sendOpsMetricObject('awsui-global-breadcrumbs-used', { breadcrumbs });
+      }
+    });
     registrationRef.current = registration;
 
     return () => {


### PR DESCRIPTION
### Description

Track adoption of this feature

Related links, issue #, if available: n/a

### How has this been tested?

Added unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
