### PR TITLE
fix: set header bg to transparent if root bg is provided

### DIFF
--- a/src/container/__tests__/__snapshots__/styles.test.tsx.snap
+++ b/src/container/__tests__/__snapshots__/styles.test.tsx.snap
@@ -1,0 +1,152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getContentStyles handles all possible style configurations 1`] = `
+{
+  "paddingBlock": undefined,
+  "paddingInline": undefined,
+}
+`;
+
+exports[`getContentStyles handles all possible style configurations 2`] = `
+{
+  "paddingBlock": undefined,
+  "paddingInline": undefined,
+}
+`;
+
+exports[`getContentStyles handles all possible style configurations 3`] = `
+{
+  "paddingBlock": "16px",
+  "paddingInline": "20px",
+}
+`;
+
+exports[`getFooterStyles handles all possible style configurations 1`] = `
+{
+  "borderColor": undefined,
+  "borderWidth": undefined,
+  "paddingBlock": undefined,
+  "paddingInline": undefined,
+}
+`;
+
+exports[`getFooterStyles handles all possible style configurations 2`] = `
+{
+  "borderColor": undefined,
+  "borderWidth": undefined,
+  "paddingBlock": undefined,
+  "paddingInline": undefined,
+}
+`;
+
+exports[`getFooterStyles handles all possible style configurations 3`] = `
+{
+  "borderColor": "#e0e0e0",
+  "borderWidth": "1px",
+  "paddingBlock": "12px",
+  "paddingInline": "20px",
+}
+`;
+
+exports[`getHeaderStyles handles all possible style configurations 1`] = `
+{
+  "borderRadius": undefined,
+  "paddingBlock": undefined,
+  "paddingInline": undefined,
+}
+`;
+
+exports[`getHeaderStyles handles all possible style configurations 2`] = `
+{
+  "borderRadius": undefined,
+  "paddingBlock": undefined,
+  "paddingInline": undefined,
+}
+`;
+
+exports[`getHeaderStyles handles all possible style configurations 3`] = `
+{
+  "background": "transparent",
+  "borderRadius": "8px",
+  "paddingBlock": "12px",
+  "paddingInline": "20px",
+}
+`;
+
+exports[`getMediaStyles handles all possible style configurations 1`] = `
+{
+  "borderEndEndRadius": "0px",
+  "borderEndStartRadius": "0px",
+  "borderRadius": undefined,
+}
+`;
+
+exports[`getMediaStyles handles all possible style configurations 2`] = `
+{
+  "borderEndEndRadius": "0px",
+  "borderEndStartRadius": "0px",
+  "borderRadius": undefined,
+}
+`;
+
+exports[`getMediaStyles handles all possible style configurations 3`] = `
+{
+  "borderEndEndRadius": "0px",
+  "borderEndStartRadius": "0px",
+  "borderRadius": "8px",
+}
+`;
+
+exports[`getMediaStyles handles all possible style configurations 4`] = `
+{
+  "borderEndEndRadius": "0px",
+  "borderRadius": undefined,
+  "borderStartEndRadius": "0px",
+}
+`;
+
+exports[`getMediaStyles handles all possible style configurations 5`] = `
+{
+  "borderEndEndRadius": "0px",
+  "borderRadius": undefined,
+  "borderStartEndRadius": "0px",
+}
+`;
+
+exports[`getMediaStyles handles all possible style configurations 6`] = `
+{
+  "borderEndEndRadius": "0px",
+  "borderRadius": "8px",
+  "borderStartEndRadius": "0px",
+}
+`;
+
+exports[`getRootStyles handles all possible style configurations 1`] = `
+{
+  "background": undefined,
+  "borderColor": undefined,
+  "borderRadius": undefined,
+  "borderWidth": undefined,
+  "boxShadow": undefined,
+}
+`;
+
+exports[`getRootStyles handles all possible style configurations 2`] = `
+{
+  "background": undefined,
+  "borderColor": undefined,
+  "borderRadius": undefined,
+  "borderWidth": undefined,
+  "boxShadow": undefined,
+}
+`;
+
+exports[`getRootStyles handles all possible style configurations 3`] = `
+{
+  "background": "#ffffff",
+  "borderColor": "#e0e0e0",
+  "borderRadius": "8px",
+  "borderWidth": "1px",
+  "boxShadow": "0 1px 3px rgba(0,0,0,0.1)",
+}
+`;

--- a/src/container/__tests__/styles.test.tsx
+++ b/src/container/__tests__/styles.test.tsx
@@ -1,54 +1,48 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import {
-  getContentStyles,
-  getContentWrapperStyles,
-  getFooterStyles,
-  getHeaderStyles,
-  getMediaStyles,
-  getRootStyles,
-} from '../style';
+import { getContentStyles, getFooterStyles, getHeaderStyles, getMediaStyles, getRootStyles } from '../style';
 
 jest.mock('../../internal/environment', () => ({
   SYSTEM: 'core',
 }));
 
-describe('Container style utilities', () => {
+const allStyles = {
+  root: {
+    background: '#ffffff',
+    borderColor: '#e0e0e0',
+    borderRadius: '8px',
+    borderWidth: '1px',
+    boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+  },
+  content: {
+    paddingBlock: '16px',
+    paddingInline: '20px',
+  },
+  header: {
+    paddingBlock: '12px',
+    paddingInline: '20px',
+  },
+  footer: {
+    root: {
+      paddingBlock: '12px',
+      paddingInline: '20px',
+    },
+    divider: {
+      borderColor: '#e0e0e0',
+      borderWidth: '1px',
+    },
+  },
+};
+
+describe('getRootStyles', () => {
   afterEach(() => {
     jest.resetModules();
   });
 
-  test('getRootStyles returns empty object when style is undefined', () => {
-    expect(getRootStyles(undefined)).toEqual({});
-  });
-
-  test('getContentStyles returns empty object when style is undefined', () => {
-    expect(getContentStyles(undefined)).toEqual({});
-  });
-
-  test('getContentWrapperStyles returns empty object when style is undefined', () => {
-    expect(getContentWrapperStyles(undefined)).toEqual({});
-  });
-
-  test('getContentWrapperStyles returns borderRadius when provided', () => {
-    expect(getContentWrapperStyles({ root: { borderRadius: '20px' } })).toEqual({
-      borderRadius: '20px',
-    });
-  });
-
-  test('getHeaderStyles returns empty object when style is undefined', () => {
-    expect(getHeaderStyles(undefined)).toEqual({});
-  });
-
-  test('getFooterStyles returns empty object when style is undefined', () => {
-    expect(getFooterStyles(undefined)).toEqual({});
-  });
-
-  test('getMediaStyles returns border radius properties when style is undefined', () => {
-    expect(getMediaStyles('top', undefined)).toEqual({
-      borderEndEndRadius: '0px',
-      borderEndStartRadius: '0px',
-    });
+  test('handles all possible style configurations', () => {
+    expect(getRootStyles(undefined)).toMatchSnapshot();
+    expect(getRootStyles({})).toMatchSnapshot();
+    expect(getRootStyles(allStyles)).toMatchSnapshot();
   });
 
   test('returns empty object when SYSTEM is not core', async () => {
@@ -57,14 +51,108 @@ describe('Container style utilities', () => {
       SYSTEM: 'visual-refresh',
     }));
 
-    const styleModule = await import('../style');
-    const style = { root: { background: 'red' } };
+    const { getRootStyles: getRootStylesNonCore } = await import('../style');
 
-    expect(styleModule.getRootStyles(style)).toEqual({});
-    expect(styleModule.getContentStyles(style)).toEqual({});
-    expect(styleModule.getContentWrapperStyles(style)).toEqual({});
-    expect(styleModule.getHeaderStyles(style)).toEqual({});
-    expect(styleModule.getFooterStyles(style)).toEqual({});
-    expect(styleModule.getMediaStyles('top', style)).toEqual({});
+    const result = getRootStylesNonCore(allStyles);
+    expect(result).toEqual({});
+  });
+});
+
+describe('getContentStyles', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('handles all possible style configurations', () => {
+    expect(getContentStyles(undefined)).toMatchSnapshot();
+    expect(getContentStyles({})).toMatchSnapshot();
+    expect(getContentStyles(allStyles)).toMatchSnapshot();
+  });
+
+  test('returns empty object when SYSTEM is not core', async () => {
+    jest.resetModules();
+    jest.doMock('../../internal/environment', () => ({
+      SYSTEM: 'visual-refresh',
+    }));
+
+    const { getContentStyles: getContentStylesNonCore } = await import('../style');
+
+    const result = getContentStylesNonCore(allStyles);
+    expect(result).toEqual({});
+  });
+});
+
+describe('getHeaderStyles', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('handles all possible style configurations', () => {
+    expect(getHeaderStyles(undefined)).toMatchSnapshot();
+    expect(getHeaderStyles({})).toMatchSnapshot();
+    expect(getHeaderStyles(allStyles)).toMatchSnapshot();
+  });
+
+  test('returns empty object when SYSTEM is not core', async () => {
+    jest.resetModules();
+    jest.doMock('../../internal/environment', () => ({
+      SYSTEM: 'visual-refresh',
+    }));
+
+    const { getHeaderStyles: getHeaderStylesNonCore } = await import('../style');
+
+    const result = getHeaderStylesNonCore(allStyles);
+    expect(result).toEqual({});
+  });
+});
+
+describe('getFooterStyles', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('handles all possible style configurations', () => {
+    expect(getFooterStyles(undefined)).toMatchSnapshot();
+    expect(getFooterStyles({})).toMatchSnapshot();
+    expect(getFooterStyles(allStyles)).toMatchSnapshot();
+  });
+
+  test('returns empty object when SYSTEM is not core', async () => {
+    jest.resetModules();
+    jest.doMock('../../internal/environment', () => ({
+      SYSTEM: 'visual-refresh',
+    }));
+
+    const { getFooterStyles: getFooterStylesNonCore } = await import('../style');
+
+    const result = getFooterStylesNonCore(allStyles);
+    expect(result).toEqual({});
+  });
+});
+
+describe('getMediaStyles', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('handles all possible style configurations', () => {
+    expect(getMediaStyles('top', undefined)).toMatchSnapshot();
+    expect(getMediaStyles('top', {})).toMatchSnapshot();
+    expect(getMediaStyles('top', allStyles)).toMatchSnapshot();
+    expect(getMediaStyles('side', undefined)).toMatchSnapshot();
+    expect(getMediaStyles('side', {})).toMatchSnapshot();
+    expect(getMediaStyles('side', allStyles)).toMatchSnapshot();
+  });
+
+  test('returns empty object when SYSTEM is not core', async () => {
+    jest.resetModules();
+    jest.doMock('../../internal/environment', () => ({
+      SYSTEM: 'visual-refresh',
+    }));
+
+    const { getMediaStyles: getMediaStylesNonCore } = await import('../style');
+
+    const result = getMediaStylesNonCore('top', allStyles);
+    expect(result).toEqual({});
   });
 });

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -14,14 +14,7 @@ import { InternalBaseComponentProps } from '../internal/hooks/use-base-component
 import { useMobile } from '../internal/hooks/use-mobile';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { ContainerProps } from './interfaces';
-import {
-  getContentStyles,
-  getContentWrapperStyles,
-  getFooterStyles,
-  getHeaderStyles,
-  getMediaStyles,
-  getRootStyles,
-} from './style';
+import { getContentStyles, getFooterStyles, getHeaderStyles, getMediaStyles, getRootStyles } from './style';
 import { StickyHeaderContext, useStickyHeader } from './use-sticky-header';
 
 import analyticsSelectors from './analytics-metadata/styles.css.js';
@@ -151,7 +144,6 @@ export default function InternalContainer({
         id={contentId}
         ref={__subStepRef}
         className={clsx(styles['content-wrapper'], fitHeight && styles['content-wrapper-fit-height'])}
-        style={getContentWrapperStyles(style)}
       >
         {header && (
           <ContainerHeaderContextProvider>

--- a/src/container/style.tsx
+++ b/src/container/style.tsx
@@ -28,16 +28,6 @@ export function getContentStyles(style: ContainerProps.Style | undefined) {
   };
 }
 
-export function getContentWrapperStyles(style: ContainerProps.Style | undefined) {
-  if (SYSTEM !== 'core') {
-    return {};
-  }
-
-  return {
-    borderRadius: style?.root?.borderRadius,
-  };
-}
-
 export function getHeaderStyles(style: ContainerProps.Style | undefined) {
   if (SYSTEM !== 'core') {
     return {};


### PR DESCRIPTION
### Description

Changes done:

- Fix for AWSUI-61442
- Introduces unit tests

Related links, issue #, if available: n/a

### How has this been tested?

Visual regression test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
