### PR TITLE
revert: "fix: preserve dropdown styles when using portal rendering"

### DIFF
--- a/src/internal/components/dropdown/styles.scss
+++ b/src/internal/components/dropdown/styles.scss
@@ -38,9 +38,6 @@
   }
 
   &-content-wrapper {
-    // Apply styles-reset to ensure font-family and other styles are properly set
-    // when expandToViewport is true (dropdown rendered via portal to document.body)
-    @include styles.styles-reset;
     position: relative;
     background-color: awsui.$color-background-dropdown-item-default;
     outline: none;


### PR DESCRIPTION
Reverts cloudscape-design/components#4276