### PR TITLE
fix: Prevent secondary actinos focus ring clipping

### DIFF
--- a/src/prompt-input/styles.scss
+++ b/src/prompt-input/styles.scss
@@ -249,7 +249,9 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
   flex-grow: 0;
   flex-shrink: 1;
   box-sizing: border-box;
-  @include styles.text-flex-wrapping;
+  // Just like styles.text-flex-wrapping without the overflow: hidden to prevent focus rings on action buttons from being clipped.
+  word-wrap: break-word;
+  max-inline-size: 100%;
   &.with-paddings {
     padding-inline: styles.$control-padding-horizontal;
     padding-block-start: awsui.$space-scaled-s;


### PR DESCRIPTION
### Description

This PR prevents the focus ring from being clipped. Similar to #1157.
Current look:
<img width="769" height="179" alt="image" src="https://github.com/user-attachments/assets/b9a6440b-6744-4a4d-8db7-38da1694cb5d" />
<img width="256" height="85" alt="image" src="https://github.com/user-attachments/assets/956010ae-6d9b-482c-8ae0-0b7418ddb0aa" />

Fix:
<img width="380" height="114" alt="image" src="https://github.com/user-attachments/assets/d680238e-23ab-4bd2-93c3-2e809cea26a3" />


<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
