### PR TITLE
chore: Fixes internal infra issue with webpack and react 18 pages

### DIFF
--- a/pages/webpack.config.base.cjs
+++ b/pages/webpack.config.base.cjs
@@ -15,9 +15,6 @@ const noop = () => ({ apply: () => {} });
 const replaceModule = (from, to) =>
   new NormalModuleReplacementPlugin(from, resource => (resource.request = resource.request.replace(from, to)));
 
-const react18Root = path.dirname(require.resolve('react18/package.json'));
-const reactDom18Root = path.dirname(require.resolve('react-dom18/package.json'));
-
 module.exports = ({
   outputPath = 'pages/lib/static/',
   componentsPath,
@@ -47,9 +44,9 @@ module.exports = ({
         ...(react18
           ? {
               '~mount': path.resolve(__dirname, './app/mount/react18.ts'),
-              react: react18Root,
-              'react-dom': reactDom18Root,
-              'react-dom/client': path.join(reactDom18Root, 'client'),
+              react: 'react18',
+              'react-dom': 'react-dom18',
+              'react-dom/client': 'react-dom18/client',
             }
           : {
               '~mount': path.resolve(__dirname, './app/mount/react16.ts'),


### PR DESCRIPTION
### Description

Internally when building pages we use the same webpack config but different package.json. As result, the react18 is not resolved when declared explicitly.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
