### PR TITLE
fix: Correctly reflect aria-rowcount on tables during loading and empty states

### DIFF
--- a/src/table/__tests__/a11y.test.tsx
+++ b/src/table/__tests__/a11y.test.tsx
@@ -130,6 +130,16 @@ describe('labels', () => {
       expect(wrapper.find('[role=table]')!.getElement().getAttribute('aria-rowcount')).toEqual('-1');
     });
 
+    test('aria-rowcount should be -1 if the table is loading', () => {
+      const wrapper = renderTableWrapper({ loading: true, loadingText: 'Loading items', totalItemsCount: 500 });
+      expect(wrapper.find('[role=table]')!.getElement().getAttribute('aria-rowcount')).toEqual('-1');
+    });
+
+    test('aria-rowcount should be 2 (header and empty state cell) if the empty state is rendered', () => {
+      const wrapper = renderTableWrapper({ items: [], totalItemsCount: 500 });
+      expect(wrapper.find('[role=table]')!.getElement().getAttribute('aria-rowcount')).toEqual('2');
+    });
+
     test.each([undefined, 21])('sets aria-rowindex on table rows', firstIndex => {
       const expectedFirstIndex = firstIndex ?? 1;
       const wrapper = renderTableWrapper({ firstIndex });

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -547,7 +547,7 @@ const InternalTable = React.forwardRef(
                     )}
                     {...getTableRoleProps({
                       tableRole,
-                      totalItemsCount,
+                      totalItemsCount: loading ? -1 : allItems.length === 0 ? 1 : totalItemsCount,
                       totalColumnsCount: totalColumnsCount,
                       ariaLabel: ariaLabels?.tableLabel,
                       ariaLabelledby,


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
