### PR TITLE
fix: Add role="tooltip" to non-modal chart popovers

### DIFF
--- a/src/internal/components/chart-popover/__tests__/chart-popover.test.tsx
+++ b/src/internal/components/chart-popover/__tests__/chart-popover.test.tsx
@@ -6,6 +6,44 @@ import { act, render } from '@testing-library/react';
 
 import ChartPopover from '../../../../../lib/components/internal/components/chart-popover';
 
+describe('accessibility', () => {
+  test('has role="tooltip" on the root element if dismissButton is false', () => {
+    const { container } = render(
+      <ChartPopover
+        trackRef={{ current: null }}
+        container={null}
+        onDismiss={() => {}}
+        dismissButton={false}
+        data-testid="chart-popover"
+      >
+        content
+      </ChartPopover>
+    );
+
+    const popoverRoot = container.querySelector('[data-testid="chart-popover"]');
+    expect(popoverRoot).toBeInTheDocument();
+    expect(popoverRoot).toHaveAttribute('role', 'tooltip');
+  });
+
+  test('does not have role="tooltip" on the root element if dismissButton is true', () => {
+    const { container } = render(
+      <ChartPopover
+        trackRef={{ current: null }}
+        container={null}
+        onDismiss={() => {}}
+        dismissButton={true}
+        data-testid="chart-popover"
+      >
+        content
+      </ChartPopover>
+    );
+
+    const popoverRoot = container.querySelector('[data-testid="chart-popover"]');
+    expect(popoverRoot).toBeInTheDocument();
+    expect(popoverRoot).not.toHaveAttribute('role', 'tooltip');
+  });
+});
+
 describe('click outside', () => {
   function TestComponent({ onDismiss }: { onDismiss: () => void }) {
     return (

--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -119,6 +119,7 @@ function ChartPopover(
   return (
     <div
       {...baseProps}
+      role={!dismissButton ? 'tooltip' : undefined}
       className={clsx(popoverStyles.root, styles.root, baseProps.className)}
       ref={popoverRef}
       onMouseEnter={onMouseEnter}


### PR DESCRIPTION
### Description

Pretty simple and direct, should filter down to both the old and the new charts.

Related links, issue #, if available: AWSUI-61648

### How has this been tested?

Unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
