### PR TITLE
fix: Prevent renderAriaLive announcements during table loading state

### DIFF
--- a/src/table/__tests__/a11y.test.tsx
+++ b/src/table/__tests__/a11y.test.tsx
@@ -182,5 +182,38 @@ describe('labels', () => {
 
       expect(getLiveRegionText()).toBe(`${totalItemsCount} ${visibleItemsCount}`);
     });
+    test('should not announce live region when loading = true', () => {
+      renderTableWrapper({
+        loading: true,
+        firstIndex: 1,
+        totalItemsCount: defaultItems.length,
+        renderAriaLive: ({ firstIndex, lastIndex, totalItemsCount, visibleItemsCount }) =>
+          `Displaying items ${firstIndex} to ${lastIndex} of ${totalItemsCount}, ${visibleItemsCount} resources visible`,
+      });
+
+      expect(getLiveRegionText()).toBe('');
+    });
+
+    test('should announce live region when loading switches from true to false', () => {
+      const firstIndex = 1;
+      const { rerender } = rerenderableTableWrapper({
+        loading: true,
+        firstIndex,
+        totalItemsCount: defaultItems.length,
+        renderAriaLive: ({ firstIndex, lastIndex, totalItemsCount, visibleItemsCount }) =>
+          `Displaying items ${firstIndex} to ${lastIndex} of ${totalItemsCount}, ${visibleItemsCount} resources visible`,
+      });
+
+      // Initially loading - no announcement
+      expect(getLiveRegionText()).toBe('');
+
+      // Loading completes - should announce
+      rerender({ loading: false });
+      const lastIndex = firstIndex + defaultItems.length - 1;
+      const visibleItemsCount = defaultItems.length;
+      expect(getLiveRegionText()).toBe(
+        `Displaying items ${firstIndex} to ${lastIndex} of ${defaultItems.length}, ${visibleItemsCount} resources visible`
+      );
+    });
   });
 });

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -521,7 +521,7 @@ const InternalTable = React.forwardRef(
                 {...wrapperProps}
               >
                 <div className={styles['wrapper-content-measure']} ref={wrapperMeasureMergedRef}></div>
-                {!!renderAriaLive && !!firstIndex && (
+                {!!renderAriaLive && !!firstIndex && !loading && (
                   <InternalLiveRegion hidden={true} tagName="span">
                     <span>
                       {renderAriaLive({


### PR DESCRIPTION
### Description

This PR fixes an accessibility issue in the Table component where screen reader announcements were triggered during data loading.

The solution prevents `renderAriaLive` from being called while the table is in a loading state. Announcements now only occur after loading completes.

Related links, issue #, if available: AWSUI-61352

### How has this been tested?

I've tested the loading state behavior:

- Confirmed that `renderAriaLive` is not called when `loading={true}` is set on the table
- Verified that announcements resume correctly when loading switches from `true` to `false`
- Modified the table cell-permutations sample page locally to include renderAriaLive implementation and tested with screen reader to validate both loading and non-loading states
- Added comprehensive unit tests that validate the loading state behavior, ensuring announcements are disabled during loading and resume when loading completes

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
