### PR TITLE
chore: Mock getBoundingClientRect in mixed chart tests

### DIFF
--- a/pages/container-queries.page.tsx
+++ b/pages/container-queries.page.tsx
@@ -21,7 +21,11 @@ function MeasureReporter(props: { id?: string; style?: React.CSSProperties; type
     [props.type]
   );
   if (value === null) {
-    return <div ref={ref}>Loading...</div>;
+    return (
+      <div ref={ref} style={{ ...boxStyles, ...props.style }}>
+        Loading...
+      </div>
+    );
   }
   return (
     <div id={props.id} ref={ref} style={{ ...boxStyles, ...props.style }}>
@@ -72,8 +76,15 @@ export default function ColumnLayoutPage() {
         type={measureType}
       />
 
+      <h2>Reports content-box dimensions when border is present</h2>
+      <MeasureReporter
+        id="test-border"
+        style={{ inlineSize: 300, blockSize: 50, border: '2px solid blue' }}
+        type={measureType}
+      />
+
       <h2>Adjusts as the element changes size (resize browser)</h2>
-      <MeasureReporter id="test-updates" style={{ blockSize: 50 }} type={measureType} />
+      <MeasureReporter id="test-updates" style={{ blockSize: 50, border: '2px solid blue' }} type={measureType} />
 
       <h2>Returns correct breakpoints</h2>
       <BreakpointReporter id="test-breakpoints" style={{ blockSize: 50 }} />

--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -24,6 +24,12 @@ jest.mock('../../../lib/components/popover/utils/positions', () => {
   };
 });
 
+jest.mock('@cloudscape-design/component-toolkit', () => ({
+  ...jest.requireActual('@cloudscape-design/component-toolkit'),
+  // Mock the chart width with enough space to fit all expected elements (labels, x ticks, etc)
+  useContainerQuery: () => [900, null],
+}));
+
 jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
   ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
   getIsRtl: jest.fn().mockReturnValue(false),
@@ -114,7 +120,6 @@ const thresholdSeries: MixedLineBarChartProps.ThresholdSeries = {
 const originalCSS = window.CSS;
 
 const originalGetComputedStyle = window.getComputedStyle;
-const originalBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
 const fakeGetComputedStyle: Window['getComputedStyle'] = (...args) => {
   const result = originalGetComputedStyle(...args);
   result.borderWidth = '2px'; // Approximate mock value for the popover body' border width
@@ -126,19 +131,11 @@ const fakeGetComputedStyle: Window['getComputedStyle'] = (...args) => {
 beforeEach(() => {
   window.CSS.supports = () => true;
   window.getComputedStyle = fakeGetComputedStyle;
-  HTMLElement.prototype.getBoundingClientRect = function () {
-    const rect = originalBoundingClientRect.apply(this);
-    rect.width = 900;
-    rect.height = 300;
-    return rect;
-  };
-
   jest.resetAllMocks();
 });
 afterEach(() => {
   window.CSS = originalCSS;
   window.getComputedStyle = originalGetComputedStyle;
-  HTMLElement.prototype.getBoundingClientRect = originalBoundingClientRect;
 });
 
 describe('Series', () => {

--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -113,7 +113,8 @@ const thresholdSeries: MixedLineBarChartProps.ThresholdSeries = {
 // Transformation to fallback colors for browsers that don't support them are covered by the `parseCssVariable` utility.
 const originalCSS = window.CSS;
 
-let originalGetComputedStyle: Window['getComputedStyle'];
+const originalGetComputedStyle = window.getComputedStyle;
+const originalBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
 const fakeGetComputedStyle: Window['getComputedStyle'] = (...args) => {
   const result = originalGetComputedStyle(...args);
   result.borderWidth = '2px'; // Approximate mock value for the popover body' border width
@@ -124,14 +125,20 @@ const fakeGetComputedStyle: Window['getComputedStyle'] = (...args) => {
 
 beforeEach(() => {
   window.CSS.supports = () => true;
-  originalGetComputedStyle = window.getComputedStyle;
   window.getComputedStyle = fakeGetComputedStyle;
+  HTMLElement.prototype.getBoundingClientRect = function () {
+    const rect = originalBoundingClientRect.apply(this);
+    rect.width = 900;
+    rect.height = 300;
+    return rect;
+  };
 
   jest.resetAllMocks();
 });
 afterEach(() => {
   window.CSS = originalCSS;
   window.getComputedStyle = originalGetComputedStyle;
+  HTMLElement.prototype.getBoundingClientRect = originalBoundingClientRect;
 });
 
 describe('Series', () => {


### PR DESCRIPTION
### Description

This is necessary for https://github.com/cloudscape-design/component-toolkit/pull/165.

JSDOM does not have access to actual element dimensions and returns 0 for everything. For this reason  in the mixed chart tests we are mocking  `window.getComputedStyle` to return 2px for border width among other things. But we are not mocking `HTMLElement.prototype.getBoundingClientRect`, so these tests still assume that all values are 0 for the values that this function returns. Then the changes in https://github.com/cloudscape-design/component-toolkit/pull/165 causes the calculated dimensions of the chart to be negative, because a non-zero border coming from `window.getComputedStyle` is subtracted from the zero width of the chart coming from `getBoundingClientRect` [here](https://github.com/cloudscape-design/component-toolkit/blob/fbeb3924d21428257f74e47df5fb0751a113595c/src/internal/container-queries/use-resize-observer.ts#L44) (which in reality won't happen, because these calculated dimensions should include the border). And these negative dimension values causes the chart not to render expected inner elements: https://github.com/cloudscape-design/component-toolkit/actions/runs/17982007963/job/51205514110?pr=165

The solution is to add one more mock for component-toolkit's `useContainerQuery`, which is used by the chart to determine its width.

### How has this been tested?

Ran the test with https://github.com/cloudscape-design/component-toolkit/pull/165 applied to the local copy of component-toolkit. The tests only passed after the changes in this PR.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
