### PR TITLE
chore: Expose clear state methods in public runtime API

### DIFF
--- a/src/alert/__tests__/runtime-action.test.tsx
+++ b/src/alert/__tests__/runtime-action.test.tsx
@@ -5,7 +5,6 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import Alert from '../../../lib/components/alert';
 import awsuiPlugins from '../../../lib/components/internal/plugins';
-import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
 import { ActionConfig } from '../../../lib/components/internal/plugins/controllers/action-buttons';
 
 const defaultAction: ActionConfig = {
@@ -23,7 +22,7 @@ function delay() {
 }
 
 afterEach(() => {
-  awsuiPluginsInternal.alert.clearRegisteredActions();
+  awsuiPlugins.alert.clearRegisteredActionsForTesting();
 });
 
 test('renders runtime action button initially', async () => {

--- a/src/alert/__tests__/runtime-content-initial.test.tsx
+++ b/src/alert/__tests__/runtime-content-initial.test.tsx
@@ -5,13 +5,12 @@ import testRenderer, { ReactTestRendererJSON } from 'react-test-renderer';
 
 import Alert from '../../../lib/components/alert';
 import awsuiPlugins from '../../../lib/components/internal/plugins';
-import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
 import { AlertFlashContentConfig } from '../../../lib/components/internal/plugins/controllers/alert-flash-content';
 
 import stylesCss from '../../../lib/components/alert/styles.css.js';
 
 afterEach(() => {
-  awsuiPluginsInternal.alertContent.clearRegisteredReplacer();
+  awsuiPlugins.alertContent.clearRegisteredReplacerForTesting();
   jest.resetAllMocks();
   jest.restoreAllMocks();
 });

--- a/src/alert/__tests__/runtime-content.test.tsx
+++ b/src/alert/__tests__/runtime-content.test.tsx
@@ -7,7 +7,6 @@ import Alert from '../../../lib/components/alert';
 import Button from '../../../lib/components/button';
 import { metrics } from '../../../lib/components/internal/metrics';
 import awsuiPlugins from '../../../lib/components/internal/plugins';
-import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
 import { AlertFlashContentConfig } from '../../../lib/components/internal/plugins/controllers/alert-flash-content';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { expectContent } from './runtime-content-utils';
@@ -36,7 +35,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  awsuiPluginsInternal.alertContent.clearRegisteredReplacer();
+  awsuiPlugins.alertContent.clearRegisteredReplacerForTesting();
   jest.resetAllMocks();
   jest.restoreAllMocks();
 });

--- a/src/app-layout-toolbar/__tests__/analytics-metadata.test.tsx
+++ b/src/app-layout-toolbar/__tests__/analytics-metadata.test.tsx
@@ -12,7 +12,7 @@ import { clearVisualRefreshState } from '@cloudscape-design/component-toolkit/in
 
 import AppLayoutToolbar, { AppLayoutToolbarProps } from '../../../lib/components/app-layout-toolbar';
 import Header from '../../../lib/components/header';
-import { awsuiPlugins, awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
+import awsuiPlugins from '../../../lib/components/internal/plugins';
 import SplitPanel from '../../../lib/components/split-panel';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { validateComponentNameAndLabels } from '../../internal/__tests__/analytics-metadata-test-utils';
@@ -48,7 +48,7 @@ const globalWithFlags = globalThis as any;
 
 beforeEach(() => {
   globalWithFlags[Symbol.for('awsui-visual-refresh-flag')] = () => true;
-  awsuiPluginsInternal.appLayout.clearRegisteredDrawers();
+  awsuiPlugins.appLayout.clearRegisteredDrawersForTesting();
 });
 
 afterEach(() => {

--- a/src/app-layout/__tests__/runtime-drawers-layout.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers-layout.test.tsx
@@ -6,7 +6,7 @@ import { act, render, waitFor } from '@testing-library/react';
 import AppLayout from '../../../lib/components/app-layout';
 import { useAppLayoutPlacement } from '../../../lib/components/app-layout/utils/use-app-layout-placement';
 import { computeHorizontalLayout } from '../../../lib/components/app-layout/visual-refresh-toolbar/compute-layout';
-import { awsuiPlugins, awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
+import awsuiPlugins from '../../../lib/components/internal/plugins';
 import { DrawerConfig } from '../../../lib/components/internal/plugins/controllers/drawers';
 import * as awsuiWidgetInternal from '../../../lib/components/internal/plugins/widget/core';
 import * as awsuiWidgetPlugins from '../../../lib/components/internal/plugins/widget/index';
@@ -15,7 +15,7 @@ import { KeyCode } from '../../internal/keycode';
 import { describeEachAppLayout, getGlobalDrawersTestUtils, testDrawer } from './utils';
 
 beforeEach(() => {
-  awsuiPluginsInternal.appLayout.clearRegisteredDrawers();
+  awsuiPlugins.appLayout.clearRegisteredDrawersForTesting();
   awsuiWidgetInternal.clearInitialMessages();
 });
 

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -9,7 +9,7 @@ import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-tool
 import { Button } from '../../../lib/components';
 import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
 import { TOOLS_DRAWER_ID } from '../../../lib/components/app-layout/utils/use-drawers';
-import { awsuiPlugins, awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
+import awsuiPlugins from '../../../lib/components/internal/plugins';
 import { DrawerConfig } from '../../../lib/components/internal/plugins/controllers/drawers';
 import * as awsuiWidgetInternal from '../../../lib/components/internal/plugins/widget/core';
 import * as awsuiWidgetPlugins from '../../../lib/components/internal/plugins/widget/index';
@@ -32,7 +32,7 @@ import toolbarStyles from '../../../lib/components/app-layout/visual-refresh-too
 import toolbarTriggerStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/trigger-button/styles.selectors.js';
 
 beforeEach(() => {
-  awsuiPluginsInternal.appLayout.clearRegisteredDrawers();
+  awsuiPlugins.appLayout.clearRegisteredDrawersForTesting();
   awsuiWidgetInternal.clearInitialMessages();
   activateAnalyticsMetadata(true);
 });

--- a/src/app-layout/__tests__/use-runtime-drawer-context.test.tsx
+++ b/src/app-layout/__tests__/use-runtime-drawer-context.test.tsx
@@ -5,7 +5,7 @@ import ReactDOM, { unmountComponentAtNode } from 'react-dom';
 import { act, render } from '@testing-library/react';
 
 import AppLayout from '../../../lib/components/app-layout';
-import { awsuiPlugins, awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
+import awsuiPlugins from '../../../lib/components/internal/plugins';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { useRuntimeDrawerContext } from '../runtime-drawer/use-runtime-drawer-context';
 import { describeEachAppLayout, getGlobalDrawersTestUtils, testDrawer } from './utils';
@@ -29,7 +29,7 @@ function delay() {
 }
 
 beforeEach(() => {
-  awsuiPluginsInternal.appLayout.clearRegisteredDrawers();
+  awsuiPlugins.appLayout.clearRegisteredDrawersForTesting();
 });
 
 jest.mock('@cloudscape-design/component-toolkit', () => ({

--- a/src/flashbar/__tests__/runtime-action.test.tsx
+++ b/src/flashbar/__tests__/runtime-action.test.tsx
@@ -5,7 +5,6 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import Flashbar, { FlashbarProps } from '../../../lib/components/flashbar';
 import awsuiPlugins from '../../../lib/components/internal/plugins';
-import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
 import { ActionConfig } from '../../../lib/components/internal/plugins/controllers/action-buttons';
 import createWrapper, { ElementWrapper } from '../../../lib/components/test-utils/dom';
 
@@ -26,7 +25,7 @@ function delay() {
 }
 
 afterEach(() => {
-  awsuiPluginsInternal.flashbar.clearRegisteredActions();
+  awsuiPlugins.flashbar.clearRegisteredActionsForTesting();
 });
 
 test('renders runtime action button initially', async () => {

--- a/src/flashbar/__tests__/runtime-content-initial.test.tsx
+++ b/src/flashbar/__tests__/runtime-content-initial.test.tsx
@@ -5,13 +5,12 @@ import testRenderer, { ReactTestRenderer, ReactTestRendererJSON } from 'react-te
 
 import Flashbar from '../../../lib/components/flashbar';
 import awsuiPlugins from '../../../lib/components/internal/plugins';
-import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
 import { AlertFlashContentConfig } from '../../../lib/components/internal/plugins/controllers/alert-flash-content';
 
 import stylesCss from '../../../lib/components/flashbar/styles.css.js';
 
 afterEach(() => {
-  awsuiPluginsInternal.flashContent.clearRegisteredReplacer();
+  awsuiPlugins.flashContent.clearRegisteredReplacerForTesting();
   jest.resetAllMocks();
   jest.restoreAllMocks();
 });

--- a/src/flashbar/__tests__/runtime-content.test.tsx
+++ b/src/flashbar/__tests__/runtime-content.test.tsx
@@ -7,7 +7,6 @@ import Button from '../../../lib/components/button';
 import Flashbar from '../../../lib/components/flashbar';
 import { metrics } from '../../../lib/components/internal/metrics';
 import awsuiPlugins from '../../../lib/components/internal/plugins';
-import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
 import { AlertFlashContentConfig } from '../../../lib/components/internal/plugins/controllers/alert-flash-content';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { expectContent } from '../../alert/__tests__/runtime-content-utils';
@@ -29,7 +28,7 @@ const defaultContent: AlertFlashContentConfig = {
 };
 
 afterEach(() => {
-  awsuiPluginsInternal.flashContent.clearRegisteredReplacer();
+  awsuiPlugins.flashContent.clearRegisteredReplacerForTesting();
   jest.resetAllMocks();
   jest.restoreAllMocks();
 });

--- a/src/internal/plugins/controllers/action-buttons.ts
+++ b/src/internal/plugins/controllers/action-buttons.ts
@@ -26,10 +26,10 @@ type ActionRegistrationListener = (action: Array<ActionConfig>) => void;
 
 export interface ActionsApiPublic {
   registerAction(config: ActionConfig): void;
+  clearRegisteredActionsForTesting(): void;
 }
 
 export interface ActionsApiInternal {
-  clearRegisteredActions(): void;
   onActionRegistered(listener: ActionRegistrationListener): () => void;
 }
 
@@ -47,7 +47,7 @@ export class ActionButtonsController {
     this.scheduleUpdate();
   };
 
-  clearRegisteredActions = () => {
+  clearRegisteredActionsForTesting = () => {
     this.actions = [];
   };
 
@@ -61,11 +61,11 @@ export class ActionButtonsController {
 
   installPublic(api: Partial<ActionsApiPublic> = {}): ActionsApiPublic {
     api.registerAction ??= this.registerAction;
+    api.clearRegisteredActionsForTesting ??= this.clearRegisteredActionsForTesting;
     return api as ActionsApiPublic;
   }
 
   installInternal(internalApi: Partial<ActionsApiInternal> = {}): ActionsApiInternal {
-    internalApi.clearRegisteredActions ??= this.clearRegisteredActions;
     internalApi.onActionRegistered ??= this.onActionRegistered;
     return internalApi as ActionsApiInternal;
   }

--- a/src/internal/plugins/controllers/alert-flash-content.ts
+++ b/src/internal/plugins/controllers/alert-flash-content.ts
@@ -51,10 +51,10 @@ type AlertFlashContentRegistrationListener = (provider: AlertFlashContentConfig)
 
 export interface AlertFlashContentApiPublic {
   registerContentReplacer(config: AlertFlashContentConfig): void;
+  clearRegisteredReplacerForTesting(): void;
 }
 
 export interface AlertFlashContentApiInternal {
-  clearRegisteredReplacer(): void;
   onContentRegistered(listener: AlertFlashContentRegistrationListener): () => void;
   initialCheck(context: AlertFlashContentInitialContext): boolean;
 }
@@ -89,7 +89,7 @@ export class AlertFlashContentController {
     this.#scheduleUpdate();
   };
 
-  clearRegisteredReplacer = () => {
+  clearRegisteredReplacerForTesting = () => {
     this.#provider = undefined;
   };
 
@@ -117,11 +117,11 @@ export class AlertFlashContentController {
 
   installPublic(api: Partial<AlertFlashContentApiPublic> = {}): AlertFlashContentApiPublic {
     api.registerContentReplacer ??= this.registerContentReplacer;
+    api.clearRegisteredReplacerForTesting ??= this.clearRegisteredReplacerForTesting;
     return api as AlertFlashContentApiPublic;
   }
 
   installInternal(internalApi: Partial<AlertFlashContentApiInternal> = {}): AlertFlashContentApiInternal {
-    internalApi.clearRegisteredReplacer ??= this.clearRegisteredReplacer;
     internalApi.onContentRegistered ??= this.onContentRegistered;
     internalApi.initialCheck ??= this.initialCheck;
     return internalApi as AlertFlashContentApiInternal;

--- a/src/internal/plugins/controllers/drawers.ts
+++ b/src/internal/plugins/controllers/drawers.ts
@@ -74,10 +74,10 @@ export interface DrawersApiPublic {
   openDrawer(drawerId: string, params?: OpenCloseDrawerParams): void;
   closeDrawer(drawerId: string, params?: OpenCloseDrawerParams): void;
   resizeDrawer(drawerId: string, size: number): void;
+  clearRegisteredDrawersForTesting(): void;
 }
 
 export interface DrawersApiInternal {
-  clearRegisteredDrawers(): void;
   onDrawersRegistered(listener: DrawersRegistrationListener): () => void;
   onDrawerOpened(listener: DrawersToggledListener): () => void;
   onDrawerClosed(listener: DrawersToggledListener): () => void;
@@ -142,7 +142,7 @@ export class DrawersController {
     };
   };
 
-  clearRegisteredDrawers = () => {
+  clearRegisteredDrawersForTesting = () => {
     this.drawers = [];
   };
 
@@ -221,11 +221,11 @@ export class DrawersController {
     api.openDrawer ??= this.openDrawer;
     api.closeDrawer ??= this.closeDrawer;
     api.resizeDrawer ??= this.resizeDrawer;
+    api.clearRegisteredDrawersForTesting ??= this.clearRegisteredDrawersForTesting;
     return api as DrawersApiPublic;
   }
 
   installInternal(internalApi: Partial<DrawersApiInternal> = {}): DrawersApiInternal {
-    internalApi.clearRegisteredDrawers ??= this.clearRegisteredDrawers;
     internalApi.onDrawersRegistered ??= this.onDrawersRegistered;
     internalApi.onDrawerOpened ??= this.onDrawerOpened;
     internalApi.onDrawerClosed ??= this.onDrawerClosed;


### PR DESCRIPTION
### Description

Move cleanup methods from `awsuiPluginsInternal` to `awsuiPlugins` so our consumers can also write unit tests on the runtime API as well

Related links, issue #, if available: n/a

### How has this been tested?

Updated related unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
