### PR TITLE
chore: Update tsconfig target to ES2021

### DIFF
--- a/pages/tsconfig.json
+++ b/pages/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "lib": ["ES2020", "DOM"],
-    "target": "ES2015",
+    "lib": ["ES2021", "DOM"],
+    "target": "ES2021",
     "declaration": false,
     "declarationMap": false,
     "rootDir": ".",

--- a/src/test-utils/tsconfig.json
+++ b/src/test-utils/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
+    "lib": ["ES2021", "DOM"],
+    "target": "ES2021",
     "strict": true,
     "incremental": true,
     "types": [],
     "module": "CommonJS",
-    "target": "ES2015",
-    "lib": ["ES2020", "DOM"],
     "declaration": true,
     "allowSyntheticDefaultImports": true,
     "outDir": "../../lib/components/test-utils",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["ES2021", "DOM"],
-    "target": "ES2015",
+    "target": "ES2021",
     "types": [],
     "module": "ES2015",
     "moduleResolution": "node",
@@ -15,11 +15,5 @@
     "incremental": true
   },
   "include": ["src", "types"],
-  "exclude": [
-    "**/__tests__/**",
-    "src/test-utils/**",
-    "**/__integ__/**",
-    "**/__a11y__/**",
-    "**/__motion__/**"
-  ]
+  "exclude": ["**/__tests__/**", "src/test-utils/**", "**/__integ__/**", "**/__a11y__/**", "**/__motion__/**"]
 }

--- a/tsconfig.unit.json
+++ b/tsconfig.unit.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2018",
-    "lib": ["es2020", "dom"],
+    "lib": ["ES2021", "DOM"],
+    "target": "ES2021",
     "types": ["node", "jest", "@testing-library/jest-dom"],
     "moduleResolution": "node",
     "downlevelIteration": true,


### PR DESCRIPTION
All targeted browsers support ES2021 syntax. This change provides an immediate bundle size reduction, with the potential for further gains if code is rewritten to take advantage of optional chaining and nullish coalescing.

* Optional chaining:
  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#browser_compatibility
* Nullish coalescing:
  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing#browser_compatibility

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
