### PR TITLE
feat: add post-copy event handlers to CopyToClipboard (#4040)

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -9757,7 +9757,44 @@ Note that the secondary header will not have a high-contrast treatement, even if
 exports[`Components definition for copy-to-clipboard matches the snapshot: copy-to-clipboard 1`] = `
 {
   "dashCaseName": "copy-to-clipboard",
-  "events": [],
+  "events": [
+    {
+      "cancelable": false,
+      "description": "Called when the copy operation fails.
+The event \`detail\` contains the text that failed to copy.",
+      "detailInlineType": {
+        "name": "CopyToClipboardProps.CopyFailureDetail",
+        "properties": [
+          {
+            "name": "text",
+            "optional": false,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "detailType": "CopyToClipboardProps.CopyFailureDetail",
+      "name": "onCopyFailure",
+    },
+    {
+      "cancelable": false,
+      "description": "Called when the text is successfully copied to the clipboard.
+The event \`detail\` contains the text that was copied.",
+      "detailInlineType": {
+        "name": "CopyToClipboardProps.CopySuccessDetail",
+        "properties": [
+          {
+            "name": "text",
+            "optional": false,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "detailType": "CopyToClipboardProps.CopySuccessDetail",
+      "name": "onCopySuccess",
+    },
+  ],
   "functions": [],
   "name": "CopyToClipboard",
   "properties": [

--- a/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
+++ b/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
@@ -283,4 +283,190 @@ describe('CopyToClipboard', () => {
       await waitFor(() => expect(wrapper.findStatusText()!.getElement().textContent).toBe('Copied to clipboard'));
     });
   });
+
+  describe('onCopySuccess callback', () => {
+    test.each(['simple text', 'special chars: @#$%^&*()', 'unicode: 你好世界 🎉', 'multiline\ntext\nhere'])(
+      'passes correct text to callback for various string types - %s',
+      async textToCopy => {
+        Object.assign(global.navigator, {
+          clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+        });
+
+        const onCopySuccess = jest.fn();
+        const { container } = render(
+          <CopyToClipboard {...defaultProps} textToCopy={textToCopy} onCopySuccess={onCopySuccess} />
+        );
+        const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+        wrapper.findCopyButton().click();
+        await waitFor(() => {
+          expect(onCopySuccess).toHaveBeenCalledWith(expect.objectContaining({ detail: { text: textToCopy } }));
+        });
+      }
+    );
+
+    test('invokes callback on successful copy', async () => {
+      const onCopySuccess = jest.fn();
+      const { container } = render(<CopyToClipboard {...defaultProps} onCopySuccess={onCopySuccess} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+      await waitFor(() => {
+        expect(onCopySuccess).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    test('callback receives correct text in detail object', async () => {
+      const onCopySuccess = jest.fn();
+      const { container } = render(<CopyToClipboard {...defaultProps} onCopySuccess={onCopySuccess} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+      await waitFor(() => {
+        expect(onCopySuccess).toHaveBeenCalledWith(
+          expect.objectContaining({
+            detail: { text: 'Text to copy' },
+          })
+        );
+      });
+    });
+
+    test('does not invoke callback on copy failure', async () => {
+      const onCopySuccess = jest.fn();
+      const { container } = render(
+        <CopyToClipboard {...defaultProps} textToCopy="Text to copy with error" onCopySuccess={onCopySuccess} />
+      );
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+      await waitFor(() =>
+        expect(wrapper.findStatusText()!.getElement().textContent).toBe('Failed to copy to clipboard')
+      );
+      expect(onCopySuccess).not.toHaveBeenCalled();
+    });
+
+    test('does not invoke callback when prop is undefined', async () => {
+      const { container } = render(<CopyToClipboard {...defaultProps} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      // Should not throw when callback is undefined
+      wrapper.findCopyButton().click();
+      await waitFor(() => expect(wrapper.findStatusText()!.getElement().textContent).toBe('Copied to clipboard'));
+    });
+
+    test('does not invoke callback when component is disabled', async () => {
+      const onCopySuccess = jest.fn();
+      const { container } = render(<CopyToClipboard {...defaultProps} disabled={true} onCopySuccess={onCopySuccess} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+      // Wait a bit to ensure no async callback is triggered
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(onCopySuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onCopyFailure callback', () => {
+    test.each(['simple text', 'special chars: @#$%^&*()', 'unicode: 你好世界 🎉', 'multiline\ntext\nhere'])(
+      'passes correct text to callback for various string types - %s',
+      async textToCopy => {
+        Object.assign(global.navigator, {
+          clipboard: { writeText: jest.fn().mockRejectedValue(new Error('Copy failed')) },
+        });
+
+        const onCopyFailure = jest.fn();
+        const { container } = render(
+          <CopyToClipboard {...defaultProps} textToCopy={textToCopy} onCopyFailure={onCopyFailure} />
+        );
+        const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+        wrapper.findCopyButton().click();
+        await waitFor(() => {
+          expect(onCopyFailure).toHaveBeenCalledWith(expect.objectContaining({ detail: { text: textToCopy } }));
+        });
+      }
+    );
+
+    test('invokes callback on copy failure', async () => {
+      const onCopyFailure = jest.fn();
+      const { container } = render(
+        <CopyToClipboard {...defaultProps} textToCopy="Text to copy with error" onCopyFailure={onCopyFailure} />
+      );
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+      await waitFor(() => {
+        expect(onCopyFailure).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    test('invokes callback when Clipboard API is unavailable', async () => {
+      Object.assign(global.navigator, { clipboard: undefined });
+
+      const onCopyFailure = jest.fn();
+      const { container } = render(<CopyToClipboard {...defaultProps} onCopyFailure={onCopyFailure} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+      await waitFor(() => {
+        expect(onCopyFailure).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    test('callback receives correct text in detail object', async () => {
+      const onCopyFailure = jest.fn();
+      const { container } = render(
+        <CopyToClipboard {...defaultProps} textToCopy="Text to copy with error" onCopyFailure={onCopyFailure} />
+      );
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+      await waitFor(() => {
+        expect(onCopyFailure).toHaveBeenCalledWith(
+          expect.objectContaining({
+            detail: { text: 'Text to copy with error' },
+          })
+        );
+      });
+    });
+
+    test('does not invoke callback on successful copy', async () => {
+      const onCopyFailure = jest.fn();
+      const { container } = render(<CopyToClipboard {...defaultProps} onCopyFailure={onCopyFailure} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+      await waitFor(() => expect(wrapper.findStatusText()!.getElement().textContent).toBe('Copied to clipboard'));
+      expect(onCopyFailure).not.toHaveBeenCalled();
+    });
+
+    test('does not invoke callback when prop is undefined', async () => {
+      const { container } = render(<CopyToClipboard {...defaultProps} textToCopy="Text to copy with error" />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      // Should not throw when callback is undefined
+      wrapper.findCopyButton().click();
+      await waitFor(() =>
+        expect(wrapper.findStatusText()!.getElement().textContent).toBe('Failed to copy to clipboard')
+      );
+    });
+
+    test('does not invoke callback when component is disabled', async () => {
+      const onCopyFailure = jest.fn();
+      const { container } = render(
+        <CopyToClipboard
+          {...defaultProps}
+          textToCopy="Text to copy with error"
+          disabled={true}
+          onCopyFailure={onCopyFailure}
+        />
+      );
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+      // Wait a bit to ensure no async callback is triggered
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(onCopyFailure).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/copy-to-clipboard/interfaces.ts
+++ b/src/copy-to-clipboard/interfaces.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BaseComponentProps } from '../internal/base-component';
+import { NonCancelableEventHandler } from '../internal/events';
 
 export interface CopyToClipboardProps extends BaseComponentProps {
   /** Determines the general styling of the copy button as follows:
@@ -64,8 +65,30 @@ export interface CopyToClipboardProps extends BaseComponentProps {
    * Applicable for all variants except inline.
    */
   disabledReason?: string;
+
+  /**
+   * Called when the text is successfully copied to the clipboard.
+   * The event `detail` contains the text that was copied.
+   */
+  onCopySuccess?: NonCancelableEventHandler<CopyToClipboardProps.CopySuccessDetail>;
+
+  /**
+   * Called when the copy operation fails.
+   * The event `detail` contains the text that failed to copy.
+   */
+  onCopyFailure?: NonCancelableEventHandler<CopyToClipboardProps.CopyFailureDetail>;
 }
 
 export namespace CopyToClipboardProps {
   export type Variant = 'button' | 'icon' | 'inline';
+
+  export interface CopySuccessDetail {
+    /** The text that was copied to the clipboard */
+    text: string;
+  }
+
+  export interface CopyFailureDetail {
+    /** The text that failed to copy to the clipboard */
+    text: string;
+  }
 }

--- a/src/copy-to-clipboard/internal.tsx
+++ b/src/copy-to-clipboard/internal.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 
 import InternalButton from '../button/internal';
 import { getBaseProps } from '../internal/base-component';
+import { fireNonCancelableEvent } from '../internal/events';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import InternalPopover from '../popover/internal';
 import InternalStatusIndicator from '../status-indicator/internal';
@@ -26,6 +27,8 @@ export default function InternalCopyToClipboard({
   popoverRenderWithPortal,
   disabled,
   disabledReason,
+  onCopySuccess,
+  onCopyFailure,
   __internalRootRef,
   ...restProps
 }: InternalCopyToClipboardProps) {
@@ -54,6 +57,7 @@ export default function InternalCopyToClipboard({
       // The clipboard API is not available in insecure contexts.
       setStatus('error');
       setStatusText(copyErrorText);
+      fireNonCancelableEvent(onCopyFailure, { text: textToCopy });
       return;
     }
 
@@ -62,10 +66,12 @@ export default function InternalCopyToClipboard({
       .then(() => {
         setStatus('success');
         setStatusText(copySuccessText);
+        fireNonCancelableEvent(onCopySuccess, { text: textToCopy });
       })
       .catch(() => {
         setStatus('error');
         setStatusText(copyErrorText);
+        fireNonCancelableEvent(onCopyFailure, { text: textToCopy });
       });
   };
 


### PR DESCRIPTION
Resolves #4040

This PR adds `onCopySuccess` and `onCopyFailure` handlers to `CopyToClipboard` so that we can detect when the user has performed a copy action.

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
