### PR TITLE
chore: improve modal custom dimensions dev warning

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -17571,11 +17571,10 @@ of the most recent getModalRoot call as an argument.",
       "type": "((container: HTMLElement | null) => void)",
     },
     {
-      "description": "Sets the width of the modal. Defaults to \`medium\`.
-
-\`max\` uses variable width up to the largest size allowed by the design guidelines.
-Other sizes have fixed widths: \`small\` (320px), \`medium\` (600px), \`large\` (820px),
-\`x-large\` (1024px), \`xx-large\` (1280px).",
+      "defaultValue": "'medium'",
+      "description": "Sets the width of the modal. \`max\` uses variable width up to the
+largest size allowed by the design guidelines. Other sizes have fixed widths:
+\`small\` (320px), \`medium\` (600px), \`large\` (820px), \`x-large\` (1024px), \`xx-large\` (1280px).",
       "inlineType": {
         "name": "ModalProps.Size",
         "type": "union",

--- a/src/modal/__tests__/modal.test.tsx
+++ b/src/modal/__tests__/modal.test.tsx
@@ -3,8 +3,6 @@
 import * as React from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 
-import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
-
 import Autosuggest from '../../../lib/components/autosuggest';
 import Button from '../../../lib/components/button/index.js';
 import ButtonDropdown from '../../../lib/components/button-dropdown';
@@ -22,11 +20,6 @@ import { PerformanceMetrics } from '../../internal/analytics';
 import { KeyCode } from '../../internal/keycode';
 
 import styles from '../../../lib/components/modal/styles.css.js';
-
-jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
-  ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
-  warnOnce: jest.fn(),
-}));
 class ModalInternalWrapper extends ModalWrapper {
   findDialog(): ElementWrapper {
     return this.findByClassName(styles.dialog)!;
@@ -560,30 +553,6 @@ describe('Modal component', () => {
       setTimeout(() => {
         expect(modalPerformanceDataSpy).toHaveBeenCalled();
       }, 10);
-    });
-  });
-
-  describe('development warnings', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-
-    it('warns when both size and width are provided', () => {
-      renderModal({ size: 'large', width: 500 });
-      expect(warnOnce).toHaveBeenCalledWith(
-        'Modal',
-        'Both `size` and `width` exist. `size` will not be used for width calculations.'
-      );
-    });
-
-    it('does not warn when only size is provided', () => {
-      renderModal({ size: 'large' });
-      expect(warnOnce).not.toHaveBeenCalled();
-    });
-
-    it('does not warn when only width is provided', () => {
-      renderModal({ width: 500 });
-      expect(warnOnce).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modal/index.tsx
+++ b/src/modal/index.tsx
@@ -3,7 +3,7 @@
 'use client';
 import React from 'react';
 
-import { useUniqueId, warnOnce } from '@cloudscape-design/component-toolkit/internal';
+import { useUniqueId } from '@cloudscape-design/component-toolkit/internal';
 
 import {
   AnalyticsFunnel,
@@ -70,12 +70,7 @@ function ModalWithAnalyticsFunnel({
   );
 }
 
-export default function Modal({ position = 'center', width, height, ...rest }: ModalProps) {
-  const { size = 'medium', ...props } = rest;
-  if (rest.size !== undefined && width !== undefined) {
-    warnOnce('Modal', 'Both `size` and `width` exist. `size` will not be used for width calculations.');
-  }
-
+export default function Modal({ size = 'medium', position = 'center', width, height, ...props }: ModalProps) {
   const { isInFunnel } = useFunnel();
   const analyticsMetadata = getAnalyticsMetadataProps(props as BasePropsWithAnalyticsMetadata);
   const baseComponentProps = useBaseComponent(

--- a/src/modal/interfaces.ts
+++ b/src/modal/interfaces.ts
@@ -40,11 +40,9 @@ export interface ModalProps extends BaseComponentProps, BaseModalProps {
   height?: number;
 
   /**
-   * Sets the width of the modal. Defaults to `medium`.
-   *
-   * `max` uses variable width up to the largest size allowed by the design guidelines.
-   * Other sizes have fixed widths: `small` (320px), `medium` (600px), `large` (820px),
-   * `x-large` (1024px), `xx-large` (1280px).
+   * Sets the width of the modal. `max` uses variable width up to the
+   * largest size allowed by the design guidelines. Other sizes have fixed widths:
+   * `small` (320px), `medium` (600px), `large` (820px), `x-large` (1024px), `xx-large` (1280px).
    */
   size?: ModalProps.Size;
   /**


### PR DESCRIPTION
### Description
This PR is a follow-up to [#4252](https://github.com/cloudscape-design/components/pull/4252) with the following improvements:
- Consolidate footer border radius styles: merge `--stuck` and `custom-height` into a single `--rounded` modifier
- Add dev warning when NaN is passed as width or height, so that builders know the width and the height are not set.

### How has this been tested?

- Added unit tests for NaN validation warnings
- Manually tested modal with custom dimensions
- Verified footer styling with stuck state and custom height

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
