### PR TITLE
chore: Nested STSN providers support

### DIFF
--- a/pages/table-fragments/grid-navigation-custom.page.tsx
+++ b/pages/table-fragments/grid-navigation-custom.page.tsx
@@ -7,6 +7,7 @@ import {
   AppLayout,
   Button,
   ButtonDropdown,
+  ButtonGroup,
   Checkbox,
   CollectionPreferences,
   ColumnLayout,
@@ -60,13 +61,14 @@ type PageContext = React.Context<
   }>
 >;
 
-type ActionsMode = 'dropdown' | 'inline';
+type ActionsMode = 'dropdown' | 'inline' | 'button-group';
 
 const tableRoleOptions = [{ value: 'table' }, { value: 'grid' }, { value: 'grid-default' }];
 
 const actionsModeOptions = [
   { value: 'dropdown', label: 'Dropdown' },
-  { value: 'inline', label: 'Inline (anti-pattern)' },
+  { value: 'inline', label: 'Inline' },
+  { value: 'button-group', label: 'Button group' },
 ];
 
 export default function Page() {
@@ -458,19 +460,47 @@ function ItemActionsCell({
       </div>
     );
   }
-  return (
-    <div style={{ display: 'flex', gap: '8px', flexWrap: 'nowrap' }}>
-      <Button variant="inline-icon" iconName="remove" ariaLabel="Delete item" onClick={onDelete} />
-      <Button variant="inline-icon" iconName="copy" ariaLabel="Duplicate item" onClick={onDuplicate} />
-      <Button
-        variant="inline-icon"
-        iconName="refresh"
-        ariaLabel="Update item"
-        onClick={onUpdate}
-        disabled={!canUpdate}
-      />
-    </div>
-  );
+  if (mode === 'inline') {
+    return (
+      <div style={{ display: 'flex', gap: '8px', flexWrap: 'nowrap' }}>
+        <Button variant="inline-icon" iconName="remove" ariaLabel="Delete item" onClick={onDelete} />
+        <Button variant="inline-icon" iconName="copy" ariaLabel="Duplicate item" onClick={onDuplicate} />
+        <Button
+          variant="inline-icon"
+          iconName="refresh"
+          ariaLabel="Update item"
+          onClick={onUpdate}
+          disabled={!canUpdate}
+        />
+      </div>
+    );
+  }
+  if (mode === 'button-group') {
+    return (
+      <div style={{ inlineSize: 100 }}>
+        <ButtonGroup
+          ariaLabel="Item actions"
+          variant="icon"
+          items={[
+            { type: 'icon-button', id: 'delete', iconName: 'remove', text: 'Delete' },
+            { type: 'icon-button', id: 'duplicate', iconName: 'copy', text: 'Duplicate' },
+            { type: 'icon-button', id: 'update', iconName: 'refresh', text: 'Update', disabled: !canUpdate },
+          ]}
+          onItemClick={event => {
+            switch (event.detail.id) {
+              case 'delete':
+                return onDelete();
+              case 'duplicate':
+                return onDuplicate();
+              case 'update':
+                return onUpdate();
+            }
+          }}
+        />
+      </div>
+    );
+  }
+  return null;
 }
 
 function DnsEditCell({ item }: { item: Instance }) {

--- a/src/internal/context/__tests__/single-tab-stop-navigation-context.test.tsx
+++ b/src/internal/context/__tests__/single-tab-stop-navigation-context.test.tsx
@@ -1,19 +1,57 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useRef } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { render } from '@testing-library/react';
 
 import {
+  SingleTabStopNavigationAPI,
   SingleTabStopNavigationContext,
+  SingleTabStopNavigationProvider,
   useSingleTabStopNavigation,
 } from '../../../../lib/components/internal/context/single-tab-stop-navigation-context';
 import { renderWithSingleTabStopNavigation } from './utils';
 
+// Simple STSN subscriber component
 function Button(props: React.HTMLAttributes<HTMLButtonElement>) {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const { tabIndex } = useSingleTabStopNavigation(buttonRef, { tabIndex: props.tabIndex });
   return <button {...props} ref={buttonRef} tabIndex={tabIndex} />;
+}
+
+// Simple STSN provider component
+function Group({
+  id,
+  navigationActive,
+  children,
+}: {
+  id: string;
+  navigationActive: boolean;
+  children: React.ReactNode;
+}) {
+  const navigationAPI = useRef<SingleTabStopNavigationAPI>(null);
+
+  useEffect(() => {
+    navigationAPI.current?.updateFocusTarget();
+  });
+
+  return (
+    <SingleTabStopNavigationProvider
+      ref={navigationAPI}
+      navigationActive={navigationActive}
+      getNextFocusTarget={() => document.querySelector(`#${id}`)!.querySelectorAll('button')[0] as HTMLElement}
+    >
+      <div id={id}>
+        <Button>First</Button>
+        <Button>Second</Button>
+        {children}
+      </div>
+    </SingleTabStopNavigationProvider>
+  );
+}
+
+function findGroupButton(groupId: string, buttonIndex: number) {
+  return document.querySelector(`#${groupId}`)!.querySelectorAll('button')[buttonIndex] as HTMLElement;
 }
 
 test('does not override tab index when keyboard navigation is not active', () => {
@@ -75,7 +113,9 @@ test('propagates and suppresses navigation active state', () => {
   }
   function Test({ navigationActive }: { navigationActive: boolean }) {
     return (
-      <SingleTabStopNavigationContext.Provider value={{ navigationActive, registerFocusable: () => () => {} }}>
+      <SingleTabStopNavigationContext.Provider
+        value={{ navigationActive, registerFocusable: () => () => {}, resetFocusTarget: () => {} }}
+      >
         <Component />
       </SingleTabStopNavigationContext.Provider>
     );
@@ -86,4 +126,125 @@ test('propagates and suppresses navigation active state', () => {
 
   rerender(<Test navigationActive={false} />);
   expect(document.querySelector('div')).toHaveTextContent('false');
+});
+
+test('subscriber components can be used without provider', () => {
+  function TestComponent(props: React.HTMLAttributes<HTMLButtonElement>) {
+    const ref = useRef(null);
+    const contextResult = useContext(SingleTabStopNavigationContext);
+    const hookResult = useSingleTabStopNavigation(ref, { tabIndex: props.tabIndex });
+    useEffect(() => {
+      contextResult.registerFocusable(ref.current!, () => {});
+      contextResult.resetFocusTarget();
+    });
+    return (
+      <div ref={ref}>
+        Context: {`${contextResult.navigationActive}`}, Hook: {`${hookResult.navigationActive}:${hookResult.tabIndex}`}
+      </div>
+    );
+  }
+  const { container } = render(<TestComponent />);
+  expect(container.textContent).toBe('Context: false, Hook: false:undefined');
+});
+
+describe('nested contexts', () => {
+  test('tab indices are distributed correctly when switching contexts from inner to outer', () => {
+    const { rerender } = render(
+      <Group id="outer-most" navigationActive={false}>
+        <Group id="outer" navigationActive={false}>
+          <Group id="inner" navigationActive={true}>
+            {null}
+          </Group>
+        </Group>
+      </Group>
+    );
+    expect(findGroupButton('outer-most', 0)).not.toHaveAttribute('tabindex');
+    expect(findGroupButton('outer-most', 1)).not.toHaveAttribute('tabindex');
+    expect(findGroupButton('outer', 0)).not.toHaveAttribute('tabindex');
+    expect(findGroupButton('outer', 1)).not.toHaveAttribute('tabindex');
+    expect(findGroupButton('inner', 0)).toHaveAttribute('tabindex', '0');
+    expect(findGroupButton('inner', 1)).toHaveAttribute('tabindex', '-1');
+
+    rerender(
+      <Group id="outer-most" navigationActive={false}>
+        <Group id="outer" navigationActive={true}>
+          <Group id="inner" navigationActive={true}>
+            {null}
+          </Group>
+        </Group>
+      </Group>
+    );
+    expect(findGroupButton('outer-most', 0)).not.toHaveAttribute('tabindex');
+    expect(findGroupButton('outer-most', 1)).not.toHaveAttribute('tabindex');
+    expect(findGroupButton('outer', 0)).toHaveAttribute('tabindex', '0');
+    expect(findGroupButton('outer', 1)).toHaveAttribute('tabindex', '-1');
+    expect(findGroupButton('inner', 0)).toHaveAttribute('tabindex', '-1');
+    expect(findGroupButton('inner', 1)).toHaveAttribute('tabindex', '-1');
+
+    rerender(
+      <Group id="outer-most" navigationActive={true}>
+        <Group id="outer" navigationActive={true}>
+          <Group id="inner" navigationActive={true}>
+            {null}
+          </Group>
+        </Group>
+      </Group>
+    );
+    expect(findGroupButton('outer-most', 0)).toHaveAttribute('tabindex', '0');
+    expect(findGroupButton('outer-most', 1)).toHaveAttribute('tabindex', '-1');
+    expect(findGroupButton('outer', 0)).toHaveAttribute('tabindex', '-1');
+    expect(findGroupButton('outer', 1)).toHaveAttribute('tabindex', '-1');
+    expect(findGroupButton('inner', 0)).toHaveAttribute('tabindex', '-1');
+    expect(findGroupButton('inner', 1)).toHaveAttribute('tabindex', '-1');
+  });
+
+  test('tab indices are distributed correctly when switching contexts from outer to inner', () => {
+    const { rerender } = render(
+      <Group id="outer-most" navigationActive={true}>
+        <Group id="outer" navigationActive={true}>
+          <Group id="inner" navigationActive={true}>
+            {null}
+          </Group>
+        </Group>
+      </Group>
+    );
+    expect(findGroupButton('outer-most', 0)).toHaveAttribute('tabindex', '0');
+    expect(findGroupButton('outer-most', 1)).toHaveAttribute('tabindex', '-1');
+    expect(findGroupButton('outer', 0)).toHaveAttribute('tabindex', '-1');
+    expect(findGroupButton('outer', 1)).toHaveAttribute('tabindex', '-1');
+    expect(findGroupButton('inner', 0)).toHaveAttribute('tabindex', '-1');
+    expect(findGroupButton('inner', 1)).toHaveAttribute('tabindex', '-1');
+
+    rerender(
+      <Group id="outer-most" navigationActive={false}>
+        <Group id="outer" navigationActive={true}>
+          <Group id="inner" navigationActive={true}>
+            {null}
+          </Group>
+        </Group>
+      </Group>
+    );
+    expect(findGroupButton('outer-most', 0)).not.toHaveAttribute('tabindex');
+    expect(findGroupButton('outer-most', 1)).not.toHaveAttribute('tabindex');
+    expect(findGroupButton('outer', 0)).toHaveAttribute('tabindex', '0');
+    expect(findGroupButton('outer', 1)).toHaveAttribute('tabindex', '-1');
+    expect(findGroupButton('inner', 0)).toHaveAttribute('tabindex', '-1');
+    expect(findGroupButton('inner', 1)).toHaveAttribute('tabindex', '-1');
+
+    rerender(
+      <Group id="outer-most" navigationActive={false}>
+        <Group id="outer" navigationActive={false}>
+          <Group id="inner" navigationActive={true}>
+            {null}
+          </Group>
+        </Group>
+      </Group>
+    );
+    expect(findGroupButton('outer-most', 0)).not.toHaveAttribute('tabindex');
+    expect(findGroupButton('outer-most', 1)).not.toHaveAttribute('tabindex');
+    expect(findGroupButton('outer', 0)).not.toHaveAttribute('tabindex');
+    expect(findGroupButton('outer', 1)).not.toHaveAttribute('tabindex');
+    expect(findGroupButton('inner', 0)).toHaveAttribute('tabindex', '0');
+    expect(findGroupButton('inner', 1)).toHaveAttribute('tabindex', '-1');
+  });
 });

--- a/src/internal/context/__tests__/utils.tsx
+++ b/src/internal/context/__tests__/utils.tsx
@@ -39,7 +39,9 @@ const FakeSingleTabStopNavigationProvider = forwardRef(
     }));
 
     return (
-      <SingleTabStopNavigationContext.Provider value={{ registerFocusable, navigationActive }}>
+      <SingleTabStopNavigationContext.Provider
+        value={{ registerFocusable, navigationActive, resetFocusTarget: () => {} }}
+      >
         {children}
       </SingleTabStopNavigationContext.Provider>
     );


### PR DESCRIPTION
### Description

The PR makes it possible to nest STSN providers. The use cases that we have are:
1. Rendering a button group inside table cells;
2. Rendering a button group inside tree view items (we are adding keyboard nave in there, too).

The idea of the change is rather simple: at any given point in time only one provider can be active. The active provider is the outer-most provider with navigationActive=true. If the outer provider changes state from true to false - the nested provider becomes active instead. This allows a dynamic switch of navigation contexts (e.g. when a tree toggle is focused - the tree navigation is engaged; when the focus is inside a tree item - the button group which can be rendered inside receives control). In some cases, it is not even necessary to do the switching. Thus, the table navigation controller is already capable of handling the nested button group navigation on its own, the only difference is that the button group focus is no longer looped.

https://github.com/user-attachments/assets/8fb839f5-a5d4-4fe9-b254-649cd9a1bec6

Rel: AWSUI-61152, [AaSEAuz8NXla]

### How has this been tested?

* Added new unit tests for nested STSN providers
* Enhanced test page for table navigation

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
