### PR TITLE
fix: inherit white-space from root element

### DIFF
--- a/src/internal/components/dropdown/styles.scss
+++ b/src/internal/components/dropdown/styles.scss
@@ -41,6 +41,7 @@
     // Apply styles-reset to ensure font-family and other styles are properly set
     // when expandToViewport is true (dropdown rendered via portal to document.body)
     @include styles.styles-reset;
+    white-space: inherit;
     position: relative;
     background-color: awsui.$color-background-dropdown-item-default;
     outline: none;


### PR DESCRIPTION
### Description

The previous [PR](https://github.com/cloudscape-design/components/pull/4276) introduced `@include styles.styles-reset;` to the dropdown wrapper which sets `white-space: normal;`which was overriding the parent containers `white-space: nowrap;`. 


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
