### PR TITLE
revert: Prevent list item jump on hover in virtual scrolling (#3943)

### DIFF
--- a/src/internal/components/selectable-item/styles.scss
+++ b/src/internal/components/selectable-item/styles.scss
@@ -206,60 +206,6 @@
     &:first-of-type:not(.selected, .highlighted) {
       border-block-start-color: awsui.$color-border-dropdown-item-top;
     }
-
-    // When using virtual scrolling, use box-shadows to mimic changing border
-    // width and set the actual border to a fixed width to prevent jumping
-    // behaviour when hovering selectable items
-
-    $virtual-border-offset: calc(#{awsui.$border-item-width} - #{awsui.$border-divider-list-width});
-    $virtual-border-offset-double: calc(2 * #{awsui.$border-item-width} - #{awsui.$border-divider-list-width});
-
-    &.highlighted:not(.selected),
-    &.selected {
-      border-width: awsui.$border-divider-list-width;
-      padding-block: calc(#{styles.$option-padding-vertical} + #{$virtual-border-offset});
-      padding-inline: calc(#{styles.$control-padding-horizontal} + #{$virtual-border-offset});
-
-      &.pad-bottom {
-        padding-block-end: calc(#{styles.$option-padding-vertical} + #{awsui.$space-xxxs} + #{$virtual-border-offset});
-      }
-
-      &.child {
-        padding-inline-start: calc(#{awsui.$space-xxl} + #{$virtual-border-offset});
-      }
-
-      &.parent.interactiveGroups {
-        padding-block: calc(#{styles.$group-option-padding-vertical} + #{$virtual-border-offset});
-      }
-    }
-
-    &.highlighted:not(.selected) {
-      box-shadow: inset 0 0 0 $virtual-border-offset awsui.$color-border-dropdown-item-hover;
-
-      &.is-keyboard {
-        box-shadow: inset 0 0 0 $virtual-border-offset awsui.$color-border-dropdown-item-focused;
-      }
-    }
-
-    &.selected {
-      box-shadow: inset 0 0 0 $virtual-border-offset awsui.$color-border-dropdown-item-selected;
-
-      &.highlighted {
-        box-shadow:
-          inset 0 0 0 $virtual-border-offset awsui.$color-border-dropdown-item-selected,
-          inset 0 0 0 $virtual-border-offset-double awsui.$color-border-dropdown-item-hover;
-
-        &.is-keyboard {
-          box-shadow:
-            inset 0 0 0 $virtual-border-offset awsui.$color-border-dropdown-item-selected,
-            inset 0 0 0 $virtual-border-offset-double awsui.$color-border-dropdown-item-focused;
-        }
-      }
-    }
-
-    &.parent:not(.interactiveGroups) {
-      border-block-start-color: awsui.$color-border-dropdown-group;
-    }
   }
 }
 

--- a/src/select/parts/virtual-list.tsx
+++ b/src/select/parts/virtual-list.tsx
@@ -100,10 +100,6 @@ const VirtualListOpen = forwardRef(
       withScrollbar,
     });
 
-    // Adjust totalSize to account for 1px overlap per item (matching the position adjustment in renderOptions)
-    const overlapAdjustment = filteredOptions.length;
-    const adjustedTotalSize = totalSize - overlapAdjustment;
-
     return (
       <OptionsList {...menuProps} stickyItemBlockSize={stickySize} ref={menuRef}>
         {finalOptions}
@@ -111,7 +107,7 @@ const VirtualListOpen = forwardRef(
           aria-hidden="true"
           key="total-size"
           className={styles['layout-strut']}
-          style={{ height: adjustedTotalSize - stickySize }}
+          style={{ height: totalSize - stickySize }}
         />
         {listBottom ? (
           <div role="option" className={styles['list-bottom']}>

--- a/src/select/utils/render-options.tsx
+++ b/src/select/utils/render-options.tsx
@@ -65,15 +65,11 @@ export const renderOptions = ({
     const ListItem = useInteractiveGroups ? MultiselectItem : Item;
     const isSticky = firstOptionSticky && globalIndex === 0;
 
-    // Adjust virtual position to create 1px overlap between items (matching non-virtual behavior)
-    // Subtract globalIndex to shift each item up by 1px per item
-    const adjustedVirtualPosition = virtualItem ? virtualItem.start - globalIndex : undefined;
-
     return (
       <ListItem
         key={globalIndex}
         {...props}
-        virtualPosition={adjustedVirtualPosition}
+        virtualPosition={virtualItem && virtualItem.start}
         ref={isSticky && stickyOptionRef ? stickyOptionRef : virtualItem && virtualItem.measureRef}
         padBottom={padBottom}
         screenReaderContent={screenReaderContent}


### PR DESCRIPTION
This reverts commit 2f763cb4d7b657d550d1fd9c568a2630dd5145ff.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
