### PR TITLE
fix: Ensure scroll position is on the file input button when focused

### DIFF
--- a/src/file-input/internal.tsx
+++ b/src/file-input/internal.tsx
@@ -19,6 +19,7 @@ import { fireNonCancelableEvent } from '../internal/events';
 import checkControlled from '../internal/hooks/check-controlled';
 import useForwardFocus from '../internal/hooks/forward-focus';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component/index.js';
+import { scrollElementIntoView } from '../internal/utils/scrollable-containers';
 import { joinStrings } from '../internal/utils/strings';
 import { GeneratedAnalyticsMetadataFileInputComponent } from './analytics-metadata/interfaces';
 import { FileInputProps } from './interfaces';
@@ -53,6 +54,7 @@ const InternalFileInput = React.forwardRef(
     const baseProps = getBaseProps(restProps);
     const uploadInputRef = useRef<HTMLInputElement>(null);
     const containerRef = useRef<HTMLButtonElement>(null);
+    const buttonWrapperRef = useRef<HTMLDivElement>(null);
     const mergedRef = useMergeRefs(__internalRootRef, containerRef);
 
     const uploadButtonLabelId = useUniqueId('upload-button-label');
@@ -66,7 +68,9 @@ const InternalFileInput = React.forwardRef(
     const onUploadButtonClick = () => uploadInputRef.current?.click();
     const onUploadInputFocus = () => {
       setIsFocused(true);
-      containerRef.current?.scrollIntoView?.();
+      if (buttonWrapperRef.current) {
+        scrollElementIntoView(buttonWrapperRef.current);
+      }
     };
     const onUploadInputBlur = () => setIsFocused(false);
 
@@ -147,20 +151,22 @@ const InternalFileInput = React.forwardRef(
 
         {/* The button is decorative. It dispatches clicks to the file input and is ARIA-hidden. */}
         {/* When the input is focused the focus outline is forced on the button. */}
-        <InternalButton
-          iconName="upload"
-          variant={variant === 'icon' ? 'icon' : undefined}
-          formAction="none"
-          onClick={onUploadButtonClick}
-          className={clsx(styles['file-input-button'], {
-            [styles['force-focus-outline-button']]: isFocused && variant === 'button',
-            [styles['force-focus-outline-icon']]: isFocused && variant === 'icon',
-          })}
-          nativeButtonAttributes={{ tabIndex: -1, 'aria-hidden': true }}
-          __skipNativeAttributesWarnings={true}
-        >
-          {variant === 'button' && children}
-        </InternalButton>
+        <div className={styles['file-input-button-wrapper']} ref={buttonWrapperRef}>
+          <InternalButton
+            iconName="upload"
+            variant={variant === 'icon' ? 'icon' : undefined}
+            formAction="none"
+            onClick={onUploadButtonClick}
+            className={clsx(styles['file-input-button'], {
+              [styles['force-focus-outline-button']]: isFocused && variant === 'button',
+              [styles['force-focus-outline-icon']]: isFocused && variant === 'icon',
+            })}
+            nativeButtonAttributes={{ tabIndex: -1, 'aria-hidden': true }}
+            __skipNativeAttributesWarnings={true}
+          >
+            {variant === 'button' && children}
+          </InternalButton>
+        </div>
 
         {/* The file input needs to be labelled with provided content. Can't use the button because it is ARIA-hidden. */}
         <ScreenreaderOnly id={uploadButtonLabelId}>{ariaLabel || children}</ScreenreaderOnly>


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
