### PR TITLE
fix: Update Get Started link in the read me file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Cloudscape was built for and is used by [Amazon Web Services (AWS)](https://aws.
 Components APIs and guidelines can be found in the [Components section of the Cloudscape website](https://cloudscape.design/components/).
 
 ## Getting started
-For an in-depth guide on getting started with Cloudscape development, check out the [Cloudscape website](https://cloudscape.design/get-started/integration/using-cloudscape-components/).
+For an in-depth guide on getting started with Cloudscape development, check out the [Cloudscape website](https://cloudscape.design/get-started/for-developers/start-developing/).
 
 ### Installation
 All Cloudscape packages are available on npm.


### PR DESCRIPTION
### Description
Updated the link for the in-depth guide on getting started with Cloudscape development for better user experience since the old link was linked to a 404 page. 


### How has this been tested?
It has been tested by clicking the link. Reviewers can reproduce the same steps by clicking the link. 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
