### PR TITLE
fix: add `$font` param to heading mixin

### DIFF
--- a/src/internal/styles/typography/mixins.scss
+++ b/src/internal/styles/typography/mixins.scss
@@ -32,8 +32,10 @@
   line-height: awsui.$line-height-body-m;
 }
 
-@mixin font-heading-xs($weight: true) {
-  font-family: constants.$font-family-heading;
+@mixin font-heading-xs($weight: true, $family: true) {
+  @if $family {
+    font-family: constants.$font-family-heading;
+  }
   font-size: awsui.$font-size-heading-xs;
   line-height: awsui.$line-height-heading-xs;
   @if $weight {
@@ -42,8 +44,10 @@
   }
 }
 
-@mixin font-heading-s($weight: true) {
-  font-family: constants.$font-family-heading;
+@mixin font-heading-s($weight: true, $family: true) {
+  @if $family {
+    font-family: constants.$font-family-heading;
+  }
   font-size: awsui.$font-size-heading-s;
   line-height: awsui.$line-height-heading-s;
   letter-spacing: awsui.$letter-spacing-heading-s;
@@ -53,8 +57,10 @@
   }
 }
 
-@mixin font-heading-m($weight: true) {
-  font-family: constants.$font-family-heading;
+@mixin font-heading-m($weight: true, $family: true) {
+  @if $family {
+    font-family: constants.$font-family-heading;
+  }
   font-size: awsui.$font-size-heading-m;
   line-height: awsui.$line-height-heading-m;
   letter-spacing: awsui.$letter-spacing-heading-m;
@@ -64,8 +70,10 @@
   }
 }
 
-@mixin font-heading-l($weight: true) {
-  font-family: constants.$font-family-heading;
+@mixin font-heading-l($weight: true, $family: true) {
+  @if $family {
+    font-family: constants.$font-family-heading;
+  }
   font-size: awsui.$font-size-heading-l;
   line-height: awsui.$line-height-heading-l;
   letter-spacing: awsui.$letter-spacing-heading-l;
@@ -75,8 +83,10 @@
   }
 }
 
-@mixin font-heading-xl($weight: true) {
-  font-family: constants.$font-family-heading;
+@mixin font-heading-xl($weight: true, $family: true) {
+  @if $family {
+    font-family: constants.$font-family-heading;
+  }
   font-size: awsui.$font-size-heading-xl;
   line-height: awsui.$line-height-heading-xl;
   letter-spacing: awsui.$letter-spacing-heading-xl;
@@ -134,19 +144,19 @@
     @include font-body-m;
   }
   @if $font-size == heading-xs {
-    @include font-heading-xs($weight: false);
+    @include font-heading-xs($weight: false, $family: false);
   }
   @if $font-size == heading-s {
-    @include font-heading-s($weight: false);
+    @include font-heading-s($weight: false, $family: false);
   }
   @if $font-size == heading-m {
-    @include font-heading-m($weight: false);
+    @include font-heading-m($weight: false, $family: false);
   }
   @if $font-size == heading-l {
-    @include font-heading-l($weight: false);
+    @include font-heading-l($weight: false, $family: false);
   }
   @if $font-size == heading-xl {
-    @include font-heading-xl($weight: false);
+    @include font-heading-xl($weight: false, $family: false);
   }
   @if $font-size == display-l {
     @include font-display-l;


### PR DESCRIPTION
### Description

Similarly to the `$weight` param, if the `$font` is set to true, the font family will be applied.  

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
