### PR TITLE
chore: Fix broken styles check

### DIFF
--- a/src/internal/hooks/use-base-component/__tests__/styles-check-pure.test.ts
+++ b/src/internal/hooks/use-base-component/__tests__/styles-check-pure.test.ts
@@ -102,6 +102,13 @@ describe('checkMissingStyles', () => {
       );
       expect(sendPanoramaMetricSpy).toHaveBeenCalledWith('awsui-missing-css-asset', {});
     });
+
+    test('should skip the check if iframe was detached', () => {
+      const mockDetachedDocument = { body: iframeDocument.body } as Document;
+      checkMissingStyles(mockDetachedDocument);
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      expect(sendPanoramaMetricSpy).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/internal/hooks/use-base-component/styles-check.ts
+++ b/src/internal/hooks/use-base-component/styles-check.ts
@@ -6,6 +6,10 @@ import { GIT_SHA, PACKAGE_VERSION, THEME } from '../../environment';
 import { metrics } from '../../metrics';
 
 export function checkMissingStyles(ownerDocument: Document) {
+  if (!ownerDocument.defaultView) {
+    // skip the check if this iframe is detached
+    return;
+  }
   const result = getComputedStyle(ownerDocument.body).getPropertyValue(`--awsui-version-info-${GIT_SHA}`);
   if (!result) {
     console.error(`Missing AWS-UI CSS for theme "${THEME}", version "${PACKAGE_VERSION}", and git sha "${GIT_SHA}".`);


### PR DESCRIPTION
### Description

Attempt to fix this build flakiness: https://github.com/cloudscape-design/components/actions/runs/18692609639/job/53302284077#step:3:1055

The current theory it happens if React strict mode quickly creates and detaches an iframe, it leaves this check failing

Related links, issue #, if available: n/a

### How has this been tested?

n/a, we merge and wait what happens next

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
