### PR TITLE
chore: Add prefer-object-spread rule to ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,6 +109,7 @@ export default tsEslint.config(
       'dot-notation': 'error',
       eqeqeq: 'error',
       'no-return-await': 'error',
+      'prefer-object-spread': 'error',
       'require-await': 'error',
       'header/header': [
         'error',

--- a/src/app-layout/visual-refresh-toolbar/state/props-merger.ts
+++ b/src/app-layout/visual-refresh-toolbar/state/props-merger.ts
@@ -20,7 +20,7 @@ function checkAlreadyExists(value: boolean, propName: string) {
 export const mergeProps: MergeProps = (ownProps, additionalProps) => {
   const toolbar: ToolbarProps = {};
   for (const props of [ownProps, ...additionalProps]) {
-    toolbar.ariaLabels = Object.assign(toolbar.ariaLabels ?? {}, props.ariaLabels);
+    toolbar.ariaLabels = { ...toolbar.ariaLabels, ...props.ariaLabels };
     if (
       props.drawers &&
       props.drawers.some(drawer => drawer.trigger) &&

--- a/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
+++ b/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
@@ -143,6 +143,7 @@ describe('CopyToClipboard', () => {
 
     describe('when the clipboard API is not available', () => {
       beforeEach(() => Object.assign(global.navigator, { clipboard: undefined }));
+
       afterEach(() => Object.assign(global.navigator, { clipboard: originalNavigatorClipboard }));
 
       test('fails to copy to clipboard and shows error message', async () => {


### PR DESCRIPTION
This commit enables the `prefer-object-spread` rule to automatically transform `Object.assign` calls that are equivalent to spreads, and fixes one violation of the rule.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
