### PR TITLE
fix: Fixes table resize handle position in classic

### DIFF
--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -323,7 +323,11 @@ export function Resizer({
     <div
       // When the table is borderless (works in visual refresh tables only), the last resize handle must not
       // exceed table's edges, as it causes an unintended overflow otherwise.
-      className={clsx(styles['resizer-wrapper'], (!isVisualRefresh || isBorderless) && styles['is-borderless'])}
+      className={clsx(
+        styles['resizer-wrapper'],
+        isVisualRefresh && styles['visual-refresh'],
+        (!isVisualRefresh || isBorderless) && styles['is-borderless']
+      )}
       ref={positioningWrapperRef}
     >
       <DragHandleWrapper

--- a/src/table/resizer/styles.scss
+++ b/src/table/resizer/styles.scss
@@ -59,7 +59,7 @@ th:not(:last-child) > .divider-disabled {
 }
 
 // stylelint-disable-next-line selector-combinator-disallowed-list
-th:last-child > .resizer-wrapper.is-borderless .divider-interactive {
+th:last-child > .resizer-wrapper.visual-refresh.is-borderless .divider-interactive {
   inset-inline-end: 0;
 }
 


### PR DESCRIPTION
### Description

Fixes a visual bug in Classic introduced in https://github.com/cloudscape-design/components/pull/4102, where the last resize handle were shown too close to the table's edge.

### How has this been tested?

Before:

<img width="1705" height="267" alt="Screenshot 2025-12-15 at 14 52 13" src="https://github.com/user-attachments/assets/4af3553c-185f-4751-aaa1-3c3d3423eaa7" />


After:

<img width="1705" height="267" alt="Screenshot 2025-12-15 at 14 51 18" src="https://github.com/user-attachments/assets/26426f82-eddb-48e3-8545-c9662262d2b3" />


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
