### PR TITLE
fix: Handle multiple intersection changes in a single callback

### DIFF
--- a/src/internal/hooks/use-intersection-observer/__tests__/use-intersection-observer.test.tsx
+++ b/src/internal/hooks/use-intersection-observer/__tests__/use-intersection-observer.test.tsx
@@ -1,52 +1,111 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render } from '@testing-library/react';
+import { act, cleanup, render } from '@testing-library/react';
 
-import { useIntersectionObserver } from '..';
-
-declare global {
-  interface Window {
-    IntersectionObserver: any;
-  }
-}
+import { useIntersectionObserver } from '../../../../../lib/components/internal/hooks/use-intersection-observer';
 
 function TestComponent({ initialState }: { initialState?: boolean }) {
   const { ref, isIntersecting } = useIntersectionObserver({ initialState });
   return <div ref={ref} data-testid="test" data-value={isIntersecting} />;
 }
 
-const mockObserve = jest.fn();
-const mockIntersectionObserver = jest.fn(() => ({
-  observe: mockObserve,
-  disconnect: jest.fn(),
-}));
+type MockIntersectionObserverCallback = (
+  // only fields actually used in our implementation
+  entries: Array<Pick<IntersectionObserverEntry, 'isIntersecting' | 'time'>>
+) => void;
+let mockObserverInstance: (IntersectionObserver & { callback: MockIntersectionObserverCallback }) | undefined;
+
+class MockIntersectionObserver {
+  constructor(callback: MockIntersectionObserverCallback) {
+    if (mockObserverInstance) {
+      throw new Error('only one observer instance expected per test');
+    }
+    const instance = {
+      observe: jest.fn() as IntersectionObserver['observe'],
+      disconnect: jest.fn() as IntersectionObserver['disconnect'],
+    } as IntersectionObserver;
+    mockObserverInstance = {
+      ...instance,
+      callback,
+    };
+    return instance;
+  }
+}
 
 describe('useIntersectionObserver', () => {
   beforeEach(() => {
-    window.IntersectionObserver = mockIntersectionObserver;
+    window.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
     jest.clearAllMocks();
   });
 
-  it('should create an observer with the defined target element', async () => {
-    const { findByTestId } = render(<TestComponent />);
-    const target = await findByTestId('test');
-
-    expect(mockIntersectionObserver).toHaveBeenCalled();
-    expect(mockObserve).toHaveBeenCalledWith(target);
+  afterEach(() => {
+    cleanup();
+    expect(mockObserverInstance!.disconnect).toHaveBeenCalled();
+    mockObserverInstance = undefined;
   });
 
-  it('defaults to not intersecting', async () => {
-    const { findByTestId } = render(<TestComponent />);
-    const target = await findByTestId('test');
+  it('should create an observer with the defined target element', () => {
+    const { getByTestId } = render(<TestComponent />);
+    const target = getByTestId('test');
+
+    expect(mockObserverInstance!.observe).toHaveBeenCalledWith(target);
+  });
+
+  it('defaults to not intersecting', () => {
+    const { getByTestId } = render(<TestComponent />);
+    const target = getByTestId('test');
 
     expect(target.dataset.value).toBe('false');
   });
 
-  it('allows overriding the default value', async () => {
-    const { findByTestId } = render(<TestComponent initialState={true} />);
-    const target = await findByTestId('test');
+  it('allows overriding the default value', () => {
+    const { getByTestId } = render(<TestComponent initialState={true} />);
+    const target = getByTestId('test');
 
+    expect(target.dataset.value).toBe('true');
+  });
+
+  it('updates value with a callback', () => {
+    const { getByTestId } = render(<TestComponent />);
+
+    const target = getByTestId('test');
+    expect(target.dataset.value).toBe('false');
+
+    act(() => mockObserverInstance!.callback([{ time: 0, isIntersecting: true }]));
+    expect(target.dataset.value).toBe('true');
+
+    act(() => mockObserverInstance!.callback([{ time: 0, isIntersecting: false }]));
+    expect(target.dataset.value).toBe('false');
+  });
+
+  it('should resolve the final state if multiple observations occurred', () => {
+    const { getByTestId } = render(<TestComponent />);
+
+    act(() =>
+      mockObserverInstance!.callback([
+        { time: 0, isIntersecting: true },
+        { time: 1, isIntersecting: false },
+        { time: 2, isIntersecting: true },
+      ])
+    );
+
+    const target = getByTestId('test');
+    expect(target.dataset.value).toBe('true');
+  });
+
+  it('should sort observations by time', () => {
+    const { getByTestId } = render(<TestComponent />);
+
+    act(() =>
+      mockObserverInstance!.callback([
+        { time: 1, isIntersecting: false },
+        { time: 2, isIntersecting: true },
+        { time: 0, isIntersecting: false },
+      ])
+    );
+
+    const target = getByTestId('test');
     expect(target.dataset.value).toBe('true');
   });
 });

--- a/src/internal/hooks/use-intersection-observer/index.ts
+++ b/src/internal/hooks/use-intersection-observer/index.ts
@@ -41,7 +41,15 @@ export function useIntersectionObserver<T extends HTMLElement>({
       } catch {
         // Tried to access a cross-origin iframe. Fall back to current IntersectionObserver.
       }
-      observerRef.current = new TopLevelIntersectionObserver(([entry]) => setIsIntersecting(entry.isIntersecting));
+      observerRef.current = new TopLevelIntersectionObserver(entries => {
+        let latestEntry = entries[0];
+        for (const entry of entries) {
+          if (entry.time > latestEntry.time) {
+            latestEntry = entry;
+          }
+        }
+        setIsIntersecting(latestEntry.isIntersecting);
+      });
       observerRef.current.observe(targetElement);
     }
   }, []);


### PR DESCRIPTION
### Description

Fixing a bug where `useIntersectionObserver` only checks the first change entry instead of the latest.

Check the docs: https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API

> The list of entries received by the callback includes one [IntersectionObserverEntry](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) object for each threshold-crossing event — multiple entries can be received at a time, either from multiple targets or from a single target crossing multiple thresholds in a short amount of time. The entries are dispatched using a queue, so they should be ordered by the time they were generated, but you should preferably use [IntersectionObserverEntry.time](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry/time) to correctly order them.

Related links, issue #, if available: n/a

### How has this been tested?

* Manually with the changes in https://github.com/cloudscape-design/components/pull/3721 which reproduced the issue
* Added more unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
