### PR TITLE
fix: Ensure hotspot has a 24x24 touch target even when surrounded by other interactive elements

### DIFF
--- a/src/annotation-context/annotation/styles.scss
+++ b/src/annotation-context/annotation/styles.scss
@@ -58,6 +58,11 @@
     content: '';
     position: absolute;
     inset: calc(-1 * #{awsui.$space-xxs});
+
+    // By default, elements later in the DOM order have a higher precedence.
+    // This increases the z-index just to cancel out that rule, so that elements
+    // immediately following the button are also overlapped by this click target.
+    z-index: 1;
   }
 
   &:focus {


### PR DESCRIPTION
### Description

At some point, we fixed the target size issue with the hotspot component (16x16) by giving it an invisible "padding" that extended 4px on each size of the component, making it 24x24 (#3246). This worked with minimal visual changes, but one thing we didn't consider was that the pseudoelement could be covered up by a subsequent element, which happened in this edge case. This PR bumps up the z-index so it beats any following elements.

This could make the subsequent element (a refresh button in this case) not meet the 24x24 requirement if it was a small button, but in this specific case, we're fine (see screenshot below — both squares are 24x24 from the center of the touch target). And this situation is pretty rare already.

<img width="460" height="335" alt="Screenshot 2025-12-19 at 14 29 26" src="https://github.com/user-attachments/assets/9bb9cbaf-e9ef-42a3-ab85-61394f9f691f" />

Related links, issue #, if available: AWSUI-61550

### How has this been tested?

Manually. This shouldn't have any visual diffs.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
