### PR TITLE
feat: Support secondaryText and labelTag for button-dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     {
       "path": "lib/components/internal/widget-exports.js",
       "brotli": false,
-      "limit": "869 kB",
+      "limit": "870 kB",
       "ignore": "react-dom"
     }
   ],

--- a/pages/button-dropdown/checkboxes.page.tsx
+++ b/pages/button-dropdown/checkboxes.page.tsx
@@ -42,6 +42,35 @@ const getItems = (firstChecked: boolean, secondChecked: boolean, thirdChecked: b
       id: 'id5',
       text: 'Option without checkbox',
     },
+    {
+      id: 'id6',
+      text: 'Disabled option with secondaryText',
+      secondaryText: 'This is a secondary text',
+      disabled: true,
+    },
+    {
+      id: 'id7',
+      text: 'Option with icon and secondaryText',
+      iconName: 'gen-ai',
+      secondaryText: 'This is a secondary text',
+    },
+    {
+      id: 'id8',
+      text: 'Option with checkbox, icon, and secondaryText',
+      iconName: 'gen-ai',
+      secondaryText: 'This is a secondary text',
+      checked: thirdChecked,
+      itemType: 'checkbox',
+    },
+    {
+      id: 'id8',
+      text: 'Option with checkbox, icon, labelTag, and secondaryText',
+      iconName: 'gen-ai',
+      secondaryText: 'This is a secondary text',
+      checked: thirdChecked,
+      itemType: 'checkbox',
+      labelTag: 'Ctrl + L',
+    },
   ];
   return items;
 };

--- a/pages/button-dropdown/disabled-reason.page.tsx
+++ b/pages/button-dropdown/disabled-reason.page.tsx
@@ -7,11 +7,18 @@ import { ButtonDropdown, ButtonDropdownProps } from '~components';
 import ScreenshotArea from '../utils/screenshot-area';
 
 const actionsItems: ButtonDropdownProps.Items = [
-  { id: 'connect', text: 'Connect', disabledReason: 'Instance must be running.', disabled: true },
-  { id: 'details', text: 'View details', disabledReason: 'A single instance needs to be selected.', disabled: true },
+  { id: 'connect', text: 'Connect', disabledReason: 'Instance must be running.', disabled: true, labelTag: 'Disabled' },
+  {
+    id: 'details',
+    text: 'View details',
+    disabledReason: 'A single instance needs to be selected.',
+    disabled: true,
+    labelTag: 'Disabled',
+  },
   {
     id: 'manage-state',
     text: 'Manage instance state',
+    secondaryText: 'Option to start/stop/edit instance',
     disabledReason: 'Instance state must not be pending or stopping.',
     disabled: true,
   },
@@ -22,6 +29,7 @@ const actionsItems: ButtonDropdownProps.Items = [
       {
         id: 'auto-scaling',
         text: 'Attach to Auto Scaling Group',
+        secondaryText: 'Manage the Instance to Auto Scaling Group',
         disabledReason: 'Instance must be running and not already be attached to an Auto Scaling Group.',
         disabled: true,
       },
@@ -32,6 +40,7 @@ const actionsItems: ButtonDropdownProps.Items = [
       {
         id: 'stop-protection',
         text: 'Change stop protection',
+        labelTag: 'Ctrl + D',
       },
       {
         id: 'shutdown-behavior',
@@ -112,6 +121,8 @@ export const selectableGroupItems: ButtonDropdownProps.Items = [
         itemType: 'checkbox',
         checked: true,
         disabled: false,
+        secondaryText: 'Manage the settings',
+        labelTag: 'Ctrl + S',
       },
       {
         text: 'Disabled setting',
@@ -119,7 +130,8 @@ export const selectableGroupItems: ButtonDropdownProps.Items = [
         itemType: 'checkbox',
         checked: true,
         disabled: true,
-        disabledReason: 'disabled reason',
+        disabledReason: '',
+        secondaryText: "Can't be modified",
       },
     ],
   },
@@ -130,7 +142,7 @@ export default function DescriptionPage() {
   const [isRightAligned, setIsRightAligned] = useState(false);
   return (
     <>
-      <h1>Descriptions in ButtonDropdown</h1>
+      <h1>Failure Reason in ButtonDropdown</h1>
       <label>
         <input
           type="checkbox"

--- a/pages/button-dropdown/events.page.tsx
+++ b/pages/button-dropdown/events.page.tsx
@@ -10,19 +10,32 @@ const dropdownItems = [
   {
     text: 'enabled category',
     items: [
-      { id: 'c1long1', text: 'VeryLongOptionTextValueHereToTestTheCaseWithThisDropdown' },
-      { id: 'c1_disabled_item', text: 'disabled item', disabled: true },
+      {
+        id: 'c1long1',
+        text: 'VeryLongOptionTextValueHereToTestTheCaseWithThisDropdown',
+        secondaryText: 'Very long option',
+      },
+      { id: 'c1_disabled_item', text: 'disabled item', disabled: true, secondaryText: 'Disabled option' },
       { id: 'c1_enabled_item', text: 'option2' },
-      { id: 'c1long2', text: 'VeryLongOptionTextValueHereToTestTheCaseWithThisDropdown', disabled: true },
-      { id: 'c1i3', text: 'option3' },
-      { id: 'c1i4', text: 'option4' },
+      {
+        id: 'c1long2',
+        text: 'VeryLongOptionTextValueHereToTestTheCaseWithThisDropdown',
+        disabled: true,
+        secondaryText: 'Very long option',
+      },
+      { id: 'c1i3', text: 'option3', secondaryText: 'option 3' },
+      { id: 'c1i4', text: 'option4', secondaryText: 'option 4' },
     ],
   },
   {
     text: 'disabled category',
     disabled: true,
     items: [
-      { id: 'dci1', text: 'VeryLongOptionTextValueHereToTestTheCaseWithThisDropdown' },
+      {
+        id: 'dci1',
+        text: 'VeryLongOptionTextValueHereToTestTheCaseWithThisDropdown',
+        secondaryText: 'Very long option',
+      },
       { id: 'item_in_disabled_category', text: 'option4' },
       { id: 'dci5', text: 'option5' },
     ],
@@ -35,11 +48,13 @@ const dropdownItems = [
     id: 'individual_disabled_item',
     text: 'VeryLongOptionTextValueHereToTestTheCaseWithThisDropdown',
     disabled: true,
+    labelTag: 'Disabled',
   },
   {
     id: 'plain_href',
     text: 'option6',
     href: '#',
+    labelTag: 'Link',
   },
   {
     id: 'plain_href_prevented',

--- a/pages/button-dropdown/expandable.page.tsx
+++ b/pages/button-dropdown/expandable.page.tsx
@@ -14,6 +14,7 @@ export const items: ButtonDropdownProps['items'] = [
     items: [...Array(2)].map((_, index) => ({
       id: 'category1Subitem' + index,
       text: 'Sub item ' + index,
+      secondaryText: `Option ${index}`,
     })),
   },
   {
@@ -22,11 +23,13 @@ export const items: ButtonDropdownProps['items'] = [
     items: [...Array(50)].map((_, index) => ({
       id: 'category2Subitem' + index,
       text: 'Cat 2 Sub item ' + index,
+      secondaryText: `Option ${index}`,
     })),
   },
   ...[...Array(10)].map((_, index) => ({
     id: 'item' + index,
     text: 'Item ' + index,
+    secondaryText: `Option ${index}`,
   })),
   {
     id: 'category3',
@@ -45,6 +48,7 @@ export const items: ButtonDropdownProps['items'] = [
   {
     id: 'item10',
     text: 'Item 10',
+    secondaryText: 'This is the last option',
   },
 ];
 

--- a/pages/button-dropdown/icon-expandable.page.tsx
+++ b/pages/button-dropdown/icon-expandable.page.tsx
@@ -19,6 +19,7 @@ export const items: ButtonDropdownProps['items'] = [
     items: [...Array(2)].map((_, index) => ({
       id: 'category1Subitem' + index,
       text: 'Sub item ' + index,
+      secondaryText: `Option ${index}`,
     })),
   },
   {
@@ -35,6 +36,7 @@ export const items: ButtonDropdownProps['items'] = [
     id: 'item1',
     text: 'Item 1',
     iconName: 'settings',
+    secondaryText: 'Option 1',
   },
   {
     id: 'category3',
@@ -50,6 +52,7 @@ export const items: ButtonDropdownProps['items'] = [
     items: [...Array(2)].map((_, index) => ({
       id: 'category3Subitem' + index,
       text: 'Sub item ' + index,
+      labelTag: ' Number ' + index,
     })),
   },
 ];

--- a/pages/button-dropdown/item-element.permutations.page.tsx
+++ b/pages/button-dropdown/item-element.permutations.page.tsx
@@ -50,6 +50,33 @@ const permutations = createPermutations<ItemProps>([
     onItemActivate: [() => {}],
     highlightItem: [() => {}],
   },
+
+  // With secondaryText
+  {
+    item: [
+      { id: '1', text: 'Option', secondaryText: 'This is the first option' },
+      { id: '2', text: 'Option 2', secondaryText: 'This is the second option' },
+    ],
+    disabled: [false, true],
+    highlighted: [false, true],
+    hasCategoryHeader: [false],
+    showDivider: [false],
+    onItemActivate: [() => {}],
+    highlightItem: [() => {}],
+  },
+  // With labelTag
+  {
+    item: [
+      { id: '1', text: 'Option', labelTag: 'This is a label tag' },
+      { id: '2', text: 'Option 2', secondaryText: 'This is the second option', labelTag: 'This is a label tag' },
+    ],
+    disabled: [false, true],
+    highlighted: [false, true],
+    hasCategoryHeader: [false],
+    showDivider: [false],
+    onItemActivate: [() => {}],
+    highlightItem: [() => {}],
+  },
   // With icons
   {
     item: [

--- a/pages/button-dropdown/main-action.page.tsx
+++ b/pages/button-dropdown/main-action.page.tsx
@@ -22,6 +22,7 @@ export default function ButtonDropdownPage() {
               {
                 text: 'Launch instance from template',
                 id: 'launch-instance-from-template',
+                secondaryText: 'Use the existing templates',
               },
             ]}
             onItemClick={() => setClickedButton('Launch instance from template')}

--- a/pages/button-dropdown/permutations-main-action.page.tsx
+++ b/pages/button-dropdown/permutations-main-action.page.tsx
@@ -17,6 +17,7 @@ const launchInstanceItem = {
 const launchInstanceFromTemplateItem = {
   text: 'Launch instance from template',
   iconName: 'file',
+  secondaryText: 'Use an existing template',
 } as const;
 
 const viewInstancesItem = {
@@ -24,6 +25,7 @@ const viewInstancesItem = {
   href: 'https://instances.com',
   external: true,
   externalIconAriaLabel: '(opens in new tab)',
+  labelTag: 'Ctrl + Click',
 } as const;
 
 const permutations = createPermutations<ButtonDropdownProps>([

--- a/pages/button-dropdown/simple.page.tsx
+++ b/pages/button-dropdown/simple.page.tsx
@@ -40,6 +40,22 @@ const items: ButtonDropdownProps['items'] = [
     text: 'Option 6',
     disabled: true,
   },
+  {
+    id: 'id7',
+    text: 'Option 7',
+    secondaryText: 'This is option 7',
+  },
+  {
+    id: 'id8',
+    text: 'Option 8',
+    labelTag: 'Ctrl + 8',
+  },
+  {
+    id: 'id9',
+    text: 'Option 9',
+    secondaryText: 'This is option 9',
+    labelTag: 'Ctrl + 9',
+  },
 ];
 
 const withNestedOptions: ButtonDropdownProps['items'] = [
@@ -49,10 +65,14 @@ const withNestedOptions: ButtonDropdownProps['items'] = [
       {
         id: '1',
         text: 'Destroy',
+        secondaryText: 'This is the Destroy option',
+        labelTag: 'Ctrl + D',
       },
       {
         id: '2',
         text: 'Restart',
+        secondaryText: 'This is the Restart option',
+        labelTag: 'Ctrl + R',
       },
     ],
   },
@@ -77,10 +97,13 @@ const withExpandedGroups: ButtonDropdownProps['items'] = [
   {
     id: 'connect',
     text: 'Connect',
+    secondaryText: 'This is the Connect option',
+    labelTag: 'Ctrl + C',
   },
   {
     id: 'password',
     text: 'Get password',
+    secondaryText: 'This is the Get password option',
   },
   {
     id: 'states',
@@ -89,29 +112,39 @@ const withExpandedGroups: ButtonDropdownProps['items'] = [
       {
         id: 'start',
         text: 'Start',
+        secondaryText: 'This is the Start option',
+        labelTag: 'Ctrl + S',
       },
       {
         id: 'stop',
         text: 'Stop',
+        secondaryText: 'This is the Stop Option',
         disabled: true,
       },
       {
         id: 'hibernate',
         text: 'Hibernate',
+        secondaryText: 'This is the Hibernate Option',
+        labelTag: 'Ctrl + H',
         disabled: true,
       },
       {
         id: 'reboot',
         text: 'Reboot',
+        secondaryText: 'This is the Reboot Option',
+        labelTag: 'Ctrl + B',
         disabled: true,
       },
       {
         id: 'terminate',
         text: 'Terminate',
+        secondaryText: 'This is the Terminate Option',
       },
       {
         id: 'external',
         text: 'Root Page',
+        secondaryText: '',
+        labelTag: 'Ctrl + P',
         external: true,
         href: '/#/light/',
       },

--- a/pages/button-dropdown/utils/button-dropdown-items.ts
+++ b/pages/button-dropdown/utils/button-dropdown-items.ts
@@ -11,10 +11,13 @@ const dropdownItems = [
     id: 'id7',
     text: 'option5',
     disabled: true,
+    secondaryText: 'This is a disabled option',
+    labelTag: 'Disabled',
   },
   {
     id: 'id8',
     text: 'VeryLongOptionTextValueHereToTestTheCaseWithThisDropdown',
+    secondaryText: 'This is the option with a long description, This is the option with a long description',
   },
   { id: 'id9', text: 'option6' },
 ];

--- a/pages/button-dropdown/word-wrap.page.tsx
+++ b/pages/button-dropdown/word-wrap.page.tsx
@@ -14,6 +14,9 @@ const dropdownItems = [
       {
         id: 'id0',
         text: 'a very long text that may overflow horizontally as in this example that is unnecessarily longer just to exemplify a long text',
+        secondaryText:
+          'A very long text that may overflow horizontally as in this example that is unnecessarily longer just to exemplify a long text',
+        labelTag: 'Label',
       },
       { id: 'id1', text: 'option1', disabled: true },
       { id: 'id2', text: 'option2' },
@@ -28,6 +31,7 @@ const dropdownItems = [
       {
         id: 'id5',
         text: 'AVeryLongWordThatMayOverflowHorizontallyAsInThisExampleThatIsUnnecessarilyLongerJustToExemplifyALongWord',
+        labelTag: 'Label',
       },
       { id: 'id6', text: 'option4' },
     ],
@@ -44,6 +48,7 @@ const dropdownItems = [
   {
     id: 'id9',
     text: 'option9',
+    secondaryText: 'This is a disabled option',
     disabled: true,
   },
   {

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -5550,11 +5550,13 @@ The following properties are supported across all types:
 - \`type\` (string) - The type of the item. Can be \`action\`, \`group\`, \`checkbox\`. Defaults to \`action\` if \`items\` undefined and \`group\` otherwise.
 - \`id\` (string) - allows to identify the item that the user clicked on. Mandatory for individual items, optional for categories.
 - \`text\` (string) - description shown in the menu for this item. Mandatory for individual items, optional for categories.
+- \`secondaryText\` (string) - (Optional) Secondary text displayed in the menu for this item.
 - \`lang\` (string) - (Optional) The language of the item, provided as a BCP 47 language tag.
 - \`disabled\` (boolean) - whether the item is disabled. Disabled items are not clickable, but they can be highlighted with the keyboard to make them accessible.
 - \`disabledReason\` (string) - (Optional) Displays text near the \`text\` property when item is disabled. Use to provide additional context.
-- \`description\` (string) - additional data that will be passed to a \`data-description\` attribute.
+- \`description\` (string) - additional data that will be passed to a \`data-description\` attribute. **Deprecated**, has no effect.
 - \`ariaLabel\` (string) - (Optional) - ARIA label of the item element.
+- \`labelTag\` (string) - (Optional) - Label for the item. Displayed near the item text for visually impaired users.
 
 ### action
 
@@ -27795,6 +27797,414 @@ Note that programmatic events ignore disabled attribute and will trigger listene
           },
         },
         {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLoadingIndicator",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTextRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "name": "isDisabled",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "boolean",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ButtonWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
           "name": "findActiveAnchor",
           "parameters": [],
           "returnType": {
@@ -29724,6 +30134,1041 @@ Note that programmatic events ignore disabled attribute and will trigger listene
         },
         {
           "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findCloseButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findHeader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHeaderActions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHeaderBefore",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHeaderDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHeaderInfo",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findOpenButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "description": "Returns the same panel if it's currently open in bottom position. If not, it returns null.
+Use this method to assert the panel position.",
+          "name": "findOpenPanelBottom",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "SplitPanelWrapper",
+          },
+        },
+        {
+          "description": "Returns the same panel if it's currently open in side position. If not, it returns null.
+Use this method to assert the panel position.",
+          "name": "findOpenPanelSide",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "SplitPanelWrapper",
+          },
+        },
+        {
+          "name": "findPreferencesButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findSlider",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "SplitPanelWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "description": "Finds the disabled reason tooltip for a dropdown item. Returns null if no disabled item with \`disabledReason\` is highlighted.",
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Finds an expandable category in the open dropdown by category id. Returns null if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findExpandableCategoryById",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "id",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Finds the highlighted item in the open dropdown. Returns null if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findHighlightedItem",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Finds an item in the open dropdown by item id. Returns null if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findItemById",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "id",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Finds \`checked\` value of item in the open dropdown by item id. Returns null if there is no open dropdown or the item is not a checkbox item.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findItemCheckedById",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "id",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "string",
+          },
+        },
+        {
+          "description": "Finds all the items in the open dropdown. Returns empty array if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findItems",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Finds the label tag element for a dropdown item. Returns null if the element has no label tag.",
+          "name": "findLabelTags",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findMainAction",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findNativeButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLButtonElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findOpenDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Finds the secondary text element for a dropdown item. Returns null if the element has no secondary text.",
+          "name": "findSecondaryText",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTriggerButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+        {
+          "name": "openDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+      ],
+      "name": "ButtonDropdownWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
             "name": "AppLayoutWrapper.findActiveDrawer",
           },
           "name": "findActiveDrawer",
@@ -30952,6 +32397,3180 @@ Note that programmatic events ignore disabled attribute and will trigger listene
           },
         },
         {
+          "description": "Selects all options by triggering corresponding events on the element that selects or deselects all options in Multiselect when using the \`enableSelectAll\` flag.
+
+This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
+
+Example:
+\`\`\`
+wrapper.openDropdown();
+wrapper.clickSelectAll();
+\`\`\`",
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.clickSelectAll",
+          },
+          "name": "clickSelectAll",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.closeDropdown",
+          },
+          "name": "closeDropdown",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.findDropdown",
+          },
+          "name": "findDropdown",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "DropdownContentWrapper",
+          },
+        },
+        {
+          "name": "findPlaceholder",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTrigger",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.openDropdown",
+          },
+          "name": "openDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Selects an option for the given index by triggering corresponding events.
+
+This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
+On selection the dropdown will close automatically.
+
+Example:
+\`\`\`
+wrapper.openDropdown();
+wrapper.selectOption(1);
+\`\`\`",
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.selectOption",
+          },
+          "name": "selectOption",
+          "parameters": [
+            {
+              "description": "1-based index of the option to select",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Selects an option for the given value by triggering corresponding events.
+
+This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
+On selection the dropdown will close automatically.
+
+Example:
+\`\`\`
+wrapper.openDropdown();
+wrapper.selectOptionByValue('option_1');
+\`\`\`",
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.selectOptionByValue",
+          },
+          "name": "selectOptionByValue",
+          "parameters": [
+            {
+              "description": "value of the option",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+      ],
+      "name": "ChartFilterWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDisabledOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "OptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findFooterRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns an option group from the dropdown.",
+          "name": "findGroup",
+          "parameters": [
+            {
+              "description": "1-based index of the group to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns all option groups in the dropdown.",
+          "name": "findGroups",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHighlightedAriaLiveRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns highlighted text fragments from all of the options.
+Options get highlighted when they match the value of the input field.",
+          "name": "findHighlightedMatches",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHighlightedOption",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "name": "findOpenDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns an option from the dropdown.",
+          "name": "findOption",
+          "parameters": [
+            {
+              "description": "1-based index of the option to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "optionIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "name": "findOptionByValue",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "description": "Returns an option from the dropdown.",
+          "name": "findOptionInGroup",
+          "parameters": [
+            {
+              "description": "1-based index of the group to select an option in.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "groupIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the option to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "optionIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "OptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Use this element to scroll through the list of options",
+          "name": "findOptionsContainer",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSelectAll",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSelectedOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "OptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "DropdownContentWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLabelTag",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTags",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "OptionWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findHighlightedItem",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findItems",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNativeList",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ChartLegendWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findContent",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findDismissButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findHeader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSeries",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ChartPopoverSeriesWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ChartPopoverWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ChartPopoverSeriesItemWrapper.findKey",
+          },
+          "name": "findKey",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSubItems",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ChartPopoverSeriesItemWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ChartPopoverSeriesItemWrapper.findValue",
+          },
+          "name": "findValue",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ChartPopoverSeriesWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findKey",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findValue",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ChartPopoverSeriesItemWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
           "inheritedFrom": {
             "name": "AbstractWrapper.find",
           },
@@ -31759,6 +36378,471 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "AttributeEditorRowWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findConstraint",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findControl",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findError",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findInfo",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSecondaryControl",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findWarning",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "FormFieldWrapper",
     },
     {
       "methods": [
@@ -34738,938 +39822,6 @@ If no matching component is found, returns an empty array.",
           },
         },
         {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findDisabledReason",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findLoadingIndicator",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findTextRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "name": "isDisabled",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "boolean",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "ButtonWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "description": "Finds the disabled reason tooltip for a dropdown item. Returns null if no disabled item with \`disabledReason\` is highlighted.",
-          "name": "findDisabledReason",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Finds an expandable category in the open dropdown by category id. Returns null if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findExpandableCategoryById",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "id",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Finds the highlighted item in the open dropdown. Returns null if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findHighlightedItem",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Finds an item in the open dropdown by item id. Returns null if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findItemById",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "id",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Finds \`checked\` value of item in the open dropdown by item id. Returns null if there is no open dropdown or the item is not a checkbox item.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findItemCheckedById",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "id",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "string",
-          },
-        },
-        {
-          "description": "Finds all the items in the open dropdown. Returns empty array if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findItems",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<HTMLElement>",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findMainAction",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "name": "findNativeButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLButtonElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findOpenDropdown",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findTriggerButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-        {
-          "name": "openDropdown",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-      ],
-      "name": "ButtonDropdownWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
           "description": "Finds a button item by its id.",
           "name": "findButtonById",
           "parameters": [
@@ -35959,6 +40111,816 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "ButtonGroupWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.findDisabledReason",
+          },
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.findLoadingIndicator",
+          },
+          "name": "findLoadingIndicator",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.findTextRegion",
+          },
+          "name": "findTextRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.isDisabled",
+          },
+          "name": "isDisabled",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "boolean",
+          },
+        },
+        {
+          "name": "isPressed",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "boolean",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ToggleButtonWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLInputElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTrigger",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "FileInputWrapper",
     },
     {
       "methods": [
@@ -38272,20 +43234,15 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findDescription",
+          "name": "findInput",
           "parameters": [],
           "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
+            "isNullable": false,
+            "name": "InputWrapper",
           },
         },
         {
-          "name": "findLabel",
+          "name": "findResultsCount",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -38293,19 +43250,6 @@ Note: This function returns the specified component's wrapper even if the specif
             "typeArguments": [
               {
                 "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findNativeInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLInputElement",
               },
             ],
           },
@@ -38447,7 +43391,443 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
       ],
-      "name": "CheckboxWrapper",
+      "name": "TextFilterWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "BaseInputWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findClearButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "BaseInputWrapper.findNativeInput",
+          },
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLInputElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "BaseInputWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "description": "Gets the value of the component.
+
+Returns the current value of the input.",
+          "inheritedFrom": {
+            "name": "BaseInputWrapper.getInputValue",
+          },
+          "name": "getInputValue",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "BaseInputWrapper.isDisabled",
+          },
+          "name": "isDisabled",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "boolean",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+        {
+          "description": "Sets the value of the component and calls the \`onChange\` handler",
+          "inheritedFrom": {
+            "name": "BaseInputWrapper.setInputValue",
+          },
+          "name": "setInputValue",
+          "parameters": [
+            {
+              "description": "The value the input is set to.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+      ],
+      "name": "InputWrapper",
     },
     {
       "methods": [
@@ -38672,8 +44052,44 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findEditor",
+          "name": "findCurrentPage",
           "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNextPageButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a page number for a given index.",
+          "name": "findPageNumberByIndex",
+          "parameters": [
+            {
+              "description": "1-based index of the page number to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+          ],
           "returnType": {
             "isNullable": true,
             "name": "ElementWrapper",
@@ -38685,96 +44101,23 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findErrorScreen",
+          "name": "findPageNumbers",
           "parameters": [],
           "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
+            "isNullable": false,
+            "name": "Array",
             "typeArguments": [
               {
-                "name": "HTMLElement",
+                "name": "ElementWrapper<HTMLElement>",
               },
             ],
           },
         },
         {
-          "name": "findErrorsTab",
+          "name": "findPreviousPageButton",
           "parameters": [],
           "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findLoadingScreen",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findNativeTextArea",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLTextAreaElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findPane",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findSettingsButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "name": "findStatusBar",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findWarningsTab",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
+            "isNullable": false,
             "name": "ElementWrapper",
             "typeArguments": [
               {
@@ -38822,6 +44165,14 @@ Note: This function returns the specified component's wrapper even if the specif
           "returnType": {
             "isNullable": false,
             "name": "ElementType",
+          },
+        },
+        {
+          "name": "isDisabled",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "boolean",
           },
         },
         {
@@ -38919,26 +44270,8 @@ Note: This function returns the specified component's wrapper even if the specif
             "name": "this",
           },
         },
-        {
-          "description": "Sets the value of the component and calls the \`onChange\` handler",
-          "name": "setValue",
-          "parameters": [
-            {
-              "description": "The value the input is set to.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "value",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
       ],
-      "name": "CodeEditorWrapper",
+      "name": "PaginationWrapper",
     },
     {
       "methods": [
@@ -39859,6 +45192,4142 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "PreferencesModalWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLInputElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "CheckboxWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "RadioButtonWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "PageSizePreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLInputElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "RadioButtonWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findOptionsGroups",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a content selector toggle.",
+          "name": "findToggleByIndex",
+          "parameters": [
+            {
+              "description": "1-based index of the content group.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "groupIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the option to return within the group.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "optionIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ToggleWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "VisibleContentPreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLInputElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ToggleWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findRadioGroup",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "RadioGroupWrapper",
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "StickyColumnsPreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findButtons",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "RadioButtonWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findInputByValue",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLInputElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "RadioGroupWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "description": "Returns the preference description displayed below the title.",
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns no match with the clear filter button.",
+          "name": "findNoMatch",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns an option for a given index.",
+          "name": "findOptionByIndex",
+          "parameters": [
+            {
+              "description": "1-based index of the option to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ContentDisplayOptionWrapper",
+          },
+        },
+        {
+          "description": "Returns options that the user can reorder.",
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ContentDisplayOptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the text filter input.",
+          "name": "findTextFilter",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "TextFilterWrapper",
+          },
+        },
+        {
+          "description": "Returns the title.",
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ContentDisplayPreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "description": "Returns the drag handle for the option item.",
+          "name": "findDragHandle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the text label displayed in the option item.",
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the visibility toggle for the option item.",
+          "name": "findVisibilityToggle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ToggleWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "ContentDisplayOptionWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findEditor",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findErrorScreen",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findErrorsTab",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLoadingScreen",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNativeTextArea",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLTextAreaElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findPane",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSettingsButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findStatusBar",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findWarningsTab",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+        {
+          "description": "Sets the value of the component and calls the \`onChange\` handler",
+          "name": "setValue",
+          "parameters": [
+            {
+              "description": "The value the input is set to.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+      ],
+      "name": "CodeEditorWrapper",
     },
     {
       "methods": [
@@ -44029,6 +53498,1419 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
+          "description": "Finds the segment with the given ID.",
+          "name": "findSegmentById",
+          "parameters": [
+            {
+              "description": "ID of the element to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "id",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "SegmentWrapper",
+          },
+        },
+        {
+          "name": "findSegments",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSelectedSegment",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "SegmentedControlWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "SegmentWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Selects all options by triggering corresponding events on the element that selects or deselects all options in Multiselect when using the \`enableSelectAll\` flag.
+
+This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
+
+Example:
+\`\`\`
+wrapper.openDropdown();
+wrapper.clickSelectAll();
+\`\`\`",
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.clickSelectAll",
+          },
+          "name": "clickSelectAll",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.closeDropdown",
+          },
+          "name": "closeDropdown",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.findDropdown",
+          },
+          "name": "findDropdown",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "DropdownContentWrapper",
+          },
+        },
+        {
+          "name": "findErrorRecoveryButton",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the input that is used for filtering.",
+          "name": "findFilteringInput",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "InputWrapper",
+          },
+        },
+        {
+          "name": "findInlineLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findPlaceholder",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findStatusIndicator",
+          "parameters": [
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTrigger",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "name": "isDisabled",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "boolean",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.openDropdown",
+          },
+          "name": "openDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Selects an option for the given index by triggering corresponding events.
+
+This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
+On selection the dropdown will close automatically.
+
+Example:
+\`\`\`
+wrapper.openDropdown();
+wrapper.selectOption(1);
+\`\`\`",
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.selectOption",
+          },
+          "name": "selectOption",
+          "parameters": [
+            {
+              "description": "1-based index of the option to select",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Selects an option for the given value by triggering corresponding events.
+
+This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
+On selection the dropdown will close automatically.
+
+Example:
+\`\`\`
+wrapper.openDropdown();
+wrapper.selectOptionByValue('option_1');
+\`\`\`",
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.selectOptionByValue",
+          },
+          "name": "selectOptionByValue",
+          "parameters": [
+            {
+              "description": "value of the option",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+            {
+              "defaultValue": "{ expandToViewport: false }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+      ],
+      "name": "SelectWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
           "name": "findContent",
           "parameters": [],
           "returnType": {
@@ -45031,388 +55913,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "FileDropzoneWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findNativeInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLInputElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findTrigger",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "FileInputWrapper",
     },
     {
       "methods": [
@@ -47198,6 +57698,429 @@ Note that programmatic events ignore disabled attribute and will trigger listene
           },
         },
         {
+          "description": "Returns the action slot.",
+          "name": "findAction",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the action button.
+
+The action button is only rendered when the \`buttonText\` property is set.",
+          "name": "findActionButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findContent",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the dismiss button.
+
+The dismiss button is only rendered when the \`dismissible\` property is set to \`true\`.",
+          "name": "findDismissButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findHeader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "FlashWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
           "name": "findActions",
           "parameters": [],
           "returnType": {
@@ -47564,471 +58487,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "FormWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findConstraint",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findControl",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findDescription",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findError",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findInfo",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findLabel",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findSecondaryControl",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findWarning",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "FormFieldWrapper",
     },
     {
       "methods": [
@@ -49982,442 +60440,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "IconWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findClearButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.findNativeInput",
-          },
-          "name": "findNativeInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLInputElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "description": "Gets the value of the component.
-
-Returns the current value of the input.",
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.getInputValue",
-          },
-          "name": "getInputValue",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.isDisabled",
-          },
-          "name": "isDisabled",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "boolean",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-        {
-          "description": "Sets the value of the component and calls the \`onChange\` handler",
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.setInputValue",
-          },
-          "name": "setInputValue",
-          "parameters": [
-            {
-              "description": "The value the input is set to.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "value",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-      ],
-      "name": "InputWrapper",
     },
     {
       "methods": [
@@ -55647,23 +65669,10 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findDisabledOptions",
+          "name": "findDismiss",
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "OptionWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findFooterRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
             "name": "ElementWrapper",
             "typeArguments": [
               {
@@ -55673,47 +65682,10 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "description": "Returns an option group from the dropdown.",
-          "name": "findGroup",
-          "parameters": [
-            {
-              "description": "1-based index of the group to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "index",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns all option groups in the dropdown.",
-          "name": "findGroups",
+          "name": "findLabel",
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<HTMLElement>",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHighlightedAriaLiveRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
             "name": "ElementWrapper",
             "typeArguments": [
               {
@@ -55723,152 +65695,11 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "description": "Returns highlighted text fragments from all of the options.
-Options get highlighted when they match the value of the input field.",
-          "name": "findHighlightedMatches",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<HTMLElement>",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHighlightedOption",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "OptionWrapper",
-          },
-        },
-        {
-          "name": "findOpenDropdown",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns an option from the dropdown.",
           "name": "findOption",
-          "parameters": [
-            {
-              "description": "1-based index of the option to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "optionIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "OptionWrapper",
-          },
-        },
-        {
-          "name": "findOptionByValue",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "value",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "OptionWrapper",
-          },
-        },
-        {
-          "description": "Returns an option from the dropdown.",
-          "name": "findOptionInGroup",
-          "parameters": [
-            {
-              "description": "1-based index of the group to select an option in.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "groupIndex",
-              "typeName": "number",
-            },
-            {
-              "description": "1-based index of the option to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "optionIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "OptionWrapper",
-          },
-        },
-        {
-          "name": "findOptions",
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "OptionWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Use this element to scroll through the list of options",
-          "name": "findOptionsContainer",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findSelectAll",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findSelectedOptions",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "OptionWrapper",
-              },
-            ],
+            "name": "OptionWrapper",
           },
         },
         {
@@ -56008,7 +65839,7 @@ Options get highlighted when they match the value of the input field.",
           },
         },
       ],
-      "name": "DropdownContentWrapper",
+      "name": "TokenWrapper",
     },
     {
       "methods": [
@@ -56383,450 +66214,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "NavigableGroupWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findCurrentPage",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findNextPageButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a page number for a given index.",
-          "name": "findPageNumberByIndex",
-          "parameters": [
-            {
-              "description": "1-based index of the page number to return.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "index",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findPageNumbers",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<HTMLElement>",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findPreviousPageButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "name": "isDisabled",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "boolean",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "PaginationWrapper",
     },
     {
       "methods": [
@@ -60769,401 +70156,6 @@ Note that programmatic events ignore disabled attribute and will trigger listene
           },
         },
         {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findButtons",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "RadioButtonWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findInputByValue",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "value",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLInputElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "RadioGroupWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
           "name": "findAlertSlot",
           "parameters": [],
           "returnType": {
@@ -62507,6 +71499,51 @@ If no matching component is found, returns an empty array.",
           },
         },
         {
+          "description": "Returns the column that is used for ascending sorting.",
+          "name": "findAscSortedColumn",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a table cell based on given row and column indices.",
+          "name": "findBodyCell",
+          "parameters": [
+            {
+              "description": "1-based index of the row of the cell to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the column of the cell to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "columnIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
           "inheritedFrom": {
             "name": "AbstractWrapper.findByClassName",
           },
@@ -62531,57 +71568,15 @@ If no matching component is found, returns an empty array.",
           },
         },
         {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
+          "name": "findCollectionPreferences",
+          "parameters": [],
           "returnType": {
             "isNullable": true,
-            "name": "Wrapper",
+            "name": "CollectionPreferencesWrapper",
           },
         },
         {
-          "description": "Finds the segment with the given ID.",
-          "name": "findSegmentById",
-          "parameters": [
-            {
-              "description": "ID of the element to return.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "id",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "SegmentWrapper",
-          },
-        },
-        {
-          "name": "findSegments",
+          "name": "findColumnHeaders",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -62594,8 +71589,18 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findSelectedSegment",
-          "parameters": [],
+          "description": "Returns the element the user clicks when resizing a column.",
+          "name": "findColumnResizer",
+          "parameters": [
+            {
+              "description": "1-based index of the column containing the resizer.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "columnIndex",
+              "typeName": "number",
+            },
+          ],
           "returnType": {
             "isNullable": true,
             "name": "ElementWrapper",
@@ -62607,190 +71612,14 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
+          "name": "findColumnSortingArea",
           "parameters": [
             {
               "flags": {
                 "isOptional": false,
               },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "SegmentedControlWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
+              "name": "colIndex",
+              "typeName": "number",
             },
           ],
           "returnType": {
@@ -62798,139 +71627,7 @@ Note that programmatic events ignore disabled attribute and will trigger listene
             "name": "ElementWrapper",
             "typeArguments": [
               {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
+                "name": "HTMLElement",
               },
             ],
           },
@@ -62968,7 +71665,8 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findDisabledReason",
+          "description": "Returns the column that is used for descending sorting.",
+          "name": "findDescSortedColumn",
           "parameters": [],
           "returnType": {
             "isNullable": true,
@@ -62978,6 +71676,317 @@ Note: This function returns the specified component's wrapper even if the specif
                 "name": "HTMLElement",
               },
             ],
+          },
+        },
+        {
+          "description": "Returns the button that activates inline editing for a table cell based on given row and column indices.",
+          "name": "findEditCellButton",
+          "parameters": [
+            {
+              "description": "1-based index of the row of the cell to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the column of the cell to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "columnIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findEditingCell",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findEditingCellCancelButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findEditingCellSaveButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Alias for findEmptySlot method for compatibility with previous versions",
+          "name": "findEmptyRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findEmptySlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the expandable row toggle button.",
+          "name": "findExpandToggle",
+          "parameters": [
+            {
+              "description": "1-based index of the row.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findFilterSlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findFooterSlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Alias for findHeaderSlot method for compatibility with previous versions",
+          "name": "findHeaderRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHeaderSlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns items loader of the specific item (matched by item's track ID).",
+          "name": "findItemsLoaderByItemId",
+          "parameters": [
+            {
+              "description": "the (expandable) item ID provided with \`trackBy\` property.
+
+Note: when used with collection-hooks the \`trackBy\` is set automatically from \`expandableRows.getId\`.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "itemId",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLoadingText",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findPagination",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "PaginationWrapper",
+          },
+        },
+        {
+          "name": "findPropertyFilter",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "PropertyFilterWrapper",
+          },
+        },
+        {
+          "description": "Returns items loader of the root table level.",
+          "name": "findRootItemsLoader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findRows",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a row selection area for a given index.",
+          "name": "findRowSelectionArea",
+          "parameters": [
+            {
+              "description": "1-based index of the row selection area to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSelectAllTrigger",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSelectedRows",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTextFilter",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "TextFilterWrapper",
           },
         },
         {
@@ -63022,545 +72031,18 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
+          "description": "Returns \`true\` if the row expand toggle is present and expanded. Returns \`false\` otherwise.",
+          "name": "isRowToggled",
           "parameters": [
             {
+              "description": "1-based index of the row.",
               "flags": {
                 "isOptional": false,
               },
-              "name": "keyCode",
-              "typeName": "KeyCode",
+              "name": "rowIndex",
+              "typeName": "number",
             },
           ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "SegmentWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Selects all options by triggering corresponding events on the element that selects or deselects all options in Multiselect when using the \`enableSelectAll\` flag.
-
-This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
-
-Example:
-\`\`\`
-wrapper.openDropdown();
-wrapper.clickSelectAll();
-\`\`\`",
-          "inheritedFrom": {
-            "name": "DropdownHostComponentWrapper.clickSelectAll",
-          },
-          "name": "clickSelectAll",
-          "parameters": [
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "DropdownHostComponentWrapper.closeDropdown",
-          },
-          "name": "closeDropdown",
-          "parameters": [
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "DropdownHostComponentWrapper.findDropdown",
-          },
-          "name": "findDropdown",
-          "parameters": [
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "DropdownContentWrapper",
-          },
-        },
-        {
-          "name": "findErrorRecoveryButton",
-          "parameters": [
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the input that is used for filtering.",
-          "name": "findFilteringInput",
-          "parameters": [
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "InputWrapper",
-          },
-        },
-        {
-          "name": "findInlineLabel",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findPlaceholder",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findStatusIndicator",
-          "parameters": [
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findTrigger",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "name": "isDisabled",
-          "parameters": [],
           "returnType": {
             "isNullable": false,
             "name": "boolean",
@@ -63661,97 +72143,8 @@ Note: This function returns the specified component's wrapper even if the specif
             "name": "this",
           },
         },
-        {
-          "inheritedFrom": {
-            "name": "DropdownHostComponentWrapper.openDropdown",
-          },
-          "name": "openDropdown",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Selects an option for the given index by triggering corresponding events.
-
-This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
-On selection the dropdown will close automatically.
-
-Example:
-\`\`\`
-wrapper.openDropdown();
-wrapper.selectOption(1);
-\`\`\`",
-          "inheritedFrom": {
-            "name": "DropdownHostComponentWrapper.selectOption",
-          },
-          "name": "selectOption",
-          "parameters": [
-            {
-              "description": "1-based index of the option to select",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "index",
-              "typeName": "number",
-            },
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Selects an option for the given value by triggering corresponding events.
-
-This utility does not open the dropdown of the given select. You will need to call \`openDropdown\` first in your test.
-On selection the dropdown will close automatically.
-
-Example:
-\`\`\`
-wrapper.openDropdown();
-wrapper.selectOptionByValue('option_1');
-\`\`\`",
-          "inheritedFrom": {
-            "name": "DropdownHostComponentWrapper.selectOptionByValue",
-          },
-          "name": "selectOptionByValue",
-          "parameters": [
-            {
-              "description": "value of the option",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "value",
-              "typeName": "string",
-            },
-            {
-              "defaultValue": "{ expandToViewport: false }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
       ],
-      "name": "SelectWrapper",
+      "name": "TableWrapper",
     },
     {
       "methods": [
@@ -66020,489 +74413,6 @@ If no matching component is found, returns an empty array.",
           },
         },
         {
-          "name": "findCloseButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findHeader",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHeaderActions",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHeaderBefore",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHeaderDescription",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHeaderInfo",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findOpenButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "description": "Returns the same panel if it's currently open in bottom position. If not, it returns null.
-Use this method to assert the panel position.",
-          "name": "findOpenPanelBottom",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "SplitPanelWrapper",
-          },
-        },
-        {
-          "description": "Returns the same panel if it's currently open in side position. If not, it returns null.
-Use this method to assert the panel position.",
-          "name": "findOpenPanelSide",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "SplitPanelWrapper",
-          },
-        },
-        {
-          "name": "findPreferencesButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "name": "findSlider",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "SplitPanelWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
           "description": "Returns the component wrapper matching the specified selector.
 If the specified selector doesn't match any element, it returns \`null\`.
 
@@ -67436,820 +75346,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "StepWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the column that is used for ascending sorting.",
-          "name": "findAscSortedColumn",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a table cell based on given row and column indices.",
-          "name": "findBodyCell",
-          "parameters": [
-            {
-              "description": "1-based index of the row of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-            {
-              "description": "1-based index of the column of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "columnIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findCollectionPreferences",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "CollectionPreferencesWrapper",
-          },
-        },
-        {
-          "name": "findColumnHeaders",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<HTMLElement>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the element the user clicks when resizing a column.",
-          "name": "findColumnResizer",
-          "parameters": [
-            {
-              "description": "1-based index of the column containing the resizer.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "columnIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findColumnSortingArea",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "colIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "description": "Returns the column that is used for descending sorting.",
-          "name": "findDescSortedColumn",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the button that activates inline editing for a table cell based on given row and column indices.",
-          "name": "findEditCellButton",
-          "parameters": [
-            {
-              "description": "1-based index of the row of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-            {
-              "description": "1-based index of the column of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "columnIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findEditingCell",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findEditingCellCancelButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findEditingCellSaveButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Alias for findEmptySlot method for compatibility with previous versions",
-          "name": "findEmptyRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findEmptySlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the expandable row toggle button.",
-          "name": "findExpandToggle",
-          "parameters": [
-            {
-              "description": "1-based index of the row.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findFilterSlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findFooterSlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Alias for findHeaderSlot method for compatibility with previous versions",
-          "name": "findHeaderRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHeaderSlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns items loader of the specific item (matched by item's track ID).",
-          "name": "findItemsLoaderByItemId",
-          "parameters": [
-            {
-              "description": "the (expandable) item ID provided with \`trackBy\` property.
-
-Note: when used with collection-hooks the \`trackBy\` is set automatically from \`expandableRows.getId\`.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "itemId",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findLoadingText",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findPagination",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "PaginationWrapper",
-          },
-        },
-        {
-          "name": "findPropertyFilter",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "PropertyFilterWrapper",
-          },
-        },
-        {
-          "description": "Returns items loader of the root table level.",
-          "name": "findRootItemsLoader",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findRows",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<HTMLElement>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a row selection area for a given index.",
-          "name": "findRowSelectionArea",
-          "parameters": [
-            {
-              "description": "1-based index of the row selection area to return.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findSelectAllTrigger",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findSelectedRows",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<HTMLElement>",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findTextFilter",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "TextFilterWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "description": "Returns \`true\` if the row expand toggle is present and expanded. Returns \`false\` otherwise.",
-          "name": "isRowToggled",
-          "parameters": [
-            {
-              "description": "1-based index of the row.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "boolean",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "TableWrapper",
     },
     {
       "methods": [
@@ -70688,388 +77784,6 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "InputWrapper",
-          },
-        },
-        {
-          "name": "findResultsCount",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "TextFilterWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
           "name": "findNativeTextarea",
           "parameters": [],
           "returnType": {
@@ -71665,6 +78379,419 @@ Note: This function returns the specified component's wrapper even if the specif
       "methods": [
         {
           "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findImage",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "TileWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
             "name": "BaseInputWrapper.blur",
           },
           "name": "blur",
@@ -72083,834 +79210,6 @@ Returns the current value of the input.",
         },
       ],
       "name": "TimeInputWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findDescription",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findLabel",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findNativeInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLInputElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "ToggleWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.blur",
-          },
-          "name": "blur",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "description": "Performs a click by triggering a mouse event.
-Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.click",
-          },
-          "name": "click",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "params",
-              "typeName": "MouseEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper<NewElementType>",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
-If no CSS selector is specified, returns all of the components that match the specified component type.
-If no matching component is found, returns an empty array.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
-            },
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Array",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "NewElementType",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the component wrapper matching the specified selector.
-If the specified selector doesn't match any element, it returns \`null\`.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper, ElementType>",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "ButtonWrapper.findDisabledReason",
-          },
-          "name": "findDisabledReason",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "ButtonWrapper.findLoadingIndicator",
-          },
-          "name": "findLoadingIndicator",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "ButtonWrapper.findTextRegion",
-          },
-          "name": "findTextRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.fireEvent",
-          },
-          "name": "fireEvent",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "event",
-              "typeName": "Event",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.focus",
-          },
-          "name": "focus",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementType",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "ButtonWrapper.isDisabled",
-          },
-          "name": "isDisabled",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "boolean",
-          },
-        },
-        {
-          "name": "isPressed",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "boolean",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keydown",
-          },
-          "name": "keydown",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyboardEventProps",
-              "typeName": "KeyboardEventInit",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keypress",
-          },
-          "name": "keypress",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.keyup",
-          },
-          "name": "keyup",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "keyCode",
-              "typeName": "KeyCode",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "void",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": true,
-            "name": "this",
-          },
-        },
-      ],
-      "name": "ToggleButtonWrapper",
     },
     {
       "methods": [
@@ -74541,6 +80840,23 @@ This utility does not open the dropdown. To find dropdown items, call \`openDrop
           },
         },
         {
+          "description": "Finds the label tag element for a dropdown item. Returns null if the element has no label tag.",
+          "inheritedFrom": {
+            "name": "ButtonDropdownWrapper.findLabelTags",
+          },
+          "name": "findLabelTags",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
           "inheritedFrom": {
             "name": "ButtonDropdownWrapper.findMainAction",
           },
@@ -74569,6 +80885,23 @@ This utility does not open the dropdown. To find dropdown items, call \`openDrop
             "name": "ButtonDropdownWrapper.findOpenDropdown",
           },
           "name": "findOpenDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Finds the secondary text element for a dropdown item. Returns null if the element has no secondary text.",
+          "inheritedFrom": {
+            "name": "ButtonDropdownWrapper.findSecondaryText",
+          },
+          "name": "findSecondaryText",
           "parameters": [],
           "returnType": {
             "isNullable": true,
@@ -76276,6 +82609,446 @@ If no matching component is found, returns an empty array.",
           },
         },
         {
+          "name": "findCollapseButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findCompleted",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the component wrapper matching the specified selector.
+If the specified selector doesn't match any element, it returns \`null\`.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper, ElementType>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findExpandButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findLearnMoreLink",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "LinkWrapper",
+          },
+        },
+        {
+          "name": "findPrerequisitesAlert",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "AlertWrapper",
+          },
+        },
+        {
+          "name": "findStartButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.fireEvent",
+          },
+          "name": "fireEvent",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "event",
+              "typeName": "Event",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.focus",
+          },
+          "name": "focus",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementType",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keydown",
+          },
+          "name": "keydown",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyboardEventProps",
+              "typeName": "KeyboardEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keypress",
+          },
+          "name": "keypress",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.keyup",
+          },
+          "name": "keyup",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "keyCode",
+              "typeName": "KeyCode",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "this",
+          },
+        },
+      ],
+      "name": "TutorialItemWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.blur",
+          },
+          "name": "blur",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "description": "Performs a click by triggering a mouse event.
+Note that programmatic events ignore disabled attribute and will trigger listeners even if the element is disabled.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.click",
+          },
+          "name": "click",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "params",
+              "typeName": "MouseEventInit",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "void",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<NewElementType>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the wrappers of all components that match the specified component type and the specified CSS selector.
+If no CSS selector is specified, returns all of the components that match the specified component type.
+If no matching component is found, returns an empty array.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper, ElementType>",
+            },
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "NewElementType",
+              },
+            ],
+          },
+        },
+        {
           "description": "Returns the component wrapper matching the specified selector.
 If the specified selector doesn't match any element, it returns \`null\`.
 
@@ -77289,6 +84062,246 @@ The dismiss button is only rendered when the \`dismissible\` property is set to 
         },
       ],
       "name": "AlertWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findLoadingIndicator",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTextRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ButtonWrapper",
     },
     {
       "methods": [
@@ -78518,6 +85531,654 @@ Note: This function returns the specified component's wrapper even if the specif
         },
         {
           "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findCloseButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findHeader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findHeaderActions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findHeaderBefore",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findHeaderDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findHeaderInfo",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findOpenButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "description": "Returns the same panel if it's currently open in bottom position. If not, it returns null.
+Use this method to assert the panel position.",
+          "name": "findOpenPanelBottom",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns the same panel if it's currently open in side position. If not, it returns null.
+Use this method to assert the panel position.",
+          "name": "findOpenPanelSide",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findPreferencesButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findSlider",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "SplitPanelWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "description": "Finds the disabled reason tooltip for a dropdown item. Returns null if no disabled item with \`disabledReason\` is highlighted.",
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Finds an expandable category in the open dropdown by category id. Returns null if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findExpandableCategoryById",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "id",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Finds the highlighted item in the open dropdown. Returns null if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findHighlightedItem",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Finds an item in the open dropdown by item id. Returns null if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findItemById",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "id",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Finds all the items in the open dropdown. Returns empty array if there is no open dropdown.
+
+This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
+          "name": "findItems",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Finds the label tag element for a dropdown item. Returns null if the element has no label tag.",
+          "name": "findLabelTags",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findMainAction",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findNativeButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findOpenDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Finds the secondary text element for a dropdown item. Returns null if the element has no secondary text.",
+          "name": "findSecondaryText",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTriggerButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ButtonDropdownWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
             "name": "AppLayoutWrapper.findActiveDrawer",
           },
           "name": "findActiveDrawer",
@@ -79355,6 +87016,1439 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.findDropdown",
+          },
+          "name": "findDropdown",
+          "parameters": [
+            {
+              "defaultValue": "{
+    expandToViewport: false
+  }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "DropdownContentWrapper",
+          },
+        },
+        {
+          "name": "findPlaceholder",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTrigger",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ChartFilterWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDisabledOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "OptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findFooterRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns an option group from the dropdown.",
+          "name": "findGroup",
+          "parameters": [
+            {
+              "description": "1-based index of the group to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns all option groups in the dropdown.",
+          "name": "findGroups",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHighlightedAriaLiveRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns highlighted text fragments from all of the options.
+Options get highlighted when they match the value of the input field.",
+          "name": "findHighlightedMatches",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findHighlightedOption",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "name": "findOpenDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns an option from the dropdown.",
+          "name": "findOption",
+          "parameters": [
+            {
+              "description": "1-based index of the option to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "optionIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "name": "findOptionByValue",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "description": "Returns an option from the dropdown.",
+          "name": "findOptionInGroup",
+          "parameters": [
+            {
+              "description": "1-based index of the group to select an option in.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "groupIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the option to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "optionIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "OptionWrapper",
+          },
+        },
+        {
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "OptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Use this element to scroll through the list of options",
+          "name": "findOptionsContainer",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSelectAll",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSelectedOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "OptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "DropdownContentWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findLabelTag",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTags",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "OptionWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findHighlightedItem",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findItems",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findNativeList",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ChartLegendWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findContent",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findDismissButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findHeader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSeries",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ChartPopoverSeriesWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ChartPopoverWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
           "name": "findAddButton",
           "parameters": [],
           "returnType": {
@@ -79870,6 +88964,286 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "AttributeEditorRowWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findConstraint",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findControl",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findError",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findInfo",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSecondaryControl",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findWarning",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "FormFieldWrapper",
     },
     {
       "methods": [
@@ -81758,568 +91132,6 @@ If no CSS selector is specified, returns a multi-element wrapper that matches th
           },
         },
         {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findDisabledReason",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findLoadingIndicator",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findTextRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "ButtonWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "description": "Finds the disabled reason tooltip for a dropdown item. Returns null if no disabled item with \`disabledReason\` is highlighted.",
-          "name": "findDisabledReason",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Finds an expandable category in the open dropdown by category id. Returns null if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findExpandableCategoryById",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "id",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Finds the highlighted item in the open dropdown. Returns null if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findHighlightedItem",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Finds an item in the open dropdown by item id. Returns null if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findItemById",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "id",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Finds all the items in the open dropdown. Returns empty array if there is no open dropdown.
-
-This utility does not open the dropdown. To find dropdown items, call \`openDropdown()\` first.",
-          "name": "findItems",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findMainAction",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "name": "findNativeButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findOpenDropdown",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findTriggerButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "ButtonDropdownWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
           "description": "Finds a button item by its id.",
           "name": "findButtonById",
           "parameters": [
@@ -82503,6 +91315,487 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "ButtonGroupWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.findDisabledReason",
+          },
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.findLoadingIndicator",
+          },
+          "name": "findLoadingIndicator",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.findTextRegion",
+          },
+          "name": "findTextRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ToggleButtonWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTrigger",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "FileInputWrapper",
     },
     {
       "methods": [
@@ -83501,7 +92794,15 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findDescription",
+          "name": "findInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "InputWrapper",
+          },
+        },
+        {
+          "name": "findResultsCount",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -83509,7 +92810,192 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findLabel",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "TextFilterWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findClearButton",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -83517,6 +93003,40 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "BaseInputWrapper.findNativeInput",
+          },
           "name": "findNativeInput",
           "parameters": [],
           "returnType": {
@@ -83566,7 +93086,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
       ],
-      "name": "CheckboxWrapper",
+      "name": "InputWrapper",
     },
     {
       "methods": [
@@ -83741,7 +93261,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findEditor",
+          "name": "findCurrentPage",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -83749,7 +93269,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findErrorScreen",
+          "name": "findNextPageButton",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -83757,55 +93277,38 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findErrorsTab",
-          "parameters": [],
+          "description": "Returns a page number for a given index.",
+          "name": "findPageNumberByIndex",
+          "parameters": [
+            {
+              "description": "1-based index of the page number to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+          ],
           "returnType": {
             "isNullable": false,
             "name": "ElementWrapper",
           },
         },
         {
-          "name": "findLoadingScreen",
+          "name": "findPageNumbers",
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "ElementWrapper",
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
           },
         },
         {
-          "name": "findNativeTextArea",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findPane",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findSettingsButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "name": "findStatusBar",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findWarningsTab",
+          "name": "findPreviousPageButton",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -83854,7 +93357,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
       ],
-      "name": "CodeEditorWrapper",
+      "name": "PaginationWrapper",
     },
     {
       "methods": [
@@ -84444,6 +93947,2299 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "PreferencesModalWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "CheckboxWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "RadioButtonWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "PageSizePreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findOptionsGroups",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a content selector toggle.",
+          "name": "findToggleByIndex",
+          "parameters": [
+            {
+              "description": "1-based index of the content group.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "groupIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the option to return within the group.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "optionIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ToggleWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "VisibleContentPreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findNativeInput",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ToggleWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findRadioGroup",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "RadioGroupWrapper",
+          },
+        },
+        {
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "StickyColumnsPreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findButtons",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "RadioButtonWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findInputByValue",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "value",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "RadioGroupWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "description": "Returns the preference description displayed below the title.",
+          "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns no match with the clear filter button.",
+          "name": "findNoMatch",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns an option for a given index.",
+          "name": "findOptionByIndex",
+          "parameters": [
+            {
+              "description": "1-based index of the option to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "index",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ContentDisplayOptionWrapper",
+          },
+        },
+        {
+          "description": "Returns options that the user can reorder.",
+          "name": "findOptions",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ContentDisplayOptionWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the text filter input.",
+          "name": "findTextFilter",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "TextFilterWrapper",
+          },
+        },
+        {
+          "description": "Returns the title.",
+          "name": "findTitle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ContentDisplayPreferenceWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "description": "Returns the drag handle for the option item.",
+          "name": "findDragHandle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns the text label displayed in the option item.",
+          "name": "findLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns the visibility toggle for the option item.",
+          "name": "findVisibilityToggle",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ToggleWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "ContentDisplayOptionWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findEditor",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findErrorScreen",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findErrorsTab",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findLoadingScreen",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findNativeTextArea",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findPane",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSettingsButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
+          "name": "findStatusBar",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findWarningsTab",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "CodeEditorWrapper",
     },
     {
       "methods": [
@@ -87057,6 +98853,809 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
+          "description": "Finds the segment with the given ID.",
+          "name": "findSegmentById",
+          "parameters": [
+            {
+              "description": "ID of the element to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "id",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "SegmentWrapper",
+          },
+        },
+        {
+          "name": "findSegments",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSelectedSegment",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "SegmentedControlWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "name": "findDisabledReason",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "SegmentWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "DropdownHostComponentWrapper.findDropdown",
+          },
+          "name": "findDropdown",
+          "parameters": [
+            {
+              "defaultValue": "{
+    expandToViewport: false
+  }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "DropdownContentWrapper",
+          },
+        },
+        {
+          "name": "findErrorRecoveryButton",
+          "parameters": [
+            {
+              "defaultValue": "{
+    expandToViewport: false
+  }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns the input that is used for filtering.",
+          "name": "findFilteringInput",
+          "parameters": [
+            {
+              "defaultValue": "{
+    expandToViewport: false
+  }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "InputWrapper",
+          },
+        },
+        {
+          "name": "findInlineLabel",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findPlaceholder",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findStatusIndicator",
+          "parameters": [
+            {
+              "defaultValue": "{
+    expandToViewport: false
+  }",
+              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "options",
+              "typeName": "{ expandToViewport: boolean; }",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTrigger",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.getElement",
+          },
+          "name": "getElement",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.matches",
+          },
+          "name": "matches",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.toSelector",
+          },
+          "name": "toSelector",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "string",
+          },
+        },
+      ],
+      "name": "SelectWrapper",
+    },
+    {
+      "methods": [
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.find",
+          },
+          "name": "find",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAll",
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllByClassName",
+          },
+          "name": "findAllByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
+If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAllComponents",
+          },
+          "name": "findAllComponents",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "ComponentWrapperClass<Wrapper>",
+            },
+            {
+              "description": "CSS Selector",
+              "flags": {
+                "isOptional": true,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "Wrapper",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findAny",
+          },
+          "name": "findAny",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selectors",
+              "typeName": "Array<string>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findByClassName",
+          },
+          "name": "findByClassName",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "className",
+              "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
+
+Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
+          "inheritedFrom": {
+            "name": "AbstractWrapper.findComponent",
+          },
+          "name": "findComponent",
+          "parameters": [
+            {
+              "description": "CSS selector",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "selector",
+              "typeName": "string",
+            },
+            {
+              "description": "Component's wrapper class",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "ComponentClass",
+              "typeName": "WrapperClass<Wrapper>",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "Wrapper",
+          },
+        },
+        {
           "name": "findContent",
           "parameters": [],
           "returnType": {
@@ -87619,238 +100218,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "FileDropzoneWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findNativeInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findTrigger",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "FileInputWrapper",
     },
     {
       "methods": [
@@ -89330,286 +101697,6 @@ If no CSS selector is specified, returns a multi-element wrapper that matches th
           },
         },
         {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findConstraint",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findControl",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findDescription",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findError",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findInfo",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findLabel",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findSecondaryControl",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findWarning",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "FormFieldWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
           "description": "Returns a column from the grid for a given index.",
           "name": "findColumn",
           "parameters": [
@@ -90645,241 +102732,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "IconWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findClearButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.findNativeInput",
-          },
-          "name": "findNativeInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "InputWrapper",
     },
     {
       "methods": [
@@ -93626,20 +105478,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findDisabledOptions",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "OptionWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findFooterRegion",
+          "name": "findDismiss",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -93647,39 +105486,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "description": "Returns an option group from the dropdown.",
-          "name": "findGroup",
-          "parameters": [
-            {
-              "description": "1-based index of the group to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "index",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns all option groups in the dropdown.",
-          "name": "findGroups",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHighlightedAriaLiveRegion",
+          "name": "findLabel",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -93687,137 +105494,11 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "description": "Returns highlighted text fragments from all of the options.
-Options get highlighted when they match the value of the input field.",
-          "name": "findHighlightedMatches",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findHighlightedOption",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "OptionWrapper",
-          },
-        },
-        {
-          "name": "findOpenDropdown",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns an option from the dropdown.",
           "name": "findOption",
-          "parameters": [
-            {
-              "description": "1-based index of the option to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "optionIndex",
-              "typeName": "number",
-            },
-          ],
+          "parameters": [],
           "returnType": {
             "isNullable": false,
             "name": "OptionWrapper",
-          },
-        },
-        {
-          "name": "findOptionByValue",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "value",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "OptionWrapper",
-          },
-        },
-        {
-          "description": "Returns an option from the dropdown.",
-          "name": "findOptionInGroup",
-          "parameters": [
-            {
-              "description": "1-based index of the group to select an option in.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "groupIndex",
-              "typeName": "number",
-            },
-            {
-              "description": "1-based index of the option to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "optionIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "OptionWrapper",
-          },
-        },
-        {
-          "name": "findOptions",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "OptionWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Use this element to scroll through the list of options",
-          "name": "findOptionsContainer",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findSelectAll",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findSelectedOptions",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "OptionWrapper",
-              },
-            ],
           },
         },
         {
@@ -93862,7 +105543,7 @@ Options get highlighted when they match the value of the input field.",
           },
         },
       ],
-      "name": "DropdownContentWrapper",
+      "name": "TokenWrapper",
     },
     {
       "methods": [
@@ -94087,277 +105768,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "NavigableGroupWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findCurrentPage",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findNextPageButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a page number for a given index.",
-          "name": "findPageNumberByIndex",
-          "parameters": [
-            {
-              "description": "1-based index of the page number to return.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "index",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findPageNumbers",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findPreviousPageButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "PaginationWrapper",
     },
     {
       "methods": [
@@ -95955,251 +107365,6 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findButtons",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "RadioButtonWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findInputByValue",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "value",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "RadioGroupWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
           "name": "findAlertSlot",
           "parameters": [],
           "returnType": {
@@ -97065,6 +108230,41 @@ If no CSS selector is specified, returns a multi-element wrapper that matches th
           },
         },
         {
+          "description": "Returns the column that is used for ascending sorting.",
+          "name": "findAscSortedColumn",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns a table cell based on given row and column indices.",
+          "name": "findBodyCell",
+          "parameters": [
+            {
+              "description": "1-based index of the row of the cell to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the column of the cell to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "columnIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
           "inheritedFrom": {
             "name": "AbstractWrapper.findByClassName",
           },
@@ -97076,6 +108276,61 @@ If no CSS selector is specified, returns a multi-element wrapper that matches th
               },
               "name": "className",
               "typeName": "string",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findCollectionPreferences",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "CollectionPreferencesWrapper",
+          },
+        },
+        {
+          "name": "findColumnHeaders",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the element the user clicks when resizing a column.",
+          "name": "findColumnResizer",
+          "parameters": [
+            {
+              "description": "1-based index of the column containing the resizer.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "columnIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findColumnSortingArea",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "colIndex",
+              "typeName": "number",
             },
           ],
           "returnType": {
@@ -97115,25 +108370,187 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "description": "Finds the segment with the given ID.",
-          "name": "findSegmentById",
+          "description": "Returns the column that is used for descending sorting.",
+          "name": "findDescSortedColumn",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns the button that activates inline editing for a table cell based on given row and column indices.",
+          "name": "findEditCellButton",
           "parameters": [
             {
-              "description": "ID of the element to return.",
+              "description": "1-based index of the row of the cell to select.",
               "flags": {
                 "isOptional": false,
               },
-              "name": "id",
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+            {
+              "description": "1-based index of the column of the cell to select.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "columnIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findEditingCell",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findEditingCellCancelButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findEditingCellSaveButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Alias for findEmptySlot method for compatibility with previous versions",
+          "name": "findEmptyRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findEmptySlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns the expandable row toggle button.",
+          "name": "findExpandToggle",
+          "parameters": [
+            {
+              "description": "1-based index of the row.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findFilterSlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findFooterSlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Alias for findHeaderSlot method for compatibility with previous versions",
+          "name": "findHeaderRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findHeaderSlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns items loader of the specific item (matched by item's track ID).",
+          "name": "findItemsLoaderByItemId",
+          "parameters": [
+            {
+              "description": "the (expandable) item ID provided with \`trackBy\` property.
+
+Note: when used with collection-hooks the \`trackBy\` is set automatically from \`expandableRows.getId\`.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "itemId",
               "typeName": "string",
             },
           ],
           "returnType": {
             "isNullable": false,
-            "name": "SegmentWrapper",
+            "name": "ElementWrapper",
           },
         },
         {
-          "name": "findSegments",
+          "name": "findLoadingText",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findPagination",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "PaginationWrapper",
+          },
+        },
+        {
+          "name": "findPropertyFilter",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "PropertyFilterWrapper",
+          },
+        },
+        {
+          "description": "Returns items loader of the root table level.",
+          "name": "findRootItemsLoader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findRows",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -97146,11 +108563,50 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findSelectedSegment",
+          "description": "Returns a row selection area for a given index.",
+          "name": "findRowSelectionArea",
+          "parameters": [
+            {
+              "description": "1-based index of the row selection area to return.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "rowIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSelectAllTrigger",
           "parameters": [],
           "returnType": {
             "isNullable": false,
             "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSelectedRows",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTextFilter",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "TextFilterWrapper",
           },
         },
         {
@@ -97195,555 +108651,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
       ],
-      "name": "SegmentedControlWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findDisabledReason",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "SegmentWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "DropdownHostComponentWrapper.findDropdown",
-          },
-          "name": "findDropdown",
-          "parameters": [
-            {
-              "defaultValue": "{
-    expandToViewport: false
-  }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "DropdownContentWrapper",
-          },
-        },
-        {
-          "name": "findErrorRecoveryButton",
-          "parameters": [
-            {
-              "defaultValue": "{
-    expandToViewport: false
-  }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns the input that is used for filtering.",
-          "name": "findFilteringInput",
-          "parameters": [
-            {
-              "defaultValue": "{
-    expandToViewport: false
-  }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "InputWrapper",
-          },
-        },
-        {
-          "name": "findInlineLabel",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findPlaceholder",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findStatusIndicator",
-          "parameters": [
-            {
-              "defaultValue": "{
-    expandToViewport: false
-  }",
-              "description": "* expandToViewport (boolean) - Use this when the component under test is rendered with an \`expandToViewport\` flag.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "options",
-              "typeName": "{ expandToViewport: boolean; }",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findTrigger",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "SelectWrapper",
+      "name": "TableWrapper",
     },
     {
       "methods": [
@@ -99132,314 +110040,6 @@ If no CSS selector is specified, returns a multi-element wrapper that matches th
           },
         },
         {
-          "name": "findCloseButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "name": "findHeader",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findHeaderActions",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findHeaderBefore",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findHeaderDescription",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findHeaderInfo",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findOpenButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "description": "Returns the same panel if it's currently open in bottom position. If not, it returns null.
-Use this method to assert the panel position.",
-          "name": "findOpenPanelBottom",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns the same panel if it's currently open in side position. If not, it returns null.
-Use this method to assert the panel position.",
-          "name": "findOpenPanelSide",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findPreferencesButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ButtonWrapper",
-          },
-        },
-        {
-          "name": "findSlider",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "SplitPanelWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
           "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
 
 Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
@@ -99743,552 +110343,6 @@ Note: This function returns the specified component's wrapper even if the specif
         },
       ],
       "name": "StepsWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns the column that is used for ascending sorting.",
-          "name": "findAscSortedColumn",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a table cell based on given row and column indices.",
-          "name": "findBodyCell",
-          "parameters": [
-            {
-              "description": "1-based index of the row of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-            {
-              "description": "1-based index of the column of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "columnIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findCollectionPreferences",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "CollectionPreferencesWrapper",
-          },
-        },
-        {
-          "name": "findColumnHeaders",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns the element the user clicks when resizing a column.",
-          "name": "findColumnResizer",
-          "parameters": [
-            {
-              "description": "1-based index of the column containing the resizer.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "columnIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findColumnSortingArea",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "colIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
-          "description": "Returns the column that is used for descending sorting.",
-          "name": "findDescSortedColumn",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns the button that activates inline editing for a table cell based on given row and column indices.",
-          "name": "findEditCellButton",
-          "parameters": [
-            {
-              "description": "1-based index of the row of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-            {
-              "description": "1-based index of the column of the cell to select.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "columnIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findEditingCell",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findEditingCellCancelButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findEditingCellSaveButton",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Alias for findEmptySlot method for compatibility with previous versions",
-          "name": "findEmptyRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findEmptySlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns the expandable row toggle button.",
-          "name": "findExpandToggle",
-          "parameters": [
-            {
-              "description": "1-based index of the row.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findFilterSlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findFooterSlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Alias for findHeaderSlot method for compatibility with previous versions",
-          "name": "findHeaderRegion",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findHeaderSlot",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns items loader of the specific item (matched by item's track ID).",
-          "name": "findItemsLoaderByItemId",
-          "parameters": [
-            {
-              "description": "the (expandable) item ID provided with \`trackBy\` property.
-
-Note: when used with collection-hooks the \`trackBy\` is set automatically from \`expandableRows.getId\`.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "itemId",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findLoadingText",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findPagination",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "PaginationWrapper",
-          },
-        },
-        {
-          "name": "findPropertyFilter",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "PropertyFilterWrapper",
-          },
-        },
-        {
-          "description": "Returns items loader of the root table level.",
-          "name": "findRootItemsLoader",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findRows",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a row selection area for a given index.",
-          "name": "findRowSelectionArea",
-          "parameters": [
-            {
-              "description": "1-based index of the row selection area to return.",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "rowIndex",
-              "typeName": "number",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findSelectAllTrigger",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "name": "findSelectedRows",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "name": "findTextFilter",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "TextFilterWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "TableWrapper",
     },
     {
       "methods": [
@@ -101887,238 +111941,6 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "name": "findInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "InputWrapper",
-          },
-        },
-        {
-          "name": "findResultsCount",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "TextFilterWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
           "name": "findNativeTextarea",
           "parameters": [],
           "returnType": {
@@ -102604,234 +112426,15 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
         {
-          "inheritedFrom": {
-            "name": "BaseInputWrapper.findNativeInput",
-          },
-          "name": "findNativeInput",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.getElement",
-          },
-          "name": "getElement",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.matches",
-          },
-          "name": "matches",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.toSelector",
-          },
-          "name": "toSelector",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "string",
-          },
-        },
-      ],
-      "name": "TimeInputWrapper",
-    },
-    {
-      "methods": [
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.find",
-          },
-          "name": "find",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAll",
-          },
-          "name": "findAll",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllByClassName",
-          },
-          "name": "findAllByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "ElementWrapper",
-              },
-            ],
-          },
-        },
-        {
-          "description": "Returns a multi-element wrapper that matches the specified component type with the specified CSS selector.
-If no CSS selector is specified, returns a multi-element wrapper that matches the specified component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAllComponents",
-          },
-          "name": "findAllComponents",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "ComponentWrapperClass<Wrapper>",
-            },
-            {
-              "description": "CSS Selector",
-              "flags": {
-                "isOptional": true,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "MultiElementWrapper",
-            "typeArguments": [
-              {
-                "name": "Wrapper",
-              },
-            ],
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findAny",
-          },
-          "name": "findAny",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selectors",
-              "typeName": "Array<string>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findByClassName",
-          },
-          "name": "findByClassName",
-          "parameters": [
-            {
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "className",
-              "typeName": "string",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "description": "Returns a wrapper that matches the specified component type with the specified CSS selector.
-
-Note: This function returns the specified component's wrapper even if the specified selector points to a different component type.",
-          "inheritedFrom": {
-            "name": "AbstractWrapper.findComponent",
-          },
-          "name": "findComponent",
-          "parameters": [
-            {
-              "description": "CSS selector",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "selector",
-              "typeName": "string",
-            },
-            {
-              "description": "Component's wrapper class",
-              "flags": {
-                "isOptional": false,
-              },
-              "name": "ComponentClass",
-              "typeName": "WrapperClass<Wrapper>",
-            },
-          ],
-          "returnType": {
-            "isNullable": false,
-            "name": "Wrapper",
-          },
-        },
-        {
           "name": "findDescription",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findImage",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -102896,7 +112499,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
       ],
-      "name": "ToggleWrapper",
+      "name": "TileWrapper",
     },
     {
       "methods": [
@@ -103072,31 +112675,9 @@ Note: This function returns the specified component's wrapper even if the specif
         },
         {
           "inheritedFrom": {
-            "name": "ButtonWrapper.findDisabledReason",
+            "name": "BaseInputWrapper.findNativeInput",
           },
-          "name": "findDisabledReason",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "ButtonWrapper.findLoadingIndicator",
-          },
-          "name": "findLoadingIndicator",
-          "parameters": [],
-          "returnType": {
-            "isNullable": false,
-            "name": "ElementWrapper",
-          },
-        },
-        {
-          "inheritedFrom": {
-            "name": "ButtonWrapper.findTextRegion",
-          },
-          "name": "findTextRegion",
+          "name": "findNativeInput",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -103145,7 +112726,7 @@ Note: This function returns the specified component's wrapper even if the specif
           },
         },
       ],
-      "name": "ToggleButtonWrapper",
+      "name": "TimeInputWrapper",
     },
     {
       "methods": [
@@ -104214,6 +113795,18 @@ This utility does not open the dropdown. To find dropdown items, call \`openDrop
           },
         },
         {
+          "description": "Finds the label tag element for a dropdown item. Returns null if the element has no label tag.",
+          "inheritedFrom": {
+            "name": "ButtonDropdownWrapper.findLabelTags",
+          },
+          "name": "findLabelTags",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
           "inheritedFrom": {
             "name": "ButtonDropdownWrapper.findMainAction",
           },
@@ -104237,6 +113830,18 @@ This utility does not open the dropdown. To find dropdown items, call \`openDrop
             "name": "ButtonDropdownWrapper.findOpenDropdown",
           },
           "name": "findOpenDropdown",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Finds the secondary text element for a dropdown item. Returns null if the element has no secondary text.",
+          "inheritedFrom": {
+            "name": "ButtonDropdownWrapper.findSecondaryText",
+          },
+          "name": "findSecondaryText",
           "parameters": [],
           "returnType": {
             "isNullable": false,

--- a/src/button-dropdown/__tests__/button-dropdown-items.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-items.test.tsx
@@ -498,4 +498,24 @@ describe('Internal ButtonDropdown badge property', () => {
     wrapper.openDropdown();
     expect(wrapper.findAllByClassName(iconStyles.badge)?.map(item => item.getElement())).toHaveLength(2);
   });
+
+  it('should render secondaryText and labelTag', () => {
+    const items = [{ id: 'i1', text: 'Option 1', secondaryText: 'Description', labelTag: 'Ctrl+D' }];
+    const wrapper = renderButtonDropdown({ items });
+    wrapper.openDropdown();
+
+    const item = wrapper.findItemById('i1')!;
+    expect(item.getElement()).toHaveTextContent('Option 1');
+    expect(wrapper.findSecondaryText()?.getElement()).toHaveTextContent('Description');
+    expect(wrapper.findLabelTags()?.getElement()).toHaveTextContent('Ctrl+D');
+  });
+
+  it('should return null when secondaryText and labelTag are not present', () => {
+    const items = [{ id: 'i1', text: 'Option 1' }];
+    const wrapper = renderButtonDropdown({ items });
+    wrapper.openDropdown();
+
+    expect(wrapper.findSecondaryText()).toBeNull();
+    expect(wrapper.findLabelTags()).toBeNull();
+  });
 });

--- a/src/button-dropdown/__tests__/button-dropdown-keyboard.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-keyboard.test.tsx
@@ -45,6 +45,22 @@ const items: ButtonDropdownProps.Items = [
       expect(wrapper.findHighlightedItem()!.getElement()).toHaveTextContent('item5');
     });
 
+    test('should show secondaryText in highlighted items', () => {
+      const itemsWithSecondary = [
+        { id: 'i1', text: 'item1', secondaryText: 'Description 1' },
+        { id: 'i2', text: 'item2' },
+      ];
+      const testWrapper = renderButtonDropdown({ ...props, items: itemsWithSecondary, onItemClick: onClickSpy });
+      testWrapper.openDropdown();
+
+      const highlighted = testWrapper.findHighlightedItem();
+      expect(highlighted).toBeTruthy();
+
+      const highlightedElement = highlighted!.getElement();
+      expect(highlightedElement).toHaveTextContent('item1');
+      expect(testWrapper.findSecondaryText()?.getElement()).toHaveTextContent('Description 1');
+    });
+
     describe('when dropdown is open', () => {
       beforeEach(() => {
         act(() => wrapper.findNativeButton().keydown(KeyCode.enter));

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -24,11 +24,13 @@ export interface ButtonDropdownProps extends BaseComponentProps, ExpandToViewpor
    * - `type` (string) - The type of the item. Can be `action`, `group`, `checkbox`. Defaults to `action` if `items` undefined and `group` otherwise.
    * - `id` (string) - allows to identify the item that the user clicked on. Mandatory for individual items, optional for categories.
    * - `text` (string) - description shown in the menu for this item. Mandatory for individual items, optional for categories.
+   * - `secondaryText` (string) - (Optional) Secondary text displayed in the menu for this item.
    * - `lang` (string) - (Optional) The language of the item, provided as a BCP 47 language tag.
    * - `disabled` (boolean) - whether the item is disabled. Disabled items are not clickable, but they can be highlighted with the keyboard to make them accessible.
    * - `disabledReason` (string) - (Optional) Displays text near the `text` property when item is disabled. Use to provide additional context.
-   * - `description` (string) - additional data that will be passed to a `data-description` attribute.
+   * - `description` (string) - additional data that will be passed to a `data-description` attribute. **Deprecated**, has no effect.
    * - `ariaLabel` (string) - (Optional) - ARIA label of the item element.
+   * - `labelTag` (string) - (Optional) - Label for the item. Displayed near the item text for visually impaired users.
    *
    * ### action
    *
@@ -184,10 +186,14 @@ export namespace ButtonDropdownProps {
     itemType?: ItemType;
     id: string;
     text: string;
+    secondaryText?: string;
     ariaLabel?: string;
     lang?: string;
     disabled?: boolean;
     disabledReason?: string;
+    /**
+     * @deprecated Has no effect.
+     */
     description?: string;
     href?: string;
     external?: boolean;
@@ -196,6 +202,7 @@ export namespace ButtonDropdownProps {
     iconName?: IconProps.Name;
     iconUrl?: string;
     iconSvg?: React.ReactNode;
+    labelTag?: string;
   }
 
   export interface CheckboxItem
@@ -204,7 +211,7 @@ export namespace ButtonDropdownProps {
     checked: boolean;
   }
 
-  export interface ItemGroup extends Omit<Item, 'id' | 'text' | 'itemType'> {
+  export interface ItemGroup extends Omit<Item, 'id' | 'text' | 'itemType' | 'secondaryText' | 'labelTag'> {
     itemType?: 'group';
     id?: string;
     text?: string;

--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -8,6 +8,7 @@ import {
   getAnalyticsMetadataAttribute,
 } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
+import InternalBox from '../../box/internal';
 import InternalIcon, { InternalIconProps } from '../../icon/internal';
 import { useDropdownContext } from '../../internal/components/dropdown/context';
 import useHiddenDescription from '../../internal/hooks/use-hidden-description';
@@ -175,8 +176,24 @@ const MenuItemContent = ({ item, disabled }: { item: InternalItem | InternalChec
           badge={item.badge}
         />
       )}
-      {item.text}
-      {hasExternal && <ExternalIcon disabled={disabled} ariaLabel={item.externalIconAriaLabel} />}
+      <div className={styles['content-wrapper']}>
+        <div className={styles['main-row']}>
+          <div>
+            {item.text}
+            {hasExternal && <ExternalIcon disabled={disabled} ariaLabel={item.externalIconAriaLabel} />}
+          </div>
+          {item.labelTag && (
+            <InternalBox fontWeight="light" data-testid={'button-dropdown-label-tag'}>
+              {item.labelTag}
+            </InternalBox>
+          )}
+        </div>
+        {item.secondaryText && (
+          <InternalBox fontSize="body-s" fontWeight="light" data-testid={'button-dropdown-secondary-text'}>
+            {item.secondaryText}
+          </InternalBox>
+        )}
+      </div>
     </>
   );
 };

--- a/src/button-dropdown/item-element/styles.scss
+++ b/src/button-dropdown/item-element/styles.scss
@@ -106,3 +106,21 @@
 .external-icon {
   margin-inline-start: awsui.$space-xxs;
 }
+
+.content-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.main-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: awsui.$space-xxs;
+}
+
+.text-with-icon {
+  display: flex;
+  align-items: center;
+}

--- a/src/test-utils/dom/button-dropdown/index.ts
+++ b/src/test-utils/dom/button-dropdown/index.ts
@@ -100,6 +100,20 @@ export default class ButtonDropdownWrapper extends ComponentWrapper {
     return createWrapper().find(`[data-testid="button-dropdown-disabled-reason"]`);
   }
 
+  /**
+   * Finds the secondary text element for a dropdown item. Returns null if the element has no secondary text.
+   */
+  findSecondaryText(): ElementWrapper | null {
+    return createWrapper().find(`[data-testid="button-dropdown-secondary-text"]`);
+  }
+
+  /**
+   * Finds the label tag element for a dropdown item. Returns null if the element has no label tag.
+   */
+  findLabelTags(): ElementWrapper | null {
+    return createWrapper().find(`[data-testid="button-dropdown-label-tag"]`);
+  }
+
   @usesDom
   openDropdown(): void {
     act(() => {


### PR DESCRIPTION
### Description

Added support for secondaryText and labelTag properties to ButtonDropdown items, enabling richer item content similar to other Cloudscape components like Select and Multiselect.

This PR also added deprecated annotation for `description` prop for button dropdown item.

New features:
**secondaryText**: Displays additional descriptive text below the main item text
**labelTag**: Adds a visual tag/label to items for categorization or status indication

Implementation details:
* Extended ButtonDropdownProps.Item interface to include the new properties
* Updated ItemElement component to render secondary text and label tags
* Added corresponding styles for proper layout and visual hierarchy
* Added comprehensive test coverage for the new functionality
* Add `deprecated` annotation into the `description` prop
* Introduce `findSecondaryText` and `findLabelTag` test utils

Related links, issue #, if available: n/a

### How has this been tested?

#### Unit Tests:
* Added tests in button-dropdown-items.test.tsx for secondaryText rendering
* Added tests in button-dropdown-keyboard.test.tsx for keyboard navigation with secondaryText
* All existing ButtonDropdown tests continue to pass

#### Manual Testing:
* Verified visual appearance and layout of items with secondaryText and labelTag
* Tested keyboard navigation and accessibility
* Confirmed backward compatibility with existing ButtonDropdown usage

#### Reviewers can test by running:
```bash
npm test -- --testPathPattern="button-dropdown"
npm run test:integ -- --testPathPattern="button-dropdown"
```

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
