### PR TITLE
fix: Share split panel context between app instances

### DIFF
--- a/src/internal/context/split-panel-context.ts
+++ b/src/internal/context/split-panel-context.ts
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { createContext, useContext } from 'react';
+import React, { useContext } from 'react';
 
 import { SplitPanelFocusControlRefs } from '../../app-layout/utils/use-split-panel-focus-control';
+import { awsuiPluginsInternal } from '../plugins/api';
 
 export interface SplitPanelSideToggleProps {
   displayed: boolean;
@@ -38,12 +39,16 @@ export interface SplitPanelContextProps extends SplitPanelContextBaseProps {
   animationDisabled?: boolean;
 }
 
-const SplitPanelContext = createContext<SplitPanelContextProps | null>(null);
+const AppLayoutWidgetSplitPanelContext =
+  awsuiPluginsInternal.sharedReactContexts.createContext<SplitPanelContextProps | null>(
+    React,
+    'AppLayoutWidgetSplitPanelContext'
+  );
 
-export const SplitPanelContextProvider = SplitPanelContext.Provider;
+export const SplitPanelContextProvider = AppLayoutWidgetSplitPanelContext.Provider;
 
 export function useSplitPanelContext() {
-  const ctx = useContext(SplitPanelContext);
+  const ctx = useContext(AppLayoutWidgetSplitPanelContext);
   if (!ctx) {
     throw new Error('Split panel can only be used inside app layout');
   }


### PR DESCRIPTION
### Description

Allow this use-case

```
import { AppLayout } from '@cloudscape-design/components';
import { SplitPanel } from 'my-custom-cloudscape-package';
```

Currently it fails [on this line](https://github.com/cloudscape-design/components/blob/9524306b3925154d4e985640ff7589c7aec52413/src/internal/context/split-panel-context.ts#L48), because components from different bundles have referentially different contexts.

Now this will work, however, with a caveat that the object shape of this context is not stable and you will need to make sure these two versions are in sync on your end

Related links, issue #, if available: n/a

### How has this been tested?

Tested in my dev pipeline

Not testable in this repository, because it requires a multi-package environment

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
