### PR TITLE
chore: Remove flaky test

### DIFF
--- a/src/code-editor/__integ__/code-editor.test.ts
+++ b/src/code-editor/__integ__/code-editor.test.ts
@@ -9,7 +9,6 @@ import styles from '../../../lib/components/code-editor/resizable-box/styles.sel
 
 const wrapper = createWrapper();
 const codeEditorWrapper = wrapper.findCodeEditor();
-const controlOrCommandKey = process.platform === 'darwin' ? 'Command' : 'Control';
 
 interface AceEditorNode {
   env: {
@@ -92,19 +91,6 @@ const setupTest = (pageUrl: string, testFn: (page: CodeEditorPageObject) => Prom
     await testFn(page);
   });
 };
-
-test(
-  'Commenting multiple lines',
-  setupTest(simplePage, async page => {
-    await page.click(codeEditorWrapper.findEditor().toSelector());
-    await page.keys('\nconst a = 123;\nconst b = 234;\nconst c = 345;\n');
-    await page.keys([controlOrCommandKey, 'a']);
-    await page.keys([controlOrCommandKey, '/']);
-    await expect(page.getEditorContent()).resolves.toEqual(
-      '// const pi = 3.14;\n// const a = 123;\n// const b = 234;\n// const c = 345;\n'
-    );
-  })
-);
 
 test(
   `Tab text reduces when screen is small`,


### PR DESCRIPTION
### Description

This test is not needed, because we do not own this behavior, it comes from a 3rd party library Ace Editor

Also this test is flaky, which blocks our builds

Related links, issue #, if available: n/a

### How has this been tested?


n/a, test only removal

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
