### PR TITLE
chore: Use flex-start instead of start in horizontal radio-group styles

### DIFF
--- a/src/radio-group/styles.scss
+++ b/src/radio-group/styles.scss
@@ -15,7 +15,7 @@
 
   &.horizontal-group {
     display: flex;
-    align-items: start;
+    align-items: flex-start;
     flex-wrap: wrap;
     gap: awsui.$space-scaled-l;
   }


### PR DESCRIPTION
### Description

`align-items: start` breaks the build for customers who have
1. old tooling (probably, an old version of Autoprefixer), which causes warnings about features that nowadays actually have widespread browser support
2. their setup configured to treat warnings as errors when building the production assets

Breaking build: `7606547220`

### How has this been tested?

- Existing tests
- Manually verified the horizontal radio group permutations dev page
- Dry run: `7607221858`

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
