### PR TITLE
chore: Fix visual diffs caused by #3833

### DIFF
--- a/src/internal/components/selectable-item/styles.scss
+++ b/src/internal/components/selectable-item/styles.scss
@@ -105,6 +105,7 @@
     }
   }
 
+  &.selected + &.selected,
   &.selected.previous-item-selected {
     border-start-start-radius: 0;
     border-start-end-radius: 0;

--- a/src/select/parts/styles.scss
+++ b/src/select/parts/styles.scss
@@ -30,8 +30,7 @@ $inlineLabel-border-radius: 2px;
 
 .option-group {
   // Mirrors the negative margin styling of the selectable item.
-  &:not(:first-child),
-  &.virtual {
+  &:not(:first-child) {
     margin-block-start: calc(-1 * #{awsui.$border-item-width});
   }
 }


### PR DESCRIPTION
### Description

Some of the last few pixel changes I made got missed in my dev pipeline because they were getting compared with the larger select icon changes. Mostly me undoing whatever CSS I added/removed because I thought it wasn't important.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
