### PR TITLE
chore: Support managing visual mode via query string parameters in dev pages

### DIFF
--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { Suspense, useContext, useEffect } from 'react';
-import { HashRouter, Redirect } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import { createHashHistory } from 'history';
 
 import { applyDensity, applyMode, disableMotion } from '@cloudscape-design/global-styles';
@@ -79,9 +79,6 @@ function App() {
     disableMotion(motionDisabled);
   }, [motionDisabled]);
 
-  if (!mode) {
-    return <Redirect to="/light/" />;
-  }
   return (
     <StrictModeWrapper pageId={pageId}>
       <Suspense fallback={<span>Loading...</span>}>


### PR DESCRIPTION
### Description

First step to harmonize the way that all parameters are managed in the URL parameters across all packages.

In this package, the visual mode (light vs dark) is taken from the URL path for historical reasons, whereas all the rest are taken from query string parameters. Also in all other packages, the visual mode is managed via a query string parameter.

This PR keeps backwards compatibility so that dev pages support both ways: via path or via query string parameter. It also defaults to light mode if not present, and does not redirect.

Once this change is fully deployed and visual regression tests have been changed to use the new paths, the support for the visual mode in the path can be removed.

Related ticket: `D349419606`

### How has this been tested?

Deployed in my pipeline, integration tests pass

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
