### PR TITLE
fix: Prevent secondary actions focus ring clipping with padding

### DIFF
--- a/src/prompt-input/styles.scss
+++ b/src/prompt-input/styles.scss
@@ -250,6 +250,7 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
   flex-shrink: 1;
   box-sizing: border-box;
   @include styles.text-flex-wrapping;
+  padding-inline-end: awsui.$space-scaled-xxs;
   &.with-paddings {
     padding-inline: styles.$control-padding-horizontal;
     padding-block-start: awsui.$space-scaled-s;


### PR DESCRIPTION
### Description

Reduce the padding side from `s` to `xxs` and add it to the secondary-actions div as padding-inline-end.

> Before

<img width="1538" height="358" alt="image" src="https://github.com/user-attachments/assets/b9c0175a-895b-44f1-adb6-d4ed14175ea7" />


> Now the focus ring is not clipped

<img width="822" height="372" alt="image" src="https://github.com/user-attachments/assets/0e884408-bf35-42d0-81a5-b884def9025c" />

<img width="760" height="228" alt="image" src="https://github.com/user-attachments/assets/48b99828-cd1e-416b-8afd-c5cfcde6b26f" />


<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
