### PR TITLE
fix: set aria-haspopup to listbox on filter input

### DIFF
--- a/src/select/parts/filter.tsx
+++ b/src/select/parts/filter.tsx
@@ -29,7 +29,7 @@ const Filter = React.forwardRef(({ filteringType, ...filterProps }: FilterProps,
       {...filterProps}
       nativeInputAttributes={{
         'aria-expanded': true,
-        'aria-haspopup': true,
+        'aria-haspopup': 'listbox',
         role: 'combobox',
         autoCorrect: 'off',
         autoCapitalize: 'off',


### PR DESCRIPTION
### Description

Fixes accessibility violation as detailed in `AWSUI-61674`.

Related links, issue #, if available: n/a

### How has this been tested?

Verified changes locally.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
