### PR TITLE
feat: add tag and filtering tag to property filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,6 +1206,216 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@cloudscape-design/browser-test-tools": {
+      "version": "3.0.98",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/browser-test-tools/-/browser-test-tools-3.0.98.tgz",
+      "integrity": "sha512-VdDkRQugzu4D5Z/ByVjTxwTK24GENEUNH+ieJswC/36yHpsCt0f6+1wVzm8wiMMh+1AwVaZi+G6/DJfNDMNWNg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-device-farm": "^3.623.0",
+        "@types/pngjs": "^6.0.4",
+        "@wdio/globals": "^9.7.0",
+        "@wdio/types": "^9.6.3",
+        "get-stream": "^6.0.1",
+        "lodash": "^4.17.21",
+        "p-retry": "^4.6.2",
+        "pixelmatch": "^5.3.0",
+        "pngjs": "^6.0.0",
+        "wait-on": "^8.0.3",
+        "webdriverio": "^9.7.0"
+      }
+    },
+    "node_modules/@cloudscape-design/build-tools": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/build-tools/-/build-tools-3.0.14.tgz",
+      "integrity": "sha512-eejlOMV1Z7t4/W9OhI+bjLz99YmwkH2HPG35LI8hiboHwA8ZDBQUkETZrDlrkTnPGAZ/gU1DRAwkPXRmBLmNGQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^10.0.1"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.8.1"
+      }
+    },
+    "node_modules/@cloudscape-design/collection-hooks": {
+      "version": "1.0.74",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/collection-hooks/-/collection-hooks-1.0.74.tgz",
+      "integrity": "sha512-yAcD7vjFqbwqMCamUcKRXp403u8RcmC9izyPEYiWod9elt7x0GT1ypPyo9ZRyQuFrBsv2nwubBUrChcYaWooZw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@cloudscape-design/component-toolkit": {
+      "version": "1.0.0-beta.116",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.116.tgz",
+      "integrity": "sha512-fSEhFK4OaRS9fBdJg4824wVLFpS28izLF0oQZ1QtRyhSZ4e6OxXWUT7GS1f/ACn+UJ6vk9Y7qDCsdGoPFd3NAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.3.1",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@cloudscape-design/documenter": {
+      "version": "1.0.57",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/documenter/-/documenter-1.0.57.tgz",
+      "integrity": "sha512-7JlqoIq36t2iFNxqkm+UYXHIHopl4qeb22sopim3GEXzi+2oJ3KI6SXV+FOEZyQ+1wff0KYGv8GkucZWTMrscQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "change-case": "^4.1.1",
+        "micromatch": "^4.0.8",
+        "pathe": "^1.1.2",
+        "typedoc": "~0.19.2"
+      }
+    },
+    "node_modules/@cloudscape-design/global-styles": {
+      "version": "1.0.45",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.45.tgz",
+      "integrity": "sha512-fSrbVpK9W+bg8tmUYqU9Wh2JGciUCGEByVUQDbgMY6feXtYEUKRP2MBL6kEHvoJB7lssZbHdh5/gYaiyxg+P5w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@cloudscape-design/jest-preset": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/jest-preset/-/jest-preset-2.0.47.tgz",
+      "integrity": "sha512-LYeM1zhtCcEi6Ux5l4Px04nlZQp1Y3satOJiyapZF42cn9b9uZbI79/V5wJm8+WM4y3vYBlQkmnikU0UiveZuw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/plugin-transform-modules-commonjs": "^7.9.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "babel-jest": ">=24",
+        "jest": ">=24"
+      }
+    },
+    "node_modules/@cloudscape-design/test-utils-converter": {
+      "version": "1.0.63",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/test-utils-converter/-/test-utils-converter-1.0.63.tgz",
+      "integrity": "sha512-tvp+qxXIxaa0KrA01wkNakBzsW48OdVmpzMqJlevRGAjqR9MSPr0t48a8i6v9JPCSxK6JgZWdXHCOXGnx92KPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "^7.16.0",
+        "@babel/plugin-syntax-decorators": "^7.16.0",
+        "@babel/plugin-syntax-typescript": "^7.16.0",
+        "glob": "^7.2.0"
+      }
+    },
+    "node_modules/@cloudscape-design/test-utils-converter/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@cloudscape-design/test-utils-converter/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@cloudscape-design/test-utils-core": {
+      "version": "1.0.63",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/test-utils-core/-/test-utils-core-1.0.63.tgz",
+      "integrity": "sha512-2w3y7gJ9LcaPjswe0SMr/lI6D/uwIDAS0+UDEYIkvecTlPhnowZJj1fazPuH1TFnN+r+y2EPXTKNwfGFAQJseA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "css-selector-tokenizer": "^0.8.0",
+        "css.escape": "^1.5.1"
+      }
+    },
+    "node_modules/@cloudscape-design/theming-build": {
+      "version": "1.0.89",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-build/-/theming-build-1.0.89.tgz",
+      "integrity": "sha512-Eq6N8x66dPJn6cFQqo2K+RYj2fLA8Bk4kLCX/ohEDYlbFCwJc6MZVumeHuFBj5jRu4ASHX8GHckVuZpn4/lCjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "autoprefixer": "^10.4.8",
+        "glob": "^7.2.3",
+        "jsonschema": "^1.4.1",
+        "loader-utils": "^3.2.1",
+        "lodash": "^4.17.21",
+        "postcss": "^8.4.31",
+        "postcss-discard-empty": "^6.0.0",
+        "postcss-inline-svg": "^6.0.0",
+        "postcss-modules": "^6.0.0",
+        "sass": "^1.77.8",
+        "string-hash": "^1.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@cloudscape-design/theming-build/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@cloudscape-design/theming-build/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@cloudscape-design/theming-runtime": {
+      "version": "1.0.82",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-runtime/-/theming-runtime-1.0.82.tgz",
+      "integrity": "sha512-YNpr4JZ5tJWjAcfH1JKAup2mZvIeA9YgPfaDpAE3DuD1sgaELb9yGGR+pMc2xWZMO2OEK3BPdZfLiXEWFaIBRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",
       "dev": true,

--- a/pages/property-filter/tags-demo.page.tsx
+++ b/pages/property-filter/tags-demo.page.tsx
@@ -1,0 +1,258 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import { Box, Container, Header, PropertyFilter, SpaceBetween } from '~components';
+import { PropertyFilterProps } from '~components/property-filter';
+
+import { i18nStrings, labels } from './common-props';
+
+// Sample filtering properties for the demo
+const filteringProperties: PropertyFilterProps.FilteringProperty[] = [
+  {
+    key: 'service',
+    propertyLabel: 'Service',
+    groupValuesLabel: 'Service values',
+    operators: ['=', '!=', ':', '!:'],
+  },
+  {
+    key: 'environment',
+    propertyLabel: 'Environment',
+    groupValuesLabel: 'Environment values',
+    operators: ['=', '!=', ':', '!:'],
+  },
+  {
+    key: 'logGroup',
+    propertyLabel: 'Log group',
+    groupValuesLabel: 'All log groups', // Use "All log groups" as the group header
+    operators: [
+      // Set token type for equals and not equals operators as enum so that
+      // the default multi-choice form and formatter are used.
+      { operator: '=', tokenType: 'enum' },
+      { operator: '!=', tokenType: 'enum' },
+      // Keep token type for contains and not contains operators as is.
+      ':',
+      '!:',
+    ],
+    defaultOperator: '=',
+  },
+];
+
+// Sample filtering options with various tag configurations
+const filteringOptions: PropertyFilterProps.FilteringOption[] = [
+  // Simple test options with tags
+  {
+    propertyKey: 'service',
+    value: 'ec2',
+    label: 'Amazon EC2',
+    tags: ['compute', 'virtual-machines'],
+  },
+  {
+    propertyKey: 'service',
+    value: 's3',
+    label: 'Amazon S3',
+    tags: ['storage', 'object-storage'],
+    filteringTags: ['bucket', 'simple-storage'],
+  },
+  {
+    propertyKey: 'service',
+    value: 'lambda',
+    label: 'AWS Lambda',
+    tags: ['serverless', 'compute', 'functions'],
+    filteringTags: ['faas', 'function-as-a-service'],
+  },
+  {
+    propertyKey: 'service',
+    value: 'rds',
+    label: 'Amazon RDS',
+    tags: ['database', 'relational', 'managed'],
+    filteringTags: ['mysql', 'postgresql', 'oracle', 'sql-server'],
+  },
+  {
+    propertyKey: 'environment',
+    value: 'production',
+    label: 'Production',
+    tags: ['live', 'critical'],
+  },
+  {
+    propertyKey: 'environment',
+    value: 'staging',
+    label: 'Staging',
+    tags: ['pre-production', 'testing', 'qa'],
+    filteringTags: ['stage', 'pre-prod'],
+  },
+  {
+    propertyKey: 'environment',
+    value: 'development',
+    label: 'Development',
+    tags: ['dev', 'testing', 'experimental'],
+    filteringTags: ['sandbox', 'playground'],
+  },
+  // Option without tags for comparison
+  {
+    propertyKey: 'service',
+    value: 'cloudfront',
+    label: 'Amazon CloudFront',
+  },
+
+  // Log group examples - individual options only
+  // Group header "All log groups" serves as the bulk selection mechanism
+  {
+    propertyKey: 'logGroup',
+    value: 'Log-group-01',
+    label: 'Log-group-01',
+    tags: ['Standard', 'AccountID', 'Tag'],
+  },
+  {
+    propertyKey: 'logGroup',
+    value: 'Log-group-02',
+    label: 'Log-group-02',
+    tags: ['Standard', 'AccountID', 'Tag'],
+  },
+  {
+    propertyKey: 'logGroup',
+    value: 'Log-group-03',
+    label: 'Log-group-03',
+    tags: ['Standard', 'AccountID', 'Tag'],
+  },
+  {
+    propertyKey: 'logGroup',
+    value: 'Log-group-04',
+    label: 'Log-group-04',
+    tags: ['Standard', 'AccountID', 'Tag'],
+  },
+  {
+    propertyKey: 'logGroup',
+    value: 'Log-group-05',
+    label: 'Log-group-05',
+    tags: ['Standard', 'AccountID', 'Tag'],
+  },
+  {
+    propertyKey: 'logGroup',
+    value: 'Log-group-06',
+    label: 'Log-group-06',
+    tags: ['Standard', 'AccountID', 'Tag'],
+  },
+  {
+    propertyKey: 'logGroup',
+    value: 'Log-group-07',
+    label: 'Log-group-07',
+    tags: ['Standard', 'AccountID', 'Tag'],
+  },
+  {
+    propertyKey: 'logGroup',
+    value: 'Log-group-08',
+    label: 'Log-group-08',
+    tags: ['Standard', 'AccountID', 'Tag'],
+  },
+  {
+    propertyKey: 'logGroup',
+    value: 'Log-group-09',
+    label: 'Log-group-09',
+    tags: ['Standard', 'AccountID', 'Tag'],
+  },
+  {
+    propertyKey: 'logGroup',
+    value: 'Log-group-10',
+    label: 'Log-group-10',
+    tags: ['Standard', 'AccountID', 'Tag'],
+  },
+  // Simulate pagination boundary
+  {
+    propertyKey: 'logGroup',
+    value: 'LOAD_MORE',
+    label: '... Load more (showing 10 of 10,000+)',
+    tags: ['Pagination', 'API-Call-Required'],
+    // description: 'Load additional log groups from API',
+    // disabled: true,
+  },
+];
+
+export default function TagsDemoPage() {
+  const [query, setQuery] = useState<PropertyFilterProps.Query>({
+    tokens: [],
+    operation: 'and',
+  });
+
+  return (
+    <Container
+      header={
+        <Header variant="h1" description="Demo page showcasing Property Filter with tags support">
+          Property Filter Tags Demo
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        <Box>
+          <Header variant="h2">Interactive Demo</Header>
+          <p>This demo showcases the Property Filter component with tags support. Try searching for:</p>
+          <ul>
+            <li>
+              <strong>Tag content:</strong> &#34;compute&#34;, &#34;storage&#34;, &#34;database&#34;,
+              &#34;serverless&#34;
+            </li>
+            <li>
+              <strong>FilteringTags content:</strong> &#34;faas&#34;, &#34;bucket&#34;, &#34;mysql&#34;,
+              &#34;sandbox&#34;
+            </li>
+            <li>
+              <strong>Service names:</strong> &#34;ec2&#34;, &#34;s3&#34;, &#34;lambda&#34;, &#34;rds&#34;
+            </li>
+            <li>
+              <strong>Environment types:</strong> &#34;production&#34;, &#34;staging&#34;, &#34;development&#34;
+            </li>
+            <li>
+              <strong>Region names:</strong> &#34;us-east-1&#34;, &#34;eu-west-1&#34;, &#34;singapore&#34;
+            </li>
+          </ul>
+        </Box>
+
+        <PropertyFilter
+          {...labels}
+          i18nStrings={i18nStrings}
+          filteringProperties={filteringProperties}
+          filteringOptions={filteringOptions}
+          query={query}
+          onChange={({ detail }) => setQuery(detail)}
+          countText={`${query.tokens.length} ${query.tokens.length === 1 ? 'filter' : 'filters'} applied`}
+        />
+
+        <Box>
+          <Header variant="h3">Current Query</Header>
+          <pre style={{ background: '#f5f5f5', padding: '10px', borderRadius: '4px' }}>
+            {JSON.stringify(query, null, 2)}
+          </pre>
+        </Box>
+
+        <Box>
+          <Header variant="h3">Tag Examples</Header>
+          <SpaceBetween size="s">
+            <div>
+              <strong>Services with visible tags:</strong>
+              <ul>
+                <li>Amazon EC2: compute, virtual-machines, aws-core</li>
+                <li>Amazon S3: storage, object-storage, aws-core (+ hidden: simple-storage-service, bucket)</li>
+                <li>AWS Lambda: serverless, compute, functions (+ hidden: faas, function-as-a-service)</li>
+                <li>Amazon RDS: database, relational, managed (+ hidden: mysql, postgresql, oracle, sql-server)</li>
+              </ul>
+            </div>
+            <div>
+              <strong>Environments with tags:</strong>
+              <ul>
+                <li>Production: live, critical, high-availability</li>
+                <li>Staging: pre-production, testing, qa (+ hidden: stage, pre-prod)</li>
+                <li>Development: dev, testing, experimental (+ hidden: sandbox, playground)</li>
+              </ul>
+            </div>
+            <div>
+              <strong>Regions with many tags (tests truncation):</strong>
+              <ul>
+                <li>US East (N. Virginia): north-america, virginia, primary, main, default, legacy, established</li>
+              </ul>
+            </div>
+          </SpaceBetween>
+        </Box>
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/src/property-filter/__tests__/property-filter-tags.test.tsx
+++ b/src/property-filter/__tests__/property-filter-tags.test.tsx
@@ -1,0 +1,256 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { OptionDefinition } from '../../internal/components/option/interfaces';
+import { filterOptions } from '../filter-options';
+
+describe('Property Filter filterOptions with tags', () => {
+  const createOption = (overrides: Partial<OptionDefinition> = {}): OptionDefinition => ({
+    value: 'test-value',
+    label: 'Test Label',
+    ...overrides,
+  });
+
+  describe('matchSingleOption tag functionality', () => {
+    test('should match options by tags', () => {
+      const options = [
+        createOption({
+          value: 'instance-1',
+          label: 'Instance 1',
+          tags: ['compute', 'ec2', 'running'],
+        }),
+        createOption({
+          value: 'instance-2',
+          label: 'Instance 2',
+          tags: ['storage', 's3'],
+        }),
+      ];
+
+      const result = filterOptions(options, 'compute');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(options[0]);
+    });
+
+    test('should match options by filteringTags', () => {
+      const options = [
+        createOption({
+          value: 'instance-1',
+          label: 'Instance 1',
+          filteringTags: ['virtual-machine', 'cloud-compute'],
+        }),
+        createOption({
+          value: 'instance-2',
+          label: 'Instance 2',
+          filteringTags: ['database', 'rds'],
+        }),
+      ];
+
+      const result = filterOptions(options, 'virtual-machine');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(options[0]);
+    });
+
+    test('should perform case-insensitive tag matching', () => {
+      const options = [
+        createOption({
+          value: 'instance-1',
+          label: 'Instance 1',
+          tags: ['COMPUTE', 'EC2'],
+        }),
+      ];
+
+      const result = filterOptions(options, 'compute');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(options[0]);
+    });
+
+    test('should match partial tag content', () => {
+      const options = [
+        createOption({
+          value: 'instance-1',
+          label: 'Instance 1',
+          tags: ['cloud-compute', 'virtual-machine'],
+        }),
+      ];
+
+      const result = filterOptions(options, 'compute');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(options[0]);
+    });
+
+    test('should match both tags and filteringTags', () => {
+      const options = [
+        createOption({
+          value: 'instance-1',
+          label: 'Instance 1',
+          tags: ['compute'],
+          filteringTags: ['ec2', 'virtual-machine'],
+        }),
+      ];
+
+      // Should match via tags
+      let result = filterOptions(options, 'compute');
+      expect(result).toHaveLength(1);
+
+      // Should match via filteringTags
+      result = filterOptions(options, 'ec2');
+      expect(result).toHaveLength(1);
+
+      // Should match via filteringTags
+      result = filterOptions(options, 'virtual-machine');
+      expect(result).toHaveLength(1);
+    });
+
+    test('should maintain backward compatibility with options without tags', () => {
+      const options = [
+        createOption({
+          value: 'instance-1',
+          label: 'Instance 1',
+        }),
+        createOption({
+          value: 'instance-2',
+          label: 'Instance 2',
+          tags: ['compute'],
+        }),
+      ];
+
+      // Should match by label
+      let result = filterOptions(options, 'Instance 1');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(options[0]);
+
+      // Should match by tag
+      result = filterOptions(options, 'compute');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(options[1]);
+    });
+
+    test('should handle empty tag arrays gracefully', () => {
+      const options = [
+        createOption({
+          value: 'instance-1',
+          label: 'Instance 1',
+          tags: [],
+          filteringTags: [],
+        }),
+      ];
+
+      const result = filterOptions(options, 'compute');
+      expect(result).toHaveLength(0);
+    });
+
+    test('should handle undefined tags gracefully', () => {
+      const options = [
+        createOption({
+          value: 'instance-1',
+          label: 'Instance 1',
+          tags: undefined,
+          filteringTags: undefined,
+        }),
+      ];
+
+      const result = filterOptions(options, 'compute');
+      expect(result).toHaveLength(0);
+    });
+
+    test('should match when search text matches both label and tags', () => {
+      const options = [
+        createOption({
+          value: 'compute-instance',
+          label: 'Compute Instance',
+          tags: ['compute', 'ec2'],
+        }),
+      ];
+
+      const result = filterOptions(options, 'compute');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(options[0]);
+    });
+
+    test('should not match when search text does not match any field or tag', () => {
+      const options = [
+        createOption({
+          value: 'instance-1',
+          label: 'Instance 1',
+          tags: ['compute', 'ec2'],
+          filteringTags: ['virtual-machine'],
+        }),
+      ];
+
+      const result = filterOptions(options, 'database');
+      expect(result).toHaveLength(0);
+    });
+
+    test('should match multiple options with different tag matches', () => {
+      const options = [
+        createOption({
+          value: 'instance-1',
+          label: 'Instance 1',
+          tags: ['compute', 'ec2'],
+        }),
+        createOption({
+          value: 'instance-2',
+          label: 'Instance 2',
+          filteringTags: ['compute-optimized'],
+        }),
+        createOption({
+          value: 'instance-3',
+          label: 'Instance 3',
+          tags: ['storage'],
+        }),
+      ];
+
+      const result = filterOptions(options, 'compute');
+      expect(result).toHaveLength(2);
+      expect(result).toContain(options[0]);
+      expect(result).toContain(options[1]);
+    });
+
+    test('should handle special characters in tags', () => {
+      const options = [
+        createOption({
+          value: 'instance-1',
+          label: 'Instance 1',
+          tags: ['t3.micro', 'us-east-1', 'prod-env'],
+        }),
+      ];
+
+      let result = filterOptions(options, 't3.micro');
+      expect(result).toHaveLength(1);
+
+      result = filterOptions(options, 'us-east');
+      expect(result).toHaveLength(1);
+
+      result = filterOptions(options, 'prod-env');
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('filterOptions with groups and tags', () => {
+    test('should filter grouped options with tags', () => {
+      const options: any[] = [
+        {
+          label: 'Compute Group',
+          options: [
+            createOption({
+              value: 'instance-1',
+              label: 'Instance 1',
+              tags: ['ec2', 'compute'],
+            }),
+            createOption({
+              value: 'instance-2',
+              label: 'Instance 2',
+              tags: ['storage', 's3'],
+            }),
+          ],
+        },
+      ];
+
+      const result = filterOptions(options, 'compute');
+      expect(result).toHaveLength(1);
+      expect(result[0].label).toBe('Compute Group');
+      expect((result[0] as any).options).toHaveLength(1); // only the matching child
+      expect((result[0] as any).options[0].tags).toContain('compute');
+    });
+  });
+});

--- a/src/property-filter/controller.ts
+++ b/src/property-filter/controller.ts
@@ -200,6 +200,8 @@ const getAllValueSuggestions = (
       value: property.propertyLabel + ' ' + (operator || '=') + ' ' + filteringOption.value,
       label: filteringOption.label,
       __labelPrefix: property.propertyLabel + ' ' + (operator || '='),
+      tags: filteringOption.tags,
+      filteringTags: filteringOption.filteringTags,
     });
   });
   return [defaultGroup, ...Object.keys(customGroups).map(group => customGroups[group])];
@@ -258,10 +260,12 @@ export const getAutosuggestOptions = (
         filterText: parsedText.value,
         options: [
           {
-            options: options.map(({ label, value }) => ({
+            options: options.map(({ label, value, tags, filteringTags }) => ({
               value: propertyLabel + ' ' + parsedText.operator + ' ' + value,
               label: label,
               __labelPrefix: propertyLabel + ' ' + parsedText.operator,
+              tags: tags,
+              filteringTags: filteringTags,
             })),
             label: groupValuesLabel,
           },

--- a/src/property-filter/filter-options.ts
+++ b/src/property-filter/filter-options.ts
@@ -36,5 +36,9 @@ function matchSingleOption(option: OptionDefinition, searchText: string): boolea
   const label = (option.label ?? '').toLowerCase();
   const labelPrefix = option.__labelPrefix ?? '';
   const value = (option.value ? option.value.slice(labelPrefix.length) : '').toLowerCase();
-  return label.indexOf(searchText) !== -1 || value.indexOf(searchText) !== -1;
+
+  const matchesLabelOrValue = label.indexOf(searchText) !== -1 || value.indexOf(searchText) !== -1;
+  const matchesTags = option.tags?.some(tag => tag.toLowerCase().indexOf(searchText) !== -1) ?? false;
+  const matchesFilteringTags = option.filteringTags?.some(tag => tag.toLowerCase().indexOf(searchText) !== -1) ?? false;
+  return matchesLabelOrValue || matchesTags || matchesFilteringTags;
 }

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -386,6 +386,8 @@ export interface InternalFilteringOption {
   property: null | InternalFilteringProperty;
   value: string;
   label: string;
+  tags?: ReadonlyArray<string>;
+  filteringTags?: ReadonlyArray<string>;
 }
 
 export interface InternalFreeTextFiltering {

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -153,6 +153,8 @@ const PropertyFilterInternal = React.forwardRef(
         property: getProperty(option.propertyKey),
         value: option.value,
         label: option.label ?? option.value ?? '',
+        tags: option.tags ?? [],
+        filteringTags: option.filteringTags ?? [],
       }));
 
       function transformToken(

--- a/src/property-filter/property-editor.tsx
+++ b/src/property-filter/property-editor.tsx
@@ -75,9 +75,9 @@ export function PropertyEditorContentEnum({
   filteringOptions: readonly InternalFilteringOption[];
   onLoadItems?: NonCancelableEventHandler<LoadItemsDetail>;
 }) {
-  const valueOptions: readonly { value: string; label: string }[] = filteringOptions
+  const valueOptions: readonly { value: string; label: string; tags?: readonly string[]; filteringTags?: readonly string[] }[] = filteringOptions
     .filter(option => option.property?.propertyKey === property.propertyKey)
-    .map(({ label, value }) => ({ label, value }));
+    .map(({ label, value, tags, filteringTags }) => ({ label, value, tags, filteringTags }));
   const valueHandlers = useLoadItems(onLoadItems, '', property.externalProperty);
   const value = !unknownValue ? [] : Array.isArray(unknownValue) ? unknownValue : [unknownValue];
   const selectedOptions = valueOptions.filter(option => value.includes(option.value));

--- a/src/property-filter/token-editor-inputs.tsx
+++ b/src/property-filter/token-editor-inputs.tsx
@@ -159,7 +159,7 @@ function ValueInputAuto({
   const valueOptions = property
     ? filteringOptions
         .filter(option => option.property?.propertyKey === property.propertyKey)
-        .map(({ label, value }) => ({ label, value }))
+        .map(({ label, value, tags, filteringTags }) => ({ label, value, tags, filteringTags }))
     : [];
 
   const valueAutosuggestHandlers = useLoadItems(onLoadItems, '', property?.externalProperty, value, operator);
@@ -198,7 +198,7 @@ function ValueInputEnum({
 }: ValueInputPropsEnum) {
   const valueOptions = filteringOptions
     .filter(option => option.property?.propertyKey === property.propertyKey)
-    .map(({ label, value }) => ({ label, value }));
+    .map(({ label, value, tags, filteringTags }) => ({ label, value, tags, filteringTags }));
   const valueAutosuggestHandlers = useLoadItems(onLoadItems, '', property.externalProperty, undefined, operator);
   const asyncValueAutosuggestProps = { statusType: 'finished' as const, ...valueAutosuggestHandlers, ...asyncProps };
   const value = !unknownValue ? [] : Array.isArray(unknownValue) ? unknownValue : [unknownValue];


### PR DESCRIPTION
### Description

This is to include tags and filteringTags to be supported in property filter.

Will use internally review for this

### How has this been tested?

Unit tests added.

Demo tag page added

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
