### PR TITLE
fix: Scope Wizard test utility findMenuNavigationLinks to sidebar navigation

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -51076,7 +51076,12 @@ Supported options:
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "Array<never> | MultiElementWrapper<ElementWrapper>",
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
           },
         },
         {

--- a/src/test-utils/dom/wizard/index.ts
+++ b/src/test-utils/dom/wizard/index.ts
@@ -37,8 +37,7 @@ export default class WizardWrapper extends FormWrapper {
   }
 
   findMenuNavigationLinks(): Array<ElementWrapper> {
-    const nav = this.findByClassName(styles.navigation);
-    return nav ? nav.findAllByClassName(styles['navigation-link']) : [];
+    return this.findByClassName(styles.navigation)!.findAllByClassName(styles['navigation-link']);
   }
 
   /**


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
After the introduction of the expandable step navigation (#4200), `findMenuNavigationLinks()` returns double the expected number of links. Both the desktop sidebar and the mobile expandable navigation render navigation links with the same CSS class in the DOM. Since `findAllByClassName` searches the entire component tree, it picks up links from both navigations.

This scopes `findMenuNavigationLinks()` and `findMenuNavigationLink()` to only search within the sidebar `<nav>` element (`.navigation` class), restoring backward-compatible behavior.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
