### PR TITLE
fix: Adjust styling for inline label on disabled select

### DIFF
--- a/src/select/parts/styles.scss
+++ b/src/select/parts/styles.scss
@@ -126,6 +126,9 @@ $inlineLabel-border-radius: 2px;
   padding-inline: awsui.$space-scaled-xxs;
   max-inline-size: calc(100% - (2 * awsui.$space-field-horizontal));
   z-index: 1;
+  &-disabled {
+    background: linear-gradient(to bottom, awsui.$color-background-layout-main, awsui.$color-background-input-disabled);
+  }
 }
 
 // Specific Styling for Inline Label Text to not overlap with Inline Tokens

--- a/src/select/parts/trigger.tsx
+++ b/src/select/parts/trigger.tsx
@@ -132,6 +132,7 @@ const Trigger = React.forwardRef(
               htmlFor={controlId}
               className={clsx(
                 styles['inline-label'],
+                disabled && styles['inline-label-disabled'],
                 triggerVariant === 'tokens' && styles['inline-label-inline-tokens']
               )}
             >


### PR DESCRIPTION
### Description

Tweak styling for the inline label when select is disabled, to make the background slightly more subtle.

https://d21d5uik3ws71m.cloudfront.net/components/84c2abf08af6b8c46fe57acf00bb46547e7b166a/dev-pages-react16/index.html#/light/app-layout/with-table-collection-select-filter

Related links, issue #, if available: AWSUI-61327

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
