### PR TITLE
chore: Move expanded mode code to use-app-layout layer

### DIFF
--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -195,6 +195,8 @@ type UseDrawersProps = Pick<AppLayoutProps, 'drawers' | 'activeDrawerId' | 'onDr
   __disableRuntimeDrawers?: boolean;
   onGlobalDrawerFocus?: (drawerId: string, open: boolean) => void;
   onAddNewActiveDrawer?: (drawerId: string) => void;
+  expandedDrawerId?: string | null;
+  setExpandedDrawerId?: (value: string | null) => void;
 };
 
 export function useDrawers(
@@ -204,6 +206,8 @@ export function useDrawers(
     onDrawerChange,
     onGlobalDrawerFocus,
     onAddNewActiveDrawer,
+    expandedDrawerId,
+    setExpandedDrawerId,
     __disableRuntimeDrawers: disableRuntimeDrawers,
   }: UseDrawersProps,
   ariaLabels: AppLayoutProps['ariaLabels'],
@@ -216,7 +220,6 @@ export function useDrawers(
   });
   const [activeGlobalDrawersIds, setActiveGlobalDrawersIds] = useState<Array<string>>([]);
   const [drawerSizes, setDrawerSizes] = useState<Record<string, number>>({});
-  const [expandedDrawerId, setExpandedDrawerId] = useState<string | null>(null);
   // FIFO queue that keeps track of open drawers, where the first element is the most recently opened drawer
   const drawersOpenQueue = useRef<Array<string>>([]);
 
@@ -271,7 +274,7 @@ export function useDrawers(
       drawersOpenQueue.current = drawersOpenQueue.current.filter(id => id !== drawerId);
       fireNonCancelableEvent(drawer?.onToggle, { isOpen: false, initiatedByUserAction });
       if (drawerId === expandedDrawerId) {
-        setExpandedDrawerId(null);
+        setExpandedDrawerId?.(null);
       }
     } else if (drawerId) {
       onAddNewActiveDrawer?.(drawerId);
@@ -360,7 +363,5 @@ export function useDrawers(
     onActiveDrawerChange,
     onActiveDrawerResize,
     onActiveGlobalDrawersChange,
-    expandedDrawerId,
-    setExpandedDrawerId,
   };
 }

--- a/src/app-layout/visual-refresh-toolbar/state/use-app-layout.tsx
+++ b/src/app-layout/visual-refresh-toolbar/state/use-app-layout.tsx
@@ -71,6 +71,7 @@ export const useAppLayout = (
   const [navigationAnimationDisabled, setNavigationAnimationDisabled] = useState(true);
   const [splitPanelAnimationDisabled, setSplitPanelAnimationDisabled] = useState(true);
   const [isNested, setIsNested] = useState(false);
+  const [expandedDrawerId, setExpandedDrawerId] = useState<string | null>(null);
   const rootRefInternal = useRef<HTMLDivElement>(null);
   // This workaround ensures the ref is defined before checking if the app layout is nested.
   // On initial render, the ref might be undefined because this component loads asynchronously via the widget API.
@@ -141,16 +142,24 @@ export const useAppLayout = (
     onActiveDrawerChange,
     onActiveDrawerResize,
     onActiveGlobalDrawersChange,
-    expandedDrawerId,
-    setExpandedDrawerId,
-  } = useDrawers({ ...rest, onGlobalDrawerFocus, onAddNewActiveDrawer }, ariaLabels, {
+  } = useDrawers(
+    {
+      ...rest,
+      onGlobalDrawerFocus,
+      onAddNewActiveDrawer,
+      expandedDrawerId,
+      setExpandedDrawerId,
+    },
     ariaLabels,
-    toolsHide,
-    toolsOpen,
-    tools,
-    toolsWidth,
-    onToolsToggle,
-  });
+    {
+      ariaLabels,
+      toolsHide,
+      toolsOpen,
+      tools,
+      toolsWidth,
+      onToolsToggle,
+    }
+  );
   const {
     aiDrawer,
     aiDrawerMessageHandler,


### PR DESCRIPTION
### Description

Move expanded mode code to use-app-layout layer as it used in use-drawers, user-ai-drawer, use-bottom-drawers and belongs at the app layout level rather than in a specific drawer

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
