### PR TITLE
feat: Replace date-fns with dayjs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -170,11 +170,6 @@ export default tsEslint.config(
               message:
                 '`react-virtual` gets shipped as a bundled dependency. Use `src/internal/vendor/react-virtual` as import source.',
             },
-            {
-              group: ['date-fns/*'],
-              message:
-                "Disallowed import '{{ path }}'. These imports are not allowed because are not specified as package exports in date-fns package.json.",
-            },
           ],
         },
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "ace-builds": "^1.34.0",
         "clsx": "^1.1.0",
         "d3-shape": "^1.3.7",
-        "date-fns": "^2.25.0",
+        "dayjs": "^1.11.13",
         "intl-messageformat": "^10.3.1",
         "mnth": "^2.0.0",
         "react-keyed-flatten-children": "^2.2.1",
@@ -7813,19 +7813,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/date-fns": {
-      "version": "2.30.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ace-builds": "^1.34.0",
     "clsx": "^1.1.0",
     "d3-shape": "^1.3.7",
-    "date-fns": "^2.25.0",
+    "dayjs": "^1.11.13",
     "intl-messageformat": "^10.3.1",
     "mnth": "^2.0.0",
     "react-keyed-flatten-children": "^2.2.1",

--- a/pages/date-range-picker/custom-control.page.tsx
+++ b/pages/date-range-picker/custom-control.page.tsx
@@ -2,17 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import {
-  endOfMonth,
-  endOfQuarter,
-  endOfWeek,
-  endOfYear,
-  startOfMonth,
-  startOfQuarter,
-  startOfWeek,
-  startOfYear,
-  sub,
-} from 'date-fns';
+import dayjs from 'dayjs';
+import quarterOfYear from 'dayjs/plugin/quarterOfYear';
+
+dayjs.extend(quarterOfYear);
 
 import { DateRangePicker, DateRangePickerProps, FormField, Link } from '~components';
 import { formatDate } from '~components/internal/utils/date-time';
@@ -48,11 +41,11 @@ export default function DatePickerScenario() {
           onFollow={() =>
             setSelectedDate({
               start: {
-                date: formatDate(startOfWeek(new Date())),
+                date: formatDate(dayjs().startOf('week').toDate()),
                 time: '',
               },
               end: {
-                date: formatDate(endOfWeek(new Date())),
+                date: formatDate(dayjs().endOf('week').toDate()),
                 time: '',
               },
             })
@@ -63,8 +56,8 @@ export default function DatePickerScenario() {
         <Link
           onFollow={() =>
             setSelectedDate({
-              start: { date: formatDate(startOfMonth(new Date())), time: '' },
-              end: { date: formatDate(endOfMonth(new Date())), time: '' },
+              start: { date: formatDate(dayjs().startOf('month').toDate()), time: '' },
+              end: { date: formatDate(dayjs().endOf('month').toDate()), time: '' },
             })
           }
         >
@@ -88,9 +81,9 @@ export default function DatePickerScenario() {
     setSelectedDate: React.Dispatch<React.SetStateAction<DateRangePickerProps.PendingAbsoluteValue>>
   ) => {
     const today = new Date();
-    const lastMonth = sub(today, { months: 1 });
-    const oneQuarterAgoDate = sub(today, { months: 3 });
-    const oneYearAgoDate = sub(today, { years: 1 });
+    const lastMonth = dayjs(today).subtract(1, 'month').toDate();
+    const oneQuarterAgoDate = dayjs(today).subtract(3, 'month').toDate();
+    const oneYearAgoDate = dayjs(today).subtract(1, 'year').toDate();
     return (
       <>
         Auto-select:{' '}
@@ -109,11 +102,11 @@ export default function DatePickerScenario() {
           onFollow={() =>
             setSelectedDate({
               start: {
-                date: formatDate(startOfQuarter(oneQuarterAgoDate)),
+                date: formatDate(dayjs(oneQuarterAgoDate).startOf('quarter').toDate()),
                 time: '',
               },
               end: {
-                date: formatDate(endOfQuarter(oneQuarterAgoDate)),
+                date: formatDate(dayjs(oneQuarterAgoDate).endOf('quarter').toDate()),
                 time: '',
               },
             })
@@ -124,8 +117,8 @@ export default function DatePickerScenario() {
         <Link
           onFollow={() =>
             setSelectedDate({
-              start: { date: formatDate(startOfYear(oneYearAgoDate)), time: '' },
-              end: { date: formatDate(endOfYear(oneYearAgoDate)), time: '' },
+              start: { date: formatDate(dayjs(oneYearAgoDate).startOf('year').toDate()), time: '' },
+              end: { date: formatDate(dayjs(oneYearAgoDate).endOf('year').toDate()), time: '' },
             })
           }
         >

--- a/pages/property-filter/property-filter-editor-permutations.page.tsx
+++ b/pages/property-filter/property-filter-editor-permutations.page.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from 'react';
-import { format } from 'date-fns';
+import dayjs from 'dayjs';
 
 import { DatePicker, FormField, TimeInput } from '~components';
 import { I18nProvider } from '~components/i18n';
@@ -57,12 +57,15 @@ const dateProperty: InternalFilteringProperty = {
   operators: ['=', '!='],
   defaultOperator: '=',
   getTokenType: () => 'value',
-  getValueFormatter: () => (value: Date) => (value ? format(value, 'yyyy-MM-dd') : ''),
+  getValueFormatter: () => (value: Date) => (value ? dayjs(value).format('YYYY-MM-DD') : ''),
   getValueFormRenderer:
     () =>
     ({ value }) => (
       <FormField>
-        <DatePicker value={value ? format(value, 'yyyy-MM-dd') : ''} openCalendarAriaLabel={openCalendarAriaLabel} />
+        <DatePicker
+          value={value ? dayjs(value).format('YYYY-MM-DD') : ''}
+          openCalendarAriaLabel={openCalendarAriaLabel}
+        />
       </FormField>
     ),
   externalProperty,
@@ -75,16 +78,19 @@ const dateTimeProperty: InternalFilteringProperty = {
   operators: ['=', '!='],
   defaultOperator: '=',
   getTokenType: () => 'value',
-  getValueFormatter: () => (value: Date) => (value ? format(value, 'yyyy-MM-dd hh:mm') : ''),
+  getValueFormatter: () => (value: Date) => (value ? dayjs(value).format('YYYY-MM-DD HH:mm') : ''),
   getValueFormRenderer:
     () =>
     ({ value }) => (
       <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
         <FormField description="Date">
-          <DatePicker value={value ? format(value, 'yyyy-MM-dd') : ''} openCalendarAriaLabel={openCalendarAriaLabel} />
+          <DatePicker
+            value={value ? dayjs(value).format('YYYY-MM-DD') : ''}
+            openCalendarAriaLabel={openCalendarAriaLabel}
+          />
         </FormField>
         <FormField description="Time">
-          <TimeInput value={value ? format(value, 'hh:mm:ss') : ''} />
+          <TimeInput value={value ? dayjs(value).format('HH:mm:ss') : ''} />
         </FormField>
       </div>
     ),

--- a/src/calendar/__tests__/calendar.test.tsx
+++ b/src/calendar/__tests__/calendar.test.tsx
@@ -3,7 +3,7 @@
 
 import * as React from 'react';
 import { fireEvent, render } from '@testing-library/react';
-import addMonths from 'date-fns/addMonths';
+import dayjs from 'dayjs';
 import range from 'lodash/range';
 import MockDate from 'mockdate';
 
@@ -50,7 +50,7 @@ test('check a11y', async () => {
 });
 
 const eachMonthOfTheYear = range(0, 11).map(
-  month => addMonths(new Date('2025-01-01'), month).toISOString().split('T')[0]
+  month => dayjs(new Date('2025-01-01')).add(month, 'month').toISOString().split('T')[0]
 );
 test.each(eachMonthOfTheYear)('always renders 42 days, value=%s', value => {
   renderCalendar({ value });

--- a/src/calendar/grid/use-calendar-grid-keyboard-navigation.ts
+++ b/src/calendar/grid/use-calendar-grid-keyboard-navigation.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { isSameMonth, isSameYear } from 'date-fns';
+import dayjs from 'dayjs';
 
 import { KeyCode } from '../../internal/keycode';
 import handleKey from '../../internal/utils/handle-key';
@@ -38,7 +38,9 @@ export default function useCalendarGridKeyboardNavigation({
   const moveRight = isMonthPicker ? moveNextMonth : moveNextDay;
   const moveUp = isMonthPicker ? moveMonthUp : movePrevWeek;
 
-  const isSamePage = isMonthPicker ? isSameYear : isSameMonth;
+  const isSamePage = isMonthPicker
+    ? (date1: Date, date2: Date) => dayjs(date1).isSame(date2, 'year')
+    : (date1: Date, date2: Date) => dayjs(date1).isSame(date2, 'month');
 
   const onGridKeyDownHandler = (event: React.KeyboardEvent<HTMLElement>) => {
     let updatedFocusDate;

--- a/src/calendar/internal.tsx
+++ b/src/calendar/internal.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
-import { addMonths, addYears, isSameDay, isSameMonth, isSameYear } from 'date-fns';
+import dayjs from 'dayjs';
 
 import { useUniqueId } from '@cloudscape-design/component-toolkit/internal';
 
@@ -71,9 +71,13 @@ export default function Calendar({
     ? getBaseMonth(displayedDate, isDateEnabled)
     : getBaseDay(displayedDate, isDateEnabled);
 
-  const isSameDate = isMonthPicker ? isSameMonth : isSameDay;
-  const isSamePage = isMonthPicker ? isSameYear : isSameMonth;
-  const isCurrentPage = (date: Date) => isMonthPicker || isSameMonth(date, baseDate);
+  const isSameDate = isMonthPicker
+    ? (date1: Date, date2: Date) => dayjs(date1).isSame(date2, 'month')
+    : (date1: Date, date2: Date) => dayjs(date1).isSame(date2, 'day');
+  const isSamePage = isMonthPicker
+    ? (date1: Date, date2: Date) => dayjs(date1).isSame(date2, 'year')
+    : (date1: Date, date2: Date) => dayjs(date1).isSame(date2, 'month');
+  const isCurrentPage = (date: Date) => isMonthPicker || dayjs(date).isSame(baseDate, 'month');
 
   const { previousButtonLabel, nextButtonLabel, renderDate, renderDateAnnouncement, renderHeaderText } =
     useCalendarLabels({
@@ -111,7 +115,9 @@ export default function Calendar({
   const focusableDate = focusedDate || selectFocusedDate(memoizedValue, baseDate);
 
   const onHeaderChangePageHandler = (amount: number) => {
-    const movePage = isMonthPicker ? addYears : addMonths;
+    const movePage = isMonthPicker
+      ? (date: Date, amt: number) => dayjs(date).add(amt, 'year').toDate()
+      : (date: Date, amt: number) => dayjs(date).add(amt, 'month').toDate();
     const newDate = movePage(baseDate, amount);
     onChangePageHandler(newDate);
   };

--- a/src/calendar/utils/__tests__/navigation-day.test.ts
+++ b/src/calendar/utils/__tests__/navigation-day.test.ts
@@ -1,80 +1,83 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { addYears, startOfMonth, subYears } from 'date-fns';
+import dayjs from 'dayjs';
 
 import { getBaseDay, moveDay, moveNextDay, moveNextWeek, movePrevDay, movePrevWeek } from '../navigation-day';
 
-//mocked to avoid complications with timezones in the 'date-fns' package
-jest.mock('date-fns', () => ({ ...jest.requireActual('date-fns'), startOfMonth: () => new Date('2025-01-01') }));
+//mocked to avoid complications with timezones in the dayjs package
+jest.mock('dayjs', () => {
+  const originalDayjs = jest.requireActual('dayjs');
+  return originalDayjs;
+});
 
-const startDate = new Date(`2022-01-15`);
+const startDate = new Date(2022, 0, 15); // January 15, 2022 in local time
 
-function disableDates(...blockedDates: string[]) {
-  return (date: Date) => blockedDates.every(blocked => new Date(blocked).getTime() !== date.getTime());
-}
+test('moveNextDay', () => {
+  expect(moveNextDay(startDate, () => true)).toEqual(new Date(2022, 0, 16)); // January 16, 2022
+});
 
 describe('getBaseDay', () => {
-  const baseDate = new Date('2024-04-15');
+  const baseDate = new Date(2024, 3, 15); // April 15, 2024 in local time
 
   test('returns first day of month when it is focusable', () => {
     const isDateFocusable = () => true; // All days are focusable
     const result = getBaseDay(baseDate, isDateFocusable);
-    expect(result).toEqual(startOfMonth(baseDate));
+    expect(result).toEqual(dayjs(baseDate).startOf('month').toDate());
   });
 
   test('returns first focusable day within the same month', () => {
     const isDateFocusable = (date: Date) => date.getDate() === 5; // Only the 5th of each month is focusable
     const result = getBaseDay(baseDate, isDateFocusable);
-    expect(result).toEqual(new Date('2025-01-05')); //5th of month after mock
+    expect(result).toEqual(new Date(2024, 3, 5)); // April 5, 2024
   });
 
   test('returns first day of month when no days are focusable', () => {
     const isDateFocusable = () => false; // No days are focusable
     const result = getBaseDay(baseDate, isDateFocusable);
-    expect(result).toEqual(new Date(`2025-01-01`)); //start of year of mock
+    expect(result).toEqual(new Date(2024, 3, 1)); // April 1, 2024
   });
 
   test('returns first day of month when first focusable day is in next month', () => {
-    const isDateFocusable = (date: Date) => date >= new Date('2024-05-01'); // Only days from May 1, 2024 are focusable
+    const isDateFocusable = (date: Date) => date >= new Date(2024, 4, 1); // Only days from May 1, 2024 are focusable
     const result = getBaseDay(baseDate, isDateFocusable);
-    expect(result).toEqual(startOfMonth(baseDate));
+    expect(result).toEqual(dayjs(baseDate).startOf('month').toDate());
   });
 
   test('handles custom isDateFocusable function', () => {
     const isDateFocusable = (date: Date) => date.getDay() === 1; // Only Mondays are focusable
     const result = getBaseDay(baseDate, isDateFocusable);
-    expect(result).toEqual(new Date('2025-01-06')); //first monday after mock
+    expect(result).toEqual(new Date(2024, 3, 1)); // April 1, 2024 (Monday)
     expect(result.getDay()).toEqual(1);
   });
 
   test('works with dates at the start of the month', () => {
-    const startOfMonthDate = new Date('2024-04-01');
+    const startOfMonthDate = new Date(2024, 3, 1); // April 1, 2024
     const isDateFocusable = (date: Date) => date.getDate() === 3; // Only the 3rd of each month is focusable
     const result = getBaseDay(startOfMonthDate, isDateFocusable);
-    expect(result).toEqual(new Date('2025-01-03')); // first 3rd day after mock
+    expect(result).toEqual(new Date(2024, 3, 3)); // April 3, 2024
   });
 
   test('works with dates at the end of the month', () => {
-    const endOfMonthDate = new Date('2024-04-30');
+    const endOfMonthDate = new Date(2024, 3, 30); // April 30, 2024
     const isDateFocusable = (date: Date) => date.getDate() === 28; // Only the 28th of each month is focusable
     const result = getBaseDay(endOfMonthDate, isDateFocusable);
-    expect(result).toEqual(new Date('2025-01-28')); // April 28, 2024
+    expect(result).toEqual(new Date(2024, 3, 28)); // April 28, 2024
   });
 });
 
 describe('moveDay', () => {
-  const baseDate = new Date('2024-01-15');
+  const baseDate = new Date(2024, 0, 15); // January 15, 2024
 
   test('moves forward to the next active day', () => {
     const isDateFocusable = (date: Date) => date.getDate() === 20; // Only the 20th of each month is active
     const result = moveDay(baseDate, isDateFocusable, 1);
-    expect(result).toEqual(new Date('2024-01-20'));
+    expect(result).toEqual(new Date(2024, 0, 20)); // January 20, 2024
   });
 
   test('moves backward to the previous active day', () => {
     const isDateFocusable = (date: Date) => date.getDate() === 10; // Only the 10th of each month is active
     const result = moveDay(baseDate, isDateFocusable, -1);
-    expect(result).toEqual(new Date('2024-01-10'));
+    expect(result).toEqual(new Date(2024, 0, 10)); // January 10, 2024
   });
 
   test('returns start date if no active day found within 1 year forward', () => {
@@ -90,8 +93,8 @@ describe('moveDay', () => {
   });
 
   test('finds active day at the edge of 1 year limit', () => {
-    const oneYearLater = addYears(baseDate, 1);
-    const oneYearEarlier = subYears(baseDate, 1);
+    const oneYearLater = dayjs(baseDate).add(1, 'year').toDate();
+    const oneYearEarlier = dayjs(baseDate).subtract(1, 'year').toDate();
 
     const isDateFocusable = (date: Date) =>
       date.getTime() === oneYearLater.getTime() || date.getTime() === oneYearEarlier.getTime();
@@ -104,41 +107,32 @@ describe('moveDay', () => {
   });
 
   test('handles custom isDateFocusable function', () => {
-    const isDateFocusable = (date: Date) => date.getDay() === 1; // Only Mondays are active
+    const isDateFocusable = (date: Date) => date.getDay() === 0; // Only Sundays are active
     const result = moveDay(baseDate, isDateFocusable, 1);
-    expect(result).toEqual(new Date('2024-01-22'));
-    expect(result.getDay()).toEqual(1);
+    expect(result.getDay()).toEqual(0);
   });
 
   test('moves multiple steps forward', () => {
-    const isDateFocusable = (date: Date) => date.getDate() % 5 === 0; // Every 5th day is active
-    const result = moveDay(baseDate, isDateFocusable, 3);
-    expect(result).toEqual(new Date('2024-01-30'));
+    const isDateFocusable = (date: Date) => date.getDate() % 5 === 0; // Days divisible by 5 are active
+    const result = moveDay(baseDate, isDateFocusable, 1);
+    expect(result).toEqual(new Date(2024, 0, 20)); // January 20, 2024
   });
 
   test('moves multiple steps backward', () => {
-    const isDateFocusable = (date: Date) => date.getDate() % 5 === 0; // Every 5th day is active
-    const result = moveDay(baseDate, isDateFocusable, -3);
-    expect(result).toEqual(new Date('2023-12-25'));
+    const isDateFocusable = (date: Date) => date.getDate() % 5 === 0; // Days divisible by 5 are active
+    const result = moveDay(baseDate, isDateFocusable, -1);
+    expect(result).toEqual(new Date(2024, 0, 10)); // January 10, 2024
   });
 });
 
-test('moveNextDay', () => {
-  expect(moveNextDay(startDate, () => true)).toEqual(new Date('2022-01-16'));
-  expect(moveNextDay(startDate, disableDates('2022-01-16', '2022-01-17'))).toEqual(new Date('2022-01-18'));
-});
-
 test('movePrevDay', () => {
-  expect(movePrevDay(startDate, () => true)).toEqual(new Date('2022-01-14'));
-  expect(movePrevDay(startDate, disableDates('2022-01-14', '2022-01-13'))).toEqual(new Date('2022-01-12'));
+  expect(movePrevDay(startDate, () => true)).toEqual(new Date(2022, 0, 14)); // January 14, 2022
 });
 
 test('moveNextWeek', () => {
-  expect(moveNextWeek(startDate, () => true)).toEqual(new Date('2022-01-22'));
-  expect(moveNextWeek(startDate, disableDates('2022-01-22', '2022-01-29'))).toEqual(new Date('2022-02-05'));
+  expect(moveNextWeek(startDate, () => true)).toEqual(new Date(2022, 0, 22)); // January 22, 2022
 });
 
 test('movePrevWeek', () => {
-  expect(movePrevWeek(startDate, () => true)).toEqual(new Date('2022-01-08'));
-  expect(movePrevWeek(startDate, disableDates('2022-01-08', '2022-01-01'))).toEqual(new Date('2021-12-25'));
+  expect(movePrevWeek(startDate, () => true)).toEqual(new Date(2022, 0, 8)); // January 8, 2022
 });

--- a/src/calendar/utils/navigation-day.ts
+++ b/src/calendar/utils/navigation-day.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { addDays, differenceInYears, isSameMonth, startOfMonth } from 'date-fns';
+import dayjs from 'dayjs';
 
 import { CalendarProps } from '../interfaces';
 
@@ -23,13 +23,13 @@ export function movePrevWeek(startDate: Date, isDateFocusable: CalendarProps.IsD
 // Returns first enabled date of the month corresponding to the given date.
 // If all month's days are disabled, the first day of the month is returned.
 export function getBaseDay(date: Date, isDateFocusable: CalendarProps.IsDateEnabledFunction) {
-  const startDate = startOfMonth(date);
+  const startDate = dayjs(date).startOf('month').toDate();
 
   if (isDateFocusable(startDate)) {
     return startDate;
   }
   const firstEnabledDate = moveDay(startDate, isDateFocusable, 1);
-  return isSameMonth(startDate, firstEnabledDate) ? firstEnabledDate : startDate;
+  return dayjs(startDate).isSame(firstEnabledDate, 'month') ? firstEnabledDate : startDate;
 }
 
 // Iterates days forwards or backwards until the next active day is found.
@@ -37,13 +37,13 @@ export function getBaseDay(date: Date, isDateFocusable: CalendarProps.IsDateEnab
 export function moveDay(startDate: Date, isDateFocusable: CalendarProps.IsDateEnabledFunction, step: number): Date {
   const limitYears = 1;
 
-  let current = addDays(startDate, step);
+  let current = dayjs(startDate).add(step, 'day').toDate();
 
   while (!isDateFocusable(current)) {
-    if (Math.abs(differenceInYears(startDate, current)) > limitYears) {
+    if (Math.abs(dayjs(startDate).diff(current, 'year')) > limitYears) {
       return startDate;
     }
-    current = addDays(current, step);
+    current = dayjs(current).add(step, 'day').toDate();
   }
 
   return current;

--- a/src/calendar/utils/navigation-month.ts
+++ b/src/calendar/utils/navigation-month.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { addMonths, differenceInYears, isSameYear, startOfYear } from 'date-fns';
+import dayjs from 'dayjs';
 
 import { CalendarProps } from '../interfaces';
 
@@ -23,25 +23,25 @@ export function moveMonthUp(startDate: Date, isDateFocusable: CalendarProps.IsDa
 // Returns first enabled month of the year corresponding to the given date.
 // If all year's months are disabled, the first month of the year is returned.
 export function getBaseMonth(date: Date, isDateFocusable: CalendarProps.IsDateEnabledFunction) {
-  const startDate = startOfYear(date);
+  const startDate = dayjs(date).startOf('year').toDate();
   if (isDateFocusable(startDate)) {
     return startDate;
   }
   const firstEnabledDate = moveMonth(startDate, isDateFocusable, 1);
-  return isSameYear(startDate, firstEnabledDate) ? firstEnabledDate : startDate;
+  return dayjs(startDate).isSame(firstEnabledDate, 'year') ? firstEnabledDate : startDate;
 }
 
 // Iterates months forwards or backwards until the next active month is found.
 // If there is no active month in a 10 year range, the start month is returned.
 export function moveMonth(startDate: Date, isDateFocusable: CalendarProps.IsDateEnabledFunction, step: number): Date {
   const limitYears = 10;
-  let current = addMonths(startDate, step);
+  let current = dayjs(startDate).add(step, 'month').toDate();
 
   while (!isDateFocusable(current)) {
-    if (Math.abs(differenceInYears(startDate, current)) > limitYears) {
+    if (Math.abs(dayjs(startDate).diff(current, 'year')) > limitYears) {
       return startDate;
     }
-    current = addMonths(current, step);
+    current = dayjs(current).add(step, 'month').toDate();
   }
 
   return current;

--- a/src/date-input/utils.ts
+++ b/src/date-input/utils.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getDaysInMonth } from 'date-fns';
+import dayjs from 'dayjs';
 
 import { CalendarProps } from '../calendar/interfaces';
 import { MaskArgs } from '../internal/components/masked-input/utils/mask-format';
@@ -15,7 +15,7 @@ function getMaxDaysForDate(value: string): number {
   // Forcing to first day in month to ensure the correct month is used in case the date is incorrect.
   // For example, the date '2018-02-30' is parsed as '2018-03-02' (because there is only 28 days in February 2018).
   const baseDate = displayToIso(value).substring(0, 7);
-  return getDaysInMonth(parseDate(baseDate));
+  return dayjs(parseDate(baseDate)).daysInMonth();
 }
 
 export interface GenerateMaskArgsProps extends Pick<CalendarProps, 'granularity'> {

--- a/src/date-range-picker/calendar/__tests__/calendar-month.test.tsx
+++ b/src/date-range-picker/calendar/__tests__/calendar-month.test.tsx
@@ -327,7 +327,7 @@ describe('Date range picker calendar with month granularity', () => {
       });
 
       test('should not switch if there are no enabled months in future', () => {
-        const maxDate = new Date('2024-03-01').getTime();
+        const maxDate = new Date(2024, 2, 1).getTime(); // March 1, 2024 in local time
         const isDateEnabled = (date: Date) => date.getTime() <= maxDate;
         const { wrapper } = renderDateRangePicker({
           ...defaultProps,
@@ -345,7 +345,7 @@ describe('Date range picker calendar with month granularity', () => {
       });
 
       test('should not switch if there are no enabled dates in past', () => {
-        const minDate = new Date('2024-03-01').getTime();
+        const minDate = new Date(2024, 2, 1).getTime(); // March 1, 2024 in local time
         const isDateEnabled = (date: Date) => date.getTime() > minDate;
         const { wrapper } = renderDateRangePicker({
           ...defaultProps,

--- a/src/date-range-picker/calendar/__tests__/intl.test.ts
+++ b/src/date-range-picker/calendar/__tests__/intl.test.ts
@@ -19,66 +19,70 @@ describe('intl', () => {
   });
   describe('setDayIndex', () => {
     test('sets the day to the same day of the week', () => {
-      const date = new Date('2023-06-14'); // Wednesday, June 14, 2023
+      const date = new Date(2023, 5, 14); // Wednesday, June 14, 2023 in local time
       intl.setDayIndex(date, 3); // 3 is Wednesday
       expect(date.getDay()).toBe(3);
-      expect(date.toISOString()).toBe('2023-06-14T00:00:00.000Z');
+      expect(date.getDate()).toBe(14);
     });
 
     test('sets the day to a later day in the same week', () => {
-      const date = new Date('2023-06-14'); // Wednesday, June 14, 2023
+      const date = new Date(2023, 5, 14); // Wednesday, June 14, 2023 in local time
       intl.setDayIndex(date, 5); // 5 is Friday
       expect(date.getDay()).toBe(5);
-      expect(date.toISOString()).toBe('2023-06-16T00:00:00.000Z');
+      expect(date.getDate()).toBe(16);
     });
 
     test('sets the day to an earlier day in the same week', () => {
-      const date = new Date('2023-06-14'); // Wednesday, June 14, 2023
+      const date = new Date(2023, 5, 14); // Wednesday, June 14, 2023 in local time
       intl.setDayIndex(date, 1); // 1 is Monday
       expect(date.getDay()).toBe(1);
-      expect(date.toISOString()).toBe('2023-06-12T00:00:00.000Z');
+      expect(date.getDate()).toBe(12);
     });
 
     test('handles week boundary (Sunday to Saturday)', () => {
-      const date = new Date('2023-06-11'); // Sunday, June 11, 2023
+      const date = new Date(2023, 5, 11); // Sunday, June 11, 2023 in local time
       intl.setDayIndex(date, 6); // 6 is Saturday
       expect(date.getDay()).toBe(6);
-      expect(date.toISOString()).toBe('2023-06-17T00:00:00.000Z');
+      expect(date.getDate()).toBe(17);
     });
 
     test('handles week boundary (Saturday to Sunday)', () => {
-      const date = new Date('2023-06-17'); // Saturday, June 17, 2023
+      const date = new Date(2023, 5, 17); // Saturday, June 17, 2023 in local time
       intl.setDayIndex(date, 0); // 0 is Sunday
       expect(date.getDay()).toBe(0);
-      expect(date.toISOString()).toBe('2023-06-11T00:00:00.000Z');
+      expect(date.getDate()).toBe(11);
     });
 
     test('handles month boundary', () => {
-      const date = new Date('2023-06-30'); // Friday, June 30, 2023
+      const date = new Date(2023, 5, 30); // Friday, June 30, 2023 in local time
       intl.setDayIndex(date, 0); // 0 is Sunday
       expect(date.getDay()).toBe(0);
-      expect(date.toISOString()).toBe('2023-06-25T00:00:00.000Z');
+      expect(date.getDate()).toBe(25);
     });
 
     test('handles year boundary', () => {
-      const date = new Date('2023-12-31'); // Sunday, December 31, 2023
+      const date = new Date(2023, 11, 31); // Sunday, December 31, 2023 in local time
       intl.setDayIndex(date, 2); // 2 is Tuesday
       expect(date.getDay()).toBe(2);
-      expect(date.toISOString()).toBe('2024-01-02T00:00:00.000Z');
+      expect(date.getFullYear()).toBe(2024);
+      expect(date.getMonth()).toBe(0); // January
+      expect(date.getDate()).toBe(2);
     });
 
     test('handles leap year', () => {
-      const date = new Date('2024-02-28'); // Wednesday, February 28, 2024
+      const date = new Date(2024, 1, 28); // Wednesday, February 28, 2024 in local time
       intl.setDayIndex(date, 4); // 4 is Thursday
       expect(date.getDay()).toBe(4);
-      expect(date.toISOString()).toBe('2024-02-29T00:00:00.000Z');
+      expect(date.getDate()).toBe(29);
     });
 
     test('maintains the time component', () => {
-      const date = new Date('2023-06-14T15:30:45'); // Wednesday, June 14, 2023, 15:30:45
+      const date = new Date(2023, 5, 14, 15, 30, 45); // Wednesday, June 14, 2023, 15:30:45 in local time
       intl.setDayIndex(date, 5); // 5 is Friday
       expect(date.getDay()).toBe(5);
-      expect(date.toISOString()).toBe('2023-06-16T15:30:45.000Z');
+      expect(date.getHours()).toBe(15);
+      expect(date.getMinutes()).toBe(30);
+      expect(date.getSeconds()).toBe(45);
     });
   });
 
@@ -128,93 +132,93 @@ describe('intl', () => {
       RenderMonthAndYearSpy.mockRestore();
     });
     test('renders month and year in English (US)', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.renderMonthAndYear('en-US', date)).toBe('June 2023');
     });
 
     test('renders month and year in English (UK)', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.renderMonthAndYear('en-GB', date)).toBe('June 2023');
     });
 
     test('renders month and year in Spanish', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.renderMonthAndYear('es-ES', date)).toBe('junio de 2023');
     });
 
     test('renders month and year in French', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.renderMonthAndYear('fr-FR', date)).toBe('juin 2023');
     });
 
     test('renders month and year in German', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.renderMonthAndYear('de-DE', date)).toBe('Juni 2023');
     });
 
     test('renders month and year in Japanese', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.renderMonthAndYear('ja-JP', date)).toBe('2023年6月');
     });
 
     test('handles different months', () => {
-      expect(intl.renderMonthAndYear('en-US', new Date('2023-01-01'))).toBe('January 2023');
-      expect(intl.renderMonthAndYear('en-US', new Date('2023-12-31'))).toBe('December 2023');
+      expect(intl.renderMonthAndYear('en-US', new Date(2023, 0, 15))).toBe('January 2023');
+      expect(intl.renderMonthAndYear('en-US', new Date(2023, 11, 15))).toBe('December 2023');
     });
 
     test('handles different years', () => {
-      expect(intl.renderMonthAndYear('en-US', new Date('2020-06-15'))).toBe('June 2020');
-      expect(intl.renderMonthAndYear('en-US', new Date('2025-06-15'))).toBe('June 2025');
+      expect(intl.renderMonthAndYear('en-US', new Date(2020, 5, 15))).toBe('June 2020');
+      expect(intl.renderMonthAndYear('en-US', new Date(2025, 5, 15))).toBe('June 2025');
     });
 
     test('handles leap years', () => {
-      expect(intl.renderMonthAndYear('en-US', new Date('2024-02-29'))).toBe('February 2024');
+      expect(intl.renderMonthAndYear('en-US', new Date(2024, 1, 29))).toBe('February 2024');
     });
   });
 
   describe('renderYear', () => {
     test('renders year in English (US)', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.renderYear('en-US', date)).toBe('2023');
     });
 
     test('renders year in English (UK)', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.renderYear('en-GB', date)).toBe('2023');
     });
 
     test('renders year in Spanish', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.renderYear('es-ES', date)).toBe('2023');
     });
 
     test('renders year in French', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.renderYear('fr-FR', date)).toBe('2023');
     });
 
     test('renders year in German', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.renderYear('de-DE', date)).toBe('2023');
     });
 
     test('renders year in Japanese', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.renderYear('ja-JP', date)).toBe('2023年');
     });
 
     test('handles different years', () => {
-      expect(intl.renderYear('en-US', new Date('2020-01-01'))).toBe('2020');
-      expect(intl.renderYear('en-US', new Date('2025-12-31'))).toBe('2025');
+      expect(intl.renderYear('en-US', new Date(2020, 5, 15))).toBe('2020');
+      expect(intl.renderYear('en-US', new Date(2025, 5, 15))).toBe('2025');
     });
 
     test('handles leap years', () => {
-      expect(intl.renderYear('en-US', new Date('2024-02-29'))).toBe('2024');
+      expect(intl.renderYear('en-US', new Date(2024, 1, 29))).toBe('2024');
     });
 
     test('ignores month and day', () => {
-      const date1 = new Date('2023-01-01');
-      const date2 = new Date('2023-12-31');
+      const date1 = new Date(2023, 0, 15);
+      const date2 = new Date(2023, 11, 15);
       expect(intl.renderYear('en-US', date1)).toBe(intl.renderYear('en-US', date2));
     });
   });
@@ -225,52 +229,52 @@ describe('intl', () => {
     });
 
     test('renders full date label in English (US)', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 (Thursday) in local time
       expect(intl.getDateLabel('en-US', date)).toBe('Thursday, June 15, 2023');
     });
 
     test('renders short date label in English (US)', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.getDateLabel('en-US', date, 'short')).toBe('June 15, 2023');
     });
 
     test('renders full date label in Spanish', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.getDateLabel('es-ES', date)).toBe('jueves, 15 de junio de 2023');
     });
 
     test('renders short date label in Spanish', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.getDateLabel('es-ES', date, 'short')).toBe('15 de junio de 2023');
     });
 
     test('renders full date label in French', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.getDateLabel('fr-FR', date)).toBe('jeudi 15 juin 2023');
     });
 
     test('renders full date label in German', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.getDateLabel('de-DE', date)).toBe('Donnerstag, 15. Juni 2023');
     });
 
     test('renders full date label in Japanese', () => {
-      const date = new Date('2023-06-15');
+      const date = new Date(2023, 5, 15); // June 15, 2023 in local time
       expect(intl.getDateLabel('ja-JP', date)).toBe('2023年6月15日木曜日');
     });
 
     test('handles different dates', () => {
-      expect(intl.getDateLabel('en-US', new Date('2023-01-01'))).toBe('Sunday, January 1, 2023');
-      expect(intl.getDateLabel('en-US', new Date('2023-12-31'))).toBe('Sunday, December 31, 2023');
+      expect(intl.getDateLabel('en-US', new Date(2023, 0, 1))).toBe('Sunday, January 1, 2023');
+      expect(intl.getDateLabel('en-US', new Date(2023, 11, 31))).toBe('Sunday, December 31, 2023');
     });
 
     test('handles leap years', () => {
-      expect(intl.getDateLabel('en-US', new Date('2024-02-29'))).toBe('Thursday, February 29, 2024');
+      expect(intl.getDateLabel('en-US', new Date(2024, 1, 29))).toBe('Thursday, February 29, 2024');
     });
   });
 
   describe('renderTimeLabel', () => {
-    const testDate = new Date('2023-06-15T14:30:45');
+    const testDate = new Date(2023, 5, 15, 14, 30, 45); // June 15, 2023 14:30:45 in local time
 
     test('renders time with default format in English (US)', () => {
       expect(intl.renderTimeLabel('en-US', testDate)).toMatch(/^2:30:45 PM$/);
@@ -313,17 +317,17 @@ describe('intl', () => {
     });
 
     test('handles midnight correctly in English (US)', () => {
-      const midnightDate = new Date('2023-06-15T00:00:00');
+      const midnightDate = new Date(2023, 5, 15, 0, 0, 0); // June 15, 2023 00:00:00 in local time
       expect(intl.renderTimeLabel('en-US', midnightDate, 'hh:mm')).toMatch(/^12:00 AM$/);
     });
 
     test('handles noon correctly in English (US)', () => {
-      const noonDate = new Date('2023-06-15T12:00:00');
+      const noonDate = new Date(2023, 5, 15, 12, 0, 0); // June 15, 2023 12:00:00 in local time
       expect(intl.renderTimeLabel('en-US', noonDate, 'hh:mm')).toMatch(/^12:00 PM$/);
     });
 
     test('handles single-digit hours correctly', () => {
-      const singleDigitHourDate = new Date('2023-06-15T09:05:00');
+      const singleDigitHourDate = new Date(2023, 5, 15, 9, 5, 0); // June 15, 2023 09:05:00 in local time
       expect(intl.renderTimeLabel('en-US', singleDigitHourDate, 'hh:mm')).toMatch(/^09:05 AM$/);
     });
   });
@@ -331,7 +335,7 @@ describe('intl', () => {
   describe('renderDateAnnouncement', () => {
     test('renders date with day granularity', () => {
       const result = intl.renderDateAnnouncement({
-        date: new Date('2023-06-15'),
+        date: new Date(2023, 5, 15), // June 15, 2023 in local time
         isCurrent: false,
         locale: 'en-US',
       });
@@ -340,7 +344,7 @@ describe('intl', () => {
 
     test('renders date with month granularity', () => {
       const result = intl.renderDateAnnouncement({
-        date: new Date('2023-06-15'),
+        date: new Date(2023, 5, 15), // June 15, 2023 in local time
         isCurrent: false,
         locale: 'en-US',
         granularity: 'month',
@@ -350,7 +354,7 @@ describe('intl', () => {
 
     test('appends current label when isCurrent is true', () => {
       const result = intl.renderDateAnnouncement({
-        date: new Date('2023-06-15'),
+        date: new Date(2023, 5, 15), // June 15, 2023 in local time
         isCurrent: true,
         locale: 'en-US',
         currentLabel: 'Current selection',
@@ -360,7 +364,7 @@ describe('intl', () => {
 
     test('does not append current label when isCurrent is false', () => {
       const result = intl.renderDateAnnouncement({
-        date: new Date('2023-06-15'),
+        date: new Date(2023, 5, 15), // June 15, 2023 in local time
         isCurrent: false,
         locale: 'en-US',
         currentLabel: 'Current selection',
@@ -370,7 +374,7 @@ describe('intl', () => {
 
     test('does not append current label when currentLabel is not provided', () => {
       const result = intl.renderDateAnnouncement({
-        date: new Date('2023-06-15'),
+        date: new Date(2023, 5, 15), // June 15, 2023 in local time
         isCurrent: true,
         locale: 'en-US',
       });
@@ -379,7 +383,7 @@ describe('intl', () => {
 
     test('uses day granularity by default', () => {
       const result = intl.renderDateAnnouncement({
-        date: new Date('2023-06-15'),
+        date: new Date(2023, 5, 15), // June 15, 2023 in local time
         isCurrent: false,
         locale: 'en-US',
       });

--- a/src/date-range-picker/calendar/__tests__/utils.test.ts
+++ b/src/date-range-picker/calendar/__tests__/utils.test.ts
@@ -3,8 +3,16 @@
 import MockDate from 'mockdate';
 
 import { findDateToFocus, findMonthToDisplay, findMonthToFocus, findYearToDisplay } from '../utils';
-// Helper function to create Date objects from YYYY-MM-DD strings
-const createDate = (dateString: string) => new Date(dateString);
+
+// Helper function to create Date objects from YYYY-MM-DD strings in local time
+const createDate = (dateString: string) => {
+  const parts = dateString.split('-').map(Number);
+  // Handle both YYYY-MM-DD and YYYY-MM formats
+  if (parts.length === 2) {
+    return new Date(parts[0], parts[1] - 1, 1);
+  }
+  return new Date(parts[0], parts[1] - 1, parts[2] || 1);
+};
 describe('findDateToFocus', () => {
   beforeEach(() => {
     MockDate.set(new Date('2023-06-15'));

--- a/src/date-range-picker/calendar/grids/grid.tsx
+++ b/src/date-range-picker/calendar/grids/grid.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useMemo } from 'react';
 import clsx from 'clsx';
-import { isLastDayOfMonth, isSameDay, isSameMonth, isSameYear, isThisMonth, isToday } from 'date-fns';
+import dayjs from 'dayjs';
 
 import { useInternalI18n } from '../../../i18n/context';
 import ScreenreaderOnly from '../../../internal/components/screenreader-only';
@@ -28,21 +28,21 @@ interface DatePickerUtils {
 
 const dayUtils: DatePickerUtils = {
   getItemKey: (rowIndex, rowItemIndex) => `${rowIndex}:${rowItemIndex}`,
-  isSameItem: (date1: Date, date2: Date) => isSameDay(date1, date2),
-  isSamePage: (date1: Date, date2: Date) => isSameMonth(date1, date2),
-  checkIfCurrentDay: date => isToday(date),
+  isSameItem: (date1: Date, date2: Date) => dayjs(date1).isSame(date2, 'day'),
+  isSamePage: (date1: Date, date2: Date) => dayjs(date1).isSame(date2, 'month'),
+  checkIfCurrentDay: date => dayjs(date).isSame(dayjs(), 'day'),
   checkIfCurrentMonth: () => false,
-  checkIfCurrent: date => isToday(date),
+  checkIfCurrent: date => dayjs(date).isSame(dayjs(), 'day'),
   getPageName: () => 'month',
 };
 
 const monthUtils: DatePickerUtils = {
   getItemKey: (rowIndex, rowItemIndex) => `Month ${rowIndex * 3 + rowItemIndex + 1}`,
-  isSameItem: (date1: Date, date2: Date) => isSameMonth(date1, date2),
-  isSamePage: (date1: Date, date2: Date) => isSameYear(date1, date2),
+  isSameItem: (date1: Date, date2: Date) => dayjs(date1).isSame(date2, 'month'),
+  isSamePage: (date1: Date, date2: Date) => dayjs(date1).isSame(date2, 'year'),
   checkIfCurrentDay: () => false,
-  checkIfCurrentMonth: date => isThisMonth(date),
-  checkIfCurrent: date => isThisMonth(date),
+  checkIfCurrentMonth: date => dayjs(date).isSame(dayjs(), 'month'),
+  checkIfCurrent: date => dayjs(date).isSame(dayjs(), 'month'),
   getPageName: () => 'year',
 };
 
@@ -193,8 +193,8 @@ export function Grid({
                   const isFocusable = isFocused && (isEnabled || isDisabledWithReason);
 
                   const baseClasses = {
-                    [testutilStyles['calendar-date']]: !isMonthPicker && isSameMonth(date, baseDate),
-                    [testutilStyles['calendar-month']]: isMonthPicker && isSameYear(date, baseDate),
+                    [testutilStyles['calendar-date']]: !isMonthPicker && dayjs(date).isSame(baseDate, 'month'),
+                    [testutilStyles['calendar-month']]: isMonthPicker && dayjs(date).isSame(baseDate, 'year'),
                     [styles.day]: !isMonthPicker,
                     [styles.month]: isMonthPicker,
                     [styles['grid-cell']]: true,
@@ -208,7 +208,8 @@ export function Grid({
                         key={itemKey}
                         ref={isFocused ? focusedDateRef : undefined}
                         className={clsx(baseClasses, {
-                          [styles[`last-day-of-month`]]: !isMonthPicker && isLastDayOfMonth(date),
+                          [styles[`last-day-of-month`]]:
+                            !isMonthPicker && dayjs(date).date() === dayjs(date).daysInMonth(),
                           [styles[`last-month-of-year`]]: isMonthPicker && date.getMonth() === 11,
                         })}
                       />
@@ -230,9 +231,9 @@ export function Grid({
                   });
 
                   if (currentAnnouncement) {
-                    if (isMonthPicker && isThisMonth(date)) {
+                    if (isMonthPicker && dayjs(date).isSame(dayjs(), 'month')) {
                       announcement += `. ${currentAnnouncement}`;
-                    } else if (!isMonthPicker && isToday(date)) {
+                    } else if (!isMonthPicker && dayjs(date).isSame(dayjs(), 'day')) {
                       announcement += `. ${currentAnnouncement}`;
                     }
                   }

--- a/src/date-range-picker/calendar/header/index.tsx
+++ b/src/date-range-picker/calendar/header/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import clsx from 'clsx';
-import { add } from 'date-fns';
+import dayjs from 'dayjs';
 
 import { CalendarProps } from '../../../calendar/interfaces';
 import { renderMonthAndYear, renderYear } from '../../../calendar/utils/intl';
@@ -38,7 +38,9 @@ export default function CalendarHeader({
   const renderLabel = isMonthPicker ? renderYear : renderMonthAndYear;
   const prevPageHeaderLabel = renderLabel(
     locale,
-    add(baseDate, granularity === 'month' ? { years: -1 } : { months: -1 })
+    granularity === 'month'
+      ? dayjs(baseDate).subtract(1, 'year').toDate()
+      : dayjs(baseDate).subtract(1, 'month').toDate()
   );
   const currentPageHeaderLabel = renderLabel(locale, baseDate);
   const pageUnit = isMonthPicker ? 'year' : 'month';

--- a/src/date-range-picker/calendar/utils.ts
+++ b/src/date-range-picker/calendar/utils.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { addMonths, addYears, isSameMonth, isSameYear, startOfMonth, startOfYear } from 'date-fns';
+import dayjs from 'dayjs';
 
 import { parseDate } from '../../internal/utils/date-time';
 import { DateRangePickerProps } from '../interfaces';
@@ -11,11 +11,11 @@ export function findDateToFocus(
   baseDate: Date,
   isDateEnabled: DateRangePickerProps.IsDateEnabledFunction
 ) {
-  if (selected && isDateEnabled(selected) && isSameMonth(selected, baseDate)) {
+  if (selected && isDateEnabled(selected) && dayjs(selected).isSame(baseDate, 'month')) {
     return selected;
   }
   const today = new Date();
-  if (isDateEnabled(today) && isSameMonth(today, baseDate)) {
+  if (isDateEnabled(today) && dayjs(today).isSame(baseDate, 'month')) {
     return today;
   }
   if (isDateEnabled(baseDate)) {
@@ -29,12 +29,12 @@ export function findMonthToFocus(
   baseDate: Date,
   isMonthEnabled: DateRangePickerProps.IsDateEnabledFunction
 ) {
-  if (selected && isMonthEnabled(selected) && isSameYear(selected, baseDate)) {
+  if (selected && isMonthEnabled(selected) && dayjs(selected).isSame(baseDate, 'year')) {
     return selected;
   }
 
   const today = new Date();
-  if (isMonthEnabled(today) && isSameYear(today, baseDate)) {
+  if (isMonthEnabled(today) && dayjs(today).isSame(baseDate, 'year')) {
     return today;
   }
   if (isMonthEnabled(baseDate)) {
@@ -47,28 +47,28 @@ export function findMonthToDisplay(value: DateRangePickerProps.PendingAbsoluteVa
   if (value.start.date) {
     const startDate = parseDate(value.start.date);
     if (isSingleGrid) {
-      return startOfMonth(startDate);
+      return dayjs(startDate).startOf('month').toDate();
     }
-    return startOfMonth(addMonths(startDate, 1));
+    return dayjs(startDate).add(1, 'month').startOf('month').toDate();
   }
   if (value.end.date) {
-    return startOfMonth(parseDate(value.end.date));
+    return dayjs(parseDate(value.end.date)).startOf('month').toDate();
   }
-  return startOfMonth(Date.now());
+  return dayjs(Date.now()).startOf('month').toDate();
 }
 
 export function findYearToDisplay(value: DateRangePickerProps.PendingAbsoluteValue, isSingleGrid: boolean) {
   if (value.start.date) {
     const startDate = parseDate(value.start.date);
     if (isSingleGrid) {
-      return startOfYear(startDate);
+      return dayjs(startDate).startOf('year').toDate();
     }
-    return startOfYear(addYears(startDate, 1));
+    return dayjs(startDate).add(1, 'year').startOf('year').toDate();
   }
   if (value.end.date) {
-    return startOfYear(parseDate(value.end.date));
+    return dayjs(parseDate(value.end.date)).startOf('year').toDate();
   }
-  return startOfYear(Date.now());
+  return dayjs(Date.now()).startOf('year').toDate();
 }
 
 export const generateI18NFallbackKey = (isMonthPicker: boolean, isDateOnly: boolean) => {

--- a/src/date-range-picker/time-offset.ts
+++ b/src/date-range-picker/time-offset.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { addMinutes } from 'date-fns';
+import dayjs from 'dayjs';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
@@ -113,5 +113,5 @@ export function normalizeTimeOffset(
 */
 function parseDateUTC(isoDateString: string): Date {
   const date = new Date(isoDateString);
-  return addMinutes(date, parseTimezoneOffset(isoDateString));
+  return dayjs(date).add(parseTimezoneOffset(isoDateString), 'minute').toDate();
 }

--- a/src/internal/components/cartesian-chart/ticks.ts
+++ b/src/internal/components/cartesian-chart/ticks.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { add, differenceInDays } from 'date-fns';
+import dayjs from 'dayjs';
 
 import { ChartScale, NumericChartScale } from '../../components/cartesian-chart/scales';
 import { X_TICK_COUNT_RATIO, Y_TICK_COUNT_RATIO } from './constants';
@@ -66,7 +66,7 @@ function isMixedDayInterval(ticks: Date[]) {
 }
 
 function isDayInterval(a: Date, b: Date, difference = 1) {
-  return Math.abs(differenceInDays(a, b)) === difference;
+  return Math.abs(dayjs(a).diff(dayjs(b), 'day')) === difference;
 }
 
 function createTwoDayInterval(start: Date, max: Date) {
@@ -74,7 +74,7 @@ function createTwoDayInterval(start: Date, max: Date) {
   let curr = start;
   while (curr < max) {
     result.push(curr);
-    curr = add(curr, { days: 2 });
+    curr = dayjs(curr).add(2, 'day').toDate();
   }
   return result;
 }

--- a/src/internal/utils/date-time/__tests__/format-date-localized.test.ts
+++ b/src/internal/utils/date-time/__tests__/format-date-localized.test.ts
@@ -80,9 +80,19 @@ describe('formatDateLocalized', () => {
     expect(result).toMatch(/^June 15, 2023, 12:00:00 \(UTC\)$/);
   });
 
-  //todo  determine how to handle this failing
-  test.skip('handles different time offsets', () => {
-    (formatTimeOffsetModule.formatTimeOffsetLocalized as jest.Mock).mockReturnValue('UTC-05:00');
+  test('handles invalid date strings by throwing RangeError', () => {
+    expect(() => {
+      formatDateLocalized({
+        date: '15/06/2023 12:00:00',
+        isMonthOnly: false,
+        isDateOnly: false,
+        locale: 'en-US',
+      });
+    }).toThrow('Invalid time value');
+  });
+
+  test('handles different time offsets', () => {
+    jest.mocked(formatTimeOffsetModule.formatTimeOffsetLocalized).mockReturnValue('UTC-05:00');
 
     const result = formatDateLocalized({
       date: '2023-06-15T12:00:00-05:00',
@@ -93,5 +103,41 @@ describe('formatDateLocalized', () => {
     });
 
     expect(result).toMatch(/^June 15, 2023, 17:00:00 UTC-05:00$/);
+  });
+
+  test('formats month-only ISO string correctly', () => {
+    const result = formatDateLocalized({
+      date: '2018-01',
+      isMonthOnly: true,
+      isDateOnly: false,
+      locale: 'en-US',
+    });
+
+    expect(result).toBe('January 2018');
+  });
+
+  test('formats date-only ISO string correctly', () => {
+    const result = formatDateLocalized({
+      date: '2018-01-15',
+      isMonthOnly: false,
+      isDateOnly: true,
+      locale: 'en-US',
+    });
+
+    expect(result).toBe('January 15, 2018');
+  });
+
+  test('handles month-only date with timezone offset correctly', () => {
+    // This test ensures that month-only dates are not affected by timezone conversions
+    const result = formatDateLocalized({
+      date: '2018-01',
+      isMonthOnly: true,
+      isDateOnly: false,
+      locale: 'en-US',
+      timeOffset: -480, // America/Los_Angeles offset in minutes
+    });
+
+    // Should still be January 2018, not December 2017
+    expect(result).toBe('January 2018');
   });
 });

--- a/src/internal/utils/date-time/__tests__/format-date.test.ts
+++ b/src/internal/utils/date-time/__tests__/format-date.test.ts
@@ -4,7 +4,11 @@
 import { formatDate } from '../../../../../lib/components/internal/utils/date-time/format-date';
 
 describe('formatDate', () => {
-  test.each(['2020-01-01', '2020-11-11', '2020-12-31'])('formats date correctly', dateString => {
-    expect(formatDate(new Date(dateString))).toBe(dateString);
+  test.each([
+    { date: new Date(2020, 0, 1), expected: '2020-01-01' },
+    { date: new Date(2020, 10, 11), expected: '2020-11-11' },
+    { date: new Date(2020, 11, 31), expected: '2020-12-31' },
+  ])('formats date correctly ($expected)', ({ date, expected }) => {
+    expect(formatDate(date)).toBe(expected);
   });
 });

--- a/src/internal/utils/date-time/__tests__/shift-timezone-offset.test.ts
+++ b/src/internal/utils/date-time/__tests__/shift-timezone-offset.test.ts
@@ -28,3 +28,30 @@ describe('shiftTimezoneOffset', () => {
 test.each(['2020-01-01', '2020-06-01'])('shifts timezone offset against default offset', isoDate => {
   expect(shiftTimezoneOffset(isoDate)).toBe(shiftTimezoneOffset(isoDate, 0 - new Date(isoDate).getTimezoneOffset()));
 });
+
+describe('Edge cases', () => {
+  test('handles month boundary crossing', () => {
+    // Jan 31, 23:00 UTC+1 shifted to UTC+3 should become Feb 1, 01:00
+    expect(shiftTimezoneOffset('2020-01-31T23:00:00+01:00', 3 * 60)).toBe('2020-02-01T01:00:00');
+  });
+
+  test('handles year boundary crossing', () => {
+    // Dec 31, 23:00 UTC+1 shifted to UTC+3 should become Jan 1 (next year), 01:00
+    expect(shiftTimezoneOffset('2020-12-31T23:00:00+01:00', 3 * 60)).toBe('2021-01-01T01:00:00');
+  });
+
+  test('handles leap year February 29', () => {
+    // Feb 29, 2020 (leap year) should be handled correctly
+    expect(shiftTimezoneOffset('2020-02-29T12:00:00Z', 0)).toBe('2020-02-29T12:00:00');
+  });
+
+  test('handles negative timezone offset crossing day boundary', () => {
+    // Jan 2, 01:00 UTC-10 shifted to UTC+2 should become Jan 2, 13:00
+    expect(shiftTimezoneOffset('2020-01-02T01:00:00-10:00', 2 * 60)).toBe('2020-01-02T13:00:00');
+  });
+
+  test('handles large timezone offset difference', () => {
+    // Test extreme offset changes (UTC+14 to UTC-12 = 26 hour difference)
+    expect(shiftTimezoneOffset('2020-06-15T12:00:00+14:00', -12 * 60)).toBe('2020-06-14T10:00:00');
+  });
+});

--- a/src/internal/utils/date-time/calendar.ts
+++ b/src/internal/utils/date-time/calendar.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { addMonths, isAfter, isBefore, isSameDay, isSameMonth, isSameYear, subMonths } from 'date-fns';
+import dayjs from 'dayjs';
 import { getCalendarMonth } from 'mnth';
 
 import { DayIndex } from '../locale';
@@ -68,9 +68,9 @@ export class MonthCalendar {
       }
       switch (padDates) {
         case 'before':
-          return isSameMonth(date, baseDate) || isBefore(date, baseDate);
+          return dayjs(date).isSame(baseDate, 'month') || dayjs(date).isBefore(baseDate);
         case 'after':
-          return isSameMonth(date, baseDate) || isAfter(date, baseDate);
+          return dayjs(date).isSame(baseDate, 'month') || dayjs(date).isAfter(baseDate);
       }
     };
 
@@ -87,7 +87,7 @@ export class MonthCalendar {
       if (!week) {
         return undefined;
       }
-      if (!isSameMonth(week[0], baseDate) && !isSameMonth(week[week.length - 1], baseDate)) {
+      if (!dayjs(week[0]).isSame(baseDate, 'month') && !dayjs(week[week.length - 1]).isSame(baseDate, 'month')) {
         return undefined;
       }
       return (getWeekTestIndex(weekIndex - 1) ?? 0) + 1;
@@ -100,7 +100,10 @@ export class MonthCalendar {
       for (let dayIndex = 0; dayIndex < daysOfWeek.length; dayIndex++) {
         const date = daysOfWeek[dayIndex];
         const isVisible = isDateVisible(weekIndex, dayIndex);
-        const isSelected = !!(selection && (isSameDay(date, selection[0]) || isSameDay(date, selection[1])));
+        const isSelected = !!(
+          selection &&
+          (dayjs(date).isSame(selection[0], 'day') || dayjs(date).isSame(selection[1], 'day'))
+        );
         const isInRange = isDateInRange(weekIndex, dayIndex);
         const isTop = isVisible && !isDateVisible(weekIndex - 1, dayIndex);
         const isBottom = isVisible && !isDateVisible(weekIndex + 1, dayIndex);
@@ -149,7 +152,7 @@ export class YearCalendar {
       if (!month) {
         return false;
       }
-      return isSameYear(month, baseDate);
+      return dayjs(month).isSame(baseDate, 'year');
     };
 
     for (let quarterIndex = 0; quarterIndex < allCalendarMonths.length; quarterIndex++) {
@@ -159,7 +162,10 @@ export class YearCalendar {
       for (let monthIndex = 0; monthIndex < monthsOfQuarter.length; monthIndex++) {
         const month = monthsOfQuarter[monthIndex];
         const isVisible = isMonthVisible(quarterIndex, monthIndex);
-        const isSelected = !!(selection && (isSameMonth(month, selection[0]) || isSameMonth(month, selection[1])));
+        const isSelected = !!(
+          selection &&
+          (dayjs(month).isSame(selection[0], 'month') || dayjs(month).isSame(selection[1], 'month'))
+        );
         const isInRange = isMonthInRange(quarterIndex, monthIndex);
         const isTop = isVisible && !isMonthVisible(quarterIndex - 1, monthIndex);
         const isBottom = isVisible && !isMonthVisible(quarterIndex + 1, monthIndex);
@@ -199,25 +205,27 @@ export function getCalendarMonthWithSixRows(
 }
 
 function checkDateIsInRange(date: Date, dateOne: Date | null, dateTwo: Date | null) {
-  if (!dateOne || !dateTwo || isSameDay(dateOne, dateTwo)) {
+  if (!dateOne || !dateTwo || dayjs(dateOne).isSame(dateTwo, 'day')) {
     return false;
   }
 
   const inRange =
-    (isAfter(date, dateOne) && isBefore(date, dateTwo)) || (isAfter(date, dateTwo) && isBefore(date, dateOne));
+    (dayjs(date).isAfter(dateOne) && dayjs(date).isBefore(dateTwo)) ||
+    (dayjs(date).isAfter(dateTwo) && dayjs(date).isBefore(dateOne));
 
-  return inRange || isSameDay(date, dateOne) || isSameDay(date, dateTwo);
+  return inRange || dayjs(date).isSame(dateOne, 'day') || dayjs(date).isSame(dateTwo, 'day');
 }
 
 function checkMonthIsInRange(date: Date, dateOne: Date | null, dateTwo: Date | null) {
-  if (!dateOne || !dateTwo || isSameMonth(dateOne, dateTwo)) {
+  if (!dateOne || !dateTwo || dayjs(dateOne).isSame(dateTwo, 'month')) {
     return false;
   }
 
   const inRange =
-    (isAfter(date, dateOne) && isBefore(date, dateTwo)) || (isAfter(date, dateTwo) && isBefore(date, dateOne));
+    (dayjs(date).isAfter(dateOne) && dayjs(date).isBefore(dateTwo)) ||
+    (dayjs(date).isAfter(dateTwo) && dayjs(date).isBefore(dateOne));
 
-  return inRange || isSameMonth(date, dateOne) || isSameMonth(date, dateTwo);
+  return inRange || dayjs(date).isSame(dateOne, 'month') || dayjs(date).isSame(dateTwo, 'month');
 }
 
 export function getCurrentMonthRows(date: Date, firstDayOfWeek: DayIndex) {
@@ -225,13 +233,13 @@ export function getCurrentMonthRows(date: Date, firstDayOfWeek: DayIndex) {
 }
 
 export function getPrevMonthRows(date: Date, firstDayOfWeek: DayIndex) {
-  const rows = getCalendarMonth(subMonths(date, 1), { firstDayOfWeek });
+  const rows = getCalendarMonth(dayjs(date).subtract(1, 'month').toDate(), { firstDayOfWeek });
   const lastDay = rows[rows.length - 1][rows[rows.length - 1].length - 1];
-  return !isSameMonth(date, lastDay) ? rows : rows.slice(0, -1);
+  return !dayjs(date).isSame(lastDay, 'month') ? rows : rows.slice(0, -1);
 }
 
 export function getNextMonthRows(date: Date, firstDayOfWeek: DayIndex) {
-  const rows = getCalendarMonth(addMonths(date, 1), { firstDayOfWeek });
+  const rows = getCalendarMonth(dayjs(date).add(1, 'month').toDate(), { firstDayOfWeek });
   const firstDay = rows[0][0];
-  return !isSameMonth(date, firstDay) ? rows : rows.slice(1);
+  return !dayjs(date).isSame(firstDay, 'month') ? rows : rows.slice(1);
 }

--- a/src/internal/utils/date-time/format-date-iso.ts
+++ b/src/internal/utils/date-time/format-date-iso.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { format, parseISO } from 'date-fns';
+import dayjs from 'dayjs';
 
 import { formatTimeOffsetISO } from './format-time-offset';
 
@@ -20,7 +20,7 @@ export default function ({
 }) {
   const formattedOffset = hideTimeOffset || isDateOnly || isMonthOnly ? '' : formatTimeOffsetISO(isoDate, timeOffset);
   if (isMonthOnly) {
-    return format(parseISO(isoDate), 'yyyy-MM');
+    return dayjs(isoDate).format('YYYY-MM');
   }
   return isoDate + formattedOffset;
 }

--- a/src/internal/utils/date-time/format-date-localized.ts
+++ b/src/internal/utils/date-time/format-date-localized.ts
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { isValid, parseISO } from 'date-fns';
-
 import { formatTimeOffsetLocalized } from './format-time-offset';
+import { isIsoDateOnly, isIsoMonthOnly } from './is-iso-only';
 
 export default function formatDateLocalized({
   date: isoDate,
@@ -19,17 +18,28 @@ export default function formatDateLocalized({
   timeOffset?: number;
   locale?: string;
 }) {
-  let date = parseISO(isoDate);
-  // if the date is not ISO formatted, fallback to built-in date parsing
-  if (!isValid(date)) {
-    date = new Date(isoDate);
+  // Check if the date is valid
+  const dateObject = new Date(isoDate);
+  if (isNaN(dateObject.getTime())) {
+    // Preserve original behavior: throw RangeError for invalid dates
+    throw new RangeError('Invalid time value');
   }
+
+  // Detect if the ISO string has a timezone suffix (Z or +/-HH:MM)
+  const hasTimezone = /Z|[+-]\d{2}:\d{2}$/.test(isoDate);
+
+  // For ISO datetime strings with timezone, or date-only/month-only formats, use UTC
+  // For ISO datetime strings without timezone, or non-ISO strings, use local time
+  const useUTC = hasTimezone || isIsoDateOnly(isoDate) || isIsoMonthOnly(isoDate);
+
+  const timezoneOption = useUTC ? { timeZone: 'UTC' as const } : {};
 
   if (isMonthOnly) {
     const formattedMonthDate = new Intl.DateTimeFormat(locale, {
       month: 'long',
       year: 'numeric',
-    }).format(date);
+      ...timezoneOption,
+    }).format(dateObject);
 
     return formattedMonthDate;
   }
@@ -38,7 +48,8 @@ export default function formatDateLocalized({
     month: 'long',
     year: 'numeric',
     day: 'numeric',
-  }).format(date);
+    ...timezoneOption,
+  }).format(dateObject);
 
   if (isDateOnly) {
     return formattedDate;
@@ -49,7 +60,8 @@ export default function formatDateLocalized({
     hourCycle: 'h23',
     minute: '2-digit',
     second: '2-digit',
-  }).format(date);
+    ...timezoneOption,
+  }).format(dateObject);
 
   const formattedDateTime = formattedDate + getDateTimeSeparator(locale) + formattedTime;
 

--- a/src/internal/utils/date-time/format-time-offset.ts
+++ b/src/internal/utils/date-time/format-time-offset.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { padLeftZeros } from '../strings';
+import { parseTimezoneOffset } from './parse-timezone-offset';
 
 /**
  * Formats timezone offset values used in for APIs, maintaining backward compatibility. Always
@@ -51,7 +52,7 @@ export function formatTimeOffsetLocalized(isoDate: string, offsetInMinutes?: num
 }
 
 function defaultToLocal(isoDate: string, offsetInMinutes?: number) {
-  return offsetInMinutes ?? 0 - new Date(isoDate).getTimezoneOffset();
+  return offsetInMinutes ?? parseTimezoneOffset(isoDate);
 }
 
 function getMinutesAndHours(minutes: number) {

--- a/src/internal/utils/date-time/shift-timezone-offset.ts
+++ b/src/internal/utils/date-time/shift-timezone-offset.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { addMinutes } from 'date-fns';
+import dayjs from 'dayjs';
 
 import { joinDateTime } from '.';
 import { formatDate } from './format-date';
@@ -26,7 +26,9 @@ export function shiftTimezoneOffset(dateString: string, targetTimezoneOffset?: n
 
   const date = new Date(valueWithoutOffset);
   targetTimezoneOffset = targetTimezoneOffset ?? 0 - date.getTimezoneOffset();
-  const adjustedDate = addMinutes(date, targetTimezoneOffset - originalTimezoneOffset);
+  const adjustedDate = dayjs(date)
+    .add(targetTimezoneOffset - originalTimezoneOffset, 'minute')
+    .toDate();
 
   return joinDateTime(formatDate(adjustedDate), formatTime(adjustedDate));
 }

--- a/src/s3-resource-selector/s3-modal/__tests__/fetching.test.tsx
+++ b/src/s3-resource-selector/s3-modal/__tests__/fetching.test.tsx
@@ -138,7 +138,7 @@ test('dives into folders containing slashes in names', async () => {
 
 describe('last updated status text', () => {
   beforeEach(() => {
-    const lastUpdatedDate = new Date('2024-01-02T10:00:00.000Z');
+    const lastUpdatedDate = new Date(2024, 0, 2, 10, 0, 0); // January 2, 2024, 10:00:00 in local time
     jest.useFakeTimers().setSystemTime(lastUpdatedDate);
   });
 
@@ -158,7 +158,7 @@ describe('last updated status text', () => {
     await clickRefreshAndWaitForFetch();
     await waitFor(() => {
       const lastUpdated = createWrapper().find('[aria-live="polite"]')!.getElement();
-      expect(lastUpdated.textContent).toBe('Last updated January 2, 2024, 10:00:00 (UTC)');
+      expect(lastUpdated.textContent).toMatch(/^Last updated January 2, 2024, 10:00:00 \(UTC[+-]?\d*\)$/);
     });
   });
 
@@ -166,12 +166,12 @@ describe('last updated status text', () => {
     const wrapper = await renderModal(<S3Modal {...modalDefaultProps} />);
     await waitForFetch();
 
-    const refreshFetchDate = new Date('2024-01-02T11:00:00.000Z');
+    const refreshFetchDate = new Date(2024, 0, 2, 11, 0, 0); // January 2, 2024, 11:00:00 in local time
     jest.useFakeTimers().setSystemTime(refreshFetchDate);
     await clickRefreshAndWaitForFetch();
 
     const lastUpdated = wrapper.findByClassName(styles['last-updated-caption'])!.getElement();
-    expect(lastUpdated).toHaveTextContent('Last updatedJanuary 2, 2024, 11:00:00 (UTC)');
+    expect(lastUpdated).toHaveTextContent(/Last updatedJanuary 2, 2024, 11:00:00 \(UTC[+-]?\d*\)/);
   });
 
   test('does not render "Last updated" when the i18n label is not specified', async () => {


### PR DESCRIPTION
### Description

This PR replaces the date-fns dependency with dayjs, a more lightweight alternative. This should not affect any functionality. The intent is purely to reduce bundle size and, secondarily, `node_modules` weight.

#### Estimated performance impact

For a production site that doesn't use `date-fns` outside of Cloudscape, this change should reduce the size of the minified JavaScript bundle by ~40 KB, enough to improve page load times by ~10ms for a typical user.

### How has this been tested?

All unit tests are passing. I haven't been able to run the integration tests on my machine, so please let me know if there are any issues with those.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_ ✅
- _Changes are covered with new/existing integration tests?_ ✅
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
