### PR TITLE
chore: Split panel in react 19

### DIFF
--- a/src/internal/components/drag-handle-wrapper/index.tsx
+++ b/src/internal/components/drag-handle-wrapper/index.tsx
@@ -188,7 +188,9 @@ export default function DragHandleWrapper({
   // The position needs to be recalculated as the element may animate into its final position.
   useEffect(() => {
     if (!showButtons || !dragHandleRef.current) {
-      setForcedPosition(null);
+      if (forcedPosition !== null) {
+        setForcedPosition(null);
+      }
       return;
     }
 
@@ -219,7 +221,7 @@ export default function DragHandleWrapper({
     return () => {
       cancelAnimationFrame(frameId);
     };
-  }, [showButtons, visibleDirections]);
+  }, [forcedPosition, showButtons, visibleDirections]);
 
   return (
     <>


### PR DESCRIPTION
### Description

Fixed a react 19 infinite loop in the split panel component by skipping redundant state updates

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
