### PR TITLE
chore: update build-tools dependency to use main branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@babel/core": "^7.23.7",
     "@babel/plugin-syntax-typescript": "^7.23.3",
     "@cloudscape-design/browser-test-tools": "^3.0.0",
-    "@cloudscape-design/build-tools": "github:cloudscape-design/build-tools#transition-main-do-not-edit",
+    "@cloudscape-design/build-tools": "github:cloudscape-design/build-tools#main",
     "@cloudscape-design/documenter": "^1.0.0",
     "@cloudscape-design/global-styles": "^1.0.0",
     "@cloudscape-design/jest-preset": "^2.0.0",


### PR DESCRIPTION
Switch from transition-main-do-not-edit branch to main branch for @cloudscape-design/build-tools dependency

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
