### PR TITLE
chore: Sync i18n messages, rename S3 Resource selectors labelBreadcrumbs property

### DIFF
--- a/src/i18n/messages/all.ar.json
+++ b/src/i18n/messages/all.ar.json
@@ -334,7 +334,7 @@
     "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
     "i18nStrings.labelFiltering": "البحث عن {itemsType}",
     "i18nStrings.labelRefresh": "تحديث البيانات",
-    "i18nStrings.labelBreadcrumbs": "التنقل في S3",
+    "i18nStrings.labelBreadcrumbs": "عمليات التنقل التفصيلي في S3",
     "i18nStrings.labelIconFolder": "المجلد",
     "i18nStrings.labelIconObject": "العنصر",
     "i18nStrings.filteringCounterText": "{count, plural, one {تطابق واحد} other {{count} تطابق}}"

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -55,7 +55,7 @@
     "expandAriaLabel": "Pfad anzeigen"
   },
   "button": {
-    "i18nStrings.externalIconAriaLabel": "Wird in einem neuen Fenster geöffnet"
+    "i18nStrings.externalIconAriaLabel": "Wird in einer neuen Registerkarte geöffnet"
   },
   "calendar": {
     "nextMonthAriaLabel": "Nächster Monat",
@@ -211,14 +211,14 @@
     "clearAriaLabel": "Löschen"
   },
   "link": {
-    "externalIconAriaLabel": "Wird in einem neuen Fenster geöffnet"
+    "externalIconAriaLabel": "Wird in einer neuen Registerkarte geöffnet"
   },
   "list": {
     "dragHandleAriaLabel": "Ziehpunkt",
-    "dragHandleAriaDescription": "Verwenden Sie Space (Leertaste) oder Enter (Eingabetaste), um das Ziehen für ein Element zu aktivieren. Verwenden Sie dann die Pfeiltasten, um die Position abzuschließen. Verwenden Sie Space (Leertaste) oder Enter (Eingabetaste) oder, um den Zug zu verwerfen, verwenden Sie Escape (Escape).",
-    "liveAnnouncementDndStarted": "Aufgeholtes Element an Position {position} von {total}",
-    "liveAnnouncementDndDiscarded": "Neuanordnung storniert",
-    "liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Objekt zurück an die Position {currentPosition} von {total} verschieben} false {Objekt an Position {currentPosition} von {total} verschieben} other {}}",
+    "dragHandleAriaDescription": "Verwenden Sie Space (Leertaste) oder Enter (Eingabetaste), um das Ziehen für ein Element zu aktivieren. Verwenden Sie dann die Pfeiltasten, um es in die gewünschte Position zu bringen. Verwenden Sie zum Bestätigen Space (Leertaste) oder Enter (Eingabetaste) oder, um den Zug zu verwerfen, verwenden Sie Escape (Escape).",
+    "liveAnnouncementDndStarted": "Element an Position {position} von {total} aufgenommen",
+    "liveAnnouncementDndDiscarded": "Neuanordnung abgebrochen",
+    "liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Objekt wird zurück an die Position {currentPosition} von {total} verschoben} false {Objekt an Position {currentPosition} von {total} verschieben} other {}}",
     "liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Das Objekt wurde zurück an seine ursprüngliche Position {initialPosition} von {total} verschoben} false {Das Objekt wurde von Position {initialPosition} zu Position {finalPosition} von {total} verschoben} other {}}"
   },
   "modal": {
@@ -334,7 +334,7 @@
     "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
     "i18nStrings.labelFiltering": "{itemsType} finden",
     "i18nStrings.labelRefresh": "Die Daten aktualisieren",
-    "i18nStrings.labelBreadcrumbs": "S3-Navigation",
+    "i18nStrings.labelBreadcrumbs": "S3-Breadcrumbs",
     "i18nStrings.labelIconFolder": "Ordner",
     "i18nStrings.labelIconObject": "Objekt",
     "i18nStrings.filteringCounterText": "{count, plural, one {1 Übereinstimmung} other {{count} Übereinstimmungen}}"
@@ -440,7 +440,7 @@
     "i18nStrings.labelTotalSteps": "Gesamte Schritte: {totalStepCount}",
     "i18nStrings.labelsTaskStatus.pending": "Ausstehend",
     "i18nStrings.labelsTaskStatus.in-progress": "In Bearbeitung",
-    "i18nStrings.labelsTaskStatus.success": "Erfolg"
+    "i18nStrings.labelsTaskStatus.success": "Erfolgreich"
   },
   "wizard": {
     "i18nStrings.stepNumberLabel": "Schritt {stepNumber}",

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -334,7 +334,7 @@
     "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
     "i18nStrings.labelFiltering": "Find {itemsType}",
     "i18nStrings.labelRefresh": "Refresh the data",
-    "i18nStrings.labelBreadcrumbs": "S3 navigation",
+    "i18nStrings.labelBreadcrumbs": "S3 Breadcrumbs",
     "i18nStrings.labelIconFolder": "Folder",
     "i18nStrings.labelIconObject": "Object",
     "i18nStrings.filteringCounterText": "{count, plural, one {1 match} other {{count} matches}}"

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -334,7 +334,7 @@
     "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
     "i18nStrings.labelFiltering": "Find {itemsType}",
     "i18nStrings.labelRefresh": "Refresh the data",
-    "i18nStrings.labelBreadcrumbs": "S3 navigation",
+    "i18nStrings.labelBreadcrumbs": "S3 Breadcrumbs",
     "i18nStrings.labelIconFolder": "Folder",
     "i18nStrings.labelIconObject": "Object",
     "i18nStrings.filteringCounterText": "{count, plural, one {1 match} other {{count} matches}}"

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -55,7 +55,7 @@
     "expandAriaLabel": "Mostrar ruta"
   },
   "button": {
-    "i18nStrings.externalIconAriaLabel": "Se abre en una pestaña nueva."
+    "i18nStrings.externalIconAriaLabel": "Se abre en una pestaña nueva"
   },
   "calendar": {
     "nextMonthAriaLabel": "Próximo mes",
@@ -211,7 +211,7 @@
     "clearAriaLabel": "Borrar"
   },
   "link": {
-    "externalIconAriaLabel": "Se abre en una pestaña nueva."
+    "externalIconAriaLabel": "Se abre en una pestaña nueva"
   },
   "list": {
     "dragHandleAriaLabel": "Arrastrar controlador",
@@ -334,7 +334,7 @@
     "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
     "i18nStrings.labelFiltering": "Encuentre {itemsType}",
     "i18nStrings.labelRefresh": "Actualizar los datos",
-    "i18nStrings.labelBreadcrumbs": "Navegación S3",
+    "i18nStrings.labelBreadcrumbs": "Rutas de navegación de S3",
     "i18nStrings.labelIconFolder": "Carpeta",
     "i18nStrings.labelIconObject": "Objeto",
     "i18nStrings.filteringCounterText": "{count, plural, one {1 coincidencia} other {{count} coincidencias}}"
@@ -440,7 +440,7 @@
     "i18nStrings.labelTotalSteps": "Total de pasos: {totalStepCount}",
     "i18nStrings.labelsTaskStatus.pending": "Pendiente",
     "i18nStrings.labelsTaskStatus.in-progress": "En curso",
-    "i18nStrings.labelsTaskStatus.success": "Acción realizada correctamente"
+    "i18nStrings.labelsTaskStatus.success": "Correcto"
   },
   "wizard": {
     "i18nStrings.stepNumberLabel": "Paso {stepNumber}",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -334,7 +334,7 @@
     "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
     "i18nStrings.labelFiltering": "Trouver {itemsType}",
     "i18nStrings.labelRefresh": "Actualiser les données",
-    "i18nStrings.labelBreadcrumbs": "Navigation S3",
+    "i18nStrings.labelBreadcrumbs": "Pistes de navigation S3",
     "i18nStrings.labelIconFolder": "Dossier",
     "i18nStrings.labelIconObject": "Objet",
     "i18nStrings.filteringCounterText": "{count, plural, one {1 correspondance} other {{count} correspondances}}"

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -214,8 +214,8 @@
     "externalIconAriaLabel": "Buka di tab baru"
   },
   "list": {
-    "dragHandleAriaLabel": "Tuas seret",
-    "dragHandleAriaDescription": "Gunakan Spasi atau Enter untuk mengaktifkan seret item, lalu gunakan tombol panah untuk memindahkan posisi item. Untuk menyelesaikan perpindahan posisi, gunakan Spasi atau Enter, atau untuk membatalkan perpindahan, gunakan Escape.",
+    "dragHandleAriaLabel": "Seret handel",
+    "dragHandleAriaDescription": "Gunakan Spasi atau Enter untuk mengaktifkan seret pada item, lalu gunakan tombol panah untuk memindahkan posisi item. Untuk menyelesaikan perpindahan posisi, gunakan Spasi atau Enter, atau untuk membatalkan perpindahan, gunakan Escape.",
     "liveAnnouncementDndStarted": "Mengambil item pada posisi {position} dari {total}",
     "liveAnnouncementDndDiscarded": "Pengurutan ulang dibatalkan",
     "liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Memindahkan item kembali ke posisi {currentPosition} dari {total}} false {Memindahkan item ke posisi {currentPosition} dari {total}} other {}}",
@@ -334,7 +334,7 @@
     "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
     "i18nStrings.labelFiltering": "Temukan {itemsType}",
     "i18nStrings.labelRefresh": "Segarkan data",
-    "i18nStrings.labelBreadcrumbs": "Navigasi S3",
+    "i18nStrings.labelBreadcrumbs": "Breadcrumb S3",
     "i18nStrings.labelIconFolder": "Folder",
     "i18nStrings.labelIconObject": "Objek",
     "i18nStrings.filteringCounterText": "{count, plural, one {1 kecocokan} other {{count} kecocokan}}"

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -215,11 +215,11 @@
   },
   "list": {
     "dragHandleAriaLabel": "Punto di trascinamento",
-    "dragHandleAriaDescription": "Utilizza Spazio o Invio per attivare il trascinamento di un elemento, quindi usa i tasti freccia per spostare la posizione dell'elemento. Per completare lo spostamento della posizione, utilizza Spazio o Invio oppure per annullare lo spostamento, usa Esc.",
+    "dragHandleAriaDescription": "Utilizza Spazio o Invio per attivare il trascinamento di un elemento, quindi usa i tasti freccia per spostare la posizione dell'elemento. Per completare lo spostamento della posizione, utilizza Spazio o Invio oppure per annullare lo spostamento, premi Esc.",
     "liveAnnouncementDndStarted": "Elemento raccolto nella posizione {position} di {total}",
     "liveAnnouncementDndDiscarded": "Riordinamento annullato",
-    "liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Spostamento dell'elemento di nuovo nella posizione {currentPosition} di {total}} false {Spostamento dell'elemento nella posizione {currentPosition} di {total}} other {}}",
-    "liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {L'elemento è stato spostato di nuovo nella posizione originale {initialPosition} di {total}} false {Elemento spostato da una posizione {initialPosition} alla posizione {finalPosition} di {total}} other {}}"
+    "liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Spostamento dell'elemento nella posizione {currentPosition} di {total} in corso} false {Spostamento dell'elemento nella posizione {currentPosition} di {total} in corso} other {}}",
+    "liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {L'elemento è stato spostato nella posizione originale {initialPosition} di {total}} false {Elemento spostato da una posizione {initialPosition} alla posizione {finalPosition} di {total}} other {}}"
   },
   "modal": {
     "closeAriaLabel": "Chiudi modale"
@@ -334,7 +334,7 @@
     "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
     "i18nStrings.labelFiltering": "Trova {itemsType}",
     "i18nStrings.labelRefresh": "Aggiorna i dati",
-    "i18nStrings.labelBreadcrumbs": "Navigazione S3",
+    "i18nStrings.labelBreadcrumbs": "Percorsi di navigazione S3",
     "i18nStrings.labelIconFolder": "Cartella",
     "i18nStrings.labelIconObject": "Oggetto",
     "i18nStrings.filteringCounterText": "{count, plural, one {1 corrispondenza} other {{count} corrispondenze}}"

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -334,7 +334,7 @@
     "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
     "i18nStrings.labelFiltering": "{itemsType} を検索",
     "i18nStrings.labelRefresh": "データを更新",
-    "i18nStrings.labelBreadcrumbs": "S3 ナビゲーション",
+    "i18nStrings.labelBreadcrumbs": "S3 パンくずリスト",
     "i18nStrings.labelIconFolder": "フォルダ",
     "i18nStrings.labelIconObject": "オブジェクト",
     "i18nStrings.filteringCounterText": "{count, plural, one {1 件の一致} other {{count} 件の一致}}"

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -214,12 +214,12 @@
     "externalIconAriaLabel": "새 탭에서 열림"
   },
   "list": {
-    "dragHandleAriaLabel": "핸들 끌기",
-    "dragHandleAriaDescription": "스페이스 또는 Enter를 사용하여 항목 끌기 기능을 활성화하고 화살표 키를 사용하여 항목의 위치를 이동합니다. 위치 이동을 완료하려면 스페이스 또는 Enter를 사용하거나 이동을 취소하려면 Escape를 사용합니다.",
+    "dragHandleAriaLabel": "끌기 핸들",
+    "dragHandleAriaDescription": "스페이스 또는 Enter를 사용하여 항목 끌기 기능을 활성화하고 화살표 키를 사용하여 항목의 위치를 이동합니다. 위치 이동을 완료하려면 스페이스 또는 Enter를 사용하고 이동을 취소하려면 Escape를 사용합니다.",
     "liveAnnouncementDndStarted": "{position}/{total}개 위치에서 선택한 항목",
     "liveAnnouncementDndDiscarded": "재정렬 취소됨",
-    "liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {{currentPosition}/{total} 위치로 항목 다시 이동} false {{currentPosition}/{total} 위치로 항목 이동} other {}}",
-    "liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {항목이 원래 위치인 {initialPosition}/{total} 위치로 다시 이동됨} false {항목이 {initialPosition}/{total} 위치에서 인 {finalPosition}/{total} 위치로 이동됨} other {}}"
+    "liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {{currentPosition}/{total}개 위치로 항목 다시 이동} false {{currentPosition}/{total}개 위치로 항목 이동} other {}}",
+    "liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {항목이 {initialPosition}/{total}개의 원래 위치로 다시 이동됨} false {항목이 {initialPosition}/{total} 위치에서 인 {finalPosition}/{total} 위치로 이동됨} other {}}"
   },
   "modal": {
     "closeAriaLabel": "모달 닫기"
@@ -334,7 +334,7 @@
     "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
     "i18nStrings.labelFiltering": "{itemsType} 찾기",
     "i18nStrings.labelRefresh": "데이터 새로고침",
-    "i18nStrings.labelBreadcrumbs": "S3 탐색",
+    "i18nStrings.labelBreadcrumbs": "S3 브레드크럼",
     "i18nStrings.labelIconFolder": "폴더",
     "i18nStrings.labelIconObject": "객체",
     "i18nStrings.filteringCounterText": "{count, plural, one {1개 일치} other {{count}개 일치}}"

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -214,7 +214,7 @@
     "externalIconAriaLabel": "Abre em uma nova guia"
   },
   "list": {
-    "dragHandleAriaLabel": "Ícone de arrastar",
+    "dragHandleAriaLabel": "Alça de arraste",
     "dragHandleAriaDescription": "Use Space ou Enter para ativar a função de arrastar para um item e, em seguida, use as teclas de setas para movimentar o posicionamento do item. Para completar o movimento de posicionamento, use Space ou Enter, ou para descartar o movimento, use Escape.",
     "liveAnnouncementDndStarted": "Item selecionado na posição {position} de {total}",
     "liveAnnouncementDndDiscarded": "Reordenação cancelada",
@@ -334,7 +334,7 @@
     "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
     "i18nStrings.labelFiltering": "Encontrar {itemsType}",
     "i18nStrings.labelRefresh": "Atualizar os dados",
-    "i18nStrings.labelBreadcrumbs": "Navegação no S3",
+    "i18nStrings.labelBreadcrumbs": "Navegação estrutural do S3",
     "i18nStrings.labelIconFolder": "Pasta",
     "i18nStrings.labelIconObject": "Objeto",
     "i18nStrings.filteringCounterText": "{count, plural, one {Uma correspondência} other {{count} correspondências}}"

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -215,11 +215,11 @@
   },
   "list": {
     "dragHandleAriaLabel": "Sürükleme tutamacı",
-    "dragHandleAriaDescription": "Bir öğe için sürüklemeyi etkinleştirmek üzere Boşluk veya Enter tuşunu ve öğenin konumunu taşımak için ok tuşlarını kullanın. Konum taşıma işlemini tamamlamak için Boşluk veya Enter tuşunu ya da taşıma işlemini iptal etmek için ESC tuşunu kullanın.",
-    "liveAnnouncementDndStarted": "Öğe {position}/{total} konumundan alındı",
+    "dragHandleAriaDescription": "Bir öğe için sürüklemeyi etkinleştirmek üzere Boşluk veya Enter tuşunu ve ögenin konumunu taşımak için ok tuşlarını kullanın. Konum taşıma işlemini tamamlamak için \"Boşluk\" veya \"Enter\" tuşunu ya da taşıma işlemini iptal etmek için \"ESC\" tuşunu kullanın.",
+    "liveAnnouncementDndStarted": "Öge {position}/{total} konumundan alındı",
     "liveAnnouncementDndDiscarded": "Yeniden sıralama iptal edildi",
-    "liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Öğe {currentPosition}/{total} konumuna geri taşınıyor} false {Öğe {currentPosition}/{total} konumuna taşınıyor} other {}}",
-    "liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Öğe ilk {initialPosition}/{total} konumuna geri taşındı} false {Öğe {initialPosition} konumundan {finalPosition}/{total} konumuna taşındı} other {}}"
+    "liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Öge {currentPosition}/{total} konumuna geri taşınıyor} false {Öge {currentPosition}/{total} konumuna taşınıyor} other {}}",
+    "liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Öge ilk {initialPosition}/{total} konumuna geri taşındı} false {Öğe {initialPosition} konumundan {finalPosition}/{total} konumuna taşındı} other {}}"
   },
   "modal": {
     "closeAriaLabel": "Kalıcı iletişim kutusunu kapat"
@@ -334,7 +334,7 @@
     "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
     "i18nStrings.labelFiltering": "{itemsType} bul",
     "i18nStrings.labelRefresh": "Verileri yenile",
-    "i18nStrings.labelBreadcrumbs": "S3 gezintisi",
+    "i18nStrings.labelBreadcrumbs": "S3 İçerik Haritaları",
     "i18nStrings.labelIconFolder": "Klasör",
     "i18nStrings.labelIconObject": "Nesne",
     "i18nStrings.filteringCounterText": "{count, plural, one {1 eşleşme} other {{count} eşleşme}}"

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -55,7 +55,7 @@
     "expandAriaLabel": "显示路径"
   },
   "button": {
-    "i18nStrings.externalIconAriaLabel": "在新标签页中打开"
+    "i18nStrings.externalIconAriaLabel": "在新选项卡中打开"
   },
   "calendar": {
     "nextMonthAriaLabel": "下个月",
@@ -334,7 +334,7 @@
     "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
     "i18nStrings.labelFiltering": "查找 {itemsType}",
     "i18nStrings.labelRefresh": "刷新数据",
-    "i18nStrings.labelBreadcrumbs": "S3 导航",
+    "i18nStrings.labelBreadcrumbs": "S3 面包屑",
     "i18nStrings.labelIconFolder": "文件夹",
     "i18nStrings.labelIconObject": "对象",
     "i18nStrings.filteringCounterText": "{count, plural, one {1 个匹配项} other {{count} 个匹配项}}"

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -216,7 +216,7 @@
   "list": {
     "dragHandleAriaLabel": "拖曳控點",
     "dragHandleAriaDescription": "使用空白鍵或 ENTER 鍵啟用項目拖曳功能，然後使用方向鍵移動項目的位置。若要完成位置移動，請使用空白鍵或 ENTER 鍵，或者若要捨棄移動，請使用 ESC 鍵。",
-    "liveAnnouncementDndStarted": "在第 {position} 位置 (共 {total} 個位置) 拾取了項目",
+    "liveAnnouncementDndStarted": "在 {position} 位置 (共 {total} 個位置) 拾取了項目",
     "liveAnnouncementDndDiscarded": "重新排序已取消",
     "liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {將項目移回 {currentPosition} 位置 (共 {total} 個位置)} false {將項目移到 {currentPosition} 位置 (共 {total} 個位置)} other {}}",
     "liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {項目移回原來的 {initialPosition} 位置 (共 {total} 個位置)} false {項目已從 {initialPosition} 位置移到 {finalPosition} 位置 (共 {total} 個位置)} other {}}"
@@ -334,7 +334,7 @@
     "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
     "i18nStrings.labelFiltering": "尋找 {itemsType}",
     "i18nStrings.labelRefresh": "重新整理資料",
-    "i18nStrings.labelBreadcrumbs": "S3 導覽",
+    "i18nStrings.labelBreadcrumbs": "S3 頁面導覽路徑",
     "i18nStrings.labelIconFolder": "資料夾",
     "i18nStrings.labelIconObject": "物件",
     "i18nStrings.filteringCounterText": "{count, plural, one {1 個符合} other {{count} 個符合}}"


### PR DESCRIPTION
### Description

Sync i18n messages, rename S3 Resource selectors labelBreadcrumbs property.

Related links, issue #, if available: `AWSUI-61048`

### How has this been tested?

- reviewed EN and DE diff manually.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
