### PR TITLE
fix: Fixes tables with infinite expandable rows

### DIFF
--- a/src/table/__tests__/expandable-rows.test.tsx
+++ b/src/table/__tests__/expandable-rows.test.tsx
@@ -299,4 +299,17 @@ describe('Expandable rows', () => {
     });
     expect(table.findEditCellButton(1, 1)).not.toBe(null);
   });
+
+  test('tolerates infinitely expandable items', () => {
+    const { table } = renderTable({
+      items: simpleItems,
+      expandableRows: {
+        isItemExpandable: () => true,
+        expandedItems: [],
+        getItemChildren: () => [{ name: Math.random().toString() }],
+        onExpandableItemToggle: () => {},
+      },
+    });
+    expect(table).not.toBe(null);
+  });
 });

--- a/src/table/expandable-rows/expandable-rows-utils.ts
+++ b/src/table/expandable-rows/expandable-rows-utils.ts
@@ -64,14 +64,14 @@ export function useExpandableTableProps<T>({
 
       if (visible) {
         visibleItems.push(item);
+        children.forEach((child, index) =>
+          traverse(
+            child,
+            { level: detail.level + 1, setSize: children.length, posInSet: index + 1, parent: item },
+            expandedSet.has(item)
+          )
+        );
       }
-      children.forEach((child, index) =>
-        traverse(
-          child,
-          { level: detail.level + 1, setSize: children.length, posInSet: index + 1, parent: item },
-          visible && expandedSet.has(item)
-        )
-      );
     };
     items.forEach((item, index) =>
       traverse(item, { level: 1, setSize: items.length, posInSet: index + 1, parent: null }, true)


### PR DESCRIPTION
### Description

A small fix that allows expandable rows to be infinite, which is useful in tests.

### How has this been tested?

* New unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
