### PR TITLE
feat: Add valueLabel to tiles component selected tile

### DIFF
--- a/src/tiles/__tests__/analytics-metadata.test.tsx
+++ b/src/tiles/__tests__/analytics-metadata.test.tsx
@@ -42,7 +42,8 @@ const getMetadata = (
   position: string,
   value: string,
   disabled: boolean = false,
-  currentValue: string | null
+  currentValue: string | null,
+  currentValueLabel: string = ''
 ) => {
   const eventMetadata = {
     action: 'select',
@@ -62,6 +63,7 @@ const getMetadata = (
           label: componentLabel,
           properties: {
             value: `${currentValue}`,
+            valueLabel: `${currentValueLabel}`,
           },
         },
       },
@@ -83,18 +85,18 @@ describe('Tiles renders correct analytics metadata', () => {
     // in the whole tile
     validateComponentNameAndLabels(wrapper.findItemByValue('second')!.getElement(), labels);
     expect(getGeneratedAnalyticsMetadata(wrapper.findItemByValue('second')!.getElement())).toEqual(
-      getMetadata('Second choice', '2', 'second', false, 'second')
+      getMetadata('Second choice', '2', 'second', false, 'second', 'Second choice')
     );
     // in the radio within the tile
     validateComponentNameAndLabels(wrapper.findInputByValue('first')!.getElement(), labels);
     expect(getGeneratedAnalyticsMetadata(wrapper.findInputByValue('first')!.getElement())).toEqual(
-      getMetadata('First choice', '2', 'first', true, 'second')
+      getMetadata('First choice', '2', 'first', true, 'second', 'Second choice')
     );
   });
   test('with null value', () => {
     const wrapper = renderTiles({ value: null });
     expect(getGeneratedAnalyticsMetadata(wrapper.findItemByValue('second')!.getElement())).toEqual(
-      getMetadata('Second choice', '2', 'second', false, null)
+      getMetadata('Second choice', '2', 'second', false, null, '')
     );
   });
   test('readonly', () => {
@@ -102,7 +104,7 @@ describe('Tiles renders correct analytics metadata', () => {
 
     validateComponentNameAndLabels(wrapper.findInputByValue('second')!.getElement(), labels);
     expect(getGeneratedAnalyticsMetadata(wrapper.findInputByValue('second')!.getElement())).toEqual(
-      getMetadata('Second choice', '2', 'second', true, 'second')
+      getMetadata('Second choice', '2', 'second', true, 'second', 'Second choice')
     );
   });
   describe('when rendered in a form field', () => {
@@ -122,6 +124,7 @@ describe('Tiles renders correct analytics metadata', () => {
               label: 'form field label',
               properties: {
                 value: '2',
+                valueLabel: '',
               },
             },
           },
@@ -151,6 +154,7 @@ describe('Tiles renders correct analytics metadata', () => {
               label: 'aria label',
               properties: {
                 value: '2',
+                valueLabel: '',
               },
             },
           },

--- a/src/tiles/analytics-metadata/interfaces.ts
+++ b/src/tiles/analytics-metadata/interfaces.ts
@@ -17,5 +17,6 @@ export interface GeneratedAnalyticsMetadataTilesComponent {
   label: string | LabelIdentifier;
   properties: {
     value: string;
+    valueLabel: string;
   };
 }

--- a/src/tiles/analytics-metadata/styles.scss
+++ b/src/tiles/analytics-metadata/styles.scss
@@ -6,3 +6,7 @@
 .radio-button {
   /* used in analytics metadata */
 }
+
+.selected {
+  /* used in analytics metadata */
+}

--- a/src/tiles/index.tsx
+++ b/src/tiles/index.tsx
@@ -11,6 +11,8 @@ import { GeneratedAnalyticsMetadataTilesComponent } from './analytics-metadata/i
 import { TilesProps } from './interfaces';
 import InternalTiles from './internal';
 
+import analyticsSelectors from './analytics-metadata/styles.css.js';
+
 export { TilesProps };
 
 const Tiles = React.forwardRef((props: TilesProps, ref: React.Ref<TilesProps.Ref>) => {
@@ -22,6 +24,7 @@ const Tiles = React.forwardRef((props: TilesProps, ref: React.Ref<TilesProps.Ref
     label: { root: 'self' },
     properties: {
       value: `${props.value}`,
+      valueLabel: `.${analyticsSelectors.selected}`,
     },
   };
   return (

--- a/src/tiles/tile.tsx
+++ b/src/tiles/tile.tsx
@@ -67,7 +67,7 @@ export const Tile = React.forwardRef(
             disabled={item.disabled}
             controlId={item.controlId}
             readOnly={readOnly}
-            className={analyticsSelectors['radio-button']}
+            className={clsx(analyticsSelectors['radio-button'], selected && analyticsSelectors.selected)}
           >
             {item.label}
           </RadioButton>


### PR DESCRIPTION
### Description

Add valueLabel to tiles component to get actual user visible label inaddition to programmatic value, needed for page scanner.

Related links JjDIAxGVIRoe ybbPAl2KONnZ


<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
