### PR TITLE
fix: Cache measured column widths to avoid getBoundingClientRect during render

### DIFF
--- a/src/internal/components/dropdown/context.tsx
+++ b/src/internal/components/dropdown/context.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 
 type Position = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
@@ -14,7 +14,8 @@ export interface DropdownContextProviderProps {
 }
 
 export function DropdownContextProvider({ children, position = 'bottom-right' }: DropdownContextProviderProps) {
-  return <DropdownContext.Provider value={{ position }}>{children}</DropdownContext.Provider>;
+  const value = useMemo(() => ({ position }), [position]);
+  return <DropdownContext.Provider value={value}>{children}</DropdownContext.Provider>;
 }
 
 export function useDropdownContext() {

--- a/src/top-navigation/parts/overflow-menu/router.tsx
+++ b/src/top-navigation/parts/overflow-menu/router.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { createContext, Dispatch, SetStateAction, useContext, useState } from 'react';
+import React, { createContext, Dispatch, SetStateAction, useContext, useMemo, useState } from 'react';
 
 type View = 'utilities' | 'dropdown-menu';
 
@@ -60,7 +60,8 @@ interface RouterProps {
 
 const Router = ({ children }: RouterProps) => {
   const [state, setState] = useState<RouteState>({ view: 'utilities', data: null });
-  return <ViewContext.Provider value={{ state, setState }}>{children}</ViewContext.Provider>;
+  const value = useMemo(() => ({ state, setState }), [state]);
+  return <ViewContext.Provider value={value}>{children}</ViewContext.Provider>;
 };
 
 export default Router;


### PR DESCRIPTION
Note: This branch includes #4142 and #4143. Those PRs should be merged first.

### Description

I noticed that `getBoundingClientRect` was being called directly in `useColumnWidths`, which adds significant overhead to table renders. With this change, `getBoundingClientRect` is only called during `updateColumnWidths`, which is called outside of the React render flow. This should make table updates smoother.

### How has this been tested?

Since this is a render performance issue, it's difficult to test directly. I'd welcome suggestions.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
