### PR TITLE
chore: Vendor react-keyed-flatten-children dependency

### DIFF
--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -277,3 +277,38 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+Name: react-keyed-flatten-children
+Version: 3.2.0
+License: MIT
+Private: false
+Description: Flattens React children and fragments to an array with predictable and stable keys
+Repository: git+https://github.com/grrowl/react-keyed-flatten-children.git
+Homepage: https://github.com/grrowl/react-keyed-flatten-children
+Author: Tom McKenzie <tom@chillidonut.com>
+License Copyright:
+===
+
+MIT License
+
+Copyright (c) 2019 Tom McKenzie
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "date-fns": "^2.25.0",
         "intl-messageformat": "^10.3.1",
         "mnth": "^2.0.0",
-        "react-keyed-flatten-children": "^2.2.1",
         "react-transition-group": "^4.4.2",
         "tslib": "^2.4.0",
         "weekstart": "^1.1.0"
@@ -52,6 +51,7 @@
         "@types/node": "^20.17.14",
         "@types/react": "^16.14.20",
         "@types/react-dom": "^16.9.14",
+        "@types/react-is": "^19.2.0",
         "@types/react-router": "^5.1.18",
         "@types/react-router-dom": "^5.3.2",
         "@types/react-test-renderer": "^16.9.12",
@@ -127,7 +127,8 @@
         "webpack-dev-server": "^5.2.1"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
+        "react": ">=16.8.0",
+        "react-is": ">=16.8.0"
       }
     },
     "build-tools/eslint": {
@@ -4483,6 +4484,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "^16"
+      }
+    },
+    "node_modules/@types/react-is": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-19.2.0.tgz",
+      "integrity": "sha512-NP2xtcjZfORsOa4g2JwdseyEnF+wUCx25fTdG/J/HIY6yKga6+NozRBg2xR2gyh7kKYyd6DXndbq0YbQuTJ7Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-router": {
@@ -17178,21 +17189,6 @@
     },
     "node_modules/react-is": {
       "version": "17.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/react-keyed-flatten-children": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "react-is": "^18.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=15.0.0"
-      }
-    },
-    "node_modules/react-keyed-flatten-children/node_modules/react-is": {
-      "version": "18.3.1",
       "license": "MIT"
     },
     "node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "date-fns": "^2.25.0",
     "intl-messageformat": "^10.3.1",
     "mnth": "^2.0.0",
-    "react-keyed-flatten-children": "^2.2.1",
+    "react-is": ">=16.8.0",
     "react-transition-group": "^4.4.2",
     "tslib": "^2.4.0",
     "weekstart": "^1.1.0"
@@ -75,6 +75,7 @@
     "@types/node": "^20.17.14",
     "@types/react": "^16.14.20",
     "@types/react-dom": "^16.9.14",
+    "@types/react-is": "^19.2.0",
     "@types/react-router": "^5.1.18",
     "@types/react-router-dom": "^5.3.2",
     "@types/react-test-renderer": "^16.9.12",

--- a/pages/flashbar/runtime-content.page.tsx
+++ b/pages/flashbar/runtime-content.page.tsx
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ReactNode, useContext, useState } from 'react';
-import flattenChildren from 'react-keyed-flatten-children';
+import React, { isValidElement, ReactNode, useContext, useState } from 'react';
 
 import {
   Box,
@@ -16,6 +15,7 @@ import {
   SpaceBetween,
 } from '~components';
 import awsuiPlugins from '~components/internal/plugins';
+import flattenChildren from '~components/internal/vendor/react-keyed-flatten-children';
 import { mount, unmount } from '~mount';
 
 import AppContext, { AppContextType } from '../app/app-context';
@@ -27,7 +27,7 @@ type PageContext = React.Context<
 
 const nodeAsString = (node: ReactNode) =>
   flattenChildren(node)
-    .map(node => (typeof node === 'object' ? node.props.children : node))
+    .map(node => (isValidElement(node) ? node.props.children : node))
     .filter(node => typeof node === 'string')
     .join('');
 

--- a/src/column-layout/flexible-column-layout/index.tsx
+++ b/src/column-layout/flexible-column-layout/index.tsx
@@ -1,11 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import flattenChildren from 'react-keyed-flatten-children';
 import clsx from 'clsx';
 
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 
+import flattenChildren from '../../internal/vendor/react-keyed-flatten-children';
 import { InternalColumnLayoutProps } from '../interfaces';
 
 import styles from './styles.css.js';

--- a/src/column-layout/grid-column-layout.tsx
+++ b/src/column-layout/grid-column-layout.tsx
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import flattenChildren from 'react-keyed-flatten-children';
 import clsx from 'clsx';
 
 import { GridProps } from '../grid/interfaces';
 import InternalGrid from '../grid/internal';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
+import flattenChildren from '../internal/vendor/react-keyed-flatten-children';
 import { InternalColumnLayoutProps } from './interfaces';
 import { COLUMN_TRIGGERS, ColumnLayoutBreakpoint } from './internal';
 import { repeat } from './util';

--- a/src/grid/internal.tsx
+++ b/src/grid/internal.tsx
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import flattenChildren from 'react-keyed-flatten-children';
 import clsx, { ClassValue } from 'clsx';
 
 import { useMergeRefs, warnOnce } from '@cloudscape-design/component-toolkit/internal';
@@ -11,6 +10,7 @@ import { Breakpoint, matchBreakpointMapping } from '../internal/breakpoints';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { isDevelopment } from '../internal/is-development';
+import flattenChildren from '../internal/vendor/react-keyed-flatten-children';
 import { GridProps } from './interfaces';
 
 import styles from './styles.css.js';

--- a/src/internal/vendor/react-keyed-flatten-children/index.ts
+++ b/src/internal/vendor/react-keyed-flatten-children/index.ts
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Vendored from react-keyed-flatten-children@3.2.0 (MIT License)
+// Original source: https://github.com/grrowl/react-keyed-flatten-children
+
+import { Children, cloneElement, isValidElement, ReactElement, ReactNode } from 'react';
+import { isFragment } from 'react-is';
+
+/* Returns React children into an array, flattening fragments. */
+
+function isFragmentWithChildren(node: unknown): node is ReactElement<{ children: ReactNode }> {
+  return isFragment(node);
+}
+
+export default function flattenChildren(children: ReactNode, depth = 0, keys: (string | number)[] = []): ReactNode[] {
+  return Children.toArray(children).reduce((acc: ReactNode[], node, nodeIndex) => {
+    if (isFragmentWithChildren(node)) {
+      acc.push(...flattenChildren(node.props.children, depth + 1, keys.concat(node.key || nodeIndex)));
+    } else if (isValidElement(node)) {
+      acc.push(
+        cloneElement(node, {
+          key: keys.concat(String(node.key)).join('.'),
+        })
+      );
+    } else if (typeof node === 'string' || typeof node === 'number') {
+      acc.push(node);
+    }
+    return acc;
+  }, []);
+}

--- a/src/space-between/internal.tsx
+++ b/src/space-between/internal.tsx
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { forwardRef } from 'react';
-import flattenChildren from 'react-keyed-flatten-children';
+import React, { forwardRef, isValidElement } from 'react';
 import clsx from 'clsx';
 
 import { useMergeRefs } from '@cloudscape-design/component-toolkit/internal';
@@ -9,6 +8,7 @@ import { useMergeRefs } from '@cloudscape-design/component-toolkit/internal';
 import { getBaseProps } from '../internal/base-component';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import WithNativeAttributes from '../internal/utils/with-native-attributes';
+import flattenChildren from '../internal/vendor/react-keyed-flatten-children';
 import { SpaceBetweenProps } from './interfaces';
 
 import styles from './styles.css.js';
@@ -52,7 +52,7 @@ const InternalSpaceBetween = forwardRef(
         ref={mergedRef}
       >
         {flattenedChildren.map(child => {
-          const key = typeof child === 'object' ? child.key : undefined;
+          const key = isValidElement(child) ? child.key : undefined;
 
           return (
             <div key={key} className={styles.child}>


### PR DESCRIPTION
### Description

We're unable to upgrade to the latest versions of [react-keyed-flatten-children](https://github.com/grrowl/react-keyed-flatten-children) because of how it's packaged: We have Jest customers that are allergic to ESM. So we're stuck on an old version.

From https://github.com/cloudscape-design/components/discussions/3080:

> It is such a small utility that sometimes I wonder if it's worth inlining into the package…

This PR does exactly that: It adds the dep (specifically, `react-keyed-flatten-children@3.2.0` to our `vendor/` dir and adds an appropriate ranged dependency on `react-is`. That ranged dependency should be a significant efficiency improvement for many of our customers: The version of `react-keyed-flatten-children` we were using depended on `react-is@^18.2.0`, which meant that customers with any higher or lower version of `react-is` would wind up with two copies of that dependency in their bundle.

### How has this been tested?

All unit tests pass.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
