### PR TITLE
fix: Close tooltip when cursor leaves chart via y-axis

### DIFF
--- a/src/mixed-line-bar-chart/__tests__/use-mouse-hover.test.ts
+++ b/src/mixed-line-bar-chart/__tests__/use-mouse-hover.test.ts
@@ -198,56 +198,25 @@ describe('Mouse hover hook', () => {
     expect(customProps.clearHighlightedSeries).toHaveBeenCalledTimes(1);
   });
 
-  test('clears highlightX when onPopoverLeave is called with relatedTarget outside SVG', () => {
-    const SvgElementDummy = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-
+  test('clears highlightX when onPopoverLeave is called', () => {
     const customProps = {
       highlightX: jest.fn(),
       clearHighlightedSeries: jest.fn(),
-      plotRef: { current: { svg: SvgElementDummy, focusApplication: jest.fn(), focusPlot: jest.fn() } },
     };
     const { hook } = renderMouseHoverHook(customProps);
-    const event = {
-      relatedTarget: document.createElement('div'),
-    } as any;
-    act(() => hook.current.onPopoverLeave(event));
+    act(() => hook.current.onPopoverLeave());
     expect(customProps.highlightX).toHaveBeenCalledWith(null);
     expect(customProps.clearHighlightedSeries).toHaveBeenCalledTimes(1);
   });
 
-  test('does not clear highlightX when onPopoverLeave is called with relatedTarget inside SVG', () => {
-    const SvgElementDummy = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    const lineElement = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-    SvgElementDummy.appendChild(lineElement);
-
-    const customProps = {
-      highlightX: jest.fn(),
-      clearHighlightedSeries: jest.fn(),
-      plotRef: { current: { svg: SvgElementDummy, focusApplication: jest.fn(), focusPlot: jest.fn() } },
-    };
-    const { hook } = renderMouseHoverHook(customProps);
-    const event = {
-      relatedTarget: lineElement,
-    } as any;
-    act(() => hook.current.onPopoverLeave(event));
-    expect(customProps.highlightX).not.toHaveBeenCalled();
-    expect(customProps.clearHighlightedSeries).not.toHaveBeenCalled();
-  });
-
   test('does not clear highlightX when onPopoverLeave is called if isHandlersDisabled is true', () => {
-    const SvgElementDummy = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     const customProps = {
       highlightX: jest.fn(),
       clearHighlightedSeries: jest.fn(),
       isHandlersDisabled: true,
-      plotRef: { current: { svg: SvgElementDummy, focusApplication: jest.fn(), focusPlot: jest.fn() } },
     };
-
     const { hook } = renderMouseHoverHook(customProps);
-    const event = {
-      relatedTarget: document.createElement('div'),
-    } as any;
-    act(() => hook.current.onPopoverLeave(event));
+    act(() => hook.current.onPopoverLeave());
     expect(customProps.highlightX).not.toHaveBeenCalled();
     expect(customProps.clearHighlightedSeries).not.toHaveBeenCalled();
   });

--- a/src/mixed-line-bar-chart/hooks/use-mouse-hover.ts
+++ b/src/mixed-line-bar-chart/hooks/use-mouse-hover.ts
@@ -141,11 +141,12 @@ export function useMouseHover<T>({
     }
   };
 
-  const onPopoverLeave = (event: React.MouseEvent) => {
-    if (!isHandlersDisabled && !nodeContains(plotRef.current!.svg, event.relatedTarget)) {
-      highlightX(null);
-      clearHighlightedSeries();
+  const onPopoverLeave = () => {
+    if (isHandlersDisabled) {
+      return;
     }
+    highlightX(null);
+    clearHighlightedSeries();
   };
 
   return { onSVGMouseMove, onSVGMouseOut, onPopoverLeave };


### PR DESCRIPTION
### Description

When hovering over a line chart and moving the cursor toward the y-axis labels, the tooltip stays open even after the cursor has completely left the chart area.

### Root cause

Two issues in `onSVGMouseOut` and `onPopoverLeave`:

1. __`onSVGMouseOut`__ used a coordinate-based `isMouseOverPopover` check with a 12px deadzone around the popover's bounding rect. When the popover is positioned near the y-axis, the cursor's exit coordinates often fell within this deadzone — causing cleanup to be skipped.

2. __`onPopoverLeave`__ only cleared highlights when the mouse moved back __into__ the SVG (`nodeContains(svg, relatedTarget)`). When the mouse exited the popover toward the outside (y-axis exit path), nothing cleared the tooltip.

### Solution

1. __`onSVGMouseOut`__: Replaced the coordinate-based `isMouseOverPopover` check with a DOM-based `nodeContains` check using `popoverRef.current?.parentElement` (which includes the transition wrapper). Cleanup is only suppressed when the mouse actually enters the popover DOM tree.

2. __`onPopoverLeave`__: Simplified to unconditionally clear highlights when the mouse leaves the popover (unless handlers are disabled). When mouse returns to the SVG, `onSVGMouseMove` naturally re-triggers the correct tooltip.

The `isMouseOverPopover` deadzone check is preserved in `onSVGMouseMove` where it remains useful for preventing tooltip flickering.

### Changes

- `src/mixed-line-bar-chart/hooks/use-mouse-hover.ts` — Updated `onSVGMouseOut` and `onPopoverLeave`
- `src/mixed-line-bar-chart/__tests__/use-mouse-hover.test.ts` — Updated and added tests for both changes

Before:



https://github.com/user-attachments/assets/e4fb22a3-4ea4-469d-af18-57598420eca5





After:

https://github.com/user-attachments/assets/60c735d6-6e4d-4d7b-bdfd-afb81b2e698c


###

Rel: AWSUI-61753, closes https://github.com/cloudscape-design/components/issues/4230

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
