### PR TITLE
fix: Update test to mock date to avoid failing when year changes

### DIFF
--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -259,7 +259,7 @@ describe('Date range picker', () => {
       });
 
       test('produces the value even if validation does not catch an incomplete range', () => {
-        Mockdate.set(new Date('2025-09-01T12:30:20'));
+        Mockdate.set(new Date('2026-01-01T12:30:20'));
         wrapper.openDropdown();
 
         changeMode(wrapper, 'absolute');
@@ -268,7 +268,7 @@ describe('Date range picker', () => {
         wrapper.findDropdown()!.findApplyButton().click();
 
         const dayObjectProperties = { endDate: 'T23:59:59+00:00', type: 'absolute' };
-        const monthObjectProperties = { endDate: '', startDate: '2025-09', type: 'absolute' };
+        const monthObjectProperties = { endDate: '', startDate: '2026-09', type: 'absolute' };
 
         expect(onChangeSpy).toHaveBeenCalledWith(
           expect.objectContaining({


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
Fix failing test due to new year (2026) not matching test code, 2025. 
Failing Test:
<img width="2078" height="996" alt="image" src="https://github.com/user-attachments/assets/8ea54684-0ce6-4977-9270-1da9e2df2d68" />


<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
