### PR TITLE
fix: Delay missing styles check until document is fully loaded

### DIFF
--- a/src/internal/hooks/use-base-component/__tests__/styles-check-hook.test.tsx
+++ b/src/internal/hooks/use-base-component/__tests__/styles-check-hook.test.tsx
@@ -37,3 +37,11 @@ test('emits style check error only once', async () => {
   await new Promise(resolve => setTimeout(resolve, 1100));
   expect(consoleMock).toHaveBeenCalledTimes(0);
 });
+
+test('no check if component is instantly unmounted', async () => {
+  const { unmount } = render(<Test key={1} />);
+  unmount();
+
+  await new Promise(resolve => setTimeout(resolve, 1100));
+  expect(consoleMock).toHaveBeenCalledTimes(0);
+});


### PR DESCRIPTION
### Description

Continuation of these changes: https://github.com/cloudscape-design/components/pull/3956, https://github.com/cloudscape-design/components/pull/4002

The check is still sometimes failing when it is not expected. We need to check `document.readyState` before firing the check

Related links, issue #, if available: n/a

### How has this been tested?

* Updated unit tests
* Checked manually

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
