### PR TITLE
chore: correct flattenChildren import and add explicit types in runtime…

### DIFF
--- a/pages/flashbar/runtime-content.page.tsx
+++ b/pages/flashbar/runtime-content.page.tsx
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ReactNode, useContext, useState } from 'react';
-import flattenChildren from 'react-keyed-flatten-children';
+import React, { isValidElement, ReactNode, useContext, useState } from 'react';
 
 import {
   Box,
@@ -16,6 +15,7 @@ import {
   SpaceBetween,
 } from '~components';
 import awsuiPlugins from '~components/internal/plugins';
+import { flattenChildren } from '~components/internal/utils/flatten-children';
 import { mount, unmount } from '~mount';
 
 import AppContext, { AppContextType } from '../app/app-context';
@@ -27,8 +27,8 @@ type PageContext = React.Context<
 
 const nodeAsString = (node: ReactNode) =>
   flattenChildren(node)
-    .map(node => (typeof node === 'object' ? node.props.children : node))
-    .filter(node => typeof node === 'string')
+    .map((childNode: ReactNode) => (isValidElement(childNode) ? childNode.props.children : childNode))
+    .filter((childNode: ReactNode) => typeof childNode === 'string')
     .join('');
 
 awsuiPlugins.flashContent.registerContentReplacer({


### PR DESCRIPTION
### Description
Clean up the import of flattenChildren in pages to use the utils from components.

Tested by running it through my pipeline.


<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
