### PR TITLE
chore: Prepare theming page for integration tests

### DIFF
--- a/pages/theming/integration.page.tsx
+++ b/pages/theming/integration.page.tsx
@@ -1,11 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
-import { Button, Link, SpaceBetween } from '~components';
+import { Button, Container, Header, Link, Multiselect, SpaceBetween, Table } from '~components';
 import { applyTheme, generateThemeStylesheet, Theme } from '~components/theming';
 import * as Tokens from '~design-tokens';
 
+import AppContext from '../app/app-context';
 import ScreenshotArea from '../utils/screenshot-area';
 
 const colorGreen900 = '#172211';
@@ -28,15 +29,47 @@ const theme: Theme = {
       dark: colorGreen500,
     },
     colorTextLinkDefault: {
-      light: 'rgba(255, 0, 0, 1)',
+      light: 'rgba(220, 24, 24, 1)',
       dark: 'rgba(255, 165, 0, 1)',
     },
   },
 };
 
+const sharedItems = [
+  {
+    alt: 'First',
+    description: 'This is the first item',
+    label: 'Item 1',
+    value: '1',
+  },
+  {
+    alt: 'Second',
+    description: 'This is the second item',
+    label: 'Item 2',
+    value: '2',
+  },
+  {
+    alt: 'Third',
+    label: 'Item 3',
+    value: '3',
+  },
+  {
+    alt: 'Fourth',
+    description: 'This is the fourth item',
+    label: 'Item 4',
+    value: '4',
+  },
+  {
+    description: 'This is the fifth item with a longer description',
+    label: 'Item 5',
+    value: '5',
+  },
+];
+
 export default function () {
+  const { urlParams } = useContext(AppContext);
   const [themed, setThemed] = useState<boolean>(false);
-  const [secondaryTheme, setSecondaryTheme] = useState<boolean>(false);
+  const [secondaryTheme, setSecondaryTheme] = useState<boolean>(urlParams.visualRefresh);
   const [themeMethod, setThemeMethod] = useState<'applyTheme' | 'generateThemeStylesheet'>('applyTheme');
 
   useEffect(() => {
@@ -96,12 +129,72 @@ export default function () {
         <span style={{ marginInlineStart: 5 }}>Use applyTheme</span>
       </label>
       <ScreenshotArea>
-        <SpaceBetween direction="vertical" size="m">
-          <Button variant="primary">Primary Button</Button>
-          <Link href="#">Link</Link>
-          <a data-testid="element-color-text-link-default" style={{ color: Tokens.colorTextLinkDefault }}>
-            Anchor using colorTextLinkDefault
-          </a>
+        <SpaceBetween size="xl" direction="horizontal">
+          <SpaceBetween direction="vertical" size="m">
+            <Button variant="primary">Primary button</Button>
+            <Button variant="normal">Normal button</Button>
+            <Link href="#">Link</Link>
+            <a data-testid="element-color-text-link-default" style={{ color: Tokens.colorTextLinkDefault }}>
+              Anchor using colorTextLinkDefault
+            </a>
+            <Button
+              variant="primary"
+              style={{
+                root: {
+                  background: { default: Tokens.colorBackgroundButtonNormalActive },
+                  borderRadius: '4px',
+                  color: { default: `light-dark(darkblue, aliceblue)` },
+                },
+              }}
+            >
+              <span style={{ fontSize: '16px' }}>Styled button</span>
+            </Button>
+          </SpaceBetween>
+          <Table
+            selectionType="multi"
+            selectedItems={[sharedItems[1]]}
+            stripedRows={true}
+            ariaLabels={{
+              selectionGroupLabel: 'Items selection',
+              allItemsSelectionLabel: () => 'select all',
+              itemSelectionLabel: (_, item) => item.label,
+            }}
+            columnDefinitions={[
+              {
+                id: 'variable',
+                header: 'Variable name',
+                cell: item => <Link href="#">{item.label || '-'}</Link>,
+                sortingField: 'label',
+                isRowHeader: true,
+              },
+              {
+                id: 'alt',
+                header: 'Text value',
+                cell: item => item.alt || '-',
+                sortingField: 'alt',
+              },
+              {
+                id: 'description',
+                header: 'Description',
+                cell: item => item.description || '-',
+              },
+            ]}
+            items={sharedItems}
+          />
+          <Container
+            header={
+              <Header variant="h2" description="Container description">
+                Container title
+              </Header>
+            }
+          >
+            <Multiselect
+              selectedOptions={[sharedItems[3]]}
+              options={sharedItems}
+              deselectAriaLabel={() => 'Remove'}
+              placeholder="Choose options"
+            />
+          </Container>
         </SpaceBetween>
       </ScreenshotArea>
     </div>

--- a/src/theming/__integ__/index.test.ts
+++ b/src/theming/__integ__/index.test.ts
@@ -44,9 +44,6 @@ const setupTest = (testFn: (page: ThemingPage) => Promise<void>, vr?: boolean) =
   return useBrowser(async browser => {
     const page = new ThemingPage(browser);
     await browser.url(`#/light/theming/integration${!vr ? '?visualRefresh=false' : ''}`);
-    if (vr) {
-      await page.setSecondaryTheme();
-    }
     await testFn(page);
   });
 };
@@ -57,7 +54,7 @@ const buttonBackgroundColor = {
 };
 
 const linkTextColor = {
-  light: 'rgba(255, 0, 0, 1)',
+  light: 'rgba(220, 24, 24, 1)',
   dark: 'rgba(255, 165, 0, 1)',
 };
 [true, false].forEach(vr => {


### PR DESCRIPTION
### Description

Theming pages aren't currently included in screenshot tests. They will be soon. This is preparing the page so we can have a more complete picture so it can test token inheritance and overrides more reliably, like adding a styled component and components which assign different tokens in classic and vr.

Related links, issue #, if available: n/a

### How has this been tested?

Dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
