### PR TITLE
chore: change selectedLabel to selectedAriaLabel

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -3528,7 +3528,7 @@ Use the \`onLoadItems\` event to perform a recovery action (for example, retryin
       "description": "Overrides the element that is announced to screen readers
 when the highlighted option changes. By default, this announces
 the option's name and properties, and its selected state if
-the \`selectedLabel\` property is defined.
+the \`selectedAriaLabel\` property is defined.
 The highlighted option is provided, and its group (if groups
 are used and it differs from the group of the previously highlighted option).
 
@@ -17608,7 +17608,7 @@ Use the \`onLoadItems\` event to perform a recovery action (for example, retryin
       "description": "Overrides the element that is announced to screen readers
 when the highlighted option changes. By default, this announces
 the option's name and properties, and its selected state if
-the \`selectedLabel\` property is defined.
+the \`selectedAriaLabel\` property is defined.
 The highlighted option is provided, and its group (if groups
 are used and it differs from the group of the previously highlighted option).
 
@@ -22917,7 +22917,7 @@ Use the \`onLoadItems\` event to perform a recovery action (for example, retryin
       "description": "Overrides the element that is announced to screen readers
 when the highlighted option changes. By default, this announces
 the option's name and properties, and its selected state if
-the \`selectedLabel\` property is defined.
+the \`selectedAriaLabel\` property is defined.
 The highlighted option is provided, and its group (if groups
 are used and it differs from the group of the previously highlighted option).
 

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -117,7 +117,7 @@ export interface AutosuggestProps
    * Overrides the element that is announced to screen readers
    * when the highlighted option changes. By default, this announces
    * the option's name and properties, and its selected state if
-   * the `selectedLabel` property is defined.
+   * the `selectedAriaLabel` property is defined.
    * The highlighted option is provided, and its group (if groups
    * are used and it differs from the group of the previously highlighted option).
    *

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -126,7 +126,7 @@ export interface BaseSelectProps
    * Overrides the element that is announced to screen readers
    * when the highlighted option changes. By default, this announces
    * the option's name and properties, and its selected state if
-   * the `selectedLabel` property is defined.
+   * the `selectedAriaLabel` property is defined.
    * The highlighted option is provided, and its group (if groups
    * are used and it differs from the group of the previously highlighted option).
    *


### PR DESCRIPTION
### Description

Updates comments to use `selectedAriaLabel` instead of the deprecated `selectedLabel`

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
