### PR TITLE
fix: Make navigable group core-only

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -17801,6 +17801,9 @@ need to be direct children of the group:
     },
   ],
   "releaseStatus": "stable",
+  "systemTags": [
+    "core",
+  ],
 }
 `;
 

--- a/src/navigable-group/index.tsx
+++ b/src/navigable-group/index.tsx
@@ -12,9 +12,6 @@ import InternalNavigableGroup from './internal';
 
 export { NavigableGroupProps };
 
-/**
- * @awsuiSystem core
- */
 const NavigableGroup = React.forwardRef(({ ...rest }: NavigableGroupProps, ref: React.Ref<NavigableGroupProps.Ref>) => {
   const baseProps = getBaseProps(rest);
   const baseComponentProps = useBaseComponent('NavigableGroup');
@@ -24,4 +21,8 @@ const NavigableGroup = React.forwardRef(({ ...rest }: NavigableGroupProps, ref: 
 });
 
 applyDisplayName(NavigableGroup, 'NavigableGroup');
+
+/**
+ * @awsuiSystem core
+ */
 export default NavigableGroup;


### PR DESCRIPTION
### Description

For the system tag to be extracted by Documenter, the comment needs to be above the `export` statement.

### How has this been tested?

- Updated the snapshot with `npm run build && npx jest -c jest.unit.config.js -u src/__tests__/snapshot-tests/documenter.test.ts` (part of this PR diff)
- Building the change in my website pipeline to make sure the website doesn't break: `7609312490`

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
