### PR TITLE
chore: Refactor card margin to its parent

### DIFF
--- a/src/cards/styles.scss
+++ b/src/cards/styles.scss
@@ -115,18 +115,19 @@
   display: flex;
   overflow-wrap: break-word;
   word-wrap: break-word;
+  box-sizing: border-box;
   margin-block: 0;
   margin-inline: 0;
-  padding-block: 0;
-  padding-inline: 0;
+  padding-block-start: 0;
+  padding-block-end: awsui.$space-grid-gutter;
+  padding-inline-start: awsui.$space-grid-gutter;
+  padding-inline-end: 0;
   list-style: none;
   &-inner {
     position: relative;
     background-color: awsui.$color-background-container-content;
-    margin-block-start: 0;
-    margin-block-end: awsui.$space-grid-gutter;
-    margin-inline-start: awsui.$space-grid-gutter;
-    margin-inline-end: 0;
+    margin-block: 0;
+    margin-inline: 0;
     padding-block: awsui.$space-card-vertical;
     padding-inline: awsui.$space-card-horizontal;
     inline-size: 100%;


### PR DESCRIPTION
### Description

Move the spacing between the cards, from within the interior of each card to within the `li` element that wraps it.

This is a small preparation for the component decomposition (related: #4084)

### How has this been tested?

Ran in my pipeline.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
