### PR TITLE
fix: Date range picker alert not focused on error

### DIFF
--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -4,6 +4,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
+import { AlertProps } from '../alert/interfaces';
 import InternalAlert from '../alert/internal';
 import InternalBox from '../box/internal';
 import { ButtonProps } from '../button/interfaces';
@@ -111,6 +112,7 @@ export function DateRangePickerDropdown({
 
   const scrollableContainerRef = useRef<HTMLDivElement | null>(null);
   const applyButtonRef = useRef<ButtonProps.Ref>(null);
+  const alertRef = useRef<AlertProps.Ref>(null);
 
   const [applyClicked, setApplyClicked] = useState<boolean>(false);
 
@@ -166,6 +168,12 @@ export function DateRangePickerDropdown({
     getTimeOffset,
     timeOffset,
   ]);
+
+  useEffect(() => {
+    if (applyClicked && !validationResult.valid) {
+      alertRef.current?.focus();
+    }
+  }, [applyClicked, validationResult]);
 
   useEffect(() => scrollableContainerRef.current?.focus(), [scrollableContainerRef]);
 
@@ -241,6 +249,7 @@ export function DateRangePickerDropdown({
                   {!validationResult.valid && (
                     <>
                       <InternalAlert
+                        ref={alertRef}
                         type="error"
                         statusIconAriaLabel={i18n('i18nStrings.errorIconAriaLabel', i18nStrings?.errorIconAriaLabel)}
                       >


### PR DESCRIPTION
### Description
In the date range picker, when a user enters an invalid date range, and presses the 'Apply' button, an error message appears. Currently, this is not being focused, creating inaccessible experiences.

Related links, issue #, if available: [AWSUI-61790]

#### Before
Focus stays on 'Apply' button.

https://github.com/user-attachments/assets/67b59d82-dae1-44b4-b6b9-df69ea6f0696

#### After
Focus goes to the Alert.

https://github.com/user-attachments/assets/65b62ac2-08cc-4f61-90f3-05fd3c8b10e2


### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
