### PR TITLE
feat: AppLayout error boundaries v2

### DIFF
--- a/pages/app-layout/with-error-boundaries.page.tsx
+++ b/pages/app-layout/with-error-boundaries.page.tsx
@@ -1,0 +1,377 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext, useEffect, useRef, useState } from 'react';
+
+import { AppLayout, Button, Container, ContentLayout, Header, SpaceBetween, SplitPanel, Toggle } from '~components';
+import { AppLayoutProps } from '~components/app-layout';
+import BreadcrumbGroup from '~components/breadcrumb-group';
+import ErrorBoundary from '~components/error-boundary';
+import awsuiPlugins from '~components/internal/plugins';
+import { registerBottomDrawer, registerLeftDrawer } from '~components/internal/plugins/widget';
+import { mount, unmount } from '~mount';
+
+import AppContext, { AppContextType } from '../app/app-context';
+import { drawerLabels } from './utils/drawers';
+import appLayoutLabels from './utils/labels';
+import { splitPaneli18nStrings } from './utils/strings';
+
+type DemoContext = React.Context<
+  AppContextType<{
+    hasParentErrorBoundary: boolean | undefined;
+    hasDrawers: boolean | undefined;
+    splitPanelPosition: AppLayoutProps.SplitPanelPreferences['position'];
+  }>
+>;
+
+export default function WithErrorBoundariesPage() {
+  const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
+  const hasParentErrorBoundary = urlParams.hasParentErrorBoundary ?? false;
+  const [isBrokenNavigation, setIsBrokenNavigation] = useState(false);
+  const appLayoutRef = useRef<AppLayoutProps.Ref>(null);
+  const [breadcrumbsItems, setBreadcrumbsItems] = useState([
+    { text: 'Home', href: '#' },
+    { text: 'Service', href: '#' },
+  ]);
+
+  useEffect(() => {
+    window.addEventListener(
+      'error',
+      error => {
+        console.log('The error gets caught by the global event handler: ', error);
+      },
+      true
+    );
+  }, []);
+
+  const appLayout = (
+    <AppLayout
+      ariaLabels={{ ...appLayoutLabels, ...drawerLabels }}
+      ref={appLayoutRef}
+      breadcrumbs={<BreadcrumbGroup items={breadcrumbsItems} />}
+      content={
+        <AppLayout
+          navigationHide={true}
+          toolsHide={true}
+          content={
+            <div data-testid="app-layout-content-area">
+              <ContentLayout
+                disableOverlap={true}
+                header={
+                  <SpaceBetween size="m">
+                    <Header variant="h1">Error boundaries in app layout slots</Header>
+                  </SpaceBetween>
+                }
+              >
+                <SpaceBetween size="xs">
+                  <Toggle
+                    checked={hasParentErrorBoundary}
+                    onChange={({ detail }) => setUrlParams({ hasParentErrorBoundary: detail.checked })}
+                  >
+                    Has parent error boundary
+                  </Toggle>
+                  <Container header={<Header>Toolbar</Header>}>
+                    <Button
+                      onClick={() => {
+                        registerLeftDrawer({
+                          id: 'ai-panel',
+                          resizable: true,
+                          isExpandable: true,
+                          defaultSize: 300,
+                          preserveInactiveContent: true,
+
+                          ariaLabels: {
+                            closeButton: 'Close AI Panel drawer',
+                            content: 'AI Panel',
+                            triggerButton: 'AI Panel',
+                            resizeHandle: 'Resize handle',
+                            expandedModeButton: 'Expanded mode button',
+                            exitExpandedModeButton: 'Console',
+                          },
+
+                          trigger: {
+                            // @ts-expect-error testing error boundaries with invalid react nodes
+                            iconSvg: Symbol(),
+                          },
+
+                          mountContent: container => {
+                            mount(<div>left drawer</div>, container);
+                          },
+                          unmountContent: container => unmount(container),
+                        });
+                      }}
+                      data-testid="break-left-drawer-trigger"
+                    >
+                      Break left drawer trigger
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        // @ts-expect-error testing error boundaries with invalid react nodes
+                        setBreadcrumbsItems(null);
+                      }}
+                      data-testid="break-breadcrumbs"
+                    >
+                      Break breadcrumbs
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        awsuiPlugins.appLayout.registerDrawer({
+                          id: 'broken-local-drawer',
+                          type: 'local',
+                          trigger: {
+                            // @ts-expect-error testing error boundaries with invalid react nodes
+                            iconSvg: Symbol(),
+                          },
+                          defaultActive: false,
+
+                          ariaLabels: {
+                            closeButton: 'Close button',
+                            content: 'Content',
+                            triggerButton: 'Trigger button',
+                            resizeHandle: 'Resize handle',
+                          },
+
+                          mountContent: container => {
+                            mount(<div>sdfsdf</div>, container);
+                          },
+                          unmountContent: () => {},
+                        });
+                      }}
+                      data-testid="break-local-drawer-trigger"
+                    >
+                      Break a local drawer
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        awsuiPlugins.appLayout.registerDrawer({
+                          id: 'broken-global-drawer',
+                          type: 'global',
+                          defaultActive: false,
+                          resizable: true,
+                          defaultSize: 320,
+                          orderPriority: -1,
+
+                          ariaLabels: {
+                            closeButton: 'Close button',
+                            content: 'Content',
+                            triggerButton: 'Trigger button',
+                            resizeHandle: 'Resize handle',
+                          },
+
+                          trigger: {
+                            // @ts-expect-error testing error boundaries with invalid react nodes
+                            iconSvg: Symbol(),
+                          },
+
+                          mountContent: container => {
+                            mount(<div>Hello!</div>, container);
+                          },
+                          unmountContent: container => unmount(container),
+                        });
+                      }}
+                      data-testid="break-global-drawer-trigger"
+                    >
+                      Break a global drawer
+                    </Button>
+                  </Container>
+                  <Container header={<Header>Panels</Header>}>
+                    <Button
+                      onClick={() => {
+                        registerLeftDrawer({
+                          id: 'ai-panel',
+                          resizable: true,
+                          isExpandable: true,
+                          defaultSize: 300,
+                          preserveInactiveContent: true,
+                          defaultActive: true,
+
+                          ariaLabels: {
+                            closeButton: 'Close AI Panel drawer',
+                            content: 'AI Panel',
+                            triggerButton: 'AI Panel',
+                            resizeHandle: 'Resize handle',
+                            expandedModeButton: 'Expanded mode button',
+                            exitExpandedModeButton: 'Console',
+                          },
+
+                          trigger: {
+                            customIcon: '',
+                          },
+
+                          mountContent: () => {
+                            throw new Error('Mount error in drawer content');
+                          },
+                          unmountContent: container => unmount(container),
+                        });
+                      }}
+                      data-testid="break-left-drawer-content"
+                    >
+                      Break left drawer content on mount
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        registerLeftDrawer({
+                          id: 'ai-panel',
+                          resizable: true,
+                          isExpandable: true,
+                          defaultSize: 300,
+                          preserveInactiveContent: true,
+                          defaultActive: true,
+
+                          ariaLabels: {
+                            closeButton: 'Close AI Panel drawer',
+                            content: 'AI Panel',
+                            triggerButton: 'AI Panel',
+                            resizeHandle: 'Resize handle',
+                            expandedModeButton: 'Expanded mode button',
+                            exitExpandedModeButton: 'Console',
+                          },
+
+                          trigger: {
+                            customIcon: '',
+                          },
+
+                          mountHeader: () => {
+                            throw new Error('Mount error in drawer content');
+                          },
+                          unmountHeader: container => unmount(container),
+                          mountContent: container => {
+                            container.innerHTML = 'hello!';
+                          },
+                          unmountContent: container => unmount(container),
+                        });
+                      }}
+                      data-testid="break-left-drawer-header"
+                    >
+                      Break left drawer header on mount
+                    </Button>
+                    <Button onClick={() => setIsBrokenNavigation(true)} data-testid="break-nav-panel">
+                      Break nav panel
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        awsuiPlugins.appLayout.registerDrawer({
+                          id: 'broken-local-drawer',
+                          type: 'local',
+                          trigger: {
+                            iconSvg: `<svg viewBox="0 0 16 16" focusable="false">
+                                      <circle stroke-width="2" stroke="currentColor" fill="none" cx="8" cy="8" r="7" />
+                                      <circle stroke-width="2" stroke="currentColor" fill="none" cx="8" cy="8" r="3" />
+                                    </svg>`,
+                          },
+                          defaultActive: true,
+
+                          ariaLabels: {
+                            closeButton: 'Close button',
+                            content: 'Content',
+                            triggerButton: 'Trigger button',
+                            resizeHandle: 'Resize handle',
+                          },
+
+                          mountContent: () => {
+                            // Simulate error during mount
+                            throw new Error('Mount error in drawer content');
+                          },
+                          unmountContent: () => {},
+                        });
+                      }}
+                      data-testid="break-local-drawer-content"
+                    >
+                      Break local drawer on mount
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        awsuiPlugins.appLayout.registerDrawer({
+                          id: 'broken-global-drawer',
+                          type: 'global',
+                          trigger: {
+                            iconSvg: `<svg viewBox="0 0 16 16" focusable="false"><circle stroke-width="2" stroke="currentColor" fill="none" cx="8" cy="8" r="7" /><circle stroke-width="2" stroke="currentColor" fill="none" cx="8" cy="8" r="3" /></svg>`,
+                          },
+                          defaultActive: true,
+
+                          ariaLabels: {
+                            closeButton: 'Close button',
+                            content: 'Content',
+                            triggerButton: 'Trigger button',
+                            resizeHandle: 'Resize handle',
+                          },
+
+                          mountContent: () => {
+                            // Simulate error during mount
+                            throw new Error('Mount error in drawer content');
+                          },
+                          unmountContent: () => {},
+                        });
+                      }}
+                      data-testid="break-global-drawer-content"
+                    >
+                      Break global drawer on mount
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        registerBottomDrawer({
+                          id: 'bottom-panel',
+                          resizable: true,
+                          isExpandable: true,
+                          defaultSize: 300,
+                          preserveInactiveContent: true,
+                          defaultActive: true,
+
+                          ariaLabels: {
+                            closeButton: 'Close AI Panel drawer',
+                            content: 'AI Panel',
+                            triggerButton: 'AI Panel',
+                            resizeHandle: 'Resize handle',
+                            expandedModeButton: 'Expanded mode button',
+                            exitExpandedModeButton: 'Console',
+                          },
+
+                          trigger: {
+                            customIcon: '',
+                          },
+
+                          mountContent: () => {
+                            throw new Error('Mount error in drawer content');
+                          },
+                          unmountContent: container => unmount(container),
+                        });
+                      }}
+                      data-testid="break-bottom-drawer-content"
+                    >
+                      Break bottom drawer on mount
+                    </Button>
+                  </Container>
+                </SpaceBetween>
+              </ContentLayout>
+            </div>
+          }
+        />
+      }
+      splitPanel={
+        <SplitPanel header="Split panel header" i18nStrings={splitPaneli18nStrings}>
+          This is the Split Panel!
+        </SplitPanel>
+      }
+      splitPanelPreferences={{
+        position: urlParams.splitPanelPosition,
+      }}
+      onSplitPanelPreferencesChange={event => {
+        const { position } = event.detail;
+        setUrlParams({ splitPanelPosition: position === 'side' ? position : undefined });
+      }}
+      toolsHide={true}
+      navigation={isBrokenNavigation ? ({} as any) : <div>navigation</div>}
+    />
+  );
+
+  return hasParentErrorBoundary ? (
+    <ErrorBoundary
+      onError={(error: any) =>
+        console.log('The error gets caught by the parent error boundary wrapping app layout: ', error)
+      }
+    >
+      {appLayout}
+    </ErrorBoundary>
+  ) : (
+    appLayout
+  );
+}

--- a/src/__a11y__/a11y-app-layout-toolbar.test.ts
+++ b/src/__a11y__/a11y-app-layout-toolbar.test.ts
@@ -10,6 +10,7 @@ const EXCLUDED_PAGES = [
   // Test page for an app layout nested inside another through an iframe.
   // Not a use case that's encouraged.
   'app-layout/multi-layout-global-drawer-child-layout',
+  'app-layout/with-error-boundaries',
 ];
 
 describe('A11y checks for app layout toolbar', () => {

--- a/src/__a11y__/run-a11y-tests.ts
+++ b/src/__a11y__/run-a11y-tests.ts
@@ -32,6 +32,7 @@ export default function runA11yTests(theme: Theme, mode: Mode, skip: string[] = 
         'theming/tokens',
         // this page intentionally has issues to test the helper
         'undefined-texts',
+        'app-layout/with-error-boundaries',
       ];
       const testFunction =
         skipPages.includes(inputUrl) ||

--- a/src/app-layout/__integ__/app-layout-error-boundaries.test.ts
+++ b/src/app-layout/__integ__/app-layout-error-boundaries.test.ts
@@ -1,0 +1,89 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+import createWrapper from '../../../lib/components/test-utils/selectors';
+import { getUrlParams } from './utils';
+
+const wrapper = createWrapper().findAppLayout();
+
+const ERROR_BOUNDARY_TEST_SELECTORS = {
+  'left drawer trigger': '[data-testid="break-left-drawer-trigger"]',
+  breadcrumbs: '[data-testid="break-breadcrumbs"]',
+  'local drawer trigger': '[data-testid="break-local-drawer-trigger"]',
+  'global drawer trigger': '[data-testid="break-global-drawer-trigger"]',
+  'left drawer content': '[data-testid="break-left-drawer-content"]',
+  'left drawer header': '[data-testid="break-left-drawer-header"]',
+  'navigation panel': '[data-testid="break-nav-panel"]',
+  'local drawer content': '[data-testid="break-local-drawer-content"]',
+  'global drawer content': '[data-testid="break-global-drawer-content"]',
+  'bottom drawer content': '[data-testid="break-bottom-drawer-content"]',
+} as const;
+
+describe('Visual refresh toolbar only', () => {
+  class PageObject extends BasePageObject {
+    async getConsoleErrorLogs() {
+      const total = (await this.browser.getLogs('browser')) as Array<{
+        level: string;
+        message: string;
+        source: string;
+      }>;
+
+      return total.filter(entry => entry.level === 'SEVERE' && entry.source !== 'network').map(entry => entry.message);
+    }
+
+    async expectConsoleErrors() {
+      const consoleErrors = await this.getConsoleErrorLogs();
+      const errorPattern = /The above error occurred in the .+ component:/;
+      const matchingErrors = consoleErrors.filter(error => errorPattern.test(error));
+      expect(matchingErrors.length).toBeGreaterThan(0);
+    }
+
+    async expectContentAreaStaysFunctional() {
+      await expect(this.getText(wrapper.findContentRegion().toSelector())).resolves.toContain(
+        'Error boundaries in app layout slots'
+      );
+    }
+  }
+  function setupTest({ hasParentErrorBoundary = 'true' }, testFn: (page: PageObject) => Promise<void>) {
+    return useBrowser(async browser => {
+      const page = new PageObject(browser);
+
+      await browser.url(
+        `#/light/app-layout/with-error-boundaries?${getUrlParams('refresh-toolbar', {
+          appLayoutToolbar: 'true',
+          hasParentErrorBoundary,
+        })}`
+      );
+      await page.waitForVisible(wrapper.findContentRegion().toSelector(), true);
+      await testFn(page);
+    });
+  }
+
+  describe('with parent error boundary', () => {
+    Object.entries(ERROR_BOUNDARY_TEST_SELECTORS).forEach(([areaName, selector]) => {
+      test(
+        `should handle error boundary in ${areaName}`,
+        setupTest({ hasParentErrorBoundary: 'true' }, async page => {
+          await page.click(selector);
+          await page.expectConsoleErrors();
+          await page.expectContentAreaStaysFunctional();
+        })
+      );
+    });
+  });
+
+  describe('without parent error boundary', () => {
+    Object.entries(ERROR_BOUNDARY_TEST_SELECTORS).forEach(([areaName, selector]) => {
+      test(
+        `should handle error boundary in ${areaName}`,
+        setupTest({ hasParentErrorBoundary: 'false' }, async page => {
+          await page.click(selector);
+          await page.expectConsoleErrors();
+          await page.expectContentAreaStaysFunctional();
+        })
+      );
+    });
+  });
+});

--- a/src/app-layout/__tests__/widget-areas-error-boundaries.test.tsx
+++ b/src/app-layout/__tests__/widget-areas-error-boundaries.test.tsx
@@ -1,0 +1,284 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import AppLayout from '../../../lib/components/app-layout';
+import ErrorBoundary from '../../../lib/components/error-boundary';
+import awsuiPlugins from '../../../lib/components/internal/plugins';
+import { DrawerConfig } from '../../../lib/components/internal/plugins/controllers/drawers';
+import * as awsuiWidgetPlugins from '../../../lib/components/internal/plugins/widget';
+import createWrapper, { ErrorBoundaryWrapper } from '../../../lib/components/test-utils/dom';
+import { describeEachAppLayout, getGlobalDrawersTestUtils } from './utils';
+
+const drawerDefaults: DrawerConfig = {
+  id: 'test',
+  ariaLabels: {},
+  trigger: { iconSvg: 'icon placeholder' },
+  mountContent: container => (container.textContent = 'runtime drawer content'),
+  unmountContent: () => {},
+};
+
+function renderComponent(jsx: React.ReactElement) {
+  const { container, rerender, getByTestId, ...rest } = render(jsx);
+  const wrapper = createWrapper(container).findAppLayout()!;
+  const errorBoundaryWrapper = createWrapper(container).findErrorBoundary()!;
+  const globalDrawersWrapper = getGlobalDrawersTestUtils(wrapper);
+  return {
+    wrapper,
+    errorBoundaryWrapper,
+    globalDrawersWrapper,
+    rerender,
+    getByTestId,
+    container,
+    ...rest,
+  };
+}
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('AppLayout error boundaries: errors in different areas does not crash the entire app layout', () => {
+  const ThrowError = ({ message = 'Test error' }: { message?: string }) => {
+    throw new Error(message);
+  };
+
+  const expectInvisibleErrorBoundary = (errorBoundaryWrapper: ErrorBoundaryWrapper) => {
+    expect(errorBoundaryWrapper.getElement()).toBeInTheDocument();
+    expect(errorBoundaryWrapper.findHeader()).toBeFalsy();
+    expect(errorBoundaryWrapper.findDescription()).toBeFalsy();
+    expect(errorBoundaryWrapper.findAction()).toBeFalsy();
+  };
+
+  describeEachAppLayout({ themes: ['refresh-toolbar'] }, () => {
+    describe.each([true, false])(
+      'entire AppLayout wrapped with error boundary component : %p',
+      (wrappedWithErrorBoundary: boolean) => {
+        const onError = jest.fn();
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const AppLayoutWrapper = wrappedWithErrorBoundary ? ErrorBoundary : 'div';
+        const appLayoutWrapperProps = wrappedWithErrorBoundary ? { onError } : {};
+        const content = <div>content</div>;
+
+        const expectErrorCallbacksToBeCalled = () => {
+          if (wrappedWithErrorBoundary) {
+            expect(onError).toHaveBeenCalled();
+          }
+          expect(consoleSpy).toHaveBeenCalled();
+        };
+
+        test('left drawer content', () => {
+          awsuiWidgetPlugins.registerLeftDrawer({
+            defaultActive: true,
+            ...drawerDefaults,
+            id: '1',
+            trigger: undefined,
+            mountContent: () => {
+              throw new Error('Mount error in drawer content');
+            },
+          });
+          const { errorBoundaryWrapper, wrapper } = renderComponent(
+            <AppLayoutWrapper {...(appLayoutWrapperProps as any)}>
+              <AppLayout content={content} />
+            </AppLayoutWrapper>
+          );
+
+          expect(wrapper.findContentRegion().getElement()).toHaveTextContent('content');
+          expectInvisibleErrorBoundary(errorBoundaryWrapper);
+          expectErrorCallbacksToBeCalled();
+        });
+
+        test('left drawer header', () => {
+          awsuiWidgetPlugins.registerLeftDrawer({
+            ...drawerDefaults,
+            id: '2',
+            defaultActive: true,
+            trigger: undefined,
+            mountHeader: () => {
+              throw new Error('Mount error in drawer content');
+            },
+          });
+          const { errorBoundaryWrapper, wrapper } = renderComponent(
+            <AppLayoutWrapper {...(appLayoutWrapperProps as any)}>
+              <AppLayout content={content} />
+            </AppLayoutWrapper>
+          );
+
+          expect(wrapper.findContentRegion().getElement()).toHaveTextContent('content');
+          expectInvisibleErrorBoundary(errorBoundaryWrapper);
+          expectErrorCallbacksToBeCalled();
+        });
+
+        test('left drawer trigger', () => {
+          awsuiWidgetPlugins.registerLeftDrawer({
+            ...drawerDefaults,
+            id: '3',
+            trigger: {
+              iconSvg: Symbol() as any,
+            },
+          });
+          const { errorBoundaryWrapper, wrapper } = renderComponent(
+            <AppLayoutWrapper {...(appLayoutWrapperProps as any)}>
+              <AppLayout content={content} />
+            </AppLayoutWrapper>
+          );
+
+          expect(wrapper.findContentRegion().getElement()).toHaveTextContent('content');
+          expectInvisibleErrorBoundary(errorBoundaryWrapper);
+          expectErrorCallbacksToBeCalled();
+        });
+
+        test('breadcrumbs', () => {
+          const { errorBoundaryWrapper, wrapper } = renderComponent(
+            <AppLayoutWrapper {...(appLayoutWrapperProps as any)}>
+              <AppLayout content={content} breadcrumbs={<ThrowError message="Breadcrumbs error" />} />
+            </AppLayoutWrapper>
+          );
+
+          expect(wrapper.findContentRegion().getElement()).toHaveTextContent('content');
+          expectInvisibleErrorBoundary(errorBoundaryWrapper);
+          expectErrorCallbacksToBeCalled();
+        });
+
+        test('local drawer trigger', () => {
+          awsuiPlugins.appLayout.registerDrawer({
+            ...drawerDefaults,
+            type: 'local',
+            trigger: {
+              iconSvg: Symbol() as any,
+            },
+          });
+
+          const { errorBoundaryWrapper, wrapper } = renderComponent(
+            <AppLayoutWrapper {...(appLayoutWrapperProps as any)}>
+              <AppLayout content={content} />
+            </AppLayoutWrapper>
+          );
+
+          expect(wrapper.findContentRegion().getElement()).toHaveTextContent('content');
+          expectInvisibleErrorBoundary(errorBoundaryWrapper);
+          expectErrorCallbacksToBeCalled();
+        });
+
+        test('global drawer trigger', () => {
+          awsuiPlugins.appLayout.registerDrawer({
+            ...drawerDefaults,
+            type: 'global',
+            trigger: {
+              iconSvg: Symbol() as any,
+            },
+          });
+
+          const { errorBoundaryWrapper, wrapper } = renderComponent(
+            <AppLayoutWrapper {...(appLayoutWrapperProps as any)}>
+              <AppLayout content={content} />
+            </AppLayoutWrapper>
+          );
+
+          expect(wrapper.findContentRegion().getElement()).toHaveTextContent('content');
+          expectInvisibleErrorBoundary(errorBoundaryWrapper);
+          expectErrorCallbacksToBeCalled();
+        });
+
+        test('nav panel', () => {
+          const { errorBoundaryWrapper, wrapper } = renderComponent(
+            <AppLayoutWrapper {...(appLayoutWrapperProps as any)}>
+              <AppLayout
+                content={content}
+                navigation={<ThrowError message="Breadcrumbs error" />}
+                navigationOpen={true}
+              />
+            </AppLayoutWrapper>
+          );
+
+          expect(wrapper.findContentRegion().getElement()).toHaveTextContent('content');
+          expectInvisibleErrorBoundary(errorBoundaryWrapper);
+          expectErrorCallbacksToBeCalled();
+        });
+
+        test('local drawer content', () => {
+          awsuiPlugins.appLayout.registerDrawer({
+            ...drawerDefaults,
+            type: 'local',
+            mountContent: () => {
+              throw new Error('Mount error in drawer content');
+            },
+          });
+
+          const { errorBoundaryWrapper, wrapper } = renderComponent(
+            <AppLayoutWrapper {...(appLayoutWrapperProps as any)}>
+              <AppLayout content={content} />
+            </AppLayoutWrapper>
+          );
+
+          expect(wrapper.findContentRegion().getElement()).toHaveTextContent('content');
+          expectInvisibleErrorBoundary(errorBoundaryWrapper);
+          expectErrorCallbacksToBeCalled();
+        });
+
+        test('global drawer content', () => {
+          awsuiPlugins.appLayout.registerDrawer({
+            ...drawerDefaults,
+            type: 'global',
+            mountContent: () => {
+              throw new Error('Mount error in drawer content');
+            },
+          });
+
+          const { errorBoundaryWrapper, wrapper } = renderComponent(
+            <AppLayoutWrapper {...(appLayoutWrapperProps as any)}>
+              <AppLayout content={content} />
+            </AppLayoutWrapper>
+          );
+
+          expect(wrapper.findContentRegion().getElement()).toHaveTextContent('content');
+          expectInvisibleErrorBoundary(errorBoundaryWrapper);
+          expectErrorCallbacksToBeCalled();
+        });
+
+        test('bottom drawer content', () => {
+          awsuiWidgetPlugins.registerBottomDrawer({
+            defaultActive: true,
+            ...drawerDefaults,
+            id: '4',
+            mountContent: () => {
+              throw new Error('Mount error in drawer content');
+            },
+          });
+
+          const { errorBoundaryWrapper, wrapper } = renderComponent(
+            <AppLayoutWrapper {...(appLayoutWrapperProps as any)}>
+              <AppLayout content={content} />
+            </AppLayoutWrapper>
+          );
+
+          expect(wrapper.findContentRegion().getElement()).toHaveTextContent('content');
+          expectInvisibleErrorBoundary(errorBoundaryWrapper);
+          expectErrorCallbacksToBeCalled();
+        });
+
+        test('content area error are not caught by app layout error boundaries', () => {
+          if (wrappedWithErrorBoundary) {
+            const { errorBoundaryWrapper } = renderComponent(
+              <AppLayoutWrapper {...(appLayoutWrapperProps as any)}>
+                <AppLayout content={<ThrowError />} />
+              </AppLayoutWrapper>
+            );
+
+            expectInvisibleErrorBoundary(errorBoundaryWrapper);
+            expectErrorCallbacksToBeCalled();
+          } else {
+            expect(() =>
+              render(
+                <AppLayoutWrapper {...(appLayoutWrapperProps as any)}>
+                  <AppLayout content={<ThrowError />} />
+                </AppLayoutWrapper>
+              )
+            ).toThrow('Test error');
+          }
+        });
+      }
+    );
+  });
+});

--- a/src/app-layout/visual-refresh-toolbar/drawer/global-ai-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/global-ai-drawer.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 
 import { InternalItemOrGroup } from '../../../button-group/interfaces';
 import ButtonGroup from '../../../button-group/internal';
+import { AppLayoutBuiltInErrorBoundary } from '../../../error-boundary/internal';
 import PanelResizeHandle from '../../../internal/components/panel-resize-handle';
 import customCssProps from '../../../internal/generated/custom-css-properties';
 import { usePrevious } from '../../../internal/hooks/use-previous';
@@ -130,127 +131,135 @@ export function AppLayoutGlobalAiDrawerImplementation({
   }
 
   return (
-    <Transition nodeRef={drawerRef} in={show} appear={show} mountOnEnter={true} timeout={250}>
-      {drawerTransitionState => {
-        return (
-          <Transition nodeRef={drawerRef} in={isExpanded} timeout={250}>
-            {expandedTransitionState => {
-              return (
-                <aside
-                  id={activeAiDrawer?.id}
-                  aria-hidden={!activeAiDrawer}
-                  aria-label={computedAriaLabels.content}
-                  className={clsx(
-                    styles.drawer,
-                    styles['ai-drawer'],
-                    !animationDisabled && isExpanded && styles['with-expanded-motion'],
-                    {
-                      [sharedStyles['with-motion-horizontal']]: !animationDisabled,
-                      [testutilStyles['active-drawer']]: show,
-                      [styles['drawer-hidden']]: !show && drawerTransitionState === 'exited',
-                      [testutilStyles['drawer-closed']]: !activeAiDrawer,
-                      [styles['drawer-expanded']]: isExpanded,
-                    }
-                  )}
-                  ref={drawerRef}
-                  onBlur={e => {
-                    if (!e.relatedTarget || !e.currentTarget.contains(e.relatedTarget)) {
-                      aiDrawerFocusControl?.loseFocus();
-                    }
-                  }}
-                  style={{
-                    blockSize: drawerHeight,
-                    insetBlockStart: `${placement.insetBlockStart}px`,
-                    ...(!isMobile && {
-                      [customCssProps.drawerMinSize]: `${size}px`,
-                      [customCssProps.drawerSize]: `${['entering', 'entered'].includes(drawerTransitionState) ? size : 0}px`,
-                    }),
-                  }}
-                  data-testid={activeDrawerId && `awsui-app-layout-drawer-${activeDrawerId}`}
-                >
-                  {!isMobile && activeAiDrawer?.resizable && (!isExpanded || expandedTransitionState !== 'entered') && (
-                    <div className={styles['drawer-slider']}>
-                      <PanelResizeHandle
-                        ref={aiDrawerFocusControl?.refs.slider}
-                        position="side-start"
-                        className={clsx(testutilStyles['drawers-slider'], styles['ai-drawer-slider-handle'])}
-                        ariaLabel={activeAiDrawer?.ariaLabels?.resizeHandle}
-                        tooltipText={activeAiDrawer?.ariaLabels?.resizeHandleTooltipText}
-                        ariaValuenow={resizeProps.relativeSize}
-                        onKeyDown={resizeProps.onKeyDown}
-                        onPointerDown={resizeProps.onPointerDown}
-                        onDirectionClick={resizeProps.onDirectionClick}
-                        disabled={isResizingDisabled}
-                      />
-                    </div>
-                  )}
-                  <div className={clsx(styles['drawer-content-container'], sharedStyles['with-motion-horizontal'])}>
-                    <div className={styles['drawer-content']}>
-                      <header className={styles['drawer-content-header']}>
-                        <div className={styles['drawer-content-header-content']}>
-                          {activeAiDrawer?.header ?? <div />}
-                          <div className={styles['drawer-actions']}>
-                            <ButtonGroup
-                              dropdownExpandToViewport={false}
-                              variant="icon"
-                              onItemClick={event => {
-                                switch (event.detail.id) {
-                                  case 'close':
-                                    onActiveAiDrawerChange?.(null, { initiatedByUserAction: true });
-                                    break;
-                                  case 'expand':
-                                    setExpandedDrawerId(isExpanded ? null : activeDrawerId!);
-                                    break;
-                                  default:
-                                    activeAiDrawer?.onHeaderActionClick?.(event);
-                                }
-                              }}
-                              ariaLabel="Left panel actions"
-                              items={drawerActions}
-                            />
-                          </div>
+    <AppLayoutBuiltInErrorBoundary>
+      <Transition nodeRef={drawerRef} in={show} appear={show} mountOnEnter={true} timeout={250}>
+        {drawerTransitionState => {
+          return (
+            <Transition nodeRef={drawerRef} in={isExpanded} timeout={250}>
+              {expandedTransitionState => {
+                return (
+                  <aside
+                    id={activeAiDrawer?.id}
+                    aria-hidden={!activeAiDrawer}
+                    aria-label={computedAriaLabels.content}
+                    className={clsx(
+                      styles.drawer,
+                      styles['ai-drawer'],
+                      !animationDisabled && isExpanded && styles['with-expanded-motion'],
+                      {
+                        [sharedStyles['with-motion-horizontal']]: !animationDisabled,
+                        [testutilStyles['active-drawer']]: show,
+                        [styles['drawer-hidden']]: !show && drawerTransitionState === 'exited',
+                        [testutilStyles['drawer-closed']]: !activeAiDrawer,
+                        [styles['drawer-expanded']]: isExpanded,
+                      }
+                    )}
+                    ref={drawerRef}
+                    onBlur={e => {
+                      if (!e.relatedTarget || !e.currentTarget.contains(e.relatedTarget)) {
+                        aiDrawerFocusControl?.loseFocus();
+                      }
+                    }}
+                    style={{
+                      blockSize: drawerHeight,
+                      insetBlockStart: `${placement.insetBlockStart}px`,
+                      ...(!isMobile && {
+                        [customCssProps.drawerMinSize]: `${size}px`,
+                        [customCssProps.drawerSize]: `${['entering', 'entered'].includes(drawerTransitionState) ? size : 0}px`,
+                      }),
+                    }}
+                    data-testid={activeDrawerId && `awsui-app-layout-drawer-${activeDrawerId}`}
+                  >
+                    {!isMobile &&
+                      activeAiDrawer?.resizable &&
+                      (!isExpanded || expandedTransitionState !== 'entered') && (
+                        <div className={styles['drawer-slider']}>
+                          <PanelResizeHandle
+                            ref={aiDrawerFocusControl?.refs.slider}
+                            position="side-start"
+                            className={clsx(testutilStyles['drawers-slider'], styles['ai-drawer-slider-handle'])}
+                            ariaLabel={activeAiDrawer?.ariaLabels?.resizeHandle}
+                            tooltipText={activeAiDrawer?.ariaLabels?.resizeHandleTooltipText}
+                            ariaValuenow={resizeProps.relativeSize}
+                            onKeyDown={resizeProps.onKeyDown}
+                            onPointerDown={resizeProps.onPointerDown}
+                            onDirectionClick={resizeProps.onDirectionClick}
+                            disabled={isResizingDisabled}
+                          />
                         </div>
-                        {!isMobile && isExpanded && activeAiDrawer?.ariaLabels?.exitExpandedModeButton && (
-                          <div className={styles['drawer-back-to-console-slot']}>
-                            <div className={styles['drawer-back-to-console-button-wrapper']}>
-                              {activeAiDrawer?.exitExpandedModeTrigger?.customIcon ? (
-                                <button
-                                  className={clsx(
-                                    testutilStyles['active-ai-drawer-leave-expanded-mode-custom-button'],
-                                    styles['drawer-back-to-console-custom-button']
-                                  )}
-                                  formAction="none"
-                                  onClick={() => setExpandedDrawerId(null)}
-                                  aria-label={activeAiDrawer?.ariaLabels?.exitExpandedModeButton}
-                                >
-                                  {activeAiDrawer?.exitExpandedModeTrigger?.customIcon}
-                                </button>
-                              ) : (
-                                <button
-                                  className={clsx(
-                                    testutilStyles['active-ai-drawer-leave-expanded-mode-custom-button'],
-                                    styles['drawer-back-to-console-button']
-                                  )}
-                                  formAction="none"
-                                  onClick={() => setExpandedDrawerId(null)}
-                                  aria-label={activeAiDrawer?.ariaLabels?.exitExpandedModeButton}
-                                >
-                                  {activeAiDrawer?.ariaLabels?.exitExpandedModeButton}
-                                </button>
-                              )}
+                      )}
+                    <div className={clsx(styles['drawer-content-container'], sharedStyles['with-motion-horizontal'])}>
+                      <div className={styles['drawer-content']}>
+                        <header className={styles['drawer-content-header']}>
+                          <div className={styles['drawer-content-header-content']}>
+                            <AppLayoutBuiltInErrorBoundary renderFallback={() => <div />}>
+                              {activeAiDrawer?.header ?? <div />}
+                            </AppLayoutBuiltInErrorBoundary>
+                            <div className={styles['drawer-actions']}>
+                              <ButtonGroup
+                                dropdownExpandToViewport={false}
+                                variant="icon"
+                                onItemClick={event => {
+                                  switch (event.detail.id) {
+                                    case 'close':
+                                      onActiveAiDrawerChange?.(null, { initiatedByUserAction: true });
+                                      break;
+                                    case 'expand':
+                                      setExpandedDrawerId(isExpanded ? null : activeDrawerId!);
+                                      break;
+                                    default:
+                                      activeAiDrawer?.onHeaderActionClick?.(event);
+                                  }
+                                }}
+                                ariaLabel="Left panel actions"
+                                items={drawerActions}
+                              />
                             </div>
                           </div>
-                        )}
-                      </header>
-                      <div className={styles['drawer-content-content']}>{activeAiDrawer?.content}</div>
+                          {!isMobile && isExpanded && activeAiDrawer?.ariaLabels?.exitExpandedModeButton && (
+                            <div className={styles['drawer-back-to-console-slot']}>
+                              <div className={styles['drawer-back-to-console-button-wrapper']}>
+                                {activeAiDrawer?.exitExpandedModeTrigger?.customIcon ? (
+                                  <button
+                                    className={clsx(
+                                      testutilStyles['active-ai-drawer-leave-expanded-mode-custom-button'],
+                                      styles['drawer-back-to-console-custom-button']
+                                    )}
+                                    formAction="none"
+                                    onClick={() => setExpandedDrawerId(null)}
+                                    aria-label={activeAiDrawer?.ariaLabels?.exitExpandedModeButton}
+                                  >
+                                    {activeAiDrawer?.exitExpandedModeTrigger?.customIcon}
+                                  </button>
+                                ) : (
+                                  <button
+                                    className={clsx(
+                                      testutilStyles['active-ai-drawer-leave-expanded-mode-custom-button'],
+                                      styles['drawer-back-to-console-button']
+                                    )}
+                                    formAction="none"
+                                    onClick={() => setExpandedDrawerId(null)}
+                                    aria-label={activeAiDrawer?.ariaLabels?.exitExpandedModeButton}
+                                  >
+                                    {activeAiDrawer?.ariaLabels?.exitExpandedModeButton}
+                                  </button>
+                                )}
+                              </div>
+                            </div>
+                          )}
+                        </header>
+                        <AppLayoutBuiltInErrorBoundary>
+                          <div className={styles['drawer-content-content']}>{activeAiDrawer?.content}</div>
+                        </AppLayoutBuiltInErrorBoundary>
+                      </div>
                     </div>
-                  </div>
-                </aside>
-              );
-            }}
-          </Transition>
-        );
-      }}
-    </Transition>
+                  </aside>
+                );
+              }}
+            </Transition>
+          );
+        }}
+      </Transition>
+    </AppLayoutBuiltInErrorBoundary>
   );
 }

--- a/src/app-layout/visual-refresh-toolbar/drawer/global-bottom-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/global-bottom-drawer.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 
 import { InternalItemOrGroup } from '../../../button-group/interfaces';
 import ButtonGroup from '../../../button-group/internal';
+import { AppLayoutBuiltInErrorBoundary } from '../../../error-boundary/internal';
 import PanelResizeHandle from '../../../internal/components/panel-resize-handle';
 import customCssProps from '../../../internal/generated/custom-css-properties';
 import { usePrevious } from '../../../internal/hooks/use-previous';
@@ -18,7 +19,6 @@ import { useResize } from './use-resize';
 import sharedStyles from '../../resize/styles.css.js';
 import testutilStyles from '../../test-classes/styles.css.js';
 import styles from './styles.css.js';
-
 export function AppLayoutBottomDrawerWrapper({ widgetizedState }: { widgetizedState: AppLayoutWidgetizedState }) {
   const { activeGlobalBottomDrawerId, bottomDrawers } = widgetizedState;
   const openBottomDrawersHistory = useRef<Set<string>>(new Set());
@@ -189,130 +189,132 @@ function AppLayoutGlobalBottomDrawerImplementation({
   }, [reportBottomDrawerSize, size]);
 
   return (
-    <Transition
-      nodeRef={drawerRef}
-      in={show || isExpanded}
-      appear={show || isExpanded}
-      mountOnEnter={true}
-      timeout={250}
-    >
-      {state => {
-        return (
-          <aside
-            id={activeDrawerId}
-            aria-hidden={!show}
-            aria-label={computedAriaLabels.content}
-            className={clsx(
-              styles.drawer,
-              styles['bottom-drawer'],
-              styles[state],
-              !animationDisabled && sharedStyles['with-motion-vertical'],
-              !animationDisabled && isExpanded && styles['with-expanded-motion'],
-              {
-                [styles['drawer-hidden']]: !show && state === 'exited',
-                [styles['last-opened']]: (!activeAiDrawer && lastOpenedDrawerId === activeDrawerId) || isExpanded,
-                [testutilStyles['active-drawer']]: show,
-                [styles['drawer-expanded']]: isExpanded,
-              }
-            )}
-            ref={drawerRef}
-            onBlur={e => {
-              // Drawers with trigger buttons follow this restore focus logic:
-              // If a previously focused element exists, restore focus on it; otherwise, focus on the associated trigger button.
-              // This function resets the previously focused element.
-              // If the drawer has no trigger button and loses focus on the previously focused element, it defaults to document.body,
-              // which ideally should never happen.
-              if (!hasTriggerButton) {
-                return;
-              }
-
-              if (!e.relatedTarget || !e.currentTarget.contains(e.relatedTarget)) {
-                bottomDrawersFocusControl.loseFocus();
-              }
-            }}
-            style={{
-              ...(isMobile && {
-                blockSize: drawerFullScreenHeight,
-                insetBlockStart: mobileDrawerTopOffset,
-              }),
-              ...(!isMobile && {
-                [customCssProps.bottomDrawerSize]: `${['entering', 'entered'].includes(state) ? (isExpanded ? drawerFullScreenHeight : size + 'px') : 0}`,
-              }),
-            }}
-            data-testid={`awsui-app-layout-drawer-${activeDrawerId}`}
-          >
-            <div className={clsx(styles['global-drawer-wrapper'])}>
-              {!isMobile && !isExpanded && <div className={styles['drawer-gap']} />}
-              {!isMobile && activeDrawer?.resizable && !isExpanded && (
-                // Prevents receiving focus in Firefox
-                <div className={styles['drawer-slider']} tabIndex={-1}>
-                  <PanelResizeHandle
-                    ref={refs?.slider}
-                    position="bottom"
-                    className={testutilStyles['drawers-slider']}
-                    ariaLabel={activeDrawer?.ariaLabels?.resizeHandle}
-                    tooltipText={activeDrawer?.ariaLabels?.resizeHandleTooltipText}
-                    ariaValuenow={resizeProps.relativeSize}
-                    onKeyDown={resizeProps.onKeyDown}
-                    onDirectionClick={resizeProps.onDirectionClick}
-                    onPointerDown={resizeProps.onPointerDown}
-                  />
-                </div>
+    <AppLayoutBuiltInErrorBoundary>
+      <Transition
+        nodeRef={drawerRef}
+        in={show || isExpanded}
+        appear={show || isExpanded}
+        mountOnEnter={true}
+        timeout={250}
+      >
+        {state => {
+          return (
+            <aside
+              id={activeDrawerId}
+              aria-hidden={!show}
+              aria-label={computedAriaLabels.content}
+              className={clsx(
+                styles.drawer,
+                styles['bottom-drawer'],
+                styles[state],
+                !animationDisabled && sharedStyles['with-motion-vertical'],
+                !animationDisabled && isExpanded && styles['with-expanded-motion'],
+                {
+                  [styles['drawer-hidden']]: !show && state === 'exited',
+                  [styles['last-opened']]: (!activeAiDrawer && lastOpenedDrawerId === activeDrawerId) || isExpanded,
+                  [testutilStyles['active-drawer']]: show,
+                  [styles['drawer-expanded']]: isExpanded,
+                }
               )}
-              <header className={styles['bottom-drawer-content-header']} ref={headerRef}>
-                <div className={styles['bottom-drawer-content-header-content']}>
-                  {activeDrawer?.header ?? <div />}
-                  <div className={styles['bottom-drawer-actions']}>
-                    <ButtonGroup
-                      dropdownExpandToViewport={false}
-                      variant="icon"
-                      onItemClick={event => {
-                        switch (event.detail.id) {
-                          case 'close':
-                            onActiveGlobalBottomDrawerChange(null, { initiatedByUserAction: true });
-                            break;
-                          case 'expand':
-                            setExpandedDrawerId(isExpanded ? null : activeDrawerId);
-                            break;
-                          default:
-                            activeDrawer?.onHeaderActionClick?.(event);
-                        }
-                      }}
-                      ariaLabel="Global panel actions"
-                      items={drawerActions}
-                      __internalRootRef={(root: HTMLElement) => {
-                        if (!root) {
-                          return;
-                        }
-                        refs.close = {
-                          current: root.querySelector('[data-itemid="close"]') as unknown as Focusable,
-                        };
-                      }}
+              ref={drawerRef}
+              onBlur={e => {
+                // Drawers with trigger buttons follow this restore focus logic:
+                // If a previously focused element exists, restore focus on it; otherwise, focus on the associated trigger button.
+                // This function resets the previously focused element.
+                // If the drawer has no trigger button and loses focus on the previously focused element, it defaults to document.body,
+                // which ideally should never happen.
+                if (!hasTriggerButton) {
+                  return;
+                }
+
+                if (!e.relatedTarget || !e.currentTarget.contains(e.relatedTarget)) {
+                  bottomDrawersFocusControl.loseFocus();
+                }
+              }}
+              style={{
+                ...(isMobile && {
+                  blockSize: drawerFullScreenHeight,
+                  insetBlockStart: mobileDrawerTopOffset,
+                }),
+                ...(!isMobile && {
+                  [customCssProps.bottomDrawerSize]: `${['entering', 'entered'].includes(state) ? (isExpanded ? drawerFullScreenHeight : size + 'px') : 0}`,
+                }),
+              }}
+              data-testid={`awsui-app-layout-drawer-${activeDrawerId}`}
+            >
+              <div className={clsx(styles['global-drawer-wrapper'])}>
+                {!isMobile && !isExpanded && <div className={styles['drawer-gap']} />}
+                {!isMobile && activeDrawer?.resizable && !isExpanded && (
+                  // Prevents receiving focus in Firefox
+                  <div className={styles['drawer-slider']} tabIndex={-1}>
+                    <PanelResizeHandle
+                      ref={refs?.slider}
+                      position="bottom"
+                      className={testutilStyles['drawers-slider']}
+                      ariaLabel={activeDrawer?.ariaLabels?.resizeHandle}
+                      tooltipText={activeDrawer?.ariaLabels?.resizeHandleTooltipText}
+                      ariaValuenow={resizeProps.relativeSize}
+                      onKeyDown={resizeProps.onKeyDown}
+                      onDirectionClick={resizeProps.onDirectionClick}
+                      onPointerDown={resizeProps.onPointerDown}
                     />
                   </div>
-                </div>
-              </header>
-              <div
-                className={clsx(styles['drawer-content-container'], sharedStyles['with-motion-horizontal'])}
-                data-testid={`awsui-app-layout-drawer-content-${activeDrawerId}`}
-              >
+                )}
+                <header className={styles['bottom-drawer-content-header']} ref={headerRef}>
+                  <div className={styles['bottom-drawer-content-header-content']}>
+                    {activeDrawer?.header ?? <div />}
+                    <div className={styles['bottom-drawer-actions']}>
+                      <ButtonGroup
+                        dropdownExpandToViewport={false}
+                        variant="icon"
+                        onItemClick={event => {
+                          switch (event.detail.id) {
+                            case 'close':
+                              onActiveGlobalBottomDrawerChange(null, { initiatedByUserAction: true });
+                              break;
+                            case 'expand':
+                              setExpandedDrawerId(isExpanded ? null : activeDrawerId);
+                              break;
+                            default:
+                              activeDrawer?.onHeaderActionClick?.(event);
+                          }
+                        }}
+                        ariaLabel="Global panel actions"
+                        items={drawerActions}
+                        __internalRootRef={(root: HTMLElement) => {
+                          if (!root) {
+                            return;
+                          }
+                          refs.close = {
+                            current: root.querySelector('[data-itemid="close"]') as unknown as Focusable,
+                          };
+                        }}
+                      />
+                    </div>
+                  </div>
+                </header>
                 <div
-                  className={styles['drawer-content']}
-                  style={{
-                    blockSize:
-                      isMobile || isExpanded
-                        ? drawerFullScreenHeight
-                        : `${size - GAP_HEIGHT - RESIZE_HANDLER_HEIGHT - (headerRef?.current?.clientHeight ?? 0)}px`,
-                  }}
+                  className={clsx(styles['drawer-content-container'], sharedStyles['with-motion-horizontal'])}
+                  data-testid={`awsui-app-layout-drawer-content-${activeDrawerId}`}
                 >
-                  {activeDrawer?.content}
+                  <div
+                    className={styles['drawer-content']}
+                    style={{
+                      blockSize:
+                        isMobile || isExpanded
+                          ? drawerFullScreenHeight
+                          : `${size - GAP_HEIGHT - RESIZE_HANDLER_HEIGHT - (headerRef?.current?.clientHeight ?? 0)}px`,
+                    }}
+                  >
+                    {activeDrawer?.content}
+                  </div>
                 </div>
               </div>
-            </div>
-          </aside>
-        );
-      }}
-    </Transition>
+            </aside>
+          );
+        }}
+      </Transition>
+    </AppLayoutBuiltInErrorBoundary>
   );
 }
 

--- a/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/global-drawer.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 
 import { InternalItemOrGroup } from '../../../button-group/interfaces';
 import ButtonGroup from '../../../button-group/internal';
+import { AppLayoutBuiltInErrorBoundary } from '../../../error-boundary/internal';
 import PanelResizeHandle from '../../../internal/components/panel-resize-handle';
 import customCssProps from '../../../internal/generated/custom-css-properties';
 import { usePrevious } from '../../../internal/hooks/use-previous';
@@ -109,110 +110,112 @@ function AppLayoutGlobalDrawerImplementation({
   }
 
   return (
-    <Transition nodeRef={drawerRef} in={show || isExpanded} appear={show || isExpanded} timeout={0}>
-      {state => {
-        return (
-          <aside
-            id={activeDrawerId}
-            aria-hidden={!show}
-            aria-label={computedAriaLabels.content}
-            className={clsx(
-              styles.drawer,
-              styles['drawer-global'],
-              styles[state],
-              !animationDisabled && sharedStyles['with-motion-horizontal'],
-              !animationDisabled && isExpanded && styles['with-expanded-motion'],
-              {
-                [styles['drawer-hidden']]: !show,
-                [styles['last-opened']]: (!activeAiDrawer && lastOpenedDrawerId === activeDrawerId) || isExpanded,
-                [testutilStyles['active-drawer']]: show,
-                [styles['drawer-expanded']]: isExpanded,
-                [styles['has-next-siblings']]:
-                  activeGlobalDrawers.findIndex(drawer => drawer.id === activeDrawerId) + 1 <
-                  activeGlobalDrawers.length,
-              }
-            )}
-            ref={drawerRef}
-            onBlur={e => {
-              // Drawers with trigger buttons follow this restore focus logic:
-              // If a previously focused element exists, restore focus on it; otherwise, focus on the associated trigger button.
-              // This function resets the previously focused element.
-              // If the drawer has no trigger button and loses focus on the previously focused element, it defaults to document.body,
-              // which ideally should never happen.
-              if (!hasTriggerButton) {
-                return;
-              }
-
-              if (!e.relatedTarget || !e.currentTarget.contains(e.relatedTarget)) {
-                globalDrawersFocusControl.loseFocus();
-              }
-            }}
-            style={{
-              blockSize: drawerHeight,
-              insetBlockStart: drawerTopOffset,
-              ...(!isMobile && {
-                [customCssProps.drawerSize]: `${['entering', 'entered'].includes(state) ? (isExpanded ? '100%' : size + 'px') : 0}`,
-              }),
-            }}
-            data-testid={`awsui-app-layout-drawer-${activeDrawerId}`}
-          >
-            <div className={clsx(styles['global-drawer-wrapper'])}>
-              {!isMobile && <div className={styles['drawer-gap']}></div>}
-              {!isMobile && activeGlobalDrawer?.resizable && !isExpanded && (
-                <div className={styles['drawer-slider']}>
-                  <PanelResizeHandle
-                    ref={refs?.slider}
-                    position="side"
-                    className={testutilStyles['drawers-slider']}
-                    ariaLabel={activeGlobalDrawer?.ariaLabels?.resizeHandle}
-                    tooltipText={activeGlobalDrawer?.ariaLabels?.resizeHandleTooltipText}
-                    ariaValuenow={resizeProps.relativeSize}
-                    onKeyDown={resizeProps.onKeyDown}
-                    onDirectionClick={resizeProps.onDirectionClick}
-                    onPointerDown={resizeProps.onPointerDown}
-                  />
-                </div>
+    <AppLayoutBuiltInErrorBoundary>
+      <Transition nodeRef={drawerRef} in={show || isExpanded} appear={show || isExpanded} timeout={0}>
+        {state => {
+          return (
+            <aside
+              id={activeDrawerId}
+              aria-hidden={!show}
+              aria-label={computedAriaLabels.content}
+              className={clsx(
+                styles.drawer,
+                styles['drawer-global'],
+                styles[state],
+                !animationDisabled && sharedStyles['with-motion-horizontal'],
+                !animationDisabled && isExpanded && styles['with-expanded-motion'],
+                {
+                  [styles['drawer-hidden']]: !show,
+                  [styles['last-opened']]: (!activeAiDrawer && lastOpenedDrawerId === activeDrawerId) || isExpanded,
+                  [testutilStyles['active-drawer']]: show,
+                  [styles['drawer-expanded']]: isExpanded,
+                  [styles['has-next-siblings']]:
+                    activeGlobalDrawers.findIndex(drawer => drawer.id === activeDrawerId) + 1 <
+                    activeGlobalDrawers.length,
+                }
               )}
+              ref={drawerRef}
+              onBlur={e => {
+                // Drawers with trigger buttons follow this restore focus logic:
+                // If a previously focused element exists, restore focus on it; otherwise, focus on the associated trigger button.
+                // This function resets the previously focused element.
+                // If the drawer has no trigger button and loses focus on the previously focused element, it defaults to document.body,
+                // which ideally should never happen.
+                if (!hasTriggerButton) {
+                  return;
+                }
 
-              <div
-                className={clsx(styles['drawer-content-container'], sharedStyles['with-motion-horizontal'])}
-                data-testid={`awsui-app-layout-drawer-content-${activeDrawerId}`}
-              >
-                <div className={styles['drawer-actions']}>
-                  <ButtonGroup
-                    dropdownExpandToViewport={false}
-                    variant="icon"
-                    onItemClick={event => {
-                      switch (event.detail.id) {
-                        case 'close':
-                          onActiveGlobalDrawersChange(activeDrawerId, { initiatedByUserAction: true });
-                          break;
-                        case 'expand':
-                          setExpandedDrawerId(isExpanded ? null : activeDrawerId);
-                          break;
-                        default:
-                          activeGlobalDrawer?.onHeaderActionClick?.(event);
-                      }
-                    }}
-                    ariaLabel="Global panel actions"
-                    items={drawerActions}
-                    __internalRootRef={(root: HTMLElement) => {
-                      if (!root) {
-                        return;
-                      }
-                      refs.close = { current: root.querySelector('[data-itemid="close"]') as unknown as Focusable };
-                    }}
-                  />
-                </div>
-                <div className={styles['drawer-content']} style={{ blockSize: drawerHeight }}>
-                  {activeGlobalDrawer?.content}
+                if (!e.relatedTarget || !e.currentTarget.contains(e.relatedTarget)) {
+                  globalDrawersFocusControl.loseFocus();
+                }
+              }}
+              style={{
+                blockSize: drawerHeight,
+                insetBlockStart: drawerTopOffset,
+                ...(!isMobile && {
+                  [customCssProps.drawerSize]: `${['entering', 'entered'].includes(state) ? (isExpanded ? '100%' : size + 'px') : 0}`,
+                }),
+              }}
+              data-testid={`awsui-app-layout-drawer-${activeDrawerId}`}
+            >
+              <div className={clsx(styles['global-drawer-wrapper'])}>
+                {!isMobile && <div className={styles['drawer-gap']}></div>}
+                {!isMobile && activeGlobalDrawer?.resizable && !isExpanded && (
+                  <div className={styles['drawer-slider']}>
+                    <PanelResizeHandle
+                      ref={refs?.slider}
+                      position="side"
+                      className={testutilStyles['drawers-slider']}
+                      ariaLabel={activeGlobalDrawer?.ariaLabels?.resizeHandle}
+                      tooltipText={activeGlobalDrawer?.ariaLabels?.resizeHandleTooltipText}
+                      ariaValuenow={resizeProps.relativeSize}
+                      onKeyDown={resizeProps.onKeyDown}
+                      onDirectionClick={resizeProps.onDirectionClick}
+                      onPointerDown={resizeProps.onPointerDown}
+                    />
+                  </div>
+                )}
+
+                <div
+                  className={clsx(styles['drawer-content-container'], sharedStyles['with-motion-horizontal'])}
+                  data-testid={`awsui-app-layout-drawer-content-${activeDrawerId}`}
+                >
+                  <div className={styles['drawer-actions']}>
+                    <ButtonGroup
+                      dropdownExpandToViewport={false}
+                      variant="icon"
+                      onItemClick={event => {
+                        switch (event.detail.id) {
+                          case 'close':
+                            onActiveGlobalDrawersChange(activeDrawerId, { initiatedByUserAction: true });
+                            break;
+                          case 'expand':
+                            setExpandedDrawerId(isExpanded ? null : activeDrawerId);
+                            break;
+                          default:
+                            activeGlobalDrawer?.onHeaderActionClick?.(event);
+                        }
+                      }}
+                      ariaLabel="Global panel actions"
+                      items={drawerActions}
+                      __internalRootRef={(root: HTMLElement) => {
+                        if (!root) {
+                          return;
+                        }
+                        refs.close = { current: root.querySelector('[data-itemid="close"]') as unknown as Focusable };
+                      }}
+                    />
+                  </div>
+                  <div className={styles['drawer-content']} style={{ blockSize: drawerHeight }}>
+                    {activeGlobalDrawer?.content}
+                  </div>
                 </div>
               </div>
-            </div>
-          </aside>
-        );
-      }}
-    </Transition>
+            </aside>
+          );
+        }}
+      </Transition>
+    </AppLayoutBuiltInErrorBoundary>
   );
 }
 

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { unstable_batchedUpdates } from 'react-dom';
 
+import { AppLayoutBuiltInErrorBoundary } from '../../error-boundary/internal';
 import ScreenreaderOnly from '../../internal/components/screenreader-only';
 import { AppLayoutProps } from '../interfaces';
 import { AppLayoutVisibilityContext } from './contexts';
@@ -76,7 +77,9 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
             <AppLayoutVisibilityContext.Provider value={appLayoutState.isIntersecting}>
               {/* Rendering a hidden copy of breadcrumbs to trigger their deduplication */}
               {(embeddedViewMode || !toolbarProps) && props.breadcrumbs ? (
-                <ScreenreaderOnly>{props.breadcrumbs}</ScreenreaderOnly>
+                <AppLayoutBuiltInErrorBoundary>
+                  <ScreenreaderOnly>{props.breadcrumbs}</ScreenreaderOnly>
+                </AppLayoutBuiltInErrorBoundary>
               ) : null}
               <SkeletonLayout
                 registered={registered}

--- a/src/app-layout/visual-refresh-toolbar/state/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/state/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { ForwardedRef, useLayoutEffect, useState } from 'react';
 
+import { AppLayoutBuiltInErrorBoundary } from '../../../error-boundary/internal';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { AppLayoutProps } from '../../interfaces';
 import { AppLayoutInternalProps, AppLayoutState } from '../interfaces';
@@ -30,7 +31,7 @@ export interface AppLayoutStateProps {
   forwardRef: ForwardedRef<AppLayoutProps.Ref>;
 }
 
-export const AppLayoutStateProvider = ({ appLayoutProps, stateManager, forwardRef }: AppLayoutStateProps) => {
+export const AppLayoutStateProviderInternal = ({ appLayoutProps, stateManager, forwardRef }: AppLayoutStateProps) => {
   const [hasToolbar, setHasToolbar] = useState(stateManager.current.hasToolbar ?? false);
   const appLayoutState = useAppLayout(hasToolbar, appLayoutProps, forwardRef);
   const skeletonSlotsAttributes = useSkeletonSlotsAttributes(hasToolbar, appLayoutProps, appLayoutState);
@@ -53,6 +54,14 @@ export const AppLayoutStateProvider = ({ appLayoutProps, stateManager, forwardRe
   }, [stateManager]);
 
   return <></>;
+};
+
+export const AppLayoutStateProvider = (props: AppLayoutStateProps) => {
+  return (
+    <AppLayoutBuiltInErrorBoundary>
+      <AppLayoutStateProviderInternal {...props} />
+    </AppLayoutBuiltInErrorBoundary>
+  );
 };
 
 export const createWidgetizedAppLayoutState = createWidgetizedComponent(AppLayoutStateProvider);

--- a/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 
+import { AppLayoutBuiltInErrorBoundary } from '../../../error-boundary/internal';
 import { useMobile } from '../../../internal/hooks/use-mobile';
 import { splitItems } from '../../drawer/drawers-helpers';
 import OverflowMenu from '../../drawer/overflow-menu';
@@ -188,42 +189,44 @@ export function DrawerTriggers({
           const selected = !expandedDrawerId && item.id === activeDrawerId;
           const isFeatureNotificationsDrawer = featureNotificationsProps?.drawer?.id === item.id;
           return (
-            <TriggerButton
-              ariaLabel={item.ariaLabels?.triggerButton}
-              ariaExpanded={selected}
-              ariaControls={activeDrawerId === item.id ? item.id : undefined}
-              className={clsx(
-                styles['drawers-trigger'],
-                !toolsOnlyMode && testutilStyles['drawers-trigger'],
-                item.id === TOOLS_DRAWER_ID && testutilStyles['tools-toggle']
-              )}
-              iconName={item.trigger!.iconName}
-              iconSvg={item.trigger!.iconSvg}
-              key={item.id}
-              onClick={() => {
-                exitExpandedMode();
-                if (!!expandedDrawerId && activeDrawerId === item.id) {
-                  return;
+            <AppLayoutBuiltInErrorBoundary key={item.id}>
+              <TriggerButton
+                ariaLabel={item.ariaLabels?.triggerButton}
+                ariaExpanded={selected}
+                ariaControls={activeDrawerId === item.id ? item.id : undefined}
+                className={clsx(
+                  styles['drawers-trigger'],
+                  !toolsOnlyMode && testutilStyles['drawers-trigger'],
+                  item.id === TOOLS_DRAWER_ID && testutilStyles['tools-toggle']
+                )}
+                iconName={item.trigger!.iconName}
+                iconSvg={item.trigger!.iconSvg}
+                key={item.id}
+                onClick={() => {
+                  exitExpandedMode();
+                  if (!!expandedDrawerId && activeDrawerId === item.id) {
+                    return;
+                  }
+                  onActiveDrawerChange?.(activeDrawerId !== item.id ? item.id : null, { initiatedByUserAction: true });
+                }}
+                ref={
+                  item.id === previousActiveLocalDrawerId.current
+                    ? drawersFocusRef
+                    : isFeatureNotificationsDrawer
+                      ? featureNotificationTriggerRef
+                      : null
                 }
-                onActiveDrawerChange?.(activeDrawerId !== item.id ? item.id : null, { initiatedByUserAction: true });
-              }}
-              ref={
-                item.id === previousActiveLocalDrawerId.current
-                  ? drawersFocusRef
-                  : isFeatureNotificationsDrawer
-                    ? featureNotificationTriggerRef
-                    : null
-              }
-              selected={selected}
-              badge={item.badge}
-              testId={`awsui-app-layout-trigger-${item.id}`}
-              hasTooltip={true}
-              hasOpenDrawer={hasOpenDrawer}
-              tooltipText={item.ariaLabels?.drawerName}
-              isForPreviousActiveDrawer={isForPreviousActiveDrawer}
-              isMobile={isMobile}
-              disabled={disabled}
-            />
+                selected={selected}
+                badge={item.badge}
+                testId={`awsui-app-layout-trigger-${item.id}`}
+                hasTooltip={true}
+                hasOpenDrawer={hasOpenDrawer}
+                tooltipText={item.ariaLabels?.drawerName}
+                isForPreviousActiveDrawer={isForPreviousActiveDrawer}
+                isMobile={isMobile}
+                disabled={disabled}
+              />
+            </AppLayoutBuiltInErrorBoundary>
           );
         })}
         {globalDrawersStartIndex > 0 && visibleItems.length > globalDrawersStartIndex && (
@@ -240,98 +243,103 @@ export function DrawerTriggers({
           }
 
           return (
-            <TriggerButton
-              ariaLabel={item.ariaLabels?.triggerButton}
-              ariaExpanded={selected}
-              ariaControls={selected ? item.id : undefined}
-              className={clsx(
-                styles['drawers-trigger'],
-                testutilStyles['drawers-trigger'],
-                testutilStyles['drawers-trigger-global']
-              )}
-              iconName={item.trigger!.iconName}
-              iconSvg={item.trigger!.iconSvg}
-              key={item.id}
-              onClick={() => {
-                exitExpandedMode();
-                if (!!expandedDrawerId && item.id !== expandedDrawerId && activeGlobalDrawersIds.includes(item.id)) {
-                  return;
-                }
-                if (isBottom) {
-                  onActiveGlobalBottomDrawerChange?.(selected ? null : item.id, { initiatedByUserAction: true });
-                  return;
-                }
-                onActiveGlobalDrawersChange?.(item.id, { initiatedByUserAction: true });
-              }}
-              ref={isBottom ? bottomDrawersFocusRef : globalDrawersFocusControl?.refs[item.id]?.toggle}
-              selected={selected}
-              badge={item.badge}
-              testId={`awsui-app-layout-trigger-${item.id}`}
-              hasTooltip={true}
-              hasOpenDrawer={hasOpenDrawer}
-              tooltipText={item.ariaLabels?.drawerName}
-              isForPreviousActiveDrawer={isForPreviousActiveDrawer}
-              isMobile={isMobile}
-              disabled={disabled}
-            />
+            <AppLayoutBuiltInErrorBoundary key={item.id}>
+              <TriggerButton
+                ariaLabel={item.ariaLabels?.triggerButton}
+                ariaExpanded={selected}
+                ariaControls={selected ? item.id : undefined}
+                className={clsx(
+                  styles['drawers-trigger'],
+                  testutilStyles['drawers-trigger'],
+                  testutilStyles['drawers-trigger-global']
+                )}
+                iconName={item.trigger!.iconName}
+                iconSvg={item.trigger!.iconSvg}
+                key={item.id}
+                onClick={() => {
+                  exitExpandedMode();
+                  if (!!expandedDrawerId && item.id !== expandedDrawerId && activeGlobalDrawersIds.includes(item.id)) {
+                    return;
+                  }
+                  if (isBottom) {
+                    onActiveGlobalBottomDrawerChange?.(selected ? null : item.id, { initiatedByUserAction: true });
+                    return;
+                  }
+                  onActiveGlobalDrawersChange?.(item.id, { initiatedByUserAction: true });
+                }}
+                ref={isBottom ? bottomDrawersFocusRef : globalDrawersFocusControl?.refs[item.id]?.toggle}
+                selected={selected}
+                badge={item.badge}
+                testId={`awsui-app-layout-trigger-${item.id}`}
+                hasTooltip={true}
+                hasOpenDrawer={hasOpenDrawer}
+                tooltipText={item.ariaLabels?.drawerName}
+                isForPreviousActiveDrawer={isForPreviousActiveDrawer}
+                isMobile={isMobile}
+                disabled={disabled}
+              />
+            </AppLayoutBuiltInErrorBoundary>
           );
         })}
         {overflowItems.length > 0 && (
-          <OverflowMenu
-            items={overflowItems.map(item => {
-              const isBottom = item?.position === 'bottom';
-              let active =
-                activeGlobalDrawersIds.includes(item.id) && (!expandedDrawerId || item.id === expandedDrawerId);
-              if (isBottom) {
-                active = item.id === activeGlobalBottomDrawerId && (!expandedDrawerId || item.id === expandedDrawerId);
-              }
-              return {
-                ...item,
-                active,
-              };
-            })}
-            ariaLabel={overflowMenuHasBadge ? ariaLabels?.drawersOverflowWithBadge : ariaLabels?.drawersOverflow}
-            customTriggerBuilder={({ onClick, triggerRef, ariaLabel, ariaExpanded, testUtilsClass }) => {
-              return (
-                <TriggerButton
-                  ref={triggerRef}
-                  ariaLabel={ariaLabel}
-                  ariaExpanded={ariaExpanded}
-                  badge={overflowMenuHasBadge}
-                  className={clsx(
-                    styles['drawers-trigger'],
-                    testutilStyles['drawers-trigger'],
-                    testutilStyles['drawers-trigger-global'],
-                    testUtilsClass
-                  )}
-                  iconName="ellipsis"
-                  onClick={onClick}
-                  disabled={disabled}
-                />
-              );
-            }}
-            onItemClick={event => {
-              const id = event.detail.id;
-              exitExpandedMode();
-              const item = overflowItems.find(item => item.id === id);
-              const isBottom = item?.position === 'bottom';
-              if (isBottom) {
-                const selected =
-                  item.id === activeGlobalBottomDrawerId && (!expandedDrawerId || item.id === expandedDrawerId);
-                onActiveGlobalBottomDrawerChange?.(selected ? null : item.id, { initiatedByUserAction: true });
-                return;
-              }
-              if (globalDrawers.find(drawer => drawer.id === id)) {
-                if (!!expandedDrawerId && id !== expandedDrawerId && activeGlobalDrawersIds.includes(id)) {
+          <AppLayoutBuiltInErrorBoundary>
+            <OverflowMenu
+              items={overflowItems.map(item => {
+                const isBottom = item?.position === 'bottom';
+                let active =
+                  activeGlobalDrawersIds.includes(item.id) && (!expandedDrawerId || item.id === expandedDrawerId);
+                if (isBottom) {
+                  active =
+                    item.id === activeGlobalBottomDrawerId && (!expandedDrawerId || item.id === expandedDrawerId);
+                }
+                return {
+                  ...item,
+                  active,
+                };
+              })}
+              ariaLabel={overflowMenuHasBadge ? ariaLabels?.drawersOverflowWithBadge : ariaLabels?.drawersOverflow}
+              customTriggerBuilder={({ onClick, triggerRef, ariaLabel, ariaExpanded, testUtilsClass }) => {
+                return (
+                  <TriggerButton
+                    ref={triggerRef}
+                    ariaLabel={ariaLabel}
+                    ariaExpanded={ariaExpanded}
+                    badge={overflowMenuHasBadge}
+                    className={clsx(
+                      styles['drawers-trigger'],
+                      testutilStyles['drawers-trigger'],
+                      testutilStyles['drawers-trigger-global'],
+                      testUtilsClass
+                    )}
+                    iconName="ellipsis"
+                    onClick={onClick}
+                    disabled={disabled}
+                  />
+                );
+              }}
+              onItemClick={event => {
+                const id = event.detail.id;
+                exitExpandedMode();
+                const item = overflowItems.find(item => item.id === id);
+                const isBottom = item?.position === 'bottom';
+                if (isBottom) {
+                  const selected =
+                    item.id === activeGlobalBottomDrawerId && (!expandedDrawerId || item.id === expandedDrawerId);
+                  onActiveGlobalBottomDrawerChange?.(selected ? null : item.id, { initiatedByUserAction: true });
                   return;
                 }
-                onActiveGlobalDrawersChange?.(id, { initiatedByUserAction: true });
-              } else {
-                onActiveDrawerChange?.(event.detail.id, { initiatedByUserAction: true });
-              }
-            }}
-            globalDrawersStartIndex={globalDrawersStartIndex - indexOfOverflowItem}
-          />
+                if (globalDrawers.find(drawer => drawer.id === id)) {
+                  if (!!expandedDrawerId && id !== expandedDrawerId && activeGlobalDrawersIds.includes(id)) {
+                    return;
+                  }
+                  onActiveGlobalDrawersChange?.(id, { initiatedByUserAction: true });
+                } else {
+                  onActiveDrawerChange?.(event.detail.id, { initiatedByUserAction: true });
+                }
+              }}
+              globalDrawersStartIndex={globalDrawersStartIndex - indexOfOverflowItem}
+            />
+          </AppLayoutBuiltInErrorBoundary>
         )}
       </div>
     </aside>

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
+import { AppLayoutBuiltInErrorBoundary } from '../../../error-boundary/internal';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { AppLayoutProps } from '../../interfaces';
 import { OnChangeParams } from '../../utils/use-drawers';
@@ -158,102 +159,110 @@ export function AppLayoutToolbarImplementation({
         insetBlockStart: verticalOffsets.toolbar,
       }}
     >
-      <Transition
-        in={!!(aiDrawer?.trigger && !activeAiDrawerId)}
-        timeout={{ enter: 0, exit: 165 }}
-        mountOnEnter={true}
-        unmountOnExit={true}
-        nodeRef={aiDrawerTransitionRef}
-      >
-        {state => (
-          <div
-            className={clsx(!!aiDrawer?.trigger?.customIcon && styles['universal-toolbar-ai-custom'], [
-              sharedStyles['with-motion-horizontal'],
-            ])}
-            style={{
-              opacity: ['entering', 'exiting'].includes(state) ? 0 : 1,
-            }}
-          >
-            <TriggerButton
-              ariaLabel={aiDrawer?.ariaLabels?.triggerButton}
-              ariaExpanded={!!activeAiDrawerId}
-              iconName={aiDrawer?.trigger!.iconName}
-              iconSvg={aiDrawer?.trigger!.iconSvg}
-              customSvg={aiDrawer?.trigger!.customIcon}
-              className={testutilStyles['ai-drawer-toggle']}
-              onClick={() => {
-                if (setExpandedDrawerId) {
-                  setExpandedDrawerId(null);
-                }
-                onActiveAiDrawerChange?.(aiDrawer?.id ?? null, { initiatedByUserAction: true });
+      <AppLayoutBuiltInErrorBoundary>
+        <Transition
+          in={!!(aiDrawer?.trigger && !activeAiDrawerId)}
+          timeout={{ enter: 0, exit: 165 }}
+          mountOnEnter={true}
+          unmountOnExit={true}
+          nodeRef={aiDrawerTransitionRef}
+        >
+          {state => (
+            <div
+              className={clsx(!!aiDrawer?.trigger?.customIcon && styles['universal-toolbar-ai-custom'], [
+                sharedStyles['with-motion-horizontal'],
+              ])}
+              style={{
+                opacity: ['entering', 'exiting'].includes(state) ? 0 : 1,
               }}
-              ref={aiDrawerFocusRef}
-              selected={!drawerExpandedMode && !!activeAiDrawerId}
-              disabled={anyPanelOpenInMobile}
-              variant={aiDrawer?.trigger?.customIcon ? 'custom' : 'circle'}
-              testId={`awsui-app-layout-trigger-${aiDrawer?.id}`}
-              isForPreviousActiveDrawer={true}
-            />
-          </div>
-        )}
-      </Transition>
+            >
+              <TriggerButton
+                ariaLabel={aiDrawer?.ariaLabels?.triggerButton}
+                ariaExpanded={!!activeAiDrawerId}
+                iconName={aiDrawer?.trigger!.iconName}
+                iconSvg={aiDrawer?.trigger!.iconSvg}
+                customSvg={aiDrawer?.trigger!.customIcon}
+                className={testutilStyles['ai-drawer-toggle']}
+                onClick={() => {
+                  if (setExpandedDrawerId) {
+                    setExpandedDrawerId(null);
+                  }
+                  onActiveAiDrawerChange?.(aiDrawer?.id ?? null, { initiatedByUserAction: true });
+                }}
+                ref={aiDrawerFocusRef}
+                selected={!drawerExpandedMode && !!activeAiDrawerId}
+                disabled={anyPanelOpenInMobile}
+                variant={aiDrawer?.trigger?.customIcon ? 'custom' : 'circle'}
+                testId={`awsui-app-layout-trigger-${aiDrawer?.id}`}
+                isForPreviousActiveDrawer={true}
+              />
+            </div>
+          )}
+        </Transition>
+      </AppLayoutBuiltInErrorBoundary>
       <ToolbarContainer hasAiDrawer={!!activeAiDrawerId}>
         {hasNavigation && (
           <nav {...navLandmarkAttributes} className={clsx(styles['universal-toolbar-nav'])}>
-            <TriggerButton
-              ariaLabel={ariaLabels?.navigationToggle ?? undefined}
-              ariaExpanded={!drawerExpandedMode && navigationOpen}
-              iconName="menu"
-              className={testutilStyles['navigation-toggle']}
-              onClick={() => {
-                if (setExpandedDrawerId) {
-                  setExpandedDrawerId(null);
-                }
-                if (navigationOpen && expandedDrawerId) {
-                  return;
-                }
-                onNavigationToggle?.(!navigationOpen);
-              }}
-              ref={navigationFocusRef}
-              selected={!drawerExpandedMode && navigationOpen}
-              disabled={anyPanelOpenInMobile}
-            />
+            <AppLayoutBuiltInErrorBoundary>
+              <TriggerButton
+                ariaLabel={ariaLabels?.navigationToggle ?? undefined}
+                ariaExpanded={!drawerExpandedMode && navigationOpen}
+                iconName="menu"
+                className={testutilStyles['navigation-toggle']}
+                onClick={() => {
+                  if (setExpandedDrawerId) {
+                    setExpandedDrawerId(null);
+                  }
+                  if (navigationOpen && expandedDrawerId) {
+                    return;
+                  }
+                  onNavigationToggle?.(!navigationOpen);
+                }}
+                ref={navigationFocusRef}
+                selected={!drawerExpandedMode && navigationOpen}
+                disabled={anyPanelOpenInMobile}
+              />
+            </AppLayoutBuiltInErrorBoundary>
           </nav>
         )}
         {(breadcrumbs || discoveredBreadcrumbs) && (
-          <ToolbarBreadcrumbsSection
-            ownBreadcrumbs={appLayoutInternals.breadcrumbs}
-            discoveredBreadcrumbs={appLayoutInternals.discoveredBreadcrumbs}
-            includeTestUtils={true}
-          />
+          <AppLayoutBuiltInErrorBoundary>
+            <ToolbarBreadcrumbsSection
+              ownBreadcrumbs={appLayoutInternals.breadcrumbs}
+              discoveredBreadcrumbs={appLayoutInternals.discoveredBreadcrumbs}
+              includeTestUtils={true}
+            />
+          </AppLayoutBuiltInErrorBoundary>
         )}
         {(drawers?.length ||
           globalDrawers?.length ||
           bottomDrawers?.length ||
           (hasSplitPanel && splitPanelToggleProps?.displayed)) && (
           <div className={clsx(styles['universal-toolbar-drawers'])}>
-            <DrawerTriggers
-              ariaLabels={ariaLabels}
-              activeDrawerId={activeDrawerId ?? null}
-              drawers={drawers?.filter(item => !!item.trigger) ?? []}
-              drawersFocusRef={drawersFocusRef}
-              onActiveDrawerChange={onActiveDrawerChange}
-              splitPanelToggleProps={splitPanelToggleProps?.displayed ? splitPanelToggleProps : undefined}
-              splitPanelFocusRef={splitPanelFocusRef}
-              onSplitPanelToggle={onSplitPanelToggle}
-              disabled={anyPanelOpenInMobile}
-              globalDrawersFocusControl={globalDrawersFocusControl}
-              bottomDrawersFocusRef={bottomDrawersFocusRef}
-              globalDrawers={globalDrawers?.filter(item => !!item.trigger) ?? []}
-              activeGlobalDrawersIds={activeGlobalDrawersIds ?? []}
-              onActiveGlobalDrawersChange={onActiveGlobalDrawersChange}
-              expandedDrawerId={expandedDrawerId}
-              setExpandedDrawerId={setExpandedDrawerId!}
-              bottomDrawers={bottomDrawers}
-              onActiveGlobalBottomDrawerChange={onActiveGlobalBottomDrawerChange}
-              activeGlobalBottomDrawerId={activeGlobalBottomDrawerId}
-              featureNotificationsProps={featureNotificationsProps}
-            />
+            <AppLayoutBuiltInErrorBoundary>
+              <DrawerTriggers
+                ariaLabels={ariaLabels}
+                activeDrawerId={activeDrawerId ?? null}
+                drawers={drawers?.filter(item => !!item.trigger) ?? []}
+                drawersFocusRef={drawersFocusRef}
+                onActiveDrawerChange={onActiveDrawerChange}
+                splitPanelToggleProps={splitPanelToggleProps?.displayed ? splitPanelToggleProps : undefined}
+                splitPanelFocusRef={splitPanelFocusRef}
+                onSplitPanelToggle={onSplitPanelToggle}
+                disabled={anyPanelOpenInMobile}
+                globalDrawersFocusControl={globalDrawersFocusControl}
+                bottomDrawersFocusRef={bottomDrawersFocusRef}
+                globalDrawers={globalDrawers?.filter(item => !!item.trigger) ?? []}
+                activeGlobalDrawersIds={activeGlobalDrawersIds ?? []}
+                onActiveGlobalDrawersChange={onActiveGlobalDrawersChange}
+                expandedDrawerId={expandedDrawerId}
+                setExpandedDrawerId={setExpandedDrawerId!}
+                bottomDrawers={bottomDrawers}
+                onActiveGlobalBottomDrawerChange={onActiveGlobalBottomDrawerChange}
+                activeGlobalBottomDrawerId={activeGlobalBottomDrawerId}
+                featureNotificationsProps={featureNotificationsProps}
+              />
+            </AppLayoutBuiltInErrorBoundary>
           </div>
         )}
       </ToolbarContainer>

--- a/src/app-layout/visual-refresh-toolbar/widget-areas/after-main-slot.tsx
+++ b/src/app-layout/visual-refresh-toolbar/widget-areas/after-main-slot.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import clsx from 'clsx';
 
+import { AppLayoutBuiltInErrorBoundary } from '../../../error-boundary/internal';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { ActiveDrawersContext } from '../../utils/visibility-context';
 import {
@@ -17,7 +18,7 @@ import { isWidgetReady } from '../state/invariants';
 import sharedStyles from '../../resize/styles.css.js';
 import styles from '../skeleton/styles.css.js';
 
-export const AfterMainSlotImplementation = ({ appLayoutState, appLayoutProps }: SkeletonPartProps) => {
+export const AfterMainSlotImplementationInternal = ({ appLayoutState, appLayoutProps }: SkeletonPartProps) => {
   if (!isWidgetReady(appLayoutState)) {
     return null;
   }
@@ -63,23 +64,25 @@ export const AfterMainSlotImplementation = ({ appLayoutState, appLayoutProps }: 
           </AppLayoutSplitPanelSide>
         </div>
       )}
-      <div
-        className={clsx(
-          styles.tools,
-          !toolsOpen && styles['panel-hidden'],
-          sharedStyles['with-motion-horizontal'],
-          navigationOpen && !toolsOpen && styles['unfocusable-mobile'],
-          toolsOpen && styles['tools-open'],
-          drawerExpandedMode && styles.hidden
-        )}
-      >
-        {drawers && drawers.length > 0 && (
-          <AppLayoutDrawer
-            appLayoutInternals={appLayoutState.appLayoutInternals}
-            bottomDrawerReportedSize={activeGlobalBottomDrawerId ? bottomDrawerReportedSize : 0}
-          />
-        )}
-      </div>
+      <AppLayoutBuiltInErrorBoundary>
+        <div
+          className={clsx(
+            styles.tools,
+            !toolsOpen && styles['panel-hidden'],
+            sharedStyles['with-motion-horizontal'],
+            navigationOpen && !toolsOpen && styles['unfocusable-mobile'],
+            toolsOpen && styles['tools-open'],
+            drawerExpandedMode && styles.hidden
+          )}
+        >
+          {drawers && drawers.length > 0 && (
+            <AppLayoutDrawer
+              appLayoutInternals={appLayoutState.appLayoutInternals}
+              bottomDrawerReportedSize={activeGlobalBottomDrawerId ? bottomDrawerReportedSize : 0}
+            />
+          )}
+        </div>
+      </AppLayoutBuiltInErrorBoundary>
       <div className={clsx(styles['global-tools'], !globalToolsOpen && styles['panel-hidden'])}>
         <ActiveDrawersContext.Provider value={activeGlobalDrawersIds ?? []}>
           <AppLayoutGlobalDrawers appLayoutInternals={appLayoutState.appLayoutInternals} />
@@ -88,5 +91,11 @@ export const AfterMainSlotImplementation = ({ appLayoutState, appLayoutProps }: 
     </>
   );
 };
+
+export const AfterMainSlotImplementation = (props: SkeletonPartProps) => (
+  <AppLayoutBuiltInErrorBoundary>
+    <AfterMainSlotImplementationInternal {...props} />
+  </AppLayoutBuiltInErrorBoundary>
+);
 
 export const createWidgetizedAppLayoutAfterMainSlot = createWidgetizedComponent(AfterMainSlotImplementation);

--- a/src/app-layout/visual-refresh-toolbar/widget-areas/before-main-slot.tsx
+++ b/src/app-layout/visual-refresh-toolbar/widget-areas/before-main-slot.tsx
@@ -3,6 +3,7 @@
 import React, { useRef } from 'react';
 import clsx from 'clsx';
 
+import { AppLayoutBuiltInErrorBoundary } from '../../../error-boundary/internal';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { ActiveDrawersContext } from '../../utils/visibility-context';
 import { AppLayoutGlobalAiDrawerImplementation } from '../drawer/global-ai-drawer';
@@ -15,7 +16,11 @@ import { AppLayoutToolbarImplementation as AppLayoutToolbar } from '../toolbar';
 import sharedStyles from '../../resize/styles.css.js';
 import styles from '../skeleton/styles.css.js';
 
-export const BeforeMainSlotImplementation = ({ toolbarProps, appLayoutState, appLayoutProps }: SkeletonPartProps) => {
+export const BeforeMainSlotImplementationInternal = ({
+  toolbarProps,
+  appLayoutState,
+  appLayoutProps,
+}: SkeletonPartProps) => {
   const wasAiDrawerOpenRef = useRef(false);
   if (!isWidgetReady(appLayoutState)) {
     return (
@@ -108,15 +113,23 @@ export const BeforeMainSlotImplementation = ({ toolbarProps, appLayoutState, app
             (drawerExpandedMode || drawerExpandedModeInChildLayout) && styles.hidden
           )}
         >
-          <AppLayoutNavigation
-            appLayoutInternals={appLayoutState.appLayoutInternals}
-            bottomDrawerReportedSize={bottomDrawerReportedSize}
-          />
+          <AppLayoutBuiltInErrorBoundary>
+            <AppLayoutNavigation
+              appLayoutInternals={appLayoutState.appLayoutInternals}
+              bottomDrawerReportedSize={bottomDrawerReportedSize}
+            />
+          </AppLayoutBuiltInErrorBoundary>
         </div>
       )}
     </>
   );
 };
+
+export const BeforeMainSlotImplementation = (props: SkeletonPartProps) => (
+  <AppLayoutBuiltInErrorBoundary>
+    <BeforeMainSlotImplementationInternal {...props} />
+  </AppLayoutBuiltInErrorBoundary>
+);
 
 export const createWidgetizedAppLayoutBeforeMainSlot = createWidgetizedComponent(
   BeforeMainSlotImplementation,

--- a/src/app-layout/visual-refresh-toolbar/widget-areas/bottom-content-slot.tsx
+++ b/src/app-layout/visual-refresh-toolbar/widget-areas/bottom-content-slot.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import clsx from 'clsx';
 
+import { AppLayoutBuiltInErrorBoundary } from '../../../error-boundary/internal';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { SkeletonPartProps } from '../skeleton/interfaces';
 import { AppLayoutSplitPanelDrawerBottomImplementation as AppLayoutSplitPanelBottom } from '../split-panel';
@@ -11,7 +12,7 @@ import { isWidgetReady } from '../state/invariants';
 import sharedStyles from '../../resize/styles.css.js';
 import styles from '../skeleton/styles.css.js';
 
-export const BottomContentSlotImplementation = ({ appLayoutState, appLayoutProps }: SkeletonPartProps) => {
+export const BottomContentSlotImplementationInternal = ({ appLayoutState, appLayoutProps }: SkeletonPartProps) => {
   if (!isWidgetReady(appLayoutState)) {
     return null;
   }
@@ -36,6 +37,14 @@ export const BottomContentSlotImplementation = ({ appLayoutState, appLayoutProps
         </div>
       )}
     </>
+  );
+};
+
+export const BottomContentSlotImplementation = (props: SkeletonPartProps) => {
+  return (
+    <AppLayoutBuiltInErrorBoundary>
+      <BottomContentSlotImplementationInternal {...props} />
+    </AppLayoutBuiltInErrorBoundary>
   );
 };
 

--- a/src/app-layout/visual-refresh-toolbar/widget-areas/top-content-slot.tsx
+++ b/src/app-layout/visual-refresh-toolbar/widget-areas/top-content-slot.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import clsx from 'clsx';
 
+import { AppLayoutBuiltInErrorBoundary } from '../../../error-boundary/internal';
 import { highContrastHeaderClassName } from '../../../internal/utils/content-header-utils';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { AppLayoutNotificationsImplementation as AppLayoutNotifications } from '../notifications';
@@ -11,7 +12,7 @@ import { isWidgetReady } from '../state/invariants';
 
 import styles from '../skeleton/styles.css.js';
 
-export const TopContentSlotImplementation = ({ appLayoutProps, appLayoutState }: SkeletonPartProps) => {
+export const TopContentSlotImplementationInternal = ({ appLayoutProps, appLayoutState }: SkeletonPartProps) => {
   if (!isWidgetReady(appLayoutState)) {
     return null;
   }
@@ -33,5 +34,11 @@ export const TopContentSlotImplementation = ({ appLayoutProps, appLayoutState }:
     </>
   );
 };
+
+export const TopContentSlotImplementation = (props: SkeletonPartProps) => (
+  <AppLayoutBuiltInErrorBoundary>
+    <TopContentSlotImplementationInternal {...props} />
+  </AppLayoutBuiltInErrorBoundary>
+);
 
 export const createWidgetizedAppLayoutTopContentSlot = createWidgetizedComponent(TopContentSlotImplementation);

--- a/src/error-boundary/interfaces.ts
+++ b/src/error-boundary/interfaces.ts
@@ -109,3 +109,7 @@ export interface BuiltInErrorBoundaryProps {
   wrapper?: (content: React.ReactNode) => React.ReactNode;
   suppressNested?: boolean;
 }
+
+export interface AppLayoutBuiltInErrorBoundaryProps extends BuiltInErrorBoundaryProps {
+  renderFallback?: ErrorBoundaryProps['renderFallback'];
+}

--- a/src/error-boundary/internal.tsx
+++ b/src/error-boundary/internal.tsx
@@ -8,7 +8,7 @@ import { useMergeRefs } from '@cloudscape-design/component-toolkit/internal';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { SomeRequired } from '../internal/types';
 import { ErrorBoundaryFallback } from './fallback';
-import { BuiltInErrorBoundaryProps, ErrorBoundaryProps } from './interfaces';
+import { AppLayoutBuiltInErrorBoundaryProps, BuiltInErrorBoundaryProps, ErrorBoundaryProps } from './interfaces';
 
 import styles from './styles.css.js';
 
@@ -84,6 +84,33 @@ export function BuiltInErrorBoundary({ wrapper, suppressNested = false, children
     </ErrorBoundaryImpl>
   ) : (
     <>{children}</>
+  );
+}
+
+export function AppLayoutBuiltInErrorBoundary({
+  wrapper,
+  suppressNested = false,
+  children,
+  renderFallback = () => <></>,
+}: AppLayoutBuiltInErrorBoundaryProps) {
+  const context = useContext(ErrorBoundariesContext);
+  const thisSuppressed = context.suppressed === true || context.suppressed === RootSuppressed;
+  const nextSuppressed = suppressNested || thisSuppressed;
+  return (
+    <ErrorBoundaryImpl
+      {...context}
+      wrapper={wrapper}
+      renderFallback={renderFallback}
+      className={styles['app-layout-part-fallback']}
+      onError={error => {
+        context?.onError?.(error);
+        // TODO Implement cloudscape error reporting
+      }}
+    >
+      <ErrorBoundariesContext.Provider value={{ ...context, suppressed: nextSuppressed, renderFallback }}>
+        {children}
+      </ErrorBoundariesContext.Provider>
+    </ErrorBoundaryImpl>
   );
 }
 

--- a/src/error-boundary/styles.scss
+++ b/src/error-boundary/styles.scss
@@ -6,6 +6,7 @@
 .error-boundary,
 .header,
 .description,
-.action {
+.action,
+.app-layout-part-fallback {
   display: contents;
 }


### PR DESCRIPTION
### Description
Error boundaries for AppLayout areas - all areas that load as widgets now have error boundary coverage.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
