### PR TITLE
feat: Remove aria-disabled=true from multi-/select trigger placeholder

### DIFF
--- a/src/select/parts/trigger.tsx
+++ b/src/select/parts/trigger.tsx
@@ -87,14 +87,14 @@ const Trigger = React.forwardRef(
         ariaLabelledbyIds = ariaLabelledby;
       } else {
         triggerContent = (
-          <span aria-disabled="true" className={clsx(styles.placeholder, styles.trigger)} id={triggerContentId}>
+          <span className={clsx(styles.placeholder, styles.trigger)} id={triggerContentId}>
             {placeholder}
           </span>
         );
       }
     } else if (!selectedOption) {
       triggerContent = (
-        <span aria-disabled="true" className={clsx(styles.placeholder, styles.trigger)} id={triggerContentId}>
+        <span className={clsx(styles.placeholder, styles.trigger)} id={triggerContentId}>
           {placeholder}
         </span>
       );


### PR DESCRIPTION
### Description
Remove the aria-disabled=true property on the multiselect and select trigger placeholder.

Related links, issue #, if available: AWSUI-61825

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
