### PR TITLE
chore: Update another test for compatibility with latest Webdriver

### DIFF
--- a/src/table/__integ__/table.test.ts
+++ b/src/table/__integ__/table.test.ts
@@ -84,6 +84,6 @@ test(
     ariaLabelledby = await page.getElementAttribute(scrollableWrapperSelector, 'aria-labelledby');
     expect(role).toEqual('region');
     expect(ariaLabelledby).not.toBeFalsy();
-    await expect(page.getElementsText(`#${CSS.escape(ariaLabelledby)}`)).resolves.toEqual([tableHeading]);
+    await expect(page.getElementsText(`#${CSS.escape(ariaLabelledby ?? '')}`)).resolves.toEqual([tableHeading]);
   })
 );


### PR DESCRIPTION
### Description

Follow-up of https://github.com/cloudscape-design/components/pull/4299.

In latest Webdriver, the return value of `getElementAttribute` can be not just a string but also null, so we need to account for that.

This should address [this remaining failure](https://github.com/cloudscape-design/browser-test-tools/actions/runs/22439544631/job/65001285270?pr=179) from https://github.com/cloudscape-design/browser-test-tools/pull/179.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
