### PR TITLE
chore: Additional test page for area chart

### DIFF
--- a/pages/area-chart/partial.page.tsx
+++ b/pages/area-chart/partial.page.tsx
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+import SpaceBetween from '~components/space-between';
+
+import ScreenshotArea from '../utils/screenshot-area';
+import Example from './example';
+import { createLinearPartialLatencyProps } from './series';
+
+const partialLatencyProps = createLinearPartialLatencyProps();
+const yDomain = [0, 300];
+
+export default function () {
+  return (
+    <>
+      <h1>Area charts with partial data</h1>
+      <ScreenshotArea>
+        <SpaceBetween direction="vertical" size="xl">
+          <Example name="Linear latency chart" {...partialLatencyProps} yDomain={yDomain} />
+        </SpaceBetween>
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/pages/area-chart/series.ts
+++ b/pages/area-chart/series.ts
@@ -116,6 +116,53 @@ export function createLogXYProps({ xLog, yLog }: { xLog?: boolean; yLog?: boolea
   };
 }
 
+export function createLinearPartialLatencyProps() {
+  const seconds = 2 * 60;
+  const valueFormatter = numberFormatter;
+
+  const rawData = range(0, seconds).map(index => {
+    const slice = (value: number, from: number, until: number) => (from <= index && index < until ? value : 0);
+    const p50 = 28 + 2 * (pseudoRandom() + 1);
+    const p60 = p50 * 1.2 * (pseudoRandom() + 1);
+    const p70 = p50 * 1.4 * (pseudoRandom() + 1);
+    const p80 = p50 * 1.6 * (pseudoRandom() + 1);
+    const p90 = p50 * 2 * (pseudoRandom() + 1);
+    return {
+      index,
+      p50: slice(p50, 10, 50),
+      p60: slice(p60, 25, 75),
+      p70: slice(p70, 80, 99),
+      p80: slice(p80, 90, 120),
+      p90: slice(p90, 0, 100),
+    };
+  });
+
+  const data = rawData.map(it => it.index);
+  const series: AreaChartProps.Series<number>[] = [
+    { title: 'p50', type: 'area', data: rawData.map(it => ({ x: it.index, y: it.p50 })), valueFormatter },
+    { title: 'p60', type: 'area', data: rawData.map(it => ({ x: it.index, y: it.p60 })), valueFormatter },
+    { title: 'p70', type: 'area', data: rawData.map(it => ({ x: it.index, y: it.p70 })), valueFormatter },
+    { title: 'Limit', type: 'threshold', y: 150, valueFormatter },
+    { title: 'p80', type: 'area', data: rawData.map(it => ({ x: it.index, y: it.p80 })), valueFormatter },
+    { title: 'p90', type: 'area', data: rawData.map(it => ({ x: it.index, y: it.p90 })), valueFormatter },
+  ];
+
+  const xScaleType: XScaleType = 'linear';
+  const yScaleType: YScaleType = 'linear';
+
+  return {
+    data,
+    xDomain: [5, 115],
+    series,
+    xTitle: 'Time',
+    xScaleType,
+    yTitle: 'Latency (ms)',
+    yScaleType,
+    xTickFormatter: numberFormatter,
+    yTickFormatter: valueFormatter,
+  };
+}
+
 export function createCategoricalProps() {
   const valueFormatter = numberFormatter;
 


### PR DESCRIPTION
### Description

In area chart we support partial data, but for that the points must be explicitly provided with y=0. The new test page demonstrates that.

Rel: AWSUI-61312

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
