### PR TITLE
chore: Add more permutations to cover minColumnWidths undefined case

### DIFF
--- a/pages/column-layout/min-width.permutations.page.tsx
+++ b/pages/column-layout/min-width.permutations.page.tsx
@@ -21,6 +21,11 @@ const permutations = createPermutations<ColumnLayoutProps>([
     columns: [1, 2, 3, 4],
     minColumnWidth: [200],
   },
+  {
+    variant: ['default', 'text-grid'],
+    columns: [5, 6, 7, 8],
+    minColumnWidth: [undefined, 100, 200],
+  },
 ]);
 
 export default function ColumnLayoutPermutationsPage() {


### PR DESCRIPTION
### Description

Add more tests in ColumnLayout to have visual regression coverage on cases where minColumnWidth is not provided and columns is set to more than 4.

Related links, issue #, if available: n/a 

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
