### PR TITLE
chore: Change theme global selector from :root to body

### DIFF
--- a/style-dictionary/classic/index.ts
+++ b/style-dictionary/classic/index.ts
@@ -50,7 +50,7 @@ export async function buildClassicOpenSource(builder: ThemeBuilder) {
   return builder.build();
 }
 
-const builder = new ThemeBuilder('classic', ':root', modes);
+const builder = new ThemeBuilder('classic', 'body', modes);
 const theme = await buildClassicOpenSource(builder);
 
 export default theme;

--- a/style-dictionary/core/index.ts
+++ b/style-dictionary/core/index.ts
@@ -56,7 +56,7 @@ async function buildCoreOpenSource(builder: ThemeBuilder) {
   return builder.build();
 }
 
-const builder = new ThemeBuilder('visual-refresh', ':root', modes);
+const builder = new ThemeBuilder('visual-refresh', 'body', modes);
 const theme = await buildCoreOpenSource(builder);
 
 export default theme;

--- a/style-dictionary/visual-refresh/index.ts
+++ b/style-dictionary/visual-refresh/index.ts
@@ -52,7 +52,7 @@ export async function buildVisualRefresh(builder: ThemeBuilder) {
   return builder.build();
 }
 
-const builder = new ThemeBuilder('visual-refresh', ':root', modes);
+const builder = new ThemeBuilder('visual-refresh', 'body', modes);
 const theme = await buildVisualRefresh(builder);
 
 export default theme;


### PR DESCRIPTION
### Description

Changed CSS theme selectors from :root to body in style-dictionary files across all theme config modules to ensure proper theme application once seed and reference token generation is added to theming-core.

We won't be resolving reference tokens to their hex value until the end of the resolution chain to allow for theming at a global level without having to replace every token value (300+ tokens). Because we are keeping the references as css values, :root has a higher specificity that doesn't allow the resolution to complete when there are multiple themes applied (primary, secondary). Using body as a global selector fixes the specificity issues.

Pre-req: [theming-core PR](https://github.com/cloudscape-design/theming-core/pull/122) to be in live.

Related links, issue #, if available: [ac9YAbqsd7e6], [CR-229505364]

### How has this been tested?

Dev pipeline: Awsui-v3-jkuelz

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
