### PR TITLE
feat: Error boundary default refresh always takes top window

### DIFF
--- a/src/error-boundary/fallback.tsx
+++ b/src/error-boundary/fallback.tsx
@@ -10,7 +10,7 @@ import InternalButton from '../button/internal';
 import { useInternalI18n } from '../i18n/context';
 import { getBaseProps } from '../internal/base-component';
 import { ErrorBoundaryProps } from './interfaces';
-import { refreshPage } from './utils';
+import { canUseRefresh, refreshPage } from './utils';
 
 import styles from './styles.css.js';
 import testUtilStyles from './test-classes/styles.css.js';
@@ -32,11 +32,11 @@ export function ErrorBoundaryFallback({
         <DefaultDescriptionContent i18nStrings={i18nStrings} />
       </div>
     ),
-    action: (
+    action: canUseRefresh() ? (
       <div className={clsx(styles.action, testUtilStyles.action)}>
         <DefaultActionContent i18nStrings={i18nStrings} />
       </div>
-    ),
+    ) : null,
   };
   return (
     <div {...baseProps} className={clsx(baseProps.className, testUtilStyles.fallback)}>

--- a/src/error-boundary/utils.ts
+++ b/src/error-boundary/utils.ts
@@ -1,7 +1,27 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/* istanbul ignore next */
-export function refreshPage() {
-  window.location.reload();
+// The default refresh action reloads the top window to avoid iframe lifecycle getting out of sync with the parent page.
+// This is not possible from cross-origin iframes, in which case the default refresh action must be hidden.
+export function canUseRefresh(): boolean {
+  try {
+    // In cross-origin iframes, accessing top.location can throw a SecurityError.
+    void getTopWindow().location.href;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function refreshPage(): void {
+  try {
+    getTopWindow().location.reload();
+  } catch {
+    // noop
+  }
+}
+
+// In browsers, window.top is always defined, but it is treated as optional by our current DOM types.
+function getTopWindow(): Window {
+  return window.top ?? window;
 }


### PR DESCRIPTION
### Description

When window.location.reload() is called from an error boundary rendered inside an iframe - the reload will cause the iframe, not the entire page, to reload. This can break iframe lifecycle when connected to the parent window via events.

The PR changes that by making the default refresh use the top window, which in not possible for cross-origin iframes, in which case the refresh action is then hidden.

### How has this been tested?

* New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
