### PR TITLE
fix: Deduplicate CSS by hoisting shared styles to base selectors

### DIFF
--- a/src/button/styles.scss
+++ b/src/button/styles.scss
@@ -35,8 +35,6 @@ $tokens: style-api.resolve($props, carrier);
     border-block-width: var(#{style-api.read($tokens, border-width)}, #{map.get($variant, 'border-width')});
     border-inline-width: var(#{style-api.read($tokens, border-width)}, #{map.get($variant, 'border-width')});
   }
-  position: relative;
-  text-decoration: none;
   @if map.get($variant, 'padding') {
     padding-block: var(#{style-api.read($tokens, padding-block)}, #{map.get($variant, 'padding')});
     padding-inline: var(#{style-api.read($tokens, padding-inline)}, #{map.get($variant, 'padding')});
@@ -57,7 +55,6 @@ $tokens: style-api.resolve($props, carrier);
       var(#{custom-props.$styleColorHover}, map.get($variant, 'hover-color'))
     );
     box-shadow: var(#{style-api.read($tokens, box-shadow)}, var(#{custom-props.$styleBoxShadowHover}));
-    text-decoration: none;
   }
 
   &:active {
@@ -90,7 +87,6 @@ $tokens: style-api.resolve($props, carrier);
       var(#{custom-props.$styleColorDisabled}, map.get($variant, 'disabled-color'))
     );
     box-shadow: var(#{style-api.read($tokens, box-shadow)}, var(#{custom-props.$styleBoxShadowDisabled}));
-    text-decoration: none;
     cursor: auto;
   }
 }
@@ -116,6 +112,7 @@ $tokens: style-api.resolve($props, carrier);
   display: inline-block; // for <a> as a button
   text-decoration: none;
   cursor: pointer;
+  position: relative;
 
   @each $variant in map.keys(constants.$variants) {
     &.variant-#{$variant} {

--- a/src/icon/mixins.scss
+++ b/src/icon/mixins.scss
@@ -74,7 +74,6 @@ $_icon-sizes: (
 
     &.size-#{$name} {
       inline-size: $size;
-      box-sizing: border-box;
       &-mapped-height {
         block-size: $supportedLineHeight;
         padding-block: $padding;
@@ -85,7 +84,6 @@ $_icon-sizes: (
       > img {
         inline-size: $size;
         block-size: $size;
-        vertical-align: top;
       }
 
       > svg {

--- a/src/icon/styles.scss
+++ b/src/icon/styles.scss
@@ -12,6 +12,8 @@
   position: relative;
   display: inline-block;
   vertical-align: top;
+  box-sizing: border-box;
+
   &-flex-height {
     display: inline-flex;
     align-items: center;
@@ -24,8 +26,14 @@
     pointer-events: none;
   }
 
-  @include mixins.style-svg();
+  /* stylelint-disable selector-max-type */
+  > svg,
+  > img {
+    vertical-align: top;
+  }
+  /* stylelint-enable selector-max-type */
 
+  @include mixins.style-svg();
   @include mixins.make-icon-sizes;
   @include mixins.make-icon-variants;
 

--- a/src/spinner/mixins.scss
+++ b/src/spinner/mixins.scss
@@ -49,7 +49,6 @@ $_spinner-variants: (
       padding-block: $padding;
       padding-inline: $padding;
       margin-block: $margin;
-      box-sizing: border-box;
     }
   }
 }

--- a/src/tiles/styles.scss
+++ b/src/tiles/styles.scss
@@ -90,7 +90,6 @@ $selected-line: calc(awsui.$border-width-item-selected - 1px);
       & > .tile-container {
         margin-block: calc((#{$gutter} / 4));
         margin-inline: calc((#{$gutter} / 4));
-        box-sizing: border-box;
         @include make-column(12);
         &.breakpoint-xs {
           @include make-column(map.get($columns-setting, 'xs'));


### PR DESCRIPTION
### Description

I noticed that some CSS declarations were being repeated in loops. For example, the class for each icon size has the same `box-sizing` and `vertical-align` declarations.

This PR moves those declarations to avoid repetition, reducing the amount of generated CSS by ~1.3KB (total) across the icon, spinner, tiles, and button components.

### How has this been tested?

Since this is purely a CSS change, the screenshot tests (which I don't have the ability to run) should be definitive.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
