### PR TITLE
chore: Update documenter snapshots

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -27795,6 +27795,414 @@ Note that programmatic events ignore disabled attribute and will trigger listene
           },
         },
         {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLoadingIndicator",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTextRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "name": "isDisabled",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "boolean",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ButtonWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
           "name": "findActiveAnchor",
           "parameters": [],
           "returnType": {
@@ -29724,6 +30132,1013 @@ Note that programmatic events ignore disabled attribute and will trigger listene
         },
         {
           "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findCloseButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findHeader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHeaderActions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHeaderBefore",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHeaderDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHeaderInfo",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findOpenButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "description": "Returns the same panel if it's currently open in bottom position. If not, it returns null.
+Use this method to assert the panel position.",
+          "name": "findOpenPanelBottom",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "SplitPanelWrapper",
+          },
+        },
+        {
+          "description": "Returns the same panel if it's currently open in side position. If not, it returns null.
+Use this method to assert the panel position.",
+          "name": "findOpenPanelSide",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "SplitPanelWrapper",
+          },
+        },
+        {
+          "name": "findPreferencesButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findSlider",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "SplitPanelWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "description": "Finds the disabled reason tooltip for a dropdown item. Returns null if no disabled item with \`disabledReason\` is highlighted.",
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Finds an expandable category in the open dropdown by category id. Returns null if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findExpandableCategoryById",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "id",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Finds the highlighted item in the open dropdown. Returns null if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findHighlightedItem",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Finds an item in the open dropdown by item id. Returns null if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findItemById",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "id",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Finds \`checked\` value of item in the open dropdown by item id. Returns null if there is no open dropdown or the item is not a checkbox item.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findItemCheckedById",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "id",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "string",
+          },
+        },
+        {
+          "description": "Finds all the items in the open dropdown. Returns empty array if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findItems",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findMainAction",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findNativeButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLButtonElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findOpenDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTriggerButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+        {
+          "name": "openDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+      ],
+      "name": "ButtonDropdownWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
             "name": "AppLayoutWrapper.findActiveDrawer",
           },
           "name": "findActiveDrawer",
@@ -30952,6 +32367,3180 @@ Note that programmatic events ignore disabled attribute and will trigger listene
           },
         },
         {
+          "description": "Selects all options by triggering corresponding events on the element that selects or deselects all options in Multiselect when using the \`enableSelectAll\` flag.
+
+This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
+
+Example:
+\`\`\`
+wrapper.openDropdown();
+wrapper.clickSelectAll();
+\`\`\`",
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.clickSelectAll",
+          },
+          "name": "clickSelectAll",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.closeDropdown",
+          },
+          "name": "closeDropdown",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.findDropdown",
+          },
+          "name": "findDropdown",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "DropdownContentWrapper",
+          },
+        },
+        {
+          "name": "findPlaceholder",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTrigger",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.openDropdown",
+          },
+          "name": "openDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Selects an option for the given index by triggering corresponding events.
+
+This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
+On selection the dropdown will close automatically.
+
+Example:
+\`\`\`
+wrapper.openDropdown();
+wrapper.selectOption(1);
+\`\`\`",
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.selectOption",
+          },
+          "name": "selectOption",
+          "parameters": [
+            {
+              "description": "1-based index of the option to select",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Selects an option for the given value by triggering corresponding events.
+
+This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
+On selection the dropdown will close automatically.
+
+Example:
+\`\`\`
+wrapper.openDropdown();
+wrapper.selectOptionByValue('option_1');
+\`\`\`",
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.selectOptionByValue",
+          },
+          "name": "selectOptionByValue",
+          "parameters": [
+            {
+              "description": "value of the option",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+      ],
+      "name": "ChartFilterWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDisabledOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "OptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findFooterRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns an option group from the dropdown.",
+          "name": "findGroup",
+          "parameters": [
+            {
+              "description": "1-based index of the group to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns all option groups in the dropdown.",
+          "name": "findGroups",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHighlightedAriaLiveRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns highlighted text fragments from all of the options.
+Options get highlighted when they match the value of the input field.",
+          "name": "findHighlightedMatches",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHighlightedOption",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "name": "findOpenDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns an option from the dropdown.",
+          "name": "findOption",
+          "parameters": [
+            {
+              "description": "1-based index of the option to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "optionIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "name": "findOptionByValue",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "description": "Returns an option from the dropdown.",
+          "name": "findOptionInGroup",
+          "parameters": [
+            {
+              "description": "1-based index of the group to select an option in.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "groupIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the option to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "optionIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "OptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Use this element to scroll through the list of options",
+          "name": "findOptionsContainer",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSelectAll",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSelectedOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "OptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "DropdownContentWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLabelTag",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTags",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "OptionWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findHighlightedItem",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findItems",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNativeList",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ChartLegendWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findContent",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findDismissButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findHeader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSeries",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ChartPopoverSeriesWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ChartPopoverWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ChartPopoverSeriesItemWrapper.findKey",
+          },
+          "name": "findKey",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSubItems",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ChartPopoverSeriesItemWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ChartPopoverSeriesItemWrapper.findValue",
+          },
+          "name": "findValue",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ChartPopoverSeriesWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findKey",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findValue",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ChartPopoverSeriesItemWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
           "inheritedFrom": {
             "name": "AbstractWrapper.find",
           },
@@ -31759,6 +36348,471 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "AttributeEditorRowWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findConstraint",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findControl",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findError",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findInfo",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSecondaryControl",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findWarning",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "FormFieldWrapper",
     },
     {
       "methods": [
@@ -34738,938 +39792,6 @@ If no matching component is found, returns an empty array.",
           },
         },
         {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findDisabledReason",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findLoadingIndicator",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findTextRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "name": "isDisabled",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "boolean",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "ButtonWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "description": "Finds the disabled reason tooltip for a dropdown item. Returns null if no disabled item with \`disabledReason\` is highlighted.",
-          "name": "findDisabledReason",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Finds an expandable category in the open dropdown by category id. Returns null if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findExpandableCategoryById",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "id",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Finds the highlighted item in the open dropdown. Returns null if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findHighlightedItem",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Finds an item in the open dropdown by item id. Returns null if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findItemById",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "id",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Finds \`checked\` value of item in the open dropdown by item id. Returns null if there is no open dropdown or the item is not a checkbox item.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findItemCheckedById",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "id",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "string",
-          },
-        },
-        {
-          "description": "Finds all the items in the open dropdown. Returns empty array if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findItems",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<HTMLElement>",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findMainAction",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "name": "findNativeButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLButtonElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findOpenDropdown",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findTriggerButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-        {
-          "name": "openDropdown",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-      ],
-      "name": "ButtonDropdownWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
           "description": "Finds a button item by its id.",
           "name": "findButtonById",
           "parameters": [
@@ -35959,6 +40081,816 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "ButtonGroupWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.findDisabledReason",
+          },
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.findLoadingIndicator",
+          },
+          "name": "findLoadingIndicator",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.findTextRegion",
+          },
+          "name": "findTextRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.isDisabled",
+          },
+          "name": "isDisabled",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "boolean",
+          },
+        },
+        {
+          "name": "isPressed",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "boolean",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ToggleButtonWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLInputElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTrigger",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "FileInputWrapper",
     },
     {
       "methods": [
@@ -38272,20 +43204,15 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findDescription",
+          "name": "findInput",
           "parameters": [],
           "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
+            "isNullable": false,
+            "name": "InputWrapper",
           },
         },
         {
-          "name": "findLabel",
+          "name": "findResultsCount",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -38293,19 +43220,6 @@ Note: This function returns the specified component's wrapper even if the specif
             "typeArguments": [
               {
                 "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findNativeInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLInputElement",
               },
             ],
           },
@@ -38447,7 +43361,443 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
       ],
-      "name": "CheckboxWrapper",
+      "name": "TextFilterWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "BaseInputWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findClearButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "BaseInputWrapper.findNativeInput",
+          },
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLInputElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "BaseInputWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "description": "Gets the value of the component.
+
+Returns the current value of the input.",
+          "inheritedFrom": {
+            "name": "BaseInputWrapper.getInputValue",
+          },
+          "name": "getInputValue",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "BaseInputWrapper.isDisabled",
+          },
+          "name": "isDisabled",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "boolean",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+        {
+          "description": "Sets the value of the component and calls the \`onChange\` handler",
+          "inheritedFrom": {
+            "name": "BaseInputWrapper.setInputValue",
+          },
+          "name": "setInputValue",
+          "parameters": [
+            {
+              "description": "The value the input is set to.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+      ],
+      "name": "InputWrapper",
     },
     {
       "methods": [
@@ -38672,8 +44022,44 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findEditor",
+          "name": "findCurrentPage",
           "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNextPageButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a page number for a given index.",
+          "name": "findPageNumberByIndex",
+          "parameters": [
+            {
+              "description": "1-based index of the page number to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+          ],
           "returnType": {
             "isNullable": true,
             "name": "ElementWrapper",
@@ -38685,96 +44071,23 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findErrorScreen",
+          "name": "findPageNumbers",
           "parameters": [],
           "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
+            "isNullable": false,
+            "name": "Array",
             "typeArguments": [
               {
-                "name": "HTMLElement",
+                "name": "ElementWrapper<HTMLElement>",
               },
             ],
           },
         },
         {
-          "name": "findErrorsTab",
+          "name": "findPreviousPageButton",
           "parameters": [],
           "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findLoadingScreen",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findNativeTextArea",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLTextAreaElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findPane",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findSettingsButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "name": "findStatusBar",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findWarningsTab",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
+            "isNullable": false,
             "name": "ElementWrapper",
             "typeArguments": [
               {
@@ -38822,6 +44135,14 @@ Note: This function returns the specified component's wrapper even if the specif
           "returnType": {
             "isNullable": false,
             "name": "ElementType",
+          },
+        },
+        {
+          "name": "isDisabled",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "boolean",
           },
         },
         {
@@ -38919,26 +44240,8 @@ Note: This function returns the specified component's wrapper even if the specif
             "name": "this",
           },
         },
-        {
-          "description": "Sets the value of the component and calls the \`onChange\` handler",
-          "name": "setValue",
-          "parameters": [
-            {
-              "description": "The value the input is set to.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "value",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
       ],
-      "name": "CodeEditorWrapper",
+      "name": "PaginationWrapper",
     },
     {
       "methods": [
@@ -39859,6 +45162,4142 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "PreferencesModalWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLInputElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "CheckboxWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "RadioButtonWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "PageSizePreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLInputElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "RadioButtonWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findOptionsGroups",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a content selector toggle.",
+          "name": "findToggleByIndex",
+          "parameters": [
+            {
+              "description": "1-based index of the content group.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "groupIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the option to return within the group.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "optionIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ToggleWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "VisibleContentPreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLInputElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ToggleWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findRadioGroup",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "RadioGroupWrapper",
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "StickyColumnsPreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findButtons",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "RadioButtonWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findInputByValue",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLInputElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "RadioGroupWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "description": "Returns the preference description displayed below the title.",
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns no match with the clear filter button.",
+          "name": "findNoMatch",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns an option for a given index.",
+          "name": "findOptionByIndex",
+          "parameters": [
+            {
+              "description": "1-based index of the option to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ContentDisplayOptionWrapper",
+          },
+        },
+        {
+          "description": "Returns options that the user can reorder.",
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ContentDisplayOptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the text filter input.",
+          "name": "findTextFilter",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "TextFilterWrapper",
+          },
+        },
+        {
+          "description": "Returns the title.",
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ContentDisplayPreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "description": "Returns the drag handle for the option item.",
+          "name": "findDragHandle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the text label displayed in the option item.",
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the visibility toggle for the option item.",
+          "name": "findVisibilityToggle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ToggleWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ContentDisplayOptionWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findEditor",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findErrorScreen",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findErrorsTab",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLoadingScreen",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNativeTextArea",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLTextAreaElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findPane",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSettingsButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findStatusBar",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findWarningsTab",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+        {
+          "description": "Sets the value of the component and calls the \`onChange\` handler",
+          "name": "setValue",
+          "parameters": [
+            {
+              "description": "The value the input is set to.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+      ],
+      "name": "CodeEditorWrapper",
     },
     {
       "methods": [
@@ -44029,6 +53468,1419 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
+          "description": "Finds the segment with the given ID.",
+          "name": "findSegmentById",
+          "parameters": [
+            {
+              "description": "ID of the element to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "id",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "SegmentWrapper",
+          },
+        },
+        {
+          "name": "findSegments",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSelectedSegment",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "SegmentedControlWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "SegmentWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Selects all options by triggering corresponding events on the element that selects or deselects all options in Multiselect when using the \`enableSelectAll\` flag.
+
+This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
+
+Example:
+\`\`\`
+wrapper.openDropdown();
+wrapper.clickSelectAll();
+\`\`\`",
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.clickSelectAll",
+          },
+          "name": "clickSelectAll",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.closeDropdown",
+          },
+          "name": "closeDropdown",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.findDropdown",
+          },
+          "name": "findDropdown",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "DropdownContentWrapper",
+          },
+        },
+        {
+          "name": "findErrorRecoveryButton",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the input that is used for filtering.",
+          "name": "findFilteringInput",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "InputWrapper",
+          },
+        },
+        {
+          "name": "findInlineLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findPlaceholder",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findStatusIndicator",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTrigger",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "name": "isDisabled",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "boolean",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.openDropdown",
+          },
+          "name": "openDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Selects an option for the given index by triggering corresponding events.
+
+This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
+On selection the dropdown will close automatically.
+
+Example:
+\`\`\`
+wrapper.openDropdown();
+wrapper.selectOption(1);
+\`\`\`",
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.selectOption",
+          },
+          "name": "selectOption",
+          "parameters": [
+            {
+              "description": "1-based index of the option to select",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Selects an option for the given value by triggering corresponding events.
+
+This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
+On selection the dropdown will close automatically.
+
+Example:
+\`\`\`
+wrapper.openDropdown();
+wrapper.selectOptionByValue('option_1');
+\`\`\`",
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.selectOptionByValue",
+          },
+          "name": "selectOptionByValue",
+          "parameters": [
+            {
+              "description": "value of the option",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+      ],
+      "name": "SelectWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
           "name": "findContent",
           "parameters": [],
           "returnType": {
@@ -45031,388 +55883,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "FileDropzoneWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findNativeInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLInputElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findTrigger",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "FileInputWrapper",
     },
     {
       "methods": [
@@ -47198,6 +57668,429 @@ Note that programmatic events ignore disabled attribute and will trigger listene
           },
         },
         {
+          "description": "Returns the action slot.",
+          "name": "findAction",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the action button.
+
+The action button is only rendered when the \`buttonText\` property is set.",
+          "name": "findActionButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findContent",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the dismiss button.
+
+The dismiss button is only rendered when the \`dismissible\` property is set to \`true\`.",
+          "name": "findDismissButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findHeader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "FlashWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
           "name": "findActions",
           "parameters": [],
           "returnType": {
@@ -47564,471 +58457,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "FormWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findConstraint",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findControl",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findDescription",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findError",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findInfo",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findLabel",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findSecondaryControl",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findWarning",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "FormFieldWrapper",
     },
     {
       "methods": [
@@ -49982,442 +60410,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "IconWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findClearButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.findNativeInput",
-          },
-          "name": "findNativeInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLInputElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "description": "Gets the value of the component.
-
-Returns the current value of the input.",
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.getInputValue",
-          },
-          "name": "getInputValue",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.isDisabled",
-          },
-          "name": "isDisabled",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "boolean",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-        {
-          "description": "Sets the value of the component and calls the \`onChange\` handler",
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.setInputValue",
-          },
-          "name": "setInputValue",
-          "parameters": [
-            {
-              "description": "The value the input is set to.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "value",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-      ],
-      "name": "InputWrapper",
     },
     {
       "methods": [
@@ -55647,23 +65639,10 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findDisabledOptions",
+          "name": "findDismiss",
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "OptionWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findFooterRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
             "name": "ElementWrapper",
             "typeArguments": [
               {
@@ -55673,47 +65652,10 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "description": "Returns an option group from the dropdown.",
-          "name": "findGroup",
-          "parameters": [
-            {
-              "description": "1-based index of the group to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "index",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns all option groups in the dropdown.",
-          "name": "findGroups",
+          "name": "findLabel",
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<HTMLElement>",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHighlightedAriaLiveRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
             "name": "ElementWrapper",
             "typeArguments": [
               {
@@ -55723,152 +65665,11 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "description": "Returns highlighted text fragments from all of the options.
-Options get highlighted when they match the value of the input field.",
-          "name": "findHighlightedMatches",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<HTMLElement>",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHighlightedOption",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "OptionWrapper",
-          },
-        },
-        {
-          "name": "findOpenDropdown",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns an option from the dropdown.",
           "name": "findOption",
-          "parameters": [
-            {
-              "description": "1-based index of the option to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "optionIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "OptionWrapper",
-          },
-        },
-        {
-          "name": "findOptionByValue",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "value",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "OptionWrapper",
-          },
-        },
-        {
-          "description": "Returns an option from the dropdown.",
-          "name": "findOptionInGroup",
-          "parameters": [
-            {
-              "description": "1-based index of the group to select an option in.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "groupIndex",
-              "typeName": "number",
-            },
-            {
-              "description": "1-based index of the option to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "optionIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "OptionWrapper",
-          },
-        },
-        {
-          "name": "findOptions",
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "OptionWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Use this element to scroll through the list of options",
-          "name": "findOptionsContainer",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findSelectAll",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findSelectedOptions",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "OptionWrapper",
-              },
-            ],
+            "name": "OptionWrapper",
           },
         },
         {
@@ -56008,7 +65809,7 @@ Options get highlighted when they match the value of the input field.",
           },
         },
       ],
-      "name": "DropdownContentWrapper",
+      "name": "TokenWrapper",
     },
     {
       "methods": [
@@ -56383,450 +66184,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "NavigableGroupWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findCurrentPage",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findNextPageButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a page number for a given index.",
-          "name": "findPageNumberByIndex",
-          "parameters": [
-            {
-              "description": "1-based index of the page number to return.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "index",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findPageNumbers",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<HTMLElement>",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findPreviousPageButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "name": "isDisabled",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "boolean",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "PaginationWrapper",
     },
     {
       "methods": [
@@ -60769,401 +70126,6 @@ Note that programmatic events ignore disabled attribute and will trigger listene
           },
         },
         {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findButtons",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "RadioButtonWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findInputByValue",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "value",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLInputElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "RadioGroupWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
           "name": "findAlertSlot",
           "parameters": [],
           "returnType": {
@@ -62507,6 +71469,51 @@ If no matching component is found, returns an empty array.",
           },
         },
         {
+          "description": "Returns the column that is used for ascending sorting.",
+          "name": "findAscSortedColumn",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a table cell based on given row and column indices.",
+          "name": "findBodyCell",
+          "parameters": [
+            {
+              "description": "1-based index of the row of the cell to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the column of the cell to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "columnIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
           "inheritedFrom": {
             "name": "AbstractWrapper.findByClassName",
           },
@@ -62531,57 +71538,15 @@ If no matching component is found, returns an empty array.",
           },
         },
         {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
+          "name": "findCollectionPreferences",
+          "parameters": [],
           "returnType": {
             "isNullable": true,
-            "name": "Wrapper",
+            "name": "CollectionPreferencesWrapper",
           },
         },
         {
-          "description": "Finds the segment with the given ID.",
-          "name": "findSegmentById",
-          "parameters": [
-            {
-              "description": "ID of the element to return.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "id",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "SegmentWrapper",
-          },
-        },
-        {
-          "name": "findSegments",
+          "name": "findColumnHeaders",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -62594,8 +71559,18 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findSelectedSegment",
-          "parameters": [],
+          "description": "Returns the element the user clicks when resizing a column.",
+          "name": "findColumnResizer",
+          "parameters": [
+            {
+              "description": "1-based index of the column containing the resizer.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "columnIndex",
+              "typeName": "number",
+            },
+          ],
           "returnType": {
             "isNullable": true,
             "name": "ElementWrapper",
@@ -62607,190 +71582,14 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
+          "name": "findColumnSortingArea",
           "parameters": [
             {
               "flags": {
                 "isOptional": false,
               },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "SegmentedControlWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
+              "name": "colIndex",
+              "typeName": "number",
             },
           ],
           "returnType": {
@@ -62798,139 +71597,7 @@ Note that programmatic events ignore disabled attribute and will trigger listene
             "name": "ElementWrapper",
             "typeArguments": [
               {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
+                "name": "HTMLElement",
               },
             ],
           },
@@ -62968,7 +71635,8 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findDisabledReason",
+          "description": "Returns the column that is used for descending sorting.",
+          "name": "findDescSortedColumn",
           "parameters": [],
           "returnType": {
             "isNullable": true,
@@ -62978,6 +71646,317 @@ Note: This function returns the specified component's wrapper even if the specif
                 "name": "HTMLElement",
               },
             ],
+          },
+        },
+        {
+          "description": "Returns the button that activates inline editing for a table cell based on given row and column indices.",
+          "name": "findEditCellButton",
+          "parameters": [
+            {
+              "description": "1-based index of the row of the cell to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the column of the cell to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "columnIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findEditingCell",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findEditingCellCancelButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findEditingCellSaveButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Alias for findEmptySlot method for compatibility with previous versions",
+          "name": "findEmptyRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findEmptySlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the expandable row toggle button.",
+          "name": "findExpandToggle",
+          "parameters": [
+            {
+              "description": "1-based index of the row.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findFilterSlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findFooterSlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Alias for findHeaderSlot method for compatibility with previous versions",
+          "name": "findHeaderRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHeaderSlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns items loader of the specific item (matched by item's track ID).",
+          "name": "findItemsLoaderByItemId",
+          "parameters": [
+            {
+              "description": "the (expandable) item ID provided with \`trackBy\` property.
+
+Note: when used with collection-hooks the \`trackBy\` is set automatically from \`expandableRows.getId\`.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "itemId",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLoadingText",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findPagination",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "PaginationWrapper",
+          },
+        },
+        {
+          "name": "findPropertyFilter",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "PropertyFilterWrapper",
+          },
+        },
+        {
+          "description": "Returns items loader of the root table level.",
+          "name": "findRootItemsLoader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findRows",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a row selection area for a given index.",
+          "name": "findRowSelectionArea",
+          "parameters": [
+            {
+              "description": "1-based index of the row selection area to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSelectAllTrigger",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSelectedRows",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTextFilter",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "TextFilterWrapper",
           },
         },
         {
@@ -63022,545 +72001,18 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
+          "description": "Returns \`true\` if the row expand toggle is present and expanded. Returns \`false\` otherwise.",
+          "name": "isRowToggled",
           "parameters": [
             {
+              "description": "1-based index of the row.",
               "flags": {
                 "isOptional": false,
               },
-              "name": "keyCode",
-              "typeName": "KeyCode",
+              "name": "rowIndex",
+              "typeName": "number",
             },
           ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "SegmentWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Selects all options by triggering corresponding events on the element that selects or deselects all options in Multiselect when using the \`enableSelectAll\` flag.
-
-This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
-
-Example:
-\`\`\`
-wrapper.openDropdown();
-wrapper.clickSelectAll();
-\`\`\`",
-          "inheritedFrom": {
-            "name": "DropdownHostComponentWrapper.clickSelectAll",
-          },
-          "name": "clickSelectAll",
-          "parameters": [
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "DropdownHostComponentWrapper.closeDropdown",
-          },
-          "name": "closeDropdown",
-          "parameters": [
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "DropdownHostComponentWrapper.findDropdown",
-          },
-          "name": "findDropdown",
-          "parameters": [
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "DropdownContentWrapper",
-          },
-        },
-        {
-          "name": "findErrorRecoveryButton",
-          "parameters": [
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the input that is used for filtering.",
-          "name": "findFilteringInput",
-          "parameters": [
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "InputWrapper",
-          },
-        },
-        {
-          "name": "findInlineLabel",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findPlaceholder",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findStatusIndicator",
-          "parameters": [
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findTrigger",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "name": "isDisabled",
-          "parameters": [],
           "returnType": {
             "isNullable": false,
             "name": "boolean",
@@ -63661,97 +72113,8 @@ Note: This function returns the specified component's wrapper even if the specif
             "name": "this",
           },
         },
-        {
-          "inheritedFrom": {
-            "name": "DropdownHostComponentWrapper.openDropdown",
-          },
-          "name": "openDropdown",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Selects an option for the given index by triggering corresponding events.
-
-This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
-On selection the dropdown will close automatically.
-
-Example:
-\`\`\`
-wrapper.openDropdown();
-wrapper.selectOption(1);
-\`\`\`",
-          "inheritedFrom": {
-            "name": "DropdownHostComponentWrapper.selectOption",
-          },
-          "name": "selectOption",
-          "parameters": [
-            {
-              "description": "1-based index of the option to select",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "index",
-              "typeName": "number",
-            },
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Selects an option for the given value by triggering corresponding events.
-
-This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
-On selection the dropdown will close automatically.
-
-Example:
-\`\`\`
-wrapper.openDropdown();
-wrapper.selectOptionByValue('option_1');
-\`\`\`",
-          "inheritedFrom": {
-            "name": "DropdownHostComponentWrapper.selectOptionByValue",
-          },
-          "name": "selectOptionByValue",
-          "parameters": [
-            {
-              "description": "value of the option",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "value",
-              "typeName": "string",
-            },
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
       ],
-      "name": "SelectWrapper",
+      "name": "TableWrapper",
     },
     {
       "methods": [
@@ -66020,489 +74383,6 @@ If no matching component is found, returns an empty array.",
           },
         },
         {
-          "name": "findCloseButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findHeader",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHeaderActions",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHeaderBefore",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHeaderDescription",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHeaderInfo",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findOpenButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "description": "Returns the same panel if it's currently open in bottom position. If not, it returns null.
-Use this method to assert the panel position.",
-          "name": "findOpenPanelBottom",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "SplitPanelWrapper",
-          },
-        },
-        {
-          "description": "Returns the same panel if it's currently open in side position. If not, it returns null.
-Use this method to assert the panel position.",
-          "name": "findOpenPanelSide",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "SplitPanelWrapper",
-          },
-        },
-        {
-          "name": "findPreferencesButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "name": "findSlider",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "SplitPanelWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
           "description": "Returns the component wrapper matching the specified selector.
 If the specified selector doesn't match any element, it returns \`null\`.
 
@@ -67436,820 +75316,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "StepWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the column that is used for ascending sorting.",
-          "name": "findAscSortedColumn",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a table cell based on given row and column indices.",
-          "name": "findBodyCell",
-          "parameters": [
-            {
-              "description": "1-based index of the row of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-            {
-              "description": "1-based index of the column of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "columnIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findCollectionPreferences",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "CollectionPreferencesWrapper",
-          },
-        },
-        {
-          "name": "findColumnHeaders",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<HTMLElement>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the element the user clicks when resizing a column.",
-          "name": "findColumnResizer",
-          "parameters": [
-            {
-              "description": "1-based index of the column containing the resizer.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "columnIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findColumnSortingArea",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "colIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "description": "Returns the column that is used for descending sorting.",
-          "name": "findDescSortedColumn",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the button that activates inline editing for a table cell based on given row and column indices.",
-          "name": "findEditCellButton",
-          "parameters": [
-            {
-              "description": "1-based index of the row of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-            {
-              "description": "1-based index of the column of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "columnIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findEditingCell",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findEditingCellCancelButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findEditingCellSaveButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Alias for findEmptySlot method for compatibility with previous versions",
-          "name": "findEmptyRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findEmptySlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the expandable row toggle button.",
-          "name": "findExpandToggle",
-          "parameters": [
-            {
-              "description": "1-based index of the row.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findFilterSlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findFooterSlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Alias for findHeaderSlot method for compatibility with previous versions",
-          "name": "findHeaderRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHeaderSlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns items loader of the specific item (matched by item's track ID).",
-          "name": "findItemsLoaderByItemId",
-          "parameters": [
-            {
-              "description": "the (expandable) item ID provided with \`trackBy\` property.
-
-Note: when used with collection-hooks the \`trackBy\` is set automatically from \`expandableRows.getId\`.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "itemId",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findLoadingText",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findPagination",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "PaginationWrapper",
-          },
-        },
-        {
-          "name": "findPropertyFilter",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "PropertyFilterWrapper",
-          },
-        },
-        {
-          "description": "Returns items loader of the root table level.",
-          "name": "findRootItemsLoader",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findRows",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<HTMLElement>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a row selection area for a given index.",
-          "name": "findRowSelectionArea",
-          "parameters": [
-            {
-              "description": "1-based index of the row selection area to return.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findSelectAllTrigger",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findSelectedRows",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<HTMLElement>",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findTextFilter",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "TextFilterWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "description": "Returns \`true\` if the row expand toggle is present and expanded. Returns \`false\` otherwise.",
-          "name": "isRowToggled",
-          "parameters": [
-            {
-              "description": "1-based index of the row.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "boolean",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "TableWrapper",
     },
     {
       "methods": [
@@ -70688,388 +77754,6 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "InputWrapper",
-          },
-        },
-        {
-          "name": "findResultsCount",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "TextFilterWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
           "name": "findNativeTextarea",
           "parameters": [],
           "returnType": {
@@ -71665,6 +78349,419 @@ Note: This function returns the specified component's wrapper even if the specif
       "methods": [
         {
           "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findImage",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "TileWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
             "name": "BaseInputWrapper.blur",
           },
           "name": "blur",
@@ -72083,834 +79180,6 @@ Returns the current value of the input.",
         },
       ],
       "name": "TimeInputWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findDescription",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findLabel",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findNativeInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLInputElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "ToggleWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "ButtonWrapper.findDisabledReason",
-          },
-          "name": "findDisabledReason",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "ButtonWrapper.findLoadingIndicator",
-          },
-          "name": "findLoadingIndicator",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "ButtonWrapper.findTextRegion",
-          },
-          "name": "findTextRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "ButtonWrapper.isDisabled",
-          },
-          "name": "isDisabled",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "boolean",
-          },
-        },
-        {
-          "name": "isPressed",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "boolean",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "ToggleButtonWrapper",
     },
     {
       "methods": [
@@ -76276,6 +82545,446 @@ If no matching component is found, returns an empty array.",
           },
         },
         {
+          "name": "findCollapseButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findCompleted",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findExpandButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findLearnMoreLink",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "LinkWrapper",
+          },
+        },
+        {
+          "name": "findPrerequisitesAlert",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "AlertWrapper",
+          },
+        },
+        {
+          "name": "findStartButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "TutorialItemWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
           "description": "Returns the component wrapper matching the specified selector.
 If the specified selector doesn't match any element, it returns \`null\`.
 
@@ -77289,6 +83998,246 @@ The dismiss button is only rendered when the \`dismissible\` property is set to 
         },
       ],
       "name": "AlertWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findLoadingIndicator",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTextRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ButtonWrapper",
     },
     {
       "methods": [
@@ -78518,6 +85467,636 @@ Note: This function returns the specified component's wrapper even if the specif
         },
         {
           "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findCloseButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findHeader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findHeaderActions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findHeaderBefore",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findHeaderDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findHeaderInfo",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findOpenButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "description": "Returns the same panel if it's currently open in bottom position. If not, it returns null.
+Use this method to assert the panel position.",
+          "name": "findOpenPanelBottom",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns the same panel if it's currently open in side position. If not, it returns null.
+Use this method to assert the panel position.",
+          "name": "findOpenPanelSide",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findPreferencesButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findSlider",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "SplitPanelWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "description": "Finds the disabled reason tooltip for a dropdown item. Returns null if no disabled item with \`disabledReason\` is highlighted.",
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Finds an expandable category in the open dropdown by category id. Returns null if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findExpandableCategoryById",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "id",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Finds the highlighted item in the open dropdown. Returns null if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findHighlightedItem",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Finds an item in the open dropdown by item id. Returns null if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findItemById",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "id",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Finds all the items in the open dropdown. Returns empty array if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findItems",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findMainAction",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findNativeButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findOpenDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTriggerButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ButtonDropdownWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
             "name": "AppLayoutWrapper.findActiveDrawer",
           },
           "name": "findActiveDrawer",
@@ -79355,6 +86934,1439 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.findDropdown",
+          },
+          "name": "findDropdown",
+          "parameters": [
+            {
+              "defaultValue": "{
+    expandToViewport: false
+  }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "DropdownContentWrapper",
+          },
+        },
+        {
+          "name": "findPlaceholder",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTrigger",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ChartFilterWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDisabledOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "OptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findFooterRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns an option group from the dropdown.",
+          "name": "findGroup",
+          "parameters": [
+            {
+              "description": "1-based index of the group to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns all option groups in the dropdown.",
+          "name": "findGroups",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHighlightedAriaLiveRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns highlighted text fragments from all of the options.
+Options get highlighted when they match the value of the input field.",
+          "name": "findHighlightedMatches",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHighlightedOption",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "name": "findOpenDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns an option from the dropdown.",
+          "name": "findOption",
+          "parameters": [
+            {
+              "description": "1-based index of the option to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "optionIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "name": "findOptionByValue",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "description": "Returns an option from the dropdown.",
+          "name": "findOptionInGroup",
+          "parameters": [
+            {
+              "description": "1-based index of the group to select an option in.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "groupIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the option to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "optionIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "OptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Use this element to scroll through the list of options",
+          "name": "findOptionsContainer",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSelectAll",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSelectedOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "OptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "DropdownContentWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findLabelTag",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTags",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "OptionWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findHighlightedItem",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findItems",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNativeList",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ChartLegendWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findContent",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findDismissButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findHeader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSeries",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ChartPopoverSeriesWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ChartPopoverWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
           "name": "findAddButton",
           "parameters": [],
           "returnType": {
@@ -79870,6 +88882,286 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "AttributeEditorRowWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findConstraint",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findControl",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findError",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findInfo",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSecondaryControl",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findWarning",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "FormFieldWrapper",
     },
     {
       "methods": [
@@ -81758,568 +91050,6 @@ If no CSS selector is specified, returns a multi-element wrapper that matches th
           },
         },
         {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findDisabledReason",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findLoadingIndicator",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findTextRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "ButtonWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "description": "Finds the disabled reason tooltip for a dropdown item. Returns null if no disabled item with \`disabledReason\` is highlighted.",
-          "name": "findDisabledReason",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Finds an expandable category in the open dropdown by category id. Returns null if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findExpandableCategoryById",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "id",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Finds the highlighted item in the open dropdown. Returns null if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findHighlightedItem",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Finds an item in the open dropdown by item id. Returns null if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findItemById",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "id",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Finds all the items in the open dropdown. Returns empty array if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findItems",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findMainAction",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "name": "findNativeButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findOpenDropdown",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findTriggerButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "ButtonDropdownWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
           "description": "Finds a button item by its id.",
           "name": "findButtonById",
           "parameters": [
@@ -82503,6 +91233,487 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "ButtonGroupWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.findDisabledReason",
+          },
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.findLoadingIndicator",
+          },
+          "name": "findLoadingIndicator",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.findTextRegion",
+          },
+          "name": "findTextRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ToggleButtonWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTrigger",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "FileInputWrapper",
     },
     {
       "methods": [
@@ -83501,7 +92712,15 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findDescription",
+          "name": "findInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "InputWrapper",
+          },
+        },
+        {
+          "name": "findResultsCount",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -83509,7 +92728,192 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findLabel",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "TextFilterWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findClearButton",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -83517,6 +92921,40 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "BaseInputWrapper.findNativeInput",
+          },
           "name": "findNativeInput",
           "parameters": [],
           "returnType": {
@@ -83566,7 +93004,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
       ],
-      "name": "CheckboxWrapper",
+      "name": "InputWrapper",
     },
     {
       "methods": [
@@ -83741,7 +93179,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findEditor",
+          "name": "findCurrentPage",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -83749,7 +93187,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findErrorScreen",
+          "name": "findNextPageButton",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -83757,55 +93195,38 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findErrorsTab",
-          "parameters": [],
+          "description": "Returns a page number for a given index.",
+          "name": "findPageNumberByIndex",
+          "parameters": [
+            {
+              "description": "1-based index of the page number to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+          ],
           "returnType": {
             "isNullable": false,
             "name": "ElementWrapper",
           },
         },
         {
-          "name": "findLoadingScreen",
+          "name": "findPageNumbers",
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "ElementWrapper",
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
           },
         },
         {
-          "name": "findNativeTextArea",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findPane",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findSettingsButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "name": "findStatusBar",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findWarningsTab",
+          "name": "findPreviousPageButton",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -83854,7 +93275,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
       ],
-      "name": "CodeEditorWrapper",
+      "name": "PaginationWrapper",
     },
     {
       "methods": [
@@ -84444,6 +93865,2299 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "PreferencesModalWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "CheckboxWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "RadioButtonWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "PageSizePreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findOptionsGroups",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a content selector toggle.",
+          "name": "findToggleByIndex",
+          "parameters": [
+            {
+              "description": "1-based index of the content group.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "groupIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the option to return within the group.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "optionIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ToggleWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "VisibleContentPreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ToggleWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findRadioGroup",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "RadioGroupWrapper",
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "StickyColumnsPreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findButtons",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "RadioButtonWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findInputByValue",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "RadioGroupWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "description": "Returns the preference description displayed below the title.",
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns no match with the clear filter button.",
+          "name": "findNoMatch",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns an option for a given index.",
+          "name": "findOptionByIndex",
+          "parameters": [
+            {
+              "description": "1-based index of the option to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ContentDisplayOptionWrapper",
+          },
+        },
+        {
+          "description": "Returns options that the user can reorder.",
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ContentDisplayOptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the text filter input.",
+          "name": "findTextFilter",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "TextFilterWrapper",
+          },
+        },
+        {
+          "description": "Returns the title.",
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ContentDisplayPreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "description": "Returns the drag handle for the option item.",
+          "name": "findDragHandle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns the text label displayed in the option item.",
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns the visibility toggle for the option item.",
+          "name": "findVisibilityToggle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ToggleWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ContentDisplayOptionWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findEditor",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findErrorScreen",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findErrorsTab",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findLoadingScreen",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findNativeTextArea",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findPane",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSettingsButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findStatusBar",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findWarningsTab",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "CodeEditorWrapper",
     },
     {
       "methods": [
@@ -87057,6 +98771,809 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
+          "description": "Finds the segment with the given ID.",
+          "name": "findSegmentById",
+          "parameters": [
+            {
+              "description": "ID of the element to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "id",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "SegmentWrapper",
+          },
+        },
+        {
+          "name": "findSegments",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSelectedSegment",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "SegmentedControlWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "SegmentWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.findDropdown",
+          },
+          "name": "findDropdown",
+          "parameters": [
+            {
+              "defaultValue": "{
+    expandToViewport: false
+  }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "DropdownContentWrapper",
+          },
+        },
+        {
+          "name": "findErrorRecoveryButton",
+          "parameters": [
+            {
+              "defaultValue": "{
+    expandToViewport: false
+  }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns the input that is used for filtering.",
+          "name": "findFilteringInput",
+          "parameters": [
+            {
+              "defaultValue": "{
+    expandToViewport: false
+  }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "InputWrapper",
+          },
+        },
+        {
+          "name": "findInlineLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findPlaceholder",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findStatusIndicator",
+          "parameters": [
+            {
+              "defaultValue": "{
+    expandToViewport: false
+  }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTrigger",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "SelectWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
           "name": "findContent",
           "parameters": [],
           "returnType": {
@@ -87619,238 +100136,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "FileDropzoneWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findNativeInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findTrigger",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "FileInputWrapper",
     },
     {
       "methods": [
@@ -89330,286 +101615,6 @@ If no CSS selector is specified, returns a multi-element wrapper that matches th
           },
         },
         {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findConstraint",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findControl",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findDescription",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findError",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findInfo",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findLabel",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findSecondaryControl",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findWarning",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "FormFieldWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
           "description": "Returns a column from the grid for a given index.",
           "name": "findColumn",
           "parameters": [
@@ -90645,241 +102650,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "IconWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findClearButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.findNativeInput",
-          },
-          "name": "findNativeInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "InputWrapper",
     },
     {
       "methods": [
@@ -93626,20 +105396,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findDisabledOptions",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "OptionWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findFooterRegion",
+          "name": "findDismiss",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -93647,39 +105404,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "description": "Returns an option group from the dropdown.",
-          "name": "findGroup",
-          "parameters": [
-            {
-              "description": "1-based index of the group to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "index",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns all option groups in the dropdown.",
-          "name": "findGroups",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHighlightedAriaLiveRegion",
+          "name": "findLabel",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -93687,137 +105412,11 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "description": "Returns highlighted text fragments from all of the options.
-Options get highlighted when they match the value of the input field.",
-          "name": "findHighlightedMatches",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHighlightedOption",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "OptionWrapper",
-          },
-        },
-        {
-          "name": "findOpenDropdown",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns an option from the dropdown.",
           "name": "findOption",
-          "parameters": [
-            {
-              "description": "1-based index of the option to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "optionIndex",
-              "typeName": "number",
-            },
-          ],
+          "parameters": [],
           "returnType": {
             "isNullable": false,
             "name": "OptionWrapper",
-          },
-        },
-        {
-          "name": "findOptionByValue",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "value",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "OptionWrapper",
-          },
-        },
-        {
-          "description": "Returns an option from the dropdown.",
-          "name": "findOptionInGroup",
-          "parameters": [
-            {
-              "description": "1-based index of the group to select an option in.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "groupIndex",
-              "typeName": "number",
-            },
-            {
-              "description": "1-based index of the option to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "optionIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "OptionWrapper",
-          },
-        },
-        {
-          "name": "findOptions",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "OptionWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Use this element to scroll through the list of options",
-          "name": "findOptionsContainer",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findSelectAll",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findSelectedOptions",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "OptionWrapper",
-              },
-            ],
           },
         },
         {
@@ -93862,7 +105461,7 @@ Options get highlighted when they match the value of the input field.",
           },
         },
       ],
-      "name": "DropdownContentWrapper",
+      "name": "TokenWrapper",
     },
     {
       "methods": [
@@ -94087,277 +105686,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "NavigableGroupWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findCurrentPage",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findNextPageButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a page number for a given index.",
-          "name": "findPageNumberByIndex",
-          "parameters": [
-            {
-              "description": "1-based index of the page number to return.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "index",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findPageNumbers",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findPreviousPageButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "PaginationWrapper",
     },
     {
       "methods": [
@@ -95955,251 +107283,6 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findButtons",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "RadioButtonWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findInputByValue",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "value",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "RadioGroupWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
           "name": "findAlertSlot",
           "parameters": [],
           "returnType": {
@@ -97065,6 +108148,41 @@ If no CSS selector is specified, returns a multi-element wrapper that matches th
           },
         },
         {
+          "description": "Returns the column that is used for ascending sorting.",
+          "name": "findAscSortedColumn",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a table cell based on given row and column indices.",
+          "name": "findBodyCell",
+          "parameters": [
+            {
+              "description": "1-based index of the row of the cell to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the column of the cell to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "columnIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
           "inheritedFrom": {
             "name": "AbstractWrapper.findByClassName",
           },
@@ -97076,6 +108194,61 @@ If no CSS selector is specified, returns a multi-element wrapper that matches th
               },
               "name": "className",
               "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findCollectionPreferences",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "CollectionPreferencesWrapper",
+          },
+        },
+        {
+          "name": "findColumnHeaders",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the element the user clicks when resizing a column.",
+          "name": "findColumnResizer",
+          "parameters": [
+            {
+              "description": "1-based index of the column containing the resizer.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "columnIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findColumnSortingArea",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "colIndex",
+              "typeName": "number",
             },
           ],
           "returnType": {
@@ -97115,25 +108288,187 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "description": "Finds the segment with the given ID.",
-          "name": "findSegmentById",
+          "description": "Returns the column that is used for descending sorting.",
+          "name": "findDescSortedColumn",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns the button that activates inline editing for a table cell based on given row and column indices.",
+          "name": "findEditCellButton",
           "parameters": [
             {
-              "description": "ID of the element to return.",
+              "description": "1-based index of the row of the cell to select.",
               "flags": {
                 "isOptional": false,
               },
-              "name": "id",
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the column of the cell to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "columnIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findEditingCell",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findEditingCellCancelButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findEditingCellSaveButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Alias for findEmptySlot method for compatibility with previous versions",
+          "name": "findEmptyRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findEmptySlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns the expandable row toggle button.",
+          "name": "findExpandToggle",
+          "parameters": [
+            {
+              "description": "1-based index of the row.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findFilterSlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findFooterSlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Alias for findHeaderSlot method for compatibility with previous versions",
+          "name": "findHeaderRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findHeaderSlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns items loader of the specific item (matched by item's track ID).",
+          "name": "findItemsLoaderByItemId",
+          "parameters": [
+            {
+              "description": "the (expandable) item ID provided with \`trackBy\` property.
+
+Note: when used with collection-hooks the \`trackBy\` is set automatically from \`expandableRows.getId\`.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "itemId",
               "typeName": "string",
             },
           ],
           "returnType": {
             "isNullable": false,
-            "name": "SegmentWrapper",
+            "name": "ElementWrapper",
           },
         },
         {
-          "name": "findSegments",
+          "name": "findLoadingText",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findPagination",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "PaginationWrapper",
+          },
+        },
+        {
+          "name": "findPropertyFilter",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "PropertyFilterWrapper",
+          },
+        },
+        {
+          "description": "Returns items loader of the root table level.",
+          "name": "findRootItemsLoader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findRows",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -97146,11 +108481,50 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findSelectedSegment",
+          "description": "Returns a row selection area for a given index.",
+          "name": "findRowSelectionArea",
+          "parameters": [
+            {
+              "description": "1-based index of the row selection area to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSelectAllTrigger",
           "parameters": [],
           "returnType": {
             "isNullable": false,
             "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSelectedRows",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTextFilter",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "TextFilterWrapper",
           },
         },
         {
@@ -97195,555 +108569,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
       ],
-      "name": "SegmentedControlWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findDisabledReason",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "SegmentWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "DropdownHostComponentWrapper.findDropdown",
-          },
-          "name": "findDropdown",
-          "parameters": [
-            {
-              "defaultValue": "{
-    expandToViewport: false
-  }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "DropdownContentWrapper",
-          },
-        },
-        {
-          "name": "findErrorRecoveryButton",
-          "parameters": [
-            {
-              "defaultValue": "{
-    expandToViewport: false
-  }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns the input that is used for filtering.",
-          "name": "findFilteringInput",
-          "parameters": [
-            {
-              "defaultValue": "{
-    expandToViewport: false
-  }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "InputWrapper",
-          },
-        },
-        {
-          "name": "findInlineLabel",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findPlaceholder",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findStatusIndicator",
-          "parameters": [
-            {
-              "defaultValue": "{
-    expandToViewport: false
-  }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findTrigger",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "SelectWrapper",
+      "name": "TableWrapper",
     },
     {
       "methods": [
@@ -99132,314 +109958,6 @@ If no CSS selector is specified, returns a multi-element wrapper that matches th
           },
         },
         {
-          "name": "findCloseButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findHeader",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findHeaderActions",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findHeaderBefore",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findHeaderDescription",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findHeaderInfo",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findOpenButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "description": "Returns the same panel if it's currently open in bottom position. If not, it returns null.
-Use this method to assert the panel position.",
-          "name": "findOpenPanelBottom",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns the same panel if it's currently open in side position. If not, it returns null.
-Use this method to assert the panel position.",
-          "name": "findOpenPanelSide",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findPreferencesButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "name": "findSlider",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "SplitPanelWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
           "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
 
 Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
@@ -99743,552 +110261,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "StepsWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns the column that is used for ascending sorting.",
-          "name": "findAscSortedColumn",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a table cell based on given row and column indices.",
-          "name": "findBodyCell",
-          "parameters": [
-            {
-              "description": "1-based index of the row of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-            {
-              "description": "1-based index of the column of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "columnIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findCollectionPreferences",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "CollectionPreferencesWrapper",
-          },
-        },
-        {
-          "name": "findColumnHeaders",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the element the user clicks when resizing a column.",
-          "name": "findColumnResizer",
-          "parameters": [
-            {
-              "description": "1-based index of the column containing the resizer.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "columnIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findColumnSortingArea",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "colIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "description": "Returns the column that is used for descending sorting.",
-          "name": "findDescSortedColumn",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns the button that activates inline editing for a table cell based on given row and column indices.",
-          "name": "findEditCellButton",
-          "parameters": [
-            {
-              "description": "1-based index of the row of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-            {
-              "description": "1-based index of the column of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "columnIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findEditingCell",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findEditingCellCancelButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findEditingCellSaveButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Alias for findEmptySlot method for compatibility with previous versions",
-          "name": "findEmptyRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findEmptySlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns the expandable row toggle button.",
-          "name": "findExpandToggle",
-          "parameters": [
-            {
-              "description": "1-based index of the row.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findFilterSlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findFooterSlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Alias for findHeaderSlot method for compatibility with previous versions",
-          "name": "findHeaderRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findHeaderSlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns items loader of the specific item (matched by item's track ID).",
-          "name": "findItemsLoaderByItemId",
-          "parameters": [
-            {
-              "description": "the (expandable) item ID provided with \`trackBy\` property.
-
-Note: when used with collection-hooks the \`trackBy\` is set automatically from \`expandableRows.getId\`.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "itemId",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findLoadingText",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findPagination",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "PaginationWrapper",
-          },
-        },
-        {
-          "name": "findPropertyFilter",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "PropertyFilterWrapper",
-          },
-        },
-        {
-          "description": "Returns items loader of the root table level.",
-          "name": "findRootItemsLoader",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findRows",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a row selection area for a given index.",
-          "name": "findRowSelectionArea",
-          "parameters": [
-            {
-              "description": "1-based index of the row selection area to return.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findSelectAllTrigger",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findSelectedRows",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findTextFilter",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "TextFilterWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "TableWrapper",
     },
     {
       "methods": [
@@ -101887,238 +111859,6 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "InputWrapper",
-          },
-        },
-        {
-          "name": "findResultsCount",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "TextFilterWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
           "name": "findNativeTextarea",
           "parameters": [],
           "returnType": {
@@ -102604,234 +112344,15 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.findNativeInput",
-          },
-          "name": "findNativeInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "TimeInputWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
           "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findImage",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -102896,7 +112417,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
       ],
-      "name": "ToggleWrapper",
+      "name": "TileWrapper",
     },
     {
       "methods": [
@@ -103072,31 +112593,9 @@ Note: This function returns the specified component's wrapper even if the specif
         },
         {
           "inheritedFrom": {
-            "name": "ButtonWrapper.findDisabledReason",
+            "name": "BaseInputWrapper.findNativeInput",
           },
-          "name": "findDisabledReason",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "ButtonWrapper.findLoadingIndicator",
-          },
-          "name": "findLoadingIndicator",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "ButtonWrapper.findTextRegion",
-          },
-          "name": "findTextRegion",
+          "name": "findNativeInput",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -103145,7 +112644,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
       ],
-      "name": "ToggleButtonWrapper",
+      "name": "TimeInputWrapper",
     },
     {
       "methods": [


### PR DESCRIPTION
### Description

Updated snapshots for this change: https://github.com/cloudscape-design/documenter/pull/90

Related links, issue #, if available: n/a

### How has this been tested?

PR build is expected to fail because the original PR is not released yet. 

I will restart the build when it is ready. But an early review and approval will save time

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
