### PR TITLE
fix: Fixes virtual list duplicate keys issue

### DIFF
--- a/src/select/utils/render-options.tsx
+++ b/src/select/utils/render-options.tsx
@@ -92,7 +92,7 @@ export const renderOptions = ({
       const optionId = props.id ?? `${idPrefix}-option-${index}`;
       return (
         <OptionGroup
-          key={index}
+          key={`group-${index}`}
           virtual={virtualItems?.[index] !== undefined}
           ariaLabelledby={optionId}
           ariaDisabled={props['aria-disabled']}


### PR DESCRIPTION
### Description

In multiselect (and likely select, too) with virtual scroll, there can be a situation when for a short period of time when scrolling the React keys of the parent and child items are the same. This causes React duplicate key issues (the state can be "cached").

Before:

https://github.com/user-attachments/assets/90337095-4a14-40b9-9d20-c4344edeb2d6

After:

https://github.com/user-attachments/assets/6bfbbb25-2460-418f-9ce6-3058a34c6848

Rel: [AWSUI-61551]

### How has this been tested?

* Tbh, I can't think of a reliable way to secure this fix with tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
