### PR TITLE
chore: Add descriptions for style API

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -209,7 +209,8 @@ If the label is assigned via the \`i18nStrings\` property, this label will be ig
       "type": "string",
     },
     {
-      "description": "An object containing CSS properties to customize the alert's visual appearance.",
+      "description": "An object containing CSS properties to customize the alert's visual appearance.
+Refer to the [style](/components/alert/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "AlertProps.Style",
         "properties": [
@@ -3638,7 +3639,8 @@ This is required to provide a good screen reader experience. For more informatio
       "type": "string",
     },
     {
-      "description": "An object containing CSS properties to customize the autosuggest's visual appearance.",
+      "description": "An object containing CSS properties to customize the autosuggest's visual appearance.
+Refer to the [style](/components/autosuggest/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "AutosuggestProps.Style",
         "properties": [
@@ -3982,7 +3984,8 @@ We do not support using this attribute to apply custom styling.",
       "type": "Omit<React.HTMLAttributes<HTMLElement>, "children"> & Record<\`data-\${string}\`, string>",
     },
     {
-      "description": "An object containing CSS properties to customize the badge's visual appearance.",
+      "description": "An object containing CSS properties to customize the badge's visual appearance.
+Refer to the [style](/components/badge/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "BadgeProps.Style",
         "properties": [
@@ -5498,7 +5501,8 @@ If the \`rel\` property is provided, it overrides the default behavior.",
       "type": "string",
     },
     {
-      "description": "An object containing CSS properties to customize the button's visual appearance.",
+      "description": "An object containing CSS properties to customize the button's visual appearance.
+Refer to the [style](/components/button/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "ButtonProps.Style",
         "properties": [
@@ -6615,7 +6619,8 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "ReadonlyArray<ButtonGroupProps.ItemOrGroup>",
     },
     {
-      "description": "An object containing CSS properties to customize the button group's visual appearance.",
+      "description": "An object containing CSS properties to customize the button group's visual appearance.
+Refer to the [style](/components/button-group/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "ButtonGroupProps.Style",
         "properties": [
@@ -7597,7 +7602,8 @@ If both \`readOnly\` and \`disabled\` are set, \`disabled\` takes precedence.",
       "type": "boolean",
     },
     {
-      "description": "An object containing CSS properties to customize the checkbox's visual appearance.",
+      "description": "An object containing CSS properties to customize the checkbox's visual appearance.
+Refer to the [style](/components/checkbox/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "CheckboxProps.Style",
         "properties": [
@@ -9560,7 +9566,8 @@ If no height is provided, the media slot will be displayed at its full height.",
       "type": "ContainerProps.Media",
     },
     {
-      "description": "An object containing CSS properties to customize the container's visual appearance.",
+      "description": "An object containing CSS properties to customize the container's visual appearance.
+Refer to the [style](/components/container/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "ContainerProps.Style",
         "properties": [
@@ -12764,7 +12771,8 @@ If the \`action\` property is set, this property is ignored. **Deprecated**, rep
       "type": "boolean",
     },
     {
-      "description": "An object containing CSS properties to customize the flashbar's visual appearance.",
+      "description": "An object containing CSS properties to customize the flashbar's visual appearance.
+Refer to the [style](/components/flashbar/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "FlashbarProps.Style",
         "properties": [
@@ -15418,7 +15426,8 @@ including the date, month, week, time, datetime-local, number and range types.",
       "type": "InputProps.Step",
     },
     {
-      "description": "An object containing CSS properties to customize the input's visual appearance.",
+      "description": "An object containing CSS properties to customize the input's visual appearance.
+Refer to the [style](/components/input/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "InputProps.Style",
         "properties": [
@@ -16462,7 +16471,8 @@ By default, the component sets the \`rel\` attribute to "noopener noreferrer" wh
       "type": "string",
     },
     {
-      "description": "An object containing CSS properties to customize the link's visual appearance.",
+      "description": "An object containing CSS properties to customize the link's visual appearance.
+Refer to the [style](/components/link/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "LinkProps.Style",
         "properties": [
@@ -19335,7 +19345,8 @@ Add a button using the \`action\` property of the flashbar item instead.",
       "type": "string",
     },
     {
-      "description": "An object containing CSS properties to customize the progress bar's visual appearance.",
+      "description": "An object containing CSS properties to customize the progress bar's visual appearance.
+Refer to the [style](/components/progress-bar/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "ProgressBarProps.Style",
         "properties": [
@@ -20047,7 +20058,8 @@ inadvertently sending data (such as user passwords) to third parties.",
       "type": "boolean",
     },
     {
-      "description": "An object containing CSS properties to customize the prompt input's visual appearance.",
+      "description": "An object containing CSS properties to customize the prompt input's visual appearance.
+Refer to the [style](/components/prompt-input/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "PromptInputProps.Style",
         "properties": [
@@ -21254,7 +21266,8 @@ This property should be set for either all or none of the radio buttons in a gro
       "type": "boolean",
     },
     {
-      "description": "An object containing CSS properties to customize the radio button's visual appearance.",
+      "description": "An object containing CSS properties to customize the radio button's visual appearance.
+Refer to the [style](/components/radio-button/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "RadioButtonProps.Style",
         "properties": [
@@ -21660,7 +21673,8 @@ being included in a form submission. A read-only control is still focusable.",
       "type": "boolean",
     },
     {
-      "description": "An object containing CSS properties to customize the radio group's visual appearance.",
+      "description": "An object containing CSS properties to customize the radio group's visual appearance.
+Refer to the [style](/components/radio-group/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "RadioButtonProps.Style",
         "properties": [
@@ -22847,7 +22861,8 @@ Each segment has the following properties:
       "type": "string | null",
     },
     {
-      "description": "An object containing CSS properties to customize the segmented control's visual appearance.",
+      "description": "An object containing CSS properties to customize the segmented control's visual appearance.
+Refer to the [style](/components/segmented-control/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "SegmentedControlProps.Style",
         "properties": [
@@ -24400,7 +24415,8 @@ being included in a form submission. A read-only control is still focusable.",
       "type": "number",
     },
     {
-      "description": "An object containing CSS properties to customize the slider's visual appearance.",
+      "description": "An object containing CSS properties to customize the slider's visual appearance.
+Refer to the [style](/components/slider/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "SliderProps.Style",
         "properties": [
@@ -26458,7 +26474,8 @@ need to introduce friction to the switching of tabs.",
       "type": "string",
     },
     {
-      "description": "An object containing CSS properties to customize the tabs' visual appearance.",
+      "description": "An object containing CSS properties to customize the tabs' visual appearance.
+Refer to the [style](/components/tabs/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "TabsProps.Style",
         "properties": [
@@ -27483,7 +27500,8 @@ If set to \`true\`, the live announcement of countText by assistive technologies
       "type": "boolean",
     },
     {
-      "description": "An object containing CSS properties to customize the text filter's visual appearance.",
+      "description": "An object containing CSS properties to customize the text filter's visual appearance.
+Refer to the [style](/components/text-filter/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "TextFilterProps.Style",
         "properties": [
@@ -28060,7 +28078,8 @@ inadvertently sending data (such as user passwords) to third parties.",
       "type": "boolean",
     },
     {
-      "description": "An object containing CSS properties to customize the textarea's visual appearance.",
+      "description": "An object containing CSS properties to customize the textarea's visual appearance.
+Refer to the [style](/components/textarea/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "TextareaProps.Style",
         "properties": [
@@ -28874,7 +28893,8 @@ If both \`readOnly\` and \`disabled\` are set, \`disabled\` takes precedence.",
       "type": "boolean",
     },
     {
-      "description": "An object containing CSS properties to customize the toggle's visual appearance.",
+      "description": "An object containing CSS properties to customize the toggle's visual appearance.
+Refer to the [style](/components/toggle/?tabId=style) tab for more details.",
       "inlineType": {
         "name": "ToggleProps.Style",
         "properties": [

--- a/src/alert/interfaces.ts
+++ b/src/alert/interfaces.ts
@@ -158,6 +158,7 @@ export interface AlertProps extends BaseComponentProps {
   analyticsMetadata?: AlertProps.AnalyticsMetadata;
   /**
    * An object containing CSS properties to customize the alert's visual appearance.
+   * Refer to the [style](/components/alert/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: AlertProps.Style;

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -166,6 +166,7 @@ export interface AutosuggestProps
 
   /**
    * An object containing CSS properties to customize the autosuggest's visual appearance.
+   * Refer to the [style](/components/autosuggest/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: AutosuggestProps.Style;

--- a/src/badge/interfaces.ts
+++ b/src/badge/interfaces.ts
@@ -30,6 +30,7 @@ export interface BadgeProps extends BaseComponentProps {
 
   /**
    * An object containing CSS properties to customize the badge's visual appearance.
+   * Refer to the [style](/components/badge/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: BadgeProps.Style;

--- a/src/button-group/interfaces.ts
+++ b/src/button-group/interfaces.ts
@@ -101,6 +101,7 @@ export interface ButtonGroupProps extends BaseComponentProps {
   onFilesChange?: NonCancelableEventHandler<ButtonGroupProps.FilesChangeDetails>;
   /**
    * An object containing CSS properties to customize the button group's visual appearance.
+   * Refer to the [style](/components/button-group/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: ButtonGroupProps.Style;

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -210,6 +210,7 @@ export interface ButtonProps extends BaseComponentProps, BaseButtonProps {
 
   /**
    * An object containing CSS properties to customize the button's visual appearance.
+   * Refer to the [style](/components/button/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: ButtonProps.Style;

--- a/src/checkbox/interfaces.ts
+++ b/src/checkbox/interfaces.ts
@@ -35,6 +35,7 @@ export interface CheckboxProps extends BaseCheckboxProps {
 
   /**
    * An object containing CSS properties to customize the checkbox's visual appearance.
+   * Refer to the [style](/components/checkbox/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: CheckboxProps.Style;

--- a/src/container/interfaces.ts
+++ b/src/container/interfaces.ts
@@ -84,6 +84,7 @@ export interface ContainerProps extends BaseComponentProps {
 
   /**
    * An object containing CSS properties to customize the container's visual appearance.
+   * Refer to the [style](/components/container/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: ContainerProps.Style;

--- a/src/flashbar/interfaces.ts
+++ b/src/flashbar/interfaces.ts
@@ -218,6 +218,7 @@ export interface FlashbarProps extends BaseComponentProps {
 
   /**
    * An object containing CSS properties to customize the flashbar's visual appearance.
+   * Refer to the [style](/components/flashbar/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: FlashbarProps.Style;

--- a/src/input/interfaces.ts
+++ b/src/input/interfaces.ts
@@ -184,6 +184,7 @@ export interface InputProps
 
   /**
    * An object containing CSS properties to customize the input's visual appearance.
+   * Refer to the [style](/components/input/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: InputProps.Style;

--- a/src/internal/components/radio-button/interfaces.ts
+++ b/src/internal/components/radio-button/interfaces.ts
@@ -73,6 +73,7 @@ export interface RadioButtonProps extends BaseComponentProps {
 
   /**
    * An object containing CSS properties to customize the radio button's visual appearance.
+   * Refer to the [style](/components/radio-button/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: RadioButtonProps.Style;

--- a/src/link/interfaces.ts
+++ b/src/link/interfaces.ts
@@ -113,6 +113,7 @@ export interface LinkProps extends BaseComponentProps {
 
   /**
    * An object containing CSS properties to customize the link's visual appearance.
+   * Refer to the [style](/components/link/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: LinkProps.Style;

--- a/src/progress-bar/interfaces.ts
+++ b/src/progress-bar/interfaces.ts
@@ -85,6 +85,7 @@ export interface ProgressBarProps extends BaseComponentProps {
 
   /**
    * An object containing CSS properties to customize the progress bar's visual appearance.
+   * Refer to the [style](/components/progress-bar/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: ProgressBarProps.Style;

--- a/src/prompt-input/interfaces.ts
+++ b/src/prompt-input/interfaces.ts
@@ -132,6 +132,7 @@ export interface PromptInputProps
 
   /**
    * An object containing CSS properties to customize the prompt input's visual appearance.
+   * Refer to the [style](/components/prompt-input/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: PromptInputProps.Style;

--- a/src/radio-group/interfaces.ts
+++ b/src/radio-group/interfaces.ts
@@ -66,6 +66,7 @@ export interface RadioGroupProps extends BaseComponentProps, FormFieldControlPro
 
   /**
    * An object containing CSS properties to customize the radio group's visual appearance.
+   * Refer to the [style](/components/radio-group/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: RadioGroupProps.Style;

--- a/src/segmented-control/interfaces.ts
+++ b/src/segmented-control/interfaces.ts
@@ -47,6 +47,7 @@ export interface SegmentedControlProps extends BaseComponentProps {
 
   /**
    * An object containing CSS properties to customize the segmented control's visual appearance.
+   * Refer to the [style](/components/segmented-control/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: SegmentedControlProps.Style;

--- a/src/slider/interfaces.ts
+++ b/src/slider/interfaces.ts
@@ -85,6 +85,7 @@ export interface SliderProps extends BaseComponentProps, FormFieldValidationCont
 
   /**
    * An object containing CSS properties to customize the slider's visual appearance.
+   * Refer to the [style](/components/slider/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: SliderProps.Style;

--- a/src/tabs/interfaces.ts
+++ b/src/tabs/interfaces.ts
@@ -105,6 +105,7 @@ export interface TabsProps extends BaseComponentProps {
 
   /**
    * An object containing CSS properties to customize the tabs' visual appearance.
+   * Refer to the [style](/components/tabs/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: TabsProps.Style;

--- a/src/text-filter/interfaces.ts
+++ b/src/text-filter/interfaces.ts
@@ -62,6 +62,7 @@ export interface TextFilterProps extends BaseComponentProps, FormFieldControlPro
 
   /**
    * An object containing CSS properties to customize the text filter's visual appearance.
+   * Refer to the [style](/components/text-filter/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: TextFilterProps.Style;

--- a/src/textarea/interfaces.ts
+++ b/src/textarea/interfaces.ts
@@ -53,6 +53,7 @@ export interface TextareaProps
 
   /**
    * An object containing CSS properties to customize the textarea's visual appearance.
+   * Refer to the [style](/components/textarea/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: TextareaProps.Style;

--- a/src/toggle/interfaces.ts
+++ b/src/toggle/interfaces.ts
@@ -24,6 +24,7 @@ export interface ToggleProps extends BaseCheckboxProps {
 
   /**
    * An object containing CSS properties to customize the toggle's visual appearance.
+   * Refer to the [style](/components/toggle/?tabId=style) tab for more details.
    * @awsuiSystem core
    */
   style?: ToggleProps.Style;


### PR DESCRIPTION
### Description

This adds descriptions to style API to be picked up by documenter. We use descriptions in tooling like our website playground and other configurators, this is to prevent them from appearing empty.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
