### PR TITLE
fix: Adjusts use-virtual safety counter to prevent max update depth crashes

### DIFF
--- a/src/internal/hooks/use-virtual/index.ts
+++ b/src/internal/hooks/use-virtual/index.ts
@@ -5,7 +5,11 @@ import React, { useEffect, useMemo, useRef } from 'react';
 import { useVirtual as useVirtualDefault, VirtualItem } from '../../vendor/react-virtual';
 import stickyRangeExtractor from './sticky-range-extractor';
 
-const MAX_ITEM_MOUNTS = 100;
+// Maximum allowed synchronous (nested) item mounts before forcing a bail-out.
+// Mirrors React’s internal safeguard for nested updates: React throws
+// "Maximum update depth exceeded" once >50 sync updates occur within a single commit.
+// See: https://github.com/facebook/react/commit/d8c90fa48d3addefe4b805ec56a3c65e4ee39127
+const MAX_ITEM_MOUNTS = 50 - 1;
 
 interface UseVirtualProps<Item> {
   items: readonly Item[];


### PR DESCRIPTION
### Description

In the PR we update the bail-out counter in the use-virtual to match React's one for "Maximum update depth exceeded". Over time, the React counter changed from 50 to 100 and then back to 50. We use 49 just for extra safety. A lower counter means that there is a chance the virtual frame does not have enough opportunity to settle down, which increases a risk of virtual frame computation errors (some items can appear smaller or larger than they should).

Rel: AWSUI-61148

### How has this been tested?

* We don't have a reliable test for this one, but we got reports logging the "Maximum update depth exceeded". We will monitor if the PR will help getting rid of those.

Update: there is a way to test this, although the exact correlation between our counter and the React one is not quite clear. We can consistently reproduce the error when using the MAX_ITEM_MOUNTS=102 and above. To reproduce, it is enough to artificially modify the code in `src/autosuggest/virtual-list.tsx` so that item dimensions update depending on the calculated virtual frame props:

```
<AutosuggestOption
  // ...other props
  option={{
    ...item,
    label:
      virtualRow.size < 40
        ? item.label +
       '????????????????????????????????????????????????????????????????????????????????????????????????????????????'
        : item.label,
  }}
/>
```

https://github.com/user-attachments/assets/5f6c33cf-e7c3-4c68-aec8-6cf4f3ac0b41




<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
