### PR TITLE
revert: "fix: Prevent secondary actions focus ring clipping with padding"

### DIFF
--- a/src/prompt-input/styles.scss
+++ b/src/prompt-input/styles.scss
@@ -261,7 +261,7 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
     }
   }
   &.with-paddings-and-actions {
-    padding-inline-end: awsui.$space-scaled-s;
+    padding-inline-end: 0;
   }
 }
 


### PR DESCRIPTION
Reverts cloudscape-design/components#4319

| Before https://github.com/cloudscape-design/components/pull/4319 | After https://github.com/cloudscape-design/components/pull/4319 |
| ------ | ------|
|<img width="337" height="195" alt="image" src="https://github.com/user-attachments/assets/d796b656-6b47-4eae-b8fb-685c66b3ce14" /> | <img width="337" height="195" alt="image" src="https://github.com/user-attachments/assets/9d2829e6-5c27-4afd-affc-fafc26121fef" />|




