### PR TITLE
fix: Runtime content page function not found runtime exception

### DIFF
--- a/pages/alert/runtime-content.page.tsx
+++ b/pages/alert/runtime-content.page.tsx
@@ -71,7 +71,7 @@ awsuiPlugins.alertContent.registerContentReplacer({
         typeof context.content === 'object' &&
         'props' in context.content &&
         typeof context.content.props.children === 'string' &&
-        context.content.props.children?.match('Access denied')
+        context.content.props.children.match('Access denied')
       )
     );
   },


### PR DESCRIPTION
The initialCheck on our alert pages has a bug that throws a "t.match is not a function" runtime error. We are trying to call "match" on the AlertFlashContentInitialContext `context.content.props.children`. However, we are missing to check if it is a string. Apparently, it can sometimes be an array, therefore throwing an error. You can test this by opening the dev pages, then select the alert runtime-content and afterwards the alert permutations page.

-> As it only appears when switching from "runtime-content" to the "permutations"-page, I assume there is a deeper bug in our dev pages. But this is blocking me, so this should be treated as a hotfix until further research was done.
 
<img width="631" height="190" alt="Screenshot 2026-02-04 at 18 04 43" src="https://github.com/user-attachments/assets/bd284fc2-d2b0-4760-80d6-1442f6ad1b0c" />

### How has this been tested?
Tested locally.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
