### PR TITLE
fix: Ensure toggle button test utils only find toggle buttons

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -84,10 +84,11 @@ exports[`test-utils selectors 1`] = `
     "awsui_item_d19fg",
   ],
   "button": [
+    "awsui_button_1ueyk",
     "awsui_button_vjswe",
-    "awsui_content_vjswe",
+    "awsui_content_1ueyk",
     "awsui_disabled-reason-tooltip_1ueyk",
-    "awsui_icon-left_vjswe",
+    "awsui_icon-left_1ueyk",
   ],
   "button-dropdown": [
     "awsui_button-dropdown_sne0l",
@@ -648,6 +649,9 @@ exports[`test-utils selectors 1`] = `
   ],
   "toggle": [
     "awsui_root_4yi2u",
+  ],
+  "toggle-button": [
+    "awsui_root_1qd09",
   ],
   "token-group": [
     "awsui_dismiss-button_dm8gx",

--- a/src/button/icon-helper.tsx
+++ b/src/button/icon-helper.tsx
@@ -9,6 +9,7 @@ import InternalSpinner from '../spinner/internal';
 import { ButtonProps } from './interfaces';
 
 import styles from './styles.css.js';
+import testUtilStyles from './test-classes/styles.css.js';
 
 export interface ButtonIconProps {
   loading?: boolean;
@@ -49,7 +50,7 @@ function IconWrapper({ iconName, iconUrl, iconAlt, iconSvg, iconSize, badge, ...
 
 export function LeftIcon(props: ButtonIconProps) {
   if (props.loading) {
-    return <InternalSpinner className={clsx(styles.icon, styles['icon-left'])} />;
+    return <InternalSpinner className={clsx(styles.icon, styles['icon-left'], testUtilStyles['icon-left'])} />;
   } else if (getIconAlign(props) === 'left') {
     return <IconWrapper {...props} />;
   }

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -56,6 +56,7 @@ export type InternalButtonProps = Omit<ButtonProps, 'variant'> & {
   __title?: string;
   __emitPerformanceMarks?: boolean;
   __skipNativeAttributesWarnings?: boolean;
+  __hideFromTestUtils?: boolean;
 } & InternalBaseComponentProps;
 
 export const InternalButton = React.forwardRef(
@@ -98,6 +99,7 @@ export const InternalButton = React.forwardRef(
       __title,
       __emitPerformanceMarks = true,
       __skipNativeAttributesWarnings,
+      __hideFromTestUtils = false,
       analyticsAction = 'click',
       ...props
     }: InternalButtonProps,
@@ -179,6 +181,7 @@ export const InternalButton = React.forwardRef(
     };
 
     const buttonClass = clsx(props.className, styles.button, styles[`variant-${variant}`], {
+      [testUtilStyles.button]: !__hideFromTestUtils,
       [styles.disabled]: isNotInteractive,
       [styles['disabled-with-reason']]: isDisabledWithReason,
       [styles['button-no-wrap']]: !wrapText,
@@ -242,7 +245,7 @@ export const InternalButton = React.forwardRef(
         <LeftIcon {...iconProps} />
         {shouldHaveContent && (
           <>
-            <span className={clsx(styles.content, analyticsSelectors.label)}>{children}</span>
+            <span className={clsx(testUtilStyles.content, analyticsSelectors.label)}>{children}</span>
             {external && (
               <>
                 &nbsp;

--- a/src/button/styles.scss
+++ b/src/button/styles.scss
@@ -49,10 +49,6 @@
   }
 }
 
-.content {
-  /* used in test-utils */
-}
-
 .button {
   @include styles.styles-reset;
   @include styles.text-wrapping;

--- a/src/test-utils/dom/button/index.ts
+++ b/src/test-utils/dom/button/index.ts
@@ -2,19 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper, createWrapper, ElementWrapper, usesDom } from '@cloudscape-design/test-utils-core/dom';
 
-import styles from '../../../button/styles.selectors.js';
 import buttonTestUtilsStyles from '../../../button/test-classes/styles.selectors.js';
 import spinnerStyles from '../../../spinner/styles.selectors.js';
 
 export default class ButtonWrapper extends ComponentWrapper<HTMLButtonElement> {
-  static rootSelector: string = styles.button;
+  static rootSelector: string = buttonTestUtilsStyles.button;
 
   findLoadingIndicator(): ElementWrapper | null {
-    return this.find(`.${styles['icon-left']}.${spinnerStyles.root}`);
+    return this.find(`.${buttonTestUtilsStyles['icon-left']}.${spinnerStyles.root}`);
   }
 
   findTextRegion(): ElementWrapper | null {
-    return this.find(`.${styles.content}`);
+    return this.find(`.${buttonTestUtilsStyles.content}`);
   }
 
   @usesDom

--- a/src/test-utils/dom/toggle-button/index.ts
+++ b/src/test-utils/dom/toggle-button/index.ts
@@ -4,14 +4,13 @@ import { usesDom } from '@cloudscape-design/test-utils-core/dom';
 
 import ButtonWrapper from '../button';
 
-import buttonStyles from '../../../button/styles.selectors.js';
-import styles from '../../../toggle-button/styles.selectors.js';
+import testStyles from '../../../toggle-button/test-classes/styles.selectors.js';
 
 export default class ToggleButtonWrapper extends ButtonWrapper {
-  static rootSelector: string = buttonStyles.button;
+  static rootSelector: string = testStyles.root;
 
   @usesDom
   isPressed(): boolean {
-    return this.element.classList.contains(styles.pressed);
+    return this.element.classList.contains(testStyles.pressed);
   }
 }

--- a/src/toggle-button/internal.tsx
+++ b/src/toggle-button/internal.tsx
@@ -12,6 +12,7 @@ import { ToggleButtonProps } from './interfaces';
 import { getToggleIcon } from './util';
 
 import styles from './styles.css.js';
+import testStyles from './test-classes/styles.css.js';
 
 export const InternalToggleButton = React.forwardRef(
   (
@@ -46,7 +47,12 @@ export const InternalToggleButton = React.forwardRef(
 
     return (
       <InternalButton
-        className={clsx(className, styles[`variant-${variant}`], { [styles.pressed]: pressed })}
+        className={clsx(
+          className,
+          testStyles.root,
+          styles[`variant-${variant}`],
+          pressed && [styles.pressed, testStyles.pressed]
+        )}
         variant={variant}
         formAction="none"
         iconName={getToggleIcon(pressed, defaultIconName, pressedIconName)}
@@ -60,6 +66,7 @@ export const InternalToggleButton = React.forwardRef(
         }}
         {...rest}
         ref={ref}
+        __hideFromTestUtils={true}
       />
     );
   }

--- a/src/toggle-button/test-classes/styles.scss
+++ b/src/toggle-button/test-classes/styles.scss
@@ -3,10 +3,7 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
-.button,
-.content,
-.icon-left,
-.disabled-reason-tooltip,
-.external-icon {
-  /* used in test-utils or tests */
+.root,
+.pressed {
+  /* Test classes for toggle button component */
 }


### PR DESCRIPTION
### Description

Previously, `findToggleButton` would also find button instances. This fixes that. (And vice-versa: `findButton` now finds no toggle buttons).

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
