### PR TITLE
fix: Apply toolbar border radius only when an AI panel is present

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -138,9 +138,14 @@ export function AppLayoutToolbarImplementation({
   return (
     <ToolbarSlot
       ref={ref}
-      className={clsx(styles['universal-toolbar'], testutilStyles.toolbar, {
-        [testutilStyles['mobile-bar']]: isMobile,
-      })}
+      className={clsx(
+        styles['universal-toolbar'],
+        aiDrawer?.trigger && styles['with-ai-drawer'],
+        testutilStyles.toolbar,
+        {
+          [testutilStyles['mobile-bar']]: isMobile,
+        }
+      )}
       style={{
         insetBlockStart: verticalOffsets.toolbar,
       }}

--- a/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
@@ -22,7 +22,7 @@ $toolbar-height: 42px;
     transition-property: inset-block-start, opacity;
   }
 
-  &:not(:has(.universal-toolbar-ai-custom)) {
+  &.with-ai-drawer:not(:has(.universal-toolbar-ai-custom)) {
     &:before,
     &:after {
       content: '';


### PR DESCRIPTION
### Description

A recent AI panel introduction caused all toolbars in the AppLayout component to show border radius, even when the AI panel wasn't present. This PR adds a check to only apply border radius styles when the AI panel is
actually being used.

<img width="954" height="362" alt="image" src="https://github.com/user-attachments/assets/01d6ecff-638e-40e0-8c9a-25f6c7719a0e" />


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
