### PR TITLE
feat: Add reference tokens to theming API in Core

### DIFF
--- a/src-themeable/internal/template/internal/generated/theming/index.cjs.d.ts
+++ b/src-themeable/internal/template/internal/generated/theming/index.cjs.d.ts
@@ -1,8 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { GlobalValue, ThemePreset, TypedModeValueOverride } from '@cloudscape-design/theming-build';
+import {
+  GlobalValue,
+  Override,
+  ReferenceTokens,
+  ThemePreset,
+  TypedModeValueOverride,
+} from '@cloudscape-design/theming-build';
 
-export interface TypedOverride {
+export interface TypedOverride extends Override {
   tokens: Partial<Record<string, GlobalValue | TypedModeValueOverride>>;
+
+  /**
+   * @awsuiSystem core
+   */
+  referenceTokens?: ReferenceTokens;
 }
 export const preset: ThemePreset;

--- a/src/internal/generated/theming/index.d.ts
+++ b/src/internal/generated/theming/index.d.ts
@@ -1,9 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 /* This file is only for the compiler. The artifacts will contain the generated file instead. */
-import { GlobalValue, ThemePreset, TypedModeValueOverride } from '@cloudscape-design/theming-runtime';
+import {
+  GlobalValue,
+  Override,
+  ReferenceTokens,
+  ThemePreset,
+  TypedModeValueOverride,
+} from '@cloudscape-design/theming-runtime';
 
-export interface TypedOverride {
+export interface TypedOverride extends Override {
   tokens: Partial<Record<string, GlobalValue | TypedModeValueOverride>>;
+
+  /**
+   * @awsuiSystem core
+   */
+  referenceTokens?: ReferenceTokens;
 }
 export declare const preset: ThemePreset;


### PR DESCRIPTION
### Description

This won't be merged until the prerequisites have been merged, but this is in preparation for release. It makes the reference token API available to use for customers and in our demos.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
