### PR TITLE
fix: Hides drag handle overlay when the UAP buttons are not visible

### DIFF
--- a/src/internal/components/drag-handle-wrapper/portal-overlay.tsx
+++ b/src/internal/components/drag-handle-wrapper/portal-overlay.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import clsx from 'clsx';
 
 import {
   getIsRtl,
@@ -80,7 +81,7 @@ export default function PortalOverlay({
 
   return (
     <Portal container={container}>
-      <span ref={ref} className={styles['portal-overlay']}>
+      <span ref={ref} className={clsx(styles['portal-overlay'], isDisabled && styles['portal-overlay-disabled'])}>
         <span className={styles['portal-overlay-contents']}>{children}</span>
       </span>
     </Portal>

--- a/src/internal/components/drag-handle-wrapper/styles.scss
+++ b/src/internal/components/drag-handle-wrapper/styles.scss
@@ -28,6 +28,10 @@ $direction-button-offset: awsui.$space-static-xxs;
   z-index: 7000;
 }
 
+.portal-overlay-disabled {
+  display: none;
+}
+
 .portal-overlay-contents {
   pointer-events: auto;
 }


### PR DESCRIPTION
### Description

The drag handles create an overlay for UAP buttons, which is present at all times to make the animations work correctly. However, this overlay creates issue as it affects page's layout even when the buttons are not visible.

Before:

https://github.com/user-attachments/assets/9f1c6ba8-3931-4982-80b3-c1a089236a15

After:

https://github.com/user-attachments/assets/20135257-125b-42c6-87d3-8941be7599ac

As you can see, the issue is not completely gone, at least for the table component - but no longer it affects the page once the UAP buttons are hidden. I will create a follow up ticket to fix the table behaviour further.

Rel: [AWSUI-61533]

### How has this been tested?

* I will create a dedicated screenshot test for that

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
