### PR TITLE
chore: Focus on h1 when last flash item dismissed

### DIFF
--- a/src/flashbar/__tests__/common.test.tsx
+++ b/src/flashbar/__tests__/common.test.tsx
@@ -15,20 +15,20 @@ const mockFocusFlashFocusableArea = focusFlashFocusableArea as jest.MockedFuncti
 import styles from '../../../lib/components/flashbar/styles.css.js';
 
 describe('handleFlashDismissedInternal', () => {
-  let mockMainElement: HTMLElement;
+  let mockH1Element: HTMLElement;
   let originalQuerySelector: typeof document.querySelector;
   let originalSetTimeout: typeof setTimeout;
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockMainElement = document.createElement('main');
-    mockMainElement.focus = jest.fn();
+    mockH1Element = document.createElement('h1');
+    mockH1Element.focus = jest.fn();
 
     originalQuerySelector = document.querySelector;
     document.querySelector = jest.fn(selector => {
-      if (selector === 'main' || selector === '[role="main"]') {
-        return mockMainElement;
+      if (selector === 'h1') {
+        return mockH1Element;
       }
       return null;
     });
@@ -62,7 +62,7 @@ describe('handleFlashDismissedInternal', () => {
     handleFlashDismissedInternal('item-1', undefined, mockRef, flashRefs);
 
     expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
-    expect(mockMainElement.focus).not.toHaveBeenCalled();
+    expect(mockH1Element.focus).not.toHaveBeenCalled();
   });
 
   test('does nothing when dismissedId is undefined', () => {
@@ -73,7 +73,7 @@ describe('handleFlashDismissedInternal', () => {
     handleFlashDismissedInternal(undefined, items, mockRef, flashRefs);
 
     expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
-    expect(mockMainElement.focus).not.toHaveBeenCalled();
+    expect(mockH1Element.focus).not.toHaveBeenCalled();
   });
 
   test('does nothing when refCurrent is null', () => {
@@ -83,7 +83,7 @@ describe('handleFlashDismissedInternal', () => {
     handleFlashDismissedInternal('item-1', items, null, flashRefs);
 
     expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
-    expect(mockMainElement.focus).not.toHaveBeenCalled();
+    expect(mockH1Element.focus).not.toHaveBeenCalled();
   });
 
   test('does nothing when dismissed item is not found', () => {
@@ -94,7 +94,7 @@ describe('handleFlashDismissedInternal', () => {
     handleFlashDismissedInternal('non-existent-item', items, mockRef, flashRefs);
 
     expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
-    expect(mockMainElement.focus).not.toHaveBeenCalled();
+    expect(mockH1Element.focus).not.toHaveBeenCalled();
   });
 
   test('focuses on next item when dismissing first item', () => {
@@ -108,7 +108,7 @@ describe('handleFlashDismissedInternal', () => {
     handleFlashDismissedInternal('item-0', items, mockRef, flashRefs);
 
     expect(mockFocusFlashFocusableArea).toHaveBeenCalledWith(mockNextElement);
-    expect(mockMainElement.focus).not.toHaveBeenCalled();
+    expect(mockH1Element.focus).not.toHaveBeenCalled();
   });
 
   test('focuses on previous item when dismissing last item', () => {
@@ -122,10 +122,10 @@ describe('handleFlashDismissedInternal', () => {
     handleFlashDismissedInternal('item-2', items, mockRef, flashRefs);
 
     expect(mockFocusFlashFocusableArea).toHaveBeenCalledWith(mockPrevElement);
-    expect(mockMainElement.focus).not.toHaveBeenCalled();
+    expect(mockH1Element.focus).not.toHaveBeenCalled();
   });
 
-  test('focuses on main element when dismissing only item', () => {
+  test('focuses on h1 element when dismissing only item', () => {
     const items = createTestItems(1);
     const mockRef = document.createElement('div');
     const flashRefs = {};
@@ -133,7 +133,7 @@ describe('handleFlashDismissedInternal', () => {
     handleFlashDismissedInternal('item-0', items, mockRef, flashRefs);
 
     expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
-    expect(mockMainElement.focus).toHaveBeenCalled();
+    expect(mockH1Element.focus).toHaveBeenCalled();
   });
 
   test('focuses on notification bar button when next flash element is not available', () => {
@@ -156,10 +156,10 @@ describe('handleFlashDismissedInternal', () => {
 
     expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
     expect(mockNotificationButton.focus).toHaveBeenCalled();
-    expect(mockMainElement.focus).not.toHaveBeenCalled();
+    expect(mockH1Element.focus).not.toHaveBeenCalled();
   });
 
-  test('falls back to main element when neither next flash element nor notification button is available', () => {
+  test('falls back to h1 element when neither next flash element nor notification button is available', () => {
     const items = createTestItems(2);
     const mockRef = document.createElement('div');
 
@@ -170,7 +170,7 @@ describe('handleFlashDismissedInternal', () => {
     handleFlashDismissedInternal('item-0', items, mockRef, flashRefs);
 
     expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
-    expect(mockMainElement.focus).toHaveBeenCalled();
+    expect(mockH1Element.focus).toHaveBeenCalled();
   });
 
   test('focuses on middle item correctly', () => {
@@ -208,7 +208,7 @@ describe('handleFlashDismissedInternal', () => {
     handleFlashDismissedInternal('item-0', items, mockRef, flashRefs);
 
     expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
-    expect(mockMainElement.focus).not.toHaveBeenCalled();
+    expect(mockH1Element.focus).not.toHaveBeenCalled();
   });
 
   test('handles dismissing item at various positions', () => {
@@ -223,27 +223,21 @@ describe('handleFlashDismissedInternal', () => {
     expect(mockFocusFlashFocusableArea).toHaveBeenCalledWith(mockNextElement);
   });
 
-  test('handles notification button fallback with role="main"', () => {
+  test('handles case when h1 element is not available', () => {
     const items = createTestItems(1);
     const mockRef = document.createElement('div');
     const flashRefs = {};
 
-    const mockRoleMainElement = document.createElement('div');
-    mockRoleMainElement.setAttribute('role', 'main');
-    mockRoleMainElement.focus = jest.fn();
-
     document.querySelector = jest.fn(selector => {
-      if (selector === 'main') {
+      if (selector === 'h1') {
         return null;
-      }
-      if (selector === '[role="main"]') {
-        return mockRoleMainElement;
       }
       return null;
     });
 
     handleFlashDismissedInternal('item-0', items, mockRef, flashRefs);
 
-    expect(mockRoleMainElement.focus).toHaveBeenCalled();
+    expect(mockFocusFlashFocusableArea).not.toHaveBeenCalled();
+    // No focus should be called when h1 is not available
   });
 });

--- a/src/flashbar/__tests__/focus-handling.test.tsx
+++ b/src/flashbar/__tests__/focus-handling.test.tsx
@@ -90,20 +90,20 @@ describe('Flashbar focus handling on add', () => {
 });
 
 describe('Flashbar focus handling on dismiss', () => {
-  let mockMainElement: HTMLElement;
+  let mockH1Element: HTMLElement;
   let originalQuerySelector: typeof document.querySelector;
 
   beforeEach(() => {
-    // Mock main element
-    mockMainElement = document.createElement('main');
-    mockMainElement.focus = jest.fn();
-    document.body.appendChild(mockMainElement);
+    // Mock h1 element
+    mockH1Element = document.createElement('h1');
+    mockH1Element.focus = jest.fn();
+    document.body.appendChild(mockH1Element);
 
-    // Mock document.querySelector for main element fallback
+    // Mock document.querySelector for h1 element fallback
     originalQuerySelector = document.querySelector;
     document.querySelector = jest.fn(selector => {
-      if (selector === 'main' || selector === '[role="main"]') {
-        return mockMainElement;
+      if (selector === 'h1') {
+        return mockH1Element;
       }
       return originalQuerySelector.call(document, selector);
     });
@@ -111,8 +111,8 @@ describe('Flashbar focus handling on dismiss', () => {
 
   afterEach(() => {
     document.querySelector = originalQuerySelector;
-    if (document.body.contains(mockMainElement)) {
-      document.body.removeChild(mockMainElement);
+    if (document.body.contains(mockH1Element)) {
+      document.body.removeChild(mockH1Element);
     }
   });
 
@@ -331,8 +331,8 @@ describe('Flashbar focus handling on dismiss', () => {
     });
   });
 
-  test('focus behavior does not cause errors when main element is not present', () => {
-    // Remove the mocked main element
+  test('focus behavior does not cause errors when h1 element is not present', () => {
+    // Remove the mocked h1 element
     document.querySelector = jest.fn(() => null);
 
     const items = createTestItems(1);
@@ -341,7 +341,7 @@ describe('Flashbar focus handling on dismiss', () => {
 
     const wrapper = createWrapper(container).findFlashbar()!;
 
-    // Should not throw when dismissing the only item (even with no main element)
+    // Should not throw when dismissing the only item (even with no h1 element)
     expect(() => {
       wrapper.findItems()[0].findDismissButton()!.click();
     }).not.toThrow();

--- a/src/flashbar/common.tsx
+++ b/src/flashbar/common.tsx
@@ -36,10 +36,10 @@ export const handleFlashDismissedInternal = (
     nextItemIndex = dismissedIndex - 1;
   }
 
-  // If there's no next item, focus the first instance of the main element (or element with role=main)
+  // If there's no next item, focus the first instance of the h1 element
   if (nextItemIndex < 0 || nextItemIndex >= items.length) {
-    const mainElement = document.querySelector('main') ?? document.querySelector('[role="main"]');
-    mainElement?.focus();
+    const h1Element = document.querySelector('h1');
+    h1Element?.focus();
     return;
   }
 
@@ -58,8 +58,8 @@ export const handleFlashDismissedInternal = (
         return;
       }
 
-      const mainElement = document.querySelector('main') ?? document.querySelector('[role="main"]');
-      mainElement?.focus();
+      const h1Element = document.querySelector('h1');
+      h1Element?.focus();
       return;
     }
     focusFlashFocusableArea(nextFlashElement);


### PR DESCRIPTION
### Description

When the last flashbar item is dismissed, we want to move the focus to the first h1 element within the page.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
