### PR TITLE
fix: header focus outline to use CDS styles instead of native outline

### DIFF
--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -5,6 +5,7 @@
 
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/styles' as styles;
+@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
 @function space-heading-button-diff($heading-height) {
   @return calc((#{awsui.$size-vertical-input} - #{$heading-height}) / 2);
@@ -219,6 +220,14 @@
   display: inline;
   font-size: inherit;
   @include styles.info-link-spacing();
+
+  &:focus {
+    outline: none;
+  }
+
+  @include focus-visible.when-visible {
+    @include styles.link-focus;
+  }
 
   &-variant-h1 {
     @include styles.font(heading-xl);


### PR DESCRIPTION
### Description

This PR fixes the Header component's focus outline to use Cloudscape Design System (CDS) styles instead of the native browser outline.

Related links, issue #, if available: AWSUI-61110

### How has this been tested?

I've tested the focus behavior locally:

**Safari with custom system colors**: 
   - Changed the system appearance accent color from default (System Settings → General → Appearance → Accent color)
   - Confirmed focus outline in Wizard component
   - Confirmed the focus outline now uses CDS blue color and is distinctly different from the custom accent color
   - Verified the outline is no longer affected by system color preferences

**Other focusable headers**:
   - Tested headers in various demo pages (App Layout Toolbar, Wizard, etc.)
   - Confirmed all headers that receive focus they display consistent CDS focus styling

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
