### PR TITLE
fix: Fix AppLayoutToolbar breadcrumbs SSR glitch (take three)

### DIFF
--- a/src/app-layout/__tests__/skeleton.test.tsx
+++ b/src/app-layout/__tests__/skeleton.test.tsx
@@ -7,7 +7,9 @@ import BreadcrumbGroup from '../../../lib/components/breadcrumb-group';
 import { getFunnelKeySelector } from '../../../lib/components/internal/analytics/selectors';
 import { describeEachAppLayout, renderComponent } from './utils';
 
+import testutilStyles from '../../../lib/components/app-layout/test-classes/styles.selectors.js';
 import skeletonStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/skeleton/styles.selectors.js';
+import toolbarStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/styles.selectors.js';
 
 let widgetMockEnabled = false;
 function createWidgetizedComponentMock(Implementation: React.ComponentType, Skeleton: React.ComponentType) {
@@ -64,7 +66,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'] }, () => {
           tools="test tools"
         />
       );
-      expect(wrapper.findToolbar()).toBeFalsy();
+      expect(wrapper.findToolbar()).toBeTruthy(); // Needed for SSR
       expect(wrapper.findNavigation()).toBeFalsy();
       expect(wrapper.findBreadcrumbs()).toBeTruthy(); // Needed for SSR
       expect(wrapper.find(getFunnelKeySelector('funnel-name'))).toBeTruthy();
@@ -95,6 +97,14 @@ describeEachAppLayout({ themes: ['refresh-toolbar'] }, () => {
       expect(wrapper.findByClassName(skeletonStyles['toolbar-container'])).toBeTruthy();
       rerender(<AppLayout navigationHide={true} toolsHide={true} />);
       expect(wrapper.findByClassName(skeletonStyles['toolbar-container'])).toBeFalsy();
+    });
+
+    it('skeleton toolbar has correct classes for SSR compatibility', () => {
+      const { wrapper } = renderComponent(<AppLayout breadcrumbs="test breadcrumbs" />);
+      const toolbarContainer = wrapper.findByClassName(skeletonStyles['toolbar-container']);
+      expect(toolbarContainer).toBeTruthy();
+      expect(toolbarContainer!.getElement()).toHaveClass(toolbarStyles['universal-toolbar']);
+      expect(toolbarContainer!.getElement()).toHaveClass(testutilStyles.toolbar);
     });
   });
 });

--- a/src/app-layout/visual-refresh-toolbar/skeleton/slots.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/slots.tsx
@@ -7,6 +7,8 @@ import { BreadcrumbGroupImplementation } from '../../../breadcrumb-group/impleme
 import { BreadcrumbGroupProps } from '../../../breadcrumb-group/interfaces';
 import { BreadcrumbsSlotContext } from '../contexts';
 
+import testutilStyles from '../../test-classes/styles.css.js';
+import toolbarStyles from '../toolbar/styles.css.js';
 import styles from './styles.css.js';
 
 interface ToolbarSlotProps {
@@ -18,7 +20,7 @@ interface ToolbarSlotProps {
 export const ToolbarSlot = React.forwardRef<HTMLElement, ToolbarSlotProps>(({ className, style, children }, ref) => (
   <section
     ref={ref as React.Ref<any>}
-    className={clsx(styles['toolbar-container'], className)}
+    className={clsx(styles['toolbar-container'], toolbarStyles['universal-toolbar'], testutilStyles.toolbar, className)}
     style={{
       insetBlockStart: style?.insetBlockStart ?? 0,
       ...style,

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -148,14 +148,9 @@ export function AppLayoutToolbarImplementation({
   return (
     <ToolbarSlot
       ref={ref}
-      className={clsx(
-        styles['universal-toolbar'],
-        aiDrawer?.trigger && styles['with-ai-drawer'],
-        testutilStyles.toolbar,
-        {
-          [testutilStyles['mobile-bar']]: isMobile,
-        }
-      )}
+      className={clsx(aiDrawer?.trigger && styles['with-ai-drawer'], {
+        [testutilStyles['mobile-bar']]: isMobile,
+      })}
       style={{
         insetBlockStart: verticalOffsets.toolbar,
       }}


### PR DESCRIPTION
### Description

Previously: https://github.com/cloudscape-design/components/pull/3856, https://github.com/cloudscape-design/components/pull/4065

Embarrassingly, that second PR was missing one of the two changes needed (as seen [on the original branch](https://github.com/TrevorBurnham/cloudscape-components/commit/cbc5ea2ce8a6def5709e474ae7093c7cee0abfbf)), so it was insufficient to fix the glitch. This PR brings over that other change and adds test coverage for it.

Fixes https://github.com/cloudscape-design/components/issues/3848 cc @pan-kot 

### How has this been tested?

I've confirmed this fix locally by cherry-picking [this SSR dev server commit](https://github.com/TrevorBurnham/cloudscape-components/commit/e8b635e0954a1c289ee91cd59a6299690f709b40) and running it.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
