### PR TITLE
chore: Updates error boundaries i18n messages format

### DIFF
--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -224,8 +224,9 @@ export interface I18nFormatArgTypes {
   }
   "error-boundary": {
     "i18nStrings.headerText": never;
-    "i18nStrings.descriptionText": never;
-    "i18nStrings.descriptionWithFeedbackText": never;
+    "i18nStrings.descriptionText": {
+      "hasFeedback": string;
+    }
     "i18nStrings.refreshActionText": never;
   }
   "file-token-group": {

--- a/src/i18n/messages/all.ar.json
+++ b/src/i18n/messages/all.ar.json
@@ -177,8 +177,7 @@
   },
   "error-boundary": {
     "i18nStrings.headerText": "خطأ غير متوقع، فشل عرض المحتوى",
-    "i18nStrings.descriptionText": "حدِّث الصفحة للمحاولة مرة أخرى.",
-    "i18nStrings.descriptionWithFeedbackText": "حدِّث الصفحة للمحاولة مرة أخرى. نحن نتتبع هذه المشكلة، ولكن يمكنك مشاركة <Feedback>المزيد من المعلومات هنا</Feedback>.",
+    "i18nStrings.descriptionText": "{hasFeedback, select, true {حدِّث الصفحة للمحاولة مرة أخرى. نحن نتتبع هذه المشكلة، ولكن يمكنك مشاركة <Feedback>المزيد من المعلومات هنا</Feedback>.} other {حدِّث الصفحة للمحاولة مرة أخرى.}}",
     "i18nStrings.refreshActionText": "تحديث الصفحة"
   },
   "file-token-group": {

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -177,8 +177,7 @@
   },
   "error-boundary": {
     "i18nStrings.headerText": "Unerwarteter Fehler, Inhalt konnte nicht angezeigt werden",
-    "i18nStrings.descriptionText": "Aktualisieren Sie die Seite, um es erneut zu versuchen.",
-    "i18nStrings.descriptionWithFeedbackText": "Aktualisieren Sie die Seite, um es erneut zu versuchen. Wir verfolgen dieses Problem nach, Sie können aber <Feedback>hier zusätzliche Informationen mitteilen</Feedback>.",
+    "i18nStrings.descriptionText": "{hasFeedback, select, true {Aktualisieren Sie die Seite, um es erneut zu versuchen. Wir verfolgen dieses Problem nach, Sie können aber <Feedback>hier zusätzliche Informationen mitteilen</Feedback>.} other {Aktualisieren Sie die Seite, um es erneut zu versuchen.}}",
     "i18nStrings.refreshActionText": "Seite aktualisieren"
   },
   "file-token-group": {

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -177,8 +177,7 @@
   },
   "error-boundary": {
     "i18nStrings.headerText": "Unexpected error, content failed to show",
-    "i18nStrings.descriptionText": "Refresh to try again.",
-    "i18nStrings.descriptionWithFeedbackText": "Refresh to try again. We are tracking this issue, but you can share <Feedback>more information here</Feedback>.",
+    "i18nStrings.descriptionText": "{hasFeedback, select, true {Refresh to try again. We are tracking this issue, but you can share <Feedback>more information here</Feedback>.} other {Refresh to try again.}}",
     "i18nStrings.refreshActionText": "Refresh page"
   },
   "file-token-group": {

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -177,8 +177,7 @@
   },
   "error-boundary": {
     "i18nStrings.headerText": "Unexpected error, content failed to show",
-    "i18nStrings.descriptionText": "Refresh to try again.",
-    "i18nStrings.descriptionWithFeedbackText": "Refresh to try again. We are tracking this issue, but you can share <Feedback>more information here</Feedback>.",
+    "i18nStrings.descriptionText": "{hasFeedback, select, true {Refresh to try again. We are tracking this issue, but you can share <Feedback>more information here</Feedback>.} other {Refresh to try again.}}",
     "i18nStrings.refreshActionText": "Refresh page"
   },
   "file-token-group": {

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -177,8 +177,7 @@
   },
   "error-boundary": {
     "i18nStrings.headerText": "Error inesperado. No se pudo mostrar el contenido",
-    "i18nStrings.descriptionText": "Actualice para intentarlo de nuevo.",
-    "i18nStrings.descriptionWithFeedbackText": "Actualice para intentarlo de nuevo. Estamos siguiendo este problema, pero puede compartir <Feedback>más información aquí</Feedback>.",
+    "i18nStrings.descriptionText": "{hasFeedback, select, true {Actualice para intentarlo de nuevo. Estamos siguiendo este problema, pero puede compartir <Feedback>más información aquí</Feedback>.} other {Actualice para intentarlo de nuevo.}}",
     "i18nStrings.refreshActionText": "Actualizar página"
   },
   "file-token-group": {

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -177,8 +177,7 @@
   },
   "error-boundary": {
     "i18nStrings.headerText": "Erreur inattendue, le contenu n'a pas pu s'afficher",
-    "i18nStrings.descriptionText": "Actualisez pour réessayer.",
-    "i18nStrings.descriptionWithFeedbackText": "Actualisez pour réessayer. Nous suivons ce problème mais vous pouvez fournir <Feedback>plus d'informations ici</Feedback>.",
+    "i18nStrings.descriptionText": "{hasFeedback, select, true {Actualisez pour réessayer. Nous suivons ce problème mais vous pouvez fournir <Feedback>plus d'informations ici</Feedback>.} other {Actualisez pour réessayer.}}",
     "i18nStrings.refreshActionText": "Actualiser la page"
   },
   "file-token-group": {

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -177,8 +177,7 @@
   },
   "error-boundary": {
     "i18nStrings.headerText": "Kesalahan tak terduga, konten gagal ditampilkan",
-    "i18nStrings.descriptionText": "Refresh untuk mencoba lagi.",
-    "i18nStrings.descriptionWithFeedbackText": "Refresh untuk mencoba lagi. Kami sedang melacak masalah ini, tetapi Anda dapat membagikan <Feedback>informasi selengkapnya di sini</Feedback>.",
+    "i18nStrings.descriptionText": "{hasFeedback, select, true {Refresh untuk mencoba lagi. Kami sedang melacak masalah ini, tetapi Anda dapat membagikan <Feedback>informasi selengkapnya di sini</Feedback>.} other {Refresh untuk mencoba lagi.}}",
     "i18nStrings.refreshActionText": "Segarkan halaman"
   },
   "file-token-group": {

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -177,8 +177,7 @@
   },
   "error-boundary": {
     "i18nStrings.headerText": "Errore imprevisto, impossibile visualizzare il contenuto",
-    "i18nStrings.descriptionText": "Aggiorna la pagina per riprovare.",
-    "i18nStrings.descriptionWithFeedbackText": "Aggiorna la pagina per riprovare. Stiamo monitorando il problema, ma puoi condividere <Feedback>maggiori informazioni qui</Feedback>.",
+    "i18nStrings.descriptionText": "{hasFeedback, select, true {Aggiorna la pagina per riprovare. Stiamo monitorando il problema, ma puoi condividere <Feedback>maggiori informazioni qui</Feedback>.} other {Aggiorna la pagina per riprovare.}}",
     "i18nStrings.refreshActionText": "Aggiorna pagina"
   },
   "file-token-group": {

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -177,8 +177,7 @@
   },
   "error-boundary": {
     "i18nStrings.headerText": "予期しないエラー、コンテンツを表示できませんでした",
-    "i18nStrings.descriptionText": "更新してもう一度お試しください。",
-    "i18nStrings.descriptionWithFeedbackText": "更新してもう一度お試しください。この問題は現在追跡中ですが、<Feedback>詳しい情報はこちら</Feedback>で共有できます。",
+    "i18nStrings.descriptionText": "{hasFeedback, select, true {更新してもう一度お試しください。この問題は現在追跡中ですが、<Feedback>詳しい情報はこちら</Feedback>で共有できます。} other {更新してもう一度お試しください。}}",
     "i18nStrings.refreshActionText": "ページを更新"
   },
   "file-token-group": {

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -177,8 +177,7 @@
   },
   "error-boundary": {
     "i18nStrings.headerText": "예상치 못한 오류 발생, 콘텐츠 표시 실패",
-    "i18nStrings.descriptionText": "새로 고침하여 다시 시도하세요.",
-    "i18nStrings.descriptionWithFeedbackText": "새로 고침하여 다시 시도하세요. 현재 이 문제를 추적하고 있지만 <Feedback>여기에서 더 자세한 정보를</Feedback> 공유할 수 있습니다.",
+    "i18nStrings.descriptionText": "{hasFeedback, select, true {새로 고침하여 다시 시도하세요. 현재 이 문제를 추적하고 있지만 <Feedback>여기에서 더 자세한 정보를</Feedback> 공유할 수 있습니다.} other {새로 고침하여 다시 시도하세요.}}",
     "i18nStrings.refreshActionText": "페이지 새로고침"
   },
   "file-token-group": {

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -177,8 +177,7 @@
   },
   "error-boundary": {
     "i18nStrings.headerText": "Erro inesperado, falha na exibição do conteúdo",
-    "i18nStrings.descriptionText": "Atualize para tentar novamente.",
-    "i18nStrings.descriptionWithFeedbackText": "Atualize para tentar novamente. Estamos rastreando esse problema, mas você pode compartilhar <Feedback>mais informações aqui</Feedback>.",
+    "i18nStrings.descriptionText": "{hasFeedback, select, true {Atualize para tentar novamente. Estamos rastreando esse problema, mas você pode compartilhar <Feedback>mais informações aqui</Feedback>.} other {Atualize para tentar novamente.}}",
     "i18nStrings.refreshActionText": "Atualizar página"
   },
   "file-token-group": {

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -177,8 +177,7 @@
   },
   "error-boundary": {
     "i18nStrings.headerText": "Beklenmeyen hata, içerik gösterilemedi",
-    "i18nStrings.descriptionText": "Yeniden denemek için yenileyin.",
-    "i18nStrings.descriptionWithFeedbackText": "Yeniden denemek için yenileyin. Bu sorunu takip ediyoruz ancak <Feedback>buradan daha fazla bilgi</Feedback> paylaşabilirsiniz.",
+    "i18nStrings.descriptionText": "{hasFeedback, select, true {Yeniden denemek için yenileyin. Bu sorunu takip ediyoruz ancak <Feedback>buradan daha fazla bilgi</Feedback> paylaşabilirsiniz.} other {Yeniden denemek için yenileyin.}}",
     "i18nStrings.refreshActionText": "Sayfayı yenile"
   },
   "file-token-group": {

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -177,8 +177,7 @@
   },
   "error-boundary": {
     "i18nStrings.headerText": "意外错误，内容无法显示",
-    "i18nStrings.descriptionText": "刷新再试一次。",
-    "i18nStrings.descriptionWithFeedbackText": "刷新再试一次。我们正在跟踪此问题，但您可以<Feedback>在此处共享更多信息</Feedback>。",
+    "i18nStrings.descriptionText": "{hasFeedback, select, true {刷新再试一次。我们正在跟踪此问题，但您可以<Feedback>在此处共享更多信息</Feedback>。} other {刷新再试一次。}}",
     "i18nStrings.refreshActionText": "刷新页面"
   },
   "file-token-group": {

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -177,8 +177,7 @@
   },
   "error-boundary": {
     "i18nStrings.headerText": "意外錯誤，內容無法顯示",
-    "i18nStrings.descriptionText": "重新整理以再試一次。",
-    "i18nStrings.descriptionWithFeedbackText": "重新整理以再試一次。我們正在追蹤此問題，但您可以在此處分享<Feedback>更多資訊</Feedback>。",
+    "i18nStrings.descriptionText": "{hasFeedback, select, true {重新整理以再試一次。我們正在追蹤此問題，但您可以在此處分享<Feedback>更多資訊</Feedback>。} other {重新整理以再試一次。}}",
     "i18nStrings.refreshActionText": "重新整理頁面"
   },
   "file-token-group": {


### PR DESCRIPTION
### Description

This is needed for https://github.com/cloudscape-design/components/pull/3736.

The updated messages format no longer requires two separate messages for the error boundary description content.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
