### PR TITLE
chore: Fixes flaky select integ test with React 18

### DIFF
--- a/src/select/__integ__/select.test.ts
+++ b/src/select/__integ__/select.test.ts
@@ -280,6 +280,7 @@ test(
     await browser.url('/#/light/select/select.test.scroll-padding');
     const page = new SelectPageObject(browser, createWrapper().findSelect());
     await page.setWindowSize({ width: 800, height: 250 });
+    await page.waitForVisible(createWrapper().findSelect().findTrigger().toSelector());
     await page.windowScrollTo({ top: 15 });
     await page.clickSelect();
     await expect(page.getWindowScroll()).resolves.toEqual({ top: 15, left: 0 });


### PR DESCRIPTION
### Description

The test was only failing in GitHub action runs. I verified the fix works by first running the test 100 times w/o the fix and observing failures in logs, then running it 100 times with the fix - there was not a single retry.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
