### PR TITLE
fix: Ensure hovered (multi)select items aren't selected when typing space

### DIFF
--- a/src/multiselect/__integ__/multiselect.test.ts
+++ b/src/multiselect/__integ__/multiselect.test.ts
@@ -179,6 +179,22 @@ describe(`Multiselect with filtering`, () => {
   );
 
   test(
+    'does not select an option using space if it was "selected" via mouse hover',
+    setupTest(async page => {
+      await page.clickSelect();
+      // Type in a filtering query that includes a space
+      await page.keys('first');
+      await page.hoverElement(wrapper.findDropdown()!.findOptions().get(2).toSelector());
+      // space here should continue typing, not select
+      await page.keys(' category');
+      await expect(page.getSelectedOptionLabels()).resolves.toEqual([]);
+      await expect(page.getValue(wrapper.findFilteringInput().findNativeInput().toSelector())).resolves.toBe(
+        'first category'
+      );
+    })
+  );
+
+  test(
     'keeps filtering state after selecting an option using keyboard',
     setupTest(async page => {
       await page.clickSelect();

--- a/src/select/utils/use-select.ts
+++ b/src/select/utils/use-select.ts
@@ -166,7 +166,7 @@ export function useSelect({
         closeDropdown();
       }
     },
-    preventNativeSpace: !hasFilter || !!highlightedOption,
+    preventNativeSpace: !hasFilter || (highlightedOption && highlightType.type === 'keyboard'),
   });
 
   const triggerKeyDownHandler = useTriggerKeyboard({


### PR DESCRIPTION
### Description

Ensure that items aren't selected when typing a space after having hovered an item with the mouse

Related links, issue #, if available: AWSUI-61276

### How has this been tested?

New integ tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
