### PR TITLE
chore: Remove legacy support for browsers without CSS custom properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
         "ace-builds": "^1.34.0",
-        "balanced-match": "^1.0.2",
         "clsx": "^1.1.0",
         "d3-shape": "^1.3.7",
         "date-fns": "^2.25.0",
@@ -5364,6 +5363,7 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.1",
     "ace-builds": "^1.34.0",
-    "balanced-match": "^1.0.2",
     "clsx": "^1.1.0",
     "d3-shape": "^1.3.7",
     "date-fns": "^2.25.0",

--- a/src/internal/utils/__tests__/dom.test.ts
+++ b/src/internal/utils/__tests__/dom.test.ts
@@ -1,48 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  findUpUntilMultiple,
-  isHTMLElement,
-  isNode,
-  isSVGElement,
-  parseCssVariable,
-} from '../../../../lib/components/internal/utils/dom';
-
-describe('parseCssVariable', () => {
-  [true, false].forEach(supports => {
-    const testCssVariable = (testName: string, input: string, output: string) =>
-      test(`${testName}`, () => expect(parseCssVariable(input)).toBe(supports ? input : output));
-
-    describe(`with${supports ? '' : 'out'} CSS variable support`, () => {
-      const originalCSS = window.CSS;
-
-      beforeAll(() => {
-        window.CSS.supports = () => supports;
-      });
-
-      afterAll(() => {
-        window.CSS = originalCSS;
-      });
-
-      testCssVariable('returns the given value if no Custom Property is used', '#000000', '#000000');
-      testCssVariable('parses variable with hex fallback', 'var(--mycolor, #1f1f1f)', '#1f1f1f');
-      testCssVariable('parses variable with rgb fallback', 'var(--mycolor, rgba(0, 200,10))', 'rgba(0, 200,10)');
-      testCssVariable('parses variable with named color fallback', 'var(--mycolor, green)', 'green');
-      testCssVariable('parses nested variables', 'var(--mycolor,var(--other-color,#1f1f1f)  )', '#1f1f1f');
-      testCssVariable(
-        'parses more nested variables',
-        'var(--mycolor, var(--other-color, rgba(0, 10, 200, 0.5)))',
-        'rgba(0, 10, 200, 0.5)'
-      );
-      testCssVariable(
-        'ignores white space',
-        'var(  --mycolor   ,  var(  --other-color, rgba(0, 10, 200, 0.5))  )',
-        'rgba(0, 10, 200, 0.5)'
-      );
-    });
-  });
-});
+import { findUpUntilMultiple, isHTMLElement, isNode, isSVGElement } from '../dom';
 
 test('an HTMLElement is recognized as a Node and HTMLElement', () => {
   const div = document.createElement('div');
@@ -82,9 +41,10 @@ describe('findUpUntilMultiple', () => {
         <div id="second" class="match"><div id="target"></div></div>
       </div>
     `;
+    const targetElement = div.querySelector('#target') as HTMLElement;
     expect(
       findUpUntilMultiple({
-        startElement: div.querySelector<HTMLElement>('#target')!,
+        startElement: targetElement,
         tests: { first: node => node.id === 'first', second: node => node.id === 'second' },
       })
     ).toEqual({ first: expect.objectContaining({ id: 'first' }), second: expect.objectContaining({ id: 'second' }) });
@@ -105,9 +65,10 @@ describe('findUpUntilMultiple', () => {
         </svg>
       </div>
     `;
+    const targetElement = div.querySelector('#target') as HTMLElement;
     expect(
       findUpUntilMultiple({
-        startElement: div.querySelector<HTMLElement>('#target')!,
+        startElement: targetElement,
         tests: { first: testFn, second: testFn },
       })
     ).toEqual({ first: expect.objectContaining({ id: 'match' }), second: expect.objectContaining({ id: 'match' }) });

--- a/src/internal/utils/create-category-color-scale.ts
+++ b/src/internal/utils/create-category-color-scale.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { colorChartsThresholdNeutral as thresholdColor } from '../generated/styles/tokens';
 import { categoryPalette } from '../styles/colors';
-import { parseCssVariable } from './dom';
 
 export default function createCategoryColorScale<T>(
   items: readonly T[],
@@ -15,7 +14,7 @@ export default function createCategoryColorScale<T>(
   for (const it of items) {
     const ownColor = getOwnColor(it);
     const defaultColor = isThreshold(it) ? thresholdColor : categoryPalette[categoryIndex % categoryPalette.length];
-    colors.push(parseCssVariable(ownColor || defaultColor));
+    colors.push(ownColor || defaultColor);
 
     if (!isThreshold(it) && !ownColor) {
       categoryIndex++;

--- a/src/internal/utils/dom.ts
+++ b/src/internal/utils/dom.ts
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import balanced from 'balanced-match';
-
 import { findUpUntil } from '@cloudscape-design/component-toolkit/dom';
 
 export function isContainingBlock(element: HTMLElement): boolean {
@@ -56,37 +54,6 @@ export function findUpUntilMultiple({
     }
   }
   return elements;
-}
-
-const cssVariableExpression = /--.+?\s*,\s*(.+)/;
-
-/**
- * Parses a CSS color value that might contain CSS Custom Properties
- * and returns a value that will be understood by the browser, no matter of support level.
- * If the browser support CSS Custom Properties, the value will be return as is. Otherwise,
- * the fallback value will be extracted and returned instead.
- */
-export function parseCssVariable(value: string) {
-  if (typeof window === 'undefined') {
-    return value;
-  }
-
-  if (window.CSS?.supports?.('color', 'var(--dummy, #000)') ?? false) {
-    return value;
-  }
-
-  const varIndex = value.lastIndexOf('var(');
-  if (varIndex === -1) {
-    return value;
-  }
-
-  const expr = balanced('(', ')', value.substr(varIndex));
-  if (!expr) {
-    return value;
-  }
-
-  const match = expr.body.match(cssVariableExpression);
-  return match ? match[1] : value;
 }
 
 // The instanceof Node/HTMLElement/SVGElement checks can fail if the target element

--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -115,11 +115,7 @@ const thresholdSeries: MixedLineBarChartProps.ThresholdSeries = {
   y: 6,
 };
 
-// Mock support for CSS Custom Properties in Jest so that we assign the correct colors.
-// Transformation to fallback colors for browsers that don't support them are covered by the `parseCssVariable` utility.
-const originalCSS = window.CSS;
-
-const originalGetComputedStyle = window.getComputedStyle;
+let originalGetComputedStyle: Window['getComputedStyle'];
 const fakeGetComputedStyle: Window['getComputedStyle'] = (...args) => {
   const result = originalGetComputedStyle(...args);
   result.borderWidth = '2px'; // Approximate mock value for the popover body' border width
@@ -129,12 +125,11 @@ const fakeGetComputedStyle: Window['getComputedStyle'] = (...args) => {
 };
 
 beforeEach(() => {
-  window.CSS.supports = () => true;
+  originalGetComputedStyle = window.getComputedStyle;
   window.getComputedStyle = fakeGetComputedStyle;
   jest.resetAllMocks();
 });
 afterEach(() => {
-  window.CSS = originalCSS;
   window.getComputedStyle = originalGetComputedStyle;
 });
 
@@ -439,15 +434,6 @@ describe('Series', () => {
         expect(wrapper.findSeries()).toHaveLength(2);
       });
     });
-  });
-
-  test('CSS color variables are changed to fallback values in unsupported browsers', () => {
-    window.CSS.supports = () => false;
-
-    const { wrapper } = renderMixedChart(
-      <MixedLineBarChart series={[{ ...lineSeries, color: 'var(--mycolor, red)' }]} />
-    );
-    expect(wrapper.findSeries()[0].find('path')?.getElement()).toHaveAttribute('stroke', 'red');
   });
 
   test('should warn when `series` changes with uncontrolled `visibleSeries`', () => {


### PR DESCRIPTION
This commit removes legacy code aimed at browsers that lack support for CSS custom properties, which are supported by all targeted browsers.

Removing this code allows the `balanced-match` dependency to be dropped.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
