### PR TITLE
perf: Remove outdated array ponyfills

### DIFF
--- a/src/internal/hooks/forward-focus/radio-group.ts
+++ b/src/internal/hooks/forward-focus/radio-group.ts
@@ -16,7 +16,7 @@ export default function useRadioGroupForwardFocus(
   value: string | null
 ): [React.Ref<HTMLInputElement>, number] {
   const itemRef = useRef<HTMLInputElement | null>(null);
-  const itemIndex = items && findIndex(items, item => item.value === value);
+  const itemIndex = items && items.findIndex(item => item.value === value);
   useImperativeHandle(forwardedRef, () => ({
     focus() {
       itemRef.current?.focus();
@@ -24,13 +24,4 @@ export default function useRadioGroupForwardFocus(
   }));
 
   return [itemRef, itemIndex !== undefined && itemIndex !== -1 ? itemIndex : 0];
-}
-
-function findIndex<T>(items: ReadonlyArray<T>, predicate: (t: T) => any): number {
-  for (let i = 0; i < items.length; i++) {
-    if (predicate(items[i])) {
-      return i;
-    }
-  }
-  return -1;
 }

--- a/src/mixed-line-bar-chart/domain.ts
+++ b/src/mixed-line-bar-chart/domain.ts
@@ -50,16 +50,6 @@ export function computeDomainX<T>(series: readonly InternalChartSeries<T>[], xSc
   }, [] as T[]);
 }
 
-function find<Q>(arr: readonly Q[], func: (el: Q) => boolean) {
-  for (let i = 0; i < arr.length; i++) {
-    const found = func(arr[i]);
-    if (found) {
-      return arr[i];
-    }
-  }
-  return null;
-}
-
 export function computeDomainY<T>(
   series: readonly InternalChartSeries<T>[],
   scaleType: 'linear' | 'log',
@@ -74,7 +64,7 @@ export function computeDomainY<T>(
         if (curr.series.type === 'bar') {
           curr.series.data.forEach(({ x, y }) => {
             const data = y < 0 ? acc.negativeData : acc.positiveData;
-            const stackedDatum = find(data, el => matchesX(el.x, x));
+            const stackedDatum = data.find(el => matchesX(el.x, x));
             if (stackedDatum) {
               stackedDatum.y += y;
             } else {
@@ -85,32 +75,13 @@ export function computeDomainY<T>(
         }
         return acc;
       },
-      {
-        positiveData: [] as MixedLineBarChartProps.Datum<T>[],
-        negativeData: [] as MixedLineBarChartProps.Datum<T>[],
-      }
+      { positiveData: [] as MixedLineBarChartProps.Datum<T>[], negativeData: [] as MixedLineBarChartProps.Datum<T>[] }
     );
 
     // Artificial series with the sum of all bars when stacked
     const stackedSeries: InternalChartSeries<T>[] = [
-      {
-        color: '',
-        index: NaN,
-        series: {
-          type: 'bar',
-          title: 'positive',
-          data: positiveData as any,
-        },
-      },
-      {
-        color: '',
-        index: NaN,
-        series: {
-          type: 'bar',
-          title: 'negative',
-          data: negativeData as any,
-        },
-      },
+      { color: '', index: NaN, series: { type: 'bar', title: 'positive', data: positiveData as any } },
+      { color: '', index: NaN, series: { type: 'bar', title: 'negative', data: negativeData as any } },
     ];
 
     // MixedLineBarChart can also contain other non-bar series,

--- a/src/s3-resource-selector/s3-modal/table-utils.ts
+++ b/src/s3-resource-selector/s3-modal/table-utils.ts
@@ -5,7 +5,7 @@ import { TableProps } from '../../table/interfaces';
 import { S3ResourceSelectorProps } from '../interfaces';
 
 export function includes<T>(array: ReadonlyArray<T> | undefined, item: T) {
-  return !!array && array.indexOf(item) > -1;
+  return !!array && array.includes(item);
 }
 
 export const compareDates = (itemA: string | undefined, itemB: string | undefined) => {

--- a/src/tag-editor/index.tsx
+++ b/src/tag-editor/index.tsx
@@ -21,7 +21,7 @@ import InternalLiveRegion from '../live-region/internal';
 import InternalStatusIndicator from '../status-indicator/internal';
 import { TagEditorProps } from './interfaces';
 import { TagControl, UndoButton } from './internal';
-import { findIndex, useMemoizedArray } from './utils';
+import { useMemoizedArray } from './utils';
 import { getTagsDiff } from './utils';
 import { validate, ValidationError } from './validation';
 
@@ -91,7 +91,7 @@ const TagEditor = React.forwardRef(
       ref,
       () => ({
         focus() {
-          const errorIndex = findIndex(internalTags, ({ error }) => error?.key || error?.value);
+          const errorIndex = internalTags.findIndex(({ error }) => error?.key || error?.value);
           if (errorIndex !== -1) {
             const refArray = internalTags[errorIndex].error?.key ? keyInputRefs : valueInputRefs;
             refArray.current[errorIndex]?.focus();

--- a/src/tag-editor/utils.ts
+++ b/src/tag-editor/utils.ts
@@ -7,18 +7,6 @@ import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import { isDevelopment } from '../internal/is-development';
 import { TagEditorProps } from './interfaces';
 
-/**
- * Ponyfill for Array.prototype.findIndex.
- */
-export function findIndex<T>(array: ReadonlyArray<T>, condition: (t: T) => unknown): number {
-  for (let i = 0; i < array.length; i++) {
-    if (condition(array[i])) {
-      return i;
-    }
-  }
-  return -1;
-}
-
 function makeMemoizedArray<T>(
   prev: ReadonlyArray<T>,
   next: ReadonlyArray<T>,


### PR DESCRIPTION
All target browsers have long supported the array functions `findIndex`, `find`, and `includes`. This PR removes "ponyfills" that redefine those functions.

MDN:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex#browser_compatibility

### How has this been tested?

✅ All unit tests pass.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
