### PR TITLE
feat: Native attributes for status indicator

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -22497,6 +22497,28 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
+      "description": "Attributes to add to the native element.
+Some attributes will be automatically combined with internal attribute values:
+- \`className\` will be appended.
+- Event handlers will be chained, unless the default is prevented.
+
+We do not support using this attribute to apply custom styling.",
+      "inlineType": {
+        "name": "Omit<React.HTMLAttributes<HTMLElement>, "children"> & Record<\`data-\${string}\`, string>",
+        "type": "union",
+        "values": [
+          "Omit<React.HTMLAttributes<HTMLElement>, "children">",
+          "Record<\`data-\${string}\`, string>",
+        ],
+      },
+      "name": "nativeAttributes",
+      "optional": true,
+      "systemTags": [
+        "core",
+      ],
+      "type": "Omit<React.HTMLAttributes<HTMLElement>, "children"> & Record<\`data-\${string}\`, string>",
+    },
+    {
       "defaultValue": "'success'",
       "description": "Specifies the status type.",
       "inlineType": {

--- a/src/status-indicator/__tests__/status-indicator.test.tsx
+++ b/src/status-indicator/__tests__/status-indicator.test.tsx
@@ -34,4 +34,18 @@ describe('StatusIndicator', () => {
     const statusIndicatorWrapper = createWrapper(container.parentElement!).findStatusIndicator()!;
     expect(statusIndicatorWrapper.findByClassName(styles.icon)!.getElement()).toHaveAttribute('aria-label', ariaLabel);
   });
+
+  describe('native attributes', () => {
+    it('adds native attributes', () => {
+      const { container } = render(<StatusIndicator type="info" nativeAttributes={{ 'data-testid': 'my-test-id' }} />);
+      expect(container.querySelectorAll('[data-testid="my-test-id"]')).toHaveLength(1);
+    });
+    it('concatenates class names', () => {
+      const { container } = render(
+        <StatusIndicator type="info" nativeAttributes={{ className: 'additional-class' }} />
+      );
+      expect(container.firstChild).toHaveClass(styles.root);
+      expect(container.firstChild).toHaveClass('additional-class');
+    });
+  });
 });

--- a/src/status-indicator/internal.tsx
+++ b/src/status-indicator/internal.tsx
@@ -8,6 +8,10 @@ import InternalIcon from '../icon/internal';
 import { BaseComponentProps, getBaseProps } from '../internal/base-component';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { SomeRequired } from '../internal/types';
+/**
+ * @awsuiSystem core
+ */
+import WithNativeAttributes, { NativeAttributes } from '../internal/utils/with-native-attributes';
 import InternalSpinner from '../spinner/internal';
 
 import styles from './styles.css.js';
@@ -46,6 +50,17 @@ export interface StatusIndicatorProps extends BaseComponentProps {
    * and truncates it with an ellipsis.
    */
   wrapText?: boolean;
+  /**
+   * Attributes to add to the native element.
+   * Some attributes will be automatically combined with internal attribute values:
+   * - `className` will be appended.
+   * - Event handlers will be chained, unless the default is prevented.
+   *
+   * We do not support using this attribute to apply custom styling.
+   *
+   * @awsuiSystem core
+   */
+  nativeAttributes?: NativeAttributes<React.HTMLAttributes<HTMLElement>>;
 }
 
 export interface InternalStatusIndicatorProps
@@ -80,6 +95,7 @@ export default function StatusIndicator({
   iconAriaLabel,
   colorOverride,
   wrapText = true,
+  nativeAttributes,
   __animate = false,
   __internalRootRef,
   __size = 'normal',
@@ -88,8 +104,11 @@ export default function StatusIndicator({
 }: InternalStatusIndicatorProps) {
   const baseProps = getBaseProps(rest);
   return (
-    <span
+    <WithNativeAttributes
       {...baseProps}
+      tag="span"
+      componentName="StatusIndicator"
+      nativeAttributes={nativeAttributes}
       className={clsx(
         styles.root,
         styles[`status-${type}`],
@@ -118,6 +137,6 @@ export default function StatusIndicator({
         </span>
         {children}
       </span>
-    </span>
+    </WithNativeAttributes>
   );
 }


### PR DESCRIPTION
### Description

Add support for native attributes for status indicator

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
