### PR TITLE
chore: Fixes npm run build && npm run start

### DIFF
--- a/pages/webpack.config.base.cjs
+++ b/pages/webpack.config.base.cjs
@@ -24,11 +24,12 @@ module.exports = ({
   moduleReplacements,
   react18,
 } = {}) => {
+  const mode = process.env.NODE_ENV;
   return {
     stats: isProd ? 'none' : 'minimal',
     context: path.resolve(__dirname),
     entry: './app/index.tsx',
-    mode: process.env.NODE_ENV,
+    mode,
     output: {
       path: path.resolve(outputPath),
       publicPath: './',
@@ -54,7 +55,7 @@ module.exports = ({
       },
     },
     devtool: 'source-map',
-    cache: isLocal ? { type: 'filesystem', name: react18 ? 'react18' : 'react16' } : false,
+    cache: isLocal ? { type: 'filesystem', name: react18 ? `${mode}:react18` : `${mode}:react16` } : false,
     module: {
       rules: [
         {


### PR DESCRIPTION
### Description

The webpack cache name was introduced here: https://github.com/cloudscape-design/components/pull/3829

It is used to ensure the artifacts are not cached between React 16 and 18 runs. However, that caused a problem when running `npm run build` (bundles pages) followed by `npm start` (runs dev-server). Both commands use the same webpack config but cannot reuse the cache.

### How has this been tested?

* Running `npm run build && npm start` now works

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
