### PR TITLE
fix: Fix focus management for flashbar when motion is enabled

### DIFF
--- a/src/flashbar/__integ__/collapsible.test.ts
+++ b/src/flashbar/__integ__/collapsible.test.ts
@@ -119,6 +119,7 @@ describe('Collapsible Flashbar', () => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
           await page.toggleCollapsedState();
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );

--- a/src/flashbar/__integ__/collapsible.test.ts
+++ b/src/flashbar/__integ__/collapsible.test.ts
@@ -41,7 +41,6 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addInfoFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -51,7 +50,6 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );
@@ -61,10 +59,8 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
           await page.addInfoFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -77,7 +73,6 @@ describe('Collapsible Flashbar', () => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
           await page.addInfoFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -88,7 +83,6 @@ describe('Collapsible Flashbar', () => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
           await page.addErrorFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );
@@ -99,10 +93,8 @@ describe('Collapsible Flashbar', () => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
           await page.addErrorFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
           await page.addInfoFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -113,10 +105,8 @@ describe('Collapsible Flashbar', () => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
           await page.addErrorFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
           await page.addInfoFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(2)).resolves.toBe(false);
         })
       );
@@ -129,7 +119,6 @@ describe('Collapsible Flashbar', () => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
           await page.toggleCollapsedState();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );

--- a/src/flashbar/__integ__/collapsible.test.ts
+++ b/src/flashbar/__integ__/collapsible.test.ts
@@ -41,6 +41,7 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addInfoFlash();
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -50,6 +51,7 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );
@@ -59,8 +61,10 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
           await page.addInfoFlash();
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -73,6 +77,7 @@ describe('Collapsible Flashbar', () => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
           await page.addInfoFlash();
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -83,6 +88,7 @@ describe('Collapsible Flashbar', () => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
           await page.addErrorFlash();
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );
@@ -93,8 +99,10 @@ describe('Collapsible Flashbar', () => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
           await page.addErrorFlash();
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
           await page.addInfoFlash();
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -105,8 +113,10 @@ describe('Collapsible Flashbar', () => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
           await page.addErrorFlash();
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
           await page.addInfoFlash();
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(2)).resolves.toBe(false);
         })
       );
@@ -119,6 +129,7 @@ describe('Collapsible Flashbar', () => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
           await page.toggleCollapsedState();
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );

--- a/src/flashbar/__integ__/collapsible.test.ts
+++ b/src/flashbar/__integ__/collapsible.test.ts
@@ -21,6 +21,7 @@ describe('Collapsible Flashbar', () => {
         await expect(page.countFlashes()).resolves.toBe(1);
         await page.keys('Space');
 
+        await page.pause(FOCUS_DEBOUNCE_DELAY);
         await expect(page.countFlashes()).resolves.toBe(5);
         await expect(page.isFlashFocused(1)).resolves.toBe(true);
 
@@ -40,7 +41,6 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addInfoFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -50,7 +50,6 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );
@@ -60,7 +59,6 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
           await page.addInfoFlash();
           await expect(page.isFlashFocused(1)).resolves.toBe(false);
@@ -74,7 +72,6 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await page.addInfoFlash();
           return expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
@@ -85,7 +82,6 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await page.addErrorFlash();
           return expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
@@ -96,11 +92,9 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await page.addErrorFlash();
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
           await page.addInfoFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -110,10 +104,8 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await page.addErrorFlash();
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await page.addInfoFlash();
           await expect(page.isFlashFocused(2)).resolves.toBe(false);
         })
@@ -126,9 +118,7 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await page.toggleCollapsedState();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );

--- a/src/flashbar/__integ__/collapsible.test.ts
+++ b/src/flashbar/__integ__/collapsible.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
-import { FOCUS_THROTTLE_DELAY } from '../utils';
+import { FOCUS_DEBOUNCE_DELAY } from '../utils';
 import { FlashbarBasePage } from './pages/base';
 import { setupTest } from './pages/interactive-page';
 import { setupTest as setupStickyFlashbarTest } from './pages/sticky-page';
@@ -40,7 +40,7 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addInfoFlash();
-          await page.pause(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -50,7 +50,7 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
-          await page.pause(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );
@@ -60,7 +60,7 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
-          await page.pause(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
           await page.addInfoFlash();
           await expect(page.isFlashFocused(1)).resolves.toBe(false);
@@ -74,7 +74,7 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
-          await page.pause(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await page.addInfoFlash();
           return expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
@@ -85,7 +85,7 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
-          await page.pause(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await page.addErrorFlash();
           return expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
@@ -96,11 +96,11 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
-          await page.pause(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await page.addErrorFlash();
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
           await page.addInfoFlash();
-          await page.pause(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -110,10 +110,10 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
-          await page.pause(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await page.addErrorFlash();
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
-          await page.pause(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await page.addInfoFlash();
           await expect(page.isFlashFocused(2)).resolves.toBe(false);
         })
@@ -126,9 +126,9 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
-          await page.pause(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await page.toggleCollapsedState();
-          await page.pause(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_DEBOUNCE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );

--- a/src/flashbar/__integ__/focus-interactions.test.ts
+++ b/src/flashbar/__integ__/focus-interactions.test.ts
@@ -1,17 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { FOCUS_DEBOUNCE_DELAY } from '../utils';
 import { setupTest } from './pages/interactive-page';
-
-// The approximate time it takes for 3 flashes to be added in a quick sequence with a 100ms delay.
-const SEQUENTIAL_FLASH_DELAY = 300;
 
 test(
   'a flash with ariaRole="status" produces no duplicate interactive content',
   setupTest(async page => {
     await page.removeAll();
     await page.addInfoFlash();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     await page.click('#focus-before');
     await page.keys('Tab');
@@ -26,7 +21,6 @@ test(
   'adding flash with ariaRole="status" does not move focus',
   setupTest(async page => {
     await page.addInfoFlash();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
     return expect(page.isFlashFocused(1)).resolves.toBe(false);
   })
 );
@@ -35,7 +29,6 @@ test(
   'adding flash with ariaRole="alert" moves focus to the new flash',
   setupTest(async page => {
     await page.addErrorFlash();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
     return expect(page.isFlashFocused(1)).resolves.toBe(true);
   })
 );
@@ -44,9 +37,7 @@ test(
   'adding new non-alert flashes does not move focus to previous alert flashes',
   setupTest(async page => {
     await page.addErrorFlash();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
     await expect(page.isFlashFocused(1)).resolves.toBe(true);
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
     await page.addInfoFlash();
     await expect(page.isFlashFocused(1)).resolves.toBe(false);
   })
@@ -56,10 +47,7 @@ test(
   'adding multiple flashes with ariaRole="alert" debounces focus moves',
   setupTest(async page => {
     await page.addSequentialErrorFlashes();
-    // Wait for sequential flashes to be added
-    await page.pause(SEQUENTIAL_FLASH_DELAY);
     // Flash items are added from bottom to top, so the last one added is the first one in the DOM.
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
     return expect(page.isFlashFocused(1)).resolves.toBe(true);
   })
 );
@@ -68,7 +56,6 @@ test(
   'adding flash with ariaRole="alert" to the top moves focus to the new flash',
   setupTest(async page => {
     await page.addErrorFlash();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
     return expect(page.isFlashFocused(1)).resolves.toBe(true);
   })
 );
@@ -78,7 +65,6 @@ test(
   setupTest(async page => {
     const initialCount = await page.countFlashes();
     await page.addErrorFlashToBottom();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
     return expect(page.isFlashFocused(initialCount + 1)).resolves.toBe(true);
   })
 );
@@ -87,10 +73,8 @@ test(
   'dismissing flash item moves focus to next item',
   setupTest(async page => {
     await page.addSequentialErrorFlashes();
-    await page.pause(SEQUENTIAL_FLASH_DELAY);
 
     await page.dismissFirstItem();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     return expect(await page.isFlashFocused(1)).toBe(true);
   })
@@ -105,7 +89,6 @@ test(
     await page.toggleCollapsedState();
 
     await page.dismissFirstItem();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     return expect(await page.isFlashFocused(1)).toBe(true);
   })
@@ -117,10 +100,8 @@ test(
     await page.removeAll();
     await page.toggleStackingFeature();
     await page.addSequentialErrorFlashes();
-    await page.pause(SEQUENTIAL_FLASH_DELAY);
 
     await page.dismissFirstItem();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     const isDismissButtonFocused = await page.isDismissButtonFocused();
 

--- a/src/flashbar/__integ__/focus-interactions.test.ts
+++ b/src/flashbar/__integ__/focus-interactions.test.ts
@@ -1,12 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { FOCUS_DEBOUNCE_DELAY } from '../utils';
 import { setupTest } from './pages/interactive-page';
+
+// The approximate time it takes for 3 flashes to be added in a quick sequence with a 100ms delay.
+const SEQUENTIAL_FLASH_DELAY = 300;
 
 test(
   'a flash with ariaRole="status" produces no duplicate interactive content',
   setupTest(async page => {
     await page.removeAll();
     await page.addInfoFlash();
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     await page.click('#focus-before');
     await page.keys('Tab');
@@ -21,6 +26,7 @@ test(
   'adding flash with ariaRole="status" does not move focus',
   setupTest(async page => {
     await page.addInfoFlash();
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
     return expect(page.isFlashFocused(1)).resolves.toBe(false);
   })
 );
@@ -29,6 +35,7 @@ test(
   'adding flash with ariaRole="alert" moves focus to the new flash',
   setupTest(async page => {
     await page.addErrorFlash();
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
     return expect(page.isFlashFocused(1)).resolves.toBe(true);
   })
 );
@@ -37,7 +44,9 @@ test(
   'adding new non-alert flashes does not move focus to previous alert flashes',
   setupTest(async page => {
     await page.addErrorFlash();
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
     await expect(page.isFlashFocused(1)).resolves.toBe(true);
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
     await page.addInfoFlash();
     await expect(page.isFlashFocused(1)).resolves.toBe(false);
   })
@@ -47,7 +56,10 @@ test(
   'adding multiple flashes with ariaRole="alert" debounces focus moves',
   setupTest(async page => {
     await page.addSequentialErrorFlashes();
+    // Wait for sequential flashes to be added
+    await page.pause(SEQUENTIAL_FLASH_DELAY);
     // Flash items are added from bottom to top, so the last one added is the first one in the DOM.
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
     return expect(page.isFlashFocused(1)).resolves.toBe(true);
   })
 );
@@ -56,6 +68,7 @@ test(
   'adding flash with ariaRole="alert" to the top moves focus to the new flash',
   setupTest(async page => {
     await page.addErrorFlash();
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
     return expect(page.isFlashFocused(1)).resolves.toBe(true);
   })
 );
@@ -65,6 +78,7 @@ test(
   setupTest(async page => {
     const initialCount = await page.countFlashes();
     await page.addErrorFlashToBottom();
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
     return expect(page.isFlashFocused(initialCount + 1)).resolves.toBe(true);
   })
 );
@@ -73,8 +87,10 @@ test(
   'dismissing flash item moves focus to next item',
   setupTest(async page => {
     await page.addSequentialErrorFlashes();
+    await page.pause(SEQUENTIAL_FLASH_DELAY);
 
     await page.dismissFirstItem();
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     return expect(await page.isFlashFocused(1)).toBe(true);
   })
@@ -89,6 +105,7 @@ test(
     await page.toggleCollapsedState();
 
     await page.dismissFirstItem();
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     return expect(await page.isFlashFocused(1)).toBe(true);
   })
@@ -100,8 +117,10 @@ test(
     await page.removeAll();
     await page.toggleStackingFeature();
     await page.addSequentialErrorFlashes();
+    await page.pause(SEQUENTIAL_FLASH_DELAY);
 
     await page.dismissFirstItem();
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     const isDismissButtonFocused = await page.isDismissButtonFocused();
 

--- a/src/flashbar/__integ__/focus-interactions.test.ts
+++ b/src/flashbar/__integ__/focus-interactions.test.ts
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { FOCUS_DEBOUNCE_DELAY } from '../utils';
 import { setupTest } from './pages/interactive-page';
 
 test(
@@ -40,20 +39,16 @@ test(
     await page.addErrorFlash();
     await expect(page.isFlashFocused(1)).resolves.toBe(true);
     await page.addInfoFlash();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
     await expect(page.isFlashFocused(1)).resolves.toBe(false);
   })
 );
 
 test(
-  'adding multiple flashes with ariaRole="alert" throttles focus moves',
+  'adding multiple flashes with ariaRole="alert" debounces focus moves',
   setupTest(async page => {
-    const initialCount = await page.countFlashes();
     await page.addSequentialErrorFlashes();
-    await page.pause(300);
-    const currentCount = await page.countFlashes();
-    const firstAddedItemIndex = currentCount - initialCount;
-    return expect(page.isFlashFocused(firstAddedItemIndex)).resolves.toBe(true);
+    // Flash items are added from bottom to top, so the last one added is the first one in the DOM.
+    return expect(page.isFlashFocused(1)).resolves.toBe(true);
   })
 );
 
@@ -78,10 +73,8 @@ test(
   'dismissing flash item moves focus to next item',
   setupTest(async page => {
     await page.addSequentialErrorFlashes();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     await page.dismissFirstItem();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     return expect(await page.isFlashFocused(1)).toBe(true);
   })
@@ -94,10 +87,8 @@ test(
     await page.toggleStackingFeature();
     await page.addSequentialErrorFlashes();
     await page.toggleCollapsedState();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     await page.dismissFirstItem();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     return expect(await page.isFlashFocused(1)).toBe(true);
   })
@@ -109,10 +100,8 @@ test(
     await page.removeAll();
     await page.toggleStackingFeature();
     await page.addSequentialErrorFlashes();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     await page.dismissFirstItem();
-    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     const isDismissButtonFocused = await page.isDismissButtonFocused();
 

--- a/src/flashbar/__integ__/focus-interactions.test.ts
+++ b/src/flashbar/__integ__/focus-interactions.test.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { FOCUS_THROTTLE_DELAY } from '../utils';
+import { FOCUS_DEBOUNCE_DELAY } from '../utils';
 import { setupTest } from './pages/interactive-page';
 
 test(
@@ -40,7 +40,7 @@ test(
     await page.addErrorFlash();
     await expect(page.isFlashFocused(1)).resolves.toBe(true);
     await page.addInfoFlash();
-    await page.pause(FOCUS_THROTTLE_DELAY);
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
     await expect(page.isFlashFocused(1)).resolves.toBe(false);
   })
 );
@@ -78,10 +78,10 @@ test(
   'dismissing flash item moves focus to next item',
   setupTest(async page => {
     await page.addSequentialErrorFlashes();
-    await page.pause(FOCUS_THROTTLE_DELAY);
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     await page.dismissFirstItem();
-    await page.pause(FOCUS_THROTTLE_DELAY);
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     return expect(await page.isFlashFocused(1)).toBe(true);
   })
@@ -94,10 +94,10 @@ test(
     await page.toggleStackingFeature();
     await page.addSequentialErrorFlashes();
     await page.toggleCollapsedState();
-    await page.pause(FOCUS_THROTTLE_DELAY);
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     await page.dismissFirstItem();
-    await page.pause(FOCUS_THROTTLE_DELAY);
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     return expect(await page.isFlashFocused(1)).toBe(true);
   })
@@ -109,10 +109,10 @@ test(
     await page.removeAll();
     await page.toggleStackingFeature();
     await page.addSequentialErrorFlashes();
-    await page.pause(FOCUS_THROTTLE_DELAY);
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     await page.dismissFirstItem();
-    await page.pause(FOCUS_THROTTLE_DELAY);
+    await page.pause(FOCUS_DEBOUNCE_DELAY);
 
     const isDismissButtonFocused = await page.isDismissButtonFocused();
 

--- a/src/flashbar/__integ__/pages/base.ts
+++ b/src/flashbar/__integ__/pages/base.ts
@@ -12,7 +12,6 @@ export class FlashbarBasePage extends BasePageObject {
   async toggleCollapsedState() {
     const selector = this.getNotificationBar();
     await this.click(selector);
-    await this.pause(500);
   }
 
   countFlashes() {

--- a/src/flashbar/__integ__/pages/base.ts
+++ b/src/flashbar/__integ__/pages/base.ts
@@ -12,6 +12,7 @@ export class FlashbarBasePage extends BasePageObject {
   async toggleCollapsedState() {
     const selector = this.getNotificationBar();
     await this.click(selector);
+    await this.pause(500);
   }
 
   countFlashes() {

--- a/src/flashbar/__integ__/pages/interactive-page.ts
+++ b/src/flashbar/__integ__/pages/interactive-page.ts
@@ -3,39 +3,31 @@
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper from '../../../../lib/components/test-utils/selectors';
-import { FOCUS_DEBOUNCE_DELAY } from '../../utils';
 import { flashbar, FlashbarBasePage } from './base';
 
 export class FlashbarInteractivePage extends FlashbarBasePage {
   async addInfoFlash() {
     await this.click('[data-id="add-info"]');
-    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   async addErrorFlash() {
     await this.click('[data-id="add-error"]');
-    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   async addErrorFlashToBottom() {
     await this.click('[data-id="add-error-to-bottom"]');
-    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   async addSequentialErrorFlashes() {
     await this.click('[data-id="add-multiple"]');
-    // Extra time for the items to be added on top of the debounce starting from the latest one.
-    await this.pause(FOCUS_DEBOUNCE_DELAY * 2);
   }
 
   async toggleStackingFeature() {
     await this.click('[data-id="stack-items"]');
-    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   async dismissFirstItem() {
     await this.click(createWrapper().findFlashbar().findItems().get(1).findDismissButton().toSelector());
-    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   getItem(index: number) {
@@ -44,7 +36,6 @@ export class FlashbarInteractivePage extends FlashbarBasePage {
 
   async removeAll() {
     await this.click('[data-id="remove-all"]');
-    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 }
 

--- a/src/flashbar/__integ__/pages/interactive-page.ts
+++ b/src/flashbar/__integ__/pages/interactive-page.ts
@@ -3,31 +3,39 @@
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper from '../../../../lib/components/test-utils/selectors';
+import { FOCUS_DEBOUNCE_DELAY } from '../../utils';
 import { flashbar, FlashbarBasePage } from './base';
 
 export class FlashbarInteractivePage extends FlashbarBasePage {
   async addInfoFlash() {
     await this.click('[data-id="add-info"]');
+    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   async addErrorFlash() {
     await this.click('[data-id="add-error"]');
+    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   async addErrorFlashToBottom() {
     await this.click('[data-id="add-error-to-bottom"]');
+    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   async addSequentialErrorFlashes() {
     await this.click('[data-id="add-multiple"]');
+    // Extra time for the items to be added on top of the debounce starting from the latest one.
+    await this.pause(FOCUS_DEBOUNCE_DELAY * 2);
   }
 
   async toggleStackingFeature() {
     await this.click('[data-id="stack-items"]');
+    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   async dismissFirstItem() {
     await this.click(createWrapper().findFlashbar().findItems().get(1).findDismissButton().toSelector());
+    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   getItem(index: number) {
@@ -36,6 +44,7 @@ export class FlashbarInteractivePage extends FlashbarBasePage {
 
   async removeAll() {
     await this.click('[data-id="remove-all"]');
+    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 }
 

--- a/src/flashbar/__tests__/focus-handling.test.tsx
+++ b/src/flashbar/__tests__/focus-handling.test.tsx
@@ -1,10 +1,93 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useEffect } from 'react';
 import { render, waitFor } from '@testing-library/react';
 
 import Flashbar, { FlashbarProps } from '../../../lib/components/flashbar';
 import createWrapper from '../../../lib/components/test-utils/dom';
+
+const createDismissibleFlashbar = (initialItems: FlashbarProps.MessageDefinition[]) => {
+  const TestComponent = ({ items = initialItems }: { items?: FlashbarProps.MessageDefinition[] }) => {
+    const [flashItems, setFlashItems] = React.useState(items);
+    useEffect(() => {
+      setFlashItems(items);
+    }, [items]);
+
+    const itemsWithHandlers = flashItems.map(item => ({
+      ...item,
+      onDismiss: () => {
+        setFlashItems(prev => prev.filter(prevItem => prevItem.id !== item.id));
+      },
+    }));
+
+    return <Flashbar items={itemsWithHandlers} />;
+  };
+
+  return TestComponent;
+};
+
+describe('Flashbar focus handling on add', () => {
+  test("doesn't affect focus when a new non-alert item is added", () => {
+    createDismissibleFlashbar([
+      { id: 'a', content: 'Item 1', type: 'info', dismissible: true },
+      { id: 'b', content: 'Item 2', type: 'info', ariaRole: 'status', dismissible: true },
+    ]);
+    expect(document.body).toHaveFocus();
+  });
+
+  test("doesn't move focus to alert item when included in first render", () => {
+    const TestComponent = createDismissibleFlashbar([
+      { id: 'a', content: 'Item 1', type: 'info', dismissible: true },
+      { id: 'b', content: 'Item 2', type: 'info', ariaRole: 'alert', dismissible: true },
+    ]);
+
+    jest.useFakeTimers();
+    render(<TestComponent />);
+    jest.runAllTimers();
+
+    expect(document.body).toHaveFocus();
+  });
+
+  test('moves focus to the new item when a new alert item is added', () => {
+    const TestComponent = createDismissibleFlashbar([{ id: 'a', content: 'Item 1', type: 'info', dismissible: true }]);
+    const { container, rerender } = render(<TestComponent />);
+
+    jest.useFakeTimers();
+    rerender(
+      <TestComponent
+        items={[
+          { id: 'a', content: 'Item 1', type: 'info', dismissible: true },
+          { id: 'b', content: 'Item 2', type: 'info', ariaRole: 'alert', dismissible: true },
+        ]}
+      />
+    );
+    jest.runAllTimers();
+
+    const wrapper = createWrapper(container).findFlashbar()!;
+    expect(wrapper.findItems()[1]!.find('[role=group]')!.getElement()).toHaveFocus();
+  });
+
+  test('moves focus to the first item added when multiple alert items are added at once', () => {
+    const TestComponent = createDismissibleFlashbar([{ id: 'a', content: 'Item 1', type: 'info', dismissible: true }]);
+    const { container, rerender } = render(<TestComponent />);
+
+    jest.useFakeTimers();
+    rerender(
+      <TestComponent
+        items={[
+          { id: 'a', content: 'Item 1', type: 'info', dismissible: true },
+          { id: 'b', content: 'Item 2', type: 'info', ariaRole: 'alert', dismissible: true },
+          { id: 'c', content: 'Item 3', type: 'info', ariaRole: 'alert', dismissible: true },
+          { id: 'd', content: 'Item 4', type: 'info', ariaRole: 'alert', dismissible: true },
+        ]}
+      />
+    );
+    jest.runAllTimers();
+
+    const wrapper = createWrapper(container).findFlashbar()!;
+    expect(wrapper.findItems()[1]!.find('[role=group]')!.getElement()).toHaveFocus();
+  });
+});
 
 describe('Flashbar focus handling on dismiss', () => {
   let mockMainElement: HTMLElement;
@@ -41,23 +124,6 @@ describe('Flashbar focus handling on dismiss', () => {
       content: `Content ${i}`,
       dismissible: true,
     }));
-  };
-
-  const createDismissibleFlashbar = (items: FlashbarProps.MessageDefinition[]) => {
-    const TestComponent = () => {
-      const [flashItems, setFlashItems] = React.useState(items);
-
-      const itemsWithHandlers = flashItems.map(item => ({
-        ...item,
-        onDismiss: () => {
-          setFlashItems(prev => prev.filter(prevItem => prevItem.id !== item.id));
-        },
-      }));
-
-      return <Flashbar items={itemsWithHandlers} />;
-    };
-
-    return TestComponent;
   };
 
   test('dismiss functionality works correctly', () => {

--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -15,6 +15,7 @@ import { animate, getDOMRects } from '../internal/animate';
 import { Transition } from '../internal/components/transition';
 import { getVisualContextClassname } from '../internal/components/visual-context';
 import customCssProps from '../internal/generated/custom-css-properties';
+import { useDebounceCallback } from '../internal/hooks/use-debounce-callback';
 import { useEffectOnUpdate } from '../internal/hooks/use-effect-on-update';
 import { scrollElementIntoView } from '../internal/utils/scrollable-containers';
 import { throttle } from '../internal/utils/throttle';
@@ -27,7 +28,14 @@ import { useFlashbar } from './common';
 import { Flash, focusFlashById } from './flash';
 import { FlashbarProps } from './interfaces';
 import { getCollapsibleFlashStyles, getNotificationBarStyles } from './style';
-import { counterTypes, getFlashTypeCount, getItemColor, getVisibleCollapsedItems, StackableItem } from './utils';
+import {
+  counterTypes,
+  FOCUS_DEBOUNCE_DELAY,
+  getFlashTypeCount,
+  getItemColor,
+  getVisibleCollapsedItems,
+  StackableItem,
+} from './utils';
 
 import styles from './styles.css.js';
 
@@ -93,16 +101,17 @@ export default function CollapsibleFlashbar({ items, style, ...restProps }: Flas
     setIsFlashbarStackExpanded(prev => !prev);
   }
 
+  const debouncedFocus = useDebounceCallback(focusFlashById, FOCUS_DEBOUNCE_DELAY);
   useLayoutEffect(() => {
     if (isFlashbarStackExpanded && items?.length) {
       const mostRecentItem = items[0];
       if (mostRecentItem.id !== undefined) {
-        focusFlashById(ref.current, mostRecentItem.id);
+        debouncedFocus(ref.current, mostRecentItem.id);
       }
     }
     // Run this after expanding, but not every time the items change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isFlashbarStackExpanded]);
+  }, [debouncedFocus, isFlashbarStackExpanded]);
 
   // When collapsing, scroll up if necessary to avoid losing track of the focused button
   useEffectOnUpdate(() => {

--- a/src/flashbar/common.tsx
+++ b/src/flashbar/common.tsx
@@ -6,10 +6,12 @@ import { useMergeRefs, useReducedMotion, warnOnce } from '@cloudscape-design/com
 
 import { getBaseProps } from '../internal/base-component';
 import useBaseComponent from '../internal/hooks/use-base-component';
+import { useDebounceCallback } from '../internal/hooks/use-debounce-callback';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { isDevelopment } from '../internal/is-development';
 import { focusFlashById, focusFlashFocusableArea } from './flash';
 import { FlashbarProps } from './interfaces';
+import { FOCUS_DEBOUNCE_DELAY } from './utils';
 
 import styles from './styles.css.js';
 
@@ -118,11 +120,13 @@ export function useFlashbar({
     }
   }
 
+  const debouncedFocus = useDebounceCallback(focusFlashById, FOCUS_DEBOUNCE_DELAY);
+
   useEffect(() => {
     if (nextFocusId) {
-      focusFlashById(ref.current, nextFocusId);
+      debouncedFocus(ref.current, nextFocusId);
     }
-  }, [nextFocusId, ref]);
+  }, [debouncedFocus, nextFocusId, ref]);
 
   const handleFlashDismissed = (dismissedId?: string) => {
     handleFlashDismissedInternal(dismissedId, items, ref.current, flashRefs.current);

--- a/src/flashbar/flash.tsx
+++ b/src/flashbar/flash.tsx
@@ -25,14 +25,12 @@ import { PACKAGE_VERSION } from '../internal/environment';
 import { isDevelopment } from '../internal/is-development';
 import { awsuiPluginsInternal } from '../internal/plugins/api';
 import { createUseDiscoveredAction, createUseDiscoveredContent } from '../internal/plugins/helpers';
-import { throttle } from '../internal/utils/throttle';
 import useContainerWidth from '../internal/utils/use-container-width';
 import InternalLiveRegion from '../live-region/internal';
 import InternalSpinner from '../spinner/internal';
 import { GeneratedAnalyticsMetadataFlashbarDismiss } from './analytics-metadata/interfaces';
 import { FlashbarProps } from './interfaces';
 import { getDismissButtonStyles, getFlashStyles } from './style';
-import { FOCUS_THROTTLE_DELAY } from './utils';
 
 import analyticsSelectors from './analytics-metadata/styles.css.js';
 import styles from './styles.css.js';
@@ -96,24 +94,19 @@ export const focusFlashFocusableArea = (flash: HTMLElement | null) => {
   }
 };
 
-export const focusFlashById = throttle(
-  (element: HTMLElement | null, itemId: string) => {
-    if (!element) {
-      return;
-    }
+export function focusFlashById(element: HTMLElement | null, itemId: string) {
+  if (!element) {
+    return;
+  }
 
-    const flashElement = element.querySelector<HTMLElement>(`[data-itemid="${CSS.escape(itemId)}"]`);
-    if (!flashElement) {
-      return;
-    }
+  const flashElement = element.querySelector<HTMLElement>(`[data-itemid="${CSS.escape(itemId)}"]`);
+  if (!flashElement) {
+    return;
+  }
 
-    const focusContainer = flashElement.querySelector<HTMLElement>(`.${styles['flash-focus-container']}`);
-
-    focusContainer?.focus();
-  },
-  FOCUS_THROTTLE_DELAY,
-  { trailing: false }
-);
+  const focusContainer = flashElement.querySelector<HTMLElement>(`.${styles['flash-focus-container']}`);
+  focusContainer?.focus();
+}
 
 interface FlashProps extends FlashbarProps.MessageDefinition {
   className: string;

--- a/src/flashbar/utils.ts
+++ b/src/flashbar/utils.ts
@@ -3,7 +3,7 @@
 import { IconProps } from '../icon/interfaces';
 import { FlashbarProps } from './interfaces';
 
-export const FOCUS_THROTTLE_DELAY = 2000;
+export const FOCUS_DEBOUNCE_DELAY = 500;
 
 // Since the position of a notification changes when the Flashbar is collapsed,
 // it is useful on some situations (e.g, for animating) to know the original position of the item


### PR DESCRIPTION
### Description

I'll be honest here, I didn't feel like diving into the weird transition/animation logic going on with the flashbar components. So I just changed the throttle logic to do a debounce instead (so it always waits for the animation to complete while still preventing repeated flashbar insertions from annoying users). Sue me.

Actually, if new flash items go from bottom to top now (as they do with collapsible flashbars), debounce is actually better. So yay me, actually!

Related links, issue #, if available: AWSUI-61128

### How has this been tested?

Added unit tests. But also tested locally in a dev page. Try it out yourself — go to the `flashbar/interactive` page, enable stack items, and add an error flash. The focus move to the newly added flash message should work (it didn't before).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
