### PR TITLE
chore: reorganize app layout feature flags

### DIFF
--- a/src/app-layout/__integ__/global-breadcrumbs.test.ts
+++ b/src/app-layout/__integ__/global-breadcrumbs.test.ts
@@ -58,7 +58,7 @@ describe('classic', () => {
     'does not react to the feature flag even if it is enabled',
     setupTest(
       {
-        url: `#/light/app-layout/global-breadcrumbs/?${new URLSearchParams({ visualRefresh: 'false', appLayoutWidget: 'true', hasOwnBreadcrumbs: 'true' }).toString()}`,
+        url: `#/light/app-layout/global-breadcrumbs/?${new URLSearchParams({ visualRefresh: 'false', appLayoutToolbar: 'true', hasOwnBreadcrumbs: 'true' }).toString()}`,
       },
       async page => {
         await page.toggleExtraBreadcrumb();

--- a/src/app-layout/__integ__/utils.ts
+++ b/src/app-layout/__integ__/utils.ts
@@ -74,7 +74,7 @@ export const setupTest = (
     const page = new AppLayoutDrawersPage(browser);
     const params = new URLSearchParams({
       visualRefresh: `${theme !== 'classic'}`,
-      appLayoutWidget: `${theme === 'refresh-toolbar'}`,
+      appLayoutToolbar: `${theme === 'refresh-toolbar'}`,
       ...(splitPanelPosition ? { splitPanelPosition } : {}),
     }).toString();
     await browser.url(`#/light/app-layout/with-drawers?${params}`);

--- a/src/app-layout/__tests__/trigger-button.test.tsx
+++ b/src/app-layout/__tests__/trigger-button.test.tsx
@@ -98,7 +98,7 @@ const renderVisualRefreshToolbarTriggerButton = (
   return { wrapper, rerender, getByTestId, getByText, container };
 };
 
-describe('Visual refresh trigger-button (not in appLayoutWidget toolbar)', () => {
+describe('Visual refresh trigger-button (not in appLayoutToolbar toolbar)', () => {
   beforeEach(() => jest.clearAllMocks());
 
   describe.each([true, false])('Toolbar trigger-button with isMobile=%s', isMobile => {

--- a/src/app-layout/__tests__/utils.tsx
+++ b/src/app-layout/__tests__/utils.tsx
@@ -59,12 +59,12 @@ export function describeEachAppLayout(
         beforeEach(() => {
           globalWithFlags[forceMobileModeSymbol] = size === 'mobile';
           globalWithFlags[Symbol.for('awsui-visual-refresh-flag')] = () => theme !== 'classic';
-          setGlobalFlag('appLayoutWidget', theme === 'refresh-toolbar');
+          setGlobalFlag('appLayoutToolbar', theme === 'refresh-toolbar');
         });
         afterEach(() => {
           delete globalWithFlags[forceMobileModeSymbol];
           delete globalWithFlags[Symbol.for('awsui-visual-refresh-flag')];
-          setGlobalFlag('appLayoutWidget', undefined);
+          setGlobalFlag('appLayoutToolbar', undefined);
           clearVisualRefreshState();
         });
         test('mocks applied correctly', () => {


### PR DESCRIPTION
### Description

Make sure we use `appLayoutToolbar` feature flag is used in all places as expected.

The `appLayoutWidget` flag logic is still tested in dedicated tests: https://github.com/cloudscape-design/components/blob/main/src/internal/widgets/__tests__/widgets.test.tsx

Related links, issue #, if available: n/a

### How has this been tested?

Test-only change

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
