### PR TITLE
fix: Fixes drag handle UAP buttons to never render outside viewport

### DIFF
--- a/pages/drag-handle/drag-handle-uap-buttons-placement.page.tsx
+++ b/pages/drag-handle/drag-handle-uap-buttons-placement.page.tsx
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useContext } from 'react';
+
+import { Box, Checkbox, SpaceBetween } from '~components';
+import DragHandle, { DragHandleProps } from '~components/internal/components/drag-handle';
+import { colorBackgroundStatusInfo } from '~design-tokens';
+
+import AppContext, { AppContextType } from '../app/app-context';
+import { SimplePage } from '../app/templates';
+
+type PageContext = React.Context<
+  AppContextType<{
+    hideStart: boolean;
+    hideEnd: boolean;
+    hideTop: boolean;
+    hideBottom: boolean;
+  }>
+>;
+
+export default function TestBoardItemButton() {
+  const {
+    urlParams: { hideStart = false, hideEnd = false, hideTop = false, hideBottom = false },
+    setUrlParams,
+  } = useContext(AppContext as PageContext);
+  const dragHandleProps = (id: string): DragHandleProps & { 'data-testid': string } => ({
+    variant: 'drag-indicator',
+    ariaLabel: id,
+    'data-testid': id,
+    directions: {
+      'inline-start': hideStart ? undefined : 'active',
+      'inline-end': hideEnd ? undefined : 'active',
+      'block-start': hideTop ? undefined : 'active',
+      'block-end': hideBottom ? undefined : 'active',
+    },
+  });
+  return (
+    <SimplePage
+      title={
+        <Box fontSize="heading-l" fontWeight="bold" margin={{ top: 'xl' }}>
+          UAP buttons placement
+        </Box>
+      }
+      i18n={{}}
+      screenshotArea={{ disableAnimations: true }}
+      settings={
+        <SpaceBetween size="s" direction="horizontal">
+          <Checkbox checked={hideStart} onChange={({ detail }) => setUrlParams({ hideStart: detail.checked })}>
+            Hide start
+          </Checkbox>
+          <Checkbox checked={hideEnd} onChange={({ detail }) => setUrlParams({ hideEnd: detail.checked })}>
+            Hide end
+          </Checkbox>
+          <Checkbox checked={hideTop} onChange={({ detail }) => setUrlParams({ hideTop: detail.checked })}>
+            Hide top
+          </Checkbox>
+          <Checkbox checked={hideBottom} onChange={({ detail }) => setUrlParams({ hideBottom: detail.checked })}>
+            Hide bottom
+          </Checkbox>
+        </SpaceBetween>
+      }
+    >
+      <div style={{ position: 'absolute', inset: 4 }}>
+        <DragHandleWrapper {...dragHandleProps('top-start')} inset={['8px', '', '', '0px']} />
+        <DragHandleWrapper {...dragHandleProps('top-mid')} inset={['8px', '', '', '50%']} />
+        <DragHandleWrapper {...dragHandleProps('top-end')} inset={['8px', '0px', '', '']} />
+        <DragHandleWrapper {...dragHandleProps('near-top-start')} inset={['50px', '', '', '0px']} />
+        <DragHandleWrapper {...dragHandleProps('near-top-mid')} inset={['50px', '', '', '50%']} />
+        <DragHandleWrapper {...dragHandleProps('near-top-end')} inset={['50px', '0px', '', '']} />
+        <DragHandleWrapper {...dragHandleProps('mid-start')} inset={['50%', '', '', '0px']} />
+        <DragHandleWrapper {...dragHandleProps('mid-mid')} inset={['50%', '', '', '50%']} />
+        <DragHandleWrapper {...dragHandleProps('mid-end')} inset={['50%', '0px', '', '']} />
+        <DragHandleWrapper {...dragHandleProps('bottom-start')} inset={['', '', '0px', '0px']} />
+        <DragHandleWrapper {...dragHandleProps('bottom-mid')} inset={['', '', '0px', '50%']} />
+        <DragHandleWrapper {...dragHandleProps('bottom-end')} inset={['', '0px', '0px', '']} />
+      </div>
+    </SimplePage>
+  );
+}
+
+function DragHandleWrapper({ inset, ...props }: DragHandleProps & { inset: string[] }) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        insetBlockStart: inset[0],
+        insetInlineEnd: inset[1],
+        insetBlockEnd: inset[2],
+        insetInlineStart: inset[3],
+      }}
+    >
+      <div style={{ display: 'inline', padding: 4, background: colorBackgroundStatusInfo, borderRadius: '50%' }}>
+        <DragHandle {...props} />
+      </div>
+    </div>
+  );
+}

--- a/src/code-editor/resizable-box/__tests__/resizable-box.test.tsx
+++ b/src/code-editor/resizable-box/__tests__/resizable-box.test.tsx
@@ -7,7 +7,7 @@ import { ResizableBox, ResizeBoxProps } from '../../../../lib/components/code-ed
 import { PointerEventMock } from '../../../../lib/components/internal/utils/pointer-events-mock';
 
 import dragHandleStyles from '../../../../lib/components/internal/components/drag-handle/styles.css.js';
-import dragHandleWrapperStyles from '../../../../lib/components/internal/components/drag-handle-wrapper/styles.css.js';
+import dragHandleTestStyles from '../../../../lib/components/internal/components/drag-handle-wrapper/test-classes/styles.css.js';
 import styles from '../../../../lib/components/code-editor/resizable-box/styles.selectors.js';
 
 const defaultProps: ResizeBoxProps = {
@@ -26,9 +26,7 @@ function findHandle() {
 }
 
 function findDirectionButton(direction: 'block-start' | 'block-end') {
-  return document.querySelector(
-    `.${dragHandleWrapperStyles[`direction-button-wrapper-${direction}`]} .${dragHandleWrapperStyles['direction-button']}`
-  )!;
+  return document.querySelector(`.${dragHandleTestStyles[`direction-button-${direction}`]}`)!;
 }
 
 beforeAll(() => {

--- a/src/internal/components/drag-handle-wrapper/direction-button.tsx
+++ b/src/internal/components/drag-handle-wrapper/direction-button.tsx
@@ -27,9 +27,18 @@ interface DirectionButtonProps {
   state: DirectionState;
   onClick: React.MouseEventHandler;
   show: boolean;
+  forcedPosition: null | 'top' | 'bottom';
+  forcedIndex: number;
 }
 
-export default function DirectionButton({ direction, state, show, onClick }: DirectionButtonProps) {
+export default function DirectionButton({
+  direction,
+  state,
+  show,
+  onClick,
+  forcedPosition,
+  forcedIndex,
+}: DirectionButtonProps) {
   return (
     <Transition in={show}>
       {(transitionState, ref) => (
@@ -40,7 +49,9 @@ export default function DirectionButton({ direction, state, show, onClick }: Dir
           ref={ref}
           className={clsx(
             styles['direction-button-wrapper'],
-            styles[`direction-button-wrapper-${direction}`],
+            !forcedPosition && styles[`direction-button-wrapper-${direction}`],
+            forcedPosition && styles['direction-button-wrapper-forced'],
+            forcedPosition && styles[`direction-button-wrapper-forced-${forcedPosition}-${forcedIndex}`],
             transitionState === 'exited' && styles['direction-button-wrapper-hidden'],
             styles[`direction-button-wrapper-motion-${transitionState}`]
           )}

--- a/src/internal/components/drag-handle-wrapper/styles.scss
+++ b/src/internal/components/drag-handle-wrapper/styles.scss
@@ -73,6 +73,34 @@ $direction-button-offset: awsui.$space-static-xxs;
   inset-block-start: calc(50% - $direction-button-wrapper-size / 2);
 }
 
+.direction-button-wrapper-forced {
+  inset-inline-start: calc(50% - $direction-button-wrapper-size / 2);
+}
+.direction-button-wrapper-forced-top-0 {
+  inset-block-start: calc(-1 * $direction-button-wrapper-size);
+}
+.direction-button-wrapper-forced-top-1 {
+  inset-block-start: calc(-2 * $direction-button-wrapper-size);
+}
+.direction-button-wrapper-forced-top-2 {
+  inset-block-start: calc(-3 * $direction-button-wrapper-size);
+}
+.direction-button-wrapper-forced-top-3 {
+  inset-block-start: calc(-4 * $direction-button-wrapper-size);
+}
+.direction-button-wrapper-forced-bottom-0 {
+  inset-block-start: calc(1 * $direction-button-wrapper-size - 50%);
+}
+.direction-button-wrapper-forced-bottom-1 {
+  inset-block-start: calc(2 * $direction-button-wrapper-size - 50%);
+}
+.direction-button-wrapper-forced-bottom-2 {
+  inset-block-start: calc(3 * $direction-button-wrapper-size - 50%);
+}
+.direction-button-wrapper-forced-bottom-3 {
+  inset-block-start: calc(4 * $direction-button-wrapper-size - 50%);
+}
+
 .direction-button {
   position: absolute;
   border-width: 0;


### PR DESCRIPTION
### Description

This updates drag handle's UAP buttons to force rendering them in a single column if the handle is close to the screen edge.

Rel: AWSUI-61553

Before:

https://github.com/user-attachments/assets/a62291ea-9d67-4a2f-a539-20c411875c68

After:

https://github.com/user-attachments/assets/4f53b996-af2c-4d81-8064-1c619d7c0abb

https://github.com/user-attachments/assets/08187540-d665-42f4-96a7-69e5524b7ec2

### How has this been tested?

* Unit tests
* New test page for manual and screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
