### PR TITLE
chore: remove tooltip from the runtime left drawer

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -193,7 +193,6 @@ export function AppLayoutToolbarImplementation({
               selected={!drawerExpandedMode && !!activeAiDrawerId}
               disabled={anyPanelOpenInMobile}
               variant={aiDrawer?.trigger?.customIcon ? 'custom' : 'circle'}
-              hasTooltip={true}
               testId={`awsui-app-layout-trigger-${aiDrawer?.id}`}
               isForPreviousActiveDrawer={true}
             />


### PR DESCRIPTION
### Description

Addressing customer feedback.

The left panel has a large trigger which includes the visible text already. Tooltip is not needed

Related links, issue #, if available: n/a

### How has this been tested?

Ran locally, tooltip is gone

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
