### PR TITLE
fix: Fix skeleton state bugs in app layout widget

### DIFF
--- a/src/app-layout/__tests__/skeleton.test.tsx
+++ b/src/app-layout/__tests__/skeleton.test.tsx
@@ -4,8 +4,10 @@ import React from 'react';
 
 import AppLayout from '../../../lib/components/app-layout';
 import BreadcrumbGroup from '../../../lib/components/breadcrumb-group';
-import { getFunnelKeySelector } from '../../internal/analytics/selectors';
+import { getFunnelKeySelector } from '../../../lib/components/internal/analytics/selectors';
 import { describeEachAppLayout, renderComponent } from './utils';
+
+import skeletonStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/skeleton/styles.selectors.js';
 
 let widgetMockEnabled = false;
 function createWidgetizedComponentMock(Implementation: React.ComponentType, Skeleton: React.ComponentType) {
@@ -69,6 +71,30 @@ describeEachAppLayout({ themes: ['refresh-toolbar'] }, () => {
       expect(wrapper.findNotifications()).toBeFalsy();
       expect(wrapper.findTools()).toBeFalsy();
       expect(wrapper.findContentRegion()).toBeTruthy();
+      expect(wrapper.getElement()).toHaveStyle({ blockSize: `calc(100vh - 0px)` });
+    });
+
+    it('the navigationOpen state can be controlled', () => {
+      const noop = () => {};
+      const { wrapper, rerender } = renderComponent(
+        <AppLayout navigation="test nav" navigationOpen={true} onNavigationChange={noop} />
+      );
+      // cannot use wrapper.findNavigation() because our public test utils resolve to nothing in skeleton state
+      expect(wrapper.findByClassName(skeletonStyles.navigation)).toBeTruthy();
+      rerender(<AppLayout navigation="test nav" navigationOpen={false} onNavigationChange={noop} />);
+      expect(wrapper.findByClassName(skeletonStyles.navigation)).toBeFalsy();
+      rerender(<AppLayout navigation="test nav" navigationOpen={true} onNavigationChange={noop} />);
+      expect(wrapper.findByClassName(skeletonStyles.navigation)).toBeTruthy();
+    });
+
+    it('toolbar can render conditionally', () => {
+      const { wrapper, rerender } = renderComponent(<AppLayout navigationHide={true} toolsHide={true} />);
+      // cannot use wrapper.findToolbar() because our public test utils resolve to nothing in skeleton state
+      expect(wrapper.findByClassName(skeletonStyles['toolbar-container'])).toBeFalsy();
+      rerender(<AppLayout navigationHide={false} toolsHide={false} breadcrumbs="dummy" />);
+      expect(wrapper.findByClassName(skeletonStyles['toolbar-container'])).toBeTruthy();
+      rerender(<AppLayout navigationHide={true} toolsHide={true} />);
+      expect(wrapper.findByClassName(skeletonStyles['toolbar-container'])).toBeFalsy();
     });
   });
 });

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -12,6 +12,7 @@ import { SkeletonLayout } from './skeleton';
 import { SkeletonSlotsAttributes } from './skeleton/interfaces';
 import { DeduplicationType, useMultiAppLayout } from './skeleton/multi-layout';
 import { StateManager } from './state';
+import { SharedProps } from './state/interfaces';
 import { getPropsToMerge, mergeProps } from './state/props-merger';
 import { ToolbarProps } from './toolbar';
 
@@ -30,12 +31,12 @@ const AppLayoutStateProvider: React.FC<{
   const [skeletonAttributes, setSkeletonAttributes] = useState<SkeletonSlotsAttributes>({});
   // use { fn: } object wrapper to avoid confusion with callback form of setState
   const [deduplicator, setDeduplicator] = useState({ fn: mergeProps });
-  const [deduplicationProps, setDeduplicationProps] = useState(() => getPropsToMerge(appLayoutProps, appLayoutState));
+  const [deduplicationProps, setDeduplicationProps] = useState<SharedProps | undefined>(undefined);
 
   const { registered, toolbarProps } = useMultiAppLayout(
     forceDeduplicationType,
     appLayoutState.isIntersecting,
-    deduplicationProps,
+    deduplicationProps ?? getPropsToMerge(appLayoutProps, appLayoutState),
     deduplicator.fn
   );
 

--- a/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
@@ -68,6 +68,7 @@ export const SkeletonLayout = ({
         className={wrapperElAttributes?.className ?? clsx(styles.root, testutilStyles.root)}
         style={
           wrapperElAttributes?.style ?? {
+            blockSize: `calc(100vh - ${appLayoutProps.placement.insetBlockStart + appLayoutProps.placement.insetBlockEnd}px)`,
             [customCssProps.navigationWidth]: `${navigationWidth}px`,
           }
         }


### PR DESCRIPTION
### Description

Fix regression introduced in https://github.com/cloudscape-design/components/pull/3721
* Loading skeleton does not stretch full screen. [Reproducible example here](https://d21d5uik3ws71m.cloudfront.net/components/45d3c65326f33493727f74107c5f1b4b0912c430/dev-pages/index.html#/light/app-layout/legacy-nav-empty?appLayoutWidget=true&appLayoutDelayedWidget=true).
* Navigation open state cannot be controlled while widget is loading. [Reproducible here](https://d21d5uik3ws71m.cloudfront.net/components/45d3c65326f33493727f74107c5f1b4b0912c430/dev-pages/index.html#/light/app-layout/notifications-refresh?appLayoutWidget=true&appLayoutDelayedWidget=true) – the programmatic "Toggle navigation" button does not work while the widget is loading

Related links, issue #, if available: n/a

### How has this been tested?

Added extra tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
