### PR TITLE
fix: Fixes tabs focus and navigation when rendered inside iframe

### DIFF
--- a/pages/tabs/with-iframe.page.tsx
+++ b/pages/tabs/with-iframe.page.tsx
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useState } from 'react';
+
+import { Box, Button, Link } from '~components';
+import Tabs from '~components/tabs';
+
+import { IframeWrapper } from '../utils/iframe-wrapper';
+
+export default function () {
+  return (
+    <Box margin="m">
+      <h1>Tabs in iframe</h1>
+
+      <IframeWrapper id="iframe" AppComponent={DemoTabs} />
+    </Box>
+  );
+}
+
+function DemoTabs() {
+  const [selectedTab, setSelectedTab] = useState('first');
+  return (
+    <>
+      <Link id="before">Focus before</Link>
+
+      <Tabs
+        tabs={[
+          {
+            label: 'First tab',
+            id: 'first',
+            content: <Button id="tab-content-button">Interactive content</Button>,
+          },
+          {
+            label: 'Second tab',
+            id: 'second',
+            content: 'Non-interactive content',
+          },
+        ]}
+        activeTabId={selectedTab}
+        onChange={event => setSelectedTab(event.detail.activeTabId)}
+        i18nStrings={{ scrollLeftAriaLabel: 'Scroll left', scrollRightAriaLabel: 'Scroll right' }}
+      />
+
+      <Link id="after">Focus after</Link>
+    </>
+  );
+}

--- a/src/tabs/__integ__/with-iframe.test.ts
+++ b/src/tabs/__integ__/with-iframe.test.ts
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+import createWrapper from '../../../lib/components/test-utils/selectors';
+
+const wrapper = createWrapper().findTabs();
+
+const setupTest = (testFn: (page: BasePageObject) => Promise<void>) => {
+  return useBrowser({ width: 1600, height: 800 }, async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/tabs/with-iframe');
+    await page.runInsideIframe('#iframe', true, async () => {
+      await page.waitForVisible(wrapper.findTabContent().toSelector());
+      await testFn(page);
+    });
+  });
+};
+
+test(
+  'allows to focus on tab content area',
+  setupTest(async page => {
+    await page.click('#before');
+    await page.keys(['Tab']);
+    await expect(page.isFocused(wrapper.findActiveTab().toSelector())).resolves.toBe(true);
+
+    await page.keys(['Tab']);
+    await expect(page.isFocused(wrapper.findTabContent().toSelector())).resolves.toBe(true);
+
+    await page.keys(['Tab']);
+    await expect(page.isFocused('#tab-content-button')).resolves.toBe(true);
+
+    await page.keys(['Tab']);
+    await expect(page.isFocused('#after')).resolves.toBe(true);
+  })
+);
+
+test(
+  'navigates tab list with left/right arrow keys',
+  setupTest(async page => {
+    await page.click('#before');
+    await page.keys(['Tab']);
+    await expect(page.getFocusedElementText()).resolves.toBe('First tab');
+
+    await page.keys(['ArrowRight']);
+    await expect(page.getFocusedElementText()).resolves.toBe('Second tab');
+
+    await page.keys(['ArrowRight']);
+    await expect(page.getFocusedElementText()).resolves.toBe('First tab');
+
+    await page.keys(['ArrowLeft']);
+    await expect(page.getFocusedElementText()).resolves.toBe('Second tab');
+
+    await page.keys(['ArrowLeft']);
+    await expect(page.getFocusedElementText()).resolves.toBe('First tab');
+  })
+);


### PR DESCRIPTION
### Description

Without this fix, pressing Tab when the focus is on the active tab header does not move focus to the content. The keyboard navigation with left/right arrow keys does not work either.

Rel: AWSUI-61144

### How has this been tested?

* New integration tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
