### PR TITLE
feat: Add enter and exit focus mode methods to the plugin API

### DIFF
--- a/pages/app-layout/utils/external-global-left-panel-widget.tsx
+++ b/pages/app-layout/utils/external-global-left-panel-widget.tsx
@@ -21,6 +21,13 @@ const AIDrawer = () => {
       >
         expand programmatically
       </Button>
+      <Button
+        onClick={() => {
+          updateDrawer({ type: 'exitExpandedMode' });
+        }}
+      >
+        exit expanded mode
+      </Button>
       {new Array(100).fill(null).map((_, index) => (
         <div key={index}>Tela content</div>
       ))}

--- a/pages/app-layout/utils/external-global-left-panel-widget.tsx
+++ b/pages/app-layout/utils/external-global-left-panel-widget.tsx
@@ -3,8 +3,8 @@
 import React from 'react';
 import ReactDOM, { unmountComponentAtNode } from 'react-dom';
 
-import { Box } from '~components';
-import { registerLeftDrawer } from '~components/internal/plugins/widget';
+import { Box, Button } from '~components';
+import { registerLeftDrawer, updateDrawer } from '~components/internal/plugins/widget';
 
 import styles from '../styles.scss';
 
@@ -14,6 +14,13 @@ const AIDrawer = () => {
       <Box variant="h2" padding={{ bottom: 'm' }}>
         Chat demo
       </Box>
+      <Button
+        onClick={() => {
+          updateDrawer({ type: 'expandDrawer', payload: { id: 'amazon-q' } });
+        }}
+      >
+        expand programmatically
+      </Button>
       {new Array(100).fill(null).map((_, index) => (
         <div key={index}>Tela content</div>
       ))}

--- a/src/app-layout/__tests__/runtime-drawers-widgetized.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers-widgetized.test.tsx
@@ -151,7 +151,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'] }, ({ size }) => {
     expect(globalDrawersWrapper.findDrawerById(drawerDefaults.id)!.isActive()).toBe(true);
   });
 
-  test('should enter focus mode in global ai drawer via API', () => {
+  test('should enter and exit focus mode in global ai drawer via API', () => {
     awsuiWidgetPlugins.registerLeftDrawer({ ...drawerDefaults, isExpandable: true, defaultActive: true });
 
     const { globalDrawersWrapper } = renderComponent(<AppLayout />);
@@ -161,6 +161,11 @@ describeEachAppLayout({ themes: ['refresh-toolbar'] }, ({ size }) => {
 
     expect(globalDrawersWrapper.findDrawerById(drawerDefaults.id)!.isDrawerInExpandedMode()).toBe(true);
     expect(globalDrawersWrapper.isLayoutInDrawerExpandedMode()).toBe(true);
+
+    act(() => awsuiWidgetPlugins.updateDrawer({ type: 'exitExpandedMode' }));
+
+    expect(globalDrawersWrapper.findDrawerById(drawerDefaults.id)!.isDrawerInExpandedMode()).toBe(false);
+    expect(globalDrawersWrapper.isLayoutInDrawerExpandedMode()).toBe(false);
   });
 
   test('onResize functionality', () => {

--- a/src/app-layout/__tests__/runtime-drawers-widgetized.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers-widgetized.test.tsx
@@ -151,6 +151,18 @@ describeEachAppLayout({ themes: ['refresh-toolbar'] }, ({ size }) => {
     expect(globalDrawersWrapper.findDrawerById(drawerDefaults.id)!.isActive()).toBe(true);
   });
 
+  test('should enter focus mode in global ai drawer via API', () => {
+    awsuiWidgetPlugins.registerLeftDrawer({ ...drawerDefaults, isExpandable: true, defaultActive: true });
+
+    const { globalDrawersWrapper } = renderComponent(<AppLayout />);
+    expect(globalDrawersWrapper.findDrawerById(drawerDefaults.id)).toBeTruthy();
+
+    act(() => awsuiWidgetPlugins.updateDrawer({ type: 'expandDrawer', payload: { id: drawerDefaults.id } }));
+
+    expect(globalDrawersWrapper.findDrawerById(drawerDefaults.id)!.isDrawerInExpandedMode()).toBe(true);
+    expect(globalDrawersWrapper.isLayoutInDrawerExpandedMode()).toBe(true);
+  });
+
   test('onResize functionality', () => {
     const onResize = jest.fn();
     awsuiWidgetPlugins.registerLeftDrawer({

--- a/src/app-layout/utils/use-ai-drawer.ts
+++ b/src/app-layout/utils/use-ai-drawer.ts
@@ -33,7 +33,7 @@ function useRuntimeAiDrawer(
       }
       return;
     }
-    if (aiDrawer && aiDrawer.id !== event.payload.id) {
+    if (aiDrawer && 'payload' in event && aiDrawer.id !== event.payload.id) {
       metrics.sendOpsMetricObject('awsui-widget-drawer-incorrect-id', { oldId: aiDrawer?.id, newId: event.payload.id });
       return;
     }
@@ -52,6 +52,9 @@ function useRuntimeAiDrawer(
         break;
       case 'expandDrawer':
         setExpandedDrawerIdStable(event.payload.id);
+        break;
+      case 'exitExpandedMode':
+        setExpandedDrawerIdStable(null);
         break;
       /* istanbul ignore next: this code is not intended to be visited */
       default:

--- a/src/app-layout/utils/use-ai-drawer.ts
+++ b/src/app-layout/utils/use-ai-drawer.ts
@@ -21,7 +21,8 @@ function useRuntimeAiDrawer(
   isEnabled: boolean,
   activeAiDrawerId: string | null,
   onActiveAiDrawerChange: (newDrawerId: string | null, { initiatedByUserAction }: OnChangeParams) => void,
-  onActiveAiDrawerResize: (size: number) => void
+  onActiveAiDrawerResize: (size: number) => void,
+  setExpandedDrawerId: (value: string | null) => void
 ) {
   const [aiDrawer, setAiDrawer] = useState<RuntimeAiDrawerConfig | null>(null);
   const appLayoutMessageHandler = useStableCallback((event: AppLayoutMessage) => {
@@ -49,6 +50,9 @@ function useRuntimeAiDrawer(
       case 'resizeDrawer':
         onActiveAiDrawerResizeStable(event.payload.size);
         break;
+      case 'expandDrawer':
+        setExpandedDrawerIdStable(event.payload.id);
+        break;
       /* istanbul ignore next: this code is not intended to be visited */
       default:
         assertNever(event);
@@ -57,6 +61,7 @@ function useRuntimeAiDrawer(
   const onAiDrawersChangeStable = useStableCallback(onActiveAiDrawerChange);
   const onActiveAiDrawerResizeStable = useStableCallback(onActiveAiDrawerResize);
   const onActiveAiDrawerChangeStable = useStableCallback(onActiveAiDrawerChange);
+  const setExpandedDrawerIdStable = useStableCallback(setExpandedDrawerId);
   const aiDrawerWasOpenRef = useRef(false);
   aiDrawerWasOpenRef.current = aiDrawerWasOpenRef.current || !!activeAiDrawerId;
 
@@ -122,7 +127,13 @@ export function useAiDrawer({ isEnabled, onAiDrawerFocus, expandedDrawerId, setE
     onAiDrawerFocus?.();
   }
 
-  const aiDrawer = useRuntimeAiDrawer(isEnabled, activeAiDrawerId, onActiveAiDrawerChange, onActiveAiDrawerResize);
+  const aiDrawer = useRuntimeAiDrawer(
+    isEnabled,
+    activeAiDrawerId,
+    onActiveAiDrawerChange,
+    onActiveAiDrawerResize,
+    setExpandedDrawerId
+  );
   const activeAiDrawer = activeAiDrawerId && activeAiDrawerId === aiDrawer?.id ? aiDrawer : null;
   const activeAiDrawerSize = activeAiDrawerId ? (size ?? activeAiDrawer?.defaultSize ?? MIN_DRAWER_SIZE) : 0;
   const minAiDrawerSize = Math.min(activeAiDrawer?.defaultSize ?? MIN_DRAWER_SIZE, MIN_DRAWER_SIZE);

--- a/src/internal/plugins/widget/interfaces.ts
+++ b/src/internal/plugins/widget/interfaces.ts
@@ -57,11 +57,13 @@ export type UpdateDrawerConfigMessage = Message<
 export type OpenDrawerMessage = Message<'openDrawer', { id: string }>;
 export type CloseDrawerMessage = Message<'closeDrawer', { id: string }>;
 export type ResizeDrawerMessage = Message<'resizeDrawer', { id: string; size: number }>;
+export type ExpandDrawerMessage = Message<'expandDrawer', { id: string }>;
 
 export type AppLayoutUpdateMessage =
   | UpdateDrawerConfigMessage
   | OpenDrawerMessage
   | CloseDrawerMessage
-  | ResizeDrawerMessage;
+  | ResizeDrawerMessage
+  | ExpandDrawerMessage;
 
 export type AppLayoutMessage = RegisterDrawerMessage | AppLayoutUpdateMessage;

--- a/src/internal/plugins/widget/interfaces.ts
+++ b/src/internal/plugins/widget/interfaces.ts
@@ -58,12 +58,16 @@ export type OpenDrawerMessage = Message<'openDrawer', { id: string }>;
 export type CloseDrawerMessage = Message<'closeDrawer', { id: string }>;
 export type ResizeDrawerMessage = Message<'resizeDrawer', { id: string; size: number }>;
 export type ExpandDrawerMessage = Message<'expandDrawer', { id: string }>;
+export interface ExitExpandedModeMessage {
+  type: 'exitExpandedMode';
+}
 
 export type AppLayoutUpdateMessage =
   | UpdateDrawerConfigMessage
   | OpenDrawerMessage
   | CloseDrawerMessage
   | ResizeDrawerMessage
-  | ExpandDrawerMessage;
+  | ExpandDrawerMessage
+  | ExitExpandedModeMessage;
 
 export type AppLayoutMessage = RegisterDrawerMessage | AppLayoutUpdateMessage;


### PR DESCRIPTION
### Description

Added a methods to programmatically expand and collapse the AI panel 
```javascript
updateDrawer({ type: 'expandDrawer', payload: { id: 'drawer-id' } });
updateDrawer({ type: 'exitExpandedMode' });
```

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
