### PR TITLE
test: Update tests for ResizeObserver polyfill removal

### DIFF
--- a/src/app-layout/__tests__/main.test.tsx
+++ b/src/app-layout/__tests__/main.test.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
+import { useLayoutEffect } from 'react';
 import { waitFor } from '@testing-library/react';
 
 import '../../__a11y__/to-validate-a11y';
@@ -10,6 +11,22 @@ import { describeEachAppLayout, renderComponent, testDrawer } from './utils';
 
 import mobileStyles from '../../../lib/components/app-layout/mobile-toolbar/styles.css.js';
 import sharedStyles from '../../../lib/components/app-layout/styles.css.js';
+
+jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
+  ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
+  useResizeObserver: (getElement: any, onObserve: any) => {
+    useLayoutEffect(() => {
+      if (typeof getElement === 'function') {
+        const element = getElement();
+        if (element) {
+          // Extract height from inline styles for JSDOM compatibility
+          const height = parseInt(element.style.height) || 0;
+          onObserve({ borderBoxHeight: height });
+        }
+      }
+    }, [getElement, onObserve]);
+  },
+}));
 
 test('does not render mobile mode by default', () => {
   const { wrapper } = renderComponent(<AppLayout />);

--- a/src/table/__integ__/resizable-columns-misc.test.ts
+++ b/src/table/__integ__/resizable-columns-misc.test.ts
@@ -89,11 +89,11 @@ test(
     await page.installObserver(wrapper.find('table').toSelector());
     await page.click('#shrink-container');
     await page.waitForJsTimers();
-    // expected 1 observation after creating observer and 1 caused by container shrink
-    await expect(page.getObservations()).resolves.toBe(2);
+    // check to ensure that we haven't triggered an infinite resize loop
+    await expect(page.getObservations()).resolves.toBeLessThanOrEqual(3);
     await page.waitForJsTimers();
-    // ensure there are no more observations added after the expected 2
-    await expect(page.getObservations()).resolves.toBe(2);
+    // check again to ensure that we haven't triggered an infinite resize loop
+    await expect(page.getObservations()).resolves.toBeLessThanOrEqual(3);
   })
 );
 


### PR DESCRIPTION
### Description

@just-boris noticed test failures when he did a dry run against https://github.com/cloudscape-design/component-toolkit/pull/154, which removes the `ResizeObserver` polyfill used by the `useResizeObserver` hook. This PR updates the affected tests to make them compatible with that change.

### How has this been tested?

I ran the unit test against the `component-toolkit` changes locally. I was unable to run the integration test, but @just-boris reported that the issue was that 3 resize observations occurred instead of 2. As he described it, the purpose of the assertion is to prevent infinite resize loops.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
