### PR TITLE
chore: Remove unused app layout widget code

### DIFF
--- a/src/app-layout/__tests__/widget-old-mocks.ts
+++ b/src/app-layout/__tests__/widget-old-mocks.ts
@@ -11,26 +11,19 @@ function createMockComponent(componentName: string) {
 
 // Mock previous widgetized components
 jest.mock('../../../lib/components/app-layout/visual-refresh-toolbar/navigation', () => ({
-  createWidgetizedAppLayoutNavigation: () => {},
   AppLayoutNavigationImplementation: createMockComponent('AppLayoutNavigationImplementation'),
 }));
 jest.mock('../../../lib/components/app-layout/visual-refresh-toolbar/drawer', () => ({
-  createWidgetizedAppLayoutDrawer: () => {},
   AppLayoutDrawerImplementation: createMockComponent('AppLayoutDrawerImplementation'),
-  createWidgetizedAppLayoutGlobalDrawers: () => {},
   AppLayoutGlobalDrawersImplementation: createMockComponent('AppLayoutGlobalDrawersImplementation'),
 }));
 jest.mock('../../../lib/components/app-layout/visual-refresh-toolbar/notifications', () => ({
-  createWidgetizedAppLayoutNotifications: () => {},
   AppLayoutNotificationsImplementation: createMockComponent('AppLayoutNotificationsImplementation'),
 }));
 jest.mock('../../../lib/components/app-layout/visual-refresh-toolbar/toolbar', () => ({
-  createWidgetizedAppLayoutToolbar: () => {},
   AppLayoutToolbarImplementation: createMockComponent('AppLayoutToolbarImplementation'),
 }));
 jest.mock('../../../lib/components/app-layout/visual-refresh-toolbar/split-panel', () => ({
-  createWidgetizedAppLayoutSplitPanelDrawerBottom: () => {},
   AppLayoutSplitPanelDrawerBottomImplementation: createMockComponent('AppLayoutSplitPanelDrawerBottomImplementation'),
-  createWidgetizedAppLayoutSplitPanelDrawerSide: () => {},
   AppLayoutSplitPanelDrawerSideImplementation: createMockComponent('AppLayoutSplitPanelDrawerSideImplementation'),
 }));

--- a/src/app-layout/visual-refresh-toolbar/drawer/global-drawers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/global-drawers.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useRef } from 'react';
 
-import { createWidgetizedComponent } from '../../../internal/widgets';
 import { AppLayoutInternals } from '../interfaces';
 import AppLayoutGlobalDrawer from './global-drawer';
 
@@ -42,5 +41,3 @@ export function AppLayoutGlobalDrawersImplementation({
     </>
   );
 }
-
-export const createWidgetizedAppLayoutGlobalDrawers = createWidgetizedComponent(AppLayoutGlobalDrawersImplementation);

--- a/src/app-layout/visual-refresh-toolbar/drawer/index.ts
+++ b/src/app-layout/visual-refresh-toolbar/drawer/index.ts
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export { createWidgetizedAppLayoutDrawer, AppLayoutDrawerImplementation } from './local-drawer';
-export { createWidgetizedAppLayoutGlobalDrawers, AppLayoutGlobalDrawersImplementation } from './global-drawers';
+export { AppLayoutDrawerImplementation } from './local-drawer';
+export { AppLayoutGlobalDrawersImplementation } from './global-drawers';

--- a/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/local-drawer.tsx
@@ -7,7 +7,6 @@ import clsx from 'clsx';
 import { InternalButton } from '../../../button/internal';
 import PanelResizeHandle from '../../../internal/components/panel-resize-handle';
 import customCssProps from '../../../internal/generated/custom-css-properties';
-import { createWidgetizedComponent } from '../../../internal/widgets';
 import { getLimitedValue } from '../../../split-panel/utils/size-utils';
 import { TOOLS_DRAWER_ID } from '../../utils/use-drawers';
 import { getDrawerStyles } from '../compute-layout';
@@ -147,5 +146,3 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
     </Transition>
   );
 }
-
-export const createWidgetizedAppLayoutDrawer = createWidgetizedComponent(AppLayoutDrawerImplementation);

--- a/src/app-layout/visual-refresh-toolbar/internal.tsx
+++ b/src/app-layout/visual-refresh-toolbar/internal.tsx
@@ -2,15 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createLoadableComponent } from '../../internal/widgets/loader-mock';
-import { createWidgetizedAppLayoutDrawer, createWidgetizedAppLayoutGlobalDrawers } from './drawer';
-import { createWidgetizedAppLayoutNavigation } from './navigation';
-import { createWidgetizedAppLayoutNotifications } from './notifications';
-import {
-  createWidgetizedAppLayoutSplitPanelDrawerBottom,
-  createWidgetizedAppLayoutSplitPanelDrawerSide,
-} from './split-panel';
 import { AppLayoutStateProvider as AppLayoutStateImplementation, createWidgetizedAppLayoutState } from './state';
-import { createWidgetizedAppLayoutToolbar } from './toolbar';
 import { AfterMainSlotImplementation, createWidgetizedAppLayoutAfterMainSlot } from './widget-areas/after-main-slot';
 import { BeforeMainSlotImplementation, createWidgetizedAppLayoutBeforeMainSlot } from './widget-areas/before-main-slot';
 import {
@@ -19,16 +11,6 @@ import {
 } from './widget-areas/bottom-content-slot';
 import { createWidgetizedAppLayoutTopContentSlot, TopContentSlotImplementation } from './widget-areas/top-content-slot';
 
-// Legacy widgetized parts
-export const AppLayoutNavigation = createWidgetizedAppLayoutNavigation();
-export const AppLayoutDrawer = createWidgetizedAppLayoutDrawer();
-export const AppLayoutGlobalDrawers = createWidgetizedAppLayoutGlobalDrawers();
-export const AppLayoutNotifications = createWidgetizedAppLayoutNotifications();
-export const AppLayoutToolbar = createWidgetizedAppLayoutToolbar();
-export const AppLayoutSplitPanelBottom = createWidgetizedAppLayoutSplitPanelDrawerBottom();
-export const AppLayoutSplitPanelSide = createWidgetizedAppLayoutSplitPanelDrawerSide();
-
-// Refactored widgetized parts
 export const AppLayoutBeforeMainSlot = createWidgetizedAppLayoutBeforeMainSlot(
   createLoadableComponent(BeforeMainSlotImplementation)
 );

--- a/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
@@ -6,10 +6,8 @@ import clsx from 'clsx';
 import { findUpUntil } from '@cloudscape-design/component-toolkit/dom';
 
 import { InternalButton } from '../../../button/internal';
-import { createWidgetizedComponent } from '../../../internal/widgets';
 import { getDrawerStyles } from '../compute-layout';
 import { AppLayoutInternals } from '../interfaces';
-import { NotificationsSlot } from '../skeleton/slots';
 
 import sharedStyles from '../../resize/styles.css.js';
 import testutilStyles from '../../test-classes/styles.css.js';
@@ -83,8 +81,3 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
     </div>
   );
 }
-
-export const createWidgetizedAppLayoutNavigation = createWidgetizedComponent(
-  AppLayoutNavigationImplementation,
-  NotificationsSlot
-);

--- a/src/app-layout/visual-refresh-toolbar/notifications/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/notifications/index.tsx
@@ -6,9 +6,7 @@ import clsx from 'clsx';
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
 import { highContrastHeaderClassName } from '../../../internal/utils/content-header-utils';
-import { createWidgetizedComponent } from '../../../internal/widgets';
 import { AppLayoutInternals } from '../interfaces';
-import { NotificationsSkeleton } from '../skeleton/skeleton-parts';
 import { NotificationsSlot } from '../skeleton/slots';
 
 import testutilStyles from '../../test-classes/styles.css.js';
@@ -58,8 +56,3 @@ export function AppLayoutNotificationsImplementation({
     </NotificationsSlot>
   );
 }
-
-export const createWidgetizedAppLayoutNotifications = createWidgetizedComponent(
-  AppLayoutNotificationsImplementation,
-  NotificationsSkeleton
-);

--- a/src/app-layout/visual-refresh-toolbar/split-panel/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/split-panel/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import { createWidgetizedComponent } from '../../../internal/widgets';
 import { SplitPanelProvider, SplitPanelProviderProps } from '../../split-panel';
 import { getDrawerStyles } from '../compute-layout';
 import { AppLayoutInternals } from '../interfaces';
@@ -57,11 +56,3 @@ export function AppLayoutSplitPanelDrawerBottomImplementation({
     </SplitPanelProvider>
   );
 }
-
-export const createWidgetizedAppLayoutSplitPanelDrawerSide = createWidgetizedComponent(
-  AppLayoutSplitPanelDrawerSideImplementation
-);
-
-export const createWidgetizedAppLayoutSplitPanelDrawerBottom = createWidgetizedComponent(
-  AppLayoutSplitPanelDrawerBottomImplementation
-);

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -6,12 +6,10 @@ import clsx from 'clsx';
 
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
-import { createWidgetizedComponent } from '../../../internal/widgets';
 import { AppLayoutProps } from '../../interfaces';
 import { OnChangeParams } from '../../utils/use-drawers';
 import { Focusable, FocusControlMultipleStates } from '../../utils/use-focus-control';
 import { AppLayoutInternals } from '../interfaces';
-import { ToolbarSkeleton } from '../skeleton/skeleton-parts';
 import { BreadcrumbsSlot, ToolbarSlot } from '../skeleton/slots';
 import { DrawerTriggers, SplitPanelToggleProps } from './drawer-triggers';
 import TriggerButton from './trigger-button';
@@ -246,8 +244,3 @@ export function AppLayoutToolbarImplementation({
     </ToolbarSlot>
   );
 }
-
-export const createWidgetizedAppLayoutToolbar = createWidgetizedComponent(
-  AppLayoutToolbarImplementation,
-  ToolbarSkeleton
-);


### PR DESCRIPTION
### Description

Follow up for https://github.com/cloudscape-design/components/pull/3721

This code is not used anymore

Related links, issue #, if available: n/a

### How has this been tested?

PR build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
