### PR TITLE
chore: consistently use direct imports for Lodash functions

### DIFF
--- a/src/__a11y__/to-validate-a11y.ts
+++ b/src/__a11y__/to-validate-a11y.ts
@@ -3,7 +3,8 @@
 
 import Axe from 'axe-core';
 import { HtmlValidate } from 'html-validate';
-import { compact, uniq } from 'lodash';
+import compact from 'lodash/compact';
+import uniq from 'lodash/uniq';
 
 import { runOptions, spec } from './axe';
 

--- a/src/__tests__/snapshot-tests/test-utils-selectors.test.tsx
+++ b/src/__tests__/snapshot-tests/test-utils-selectors.test.tsx
@@ -4,7 +4,8 @@
 import { NodePath, PluginObj, transformSync, types } from '@babel/core';
 import fs from 'fs';
 import * as glob from 'glob';
-import { flatten, zip } from 'lodash';
+import flatten from 'lodash/flatten';
+import zip from 'lodash/zip';
 import path from 'path';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/src/area-chart/__tests__/area-chart-initial-state.test.tsx
+++ b/src/area-chart/__tests__/area-chart-initial-state.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { render } from '@testing-library/react';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import { KeyCode } from '@cloudscape-design/test-utils-core/utils';

--- a/src/button-group/__integ__/button-group.test.ts
+++ b/src/button-group/__integ__/button-group.test.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';

--- a/src/i18n/__tests__/i18n.test.tsx
+++ b/src/i18n/__tests__/i18n.test.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import * as IntlMessageFormat from 'intl-messageformat';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import { I18nProvider, I18nProviderProps } from '../../../lib/components/i18n';
 import { namespace } from '../../../lib/components/i18n/context';

--- a/src/multiselect/__integ__/select-all.test.ts
+++ b/src/multiselect/__integ__/select-all.test.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';

--- a/src/table/table-role/__integ__/grid-navigation.test.ts
+++ b/src/table/table-role/__integ__/grid-navigation.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 


### PR DESCRIPTION
This commit replaces barrel imports like

```
import { range } from 'lodash'
```

with direct imports like

```
import range from 'lodash/range'
```

All of these imports are in test code (Lodash is a devDependency only), so this won't affect the build. But it will make code style more consistent, and it should slightly improve test performance.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
