### PR TITLE
fix: Remove focus outline from tree-view focus target

### DIFF
--- a/src/tree-view/tree-item/styles.scss
+++ b/src/tree-view/tree-item/styles.scss
@@ -35,6 +35,7 @@ $item-toggle-column-width: 28px;
     }
 
     > .expand-toggle-wrapper {
+      display: grid;
       grid-column: 1;
       grid-row: 1;
       padding-inline-end: awsui.$space-scaled-xxs;
@@ -56,7 +57,10 @@ $item-toggle-column-width: 28px;
   }
 }
 
-.tree-item-structured-item,
-.tree-item-focus-target {
+.tree-item-structured-item {
   /* used in keyboard navigation */
+}
+
+.tree-item-focus-target {
+  outline: none;
 }


### PR DESCRIPTION
### Description

In firefox, an outline is added except when outline is set to none. The display grid is added so the toggle aligns well in firefox. 

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
