### PR TITLE
fix: Improve alert focus behavior for accessibility

### DIFF
--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useRef } from 'react';
+import React, { useImperativeHandle, useRef } from 'react';
 import clsx from 'clsx';
 
 import { useMergeRefs } from '@cloudscape-design/component-toolkit/internal';
@@ -15,7 +15,6 @@ import { getBaseProps } from '../internal/base-component';
 import VisualContext from '../internal/components/visual-context';
 import { LinkDefaultVariantContext } from '../internal/context/link-default-variant-context';
 import { fireNonCancelableEvent } from '../internal/events';
-import useForwardFocus from '../internal/hooks/forward-focus';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { awsuiPluginsInternal } from '../internal/plugins/api';
@@ -72,7 +71,19 @@ const InternalAlert = React.forwardRef(
     const i18n = useInternalI18n('alert');
 
     const focusRef = useRef<HTMLDivElement>(null);
-    useForwardFocus(ref, focusRef);
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        if (focusRef.current) {
+          focusRef.current.tabIndex = -1;
+          focusRef.current.focus();
+        }
+      },
+    }));
+    const handleBlur = () => {
+      if (focusRef.current) {
+        focusRef.current.removeAttribute('tabindex');
+      }
+    };
 
     const { discoveredActions, headerRef: headerRefAction, contentRef: contentRefAction } = useDiscoveredAction(type);
     const {
@@ -138,7 +149,7 @@ const InternalAlert = React.forwardRef(
               style={getAlertStyles(style)}
             >
               <div className={styles['alert-wrapper']}>
-                <div className={styles['alert-focus-wrapper']} tabIndex={-1} ref={focusRef} role="group">
+                <div className={styles['alert-focus-wrapper']} ref={focusRef} role="group" onBlur={handleBlur}>
                   <div className={clsx(styles.icon, styles.text)} style={getIconStyles(style)}>
                     <InternalIcon name={typeToIcon[type]} size={size} ariaLabel={statusIconAriaLabel} />
                   </div>


### PR DESCRIPTION
### Description

This PR fixes the Alert component focus outline issue where clicking an alert and then pressing keyboard keys would show an unwanted focus outline.

The solution implements dynamic tab indexing so that alerts have no tabindex by default, only adding `tabIndex=-1` when programmatically focused via the `.focus()` method, and removing it on blur. This maintains screen reader functionality while preventing focus outlines from appearing after mouse interactions.

Related links, issue #, if available: AWSUI-61231

### How has this been tested?

I've tested the focus behavior:

- Confirmed clicking alerts no longer shows focus outline when followed by keyboard navigation
- Verified programmatic focusing still works for screen reader announcements
- Used `document.activeElement` to validate tabindex is only present when needed
- Tested with VoiceOver to ensure accessibility functionality remains intact

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
