### PR TITLE
fix: Trigger-less drawers in classic theme

### DIFF
--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -76,6 +76,11 @@ describeEachAppLayout(({ size }) => {
     expect(wrapper.findDrawersTriggers()).toHaveLength(0);
   });
 
+  test('runtime drawer triggerless does not crash page', async () => {
+    awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, trigger: undefined });
+    await expect(renderComponent(<AppLayout />)).resolves.not.toThrow();
+  });
+
   test('runtime drawers integration can be dynamically enabled and disabled', async () => {
     awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
     const { wrapper, rerender } = await renderComponent(<AppLayout />);

--- a/src/app-layout/classic.tsx
+++ b/src/app-layout/classic.tsx
@@ -408,7 +408,7 @@ const ClassicAppLayout = React.forwardRef(
             onToolsOpen={() => onToolsToggle(true)}
             unfocusable={anyPanelOpen}
             mobileBarRef={mobileBarRef}
-            drawers={drawers}
+            drawers={drawers?.filter(drawer => drawer.trigger)}
             activeDrawerId={activeDrawerId}
             onDrawerChange={newDrawerId => {
               onActiveDrawerChange(newDrawerId, { initiatedByUserAction: true });
@@ -590,7 +590,7 @@ const ClassicAppLayout = React.forwardRef(
               bottomOffset={placement.insetBlockEnd}
               topOffset={placement.insetBlockStart}
               isMobile={isMobile}
-              drawers={drawers}
+              drawers={drawers.filter(drawer => drawer.trigger)}
               activeDrawerId={activeDrawerId}
               onDrawerChange={newDrawerId => {
                 if (activeDrawerId !== newDrawerId) {


### PR DESCRIPTION
### Description

Fixed an issue where runtime drawers without triggers crashed the entire page on classic theme.

Related links, issue #, if available: n/a

### How has this been tested?

U test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
