### PR TITLE
fix: apply gap only when both pagination && prefrences are present

### DIFF
--- a/src/table/tools-header.tsx
+++ b/src/table/tools-header.tsx
@@ -28,6 +28,7 @@ export default function ToolsHeader({ header, filter, pagination, preferences, s
   }
   const isSmall = breakpoint === 'default';
   const hasTools = filter || pagination || preferences;
+  const hasRightAlignedTools = !!(pagination || preferences);
   return (
     <>
       {isHeaderString ? <span id={headingId}>{header}</span> : header}
@@ -42,18 +43,20 @@ export default function ToolsHeader({ header, filter, pagination, preferences, s
               {filter}
             </div>
           )}
-          <div className={styles['tools-align-right']}>
-            {pagination && (
-              <div className={styles['tools-pagination']} onClickCapture={() => setLastUserAction?.('pagination')}>
-                {pagination}
-              </div>
-            )}
-            {preferences && (
-              <div className={styles['tools-preferences']} onClickCapture={() => setLastUserAction?.('preferences')}>
-                {preferences}
-              </div>
-            )}
-          </div>
+          {hasRightAlignedTools && (
+            <div className={styles['tools-align-right']}>
+              {pagination && (
+                <div className={styles['tools-pagination']} onClickCapture={() => setLastUserAction?.('pagination')}>
+                  {pagination}
+                </div>
+              )}
+              {preferences && (
+                <div className={styles['tools-preferences']} onClickCapture={() => setLastUserAction?.('preferences')}>
+                  {preferences}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
     </>


### PR DESCRIPTION
### Description
Fixes unnecessary gap in table tools header when pagination and preferences slots are empty.

When a table has only a filter (no pagination and preferences), an unwanted horizontal gap appeared after the filter due to the empty `tools-align-right` wrapper being rendered. The flex `gap` property applies spacing between all flex children, including empty elements. The `tools-align-right` wrapper was always rendered, even when both pagination and preferences were absent.

Large Screen
Before          |  After
:-------------------------:|:-------------------------:
<img width="1502" height="862" alt="image" src="https://github.com/user-attachments/assets/aa8d873c-ed3e-4547-806c-1ab52f96fbe5" />  |  <img width="1511" height="860" alt="image" src="https://github.com/user-attachments/assets/c8e57d46-b7cc-4a57-97d6-b63ec4cb33cc" />

Small Screen
Before          |  After
:-------------------------:|:-------------------------:
<img width="1512" height="862" alt="image" src="https://github.com/user-attachments/assets/e45712fa-11ca-488a-90f2-e0e8049441f2" /> |  <img width="1512" height="860" alt="image" src="https://github.com/user-attachments/assets/67caafdc-07a1-4d2b-b438-0ded2f797c46" />
Tested by:
- Running through pipeline and only expected changes are visible which is the above one


<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-61752

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
