### PR TITLE
fix: Fixes popover position recomputation for charts

### DIFF
--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -50,6 +50,7 @@ function isAppLayoutPage(pageId?: string) {
     'prompt-input/simple',
     'funnel-analytics/static-single-page-flow',
     'funnel-analytics/static-multi-page-flow',
+    'charts-with-side-panel',
   ];
   return pageId !== undefined && appLayoutPages.some(match => pageId.includes(match));
 }

--- a/pages/charts-with-side-panel.page.tsx
+++ b/pages/charts-with-side-panel.page.tsx
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import { AppLayout, Button, MixedLineBarChartProps, PieChart, SpaceBetween, SplitPanel } from '~components';
+import LineChart from '~components/line-chart';
+
+import { SimplePage } from './app/templates';
+import labels from './app-layout/utils/labels';
+import { splitPaneli18nStrings } from './app-layout/utils/strings';
+import AreaChartExample from './area-chart/example';
+import { createLinearTimeLatencyProps } from './area-chart/series';
+import { commonProps as commonLineProps, data2 as lineData } from './mixed-line-bar-chart/common';
+import { commonProps as commonPieProps, data1 as pieData } from './pie-chart/common';
+
+const linearLatencyProps = createLinearTimeLatencyProps();
+
+type ExpectedSeries = MixedLineBarChartProps.LineDataSeries<number> | MixedLineBarChartProps.ThresholdSeries;
+
+const series: ReadonlyArray<ExpectedSeries> = [
+  { title: 'Series 1', type: 'line', data: lineData },
+  { title: 'Threshold', type: 'threshold', y: 150 },
+];
+
+export default function () {
+  const [splitPanelSize, setSplitPanelSize] = useState(300);
+  const [sidePanelVisible, setSidePanelVisible] = useState(false);
+  const toggleButton = <Button onClick={() => setSidePanelVisible(prev => !prev)}>Toggle side panel</Button>;
+  return (
+    <AppLayout
+      ariaLabels={labels}
+      navigationHide={true}
+      toolsHide={true}
+      splitPanelOpen={sidePanelVisible}
+      splitPanelPreferences={{ position: 'side' }}
+      splitPanel={
+        <SplitPanel header="Details" i18nStrings={splitPaneli18nStrings}>
+          Side panel content
+        </SplitPanel>
+      }
+      splitPanelSize={splitPanelSize}
+      onSplitPanelResize={({ detail }) => setSplitPanelSize(detail.size)}
+      content={
+        <SimplePage
+          title="Line chart with side panel demo"
+          subtitle="Open side panel from chart's popover. The popover's position should be updated."
+          screenshotArea={{}}
+        >
+          <SpaceBetween size="m">
+            <LineChart
+              {...commonLineProps}
+              hideFilter={true}
+              height={200}
+              series={series}
+              xTitle="Time"
+              yTitle="Latency (ms)"
+              xScaleType="linear"
+              ariaLabel="Line chart"
+              detailPopoverFooter={() => toggleButton}
+            />
+
+            <AreaChartExample
+              name="Linear latency chart"
+              {...linearLatencyProps}
+              detailPopoverFooter={() => toggleButton}
+            />
+
+            <PieChart
+              {...commonPieProps}
+              data={pieData}
+              ariaLabel="Food facts"
+              size="medium"
+              detailPopoverFooter={() => toggleButton}
+            />
+          </SpaceBetween>
+        </SimplePage>
+      }
+    />
+  );
+}

--- a/src/popover/__integ__/use-position-observer.test.ts
+++ b/src/popover/__integ__/use-position-observer.test.ts
@@ -9,7 +9,6 @@ import tooltipStyles from '../../../lib/components/internal/components/tooltip/s
 
 const wrapper = createWrapper();
 const expandableSectionWrapper = wrapper.findExpandableSection();
-const keepPositionPopoverWrapper = wrapper.findByClassName('keepPositionPopover');
 const updatePositionPopoverWrapper = wrapper.findByClassName('updatePositionPopover');
 
 const sliderWrapper = wrapper.findSlider();
@@ -47,23 +46,6 @@ const setupTest = (testFn: (page: UsePositionObserverPageObject) => Promise<void
 };
 
 describe('Use position observer', () => {
-  test(
-    'Keep position popover does not move when expandable section is expanded',
-    setupTest(async page => {
-      await page.waitForVisible(expandableSectionWrapper.toSelector());
-
-      const initialKeepPosition = await page.getBoundingBox(keepPositionPopoverWrapper.toSelector());
-
-      // Expand the expandable section
-      await page.click(expandableSectionWrapper.toSelector());
-
-      const newKeepPosition = await page.getBoundingBox(keepPositionPopoverWrapper.toSelector());
-
-      expect(newKeepPosition.top).toEqual(initialKeepPosition.top);
-      expect(newKeepPosition.left).toEqual(initialKeepPosition.left);
-    })
-  );
-
   test(
     'Update position popover moves when expandable section is expanded',
     setupTest(async page => {

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -113,19 +113,12 @@ export default function PopoverContainer({
 
   // Recalculate position when the DOM changes.
   // istanbul ignore next - tested via integration tests
-  usePositionObserver(trackRef, trackKey, () => {
+  usePositionObserver(getTrack.current, trackKey, () => {
     // Do not update position if popover moved offscreen
     const popoverOffset = popoverRef.current && getLogicalBoundingClientRect(popoverRef.current);
-
-    if (
-      keepPosition ||
-      !popoverOffset ||
-      popoverOffset.insetBlockStart < 0 ||
-      popoverOffset.insetBlockEnd > window.innerHeight
-    ) {
+    if (!popoverOffset || popoverOffset.insetBlockStart < 0 || popoverOffset.insetBlockEnd > window.innerHeight) {
       return;
     }
-
     positionHandlerRef.current();
   });
 

--- a/src/popover/use-position-observer.ts
+++ b/src/popover/use-position-observer.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 /* istanbul ignore file - Tested with integration tests */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { useStableCallback } from '@cloudscape-design/component-toolkit/internal';
 
@@ -12,30 +12,32 @@ interface Coords {
 }
 
 export default function usePositionObserver(
-  triggerRef: React.RefObject<Element> | undefined,
+  getTrack: () => null | Element,
   trackKey: string | number | undefined,
   callback: () => void
 ) {
   const stableCallback = useStableCallback(callback);
 
   useEffect(() => {
-    if (!triggerRef?.current) {
+    const track = getTrack();
+    if (!track) {
       return;
     }
 
     let lastTrackKey = trackKey;
 
     let lastPosition: Coords = {
-      x: triggerRef.current.getBoundingClientRect().x,
-      y: triggerRef.current.getBoundingClientRect().y,
+      x: track.getBoundingClientRect().x,
+      y: track.getBoundingClientRect().y,
     };
 
     const observer = new MutationObserver(() => {
-      if (!triggerRef.current) {
+      const track = getTrack();
+      if (!track) {
         return;
       }
 
-      const { x, y } = triggerRef.current.getBoundingClientRect();
+      const { x, y } = track.getBoundingClientRect();
 
       // Only trigger the callback when the position changes or the track key changes
       if (x !== lastPosition.x || y !== lastPosition.y || trackKey !== lastTrackKey) {
@@ -46,7 +48,7 @@ export default function usePositionObserver(
     });
 
     // Observe the entire ownerDocument for DOM changes
-    observer.observe(triggerRef.current.ownerDocument, {
+    observer.observe(track.ownerDocument, {
       attributes: true,
       subtree: true,
       childList: true,
@@ -54,5 +56,5 @@ export default function usePositionObserver(
 
     return () => observer.disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [triggerRef, stableCallback]); // trackKey excluded to avoid the observer being recreated everytime the value changes, causing rendering issues for Tooltip
+  }, [getTrack, stableCallback]); // trackKey excluded to avoid the observer being recreated everytime the value changes, causing rendering issues for Tooltip
 }


### PR DESCRIPTION
### Description

The popover includes code that should recompute its position when there is a layout shift on the page, e.g. when a split-panel opens, causing the popover target to change. The keepPosition property is only used for charts popover, and for some reason the popovers with keepPosition=true were not updated. However, this causes the charts popover position to be off if the layout shift occurs.

See how legacy charts reacted to a split panel open before the change:

https://github.com/user-attachments/assets/e6da8e9c-1271-4102-b426-5bbfb8525443

With the change (removing keepPosition check), the popover position is correctly adjusted.

https://github.com/user-attachments/assets/aef2d3a4-b2ed-4e6b-8b15-ef49a4a3aaf1

The fix only works well when the layout change does not cause the chart to change size. If that happens, then the popover (even if pinned) is closed in area- and pie charts. In mixed charts (incl. bar- and line charts, too), the popover is not closed, but the track marker is not updated, causing both the marker and the popover to have incorrect position. That is an existing bug, reproducible with both old and new code, and it is not addressed by this change.

https://github.com/user-attachments/assets/1c404a7c-3d47-4cff-914b-dd63fcafa1bd

The fix also works in the new cartesian and pie charts. There, the positions of the tooltip and the marker are correctly recomputed.

https://github.com/user-attachments/assets/4ae1b78e-57f3-4d71-a534-82afe43aa662

Rel: AWSUI-61377

### How has this been tested?

* Manual tests using the new test pages for legacy and new charts
* Removed the now irrelevant integ test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
