### PR TITLE
chore: Fixes flaky flashbar test

### DIFF
--- a/src/flashbar/__integ__/collapsible.test.ts
+++ b/src/flashbar/__integ__/collapsible.test.ts
@@ -135,8 +135,8 @@ describe('Collapsible Flashbar', () => {
         await page.setWindowSize(windowDimensions);
         await page.toggleCollapsedState();
         expect(await page.getNotificationBarBottom()).toBeGreaterThan(windowDimensions.height);
-        await page.windowScrollTo({ top: 1200 });
         await page.waitForAssertion(async () => {
+          await page.windowScrollTo({ top: 1200 });
           await expect(page.getNotificationBarBottom()).resolves.toBeLessThan(windowDimensions.height);
         });
       })


### PR DESCRIPTION
### Description

The flashbar test is flaky and fails occasionally in GitHub actions. That seems to be related to the scrolling not being completed. The nature of the test allows to repeat the scrolling action and assertion until it completes w/o sacrificing coverage.

### How has this been tested?

Tested by running the test over 100 times with GitHub actions - there was not a single retry.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
