### PR TITLE
chore: Refactor radio button into internal component

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -20111,7 +20111,7 @@ being included in a form submission. A read-only control is still focusable.",
     },
     {
       "inlineType": {
-        "name": "RadioGroupProps.Style",
+        "name": "RadioButtonProps.Style",
         "properties": [
           {
             "inlineType": {
@@ -20336,7 +20336,7 @@ being included in a form submission. A read-only control is still focusable.",
       "systemTags": [
         "core",
       ],
-      "type": "RadioGroupProps.Style",
+      "type": "RadioButtonProps.Style",
     },
     {
       "description": "Sets the value of the selected radio button.

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -389,6 +389,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_placeholder_18eso",
     "awsui_recovery_vrgzu",
     "awsui_root_11n0s",
+    "awsui_root_15oj2",
     "awsui_root_1fcus",
     "awsui_root_1kjc7",
     "awsui_root_1om0h",
@@ -514,8 +515,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_token-editor-token-remove-actions_1heb1",
   ],
   "radio-group": [
-    "awsui_radio_1mabk",
-    "awsui_root_1mabk",
+    "awsui_root_1np5w",
   ],
   "s3-resource-selector": [
     "awsui_alert_1u0yw",

--- a/src/internal/components/radio-button/index.tsx
+++ b/src/internal/components/radio-button/index.tsx
@@ -7,26 +7,20 @@ import { useMergeRefs } from '@cloudscape-design/component-toolkit/internal';
 import { useSingleTabStopNavigation } from '@cloudscape-design/component-toolkit/internal';
 import { copyAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
-import AbstractSwitch from '../internal/components/abstract-switch';
-import { fireNonCancelableEvent, NonCancelableEventHandler } from '../internal/events';
-import { RadioGroupProps } from './interfaces';
-import { getAbstractSwitchStyles, getInnerCircleStyle, getOuterCircleStyle } from './style';
+import { getAbstractSwitchStyles, getInnerCircleStyle, getOuterCircleStyle } from '../../../radio-group/style';
+import { getBaseProps } from '../../base-component';
+import AbstractSwitch from '../../components/abstract-switch';
+import { fireNonCancelableEvent } from '../../events';
+import { InternalBaseComponentProps } from '../../hooks/use-base-component';
+import { RadioButtonProps } from './interfaces';
 
 import styles from './styles.css.js';
-
-interface RadioButtonProps extends RadioGroupProps.RadioButtonDefinition {
-  name: string;
-  checked: boolean;
-  onChange?: NonCancelableEventHandler<RadioGroupProps.ChangeDetail>;
-  readOnly?: boolean;
-  className?: string;
-  style?: RadioGroupProps.Style;
-}
+import testUtilStyles from './test-classes/styles.css.js';
 
 export default React.forwardRef(function RadioButton(
   {
     name,
-    label,
+    children,
     value,
     checked,
     description,
@@ -37,25 +31,28 @@ export default React.forwardRef(function RadioButton(
     className,
     style,
     ...rest
-  }: RadioButtonProps,
+  }: RadioButtonProps & InternalBaseComponentProps,
   ref: React.Ref<HTMLInputElement>
 ) {
   const radioButtonRef = useRef<HTMLInputElement>(null);
   const mergedRefs = useMergeRefs(radioButtonRef, ref);
 
   const { tabIndex } = useSingleTabStopNavigation(radioButtonRef);
+  const baseProps = getBaseProps(rest);
 
   return (
     <AbstractSwitch
-      className={clsx(styles.radio, description && styles['radio--has-description'], className)}
+      {...baseProps}
+      className={clsx(testUtilStyles.root, className)}
       controlClassName={styles['radio-control']}
       outlineClassName={styles.outline}
-      label={label}
+      label={children}
       description={description}
       disabled={disabled}
       readOnly={readOnly}
       controlId={controlId}
       style={getAbstractSwitchStyles(style, checked, disabled, readOnly)}
+      __internalRootRef={rest.__internalRootRef}
       {...copyAnalyticsMetadataAttribute(rest)}
       nativeControl={nativeControlProps => (
         <input
@@ -73,10 +70,7 @@ export default React.forwardRef(function RadioButton(
       )}
       onClick={() => {
         radioButtonRef.current?.focus();
-        if (checked) {
-          return;
-        }
-        fireNonCancelableEvent(onChange, { value });
+        fireNonCancelableEvent(onChange, { checked: !checked });
       }}
       styledControl={
         <svg viewBox="0 0 100 100" focusable="false" aria-hidden="true">

--- a/src/internal/components/radio-button/interfaces.ts
+++ b/src/internal/components/radio-button/interfaces.ts
@@ -1,0 +1,143 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { BaseComponentProps } from '../../base-component';
+import { NonCancelableEventHandler } from '../../events';
+/**
+ * @awsuiSystem core
+ */
+import { NativeAttributes } from '../../utils/with-native-attributes';
+
+export interface RadioButtonProps extends BaseComponentProps {
+  /**
+   * Specifies if the component is selected.
+   */
+  checked: boolean;
+
+  /**
+   * Specifies the ID of the native form element. You can use it to relate
+   * a label element's `for` attribute to this control.
+   */
+  controlId?: string;
+
+  /**
+   * Name of the group that the radio button belongs to.
+   */
+  name: string;
+
+  /**
+   * Description that appears below the label.
+   */
+  description?: React.ReactNode;
+
+  /**
+   * Specifies if the control is disabled, which prevents the
+   * user from modifying the value and prevents the value from
+   * being included in a form submission. A disabled control can't
+   * receive focus.
+   */
+  disabled?: boolean;
+
+  /**
+   * The control's label that's displayed next to the radio button. A state change occurs when a user clicks on it.
+   * @displayname label
+   */
+  children?: React.ReactNode;
+
+  /**
+   * Attributes to add to the native `input` element.
+   * Some attributes will be automatically combined with internal attribute values:
+   * - `className` will be appended.
+   * - Event handlers will be chained, unless the default is prevented.
+   *
+   * We do not support using this attribute to apply custom styling.
+   *
+   * @awsuiSystem core
+   */
+  nativeInputAttributes?: NativeAttributes<React.InputHTMLAttributes<HTMLInputElement>>;
+
+  /**
+   * Called when the user changes the component state. The event `detail` contains the current value for the `checked` property.
+   */
+  onChange?: NonCancelableEventHandler<RadioButtonProps.ChangeDetail>;
+
+  /**
+   * Specifies if the radio button is read-only, which prevents the
+   * user from modifying the value, but does not prevent the value from
+   * being included in a form submission. A read-only control is still focusable.
+   *
+   * This property should be set for either all or none of the radio buttons in a group.
+   */
+  readOnly?: boolean;
+
+  /**
+   * @awsuiSystem core
+   */
+  style?: RadioButtonProps.Style;
+
+  /**
+   * Sets the value attribute to the native control.
+   * If using native form submission, this value is sent to the server if the radio button is checked.
+   * It is never shown to the user by their user agent.
+   * For more details, see the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/radio#value).
+   */
+  value?: string;
+}
+
+export namespace RadioButtonProps {
+  export interface ChangeDetail {
+    checked: boolean;
+  }
+
+  export interface Ref {
+    /**
+     * Sets input focus onto the UI control.
+     */
+    focus(): void;
+  }
+
+  export interface Style {
+    input?: {
+      fill?: {
+        checked?: string;
+        default?: string;
+        disabled?: string;
+        readOnly?: string;
+      };
+      stroke?: {
+        default?: string;
+        disabled?: string;
+        readOnly?: string;
+      };
+      circle?: {
+        fill?: {
+          checked?: string;
+          disabled?: string;
+          readOnly?: string;
+        };
+      };
+      focusRing?: {
+        borderColor?: string;
+        borderRadius?: string;
+        borderWidth?: string;
+      };
+    };
+    label?: {
+      color?: {
+        checked?: string;
+        default?: string;
+        disabled?: string;
+        readOnly?: string;
+      };
+    };
+    description?: {
+      color?: {
+        checked?: string;
+        default?: string;
+        disabled?: string;
+        readOnly?: string;
+      };
+    };
+  }
+}

--- a/src/internal/components/radio-button/styles.scss
+++ b/src/internal/components/radio-button/styles.scss
@@ -1,0 +1,57 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '../../styles' as styles;
+@use '../../styles/tokens' as awsui;
+@use '../../styles/foundation' as foundation;
+@use '../../generated/custom-css-properties/index.scss' as custom-props;
+
+$radio-size: awsui.$size-control;
+
+.radio-control {
+  @include styles.make-control-size($radio-size);
+}
+
+.outline {
+  #{custom-props.$styleFocusRingBoxShadow}: 0 0 0
+    var(#{custom-props.$styleFocusRingBorderWidth}, foundation.$box-shadow-focused-width)
+    var(#{custom-props.$styleFocusRingBorderColor}, awsui.$color-border-item-focused);
+
+  @include styles.focus-highlight(
+    $gutter: 2px,
+    $border-radius: var(#{custom-props.$styleFocusRingBorderRadius}, awsui.$border-radius-control-circular-focus-ring),
+    $box-shadow: var(#{custom-props.$styleFocusRingBoxShadow})
+  );
+}
+
+.styled-circle-border {
+  stroke: awsui.$color-border-control-default;
+  fill: awsui.$color-background-control-default;
+  &.styled-circle-disabled,
+  &.styled-circle-readonly {
+    fill: awsui.$color-background-control-disabled;
+    stroke: awsui.$color-background-control-disabled;
+  }
+}
+
+.styled-circle-fill {
+  stroke: awsui.$color-background-control-checked;
+  fill: awsui.$color-foreground-control-default;
+  opacity: 0;
+  @include styles.with-motion {
+    transition: opacity awsui.$motion-duration-transition-quick awsui.$motion-easing-transition-quick;
+  }
+  &.styled-circle-checked {
+    opacity: 1;
+  }
+  &.styled-circle-disabled {
+    fill: awsui.$color-foreground-control-disabled;
+    stroke: awsui.$color-background-control-disabled;
+  }
+  &.styled-circle-readonly {
+    fill: awsui.$color-foreground-control-read-only;
+    stroke: awsui.$color-background-control-disabled;
+  }
+}

--- a/src/internal/components/radio-button/test-classes/styles.scss
+++ b/src/internal/components/radio-button/test-classes/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.root {
+  /*used in test-utils*/
+}

--- a/src/radio-group/__integ__/radio-group.test.ts
+++ b/src/radio-group/__integ__/radio-group.test.ts
@@ -5,7 +5,7 @@ import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper, { RadioGroupWrapper } from '../../../lib/components/test-utils/selectors';
 
-import styles from '../../../lib/components/radio-group/styles.selectors.js';
+import radioButtonStyles from '../../../lib/components/internal/components/radio-button/styles.selectors.js';
 
 const radioGroupWrapper = createWrapper().findRadioGroup('#simple');
 
@@ -75,8 +75,8 @@ test(
 
     await page.click('[data-testid="1"]');
     await page.keys('Tab');
-    await expect((await browser.$(`.${styles.outline}`).getCSSProperty('box-shadow', '::before')).value).toBe(
-      'rgb(4,125,149)0px0px0px1px'
-    );
+    await expect(
+      (await browser.$(`.${radioButtonStyles.outline}`).getCSSProperty('box-shadow', '::before')).value
+    ).toBe('rgb(4,125,149)0px0px0px1px');
   })
 );

--- a/src/radio-group/__tests__/radio-group.test.tsx
+++ b/src/radio-group/__tests__/radio-group.test.tsx
@@ -15,7 +15,7 @@ import RadioButtonWrapper from '../../../lib/components/test-utils/dom/radio-gro
 import customCssProps from '../../internal/generated/custom-css-properties';
 
 import abstractSwitchStyles from '../../../lib/components/internal/components/abstract-switch/styles.css.js';
-import styles from '../../../lib/components/radio-group/styles.selectors.js';
+import radioButtonStyles from '../../../lib/components/internal/components/radio-button/styles.selectors.js';
 
 const defaultItems: RadioGroupProps.RadioButtonDefinition[] = [
   { value: 'val1', label: 'Option one' },
@@ -434,8 +434,8 @@ test('all style api properties', function () {
     />
   );
 
-  const outerCircle = wrapper.findByClassName(styles['styled-circle-border'])!.getElement();
-  const innerCircle = wrapper.findByClassName(styles['styled-circle-fill'])!.getElement();
+  const outerCircle = wrapper.findByClassName(radioButtonStyles['styled-circle-border'])!.getElement();
+  const innerCircle = wrapper.findByClassName(radioButtonStyles['styled-circle-fill'])!.getElement();
   const label = wrapper.findByClassName(abstractSwitchStyles.label)!.getElement();
   const description = wrapper.findByClassName(abstractSwitchStyles.description)!.getElement();
   const control = wrapper.findByClassName(abstractSwitchStyles.control)!.getElement();

--- a/src/radio-group/interfaces.ts
+++ b/src/radio-group/interfaces.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
 
 import { BaseComponentProps } from '../internal/base-component';
+import { RadioButtonProps } from '../internal/components/radio-button/interfaces';
 import { FormFieldControlProps } from '../internal/context/form-field-context';
 import { NonCancelableEventHandler } from '../internal/events';
 
@@ -83,54 +83,7 @@ export namespace RadioGroupProps {
     value: string;
   }
 
-  export interface Ref {
-    /**
-     * Sets input focus onto the UI control.
-     */
-    focus(): void;
-  }
+  export type Ref = RadioButtonProps.Ref;
 
-  export interface Style {
-    input?: {
-      fill?: {
-        checked?: string;
-        default?: string;
-        disabled?: string;
-        readOnly?: string;
-      };
-      stroke?: {
-        default?: string;
-        disabled?: string;
-        readOnly?: string;
-      };
-      circle?: {
-        fill?: {
-          checked?: string;
-          disabled?: string;
-          readOnly?: string;
-        };
-      };
-      focusRing?: {
-        borderColor?: string;
-        borderRadius?: string;
-        borderWidth?: string;
-      };
-    };
-    label?: {
-      color?: {
-        checked?: string;
-        default?: string;
-        disabled?: string;
-        readOnly?: string;
-      };
-    };
-    description?: {
-      color?: {
-        checked?: string;
-        default?: string;
-        disabled?: string;
-        readOnly?: string;
-      };
-    };
-  }
+  export type Style = RadioButtonProps.Style;
 }

--- a/src/radio-group/internal.tsx
+++ b/src/radio-group/internal.tsx
@@ -7,15 +7,17 @@ import { useUniqueId } from '@cloudscape-design/component-toolkit/internal';
 import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 import { getBaseProps } from '../internal/base-component';
+import RadioButton from '../internal/components/radio-button';
 import { useFormFieldContext } from '../internal/context/form-field-context';
+import { fireNonCancelableEvent } from '../internal/events';
 import useRadioGroupForwardFocus from '../internal/hooks/forward-focus/radio-group';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { GeneratedAnalyticsMetadataRadioGroupSelect } from './analytics-metadata/interfaces';
 import { RadioGroupProps } from './interfaces';
-import RadioButton from './radio-button';
 
 import analyticsSelectors from './analytics-metadata/styles.css.js';
 import styles from './styles.css.js';
+import testUtilStyles from './test-classes/styles.css.js';
 
 type InternalRadioGroupProps = RadioGroupProps & InternalBaseComponentProps;
 
@@ -52,7 +54,7 @@ const InternalRadioGroup = React.forwardRef(
         aria-controls={ariaControls}
         aria-readonly={readOnly ? 'true' : undefined}
         {...baseProps}
-        className={clsx(baseProps.className, styles.root)}
+        className={clsx(baseProps.className, testUtilStyles.root, styles['radio-group'])}
         ref={__internalRootRef}
       >
         {items &&
@@ -60,14 +62,21 @@ const InternalRadioGroup = React.forwardRef(
             <RadioButton
               key={item.value}
               ref={index === radioButtonRefIndex ? radioButtonRef : undefined}
-              className={clsx(item.value === value && analyticsSelectors.selected)}
+              className={clsx(
+                styles.radio,
+                item.description && styles['radio--has-description'],
+                item.value === value && analyticsSelectors.selected
+              )}
               checked={item.value === value}
               name={name || generatedName}
               value={item.value}
-              label={item.label}
               description={item.description}
               disabled={item.disabled}
-              onChange={onChange}
+              onChange={({ detail }) => {
+                if (onChange && detail.checked) {
+                  fireNonCancelableEvent(onChange, { value: item.value });
+                }
+              }}
               controlId={item.controlId}
               readOnly={readOnly}
               style={style}
@@ -81,7 +90,9 @@ const InternalRadioGroup = React.forwardRef(
                     }
                   : {}
               )}
-            />
+            >
+              {item.label}
+            </RadioButton>
           ))}
       </div>
     );

--- a/src/radio-group/styles.scss
+++ b/src/radio-group/styles.scss
@@ -5,19 +5,10 @@
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '../internal/styles/foundation' as foundation;
-@use '../internal/generated/custom-css-properties/index.scss' as custom-props;
-@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
-$radio-size: awsui.$size-control;
-
-.root {
+.radio-group {
   @include styles.styles-reset;
   display: block;
-}
-
-.radio {
-  /*used in test-utils*/
 }
 
 .radio + .radio {
@@ -26,50 +17,4 @@ $radio-size: awsui.$size-control;
 
 .radio--has-description + .radio {
   margin-block-start: awsui.$space-scaled-xs;
-}
-
-.radio-control {
-  @include styles.make-control-size($radio-size);
-}
-
-.outline {
-  #{custom-props.$styleFocusRingBoxShadow}: 0 0 0
-    var(#{custom-props.$styleFocusRingBorderWidth}, foundation.$box-shadow-focused-width)
-    var(#{custom-props.$styleFocusRingBorderColor}, awsui.$color-border-item-focused);
-
-  @include styles.focus-highlight(
-    $gutter: 2px,
-    $border-radius: var(#{custom-props.$styleFocusRingBorderRadius}, awsui.$border-radius-control-circular-focus-ring),
-    $box-shadow: var(#{custom-props.$styleFocusRingBoxShadow})
-  );
-}
-
-.styled-circle-border {
-  stroke: awsui.$color-border-control-default;
-  fill: awsui.$color-background-control-default;
-  &.styled-circle-disabled,
-  &.styled-circle-readonly {
-    fill: awsui.$color-background-control-disabled;
-    stroke: awsui.$color-background-control-disabled;
-  }
-}
-
-.styled-circle-fill {
-  stroke: awsui.$color-background-control-checked;
-  fill: awsui.$color-foreground-control-default;
-  opacity: 0;
-  @include styles.with-motion {
-    transition: opacity awsui.$motion-duration-transition-quick awsui.$motion-easing-transition-quick;
-  }
-  &.styled-circle-checked {
-    opacity: 1;
-  }
-  &.styled-circle-disabled {
-    fill: awsui.$color-foreground-control-disabled;
-    stroke: awsui.$color-background-control-disabled;
-  }
-  &.styled-circle-readonly {
-    fill: awsui.$color-foreground-control-read-only;
-    stroke: awsui.$color-background-control-disabled;
-  }
 }

--- a/src/radio-group/test-classes/styles.scss
+++ b/src/radio-group/test-classes/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.root {
+  /*used in test-utils*/
+}

--- a/src/table/selection/selection-control.tsx
+++ b/src/table/selection/selection-control.tsx
@@ -7,8 +7,8 @@ import { useSingleTabStopNavigation, useUniqueId } from '@cloudscape-design/comp
 import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 import InternalCheckbox from '../../checkbox/internal';
+import RadioButton from '../../internal/components/radio-button';
 import { KeyCode } from '../../internal/keycode';
-import RadioButton from '../../radio-group/radio-button';
 import { SelectionProps } from './interfaces';
 
 import styles from './styles.css.js';
@@ -90,7 +90,7 @@ export function SelectionControl({
       indeterminate={indeterminate}
     />
   ) : (
-    <RadioButton {...sharedProps} controlId={controlId} name={name} value={''} label={''} />
+    <RadioButton {...sharedProps} controlId={controlId} name={name} value={''} />
   );
 
   return (

--- a/src/test-utils/dom/radio-group/index.ts
+++ b/src/test-utils/dom/radio-group/index.ts
@@ -5,13 +5,14 @@ import { escapeSelector } from '@cloudscape-design/test-utils-core/utils';
 
 import RadioButtonWrapper from './radio-button';
 
-import styles from '../../../radio-group/styles.selectors.js';
+import radioButtonStyles from '../../../internal/components/radio-button/test-classes/styles.selectors.js';
+import styles from '../../../radio-group/test-classes/styles.selectors.js';
 
 export default class RadioGroupWrapper extends ComponentWrapper {
   static rootSelector: string = styles.root;
 
   findButtons(): Array<RadioButtonWrapper> {
-    return this.findAllByClassName(styles.radio).map(r => new RadioButtonWrapper(r.getElement()));
+    return this.findAllByClassName(radioButtonStyles.root).map(r => new RadioButtonWrapper(r.getElement()));
   }
 
   findInputByValue(value: string): ElementWrapper<HTMLInputElement> | null {

--- a/src/test-utils/dom/radio-group/radio-button.ts
+++ b/src/test-utils/dom/radio-group/radio-button.ts
@@ -4,7 +4,11 @@ import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-
 
 import AbstractSwitchWrapper from '../internal/abstract-switch';
 
+import styles from '../../../internal/components/radio-button/test-classes/styles.selectors.js';
+
 export default class RadioButtonWrapper extends ComponentWrapper {
+  static rootSelector: string = styles.root;
+
   private findAbstractSwitch(): AbstractSwitchWrapper {
     return new AbstractSwitchWrapper(this.getElement());
   }

--- a/src/tiles/tile.tsx
+++ b/src/tiles/tile.tsx
@@ -6,10 +6,10 @@ import clsx from 'clsx';
 import { useMergeRefs } from '@cloudscape-design/component-toolkit/internal';
 import { copyAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
+import RadioButton from '../internal/components/radio-button';
 import { fireNonCancelableEvent } from '../internal/events';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
-import RadioButton from '../radio-group/radio-button';
 import { TilesProps } from './interfaces';
 
 import analyticsSelectors from './analytics-metadata/styles.css.js';
@@ -63,13 +63,14 @@ export const Tile = React.forwardRef(
             ref={mergedRef}
             name={name}
             value={item.value}
-            label={item.label}
             description={item.description}
             disabled={item.disabled}
             controlId={item.controlId}
             readOnly={readOnly}
             className={analyticsSelectors['radio-button']}
-          />
+          >
+            {item.label}
+          </RadioButton>
         </div>
         {item.image && <div className={clsx(styles.image, { [styles.disabled]: !!item.disabled })}>{item.image}</div>}
       </div>


### PR DESCRIPTION
### Description

In preparation for #3860:
- Separate radio-button from radio-group and let it have its own directory, under `src/internal/components`
- Update its (still internal) API to already match the API proposal (doc: `K9fjAlBZGYzg`)

### How has this been tested?

- Existing tests
- Ran in my pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
