### PR TITLE
revert: Revert "fix: Fix focus management for flashbar when motion is enabled"

### DIFF
--- a/src/flashbar/__integ__/collapsible.test.ts
+++ b/src/flashbar/__integ__/collapsible.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
-import { FOCUS_DEBOUNCE_DELAY } from '../utils';
+import { FOCUS_THROTTLE_DELAY } from '../utils';
 import { FlashbarBasePage } from './pages/base';
 import { setupTest } from './pages/interactive-page';
 import { setupTest as setupStickyFlashbarTest } from './pages/sticky-page';
@@ -21,7 +21,6 @@ describe('Collapsible Flashbar', () => {
         await expect(page.countFlashes()).resolves.toBe(1);
         await page.keys('Space');
 
-        await page.pause(FOCUS_DEBOUNCE_DELAY);
         await expect(page.countFlashes()).resolves.toBe(5);
         await expect(page.isFlashFocused(1)).resolves.toBe(true);
 
@@ -41,6 +40,7 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addInfoFlash();
+          await page.pause(FOCUS_THROTTLE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -50,6 +50,7 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
+          await page.pause(FOCUS_THROTTLE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );
@@ -59,6 +60,7 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
           await page.addInfoFlash();
           await expect(page.isFlashFocused(1)).resolves.toBe(false);
@@ -72,6 +74,7 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await page.addInfoFlash();
           return expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
@@ -82,6 +85,7 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await page.addErrorFlash();
           return expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
@@ -92,9 +96,11 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await page.addErrorFlash();
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
           await page.addInfoFlash();
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -104,8 +110,10 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.toggleCollapsedState();
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await page.addErrorFlash();
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await page.addInfoFlash();
           await expect(page.isFlashFocused(2)).resolves.toBe(false);
         })
@@ -118,8 +126,9 @@ describe('Collapsible Flashbar', () => {
         setupTest(async page => {
           await page.toggleStackingFeature();
           await page.addErrorFlash();
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await page.toggleCollapsedState();
-          await page.pause(FOCUS_DEBOUNCE_DELAY);
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );

--- a/src/flashbar/__integ__/focus-interactions.test.ts
+++ b/src/flashbar/__integ__/focus-interactions.test.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { FOCUS_THROTTLE_DELAY } from '../utils';
 import { setupTest } from './pages/interactive-page';
 
 test(
@@ -39,16 +40,20 @@ test(
     await page.addErrorFlash();
     await expect(page.isFlashFocused(1)).resolves.toBe(true);
     await page.addInfoFlash();
+    await page.pause(FOCUS_THROTTLE_DELAY);
     await expect(page.isFlashFocused(1)).resolves.toBe(false);
   })
 );
 
 test(
-  'adding multiple flashes with ariaRole="alert" debounces focus moves',
+  'adding multiple flashes with ariaRole="alert" throttles focus moves',
   setupTest(async page => {
+    const initialCount = await page.countFlashes();
     await page.addSequentialErrorFlashes();
-    // Flash items are added from bottom to top, so the last one added is the first one in the DOM.
-    return expect(page.isFlashFocused(1)).resolves.toBe(true);
+    await page.pause(300);
+    const currentCount = await page.countFlashes();
+    const firstAddedItemIndex = currentCount - initialCount;
+    return expect(page.isFlashFocused(firstAddedItemIndex)).resolves.toBe(true);
   })
 );
 
@@ -73,8 +78,10 @@ test(
   'dismissing flash item moves focus to next item',
   setupTest(async page => {
     await page.addSequentialErrorFlashes();
+    await page.pause(FOCUS_THROTTLE_DELAY);
 
     await page.dismissFirstItem();
+    await page.pause(FOCUS_THROTTLE_DELAY);
 
     return expect(await page.isFlashFocused(1)).toBe(true);
   })
@@ -87,8 +94,10 @@ test(
     await page.toggleStackingFeature();
     await page.addSequentialErrorFlashes();
     await page.toggleCollapsedState();
+    await page.pause(FOCUS_THROTTLE_DELAY);
 
     await page.dismissFirstItem();
+    await page.pause(FOCUS_THROTTLE_DELAY);
 
     return expect(await page.isFlashFocused(1)).toBe(true);
   })
@@ -100,8 +109,10 @@ test(
     await page.removeAll();
     await page.toggleStackingFeature();
     await page.addSequentialErrorFlashes();
+    await page.pause(FOCUS_THROTTLE_DELAY);
 
     await page.dismissFirstItem();
+    await page.pause(FOCUS_THROTTLE_DELAY);
 
     const isDismissButtonFocused = await page.isDismissButtonFocused();
 

--- a/src/flashbar/__integ__/pages/interactive-page.ts
+++ b/src/flashbar/__integ__/pages/interactive-page.ts
@@ -3,39 +3,31 @@
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper from '../../../../lib/components/test-utils/selectors';
-import { FOCUS_DEBOUNCE_DELAY } from '../../utils';
 import { flashbar, FlashbarBasePage } from './base';
 
 export class FlashbarInteractivePage extends FlashbarBasePage {
   async addInfoFlash() {
     await this.click('[data-id="add-info"]');
-    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   async addErrorFlash() {
     await this.click('[data-id="add-error"]');
-    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   async addErrorFlashToBottom() {
     await this.click('[data-id="add-error-to-bottom"]');
-    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   async addSequentialErrorFlashes() {
     await this.click('[data-id="add-multiple"]');
-    // Extra time for the items to be added on top of the debounce starting from the latest one.
-    await this.pause(FOCUS_DEBOUNCE_DELAY * 2);
   }
 
   async toggleStackingFeature() {
     await this.click('[data-id="stack-items"]');
-    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   async dismissFirstItem() {
     await this.click(createWrapper().findFlashbar().findItems().get(1).findDismissButton().toSelector());
-    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 
   getItem(index: number) {
@@ -44,7 +36,6 @@ export class FlashbarInteractivePage extends FlashbarBasePage {
 
   async removeAll() {
     await this.click('[data-id="remove-all"]');
-    await this.pause(FOCUS_DEBOUNCE_DELAY);
   }
 }
 

--- a/src/flashbar/__tests__/focus-handling.test.tsx
+++ b/src/flashbar/__tests__/focus-handling.test.tsx
@@ -1,93 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect } from 'react';
+import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 
 import Flashbar, { FlashbarProps } from '../../../lib/components/flashbar';
 import createWrapper from '../../../lib/components/test-utils/dom';
-
-const createDismissibleFlashbar = (initialItems: FlashbarProps.MessageDefinition[]) => {
-  const TestComponent = ({ items = initialItems }: { items?: FlashbarProps.MessageDefinition[] }) => {
-    const [flashItems, setFlashItems] = React.useState(items);
-    useEffect(() => {
-      setFlashItems(items);
-    }, [items]);
-
-    const itemsWithHandlers = flashItems.map(item => ({
-      ...item,
-      onDismiss: () => {
-        setFlashItems(prev => prev.filter(prevItem => prevItem.id !== item.id));
-      },
-    }));
-
-    return <Flashbar items={itemsWithHandlers} />;
-  };
-
-  return TestComponent;
-};
-
-describe('Flashbar focus handling on add', () => {
-  test("doesn't affect focus when a new non-alert item is added", () => {
-    createDismissibleFlashbar([
-      { id: 'a', content: 'Item 1', type: 'info', dismissible: true },
-      { id: 'b', content: 'Item 2', type: 'info', ariaRole: 'status', dismissible: true },
-    ]);
-    expect(document.body).toHaveFocus();
-  });
-
-  test("doesn't move focus to alert item when included in first render", () => {
-    const TestComponent = createDismissibleFlashbar([
-      { id: 'a', content: 'Item 1', type: 'info', dismissible: true },
-      { id: 'b', content: 'Item 2', type: 'info', ariaRole: 'alert', dismissible: true },
-    ]);
-
-    jest.useFakeTimers();
-    render(<TestComponent />);
-    jest.runAllTimers();
-
-    expect(document.body).toHaveFocus();
-  });
-
-  test('moves focus to the new item when a new alert item is added', () => {
-    const TestComponent = createDismissibleFlashbar([{ id: 'a', content: 'Item 1', type: 'info', dismissible: true }]);
-    const { container, rerender } = render(<TestComponent />);
-
-    jest.useFakeTimers();
-    rerender(
-      <TestComponent
-        items={[
-          { id: 'a', content: 'Item 1', type: 'info', dismissible: true },
-          { id: 'b', content: 'Item 2', type: 'info', ariaRole: 'alert', dismissible: true },
-        ]}
-      />
-    );
-    jest.runAllTimers();
-
-    const wrapper = createWrapper(container).findFlashbar()!;
-    expect(wrapper.findItems()[1]!.find('[role=group]')!.getElement()).toHaveFocus();
-  });
-
-  test('moves focus to the first item added when multiple alert items are added at once', () => {
-    const TestComponent = createDismissibleFlashbar([{ id: 'a', content: 'Item 1', type: 'info', dismissible: true }]);
-    const { container, rerender } = render(<TestComponent />);
-
-    jest.useFakeTimers();
-    rerender(
-      <TestComponent
-        items={[
-          { id: 'a', content: 'Item 1', type: 'info', dismissible: true },
-          { id: 'b', content: 'Item 2', type: 'info', ariaRole: 'alert', dismissible: true },
-          { id: 'c', content: 'Item 3', type: 'info', ariaRole: 'alert', dismissible: true },
-          { id: 'd', content: 'Item 4', type: 'info', ariaRole: 'alert', dismissible: true },
-        ]}
-      />
-    );
-    jest.runAllTimers();
-
-    const wrapper = createWrapper(container).findFlashbar()!;
-    expect(wrapper.findItems()[1]!.find('[role=group]')!.getElement()).toHaveFocus();
-  });
-});
 
 describe('Flashbar focus handling on dismiss', () => {
   let mockMainElement: HTMLElement;
@@ -124,6 +41,23 @@ describe('Flashbar focus handling on dismiss', () => {
       content: `Content ${i}`,
       dismissible: true,
     }));
+  };
+
+  const createDismissibleFlashbar = (items: FlashbarProps.MessageDefinition[]) => {
+    const TestComponent = () => {
+      const [flashItems, setFlashItems] = React.useState(items);
+
+      const itemsWithHandlers = flashItems.map(item => ({
+        ...item,
+        onDismiss: () => {
+          setFlashItems(prev => prev.filter(prevItem => prevItem.id !== item.id));
+        },
+      }));
+
+      return <Flashbar items={itemsWithHandlers} />;
+    };
+
+    return TestComponent;
   };
 
   test('dismiss functionality works correctly', () => {

--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -15,7 +15,6 @@ import { animate, getDOMRects } from '../internal/animate';
 import { Transition } from '../internal/components/transition';
 import { getVisualContextClassname } from '../internal/components/visual-context';
 import customCssProps from '../internal/generated/custom-css-properties';
-import { useDebounceCallback } from '../internal/hooks/use-debounce-callback';
 import { useEffectOnUpdate } from '../internal/hooks/use-effect-on-update';
 import { scrollElementIntoView } from '../internal/utils/scrollable-containers';
 import { throttle } from '../internal/utils/throttle';
@@ -28,14 +27,7 @@ import { useFlashbar } from './common';
 import { Flash, focusFlashById } from './flash';
 import { FlashbarProps } from './interfaces';
 import { getCollapsibleFlashStyles, getNotificationBarStyles } from './style';
-import {
-  counterTypes,
-  FOCUS_DEBOUNCE_DELAY,
-  getFlashTypeCount,
-  getItemColor,
-  getVisibleCollapsedItems,
-  StackableItem,
-} from './utils';
+import { counterTypes, getFlashTypeCount, getItemColor, getVisibleCollapsedItems, StackableItem } from './utils';
 
 import styles from './styles.css.js';
 
@@ -101,17 +93,16 @@ export default function CollapsibleFlashbar({ items, style, ...restProps }: Flas
     setIsFlashbarStackExpanded(prev => !prev);
   }
 
-  const debouncedFocus = useDebounceCallback(focusFlashById, FOCUS_DEBOUNCE_DELAY);
   useLayoutEffect(() => {
     if (isFlashbarStackExpanded && items?.length) {
       const mostRecentItem = items[0];
       if (mostRecentItem.id !== undefined) {
-        debouncedFocus(ref.current, mostRecentItem.id);
+        focusFlashById(ref.current, mostRecentItem.id);
       }
     }
     // Run this after expanding, but not every time the items change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedFocus, isFlashbarStackExpanded]);
+  }, [isFlashbarStackExpanded]);
 
   // When collapsing, scroll up if necessary to avoid losing track of the focused button
   useEffectOnUpdate(() => {

--- a/src/flashbar/common.tsx
+++ b/src/flashbar/common.tsx
@@ -6,12 +6,10 @@ import { useMergeRefs, useReducedMotion, warnOnce } from '@cloudscape-design/com
 
 import { getBaseProps } from '../internal/base-component';
 import useBaseComponent from '../internal/hooks/use-base-component';
-import { useDebounceCallback } from '../internal/hooks/use-debounce-callback';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { isDevelopment } from '../internal/is-development';
 import { focusFlashById, focusFlashFocusableArea } from './flash';
 import { FlashbarProps } from './interfaces';
-import { FOCUS_DEBOUNCE_DELAY } from './utils';
 
 import styles from './styles.css.js';
 
@@ -120,13 +118,11 @@ export function useFlashbar({
     }
   }
 
-  const debouncedFocus = useDebounceCallback(focusFlashById, FOCUS_DEBOUNCE_DELAY);
-
   useEffect(() => {
     if (nextFocusId) {
-      debouncedFocus(ref.current, nextFocusId);
+      focusFlashById(ref.current, nextFocusId);
     }
-  }, [debouncedFocus, nextFocusId, ref]);
+  }, [nextFocusId, ref]);
 
   const handleFlashDismissed = (dismissedId?: string) => {
     handleFlashDismissedInternal(dismissedId, items, ref.current, flashRefs.current);

--- a/src/flashbar/flash.tsx
+++ b/src/flashbar/flash.tsx
@@ -25,12 +25,14 @@ import { PACKAGE_VERSION } from '../internal/environment';
 import { isDevelopment } from '../internal/is-development';
 import { awsuiPluginsInternal } from '../internal/plugins/api';
 import { createUseDiscoveredAction, createUseDiscoveredContent } from '../internal/plugins/helpers';
+import { throttle } from '../internal/utils/throttle';
 import useContainerWidth from '../internal/utils/use-container-width';
 import InternalLiveRegion from '../live-region/internal';
 import InternalSpinner from '../spinner/internal';
 import { GeneratedAnalyticsMetadataFlashbarDismiss } from './analytics-metadata/interfaces';
 import { FlashbarProps } from './interfaces';
 import { getDismissButtonStyles, getFlashStyles } from './style';
+import { FOCUS_THROTTLE_DELAY } from './utils';
 
 import analyticsSelectors from './analytics-metadata/styles.css.js';
 import styles from './styles.css.js';
@@ -94,19 +96,24 @@ export const focusFlashFocusableArea = (flash: HTMLElement | null) => {
   }
 };
 
-export function focusFlashById(element: HTMLElement | null, itemId: string) {
-  if (!element) {
-    return;
-  }
+export const focusFlashById = throttle(
+  (element: HTMLElement | null, itemId: string) => {
+    if (!element) {
+      return;
+    }
 
-  const flashElement = element.querySelector<HTMLElement>(`[data-itemid="${CSS.escape(itemId)}"]`);
-  if (!flashElement) {
-    return;
-  }
+    const flashElement = element.querySelector<HTMLElement>(`[data-itemid="${CSS.escape(itemId)}"]`);
+    if (!flashElement) {
+      return;
+    }
 
-  const focusContainer = flashElement.querySelector<HTMLElement>(`.${styles['flash-focus-container']}`);
-  focusContainer?.focus();
-}
+    const focusContainer = flashElement.querySelector<HTMLElement>(`.${styles['flash-focus-container']}`);
+
+    focusContainer?.focus();
+  },
+  FOCUS_THROTTLE_DELAY,
+  { trailing: false }
+);
 
 interface FlashProps extends FlashbarProps.MessageDefinition {
   className: string;

--- a/src/flashbar/utils.ts
+++ b/src/flashbar/utils.ts
@@ -3,7 +3,7 @@
 import { IconProps } from '../icon/interfaces';
 import { FlashbarProps } from './interfaces';
 
-export const FOCUS_DEBOUNCE_DELAY = 500;
+export const FOCUS_THROTTLE_DELAY = 2000;
 
 // Since the position of a notification changes when the Flashbar is collapsed,
 // it is useful on some situations (e.g, for animating) to know the original position of the item


### PR DESCRIPTION
Reverts cloudscape-design/components#3758.

Adding a surprise focus move where it was previously broken turns out to perhaps be a bad idea. Will revisit tomorrow.