### PR TITLE
fix: Fixes bar chart popover placement in Firefox

### DIFF
--- a/src/mixed-line-bar-chart/bar-groups.tsx
+++ b/src/mixed-line-bar-chart/bar-groups.tsx
@@ -46,7 +46,9 @@ export default function BarGroups<T extends ChartDataTypes>({
           aria-label={ariaLabel}
           aria-haspopup={true}
           aria-expanded={isPopoverPinned}
-          fill="none"
+          // We must use "transparent" instead of "none" so that Firefox popover placement works correctly.
+          // When an SVG element has no stroke or fill color the Firefox optimizes it out.
+          fill="transparent"
           className={styles['bar-group']}
         />
       ))}


### PR DESCRIPTION
### Description

The PR fixes an issue reproducible in the latest Firefox version. The browser ignores SVG elements placement if the element has no color.

Before:


https://github.com/user-attachments/assets/1dedc4f9-d493-470e-b305-0e9286ba3b35

After:


https://github.com/user-attachments/assets/a298d72f-c04c-498b-9475-f65584bc8917



### How has this been tested?

* This will be captured by existing screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
