### PR TITLE
fix: Use Map for O(1) column lookups in table width calculations

### DIFF
--- a/src/table/__tests__/columns-width.test.tsx
+++ b/src/table/__tests__/columns-width.test.tsx
@@ -224,3 +224,28 @@ describe('with stickyHeader=true', () => {
     ]);
   });
 });
+
+test('does not measure column widths when re-rendering with unchanged columns', () => {
+  const getBoundingClientRectSpy = jest.spyOn(Element.prototype, 'getBoundingClientRect');
+  const columns: TableProps.ColumnDefinition<Item>[] = [
+    { id: 'id', header: 'id', cell: item => item.id, width: 150 },
+    { id: 'text', header: 'text', cell: item => item.text, width: 200 },
+  ];
+  const { rerender } = renderTable(
+    <Table columnDefinitions={columns} items={defaultItems} resizableColumns={true} stickyColumns={{ first: 1 }} />
+  );
+
+  // Clear call count after initial render
+  getBoundingClientRectSpy.mockClear();
+
+  // Re-render with different items but same columns
+  const newItems = [
+    { id: 1, text: 'updated' },
+    { id: 2, text: 'new item' },
+  ];
+  rerender(<Table columnDefinitions={columns} items={newItems} resizableColumns={true} stickyColumns={{ first: 1 }} />);
+
+  expect(getBoundingClientRectSpy).not.toHaveBeenCalled();
+
+  getBoundingClientRectSpy.mockRestore();
+});

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useCallback, useImperativeHandle, useRef } from 'react';
+import React, { useCallback, useImperativeHandle, useMemo, useRef } from 'react';
 import clsx from 'clsx';
 
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
@@ -294,11 +294,10 @@ const InternalTable = React.forwardRef(
     const { moveFocusDown, moveFocusUp, moveFocus } = useSelectionFocusMove(selectionType, allItems.length);
     const { onRowClickHandler, onRowContextMenuHandler } = useRowEvents({ onRowClick, onRowContextMenu });
 
-    const visibleColumnDefinitions = getVisibleColumnDefinitions({
-      columnDefinitions,
-      columnDisplay,
-      visibleColumns,
-    });
+    const visibleColumnDefinitions = useMemo(
+      () => getVisibleColumnDefinitions({ columnDefinitions, columnDisplay, visibleColumns }),
+      [columnDefinitions, columnDisplay, visibleColumns]
+    );
 
     const { isItemSelected, getSelectAllProps, getItemSelectionProps } = useSelection({
       items: allItems,
@@ -344,17 +343,20 @@ const InternalTable = React.forwardRef(
       headerIdRef.current = id;
     }, []);
 
-    const visibleColumnWidthsWithSelection: ColumnWidthDefinition[] = [];
-    const visibleColumnIdsWithSelection: PropertyKey[] = [];
-    if (hasSelection) {
-      visibleColumnWidthsWithSelection.push({ id: selectionColumnId, width: SELECTION_COLUMN_WIDTH });
-      visibleColumnIdsWithSelection.push(selectionColumnId);
-    }
-    for (let columnIndex = 0; columnIndex < visibleColumnDefinitions.length; columnIndex++) {
-      const columnId = getColumnKey(visibleColumnDefinitions[columnIndex], columnIndex);
-      visibleColumnWidthsWithSelection.push({ ...visibleColumnDefinitions[columnIndex], id: columnId });
-      visibleColumnIdsWithSelection.push(columnId);
-    }
+    const { visibleColumnWidthsWithSelection, visibleColumnIdsWithSelection } = useMemo(() => {
+      const widths: ColumnWidthDefinition[] = [];
+      const ids: PropertyKey[] = [];
+      if (hasSelection) {
+        widths.push({ id: selectionColumnId, width: SELECTION_COLUMN_WIDTH });
+        ids.push(selectionColumnId);
+      }
+      for (let columnIndex = 0; columnIndex < visibleColumnDefinitions.length; columnIndex++) {
+        const columnId = getColumnKey(visibleColumnDefinitions[columnIndex], columnIndex);
+        widths.push({ ...visibleColumnDefinitions[columnIndex], id: columnId });
+        ids.push(columnId);
+      }
+      return { visibleColumnWidthsWithSelection: widths, visibleColumnIdsWithSelection: ids };
+    }, [hasSelection, visibleColumnDefinitions]);
 
     const stickyState = useStickyColumns({
       visibleColumns: visibleColumnIdsWithSelection,

--- a/src/table/use-column-widths.tsx
+++ b/src/table/use-column-widths.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useResizeObserver, useStableCallback } from '@cloudscape-design/component-toolkit/internal';
 import { getLogicalBoundingClientRect } from '@cloudscape-design/component-toolkit/internal';
@@ -35,18 +35,17 @@ function readWidths(
 }
 
 function updateWidths(
-  visibleColumns: readonly ColumnWidthDefinition[],
+  column: ColumnWidthDefinition | undefined,
   oldWidths: Map<PropertyKey, number>,
   newWidth: number,
   columnId: PropertyKey
 ) {
-  const column = visibleColumns.find(column => column.id === columnId);
   let minWidth = DEFAULT_COLUMN_WIDTH;
   if (typeof column?.width === 'number' && column.width < DEFAULT_COLUMN_WIDTH) {
-    minWidth = column?.width;
+    minWidth = column.width;
   }
   if (typeof column?.minWidth === 'number') {
-    minWidth = column?.minWidth;
+    minWidth = column.minWidth;
   }
   newWidth = Math.max(newWidth, minWidth);
   if (oldWidths.get(columnId) === newWidth) {
@@ -83,6 +82,8 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, contain
   const containerWidthRef = useRef(0);
   const [columnWidths, setColumnWidths] = useState<null | Map<PropertyKey, number>>(null);
 
+  const columnById = useMemo(() => new Map(visibleColumns.map(column => [column.id, column])), [visibleColumns]);
+
   const cellsRef = useRef(new Map<PropertyKey, HTMLElement>());
   const stickyCellsRef = useRef(new Map<PropertyKey, HTMLElement>());
   const getCell = (columnId: PropertyKey): null | HTMLElement => cellsRef.current.get(columnId) ?? null;
@@ -96,7 +97,7 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, contain
   };
 
   const getColumnStyles = (sticky: boolean, columnId: PropertyKey): ColumnWidthStyle => {
-    const column = visibleColumns.find(column => column.id === columnId);
+    const column = columnById.get(columnId);
     if (!column) {
       return {};
     }
@@ -190,7 +191,8 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, contain
   }, []);
 
   function updateColumn(columnId: PropertyKey, newWidth: number) {
-    setColumnWidths(columnWidths => updateWidths(visibleColumns, columnWidths ?? new Map(), newWidth, columnId));
+    const column = columnById.get(columnId);
+    setColumnWidths(columnWidths => updateWidths(column, columnWidths ?? new Map(), newWidth, columnId));
   }
 
   return (


### PR DESCRIPTION
### Description

Currently the table width calculations use repeated `find` calls across columns in `getColumnStyles`, which is called for each column, so worst-case performance is `O(n^2)`. This PR switches to creating a `Map` for that lookup, making performance consistently `O(n)`.

### How has this been tested?

This functionality is well-covered by existing tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
