### PR TITLE
revert: Use succinct UTC time zone offset: "+00:00" -> "Z"

### DIFF
--- a/src/date-range-picker/__integ__/date-range-picker.test.ts
+++ b/src/date-range-picker/__integ__/date-range-picker.test.ts
@@ -39,7 +39,7 @@ describe('Date Range Picker', () => {
         await page.keys('Enter');
 
         await expect(page.getTriggerText()).resolves.toBe(
-          granularity === 'day' ? '2018-01-16T00:00:00Z — 2018-01-24T23:59:59Z' : '2018-01 — 2018-01'
+          granularity === 'day' ? '2018-01-16T00:00:00+00:00 — 2018-01-24T23:59:59+00:00' : '2018-01 — 2018-01'
         );
       }, granularity)
     );
@@ -65,7 +65,7 @@ describe('Date Range Picker', () => {
         await page.keys('Enter');
 
         await expect(page.getTriggerText()).resolves.toBe(
-          granularity === 'day' ? '2018-01-17T00:00:00Z — 2018-01-19T15:30:00Z' : '2018-01 — 2018-01'
+          granularity === 'day' ? '2018-01-17T00:00:00+00:00 — 2018-01-19T15:30:00+00:00' : '2018-01 — 2018-01'
         );
       }, granularity)
     );

--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -266,7 +266,7 @@ describe('Date range picker', () => {
 
         wrapper.findDropdown()!.findApplyButton().click();
 
-        const dayObjectProperties = { endDate: 'T23:59:59Z', type: 'absolute' };
+        const dayObjectProperties = { endDate: 'T23:59:59+00:00', type: 'absolute' };
         const monthObjectProperties = { endDate: '', startDate: '2025-09', type: 'absolute' };
 
         expect(onChangeSpy).toHaveBeenCalledWith(

--- a/src/date-range-picker/__tests__/time-offset.test.ts
+++ b/src/date-range-picker/__tests__/time-offset.test.ts
@@ -59,14 +59,14 @@ describe('Date range picker', () => {
           { type: 'absolute', startDate: '2020-10-11T23:23:45', endDate: '2020-10-12T08:23:45' },
         ],
         [
-          'UTC and Z with negative offset',
-          { type: 'absolute', startDate: '2020-10-12T01:23:45Z', endDate: '2020-10-12T01:23:45Z' },
+          'UTC and +00:00 with negative offset',
+          { type: 'absolute', startDate: '2020-10-12T01:23:45Z', endDate: '2020-10-12T01:23:45+00:00' },
           { startDate: -240, endDate: -240 },
           { type: 'absolute', startDate: '2020-10-11T21:23:45', endDate: '2020-10-11T21:23:45' },
         ],
         [
           'UTC with mixed offsets',
-          { type: 'absolute', startDate: '2020-10-12T01:23:45Z', endDate: '2020-10-12T01:23:45Z' },
+          { type: 'absolute', startDate: '2020-10-12T01:23:45Z', endDate: '2020-10-12T01:23:45+00:00' },
           { startDate: 120, endDate: -240 },
           { type: 'absolute', startDate: '2020-10-12T03:23:45', endDate: '2020-10-11T21:23:45' },
         ],

--- a/src/date-range-picker/__tests__/utils.test.ts
+++ b/src/date-range-picker/__tests__/utils.test.ts
@@ -215,8 +215,8 @@ describe('DateRangePicker utils', () => {
 
       const expected = {
         type: 'absolute',
-        startDate: '2023-06-15T00:00:00+60000:00',
-        endDate: '2023-07-20T23:59:59+120000:00',
+        startDate: '2023-06-15T00:00:00Z+60000:00',
+        endDate: '2023-07-20T23:59:59Z+120000:00',
       };
 
       const result = formatValue(input as DateRangePickerProps.Value, { ...defaultOptions, timeOffset });
@@ -235,8 +235,8 @@ describe('DateRangePicker utils', () => {
 
       const expected = {
         type: 'absolute',
-        startDate: '2023-06-15T00:00:00Z',
-        endDate: '2023-07-20T23:59:59Z',
+        startDate: '2023-06-15T00:00:00Z+00:00',
+        endDate: '2023-07-20T23:59:59Z+00:00',
       };
 
       const result = formatValue(input as DateRangePickerProps.Value, { ...defaultOptions, timeOffset });

--- a/src/date-range-picker/time-offset.ts
+++ b/src/date-range-picker/time-offset.ts
@@ -8,7 +8,7 @@ import { formatTimeOffsetISO, parseTimezoneOffset, shiftTimezoneOffset } from '.
 import { DateRangePickerProps } from './interfaces';
 
 /**
- * Appends a time zone offset to a date string, replacing any existing timezone information.
+ * Appends a time zone offset to an offset-less date string.
  */
 export function setTimeOffset(
   value: DateRangePickerProps.Value | null,
@@ -17,16 +17,10 @@ export function setTimeOffset(
   if (!(value?.type === 'absolute')) {
     return value;
   }
-
-  const stripTimezone = (dateString: string): string => {
-    // Remove existing timezone info: Z, +HH:MM, -HH:MM, +HHMM, -HHMM
-    return dateString.replace(/[Z]$|[+-]\d{2}:?\d{2}$/, '');
-  };
-
   return {
     type: 'absolute',
-    startDate: stripTimezone(value.startDate) + formatTimeOffsetISO(value.startDate, timeOffset.startDate),
-    endDate: stripTimezone(value.endDate) + formatTimeOffsetISO(value.endDate, timeOffset.endDate),
+    startDate: value.startDate + formatTimeOffsetISO(value.startDate, timeOffset.startDate),
+    endDate: value.endDate + formatTimeOffsetISO(value.endDate, timeOffset.endDate),
   };
 }
 

--- a/src/internal/utils/date-time/__tests__/format-date-iso.test.ts
+++ b/src/internal/utils/date-time/__tests__/format-date-iso.test.ts
@@ -7,7 +7,7 @@ describe('formatDateISO', () => {
   let formatTimeOffsetISOMock: jest.SpyInstance;
 
   beforeEach(() => {
-    formatTimeOffsetISOMock = jest.spyOn(formatTimeOffsetModule, 'formatTimeOffsetISO').mockReturnValue('Z');
+    formatTimeOffsetISOMock = jest.spyOn(formatTimeOffsetModule, 'formatTimeOffsetISO').mockReturnValue('+00:00');
   });
 
   afterEach(() => {
@@ -55,7 +55,7 @@ describe('formatDateISO', () => {
       isMonthOnly: false,
     });
 
-    expect(result).toBe('2023-06-15T12:00:00Z');
+    expect(result).toBe('2023-06-15T12:00:00+00:00');
     expect(formatTimeOffsetISOMock).toHaveBeenCalledWith('2023-06-15T12:00:00', undefined);
   });
 

--- a/src/internal/utils/date-time/__tests__/format-date-localized.test.ts
+++ b/src/internal/utils/date-time/__tests__/format-date-localized.test.ts
@@ -6,7 +6,7 @@ import * as formatTimeOffsetModule from '../format-time-offset';
 describe('formatDateLocalized', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.spyOn(formatTimeOffsetModule, 'formatTimeOffsetLocalized').mockReturnValue('UTCZ');
+    jest.spyOn(formatTimeOffsetModule, 'formatTimeOffsetLocalized').mockReturnValue('UTC+00:00');
   });
 
   afterEach(() => {
@@ -32,7 +32,7 @@ describe('formatDateLocalized', () => {
       locale: 'en-US',
     });
 
-    expect(result).toMatch(/^June 15, 2023, 12:00:00 UTCZ$/);
+    expect(result).toMatch(/^June 15, 2023, 12:00:00 UTC\+00:00$/);
   });
 
   test('formats date only when isDateOnly is true', () => {
@@ -66,7 +66,7 @@ describe('formatDateLocalized', () => {
       locale: 'ja',
     });
 
-    expect(result).toMatch(/^2023年6月15日 12:00:00 UTCZ$/);
+    expect(result).toMatch(/^2023年6月15日 12:00:00 UTC\+00:00$/);
   });
 
   test('handles non-ISO formatted date strings', () => {
@@ -77,7 +77,7 @@ describe('formatDateLocalized', () => {
       locale: 'en-US',
     });
 
-    expect(result).toMatch(/^June 15, 2023, 12:00:00 UTCZ$/);
+    expect(result).toMatch(/^June 15, 2023, 12:00:00 UTC\+00:00$/);
   });
 
   //todo  determine how to handle this failing

--- a/src/internal/utils/date-time/__tests__/format-date-time-with-offset.test.ts
+++ b/src/internal/utils/date-time/__tests__/format-date-time-with-offset.test.ts
@@ -63,7 +63,7 @@ describe('formatDateTimeWithOffset', () => {
           date: '2020-01-01T00:00:00',
           timeOffset: regional,
           expected: {
-            iso: '2020-01-01T00:00:00Z',
+            iso: '2020-01-01T00:00:00+00:00',
             localized: { 'en-US': 'January 1, 2020, 00:00:00 (UTC)' },
           },
         },

--- a/src/internal/utils/date-time/__tests__/format-time-offset.test.ts
+++ b/src/internal/utils/date-time/__tests__/format-time-offset.test.ts
@@ -6,11 +6,6 @@ import { formatTimeOffsetISO } from '../../../../../lib/components/internal/util
 test('formatTimeOffsetISO', () => {
   for (let offset = -120; offset <= 120; offset++) {
     const formatted = formatTimeOffsetISO('2020-01-01', offset);
-    if (offset === 0) {
-      expect(formatted).toBe('Z');
-      continue;
-    }
-
     const sign = Number(formatted[0] + '1');
     const hours = Number(formatted[1] + formatted[2]);
     const minutes = Number(formatted[4] + formatted[5]);

--- a/src/internal/utils/date-time/format-time-offset.ts
+++ b/src/internal/utils/date-time/format-time-offset.ts
@@ -5,9 +5,6 @@ import { padLeftZeros } from '../strings';
 
 export function formatTimeOffsetISO(isoDate: string, offsetInMinutes?: number) {
   offsetInMinutes = defaultToLocal(isoDate, offsetInMinutes);
-  if (offsetInMinutes === 0) {
-    return 'Z';
-  }
   const { hours, minutes } = getMinutesAndHours(offsetInMinutes);
 
   const sign = offsetInMinutes < 0 ? '-' : '+';


### PR DESCRIPTION
This reverts commit 4d2f45b542c5844105722db71819c96134f49344.

### Description

Reverting because of downstream impact.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
