### PR TITLE
fix: Open button dropdown when pressing up/down arrow keys

### DIFF
--- a/src/button-dropdown/__tests__/button-dropdown-keyboard.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-keyboard.test.tsx
@@ -29,93 +29,114 @@ const items: ButtonDropdownProps.Items = [
       onClickSpy = jest.fn();
       onFollowSpy = jest.fn();
       wrapper = renderButtonDropdown({ ...props, items, onItemClick: onClickSpy, onItemFollow: onFollowSpy });
-      act(() => wrapper.findNativeButton().keydown(KeyCode.enter));
     });
 
-    test('should close the dropdown when escape is pressed', () => {
-      expect(wrapper.findOpenDropdown()).not.toBe(null);
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.escape));
+    test('should open the dropdown and focus first item when pressing down arrow key', () => {
       expect(wrapper.findOpenDropdown()).toBe(null);
-    });
-    test('should select the next item if "down" is pressed', () => {
-      expect(wrapper.findHighlightedItem()!.getElement()).toHaveTextContent('item1');
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
-      expect(wrapper.findHighlightedItem()!.getElement()).toHaveTextContent('item2');
-    });
-
-    test('should select the previous item if "up" is pressed', () => {
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.up));
+      act(() => wrapper.findTriggerButton()!.keydown(KeyCode.down));
+      expect(wrapper.findOpenDropdown()).toBeTruthy();
       expect(wrapper.findHighlightedItem()!.getElement()).toHaveTextContent('item1');
     });
 
-    test('should include disabled items', () => {
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
-      expect(wrapper.findHighlightedItem()!.getElement()).toHaveTextContent('item3');
+    test('should open the dropdown and focus last item when pressing up arrow key', () => {
+      expect(wrapper.findOpenDropdown()).toBe(null);
+      act(() => wrapper.findTriggerButton()!.keydown(KeyCode.up));
+      expect(wrapper.findOpenDropdown()).toBeTruthy();
+      expect(wrapper.findHighlightedItem()!.getElement()).toHaveTextContent('item5');
     });
 
-    test('should call onClick on enter', () => {
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.enter));
-      expect(onClickSpy).toHaveBeenCalledTimes(1);
-    });
-
-    test('should not call onClick on enter a disabled item', () => {
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.enter));
-      expect(onClickSpy).not.toHaveBeenCalled();
-    });
-
-    test('should call onClick on space', () => {
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.space));
-      act(() => wrapper.findOpenDropdown()!.keyup(KeyCode.space));
-      expect(onClickSpy).toHaveBeenCalledTimes(1);
-    });
-
-    test('should not call onClick on space a disabled item', () => {
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.space));
-      expect(onClickSpy).not.toHaveBeenCalled();
-    });
-
-    test('should call onFollow on space if item has href', () => {
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
-      act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.space));
-      act(() => wrapper.findOpenDropdown()!.keyup(KeyCode.space));
-      expect(onFollowSpy).toHaveBeenCalledTimes(1);
-    });
-
-    test.each([KeyCode.enter, KeyCode.space])(
-      'should fire event correctly when items with checkbox pressed using key=%s',
-      keyCode => {
-        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
-        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
-        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
-        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
-
-        // Fire keydown on the 5th element, checkbox should be false after click
-        act(() => wrapper.findItems()[4]!.keydown(keyCode));
-        // Space handling is triggered on keyup
-        if (keyCode === KeyCode.space) {
-          act(() => wrapper.findItems()[4]!.keyup(keyCode));
-        }
-        expect(onClickSpy).toHaveBeenCalledTimes(1);
-        expect(onClickSpy).toHaveBeenCalledWith(expect.objectContaining({ detail: { id: 'i5', checked: false } }));
-
-        // Open button dropdown again
+    describe('when dropdown is open', () => {
+      beforeEach(() => {
         act(() => wrapper.findNativeButton().keydown(KeyCode.enter));
+      });
 
-        // Fire keydown on the 1st element, checked should be undefined
-        act(() => wrapper.findItems()[0]!.keydown(keyCode));
-        // Space handling is triggered on keyup
-        if (keyCode === KeyCode.space) {
-          act(() => wrapper.findItems()[0]!.keyup(keyCode));
+      test('should close the dropdown when escape is pressed', () => {
+        expect(wrapper.findOpenDropdown()).not.toBe(null);
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.escape));
+        expect(wrapper.findOpenDropdown()).toBe(null);
+      });
+      test('should select the next item if "down" is pressed', () => {
+        expect(wrapper.findHighlightedItem()!.getElement()).toHaveTextContent('item1');
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+        expect(wrapper.findHighlightedItem()!.getElement()).toHaveTextContent('item2');
+      });
+
+      test('should select the previous item if "up" is pressed', () => {
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.up));
+        expect(wrapper.findHighlightedItem()!.getElement()).toHaveTextContent('item1');
+      });
+
+      test('should include disabled items', () => {
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+        expect(wrapper.findHighlightedItem()!.getElement()).toHaveTextContent('item3');
+      });
+
+      test('should call onClick on enter', () => {
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.enter));
+        expect(onClickSpy).toHaveBeenCalledTimes(1);
+      });
+
+      test('should not call onClick on enter a disabled item', () => {
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.enter));
+        expect(onClickSpy).not.toHaveBeenCalled();
+      });
+
+      test('should call onClick on space', () => {
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.space));
+        act(() => wrapper.findOpenDropdown()!.keyup(KeyCode.space));
+        expect(onClickSpy).toHaveBeenCalledTimes(1);
+      });
+
+      test('should not call onClick on space a disabled item', () => {
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.space));
+        expect(onClickSpy).not.toHaveBeenCalled();
+      });
+
+      test('should call onFollow on space if item has href', () => {
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+        act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.space));
+        act(() => wrapper.findOpenDropdown()!.keyup(KeyCode.space));
+        expect(onFollowSpy).toHaveBeenCalledTimes(1);
+      });
+
+      test.each([KeyCode.enter, KeyCode.space])(
+        'should fire event correctly when items with checkbox pressed using key=%s',
+        keyCode => {
+          act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+          act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+          act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+          act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+
+          // Fire keydown on the 5th element, checkbox should be false after click
+          act(() => wrapper.findItems()[4]!.keydown(keyCode));
+          // Space handling is triggered on keyup
+          if (keyCode === KeyCode.space) {
+            act(() => wrapper.findItems()[4]!.keyup(keyCode));
+          }
+          expect(onClickSpy).toHaveBeenCalledTimes(1);
+          expect(onClickSpy).toHaveBeenCalledWith(expect.objectContaining({ detail: { id: 'i5', checked: false } }));
+
+          // Open button dropdown again
+          act(() => wrapper.findNativeButton().keydown(KeyCode.enter));
+
+          // Fire keydown on the 1st element, checked should be undefined
+          act(() => wrapper.findItems()[0]!.keydown(keyCode));
+          // Space handling is triggered on keyup
+          if (keyCode === KeyCode.space) {
+            act(() => wrapper.findItems()[0]!.keyup(keyCode));
+          }
+          expect(onClickSpy).toHaveBeenCalledTimes(2);
+          expect(onClickSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ detail: { id: 'i1', checked: undefined } })
+          );
         }
-        expect(onClickSpy).toHaveBeenCalledTimes(2);
-        expect(onClickSpy).toHaveBeenCalledWith(expect.objectContaining({ detail: { id: 'i1', checked: undefined } }));
-      }
-    );
+      );
+    });
   });
 });

--- a/src/button-dropdown/__tests__/create-items-tree.test.ts
+++ b/src/button-dropdown/__tests__/create-items-tree.test.ts
@@ -63,4 +63,14 @@ describe('create-items-tree util', () => {
     expect(tree.getSequentialIndex([2, 0], -1)).toEqual([2]);
     expect(tree.getSequentialIndex([0, 0], -1)).toEqual(null);
   });
+
+  test('increment with looping', () => {
+    const tree = createItemsTree(items);
+    expect(tree.getSequentialIndex([4, 1], 1, true)).toEqual([0]);
+  });
+
+  test('decrement with looping', () => {
+    const tree = createItemsTree(items);
+    expect(tree.getSequentialIndex([0, 0], -1, true)).toEqual([4, 1]);
+  });
 });

--- a/src/button-dropdown/utils/create-items-tree.ts
+++ b/src/button-dropdown/utils/create-items-tree.ts
@@ -16,7 +16,7 @@ interface ItemsTreeApi {
   // in the tree (referential comparison), or an error will be thrown
   getItemIndex: (item: ButtonDropdownProps.ItemOrGroup) => TreeIndex;
   // Returns the index of next or previous sequential node or null if out of bounds
-  getSequentialIndex: (index: TreeIndex, direction: -1 | 1) => TreeIndex | null;
+  getSequentialIndex: (index: TreeIndex, direction: -1 | 1, loop?: boolean) => TreeIndex | null;
   // Returns parent tree index of a given item or null if no parent is present
   getParentIndex: (item: ButtonDropdownProps.ItemOrGroup) => TreeIndex | null;
 }
@@ -48,11 +48,19 @@ export default function createItemsTree(items: ButtonDropdownProps.Items): Items
 
       return parseIndex(indexKey);
     },
-    getSequentialIndex: (index: TreeIndex, direction: -1 | 1): TreeIndex | null => {
+    getSequentialIndex: (index: TreeIndex, direction: -1 | 1, loop = false): TreeIndex | null => {
       const indexKey = stringifyIndex(index);
       const position = flatIndices.indexOf(indexKey);
 
-      const nextIndexKey = flatIndices[position + direction];
+      let nextIndex = position + direction;
+      if (loop) {
+        if (nextIndex < 0) {
+          nextIndex = flatIndices.length - 1;
+        } else if (nextIndex >= flatIndices.length) {
+          nextIndex = 0;
+        }
+      }
+      const nextIndexKey = flatIndices[nextIndex];
 
       if (!nextIndexKey) {
         return null;

--- a/src/button-dropdown/utils/use-button-dropdown.ts
+++ b/src/button-dropdown/utils/use-button-dropdown.ts
@@ -85,12 +85,6 @@ export function useButtonDropdown({
     closeDropdown();
   };
 
-  const doVerticalNavigation = (direction: -1 | 1) => {
-    if (isOpen) {
-      moveHighlight(direction);
-    }
-  };
-
   const openAndSelectFirst = (event: React.KeyboardEvent) => {
     toggleDropdown();
     event.preventDefault();
@@ -129,12 +123,22 @@ export function useButtonDropdown({
     setIsUsingMouse(false);
     switch (event.keyCode) {
       case KeyCode.down: {
-        doVerticalNavigation(1);
+        if (!isOpen) {
+          toggleDropdown();
+          moveHighlight(1, true);
+        } else {
+          moveHighlight(1);
+        }
         event.preventDefault();
         break;
       }
       case KeyCode.up: {
-        doVerticalNavigation(-1);
+        if (!isOpen) {
+          toggleDropdown();
+          moveHighlight(-1, true);
+        } else {
+          moveHighlight(-1);
+        }
         event.preventDefault();
         break;
       }

--- a/src/button-dropdown/utils/use-highlighted-menu.ts
+++ b/src/button-dropdown/utils/use-highlighted-menu.ts
@@ -14,7 +14,7 @@ interface UseHighlightedMenuOptions {
 }
 
 interface UseHighlightedMenuApi extends HighlightProps {
-  moveHighlight: (direction: -1 | 1) => void;
+  moveHighlight: (direction: -1 | 1, loop?: boolean) => void;
   expandGroup: (group?: ButtonDropdownProps.ItemGroup) => void;
   collapseGroup: () => void;
   reset: () => void;
@@ -61,9 +61,9 @@ export default function useHighlightedMenu({
   );
 
   const moveHighlight = useCallback(
-    (direction: -1 | 1) => {
+    (direction: -1 | 1, loop?: boolean) => {
       const getNext = (index: TreeIndex) => {
-        const nextIndex = getSequentialIndex(index, direction);
+        const nextIndex = getSequentialIndex(index, direction, loop);
         const item = getItem(nextIndex || [-1]);
 
         if (!nextIndex || !item) {


### PR DESCRIPTION
### Description

Currently, button dropdown listens for these key events and prevents default, but does nothing (unless the dropdown is open). To better align with common patterns (e.g. https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/examples/menu-button-actions/) this PR opens the dropdown when up/down keys are pressed.

Related links, issue #, if available: n/a

### How has this been tested?

New unit and integ tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
