### PR TITLE
chore: Extensible test utils prep

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -39282,7 +39282,7 @@ Returns null if the panel layout is not resizable.",
           "name": "findResultText",
           "parameters": [
             {
-              "description": "[optional] Status of the result text. It can be aither "error" or "succes".
+              "description": "[optional] Status of the result text. It can be either "error" or "success".
 If not specified, the method returns the result text that is currently displayed, independently of the result status.",
               "flags": {
                 "isOptional": true,
@@ -48578,7 +48578,7 @@ Returns null if the panel layout is not resizable.",
           "name": "findResultText",
           "parameters": [
             {
-              "description": "[optional] Status of the result text. It can be aither "error" or "succes".
+              "description": "[optional] Status of the result text. It can be either "error" or "success".
 If not specified, the method returns the result text that is currently displayed, independently of the result status.",
               "flags": {
                 "isOptional": true,

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-wrappers.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-wrappers.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Generate test utils ElementWrapper dom ElementWrapper matches the snapshot 1`] = `
 "

--- a/src/__tests__/test-utils-dom-compilation.test.ts
+++ b/src/__tests__/test-utils-dom-compilation.test.ts
@@ -5,12 +5,11 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 
+const cwd = path.resolve(__dirname, '../..');
 const indexFilePath = path.resolve(__dirname, '../test-utils/dom/index.ts');
-
-const minimalIndexContent = `import { ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
-
+const minimalElementWrapperImpl = `
+import { ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 export { ElementWrapper };
-
 export default function wrapper(root: Element = document.body) {
   return new ElementWrapper(root);
 }
@@ -18,33 +17,21 @@ export default function wrapper(root: Element = document.body) {
 
 let originalContent: string;
 
-/**
- * This test ensures that the test-utils methods do not rely on methods added to the global ElementWrapper.
- * This allows to override ElementWrapper methods safely in the downstream packages.
- */
-describe('test-utils/dom compilation', () => {
-  beforeAll(() => {
+test('should compile test-utils without ElementWrapper methods', () => {
+  try {
+    // Replace generated ElementWrapper with minimal one.
     originalContent = fs.readFileSync(indexFilePath, 'utf-8');
-    fs.writeFileSync(indexFilePath, minimalIndexContent, 'utf-8');
-  });
+    fs.writeFileSync(indexFilePath, minimalElementWrapperImpl, 'utf-8');
 
-  afterAll(() => {
-    // Restore the original content
+    // Run TypeScript compiler on the test-utils/dom folder.
+    // Using --noEmit to just check for errors without generating output.
+    execSync(`npx tsc --project ./src/test-utils/tsconfig.json --noEmit`, { cwd, stdio: 'pipe', encoding: 'utf-8' });
+  } catch (error: any) {
+    // Re-throw with TypeScript compiler output included.
+    const tscOutput = (error.stdout || '') + (error.stderr || '') || 'No output captured';
+    throw new Error(`TypeScript compilation failed for src/test-utils/dom:\n\n${tscOutput}`);
+  } finally {
+    // Restore original ElementWrapper.
     fs.writeFileSync(indexFilePath, originalContent, 'utf-8');
-  });
-
-  test('should compile src/test-utils/dom with TypeScript', () => {
-    // Create a temporary tsconfig specifically for test-utils/dom
-    const rootDir = path.resolve(__dirname, '../..');
-
-    // Run TypeScript compiler on the test-utils/dom folder
-    // Using --noEmit to just check for errors without generating output
-    try {
-      execSync(`npx tsc --project ./src/test-utils/tsconfig.json`, { cwd: rootDir, stdio: 'pipe', encoding: 'utf-8' });
-    } catch (error: any) {
-      // Re-throw with TypeScript compiler output included
-      const tscOutput = (error.stdout || '') + (error.stderr || '') || 'No output captured';
-      throw new Error(`TypeScript compilation failed for src/test-utils/dom:\n\n${tscOutput}`);
-    }
-  });
+  }
 });

--- a/src/test-utils/dom/hotspot/index.ts
+++ b/src/test-utils/dom/hotspot/index.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 
+import AnnotationWrapper from '../annotation';
 import createWrapper from '../index';
-import { AnnotationWrapper } from '../index.js';
 
 import annotationStyles from '../../../annotation-context/annotation/styles.selectors.js';
 import hotspotStyles from '../../../hotspot/styles.selectors.js';

--- a/src/test-utils/dom/internal/autosuggest-input.ts
+++ b/src/test-utils/dom/internal/autosuggest-input.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper } from '@cloudscape-design/test-utils-core/dom';
 
-import { InputWrapper } from '../index.js';
+import InputWrapper from '../input';
 import DropdownWrapper from './dropdown.js';
 
 import inputStyles from '../../../input/styles.selectors.js';

--- a/src/test-utils/dom/popover/index.ts
+++ b/src/test-utils/dom/popover/index.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 
-import createWrapper, { ButtonWrapper } from '../index.js';
+import ButtonWrapper from '../button';
+import createWrapper from '../index.js';
 
 import styles from '../../../popover/styles.selectors.js';
 

--- a/src/test-utils/dom/progress-bar/index.ts
+++ b/src/test-utils/dom/progress-bar/index.ts
@@ -14,7 +14,10 @@ export default class ProgressBarWrapper extends ComponentWrapper {
   }
 
   findResultButton(): ButtonWrapper | null {
-    return this.findByClassName(styles['result-button'])?.findButton() || null;
+    return (
+      this.findByClassName(styles['result-button'])?.findComponent(`.${ButtonWrapper.rootSelector}`, ButtonWrapper) ||
+      null
+    );
   }
 
   /**
@@ -22,7 +25,7 @@ export default class ProgressBarWrapper extends ComponentWrapper {
    *
    * @param status
    *
-   * [optional] Status of the result text. It can be aither "error" or "succes".
+   * [optional] Status of the result text. It can be either "error" or "success".
    * If not specified, the method returns the result text that is currently displayed, independently of the result status.
    */
   findResultText(status?: string): ElementWrapper | null {

--- a/src/test-utils/dom/s3-resource-selector/index.ts
+++ b/src/test-utils/dom/s3-resource-selector/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { appendSelector } from '@cloudscape-design/test-utils-core/utils';
 
 import createWrapper from '../';
 import ButtonWrapper from '../button';
@@ -27,7 +28,7 @@ class S3InContextWrapper extends ComponentWrapper {
 
   findVersionsSelect(): SelectWrapper | null {
     const select = this.findByClassName(inContextStyles['layout-version']);
-    return select && select.findSelect();
+    return select && select.findComponent(`.${SelectWrapper.rootSelector}`, SelectWrapper);
   }
 
   findViewButton(): ButtonWrapper {
@@ -51,12 +52,15 @@ export default class S3ResourceSelectorWrapper extends ComponentWrapper {
   }
 
   findModal(): S3ModalWrapper | null {
-    const modal = createWrapper().findModal(`.${testUtilStyles['modal-root']}`);
+    const modal = createWrapper().findComponent(
+      appendSelector(`.${testUtilStyles['modal-root']}`, `.${ModalWrapper.rootSelector}`),
+      ModalWrapper
+    );
     return modal && new S3ModalWrapper(modal.getElement());
   }
 
   findTable(): TableWrapper | null {
-    const modal = this.findModal();
+    const modal = createWrapper().findComponent(`.${ModalWrapper.rootSelector}`, ModalWrapper);
     return modal && modal.findComponent(`.${TableWrapper.rootSelector}`, TableWrapper);
   }
 }

--- a/src/test-utils/dom/tutorial-panel/tutorial.ts
+++ b/src/test-utils/dom/tutorial-panel/tutorial.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 
+import AlertWrapper from '../alert';
 import ButtonWrapper from '../button';
-import { AlertWrapper } from '../index.js';
 import LinkWrapper from '../link';
 
 import styles from '../../../tutorial-panel/components/tutorial-list/styles.selectors.js';


### PR DESCRIPTION
### Description

I am preparing a change to the test-utils to allow overriding ElementWrapper methods such as fundButton to return a n updated/custom version of the component. That can only work if the component test utils do not rely on the existing generated methods (use other component wrapper directly) - which can be ensured with a simple test, which this PR adds.

Rel: D397469120

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
