### PR TITLE
chore: Fixes flaky button dropdown performance marks test

### DIFF
--- a/src/button-dropdown/__integ__/performance-marks.test.ts
+++ b/src/button-dropdown/__integ__/performance-marks.test.ts
@@ -1,39 +1,27 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
-function setupTest(
-  pageName: string,
-  testFn: (parameters: {
-    page: BasePageObject;
-    getMarks: () => Promise<PerformanceMark[]>;
-    getElementPerformanceMarkText: (id: string) => Promise<string>;
-  }) => Promise<void>
-) {
-  return useBrowser(async browser => {
-    const page = new BasePageObject(browser);
-    await browser.url(`#/light/button-dropdown/${pageName}`);
-    const getMarks = async () => {
-      await new Promise(r => setTimeout(r, 200));
-      const marks = await browser.execute(() => performance.getEntriesByType('mark') as PerformanceMark[]);
-      return marks.filter(m => m.detail?.source === 'awsui');
-    };
-    const getElementPerformanceMarkText = (id: string) => page.getText(`[data-analytics-performance-mark="${id}"]`);
-
-    await testFn({ page, getMarks, getElementPerformanceMarkText });
-  });
+function getMarkSelector(mark: PerformanceMark) {
+  return `[data-analytics-performance-mark="${mark.detail.instanceIdentifier}"]`;
 }
 
-describe('ButtonDropdown', () => {
-  test(
-    'Emits a single mark',
-    setupTest('main-action', async ({ getMarks, getElementPerformanceMarkText }) => {
-      const marks = await getMarks();
+test(
+  'ButtonDropdown emits a single mark',
+  useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/button-dropdown/main-action');
+    await new Promise(r => setTimeout(r, 200));
 
-      expect(marks).toHaveLength(1);
-      expect(marks[0].name).toBe('primaryButtonRendered');
-      expect(marks[0].detail).toMatchObject({
+    await page.waitForAssertion(async () => {
+      const allMarks = await browser.execute(() => performance.getEntriesByType('mark') as PerformanceMark[]);
+      const awsuiMarks = allMarks.filter(m => m.detail?.source === 'awsui');
+
+      expect(awsuiMarks).toHaveLength(1);
+      expect(awsuiMarks[0].name).toBe('primaryButtonRendered');
+      expect(awsuiMarks[0].detail).toMatchObject({
         source: 'awsui',
         instanceIdentifier: expect.any(String),
         loading: false,
@@ -41,8 +29,7 @@ describe('ButtonDropdown', () => {
         inViewport: true,
         text: 'Launch instance',
       });
-
-      await expect(getElementPerformanceMarkText(marks[0].detail.instanceIdentifier)).resolves.toBe('Launch instance');
-    })
-  );
-});
+      await expect(page.getText(getMarkSelector(awsuiMarks[0]))).resolves.toBe('Launch instance');
+    });
+  })
+);


### PR DESCRIPTION
### Description

The particular test is flaky and fails from time to time in GitHub actions after 3 retries.

### How has this been tested?

Tested in GitHub actions with 100 test runs - there was not a single retry for this test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
