### PR TITLE
chore: Silence circular dependency warning from d3-interpolate

### DIFF
--- a/vendor/rollup.config.mjs
+++ b/vendor/rollup.config.mjs
@@ -17,6 +17,15 @@ export default ['d3-scale', 'react-virtual'].map(entry => ({
     format: 'es',
   },
   external: ['react', 'react-dom'],
+  onwarn(warning, warn) {
+    // Suppress circular dependency warnings for d3-interpolate
+    // These are known harmless circular dependencies acknowledged by d3 maintainers
+    // See: https://github.com/d3/d3-interpolate/issues/58, https://github.com/d3/d3-interpolate/issues/71
+    if (warning.code === 'CIRCULAR_DEPENDENCY' && warning.ids.some(id => id.includes('d3-interpolate'))) {
+      return;
+    }
+    warn(warning);
+  },
   plugins: [
     resolve({
       extensions: ['.js'],


### PR DESCRIPTION
Builds emit this warning:

```
./src/internal/vendor/d3-scale.js → lib/components/internal/vendor...
(!) Circular dependencies
node_modules/d3-interpolate/src/value.js -> node_modules/d3-interpolate/src/array.js -> node_modules/d3-interpolate/src/value.js
node_modules/d3-interpolate/src/value.js -> node_modules/d3-interpolate/src/object.js -> node_modules/d3-interpolate/src/value.js
created lib/components/internal/vendor in 260ms
```

This is due to a known issue in `d3-interpolate`, which the maintainers
of that package content is not a bug:
https://github.com/d3/d3-interpolate/issues/58

Since the warning isn't actionable, this PR silences it.

### How has this been tested?

This change to the Rollup config should have no effect on the build output.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
