### PR TITLE
feat: Add focus and blur handlers for s3-resource-selector

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -20277,6 +20277,16 @@ path of the selected resource and \`errorText\` that may contain a validation er
       "detailType": "S3ResourceSelectorProps.ChangeDetail",
       "name": "onChange",
     },
+    {
+      "cancelable": false,
+      "description": "Called when input focus is removed from the S3 URI input.",
+      "name": "onInputBlur",
+    },
+    {
+      "cancelable": false,
+      "description": "Called when input focus is moved to the S3 URI input.",
+      "name": "onInputFocus",
+    },
   ],
   "functions": [
     {

--- a/src/s3-resource-selector/__tests__/main.test.tsx
+++ b/src/s3-resource-selector/__tests__/main.test.tsx
@@ -139,6 +139,18 @@ test('focuses the S3Uri field when calling the focus function', () => {
   expect(wrapper.findInContext().findUriInput().findNativeInput().getElement()).toBe(document.activeElement);
 });
 
+test('supports input focus and blur handlers', () => {
+  const onInputFocus = jest.fn();
+  const onInputBlur = jest.fn();
+  const wrapper = renderComponent(
+    <S3ResourceSelector {...defaultProps} onInputFocus={onInputFocus} onInputBlur={onInputBlur} />
+  );
+  wrapper.findInContext().findUriInput().focus();
+  expect(onInputFocus).toHaveBeenCalled();
+  wrapper.findInContext().findUriInput().blur();
+  expect(onInputBlur).toHaveBeenCalled();
+});
+
 describe('URL sanitization', () => {
   let consoleWarnSpy: jest.SpyInstance;
   let consoleErrorSpy: jest.SpyInstance;

--- a/src/s3-resource-selector/index.tsx
+++ b/src/s3-resource-selector/index.tsx
@@ -44,6 +44,8 @@ const S3ResourceSelector = React.forwardRef(
       ariaLabel,
       getModalRoot,
       removeModalRoot,
+      onInputFocus,
+      onInputBlur,
       ...rest
     }: S3ResourceSelectorProps,
     ref: React.Ref<S3ResourceSelectorProps.Ref>
@@ -110,6 +112,8 @@ const S3ResourceSelector = React.forwardRef(
           fetchVersions={fetchVersions}
           onBrowse={() => setModalOpen(true)}
           onChange={(resource, errorText) => fireNonCancelableEvent(onChange, { resource, errorText })}
+          onInputFocus={onInputFocus}
+          onInputBlur={onInputBlur}
         />
         {!modalOpen && alert && (
           <InternalBox className={styles.alert} margin={{ top: 's' }}>

--- a/src/s3-resource-selector/interfaces.ts
+++ b/src/s3-resource-selector/interfaces.ts
@@ -158,6 +158,16 @@ export interface S3ResourceSelectorProps extends BaseComponentProps, BaseModalPr
   fetchVersions: (bucketName: string, pathPrefix: string) => Promise<ReadonlyArray<S3ResourceSelectorProps.Version>>;
 
   /**
+   * Called when input focus is removed from the S3 URI input.
+   */
+  onInputBlur?: NonCancelableEventHandler<null>;
+
+  /**
+   * Called when input focus is moved to the S3 URI input.
+   */
+  onInputFocus?: NonCancelableEventHandler<null>;
+
+  /**
    * Fired when the resource selection is changed. The event detail object contains resource that represents the full
    * path of the selected resource and `errorText` that may contain a validation error.
    */

--- a/src/s3-resource-selector/s3-in-context/index.tsx
+++ b/src/s3-resource-selector/s3-in-context/index.tsx
@@ -7,7 +7,7 @@ import { InternalButton } from '../../button/internal';
 import InternalFormField from '../../form-field/internal';
 import { useInternalI18n } from '../../i18n/context';
 import { InputProps } from '../../input/interfaces';
-import { NonCancelableCustomEvent } from '../../internal/events';
+import { fireNonCancelableEvent, NonCancelableCustomEvent, NonCancelableEventHandler } from '../../internal/events';
 import useForwardFocus from '../../internal/hooks/forward-focus';
 import InternalLiveRegion from '../../live-region/internal';
 import InternalSelect from '../../select/internal';
@@ -28,6 +28,8 @@ interface S3InContextProps {
   inputAriaDescribedby: string | undefined;
   selectableItemsTypes: S3ResourceSelectorProps['selectableItemsTypes'];
   fetchVersions: S3ResourceSelectorProps['fetchVersions'];
+  onInputBlur: NonCancelableEventHandler<null> | undefined;
+  onInputFocus: NonCancelableEventHandler<null> | undefined;
   onBrowse: () => void;
   onChange: (newResource: S3ResourceSelectorProps.Resource, errorText: string | undefined) => void;
 }
@@ -47,6 +49,8 @@ export const S3InContext = React.forwardRef(
       inputAriaDescribedby,
       selectableItemsTypes,
       fetchVersions,
+      onInputBlur,
+      onInputFocus,
       onChange,
       onBrowse,
     }: S3InContextProps,
@@ -76,9 +80,15 @@ export const S3InContext = React.forwardRef(
       setInputTouched(true);
       const errorCode = validate(resource.uri);
       onChange(resource, getErrorText(i18n, i18nStrings, errorCode));
+      fireNonCancelableEvent(onInputBlur);
       if (supportsVersions) {
         loadVersions(resource.uri);
       }
+    }
+
+    function handleUriFocus() {
+      isInputBlurredRef.current = false;
+      fireNonCancelableEvent(onInputFocus);
     }
 
     useEffect(() => {
@@ -105,7 +115,7 @@ export const S3InContext = React.forwardRef(
               placeholder={inputPlaceholder ?? i18nStrings?.inContextInputPlaceholder}
               onChange={handleUriChange}
               invalid={invalid}
-              onFocus={() => (isInputBlurredRef.current = false)}
+              onFocus={handleUriFocus}
               onBlur={handleUriBlur}
             />
           </InternalFormField>


### PR DESCRIPTION
### Description

Address this request: AWSUI-61424

Related links, issue #, if available: n/a

### How has this been tested?

Added a unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
