### PR TITLE
fix: Selects in Lists using renderItem not truncating correctly

### DIFF
--- a/src/internal/components/structured-item/styles.scss
+++ b/src/internal/components/structured-item/styles.scss
@@ -22,6 +22,7 @@
   flex-grow: 1;
   display: flex;
   flex-direction: column;
+  min-inline-size: 0;
 }
 
 .content-wrap {
@@ -41,6 +42,7 @@
 
 .content {
   flex-grow: 1;
+  min-inline-size: 0;
 }
 
 .actions {


### PR DESCRIPTION
### Description

When a Select is included in the content returned from `renderItem` it does not trucate correctly. This PR addresses that issue.

Related links, issue #, if available:
`AWSUI-61306`

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
