### PR TITLE
fix: Avoid cropping popover trigger focus ring when not wrapping text

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     {
       "path": "lib/components/internal/widget-exports.js",
       "brotli": false,
-      "limit": "1040 kB",
+      "limit": "1100 kB",
       "ignore": "react-dom"
     }
   ],

--- a/pages/popover/text-wrap.page.tsx
+++ b/pages/popover/text-wrap.page.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import Popover, { PopoverProps } from '~components/popover';
 import PopoverBody, { PopoverBodyProps } from '~components/popover/body';
 
+import FocusTarget from '../common/focus-target';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
@@ -59,6 +60,7 @@ export default function () {
   return (
     <article>
       <h1>Popover text wrapping</h1>
+      <FocusTarget />
       <ScreenshotArea>
         <PermutationsView
           permutations={triggerPermutations}

--- a/src/popover/styles.scss
+++ b/src/popover/styles.scss
@@ -20,6 +20,15 @@ $trigger-underline-offset: 0.25em;
   &.no-wrap {
     white-space: nowrap;
   }
+
+  // When the trigger text is set to be ellipsized, render the focus ring on the root element instead of the trigger,
+  // to prevent it from being cropped by its `overflow: hidden` rule.
+  // We do this in only this case because when the trigger has multiple lines of texts its height can differ from the root element.
+  &:has(.trigger-type-text-inline.overflow-ellipsis:focus, .trigger-type-text.overflow-ellipsis:focus) {
+    @include focus-visible.when-visible-unfocused {
+      @include styles.focus-highlight(1px);
+    }
+  }
 }
 
 .root-filtering-token {
@@ -77,8 +86,10 @@ $trigger-underline-offset: 0.25em;
     outline: none;
   }
 
-  @include focus-visible.when-visible {
-    @include styles.focus-highlight(1px);
+  &:not(.overflow-ellipsis) {
+    @include focus-visible.when-visible {
+      @include styles.focus-highlight(1px);
+    }
   }
 }
 


### PR DESCRIPTION
Ticket: `AWSUI-61589`

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

- Manually on dev pages
- Ran on my pipeline
- Visual regression tests: `CR-241717181` (not published yet)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
