### PR TITLE
feat: Add support for itemType checkbox in top-nav dropdown-menus

### DIFF
--- a/pages/top-navigation/common.tsx
+++ b/pages/top-navigation/common.tsx
@@ -30,7 +30,7 @@ export const profileActions = [
         externalIconAriaLabel: ' (opens in new tab)',
       },
       { id: 'feedback', text: 'Feedback', href: '#', external: true, externalIconAriaLabel: ' (opens in new tab)' },
-      { id: 'support', text: 'Customer support' },
+      { id: 'support', text: 'Customer support', itemType: 'checkbox', checked: true },
     ],
   },
   { type: 'button', id: 'signout', text: 'Sign out' },

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -26782,7 +26782,7 @@ The following properties are supported across all utility types:
 ### menu-dropdown
 
 * \`description\` (string) - The description displayed inside the dropdown.
-* \`items\` (ButtonDropdownProps.Items) - An array of dropdown items. This follows the same structure as the \`items\` property of the [button dropdown component](/components/button-dropdown), with the exception of the checkbox item type.
+* \`items\` (ButtonDropdownProps.Items) - An array of dropdown items. This follows the same structure as the \`items\` property of the [button dropdown component](/components/button-dropdown).
 * \`onItemClick\` (NonCancelableEventHandler<ButtonDropdownProps.ItemClickDetails>) - Specifies the event handler called when a dropdown item is selected.
 * \`onItemFollow\` (NonCancelableEventHandler<ButtonDropdownProps.ItemClickDetails>) - Specifies the event handler called when a dropdown item is selected without pressing modifier keys, and the item has an \`href\` set.
 * \`expandableGroups\` (boolean) - Controls expandability of the item groups.",

--- a/src/top-navigation/__tests__/top-navigation.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation.test.tsx
@@ -214,53 +214,7 @@ describe('TopNavigation Component', () => {
     });
   });
 
-  test('throws warning when menu-dropdown item with checkbox is provided', () => {
-    expect(warnOnce).toHaveBeenCalledTimes(0);
-    renderTopNavigation({
-      identity: { href: '#' },
-      utilities: [
-        {
-          type: 'menu-dropdown',
-          text: 'Menu dropdown',
-          title: 'Jane Doe',
-          description: 'jane.doe@example.com',
-          items: [{ id: 'one', text: 'First', itemType: 'checkbox', checked: true }],
-        },
-      ],
-    });
-    expect(warnOnce).toHaveBeenCalledWith(
-      'TopNavigation',
-      'The TopNavigation component does not support menu-dropdown items with `itemType` equal to `checkbox`.'
-    );
-  });
-
-  test('throws warning when menu-dropdown item with checkbox is provided (nested)', () => {
-    expect(warnOnce).toHaveBeenCalledTimes(0);
-    renderTopNavigation({
-      identity: { href: '#' },
-      utilities: [
-        {
-          type: 'menu-dropdown',
-          text: 'Menu dropdown',
-          title: 'Jane Doe',
-          description: 'jane.doe@example.com',
-          items: [
-            {
-              id: 'group',
-              itemType: 'group',
-              items: [{ id: 'one', text: 'First', itemType: 'checkbox', checked: true }],
-            },
-          ],
-        },
-      ],
-    });
-    expect(warnOnce).toHaveBeenCalledWith(
-      'TopNavigation',
-      'The TopNavigation component does not support menu-dropdown items with `itemType` equal to `checkbox`.'
-    );
-  });
-
-  test('excludes checkbox items', () => {
+  test('supports checkbox items', () => {
     const rendered = renderTopNavigation({
       identity: { href: '#' },
       utilities: [
@@ -282,8 +236,8 @@ describe('TopNavigation Component', () => {
     });
     const dropdown = rendered.findUtility(1)!.findMenuDropdownType()!;
     dropdown.openDropdown();
-    expect(dropdown.findItemById('checkbox')).toBeNull();
-    expect(dropdown.findItemById('checkbox-nested')).toBeNull();
+    expect(dropdown.findItemById('checkbox')).not.toBeNull();
+    expect(dropdown.findItemById('checkbox-nested')).not.toBeNull();
   });
 });
 

--- a/src/top-navigation/interfaces.ts
+++ b/src/top-navigation/interfaces.ts
@@ -54,7 +54,7 @@ export interface TopNavigationProps extends BaseComponentProps {
    * ### menu-dropdown
    *
    * * `description` (string) - The description displayed inside the dropdown.
-   * * `items` (ButtonDropdownProps.Items) - An array of dropdown items. This follows the same structure as the `items` property of the [button dropdown component](/components/button-dropdown), with the exception of the checkbox item type.
+   * * `items` (ButtonDropdownProps.Items) - An array of dropdown items. This follows the same structure as the `items` property of the [button dropdown component](/components/button-dropdown).
    * * `onItemClick` (NonCancelableEventHandler<ButtonDropdownProps.ItemClickDetails>) - Specifies the event handler called when a dropdown item is selected.
    * * `onItemFollow` (NonCancelableEventHandler<ButtonDropdownProps.ItemClickDetails>) - Specifies the event handler called when a dropdown item is selected without pressing modifier keys, and the item has an `href` set.
    * * `expandableGroups` (boolean) - Controls expandability of the item groups.

--- a/src/top-navigation/internal.tsx
+++ b/src/top-navigation/internal.tsx
@@ -3,9 +3,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
-import { isDevelopment, warnOnce } from '@cloudscape-design/component-toolkit/internal';
-
-import { hasCheckboxItems } from '../button-dropdown/utils/utils';
 import { useInternalI18n } from '../i18n/context';
 import { getBaseProps } from '../internal/base-component';
 import { ButtonTrigger } from '../internal/components/menu-dropdown';
@@ -43,17 +40,6 @@ export default function InternalTopNavigation({
   const isMediumViewport = breakpoint === 'xxs';
   const isLargeViewport = breakpoint === 's';
   const i18n = useInternalI18n('top-navigation');
-
-  // ButtonDropdown supports checkbox items but we don't support these in TopNavigation. Shown an error in development mode
-  // to alert users of this and that it might change in the future.
-  if (isDevelopment) {
-    if (utilities.some(item => item.type === 'menu-dropdown' && hasCheckboxItems(item.items))) {
-      warnOnce(
-        'TopNavigation',
-        'The TopNavigation component does not support menu-dropdown items with `itemType` equal to `checkbox`.'
-      );
-    }
-  }
 
   const onIdentityClick = (event: React.MouseEvent) => {
     if (isPlainLeftClick(event)) {

--- a/src/top-navigation/parts/utility.tsx
+++ b/src/top-navigation/parts/utility.tsx
@@ -110,14 +110,11 @@ export default function Utility({ hideText, definition, offsetRight }: UtilityPr
     const title = definition.title || definition.text;
     const shouldShowTitle = shouldHideText || !definition.text;
 
-    const items = excludeCheckboxes(definition.items);
-
     checkSafeUrlRecursively(definition.items);
 
     return (
       <MenuDropdown
         {...definition}
-        items={items}
         title={shouldShowTitle ? title : ''}
         ariaLabel={ariaLabel}
         offsetRight={offsetRight}
@@ -140,21 +137,4 @@ function checkSafeUrlRecursively(itemOrGroup: MenuDropdownProps['items']) {
       checkSafeUrlRecursively(item.items);
     }
   }
-}
-
-function excludeCheckboxes(items: MenuDropdownProps['items']): MenuDropdownProps['items'] {
-  return items
-    .map(item => {
-      if (item.itemType === 'checkbox') {
-        return null;
-      }
-      if ('items' in item) {
-        return {
-          ...item,
-          items: excludeCheckboxes(item.items),
-        };
-      }
-      return item;
-    })
-    .filter(item => item !== null) as MenuDropdownProps['items'];
 }


### PR DESCRIPTION
### Description

The top-nav menu-dropdown should (in theory) support all the same types as `ButtonDropdownProps.Items`. However, the `checkbox` item type was originally excluded from the contribution's scope due to lack of clear use cases. We now have a clear use case for making this type available in the top-nav component, with the upcoming improvements to demos navigation:

<img width="354" height="232" alt="Screenshot 2025-10-22 at 9 44 50 PM" src="https://github.com/user-attachments/assets/5fd03b64-c235-4139-b520-0c57c7ae7d39" />

Related links, issue #, if available: AWSUI-49134, #1303

### How has this been tested?

Dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
