### PR TITLE
fix: AI drawer's resize handler horizontal alignment

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
@@ -258,6 +258,8 @@ $ai-drawer-heider-height: 41px;
     }
 
     > .drawer-slider {
+      display: flex;
+      justify-content: center;
       inline-size: awsui.$space-xs;
       overflow: hidden;
       grid-column: 2;
@@ -267,7 +269,6 @@ $ai-drawer-heider-height: 41px;
     // maybe we need to introduce an additional prop in the component to make it more flexible?
     // stylelint-disable-next-line @cloudscape-design/no-implicit-descendant
     .ai-drawer-slider-handle {
-      transform: translate(-4px);
       color: awsui.$color-text-interactive-inverted-default;
 
       &:hover {


### PR DESCRIPTION
### Description

This PR fixes horizontal alignment issue on the AI drawer's resize handle.

<img width="60" height="159" alt="image" src="https://github.com/user-attachments/assets/2c14be91-3686-4d86-a6da-4c34328bbf84" />


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
