### PR TITLE
chore: Make 'h1' Box variant auto-focusable

### DIFF
--- a/src/box/__tests__/box.test.tsx
+++ b/src/box/__tests__/box.test.tsx
@@ -158,6 +158,11 @@ describe('Box', () => {
     expect(boxWrapper.getElement()).toHaveClass(styles['font-weight-default']);
   });
 
+  test('sets tabindex for h1 variant', () => {
+    const boxWrapper = renderBox({ variant: 'h1' });
+    expect(boxWrapper.getElement()).toHaveAttribute('tabindex', '-1');
+  });
+
   describe('native attributes', () => {
     it('adds native attributes', () => {
       const { container } = render(<Box nativeAttributes={{ 'data-testid': 'my-test-id' }} />);

--- a/src/box/internal.tsx
+++ b/src/box/internal.tsx
@@ -47,11 +47,15 @@ export default function InternalBox({
     styles[`t-${textAlign}`]
   );
 
+  // allow auto-focusing of h1 boxes from flashbar
+  const tabindex = variant === 'h1' ? -1 : undefined;
+
   return (
     <WithNativeAttributes
       {...baseProps}
       tag={getTag(variant, tagOverride)}
       componentName="Box"
+      tabIndex={tabindex}
       nativeAttributes={nativeAttributes}
       className={className}
       ref={__internalRootRef}


### PR DESCRIPTION
### Description

Add `tabindex="-1"` to `<Box variant="h1">` to match the behavior of the same variant of the Header component. This allows the element to be programmatically focused, for example by the flashbar component.

Related links, issue #, if available: AWSUI-61544

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
