### PR TITLE
fix: Fixes UAP buttons forced padding

### DIFF
--- a/src/internal/components/drag-handle-wrapper/styles.scss
+++ b/src/internal/components/drag-handle-wrapper/styles.scss
@@ -89,16 +89,16 @@ $direction-button-offset: awsui.$space-static-xxs;
   inset-block-start: calc(-4 * $direction-button-wrapper-size);
 }
 .direction-button-wrapper-forced-bottom-0 {
-  inset-block-start: calc(1 * $direction-button-wrapper-size - 50%);
+  inset-block-start: calc(1 * $direction-button-wrapper-size);
 }
 .direction-button-wrapper-forced-bottom-1 {
-  inset-block-start: calc(2 * $direction-button-wrapper-size - 50%);
+  inset-block-start: calc(2 * $direction-button-wrapper-size);
 }
 .direction-button-wrapper-forced-bottom-2 {
-  inset-block-start: calc(3 * $direction-button-wrapper-size - 50%);
+  inset-block-start: calc(3 * $direction-button-wrapper-size);
 }
 .direction-button-wrapper-forced-bottom-3 {
-  inset-block-start: calc(4 * $direction-button-wrapper-size - 50%);
+  inset-block-start: calc(4 * $direction-button-wrapper-size);
 }
 
 .direction-button {


### PR DESCRIPTION
### Description

A follow-up for https://github.com/cloudscape-design/components/pull/4155 that fixes bottom paddings for forced uap buttons.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
