### PR TITLE
chore: Minor fix for date input permutations page

### DIFF
--- a/pages/date-input/permutations-formats.page.tsx
+++ b/pages/date-input/permutations-formats.page.tsx
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 
+import { SpaceBetween } from '~components';
 import Box from '~components/box';
 import DateInput, { DateInputProps } from '~components/date-input';
 
@@ -42,23 +44,24 @@ export default function DateInputPermutations() {
     <Box padding="l">
       <h1>Date Input permutations - formats</h1>
       <ScreenshotArea>
-        <PermutationsView
-          permutations={permutationsFormatsDay}
-          render={permutation => <DateInput {...permutation} onChange={() => {}} />}
-        />
-        <PermutationsView
-          permutations={permutationsFormatsMonth}
-          render={permutation => <DateInput {...permutation} onChange={() => {}} />}
-        />
+        <SpaceBetween size="m">
+          <PermutationsView
+            permutations={permutationsFormatsDay}
+            render={permutation => <DateInput {...permutation} onChange={() => {}} />}
+          />
 
-        <br />
-        <hr />
-        <br />
+          <PermutationsView
+            permutations={permutationsFormatsMonth}
+            render={permutation => <DateInput {...permutation} onChange={() => {}} />}
+          />
 
-        <PermutationsView
-          permutations={permutationsLongLocalizedLocales}
-          render={permutation => <DateInput {...permutation} onChange={() => {}} />}
-        />
+          <hr />
+
+          <PermutationsView
+            permutations={permutationsLongLocalizedLocales}
+            render={permutation => <DateInput {...permutation} onChange={() => {}} />}
+          />
+        </SpaceBetween>
       </ScreenshotArea>
     </Box>
   );

--- a/pages/date-picker/permutations-formats.page.tsx
+++ b/pages/date-picker/permutations-formats.page.tsx
@@ -64,14 +64,13 @@ export default function DatePickerScenario() {
             permutations={permutationsFormatsDay}
             render={permutation => <DatePicker {...permutation} onChange={() => {}} />}
           />
+
           <PermutationsView
             permutations={permutationsFormatsMonth}
             render={permutation => <DatePicker {...permutation} onChange={() => {}} />}
           />
 
-          <br />
           <hr />
-          <br />
 
           <PermutationsView
             permutations={permutationsLongLocalizedLocales}


### PR DESCRIPTION
### Description

The PR fixes a small issue which caused two date input permutations render w/o padding. It also aligns implementation between date input and date picker permutation pages.

<img width="907" height="333" alt="Screenshot 2025-08-13 at 16 01 07" src="https://github.com/user-attachments/assets/29677f69-541d-4766-a35e-87d5db56e8c7" />


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
