### PR TITLE
feat: add `triggerRef` prop to dropdown

### DIFF
--- a/src/internal/components/dropdown/__tests__/dropdown.test.tsx
+++ b/src/internal/components/dropdown/__tests__/dropdown.test.tsx
@@ -504,7 +504,6 @@ describe('triggerRef prop', () => {
     }
     render(<TestComponent />);
 
-    // Open the dropdown after mount so that externalTriggerRef.current is populated
     act(() => screen.getByTestId('open-btn').click());
 
     const trigger = screen.getByTestId('trigger');

--- a/src/internal/components/dropdown/__tests__/dropdown.test.tsx
+++ b/src/internal/components/dropdown/__tests__/dropdown.test.tsx
@@ -1,11 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 import Dropdown from '../../../../../lib/components/internal/components/dropdown';
 import { calculatePosition } from '../../../../../lib/components/internal/components/dropdown/dropdown-fit-handler';
 import customCssProps from '../../../../../lib/components/internal/generated/custom-css-properties';
+import { nodeBelongs } from '../../../../../lib/components/internal/utils/node-belongs';
 import DropdownWrapper from '../../../../../lib/components/test-utils/dom/internal/dropdown';
 
 const outsideId = 'outside';
@@ -430,6 +433,86 @@ describe('Dropdown Component', () => {
       const dropdown = wrapper.findOpenDropdown()!.getElement();
       expect(dropdown.style.getPropertyValue(customCssProps.dropdownDefaultMaxWidth)).toBe('250px');
     });
+  });
+});
+
+jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
+  ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
+  warnOnce: jest.fn(),
+}));
+
+afterEach(() => {
+  (warnOnce as jest.Mock).mockReset();
+});
+
+describe('triggerRef prop', () => {
+  test('renders trigger without a wrapper div when triggerRef is provided', () => {
+    function TestComponent() {
+      const ref = useRef<HTMLButtonElement>(null);
+      return (
+        <Dropdown trigger={<button id="my-trigger" ref={ref} data-testid="trigger" />} triggerRef={ref} open={false} />
+      );
+    }
+    const { container } = render(<TestComponent />);
+    // The trigger should be a direct child of the root div, not wrapped in another div
+    const root = container.firstElementChild!;
+    expect(root.firstElementChild!.tagName).toBe('BUTTON');
+  });
+
+  test('wraps trigger in a div when triggerRef is not provided', () => {
+    const { container } = render(<Dropdown trigger={<button data-testid="trigger" />} open={false} />);
+    const root = container.firstElementChild!;
+    expect(root.firstElementChild!.tagName).toBe('DIV');
+  });
+
+  test('warns when triggerRef is provided but trigger element has no id', async () => {
+    function TestComponent() {
+      const ref = useRef<HTMLButtonElement>(null);
+      return <Dropdown trigger={<button ref={ref} />} triggerRef={ref} open={false} />;
+    }
+    render(<TestComponent />);
+    await act(() => Promise.resolve());
+    expect(warnOnce).toHaveBeenCalledWith('Dropdown', expect.stringContaining('id'));
+  });
+
+  test('does not warn when triggerRef is provided and trigger element has an id', async () => {
+    function TestComponent() {
+      const ref = useRef<HTMLButtonElement>(null);
+      return <Dropdown trigger={<button id="my-trigger" ref={ref} />} triggerRef={ref} open={false} />;
+    }
+    render(<TestComponent />);
+    await act(() => Promise.resolve());
+    expect(warnOnce).not.toHaveBeenCalled();
+  });
+
+  test('portal container references the trigger id via data-awsui-referrer-id when expandToViewport is used', () => {
+    function TestComponent() {
+      const ref = useRef<HTMLButtonElement>(null);
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button data-testid="open-btn" onClick={() => setOpen(true)} />
+          <Dropdown
+            trigger={<button id="my-trigger" ref={ref} data-testid="trigger" />}
+            triggerRef={ref}
+            open={open}
+            expandToViewport={true}
+            content={<div data-testid="dropdown-content">content</div>}
+          />
+        </>
+      );
+    }
+    render(<TestComponent />);
+
+    // Open the dropdown after mount so that externalTriggerRef.current is populated
+    act(() => screen.getByTestId('open-btn').click());
+
+    const trigger = screen.getByTestId('trigger');
+    const content = screen.getByTestId('dropdown-content');
+
+    // The portal container should have data-awsui-referrer-id pointing to the trigger's id,
+    // allowing nodeBelongs to trace the portaled content back to the trigger
+    expect(nodeBelongs(trigger, content)).toBe(true);
   });
 });
 

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -358,7 +358,7 @@ const getInteriorDropdownPosition = (
 
 export const calculatePosition = (
   dropdownElement: HTMLDivElement,
-  triggerElement: HTMLDivElement,
+  triggerElement: HTMLElement,
   verticalContainerElement: HTMLDivElement,
   interior: boolean,
   expandToViewport: boolean,

--- a/src/internal/components/dropdown/interfaces.ts
+++ b/src/internal/components/dropdown/interfaces.ts
@@ -64,6 +64,13 @@ export interface DropdownProps extends ExpandToViewport {
   trigger: React.ReactNode;
 
   /**
+   * Optional ref to the trigger element. When provided, the trigger will not be wrapped in a div,
+   * and the element's `id` attribute will be used as the referrer ID for portal-mode dropdowns.
+   * The trigger element must have a unique `id` set.
+   */
+  triggerRef?: React.RefObject<HTMLElement>;
+
+  /**
    * "Sticky" header of the dropdown content
    */
   header?: React.ReactNode;


### PR DESCRIPTION
### Description

Introduces a new `triggerRef` prop to the Dropdown.

Related links, issue #, if available: n/a

### How has this been tested?

Pipeline is green.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
