### PR TITLE
fix: Respect minWidth for dynamically added columns in resizable mode

### DIFF
--- a/src/table/__tests__/columns-width.test.tsx
+++ b/src/table/__tests__/columns-width.test.tsx
@@ -137,6 +137,33 @@ test('should use the fallback value for columns without explicit width', () => {
   ]);
 });
 
+test('should respect minWidth for dynamically added columns without explicit width', () => {
+  const columns: TableProps.ColumnDefinition<Item>[] = [
+    { id: 'id', header: '', cell: item => item.id, width: 100 },
+    { id: 'name', header: '', cell: () => '-', minWidth: 250 },
+    { id: 'description', header: '', cell: () => '-', minWidth: 300 },
+  ];
+  const { wrapper, rerender } = renderTable(
+    <Table columnDefinitions={columns} visibleColumns={['id']} items={defaultItems} resizableColumns={true} />
+  );
+  expect(wrapper.findColumnHeaders().map(column => column.getElement().style.width)).toEqual(['100px']);
+  // Dynamically add columns that have minWidth but no explicit width
+  rerender(
+    <Table
+      columnDefinitions={columns}
+      visibleColumns={['id', 'name', 'description']}
+      items={defaultItems}
+      resizableColumns={true}
+    />
+  );
+  // Bug #4236: Previously these would be '120px' (DEFAULT_COLUMN_WIDTH) instead of respecting minWidth
+  expect(wrapper.findColumnHeaders().map(column => column.getElement().style.width)).toEqual([
+    '100px',
+    '250px',
+    '300px',
+  ]);
+});
+
 describe('reading widths from the DOM', () => {
   const originalBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
   beforeEach(() => {

--- a/src/table/use-column-widths.tsx
+++ b/src/table/use-column-widths.tsx
@@ -168,7 +168,10 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, contain
         const column = visibleColumns[index];
         if (!columnWidths?.get(column.id) && lastVisible.indexOf(column.id) === -1) {
           updated = true;
-          newColumnWidths.set(column.id, (column.width as number) || DEFAULT_COLUMN_WIDTH);
+          // Handle minWidth consistently with readWidths() for initial render
+          const width = (column.width as number) || 0;
+          const minWidth = (column.minWidth as number) || width || DEFAULT_COLUMN_WIDTH;
+          newColumnWidths.set(column.id, Math.max(width, minWidth));
         }
       }
       if (updated) {


### PR DESCRIPTION
## Description

Fixes #4236

When columns are dynamically added to a table with `resizableColumns` enabled, the `minWidth` property was being ignored. Instead, columns defaulted to `DEFAULT_COLUMN_WIDTH` (120px) even when they had a `minWidth` property set.

### Problem

In `use-column-widths.tsx`, the code path for dynamically added columns (line ~171) only checked `column.width`:

```ts
newColumnWidths.set(column.id, (column.width as number) || DEFAULT_COLUMN_WIDTH);
```

This is inconsistent with the initial render behavior in `readWidths()` (lines 27-32), which correctly handles `minWidth`:

```ts
let width = (column.width as number) || 0;
const minWidth = (column.minWidth as number) || width || DEFAULT_COLUMN_WIDTH;
result.set(column.id, Math.max(width, minWidth));
```

### Solution

Apply the same logic to dynamically added columns, ensuring `minWidth` is respected consistently:

```ts
const width = (column.width as number) || 0;
const minWidth = (column.minWidth as number) || width || DEFAULT_COLUMN_WIDTH;
newColumnWidths.set(column.id, Math.max(width, minWidth));
```

### Testing

Added a new test case `should respect minWidth for dynamically added columns without explicit width` that:
1. Renders a table with only one visible column
2. Dynamically adds columns that have `minWidth` but no explicit `width`
3. Verifies the columns respect their `minWidth` values instead of falling back to `DEFAULT_COLUMN_WIDTH`

All existing tests continue to pass.