### PR TITLE
chore: Close autosuggest dropdown when recovery button is focused and ESC clicked

### DIFF
--- a/src/autosuggest/__tests__/autosuggest-dropdown-states.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest-dropdown-states.test.tsx
@@ -169,6 +169,32 @@ describe.each([true, false])('footer live announcements [expandToViewport=%s]', 
   });
 });
 
+describe('recovery button keyboard interaction', () => {
+  test('closes dropdown when ESC is pressed on recovery button', () => {
+    const onLoadItems = jest.fn();
+    renderAutosuggest({ statusType: 'error', recoveryText: 'Retry', onLoadItems });
+    focusInput();
+    expectDropdown();
+
+    const wrapper = createWrapper().findAutosuggest()!;
+    const recoveryButton = wrapper.findErrorRecoveryButton();
+    expect(recoveryButton).not.toBe(null);
+
+    // Focus the recovery button
+    recoveryButton!.focus();
+
+    // Press ESC key
+    recoveryButton!.keydown(KeyCode.escape);
+
+    // Dropdown should be closed
+    expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
+    expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'false');
+
+    // Focus should return to input
+    expect(wrapper.findNativeInput().getElement()).toHaveFocus();
+  });
+});
+
 describe('filtering results', () => {
   describe('with empty state', () => {
     test('displays empty state footer when value is empty', () => {


### PR DESCRIPTION
### Description

Currently, focusing the autosuggest recovery button and clicking ESC does not close the autosuggest dropdown.

This solves this issues

Related links, issue -> AWSUI-61304

### How has this been tested?

Added unit tests for it

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
