### PR TITLE
feat: Adds class-name and data- props to error boundaries

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -11533,6 +11533,13 @@ exports[`Components definition for error-boundary matches the snapshot: error-bo
   "name": "ErrorBoundary",
   "properties": [
     {
+      "deprecatedTag": "Custom CSS is not supported. For testing and other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
+      "description": "Adds the specified classes to the root element of the component.",
+      "name": "className",
+      "optional": true,
+      "type": "string",
+    },
+    {
       "description": "Optional identifier for the error boundary instance.
 
 When provided, the identifier is included in the \`onError\` callback payload.
@@ -11600,6 +11607,15 @@ attribute \`data-awsui-boundary-id={errorBoundaryId}\` to support debugging.",
       "name": "i18nStrings",
       "optional": true,
       "type": "ErrorBoundaryProps.I18nStrings",
+    },
+    {
+      "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
+use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes). If you must
+use the \`id\` attribute, consider setting it on a parent element instead.",
+      "description": "Adds the specified ID to the root element of the component.",
+      "name": "id",
+      "optional": true,
+      "type": "string",
     },
     {
       "description": "Callback invoked when an error is intercepted by the boundary.

--- a/src/error-boundary/__tests__/error-boundary.test.tsx
+++ b/src/error-boundary/__tests__/error-boundary.test.tsx
@@ -17,7 +17,9 @@ jest.mock('../../../lib/components/error-boundary/utils', () => ({
 }));
 
 type RenderProps = Omit<
-  Partial<ErrorBoundaryProps> & { i18nProvider?: Record<string, Record<string, string>> },
+  Partial<ErrorBoundaryProps> & { i18nProvider?: Record<string, Record<string, string>> } & {
+    [key: `data-${string}`]: string;
+  },
   'children'
 >;
 
@@ -620,6 +622,23 @@ describe('default behaviors', () => {
     renderWithErrorBoundary(<b>{{}}</b>);
     findRefreshAction()!.click();
     expect(refreshPage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('base props passing to fallback', () => {
+  test('class name is added to the fallback', () => {
+    renderWithErrorBoundary(<b>{{}}</b>, { className: 'test' });
+    expect(findBoundary()!.getElement()).toHaveClass('test');
+  });
+
+  test('data-attributes are added to the fallback', () => {
+    renderWithErrorBoundary(<b>{{}}</b>, { 'data-resource-guidance': 'off' });
+    expect(findBoundary()!.getElement().dataset.resourceGuidance).toBe('off');
+  });
+
+  test('other attributes are not added to the fallback', () => {
+    renderWithErrorBoundary(<b>{{}}</b>, { 'aria-label': 'label' } as any);
+    expect(findBoundary()!.getElement()).not.toHaveAttribute('aria-label');
   });
 });
 

--- a/src/error-boundary/fallback.tsx
+++ b/src/error-boundary/fallback.tsx
@@ -8,6 +8,7 @@ import IntlMessageFormat from 'intl-messageformat';
 import InternalAlert from '../alert/internal';
 import InternalButton from '../button/internal';
 import { useInternalI18n } from '../i18n/context';
+import { getBaseProps } from '../internal/base-component';
 import { ErrorBoundaryProps } from './interfaces';
 import { refreshPage } from './utils';
 
@@ -17,7 +18,9 @@ import testUtilStyles from './test-classes/styles.css.js';
 export function ErrorBoundaryFallback({
   i18nStrings = {},
   renderFallback,
+  ...props
 }: Pick<ErrorBoundaryProps, 'renderFallback' | 'i18nStrings'>) {
+  const baseProps = getBaseProps(props);
   const defaultSlots = {
     header: (
       <div className={clsx(styles.header, testUtilStyles.header)}>
@@ -36,7 +39,7 @@ export function ErrorBoundaryFallback({
     ),
   };
   return (
-    <div className={testUtilStyles.fallback}>
+    <div {...baseProps} className={clsx(baseProps.className, testUtilStyles.fallback)}>
       {renderFallback?.(defaultSlots) ?? (
         <InternalAlert type="error" header={defaultSlots.header} action={defaultSlots.action}>
           {defaultSlots.description}

--- a/src/error-boundary/interfaces.ts
+++ b/src/error-boundary/interfaces.ts
@@ -3,7 +3,9 @@
 
 import { ErrorInfo } from 'react';
 
-export interface ErrorBoundaryProps {
+import { BaseComponentProps } from '../internal/base-component';
+
+export interface ErrorBoundaryProps extends BaseComponentProps {
   /**
    * Optional identifier for the error boundary instance.
    *


### PR DESCRIPTION
### Description

This change allows passing custom class names or data-* attributes to the fallback. It is consistent with how findErrorBoundary() test-util only finds the component when in fallback state.

The change is needed to pass a particular data-attribute to the default fallback message, which is used to alter the runtime behaviour of alerts (coming from the awsuiPlugins.alert runtime API):

```
// Wrong: this affects both the alert in EB fallback but also all alerts in the content
<div data-runtime-behaviour="off">
  <ErrorBoundary ... />
</div>

// Works (with this change)
<ErrorBoundary ... data-runtime-behaviour="off" />
```

### How has this been tested?

* Unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
