### PR TITLE
chore: Introduce updateContent callback for alert flashbar runtime action api

### DIFF
--- a/src/flashbar/__tests__/runtime-action.test.tsx
+++ b/src/flashbar/__tests__/runtime-action.test.tsx
@@ -178,6 +178,101 @@ test('propagates flash message context into callback', async () => {
   });
 });
 
+test('propagates state changes to update callback', async () => {
+  const updateContentSpy = jest.fn();
+  const testAction: ActionConfig = {
+    ...defaultAction,
+    updateContent: (container, context) => updateContentSpy(context.contentRef.current?.textContent),
+  };
+
+  awsuiPlugins.flashbar.registerAction(testAction);
+  const { rerender } = render(<Flashbar items={[{ ...defaultItem, content: 'Initial content' }]} />);
+  await delay();
+  expect(updateContentSpy).toHaveBeenCalledTimes(0);
+  rerender(<Flashbar items={[{ ...defaultItem, content: 'Updated content' }]} />);
+  expect(updateContentSpy).toHaveBeenCalledTimes(1);
+  expect(updateContentSpy).toHaveBeenCalledWith('Updated content');
+});
+
+test('container reference is permanent between mount/update/unmount', async () => {
+  let container: HTMLElement | null = null;
+  const testAction: ActionConfig = {
+    id: 'test-action',
+    mountContent: jest.fn(newContainer => (container = newContainer)),
+    updateContent: jest.fn(newContainer => expect(container).toBe(newContainer)),
+    unmountContent: jest.fn(newContainer => expect(container).toBe(newContainer)),
+  };
+  awsuiPlugins.flashbar.registerAction(testAction);
+  const { rerender } = render(<Flashbar items={[{ ...defaultItem }]} />);
+  await delay();
+  expect(testAction.mountContent).toHaveBeenCalledTimes(1);
+  expect(testAction.updateContent).toHaveBeenCalledTimes(0);
+  expect(testAction.unmountContent).toHaveBeenCalledTimes(0);
+  rerender(<Flashbar items={[{ ...defaultItem }]} />);
+  expect(testAction.mountContent).toHaveBeenCalledTimes(1);
+  expect(testAction.updateContent).toHaveBeenCalledTimes(1);
+  expect(testAction.unmountContent).toHaveBeenCalledTimes(0);
+  rerender(<></>);
+  expect(testAction.mountContent).toHaveBeenCalledTimes(1);
+  expect(testAction.updateContent).toHaveBeenCalledTimes(1);
+  expect(testAction.unmountContent).toHaveBeenCalledTimes(1);
+});
+
+test('allows conditionally render content when an item changes', async () => {
+  const unmount = (container: HTMLElement) => (container.innerHTML = '');
+  const renderIfApplicable = (container: HTMLElement, content: string) => {
+    if (content.includes('permission')) {
+      container.innerHTML = '<button data-testid="troubleshooter"></button>';
+    } else {
+      unmount(container);
+    }
+  };
+  const testAction: ActionConfig = {
+    ...defaultAction,
+    mountContent: (container, { contentRef }) => renderIfApplicable(container, contentRef.current!.textContent!),
+    updateContent: (container, { contentRef }) => renderIfApplicable(container, contentRef.current!.textContent!),
+    unmountContent: unmount,
+  };
+  awsuiPlugins.flashbar.registerAction(testAction);
+  const { rerender, queryAllByTestId } = render(<Flashbar items={[{ id: '1', content: 'random content' }]} />);
+  await delay();
+  expect(queryAllByTestId('troubleshooter')).toHaveLength(0);
+
+  // add new notification matching the pattern
+  rerender(
+    <Flashbar
+      items={[
+        { id: '1', content: 'random content' },
+        { id: '2', content: 'permission issue' },
+      ]}
+    />
+  );
+  await delay();
+  expect(queryAllByTestId('troubleshooter')).toHaveLength(1);
+
+  // update the existing notification to match the pattern
+  rerender(
+    <Flashbar
+      items={[
+        { id: '1', content: 'permission issue dynamic' },
+        { id: '2', content: 'permission issue' },
+      ]}
+    />
+  );
+  expect(queryAllByTestId('troubleshooter')).toHaveLength(2);
+
+  // update the existing notification to not match the pattern anymore
+  rerender(
+    <Flashbar
+      items={[
+        { id: '1', content: 'resolved issue' },
+        { id: '2', content: 'permission issue' },
+      ]}
+    />
+  );
+  expect(queryAllByTestId('troubleshooter')).toHaveLength(1);
+});
+
 test('cleans up on unmount', async () => {
   const testAction: ActionConfig = {
     ...defaultAction,

--- a/src/internal/plugins/controllers/action-buttons.ts
+++ b/src/internal/plugins/controllers/action-buttons.ts
@@ -18,6 +18,7 @@ export interface ActionConfig {
   id: string;
   orderPriority?: number;
   mountContent: (container: HTMLElement, context: ActionContext) => void;
+  updateContent?: (container: HTMLElement, context: ActionContext) => void;
   unmountContent: (container: HTMLElement) => void;
 }
 


### PR DESCRIPTION
### Description

Allow to receive `updateContent` callback to be notified if alert/flash content changed and some checks need to re-run


Related links, issue #, if available: n/a

### How has this been tested?

Added more unit tests to showcase the change

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
