### PR TITLE
fix: Forward data-* attributes to inner button element in copy-to-clipboard

### DIFF
--- a/src/copy-to-clipboard/internal.tsx
+++ b/src/copy-to-clipboard/internal.tsx
@@ -52,6 +52,14 @@ export default function InternalCopyToClipboard({
   }, [copyErrorText]);
 
   const baseProps = getBaseProps(restProps);
+
+  // Extract data-* attributes to forward to the inner button for analytics support.
+  const dataAttributes: Record<string, string> = {};
+  Object.keys(restProps).forEach(key => {
+    if (key.match(/^data-/)) {
+      dataAttributes[key] = (restProps as Record<string, string>)[key];
+    }
+  });
   const onClick = () => {
     if (!navigator.clipboard) {
       // The clipboard API is not available in insecure contexts.
@@ -87,6 +95,7 @@ export default function InternalCopyToClipboard({
 
   const button = (
     <InternalButton
+      {...dataAttributes}
       ariaLabel={copyButtonAriaLabel ?? copyButtonText}
       iconName="copy"
       variant={triggerVariant}


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
## Problem

`data-*` attributes passed to `CopyToClipboard` (e.g. `data-analytics-type`, `data-analytics`) are only
applied to the outer `<span>` wrapper via `getBaseProps()`. The actual clickable `<button>` element is nested
inside an `InternalPopover`, several DOM layers deep. Analytics tools like Panorama that rely on `data-*`
attributes being on or near the click target cannot associate click events with the analytics metadata,
resulting in empty values in dashboards.

## Root Cause

Unlike components like `Button` (where the root element IS the interactive `<button>`), `CopyToClipboard`
has a passive `<span>` root with the click target buried inside a Popover:
<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
