### PR TITLE
fix: Allow interactive elements to be placed inside key of a key-value pair

### DIFF
--- a/src/key-value-pairs/internal.tsx
+++ b/src/key-value-pairs/internal.tsx
@@ -19,9 +19,9 @@ const InternalKeyValuePair = ({ label, info, value, id }: KeyValuePairsProps.Pai
   return (
     <>
       <dt className={styles.term}>
-        <label className={styles['key-label']} id={id || kvPairId}>
+        <div className={styles['key-label']} id={id || kvPairId}>
           {label}
-        </label>
+        </div>
         <InfoLinkLabelContext.Provider value={id || kvPairId}>
           {info && <span className={styles.info}>{info}</span>}
         </InfoLinkLabelContext.Provider>


### PR DESCRIPTION
### Description

Putting a popover inside a key meant that the dismiss button was nested inside the `<label>` of the key, and clicking on that counted as clicking on the button and the popover would just reopen. I don't think we need the label here; the `<dt>`/`<dd>` already creates a relationship between the key and the value, more isn't needed here.

Related links, issue #, if available: AWSUI-61213

### How has this been tested?

Just a simple element change, relying on existing tests to not fail.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
