### PR TITLE
fix: Make tutorial panel compatible with React 19

### DIFF
--- a/src/tutorial-panel/components/tutorial-list/index.tsx
+++ b/src/tutorial-panel/components/tutorial-list/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import clsx from 'clsx';
 
@@ -113,6 +113,8 @@ function Tutorial({
 
   const [expanded, setExpanded] = useState(!tutorial.prerequisitesNeeded && !tutorial.completed);
 
+  const expandableSectionRef = useRef<HTMLDivElement>(null);
+
   const onClick = useCallback(() => {
     setExpanded(expanded => !expanded);
   }, []);
@@ -156,8 +158,17 @@ function Tutorial({
       </InternalSpaceBetween>
 
       <div aria-live="polite">
-        <CSSTransition in={expanded} timeout={30} classNames={{ enter: styles['content-enter'] }}>
-          <div className={clsx(styles['expandable-section'], expanded && styles.expanded)} id={controlId}>
+        <CSSTransition
+          in={expanded}
+          timeout={30}
+          classNames={{ enter: styles['content-enter'] }}
+          nodeRef={expandableSectionRef}
+        >
+          <div
+            className={clsx(styles['expandable-section'], expanded && styles.expanded)}
+            id={controlId}
+            ref={expandableSectionRef}
+          >
             <InternalSpaceBetween size="l">
               <InternalSpaceBetween size="m">
                 {tutorial.prerequisitesNeeded && tutorial.prerequisitesAlert && (


### PR DESCRIPTION
### Description

See `AWSUI-61757`

### How has this been tested?

Cannot easily add coverage. We need to properly add coverage for React 19 in our setup. Created operational task: `D398045845`.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
