### PR TITLE
revert: "fix: Prevent secondary actinos focus ring clipping"

### DIFF
--- a/src/prompt-input/styles.scss
+++ b/src/prompt-input/styles.scss
@@ -249,9 +249,7 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
   flex-grow: 0;
   flex-shrink: 1;
   box-sizing: border-box;
-  // Just like styles.text-flex-wrapping without the overflow: hidden to prevent focus rings on action buttons from being clipped.
-  word-wrap: break-word;
-  max-inline-size: 100%;
+  @include styles.text-flex-wrapping;
   &.with-paddings {
     padding-inline: styles.$control-padding-horizontal;
     padding-block-start: awsui.$space-scaled-s;


### PR DESCRIPTION
Reverts cloudscape-design/components#4309

| Before #4309    | After #4309 |
| -------- | ------- |
| <img width="282" height="145" alt="image" src="https://github.com/user-attachments/assets/5e948c9f-b5d2-4b87-b1b6-cb7f9c5434f1" />  | <img width="282" height="145" alt="image" src="https://github.com/user-attachments/assets/1eeccb4c-5f92-4354-bdad-1d84c182a0e7" />    |




