### PR TITLE
fix: wrap scrollToIndex in requestAnimationFrame

### DIFF
--- a/src/select/parts/virtual-list.tsx
+++ b/src/select/parts/virtual-list.tsx
@@ -75,7 +75,7 @@ const VirtualListOpen = forwardRef(
             });
           } else {
             // Fix for AWSUI-61506. Defer scroll to next frame to ensure
-            // virtual items are measured after re-render.  When called from
+            // virtual items are measured after re-render. When called from
             // parent's useEffect, measurements may not be ready yet.
             requestAnimationFrame(() => scrollToIndex(index));
           }


### PR DESCRIPTION
### Description

Fixes incorrect scroll positioning in virtual lists by deferring `scrollToIndex` calls with `requestAnimationFrame`. This ensures virtual items are measured before scrolling occurs.

Related links, issue #, if available: AWSUI-61506

### How has this been tested?

- Verified changes manually 
- Changes wend through pipeline 
- Dry-run build request (ID: 7659319803)

Visual changes in scroll positions are expected, since it scrolls correctly.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
