### PR TITLE
fix: Toolbar styles with triggerless left drawer

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -148,7 +148,7 @@ export function AppLayoutToolbarImplementation({
   return (
     <ToolbarSlot
       ref={ref}
-      className={clsx(aiDrawer?.trigger && styles['with-ai-drawer'], {
+      className={clsx((aiDrawer?.trigger || !!activeAiDrawerId) && styles['with-ai-drawer'], {
         [testutilStyles['mobile-bar']]: isMobile,
       })}
       style={{


### PR DESCRIPTION
### Description

Fixed visual issue on the toolbar with the triggerless left drawer.

Before:
<img width="120" height="46" alt="image" src="https://github.com/user-attachments/assets/2a27801e-9f7e-4d12-a920-ef2458b0c84d" />

After:
<img width="118" height="46" alt="image" src="https://github.com/user-attachments/assets/205ddb67-6bf7-4a31-b05f-485e4af36d87" />


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
