### PR TITLE
fix: AI drawer radius styles

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
@@ -395,7 +395,7 @@ $ai-drawer-heider-height: 41px;
     &:not(.drawer-expanded) {
       > .drawer-content-container {
         @include desktop-only {
-          clip-path: inset(0 0 -9999px 0 round awsui.$space-xxs);
+          clip-path: inset(0 0 -9999px 0 round 0 awsui.$space-xxs 0 0);
           @include theming.dark-mode-only {
             border-inline-end: awsui.$border-divider-section-width solid awsui.$color-border-layout;
           }


### PR DESCRIPTION
### Description

This PR fixes the top left (top right for rtl) corner of the AI drawer, which was incorrectly rounded

<img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/169294e7-c838-4003-98eb-cae849db6bec" />


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
