### PR TITLE
revert: Drawers triggers size

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
@@ -117,7 +117,7 @@ $toolbar-height: 42px;
     align-items: center;
     display: grid;
     inline-size: 100%;
-    grid-template-columns: min-content min-content 1fr min-content;
+    grid-template-columns: min-content min-content minmax(0, 3fr) minmax(auto, 1fr);
     grid-template-rows: 1fr;
 
     @include theming.dark-mode-only {
@@ -150,9 +150,6 @@ $toolbar-height: 42px;
       display: flex;
       justify-content: flex-end;
       block-size: 100%;
-      min-inline-size: 0;
-      flex-shrink: 0;
-      inline-size: clamp(200px, 25vw, 400px);
     }
   }
 }


### PR DESCRIPTION
Reverts cloudscape-design/components#3854 because it introduced visual regression