### PR TITLE
chore: Add new Box variant for inline-code

### DIFF
--- a/pages/box/inline-code-example.page.tsx
+++ b/pages/box/inline-code-example.page.tsx
@@ -1,0 +1,136 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Alert from '~components/alert';
+import Box from '~components/box';
+import Header from '~components/header';
+import Link from '~components/link';
+import SpaceBetween from '~components/space-between';
+import Table from '~components/table';
+import { TableProps } from '~components/table';
+
+interface TableItem {
+  name: string;
+  alt: string;
+  description: React.ReactNode;
+  type: string;
+  size: string;
+}
+
+export default function InlineCodeExample() {
+  return (
+    <>
+      <h1>Inline-code examples</h1>
+      <Box padding={{ left: 'xl', right: 'xl', top: 'xxl', bottom: 'xl' }}>
+        <SpaceBetween size="l">
+          <div>
+            <h2>Example usage in paragraph</h2>
+            <p>
+              When writing documentation, you can use inline code elements to highlight variables like{' '}
+              <Box variant="awsui-inline-code">const myVariable = 42;</Box> or function names like{' '}
+              <Box variant="awsui-inline-code">calculateTotal()</Box>. For example:{' '}
+              <Box variant="awsui-inline-code">export API_ENDPOINT=&quot;https://api.example.com&quot;</Box>
+            </p>
+          </div>
+
+          <div>
+            <Table<TableItem>
+              totalItemsCount={4}
+              renderAriaLive={({ firstIndex, lastIndex, totalItemsCount }: TableProps.LiveAnnouncement) =>
+                `Displaying items ${firstIndex} to ${lastIndex} of ${totalItemsCount}`
+              }
+              columnDefinitions={[
+                {
+                  id: 'variable',
+                  header: 'Variable name',
+                  cell: (item: TableItem) => <Link href="#">{item.name || '-'}</Link>,
+                  sortingField: 'name',
+                  isRowHeader: true,
+                },
+                {
+                  id: 'alt',
+                  header: 'Text value',
+                  cell: (item: TableItem) => item.alt || '-',
+                  sortingField: 'alt',
+                },
+                {
+                  id: 'description',
+                  header: 'Description',
+                  cell: (item: TableItem) => item.description || '-',
+                },
+              ]}
+              enableKeyboardNavigation={true}
+              items={[
+                {
+                  name: 'Item 1',
+                  alt: 'First',
+                  description: (
+                    <>
+                      This is the first <Box variant="awsui-inline-code">db.t2.large</Box> item
+                    </>
+                  ),
+                  type: '1A',
+                  size: 'Small',
+                },
+                {
+                  name: 'Item 2',
+                  alt: 'Second',
+                  description: (
+                    <>
+                      This is the second <Box variant="awsui-inline-code">S3-aws-phoenix.example.com</Box> item
+                    </>
+                  ),
+                  type: '1B',
+                  size: 'Large',
+                },
+                {
+                  name: 'Item 3',
+                  alt: 'Third',
+                  description: '-',
+                  type: '1A',
+                  size: 'Large',
+                },
+                {
+                  name: 'Item 4',
+                  alt: 'Fourth',
+                  description: 'This is the fourth item',
+                  type: '2A',
+                  size: 'Small',
+                },
+              ]}
+              loadingText="Loading resources"
+              sortingDisabled={true}
+              header={<Header> In table </Header>}
+            />
+          </div>
+
+          <div>
+            <h2>In Alert component</h2>
+            <SpaceBetween size="xs">
+              <Alert type="info" header="Configuration required">
+                To configure your application, set the <Box variant="awsui-inline-code">API_ENDPOINT</Box> environment
+                variable to your API URL.
+              </Alert>
+
+              <Alert type="warning" header="Deprecated function">
+                The function <Box variant="awsui-inline-code">getUserData()</Box> is deprecated. Please use{' '}
+                <Box variant="awsui-inline-code">fetchUserProfile()</Box> instead.
+              </Alert>
+
+              <Alert type="error" header="Deprecated version">
+                The function <Box variant="awsui-inline-code">getUserData()</Box> is deprecated. Please use{' '}
+                <Box variant="awsui-inline-code">fetchUserProfile()</Box> instead.
+              </Alert>
+
+              <Alert type="success" header="Versionset is set">
+                The function <Box variant="awsui-inline-code">getUserData()</Box> is deprecated. Please use{' '}
+                <Box variant="awsui-inline-code">fetchUserProfile()</Box> instead.
+              </Alert>
+            </SpaceBetween>
+          </div>
+        </SpaceBetween>
+      </Box>
+    </>
+  );
+}

--- a/src/box/interfaces.ts
+++ b/src/box/interfaces.ts
@@ -151,7 +151,8 @@ export namespace BoxProps {
     | 'samp'
     | 'awsui-key-label'
     | 'awsui-gen-ai-label'
-    | 'awsui-value-large';
+    | 'awsui-value-large'
+    | 'awsui-inline-code';
 
   export type Display = 'block' | 'inline' | 'inline-block' | 'none';
   export type TextAlign = 'left' | 'center' | 'right';

--- a/src/box/internal.tsx
+++ b/src/box/internal.tsx
@@ -82,5 +82,9 @@ const getTag = (variant: BoxProps.Variant, tagOverride: BoxProps['tagOverride'])
     return 'div';
   }
 
+  if (variant === 'awsui-inline-code') {
+    return 'code';
+  }
+
   return variant;
 };

--- a/src/box/text.scss
+++ b/src/box/text.scss
@@ -53,6 +53,17 @@
       font-weight: awsui.$font-box-value-large-weight;
       color: inherit;
     }
+    &.inline-code-variant {
+      @include base-styles.code-extra-defaults;
+      @include styles.font-body-s;
+      border-start-start-radius: awsui.$space-static-xxs;
+      border-start-end-radius: awsui.$space-static-xxs;
+      border-end-start-radius: awsui.$space-static-xxs;
+      border-end-end-radius: awsui.$space-static-xxs;
+      background-color: awsui.$color-background-inline-code;
+      padding-block: awsui.$space-static-xxxs;
+      padding-inline: awsui.$space-static-xxs;
+    }
     &.h1-variant.font-weight-default,
     &.h2-variant.font-weight-default,
     &.h3-variant.font-weight-default,

--- a/style-dictionary/utils/token-names.ts
+++ b/style-dictionary/utils/token-names.ts
@@ -456,6 +456,7 @@ export type ColorsTokenName =
   | 'colorBackgroundDropdownItemHover'
   | 'colorBackgroundDropdownItemSelected'
   | 'colorBackgroundHomeHeader'
+  | 'colorBackgroundInlineCode'
   | 'colorBackgroundInputDefault'
   | 'colorBackgroundInputDisabled'
   | 'colorBackgroundItemSelected'

--- a/style-dictionary/visual-refresh/colors.ts
+++ b/style-dictionary/visual-refresh/colors.ts
@@ -51,6 +51,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorBackgroundDropdownItemHover: { light: '{colorGrey200}', dark: '{colorGrey900}' },
   colorBackgroundDropdownItemSelected: '{colorBackgroundItemSelected}',
   colorBackgroundHomeHeader: '{colorGrey950}',
+  colorBackgroundInlineCode: { light: 'rgba(0, 0, 0, 0.1)', dark: 'rgba(255, 255, 255, 0.1)' },
   colorBackgroundInputDefault: { light: '{colorWhite}', dark: '{colorGrey850}' },
   colorBackgroundInputDisabled: { light: '{colorGrey250}', dark: '{colorGrey800}' },
   colorBackgroundItemSelected: { light: '{colorBlue50}', dark: '{colorBlue1000}' },

--- a/style-dictionary/visual-refresh/contexts/flashbar-warning.ts
+++ b/style-dictionary/visual-refresh/contexts/flashbar-warning.ts
@@ -39,6 +39,9 @@ export const sharedTokens: StyleDictionary.ColorsDictionary = {
   // Tutorial hotspot
   colorTextTutorialHotspotDefault: '{colorGrey600}',
   colorTextTutorialHotspotHover: '{colorGrey900}',
+
+  // Inline-code variant background in Box
+  colorBackgroundInlineCode: 'rgba(0, 0, 0, 0.1)',
 };
 
 const tokens: StyleDictionary.ColorsDictionary = {

--- a/style-dictionary/visual-refresh/contexts/flashbar.ts
+++ b/style-dictionary/visual-refresh/contexts/flashbar.ts
@@ -24,6 +24,7 @@ export const baseTokens: StyleDictionary.ColorsDictionary = {
   colorBorderDividerDefault: '{colorGrey100}',
   colorTextTutorialHotspotDefault: '{colorGrey300}',
   colorTextTutorialHotspotHover: '{colorGrey100}',
+  colorBackgroundInlineCode: 'rgba(0, 0, 0, 0.2)',
 };
 
 const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = expandColorDictionary(


### PR DESCRIPTION
### Description
We identified the lack of a consistent visual style for inline code elements across services. In the absence of a standardized approach, teams have implemented custom styles, resulting in visual inconsistencies.

This PR introduces a new variant in Box component called awsui-inline-code, which can be used to display a unified style for inline-code elements.

<img width="1438" height="900" alt="App layout" src="https://github.com/user-attachments/assets/56e7a035-0203-4329-b6a1-883d6efafa57" />


<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
