### PR TITLE
fix: Prevent use-table-interaction-metrics from calling debounced function after unmounting

### DIFF
--- a/src/internal/hooks/use-table-interaction-metrics/__tests__/use-table-interaction-metrics.test.tsx
+++ b/src/internal/hooks/use-table-interaction-metrics/__tests__/use-table-interaction-metrics.test.tsx
@@ -273,5 +273,22 @@ describe('useTableInteractionMetrics', () => {
         })
       );
     });
+
+    test('componentUpdated should not be called after unmount', () => {
+      const { setLastUserAction, rerender, unmount } = renderUseTableInteractionMetricsHook({});
+
+      setLastUserAction('filter');
+      rerender({ loading: true });
+      rerender({ loading: false });
+
+      // Unmount before the debounced callback fires
+      unmount();
+
+      // Run timers to trigger the debounced callback
+      jest.runAllTimers();
+
+      // componentUpdated should not have been called because component was unmounted
+      expect(ComponentMetrics.componentUpdated).toHaveBeenCalledTimes(0);
+    });
   });
 });

--- a/src/internal/hooks/use-table-interaction-metrics/index.ts
+++ b/src/internal/hooks/use-table-interaction-metrics/index.ts
@@ -49,9 +49,17 @@ export function useTableInteractionMetrics<T>({
   const lastUserAction = useRef<{ name: string; time: number } | null>(null);
   const capturedUserAction = useRef<string | null>(null);
   const loadingStartTime = useRef<number | null>(null);
+  const isMountedRef = useRef(true);
 
   const metadata = useRef({ itemCount, getComponentIdentifier, getComponentConfiguration, interactionMetadata });
   metadata.current = { itemCount, getComponentIdentifier, getComponentConfiguration, interactionMetadata };
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (isInFunnel) {
@@ -94,6 +102,9 @@ export function useTableInteractionMetrics<T>({
   }, [instanceIdentifier, loading, taskInteractionId, isInFunnel]);
 
   const debouncedUpdated = useDebounceCallback(() => {
+    if (!isMountedRef.current) {
+      return;
+    }
     ComponentMetrics.componentUpdated({
       taskInteractionId,
       componentName: 'table',


### PR DESCRIPTION
### Description

Added a ref to prevent calling the debounced function after unmounting, this matches an [existing implementation](https://github.com/cloudscape-design/components/blob/fix-table-D343619604/src/internal/analytics/components/analytics-funnel.tsx#L366)

Related links, issue #, if available: `D343619604`

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
