### PR TITLE
poc: prevent icon-text overlap with custom padding

### DIFF
--- a/build-tools/utils/custom-css-properties.js
+++ b/build-tools/utils/custom-css-properties.js
@@ -95,6 +95,9 @@ const customCssPropertiesList = [
   'styleBoxShadowDefault',
   'styleBoxShadowDisabled',
   'styleBoxShadowHover',
+  'stylePaddingInline',
+  'stylePaddingInlineStart',
+  'stylePaddingInlineEnd',
   // Readonly state
   'styleBackgroundReadonly',
   'styleBorderColorReadonly',

--- a/src/input/styles.scss
+++ b/src/input/styles.scss
@@ -34,7 +34,7 @@
 .input {
   @include styles.styles-reset;
   padding-block: styles.$control-padding-vertical;
-  padding-inline: styles.$control-padding-horizontal;
+  padding-inline: var(#{custom-props.$stylePaddingInline}, #{styles.$control-padding-horizontal});
   color: var(#{custom-props.$styleColorDefault}, awsui.$color-text-body-default);
   inline-size: 100%;
   cursor: text;
@@ -128,9 +128,12 @@
   &.input-invalid {
     @include styles.form-invalid-control();
     &.input-has-icon-left {
-      padding-inline-start: calc(
-        #{styles.$control-icon-horizontal-padding} -
-          (#{styles.$invalid-control-left-border} - #{awsui.$border-width-field})
+      padding-inline-start: max(
+        var(#{custom-props.$stylePaddingInlineStart}, #{styles.$control-padding-horizontal}),
+        calc(
+          #{styles.$control-icon-horizontal-padding} -
+            (#{styles.$invalid-control-left-border} - #{awsui.$border-width-field})
+        )
       );
     }
   }
@@ -138,9 +141,12 @@
   &.input-warning {
     @include styles.form-warning-control();
     &.input-has-icon-left {
-      padding-inline-start: calc(
-        #{styles.$control-icon-horizontal-padding} -
-          (#{styles.$invalid-control-left-border} - #{awsui.$border-width-field})
+      padding-inline-start: max(
+        var(#{custom-props.$stylePaddingInlineStart}, #{styles.$control-padding-horizontal}),
+        calc(
+          #{styles.$control-icon-horizontal-padding} -
+            (#{styles.$invalid-control-left-border} - #{awsui.$border-width-field})
+        )
       );
     }
   }
@@ -159,10 +165,16 @@
     }
   }
   &.input-has-icon-left {
-    padding-inline-start: styles.$control-icon-horizontal-padding;
+    padding-inline-start: max(
+      var(#{custom-props.$stylePaddingInlineStart}, #{styles.$control-padding-horizontal}),
+      #{styles.$control-icon-horizontal-padding}
+    );
   }
   &.input-has-icon-right {
-    padding-inline-end: styles.$control-icon-horizontal-padding;
+    padding-inline-end: max(
+      var(#{custom-props.$stylePaddingInlineEnd}, #{styles.$control-padding-horizontal}),
+      #{styles.$control-icon-horizontal-padding}
+    );
   }
   &.input-has-no-border-radius {
     border-start-start-radius: awsui.$border-radius-dropdown;

--- a/src/input/styles.tsx
+++ b/src/input/styles.tsx
@@ -3,18 +3,32 @@
 import { SYSTEM } from '../internal/environment';
 import customCssProps from '../internal/generated/custom-css-properties';
 import { InputProps } from './interfaces';
+import { parsePaddingInline } from './utils';
 
 export function getInputStyles(style: InputProps['style']) {
   let properties = {};
 
   if (style?.root && SYSTEM === 'core') {
+    // We are only supporting logical shorthand properties for padding (e.g. "10px 30px"),
+    // so wen ened to deconstruct this into start- and end-padding to be able to style
+    // them separately.
+    const { start: paddingStart, end: paddingEnd } = parsePaddingInline(style?.root?.paddingInline);
+
     properties = {
       borderRadius: style?.root?.borderRadius,
       borderWidth: style?.root?.borderWidth,
       fontSize: style?.root?.fontSize,
       fontWeight: style?.root?.fontWeight,
       paddingBlock: style?.root?.paddingBlock,
-      paddingInline: style?.root?.paddingInline,
+      ...(style?.root?.paddingInline && {
+        [customCssProps.stylePaddingInline]: style.root.paddingInline,
+      }),
+      ...(paddingStart && {
+        [customCssProps.stylePaddingInlineStart]: paddingStart,
+      }),
+      ...(paddingEnd && {
+        [customCssProps.stylePaddingInlineEnd]: paddingEnd,
+      }),
       ...(style?.root?.backgroundColor && {
         [customCssProps.styleBackgroundDefault]: style.root.backgroundColor?.default,
         [customCssProps.styleBackgroundDisabled]: style.root.backgroundColor?.disabled,

--- a/src/input/utils.ts
+++ b/src/input/utils.ts
@@ -37,3 +37,18 @@ export const convertAutoComplete = (propertyValue: boolean | string = false): st
   }
   return propertyValue || 'off';
 };
+
+/**
+ * Parses CSS paddingInline value into separate start and end values.
+ * Handles both single values ('10px') and shorthand notation ('10px 20px').
+ */
+export const parsePaddingInline = (
+  paddingInline: string | undefined
+): { start: string | undefined; end: string | undefined } => {
+  if (!paddingInline) {
+    return { start: undefined, end: undefined };
+  }
+
+  const [start, end = start] = paddingInline.trim().split(/\s+/);
+  return { start, end };
+};


### PR DESCRIPTION
### Description

Custom `padding-inline` values on inputs can cause text to overlap with icons:

<img width="732" height="63" alt="image" src="https://github.com/user-attachments/assets/773556d0-1558-494e-aefc-83a22dab0983" />

This solution:
- Parses `paddingInline` values (including shorthand notation like '30px 10px') into separate start/end values
- Uses CSS `max()` to compare custom padding vs required icon padding
- Applies whichever is larger, preventing text overlap while respecting custom padding

### How has this been tested?

- Verified with screenshot tests - no regressions
- Added unit tests for padding parsing and style generation

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
