### PR TITLE
fix: Maximum update depth exceeded during SplitPanel resize 

### DIFF
--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -281,35 +281,6 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as const)('%s', theme =>
     })
   );
 
-  test(
-    'should not cause infinite update loop when resizing split panel from max to smaller size',
-    setupTest(async page => {
-      await page.setWindowSize({ width: 2000, height: 1000 });
-      await page.openPanel();
-      const { height: viewportHeight } = await page.getViewportSize();
-
-      // Drag resizer to the top (max size), then back down.
-      await page.dragResizerTo({ x: 0, y: 0 });
-
-      // Slowly drag the resizer back down in small increments to reproduce the bug.
-      // The infinite loop only triggers when the handle moves gradually near the edge,
-      // causing repeated forced-position recalculations on each animation frame.
-      const targetY = Math.ceil(viewportHeight / 2);
-      const resizerSelector = wrapper.findSplitPanel().findSlider().toSelector();
-      const { top: startY } = await page.getBoundingBox(resizerSelector);
-      const steps = 5;
-      const stepSize = Math.ceil((targetY - startY) / steps);
-      for (let i = 1; i <= steps; i++) {
-        await page.dragResizerTo({ x: 0, y: Math.ceil(startY) + stepSize * i });
-      }
-
-      const consoleErrors = await page.getConsoleErrorLogs();
-      const errorPattern = /Maximum update depth exceeded/;
-      const matchingErrors = consoleErrors.filter(error => errorPattern.test(error));
-      expect(matchingErrors.length).toBe(0);
-    })
-  );
-
   describe('interaction with table sticky elements', () => {
     // bottom padding is included into the offset in VR but not in classic
     const splitPanelPadding = theme === 'refresh' ? 40 : 0;

--- a/src/app-layout/__integ__/utils.ts
+++ b/src/app-layout/__integ__/utils.ts
@@ -168,14 +168,4 @@ export class AppLayoutSplitViewPage extends BasePageObject {
       ? this.isExisting(wrapper.findSplitPanel().findOpenPanelSide().toSelector())
       : this.isExisting(wrapper.findSplitPanel().findOpenPanelBottom().toSelector());
   }
-
-  async getConsoleErrorLogs() {
-    const total = (await this.browser.getLogs('browser')) as Array<{
-      level: string;
-      message: string;
-      source: string;
-    }>;
-
-    return total.filter(entry => entry.level === 'SEVERE' && entry.source !== 'network').map(entry => entry.message);
-  }
 }


### PR DESCRIPTION
### Description

#### Steps to reproduce:

Render an AppLayout with a SplitPanel and splitPanelOpen={true}
Open Chrome DevTools
Rapidly drag the split panel resize handle, or resize the browser
The crash is somewhat intermittent with the split panel, but resizing the browser will guarantee the crash.

`AWSUI-61789`

Fixes two infinite update loops triggered in React 19. In SplitPanelProvider, subpixel `cappedSize` values from `getBoundingClientRect` caused `reportSize` to refire every frame during drag - fixed by rounding before the effect. In DragHandleWrapper, visibleDirections are wrapped with ref.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
