### PR TITLE
fix: Add role="button" to table column resize control

### DIFF
--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -84,6 +84,11 @@ test('should render resizers when enabled', () => {
   expect(wrapper.findColumnResizer(2)).not.toBeNull();
 });
 
+test('should not submit surrounding forms when activated', () => {
+  const { wrapper } = renderTable(<Table {...defaultProps} />);
+  expect(wrapper.findColumnResizer(1)!.getElement()).toHaveAttribute('type', 'button');
+});
+
 test('should allow dragging a column only with the left mouse button', () => {
   const { wrapper } = renderTable(<Table {...defaultProps} />);
   const leftButton = 0;

--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -356,6 +356,7 @@ export function Resizer({
         }}
       >
         <button
+          type="button"
           ref={resizerToggleRef}
           className={clsx(
             styles.resizer,


### PR DESCRIPTION
### Description

See ticket for more details. Having an implicit submit button seems to trigger unintentional behavior with JAWS.

Related links, issue #, if available: AWSUI-61539

### How has this been tested?

Wrote a unit test, but we don't _support_ support this use-case so that's good enough for me.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
