### PR TITLE
fix: padding for custom renderer changes after #4064

### DIFF
--- a/src/internal/components/selectable-item/styles.scss
+++ b/src/internal/components/selectable-item/styles.scss
@@ -54,13 +54,6 @@ $neg-divider-w: calc(-1 * #{$divider-w});
   @include divider-shadow(awsui.$color-border-dropdown-item-default, awsui.$color-border-dropdown-item-default);
 }
 
-@mixin border-padding {
-  border-width: 0;
-  padding-block: 0;
-  padding-inline: 0;
-  @include option-content-pad-with-offset(styles.$option-padding-vertical, styles.$control-padding-horizontal);
-}
-
 @mixin highlighted-shadow {
   box-shadow: inset 0 0 0 $border-offset awsui.$color-border-dropdown-item-hover;
   &.is-keyboard {
@@ -140,13 +133,6 @@ $neg-divider-w: calc(-1 * #{$divider-w});
   &.selected {
     color: awsui.$color-text-dropdown-item-highlighted;
     @include logical-radius(awsui.$border-radius-item);
-    @include border-padding;
-    &.child > .selectable-item-content {
-      padding-inline-start: add-offset(awsui.$space-xxl);
-    }
-    &.pad-bottom > .selectable-item-content {
-      padding-block-end: calc(#{styles.$option-padding-vertical} + #{awsui.$space-xxxs} + #{$border-offset});
-    }
   }
 
   &.highlighted {
@@ -214,14 +200,6 @@ $neg-divider-w: calc(-1 * #{$divider-w});
       }
       &.highlighted > .selectable-item-content {
         color: awsui.$color-text-dropdown-item-highlighted;
-      }
-      &.highlighted,
-      &.selected {
-        @include border-padding;
-        > .selectable-item-content {
-          padding-block: add-offset(styles.$group-option-padding-vertical);
-          padding-inline: add-offset(styles.$control-padding-horizontal);
-        }
       }
     }
   }


### PR DESCRIPTION
### Description

Fixes a bug in custom rendering (in selectable-item) that was introduced in #4064.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?
Manual testing

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
