### PR TITLE
fix: Fixes mixed chart popover reopen in tests

### DIFF
--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -981,6 +981,32 @@ describe('Details popover', () => {
     expect(wrapper.findByClassName(styles.exiting)).not.toBeNull();
   });
 
+  test('can be hidden with Escape and then reopened', () => {
+    const { wrapper } = renderMixedChart(<MixedLineBarChart {...mixedChartProps} />);
+    document.body.classList.add('awsui-motion-disabled');
+    const isPopoverVisible = () => !wrapper.findByClassName(styles.exiting);
+    const isPopoverPinned = () => !!wrapper.findDetailPopover()!.findDismissButton();
+
+    wrapper.findApplication()!.focus();
+    expect(isPopoverVisible()).toBe(true);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(isPopoverVisible()).toBe(false);
+
+    wrapper.findApplication()!.keydown(KeyCode.right);
+    expect(isPopoverVisible()).toBe(true);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(isPopoverVisible()).toBe(false);
+
+    wrapper.findApplication()!.keydown(KeyCode.enter);
+    expect(isPopoverVisible()).toBe(true);
+    expect(isPopoverPinned()).toBe(true);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(isPopoverVisible()).toBe(false);
+  });
+
   test('delegates focus back to chart when unpinned in a non-grouped chart', async () => {
     const { wrapper } = renderMixedChart(<MixedLineBarChart {...lineChartProps} />);
 

--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -981,9 +981,8 @@ describe('Details popover', () => {
     expect(wrapper.findByClassName(styles.exiting)).not.toBeNull();
   });
 
-  test('can be hidden with Escape and then reopened', () => {
+  test('can be hidden with Escape and then reopened', async () => {
     const { wrapper } = renderMixedChart(<MixedLineBarChart {...mixedChartProps} />);
-    document.body.classList.add('awsui-motion-disabled');
     const isPopoverVisible = () => !wrapper.findByClassName(styles.exiting);
     const isPopoverPinned = () => !!wrapper.findDetailPopover()!.findDismissButton();
 
@@ -1005,6 +1004,15 @@ describe('Details popover', () => {
 
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     expect(isPopoverVisible()).toBe(false);
+
+    // The popover is not re-opened within 50ms from un-pinning.
+    wrapper.findApplication()!.keydown(KeyCode.right);
+    expect(isPopoverVisible()).toBe(false);
+
+    await new Promise(resolve => setTimeout(resolve, 50 + 1));
+
+    wrapper.findApplication()!.keydown(KeyCode.right);
+    expect(isPopoverVisible()).toBe(true);
   });
 
   test('delegates focus back to chart when unpinned in a non-grouped chart', async () => {

--- a/src/mixed-line-bar-chart/hooks/use-popover.ts
+++ b/src/mixed-line-bar-chart/hooks/use-popover.ts
@@ -23,8 +23,12 @@ export function usePopover() {
   const pinPopover = useCallback(() => setState('pinned'), []);
   const hidePopover = useCallback(() => setState('closed'), []);
   const dismissPopover = useCallback(() => {
-    setState('closed');
-    dismissedTimeRef.current = Date.now();
+    setState(prev => {
+      if (prev === 'pinned') {
+        dismissedTimeRef.current = Date.now();
+      }
+      return 'closed';
+    });
   }, []);
 
   return { isPopoverOpen, isPopoverPinned, showPopover, pinPopover, hidePopover, dismissPopover };


### PR DESCRIPTION
### Description

The charts popover should not reopen immediately after it was unpinned and dismissed. The prev implementation did not checked for popover's prev state, which means that any call to dismissPopover() would result in the timeout reset. That affected our tests where we issue the Escape command and then navigate the popover immediately after.

### How has this been tested?

* New unit test for Escape listener that secures regression

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
