### PR TITLE
fix: Fix AppLayoutToolbar breadcrumbs SSR glitch (take two)

### DIFF
--- a/src/app-layout/__tests__/skeleton.test.tsx
+++ b/src/app-layout/__tests__/skeleton.test.tsx
@@ -66,7 +66,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'] }, () => {
       );
       expect(wrapper.findToolbar()).toBeFalsy();
       expect(wrapper.findNavigation()).toBeFalsy();
-      expect(wrapper.findBreadcrumbs()).toBeFalsy();
+      expect(wrapper.findBreadcrumbs()).toBeTruthy(); // Needed for SSR
       expect(wrapper.find(getFunnelKeySelector('funnel-name'))).toBeTruthy();
       expect(wrapper.findNotifications()).toBeFalsy();
       expect(wrapper.findTools()).toBeFalsy();

--- a/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
@@ -51,7 +51,11 @@ export const ToolbarSkeletonStructure = React.forwardRef<HTMLElement, ToolbarSke
   ({ ownBreadcrumbs, discoveredBreadcrumbs }, ref) => (
     <ToolbarSlot ref={ref}>
       <ToolbarContainer>
-        <ToolbarBreadcrumbsSection ownBreadcrumbs={ownBreadcrumbs} discoveredBreadcrumbs={discoveredBreadcrumbs} />
+        <ToolbarBreadcrumbsSection
+          ownBreadcrumbs={ownBreadcrumbs}
+          discoveredBreadcrumbs={discoveredBreadcrumbs}
+          includeTestUtils={true}
+        />
         <div className={toolbarStyles['universal-toolbar-drawers']} />
       </ToolbarContainer>
     </ToolbarSlot>


### PR DESCRIPTION
### Description

I previously submitted a fix for a visual glitch when rendering the `AppLayoutToolbar` breadcrumbs with SSR: #3856 Unfortunately, although that fix was merged, I'm still seeing the glitch.

I investigated and found that while the original PR commit fixed the glitch, it was no longer effective after making updates in response to suggestions. That's my fault; I should've validated those updates. This PR restores the key fixes.

Fixes #3848

### How has this been tested?

I have an [updated branch](https://github.com/TrevorBurnham/cloudscape-components/tree/applayouttoolbar-ssr-updated) with an SSR server. Check out that branch and run `npm install && npm run dev:ssr`. Load http://localhost:3000 in a browser and you can see that the glitch is fixed (thanks to the change in this PR). Check out `HEAD~1` and you can see that the glitch occurs without this change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
