### PR TITLE
fix: Cache Intl.DateTimeFormat instances for better performance

### DIFF
--- a/src/internal/utils/date-time/__tests__/intl-date-time-format-cache.test.ts
+++ b/src/internal/utils/date-time/__tests__/intl-date-time-format-cache.test.ts
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { getDateTimeFormat } from '../intl-date-time-format-cache';
+
+describe('getDateTimeFormat', () => {
+  test('returns an Intl.DateTimeFormat instance', () => {
+    const formatter = getDateTimeFormat('en-US', { month: 'long' });
+    expect(formatter).toBeInstanceOf(Intl.DateTimeFormat);
+  });
+
+  test('returns the same instance for identical locale and options', () => {
+    const formatter1 = getDateTimeFormat('en-US', { month: 'long', year: 'numeric' });
+    const formatter2 = getDateTimeFormat('en-US', { month: 'long', year: 'numeric' });
+    expect(formatter1).toBe(formatter2);
+  });
+
+  test('returns the same instance regardless of options property order', () => {
+    const formatter1 = getDateTimeFormat('en-US', { month: 'long', year: 'numeric' });
+    const formatter2 = getDateTimeFormat('en-US', { year: 'numeric', month: 'long' });
+    expect(formatter1).toBe(formatter2);
+  });
+
+  test('returns different instances for different locales', () => {
+    const formatter1 = getDateTimeFormat('en-US', { month: 'long' });
+    const formatter2 = getDateTimeFormat('de-DE', { month: 'long' });
+    expect(formatter1).not.toBe(formatter2);
+  });
+
+  test('returns different instances for different options', () => {
+    const formatter1 = getDateTimeFormat('en-US', { month: 'long' });
+    const formatter2 = getDateTimeFormat('en-US', { month: 'short' });
+    expect(formatter1).not.toBe(formatter2);
+  });
+
+  test('handles undefined locale', () => {
+    const formatter = getDateTimeFormat(undefined, { month: 'long' });
+    expect(formatter).toBeInstanceOf(Intl.DateTimeFormat);
+  });
+
+  test('formats dates correctly', () => {
+    const formatter = getDateTimeFormat('en-US', { month: 'long', year: 'numeric' });
+    const date = new Date(2023, 5, 15); // June 15, 2023
+    expect(formatter.format(date)).toBe('June 2023');
+  });
+
+  test('caches formatters with complex options', () => {
+    const options: Intl.DateTimeFormatOptions = {
+      hour: '2-digit',
+      hourCycle: 'h23',
+      minute: '2-digit',
+      second: '2-digit',
+    };
+    const formatter1 = getDateTimeFormat('en-US', options);
+    const formatter2 = getDateTimeFormat('en-US', options);
+    expect(formatter1).toBe(formatter2);
+  });
+});

--- a/src/internal/utils/date-time/format-date-localized.ts
+++ b/src/internal/utils/date-time/format-date-localized.ts
@@ -3,6 +3,7 @@
 import { isValid, parseISO } from 'date-fns';
 
 import { formatTimeOffsetLocalized } from './format-time-offset';
+import { getDateTimeFormat } from './intl-date-time-format-cache';
 
 export default function formatDateLocalized({
   date: isoDate,
@@ -26,7 +27,7 @@ export default function formatDateLocalized({
   }
 
   if (isMonthOnly) {
-    const formattedMonthDate = new Intl.DateTimeFormat(locale, {
+    const formattedMonthDate = getDateTimeFormat(locale, {
       month: 'long',
       year: 'numeric',
     }).format(date);
@@ -34,7 +35,7 @@ export default function formatDateLocalized({
     return formattedMonthDate;
   }
 
-  const formattedDate = new Intl.DateTimeFormat(locale, {
+  const formattedDate = getDateTimeFormat(locale, {
     month: 'long',
     year: 'numeric',
     day: 'numeric',
@@ -44,7 +45,7 @@ export default function formatDateLocalized({
     return formattedDate;
   }
 
-  const formattedTime = new Intl.DateTimeFormat(locale, {
+  const formattedTime = getDateTimeFormat(locale, {
     hour: '2-digit',
     hourCycle: 'h23',
     minute: '2-digit',

--- a/src/internal/utils/date-time/intl-date-time-format-cache.ts
+++ b/src/internal/utils/date-time/intl-date-time-format-cache.ts
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Cache for Intl.DateTimeFormat instances.
+ *
+ * Creating Intl.DateTimeFormat objects is expensive because the browser must
+ * parse locale data and resolve options. This cache stores formatter instances
+ * keyed by locale and options, allowing reuse across multiple format calls.
+ *
+ * The cache uses a simple Map with a string key derived from the locale and
+ * serialized options. Since the number of unique locale/option combinations
+ * in a typical application is small and bounded, we don't implement cache
+ * eviction.
+ */
+
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+/**
+ * Returns a cached Intl.DateTimeFormat instance for the given locale and options.
+ * If no cached instance exists, creates one and stores it in the cache.
+ */
+export function getDateTimeFormat(
+  locale: string | undefined,
+  options: Intl.DateTimeFormatOptions
+): Intl.DateTimeFormat {
+  const cacheKey = createCacheKey(locale, options);
+  const cached = formatterCache.get(cacheKey);
+
+  if (cached) {
+    return cached;
+  }
+
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  formatterCache.set(cacheKey, formatter);
+  return formatter;
+}
+
+/**
+ * Creates a cache key from locale and options.
+ * Options are sorted by key to ensure consistent cache hits regardless of property order.
+ */
+function createCacheKey(locale: string | undefined, options: Intl.DateTimeFormatOptions): string {
+  const localeKey = locale ?? '';
+  const optionsKey = Object.keys(options)
+    .sort()
+    .map(key => `${key}:${options[key as keyof Intl.DateTimeFormatOptions]}`)
+    .join(',');
+  return `${localeKey}|${optionsKey}`;
+}

--- a/src/internal/utils/date-time/intl-date-time-format-cache.ts
+++ b/src/internal/utils/date-time/intl-date-time-format-cache.ts
@@ -1,25 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/**
- * Cache for Intl.DateTimeFormat instances.
- *
- * Creating Intl.DateTimeFormat objects is expensive because the browser must
- * parse locale data and resolve options. This cache stores formatter instances
- * keyed by locale and options, allowing reuse across multiple format calls.
- *
- * The cache uses a simple Map with a string key derived from the locale and
- * serialized options. Since the number of unique locale/option combinations
- * in a typical application is small and bounded, we don't implement cache
- * eviction.
- */
+// Constructing Intl.DateTimeFormat is expensive (the browser parses locale data and
+// resolves options), so we cache instances keyed by locale and options for reuse.
 
+// No eviction: the number of unique locale/option combinations in an application is
+// small and bounded.
 const formatterCache = new Map<string, Intl.DateTimeFormat>();
 
-/**
- * Returns a cached Intl.DateTimeFormat instance for the given locale and options.
- * If no cached instance exists, creates one and stores it in the cache.
- */
 export function getDateTimeFormat(
   locale: string | undefined,
   options: Intl.DateTimeFormatOptions
@@ -36,10 +24,7 @@ export function getDateTimeFormat(
   return formatter;
 }
 
-/**
- * Creates a cache key from locale and options.
- * Options are sorted by key to ensure consistent cache hits regardless of property order.
- */
+// Options are sorted by key so the cache hits regardless of property order.
 function createCacheKey(locale: string | undefined, options: Intl.DateTimeFormatOptions): string {
   const localeKey = locale ?? '';
   const optionsKey = Object.keys(options)


### PR DESCRIPTION
### Description

Currently, every call to `formatDateLocalized` (used in `DateInput`) allocates new `Intl.DateTimeFormat` instances, which have significant initialization overhead. This PR adds caching for those formatters so that they're only created the first time `formatDateLocalized` is called.

### How has this been tested?

I've added thorough unit test coverage.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
