### PR TITLE
feat: Add ability to control first month shown in date range picker

### DIFF
--- a/pages/date-range-picker/common.tsx
+++ b/pages/date-range-picker/common.tsx
@@ -27,6 +27,7 @@ interface DateRangePickerPageSettings {
   disabledDates?: DisabledDate;
   showDisabledReason?: boolean;
   hasValue?: boolean;
+  absoluteMultiGridStartPeriod?: DateRangePickerProps.StartPeriod;
 }
 
 const defaultSettings: Required<DateRangePickerPageSettings> = {
@@ -45,6 +46,7 @@ const defaultSettings: Required<DateRangePickerPageSettings> = {
   disabledDates: 'none',
   showDisabledReason: true,
   hasValue: true,
+  absoluteMultiGridStartPeriod: 'current',
 };
 
 export function useDateRangePickerSettings(
@@ -89,6 +91,7 @@ export function useDateRangePickerSettings(
   const disabledDates = urlParams.disabledDates ?? def('disabledDates');
   const showDisabledReason = parseBoolean(def('showDisabledReason'), urlParams.showDisabledReason);
   const hasValue = parseBoolean(def('hasValue'), urlParams.hasValue);
+  const absoluteMultiGridStartPeriod = urlParams.absoluteMultiGridStartPeriod ?? def('absoluteMultiGridStartPeriod');
   const settings: Required<DateRangePickerPageSettings> = {
     dateOnly,
     monthOnly,
@@ -105,6 +108,7 @@ export function useDateRangePickerSettings(
     disabledDates,
     showDisabledReason,
     hasValue,
+    absoluteMultiGridStartPeriod,
   };
   const setSettings = (settings: DateRangePickerPageSettings) => setUrlParams(settings);
 
@@ -211,6 +215,7 @@ export function useDateRangePickerSettings(
     isValidRange: isValid(monthOnly ? 'month' : 'day'),
     placeholder,
     i18nStrings,
+    absoluteMultiGridStartPeriod,
     locale: 'en-GB',
   };
 
@@ -256,6 +261,7 @@ export function Settings({
     disabledDates,
     showDisabledReason,
     hasValue,
+    absoluteMultiGridStartPeriod,
   },
   setSettings,
 }: {
@@ -274,6 +280,7 @@ export function Settings({
   const dateFormatOptions = [{ value: 'iso' }, { value: 'slashed' }, { value: 'long-localized' }];
   const inputDateFormat = [{ value: 'iso' }, { value: 'slashed' }];
   const timeFormatOptions = [{ value: 'hh:mm:ss' }, { value: 'hh:mm' }, { value: 'hh' }];
+  const absoluteMultiGridStartPeriodOptions = [{ value: 'current' }, { value: 'previous' }, { value: 'auto' }];
   return (
     <SpaceBetween size="m" direction="horizontal">
       <FormField label="Range selector mode">
@@ -329,6 +336,20 @@ export function Settings({
           type="number"
           value={`${timeOffset}`}
           onChange={({ detail }) => setSettings({ timeOffset: parseInt(detail.value) })}
+        />
+      </FormField>
+
+      <FormField label="Start period">
+        <Select
+          options={absoluteMultiGridStartPeriodOptions}
+          selectedOption={
+            absoluteMultiGridStartPeriodOptions.find(o => o.value === absoluteMultiGridStartPeriod) ?? null
+          }
+          onChange={({ detail }) =>
+            setSettings({
+              absoluteMultiGridStartPeriod: detail.selectedOption.value as DateRangePickerProps.StartPeriod,
+            })
+          }
         />
       </FormField>
 

--- a/pages/date-range-picker/month-calendar-permutations.page.tsx
+++ b/pages/date-range-picker/month-calendar-permutations.page.tsx
@@ -36,6 +36,7 @@ const permutations = createPermutations<DateRangePickerCalendarProps>([
     customAbsoluteRangeControl: [undefined],
     timeInputFormat: ['hh:mm:ss'] as const,
     absoluteFormat: ['long-localized'] as const,
+    multiGridStartPeriod: ['current'] as const,
   })),
   // Disabled dates
   {
@@ -45,6 +46,7 @@ const permutations = createPermutations<DateRangePickerCalendarProps>([
     customAbsoluteRangeControl: [undefined],
     timeInputFormat: ['hh:mm:ss'] as const,
     absoluteFormat: ['long-localized'] as const,
+    multiGridStartPeriod: ['current'] as const,
   },
   // Date-only
   {
@@ -54,6 +56,7 @@ const permutations = createPermutations<DateRangePickerCalendarProps>([
     customAbsoluteRangeControl: [undefined],
     timeInputFormat: ['hh:mm:ss'] as const,
     absoluteFormat: ['long-localized'] as const,
+    multiGridStartPeriod: ['current'] as const,
   },
   // Custom control
   {
@@ -62,6 +65,7 @@ const permutations = createPermutations<DateRangePickerCalendarProps>([
     customAbsoluteRangeControl: [() => 'Custom control'],
     timeInputFormat: ['hh:mm:ss'] as const,
     absoluteFormat: ['long-localized'] as const,
+    multiGridStartPeriod: ['current'] as const,
   },
   // Date input formats
   {
@@ -71,6 +75,7 @@ const permutations = createPermutations<DateRangePickerCalendarProps>([
     timeInputFormat: ['hh:mm:ss'] as const,
     dateInputFormat: ['iso', 'slashed'] as const,
     absoluteFormat: ['long-localized'] as const,
+    multiGridStartPeriod: ['current'] as const,
   },
   // Time input formats
   {
@@ -79,6 +84,7 @@ const permutations = createPermutations<DateRangePickerCalendarProps>([
     customAbsoluteRangeControl: [undefined],
     timeInputFormat: ['hh:mm', 'hh'] as const,
     absoluteFormat: ['long-localized'] as const,
+    multiGridStartPeriod: ['current'] as const,
   },
 ]);
 

--- a/pages/date-range-picker/range-calendar.page.tsx
+++ b/pages/date-range-picker/range-calendar.page.tsx
@@ -30,6 +30,7 @@ export default function RangeCalendarScenario() {
           customAbsoluteRangeControl={undefined}
           timeInputFormat="hh:mm:ss"
           absoluteFormat="slashed"
+          multiGridStartPeriod="current"
         />
 
         <Link id="focusable-after">Focusable element after</Link>

--- a/pages/date-range-picker/year-calendar-permutations.page.tsx
+++ b/pages/date-range-picker/year-calendar-permutations.page.tsx
@@ -19,7 +19,7 @@ const intervals = [
   ['2022-02', '2022-03'], //next
   ['2021-01', '2021-03'], //q1
   ['2022-04', '2022-06'], //q2
-  ['2023-07', '2022-09'], //q3
+  ['2022-07', '2022-09'], //q3
   ['2024-10', '2024-12'], //q4
 ];
 
@@ -33,6 +33,7 @@ const permutations = createPermutations<DateRangePickerCalendarProps>([
     customAbsoluteRangeControl: [undefined],
     timeInputFormat: ['hh:mm:ss'] as const,
     absoluteFormat: ['long-localized'] as const,
+    multiGridStartPeriod: ['current', 'previous'] as const,
   })),
   // Disabled dates
   {
@@ -42,6 +43,7 @@ const permutations = createPermutations<DateRangePickerCalendarProps>([
     customAbsoluteRangeControl: [undefined],
     timeInputFormat: ['hh:mm:ss'] as const,
     absoluteFormat: ['long-localized'] as const,
+    multiGridStartPeriod: ['current'] as const,
   },
   // Custom control
   {
@@ -50,6 +52,7 @@ const permutations = createPermutations<DateRangePickerCalendarProps>([
     customAbsoluteRangeControl: [() => 'Custom control'],
     timeInputFormat: ['hh:mm:ss'] as const,
     absoluteFormat: ['long-localized'] as const,
+    multiGridStartPeriod: ['current'] as const,
   },
   // Input date formats
   {
@@ -59,6 +62,7 @@ const permutations = createPermutations<DateRangePickerCalendarProps>([
     timeInputFormat: ['hh:mm:ss'] as const,
     dateInputFormat: ['iso', 'slashed'] as const,
     absoluteFormat: ['long-localized'] as const,
+    multiGridStartPeriod: ['current'] as const,
   },
 ]);
 

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -10819,6 +10819,26 @@ It can take the following values:
       "type": "string",
     },
     {
+      "defaultValue": "'auto'",
+      "description": "Specifies whether to start with the previous or current period (month or year)
+when multiple calendar grids are displayed in absolute mode.
+
+Defaults to 'auto', which starts with previous if no date is selected,
+or current if a selection is present.",
+      "inlineType": {
+        "name": "DateRangePickerProps.StartPeriod",
+        "type": "union",
+        "values": [
+          "auto",
+          "current",
+          "previous",
+        ],
+      },
+      "name": "absoluteMultiGridStartPeriod",
+      "optional": true,
+      "type": "string",
+    },
+    {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
 

--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 import { render } from '@testing-library/react';
+import mockdate from 'mockdate';
 
 import '../../__a11y__/to-validate-a11y';
 import DateRangePicker, { DateRangePickerProps } from '../../../lib/components/date-range-picker';
@@ -52,6 +53,7 @@ beforeEach(() => {
 });
 afterEach(() => {
   spy.mockRestore();
+  mockdate.reset();
 });
 
 describe('Date range picker', () => {
@@ -1155,7 +1157,7 @@ describe('Date range picker', () => {
       });
 
       describe('absoluteMultiGridStartPeriod', () => {
-        test('defaults to "current" - header shows start date period on the left grid', () => {
+        test('defaults to "auto" - header shows start date period on the left grid', () => {
           const { wrapper } = renderDateRangePicker({
             ...defaultProps,
             granularity,
@@ -1171,7 +1173,24 @@ describe('Date range picker', () => {
           expect(wrapper.findDropdown()!.findHeader().getElement()).toHaveTextContent(expectedResult);
         });
 
-        test('"current" explicitly set shows same as default', () => {
+        test('defaults to "auto" - header shows current date on the right grid', () => {
+          mockdate.set(new Date('2026-04-08T12:00:00'));
+          const { wrapper } = renderDateRangePicker({
+            ...defaultProps,
+            granularity,
+            rangeSelectorMode: 'absolute-only',
+          });
+
+          wrapper.findTrigger().click();
+
+          // Default "current" means the start date's month/year appears in the left grid
+          // For day: left=March 2020, right=April 2020, header shows "March 2020April 2020"
+          // For month: left=2020, right=2021, header shows "20202021"
+          const expectedResult = granularity === 'day' ? 'March 2026April 2026' : '20252026';
+          expect(wrapper.findDropdown()!.findHeader().getElement()).toHaveTextContent(expectedResult);
+        });
+
+        test('"current" shows selected date on right grid', () => {
           const { wrapper } = renderDateRangePicker({
             ...defaultProps,
             granularity,
@@ -1181,11 +1200,26 @@ describe('Date range picker', () => {
 
           wrapper.findTrigger().click();
 
-          const expectedResult = granularity === 'day' ? 'March 2020' : '20202021';
+          const expectedResult = granularity === 'day' ? 'March 2020April 2020' : '20202021';
           expect(wrapper.findDropdown()!.findHeader().getElement()).toHaveTextContent(expectedResult);
         });
 
-        test('"previous" shows the previous period on the left grid', () => {
+        test('"current" shows current date on right grid', () => {
+          mockdate.set(new Date('2026-04-08T12:00:00'));
+          const { wrapper } = renderDateRangePicker({
+            ...defaultProps,
+            granularity,
+            absoluteMultiGridStartPeriod: 'current',
+            rangeSelectorMode: 'absolute-only',
+          });
+
+          wrapper.findTrigger().click();
+
+          const expectedResult = granularity === 'day' ? 'April 2026May 2026' : '20262027';
+          expect(wrapper.findDropdown()!.findHeader().getElement()).toHaveTextContent(expectedResult);
+        });
+
+        test('"previous" shows the previous to selected period on the left grid', () => {
           const { wrapper } = renderDateRangePicker({
             ...defaultProps,
             granularity,
@@ -1198,23 +1232,25 @@ describe('Date range picker', () => {
           // "previous" means start date's month/year is shown on the right grid, previous on the left
           // For day: left=February 2020, right=March 2020, header shows "February 2020March 2020"
           // For month: left=2019, right=2020, header shows "20192020"
-          const expectedResult = granularity === 'day' ? 'February 2020' : '20192020';
+          const expectedResult = granularity === 'day' ? 'February 2020March 2020' : '20192020';
           expect(wrapper.findDropdown()!.findHeader().getElement()).toHaveTextContent(expectedResult);
         });
 
-        test('"previous" allows start date to be visible in right grid', () => {
+        test('"previous" shows the previous to current period on the left grid', () => {
+          mockdate.set(new Date('2026-04-08T12:00:00'));
           const { wrapper } = renderDateRangePicker({
             ...defaultProps,
             granularity,
             absoluteMultiGridStartPeriod: 'previous',
-            value: { type: 'absolute', startDate: '2021-06-15T00:00:00+08:45', endDate: '2021-06-20T23:59:59+08:45' },
+            rangeSelectorMode: 'absolute-only',
           });
 
           wrapper.findTrigger().click();
 
-          // For day: left=May 2021, right=June 2021
-          // For month: left=2020, right=2021
-          const expectedResult = granularity === 'day' ? 'May 2021' : '20202021';
+          // "previous" means start date's month/year is shown on the right grid, previous on the left
+          // For day: left=February 2020, right=March 2020, header shows "February 2020March 2020"
+          // For month: left=2019, right=2020, header shows "20192020"
+          const expectedResult = granularity === 'day' ? 'March 2026April 2026' : '20252026';
           expect(wrapper.findDropdown()!.findHeader().getElement()).toHaveTextContent(expectedResult);
         });
       });

--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -13,6 +13,14 @@ import { testIf } from '../../__tests__/utils';
 import { i18nStrings } from './i18n-strings';
 import { isValidRange } from './is-valid-range';
 
+import testutilStyles from '../../../lib/components/date-range-picker/test-classes/styles.selectors.js';
+
+jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
+  useMobile: jest.fn().mockReturnValue(false),
+}));
+
+import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
+
 const defaultProps: DateRangePickerProps = {
   locale: 'en-US',
   granularity: 'day',
@@ -1413,6 +1421,86 @@ describe('Date range picker', () => {
               );
             }
           });
+        });
+      });
+
+      describe('mobile/single-grid mode', () => {
+        beforeEach(() => {
+          jest.mocked(useMobile).mockReturnValue(true);
+        });
+
+        afterEach(() => {
+          jest.mocked(useMobile).mockReturnValue(false);
+        });
+
+        test('renders only one calendar grid in mobile mode', () => {
+          const { wrapper } = renderDateRangePicker({
+            ...defaultProps,
+            granularity,
+            value: { type: 'absolute', startDate: '2020-03-02T05:00:00+08:45', endDate: '2020-03-12T13:05:21+08:45' },
+          });
+
+          wrapper.findTrigger().click();
+
+          // In single-grid mode, there should only be one grid (second-grid)
+          expect(wrapper.findDropdown()!.findByClassName(testutilStyles['first-grid'])).not.toBeNull();
+          expect(wrapper.findDropdown()!.findByClassName(testutilStyles['second-grid'])).toBeNull();
+        });
+
+        test('header shows only one period in mobile mode', () => {
+          const { wrapper } = renderDateRangePicker({
+            ...defaultProps,
+            granularity,
+            value: { type: 'absolute', startDate: '2020-03-02T05:00:00+08:45', endDate: '2020-03-12T13:05:21+08:45' },
+          });
+
+          wrapper.findTrigger().click();
+
+          // In single-grid mode, header should show only one month/year
+          const expectedResult = granularity === 'day' ? 'March 2020' : '2020';
+          expect(wrapper.findDropdown()!.findHeader().getElement().textContent).toBe(expectedResult);
+        });
+
+        test('displays current month if no selected value in mobile mode', () => {
+          mockdate.set(new Date('2026-04-08T12:00:00'));
+          const { wrapper } = renderDateRangePicker({
+            ...defaultProps,
+            granularity,
+            rangeSelectorMode: 'absolute-only',
+          });
+
+          wrapper.findTrigger().click();
+
+          // In single-grid mode, header should show only one month/year
+          const expectedResult = granularity === 'day' ? 'April 2026' : '2026';
+          expect(wrapper.findDropdown()!.findHeader().getElement().textContent).toBe(expectedResult);
+        });
+
+        test('absoluteMultiGridStartPeriod is ignored in mobile mode (always shows single grid)', () => {
+          const { wrapper: wrapperCurrent } = renderDateRangePicker({
+            ...defaultProps,
+            granularity,
+            absoluteMultiGridStartPeriod: 'current',
+            value: { type: 'absolute', startDate: '2020-03-02T05:00:00+08:45', endDate: '2020-03-12T13:05:21+08:45' },
+          });
+
+          wrapperCurrent.findTrigger().click();
+          const currentHeader = wrapperCurrent.findDropdown()!.findHeader().getElement().textContent;
+
+          const { wrapper: wrapperPrevious } = renderDateRangePicker({
+            ...defaultProps,
+            granularity,
+            absoluteMultiGridStartPeriod: 'previous',
+            value: { type: 'absolute', startDate: '2020-03-02T05:00:00+08:45', endDate: '2020-03-12T13:05:21+08:45' },
+          });
+
+          wrapperPrevious.findTrigger().click();
+          const previousHeader = wrapperPrevious.findDropdown()!.findHeader().getElement().textContent;
+
+          // Both should show the same single grid regardless of absoluteMultiGridStartPeriod
+          const expectedResult = granularity === 'day' ? 'March 2020' : '2020';
+          expect(currentHeader).toBe(expectedResult);
+          expect(previousHeader).toBe(expectedResult);
         });
       });
     });

--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -1154,6 +1154,71 @@ describe('Date range picker', () => {
         });
       });
 
+      describe('absoluteMultiGridStartPeriod', () => {
+        test('defaults to "current" - header shows start date period on the left grid', () => {
+          const { wrapper } = renderDateRangePicker({
+            ...defaultProps,
+            granularity,
+            value: { type: 'absolute', startDate: '2020-03-02T05:00:00+08:45', endDate: '2020-03-12T13:05:21+08:45' },
+          });
+
+          wrapper.findTrigger().click();
+
+          // Default "current" means the start date's month/year appears in the left grid
+          // For day: left=March 2020, right=April 2020, header shows "March 2020April 2020"
+          // For month: left=2020, right=2021, header shows "20202021"
+          const expectedResult = granularity === 'day' ? 'March 2020' : '20202021';
+          expect(wrapper.findDropdown()!.findHeader().getElement()).toHaveTextContent(expectedResult);
+        });
+
+        test('"current" explicitly set shows same as default', () => {
+          const { wrapper } = renderDateRangePicker({
+            ...defaultProps,
+            granularity,
+            absoluteMultiGridStartPeriod: 'current',
+            value: { type: 'absolute', startDate: '2020-03-02T05:00:00+08:45', endDate: '2020-03-12T13:05:21+08:45' },
+          });
+
+          wrapper.findTrigger().click();
+
+          const expectedResult = granularity === 'day' ? 'March 2020' : '20202021';
+          expect(wrapper.findDropdown()!.findHeader().getElement()).toHaveTextContent(expectedResult);
+        });
+
+        test('"previous" shows the previous period on the left grid', () => {
+          const { wrapper } = renderDateRangePicker({
+            ...defaultProps,
+            granularity,
+            absoluteMultiGridStartPeriod: 'previous',
+            value: { type: 'absolute', startDate: '2020-03-02T05:00:00+08:45', endDate: '2020-03-12T13:05:21+08:45' },
+          });
+
+          wrapper.findTrigger().click();
+
+          // "previous" means start date's month/year is shown on the right grid, previous on the left
+          // For day: left=February 2020, right=March 2020, header shows "February 2020March 2020"
+          // For month: left=2019, right=2020, header shows "20192020"
+          const expectedResult = granularity === 'day' ? 'February 2020' : '20192020';
+          expect(wrapper.findDropdown()!.findHeader().getElement()).toHaveTextContent(expectedResult);
+        });
+
+        test('"previous" allows start date to be visible in right grid', () => {
+          const { wrapper } = renderDateRangePicker({
+            ...defaultProps,
+            granularity,
+            absoluteMultiGridStartPeriod: 'previous',
+            value: { type: 'absolute', startDate: '2021-06-15T00:00:00+08:45', endDate: '2021-06-20T23:59:59+08:45' },
+          });
+
+          wrapper.findTrigger().click();
+
+          // For day: left=May 2021, right=June 2021
+          // For month: left=2020, right=2021
+          const expectedResult = granularity === 'day' ? 'May 2021' : '20202021';
+          expect(wrapper.findDropdown()!.findHeader().getElement()).toHaveTextContent(expectedResult);
+        });
+      });
+
       describe('i18n', () => {
         describe.each([true, false] as const)('With dateOnly of %s', dateOnly => {
           test('supports using absolute range with i18n defaults', () => {

--- a/src/date-range-picker/calendar/__tests__/utils.test.ts
+++ b/src/date-range-picker/calendar/__tests__/utils.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import MockDate from 'mockdate';
 
+import { DateRangePickerProps } from '../../interfaces';
 import { findDateToFocus, findMonthToDisplay, findMonthToFocus, findYearToDisplay } from '../utils';
 // Helper function to create Date objects from YYYY-MM-DD strings
 const createDate = (dateString: string) => new Date(dateString);
@@ -15,37 +16,49 @@ describe('findDateToFocus', () => {
   test('should return selected date if it is enabled and in the same month as baseDate', () => {
     const selected = createDate('2023-06-10');
     const baseDate = createDate('2023-06-01');
-    expect(findDateToFocus(selected, baseDate, () => true)).toEqual(selected);
+    expect(findDateToFocus(selected, baseDate, () => true, true)).toEqual(selected);
   });
   test('should return today if selected is null, today is enabled and in the same month as baseDate', () => {
     const baseDate = createDate('2023-06-01');
     const today = new Date();
-    expect(findDateToFocus(null, baseDate, () => true)).toEqual(today);
+    expect(findDateToFocus(null, baseDate, () => true, true)).toEqual(today);
   });
   test('should return baseDate if selected is null, today is not in the same month, and baseDate is enabled', () => {
     const baseDate = createDate('2023-07-01');
-    expect(findDateToFocus(null, baseDate, () => true)).toEqual(baseDate);
+    expect(findDateToFocus(null, baseDate, () => true, true)).toEqual(baseDate);
   });
   test('should return null if no date is suitable', () => {
     const baseDate = createDate('2023-07-01');
-    expect(findDateToFocus(null, baseDate, () => false)).toBeNull();
+    expect(findDateToFocus(null, baseDate, () => false, true)).toBeNull();
   });
   test('should return today even if selected is provided but not in the same month as baseDate', () => {
     const selected = createDate('2023-05-01');
     const baseDate = createDate('2023-06-01');
     const today = new Date();
-    expect(findDateToFocus(selected, baseDate, () => true)).toEqual(today);
+    expect(findDateToFocus(selected, baseDate, () => true, true)).toEqual(today);
   });
   test('should return baseDate if selected and today are not suitable', () => {
     const selected = createDate('2023-05-01');
     const baseDate = createDate('2023-08-01');
-    expect(findDateToFocus(selected, baseDate, (date: Date) => date.getMonth() === 7)).toEqual(baseDate);
+    expect(findDateToFocus(selected, baseDate, (date: Date) => date.getMonth() === 7, true)).toEqual(baseDate);
   });
   test('should handle leap years correctly', () => {
     MockDate.set(new Date('2024-02-29')); // Set 'today' to a leap year
     const baseDate = createDate('2024-02-01');
     const today = new Date();
-    expect(findDateToFocus(null, baseDate, () => true)).toEqual(today);
+    expect(findDateToFocus(null, baseDate, () => true, true)).toEqual(today);
+  });
+  describe('2-up grid', () => {
+    test('should return selected date if it is enabled and in the next month as baseDate', () => {
+      const selected = createDate('2023-07-10');
+      const baseDate = createDate('2023-06-01');
+      expect(findDateToFocus(selected, baseDate, () => true, false)).toEqual(selected);
+    });
+    test('should return today if selected is null, today is enabled and in the next month as baseDate', () => {
+      const baseDate = createDate('2023-05-01');
+      const today = new Date();
+      expect(findDateToFocus(null, baseDate, () => true, false)).toEqual(today);
+    });
   });
 });
 describe('findMonthToFocus', () => {
@@ -58,31 +71,43 @@ describe('findMonthToFocus', () => {
   test('should return selected date if it is enabled and in the same year as baseDate', () => {
     const selected = createDate('2023-03');
     const baseDate = createDate('2023-06');
-    expect(findMonthToFocus(selected, baseDate, () => true)).toEqual(selected);
+    expect(findMonthToFocus(selected, baseDate, () => true, true)).toEqual(selected);
   });
   test('should return today if selected is null, today is enabled and in the same year as baseDate', () => {
     const baseDate = createDate('2023-12-01');
     const today = new Date();
-    expect(findMonthToFocus(null, baseDate, () => true)).toEqual(today);
+    expect(findMonthToFocus(null, baseDate, () => true, true)).toEqual(today);
   });
   test('should return baseDate if selected is null, today is not in the same year, and baseDate is enabled', () => {
     const baseDate = createDate('2024-01-01');
-    expect(findMonthToFocus(null, baseDate, () => true)).toEqual(baseDate);
+    expect(findMonthToFocus(null, baseDate, () => true, true)).toEqual(baseDate);
   });
   test('should return null if no date is suitable', () => {
     const baseDate = createDate('2024-01-01');
-    expect(findMonthToFocus(null, baseDate, () => false)).toBeNull();
+    expect(findMonthToFocus(null, baseDate, () => false, true)).toBeNull();
   });
   test('should return today even if selected is provided but not in the same year as baseDate', () => {
     const selected = createDate('2022-12-01');
     const baseDate = createDate('2023-01-01');
     const today = new Date();
-    expect(findMonthToFocus(selected, baseDate, () => true)).toEqual(today);
+    expect(findMonthToFocus(selected, baseDate, () => true, true)).toEqual(today);
   });
   test('should return baseDate if selected and today are not suitable', () => {
     const selected = createDate('2022-12-01');
     const baseDate = createDate('2024-01-01');
-    expect(findMonthToFocus(selected, baseDate, date => date.getFullYear() === 2024)).toEqual(baseDate);
+    expect(findMonthToFocus(selected, baseDate, date => date.getFullYear() === 2024, true)).toEqual(baseDate);
+  });
+  describe('2-up grid', () => {
+    test('should return selected date if it is enabled and in the next year as baseDate', () => {
+      const selected = createDate('2024-03');
+      const baseDate = createDate('2023-06');
+      expect(findMonthToFocus(selected, baseDate, () => true, false)).toEqual(selected);
+    });
+    test('should return today if selected is null, today is enabled and in the next year as baseDate', () => {
+      const baseDate = createDate('2022-12-01');
+      const today = new Date();
+      expect(findMonthToFocus(null, baseDate, () => true, false)).toEqual(today);
+    });
   });
 });
 describe('findMonthToDisplay', () => {
@@ -92,40 +117,100 @@ describe('findMonthToDisplay', () => {
   afterEach(() => {
     MockDate.reset();
   });
-  test('should return start date month for single grid', () => {
+  test.each(['current', 'previous', 'auto'] as DateRangePickerProps.StartPeriod[])(
+    'should return start date month for single grid, regardless of startPeriod (%s)',
+    startPeriod => {
+      const value = { start: { date: '2023-03-15', time: '00:00' }, end: { date: '', time: '' } };
+      const result = findMonthToDisplay(value, true, startPeriod);
+      expect(result).toEqual(createDate('2023-03-01'));
+    }
+  );
+  test('should return month of start date for double grid with startPeriod "current"', () => {
     const value = { start: { date: '2023-03-15', time: '00:00' }, end: { date: '', time: '' } };
-    const result = findMonthToDisplay(value, true);
+    const result = findMonthToDisplay(value, false, 'current');
     expect(result).toEqual(createDate('2023-03-01'));
   });
-  test('should return next month of start date for double grid', () => {
+  test('should return month of start date for double grid with startPeriod "auto"', () => {
     const value = { start: { date: '2023-03-15', time: '00:00' }, end: { date: '', time: '' } };
-    const result = findMonthToDisplay(value, false);
-    expect(result).toEqual(createDate('2023-04-01'));
+    const result = findMonthToDisplay(value, false, 'auto');
+    expect(result).toEqual(createDate('2023-03-01'));
   });
-  test('should return end date month when start date is null', () => {
+  test('should return previous month to start date for double grid with startPeriod "previous"', () => {
+    const value = { start: { date: '2023-03-15', time: '00:00' }, end: { date: '', time: '' } };
+    const result = findMonthToDisplay(value, false, 'previous');
+    expect(result).toEqual(createDate('2023-02-01'));
+  });
+  test('should keep startPeriod "previous" when range spans 1 month (same month)', () => {
+    const value = { start: { date: '2023-03-10', time: '00:00' }, end: { date: '2023-03-20', time: '00:00' } };
+    const result = findMonthToDisplay(value, false, 'previous');
+    expect(result).toEqual(createDate('2023-02-01'));
+  });
+  test('should override startPeriod "previous" to "current" when range spans more than 1 month', () => {
+    const value = { start: { date: '2023-03-15', time: '00:00' }, end: { date: '2023-04-01', time: '00:00' } };
+    const result = findMonthToDisplay(value, false, 'previous');
+    // Should behave like 'current': left panel shows March, right panel shows April
+    expect(result).toEqual(createDate('2023-03-01'));
+  });
+  test.each(['current', 'previous', 'auto'] as DateRangePickerProps.StartPeriod[])(
+    'should return month of end date when start date is null in single grid, regardless of startPeriod (%s)',
+    startPeriod => {
+      const value = { start: { date: '', time: '' }, end: { date: '2023-07-20', time: '00:00' } };
+      const result = findMonthToDisplay(value, true, startPeriod);
+      expect(result).toEqual(createDate('2023-07-01'));
+    }
+  );
+  test('should return end date month when start date is null with startPeriod "current"', () => {
     const value = { start: { date: '', time: '' }, end: { date: '2023-07-20', time: '00:00' } };
-    const result = findMonthToDisplay(value, true); // isSingleGrid doesn't matter in this case
+    const result = findMonthToDisplay(value, false, 'current');
     expect(result).toEqual(createDate('2023-07-01'));
   });
-  test('should return current month when both start and end dates are null', () => {
+  test('should return month before end date month when start date is null with startPeriod "previous"', () => {
+    const value = { start: { date: '', time: '' }, end: { date: '2023-07-20', time: '00:00' } };
+    const result = findMonthToDisplay(value, false, 'previous');
+    expect(result).toEqual(createDate('2023-06-01'));
+  });
+  test.each(['current', 'previous', 'auto'] as DateRangePickerProps.StartPeriod[])(
+    'should return current monthwhen both start and end dates are null in single grid, regardless of startPeriod (%s)',
+    startPeriod => {
+      const value = { start: { date: '', time: '' }, end: { date: '', time: '' } };
+      const result = findMonthToDisplay(value, true, startPeriod);
+      expect(result).toEqual(createDate('2023-06-01')); // Based on the mocked current date
+    }
+  );
+  test('should return current month when value is empty with startPeriod "current"', () => {
     const value = { start: { date: '', time: '' }, end: { date: '', time: '' } };
-    const result = findMonthToDisplay(value, true); // isSingleGrid doesn't matter in this case
-    expect(result).toEqual(createDate('2023-06-01')); // Based on the mocked current date
+    const result = findMonthToDisplay(value, false, 'current');
+    expect(result).toEqual(createDate('2023-06-01'));
+  });
+  test('should return month before current month when value is empty with startPeriod "previous"', () => {
+    const value = { start: { date: '', time: '' }, end: { date: '', time: '' } };
+    const result = findMonthToDisplay(value, false, 'previous');
+    expect(result).toEqual(createDate('2023-05-01'));
   });
   test('should handle leap years correctly', () => {
     jest.setSystemTime(createDate('2024-02-15').getTime());
     const value = { start: { date: '2024-02-29', time: '00:00' }, end: { date: '', time: '' } };
-    const result = findMonthToDisplay(value, true);
+    const result = findMonthToDisplay(value, true, 'current');
     expect(result).toEqual(createDate('2024-02-01'));
   });
-  test('should handle year change for double grid', () => {
+  test('should handle year change for double grid with startPeriod "current"', () => {
     const value = { start: { date: '2023-12-15', time: '00:00' }, end: { date: '', time: '' } };
-    const result = findMonthToDisplay(value, false);
-    expect(result).toEqual(createDate('2024-01-01'));
+    const result = findMonthToDisplay(value, false, 'current');
+    expect(result).toEqual(createDate('2023-12-01'));
+  });
+  test('should not change year for double grid with startPeriod "previous" on December', () => {
+    const value = { start: { date: '2023-12-15', time: '00:00' }, end: { date: '', time: '' } };
+    const result = findMonthToDisplay(value, false, 'previous');
+    expect(result).toEqual(createDate('2023-11-01'));
+  });
+  test('should override startPeriod "previous" when range crosses year boundary and spans more than 2 months', () => {
+    const value = { start: { date: '2023-11-15', time: '00:00' }, end: { date: '2024-03-15', time: '00:00' } };
+    const result = findMonthToDisplay(value, false, 'previous');
+    expect(result).toEqual(createDate('2023-11-01'));
   });
   test('should prioritize start date over end date', () => {
     const value = { start: { date: '2023-03-15', time: '00:00' }, end: { date: '2023-07-20', time: '00:00' } };
-    const result = findMonthToDisplay(value, true);
+    const result = findMonthToDisplay(value, true, 'current');
     expect(result).toEqual(createDate('2023-03-01'));
   });
 });
@@ -136,49 +221,126 @@ describe('findYearToDisplay', () => {
   afterEach(() => {
     MockDate.reset();
   });
-  test('should return start year for single grid', () => {
+  test.each(['current', 'previous', 'auto'] as DateRangePickerProps.StartPeriod[])(
+    'should return start date year for single grid, regardless of startPeriod (%s)',
+    startPeriod => {
+      const value = { start: { date: '2023-03-15', time: '00:00' }, end: { date: '', time: '' } };
+      const result = findYearToDisplay(value, true, startPeriod);
+      expect(result).toEqual(createDate('2023-01-01'));
+    }
+  );
+  test('should return year of start date for double grid with startPeriod "current"', () => {
     const value = { start: { date: '2023-03-15', time: '00:00' }, end: { date: '', time: '' } };
-    const result = findYearToDisplay(value, true);
+    const result = findYearToDisplay(value, false, 'current');
     expect(result).toEqual(createDate('2023-01-01'));
   });
-  test('should return next year of start date for double grid', () => {
+  test('should return year of start date for double grid with startPeriod "auto"', () => {
     const value = { start: { date: '2023-03-15', time: '00:00' }, end: { date: '', time: '' } };
-    const result = findYearToDisplay(value, false);
-    expect(result).toEqual(createDate('2024-01-01'));
+    const result = findYearToDisplay(value, false, 'auto');
+    expect(result).toEqual(createDate('2023-01-01'));
   });
-  test('should return end year when start date is empty', () => {
+  test('should return previous year to start date for double grid with startPeriod "previous"', () => {
+    const value = { start: { date: '2023-03-15', time: '00:00' }, end: { date: '', time: '' } };
+    const result = findYearToDisplay(value, false, 'previous');
+    expect(result).toEqual(createDate('2022-01-01'));
+  });
+  test('should keep startPeriod "previous" when range spans 1 year (same year)', () => {
+    const value = { start: { date: '2023-03-15', time: '00:00' }, end: { date: '2023-11-15', time: '00:00' } };
+    const result = findYearToDisplay(value, false, 'previous');
+    expect(result).toEqual(createDate('2022-01-01'));
+  });
+  test('should override startPeriod "previous" to "current" when range spans more than 1 year', () => {
+    const value = { start: { date: '2023-03-15', time: '00:00' }, end: { date: '2024-06-15', time: '00:00' } };
+    const result = findYearToDisplay(value, false, 'previous');
+    expect(result).toEqual(createDate('2023-01-01'));
+  });
+  test('should override startPeriod "previous" to "current" when range spans exactly 3 years', () => {
+    const value = { start: { date: '2023-01-01', time: '00:00' }, end: { date: '2025-12-31', time: '00:00' } };
+    const result = findYearToDisplay(value, false, 'previous');
+    expect(result).toEqual(createDate('2023-01-01'));
+  });
+  test.each(['current', 'previous', 'auto'] as DateRangePickerProps.StartPeriod[])(
+    'should return year of end date when start date is null in single grid, regardless of startPeriod (%s)',
+    startPeriod => {
+      const value = { start: { date: '', time: '' }, end: { date: '2024-07-20', time: '00:00' } };
+      const result = findYearToDisplay(value, true, startPeriod);
+      expect(result).toEqual(createDate('2024-01-01'));
+    }
+  );
+  test('should return end date year when start date is null with startPeriod "current"', () => {
     const value = { start: { date: '', time: '' }, end: { date: '2024-07-20', time: '00:00' } };
-    const result = findYearToDisplay(value, true); // isSingleGrid doesn't matter in this case
+    const result = findYearToDisplay(value, false, 'current');
     expect(result).toEqual(createDate('2024-01-01'));
   });
-  test('should return current year when both start and end dates are empty', () => {
+  test('should return year before end date year when start date is null with startPeriod "previous"', () => {
+    const value = { start: { date: '', time: '' }, end: { date: '2024-07-20', time: '00:00' } };
+    const result = findYearToDisplay(value, false, 'previous');
+    expect(result).toEqual(createDate('2023-01-01'));
+  });
+  test.each(['current', 'previous', 'auto'] as DateRangePickerProps.StartPeriod[])(
+    'should return current year when both start and end dates are null in single grid, regardless of startPeriod (%s)',
+    startPeriod => {
+      const value = { start: { date: '', time: '' }, end: { date: '', time: '' } };
+      const result = findYearToDisplay(value, true, startPeriod);
+      expect(result).toEqual(createDate('2023-01-01')); // Based on the mocked current date
+    }
+  );
+  test('should return current year when value is empty with startPeriod "current"', () => {
     const value = { start: { date: '', time: '' }, end: { date: '', time: '' } };
-    const result = findYearToDisplay(value, true); // isSingleGrid doesn't matter in this case
-    expect(result).toEqual(createDate('2023-01-01')); // Based on the mocked current date
+    const result = findYearToDisplay(value, false, 'current');
+    expect(result).toEqual(createDate('2023-01-01'));
+  });
+  test('should return year before current year when value is empty with startPeriod "previous"', () => {
+    const value = { start: { date: '', time: '' }, end: { date: '', time: '' } };
+    const result = findYearToDisplay(value, false, 'previous');
+    expect(result).toEqual(createDate('2022-01-01'));
   });
   test('should handle leap years correctly', () => {
     const value = { start: { date: '2024-02-29', time: '00:00' }, end: { date: '', time: '' } };
-    const result = findYearToDisplay(value, true);
+    const result = findYearToDisplay(value, true, 'current');
     expect(result).toEqual(createDate('2024-01-01'));
   });
-  test('should handle year change for double grid', () => {
+  test('should handle year change for double grid with startPeriod "current"', () => {
     const value = { start: { date: '2023-12-15', time: '00:00' }, end: { date: '', time: '' } };
-    const result = findYearToDisplay(value, false);
-    expect(result).toEqual(createDate('2024-01-01'));
+    const result = findYearToDisplay(value, false, 'current');
+    expect(result).toEqual(createDate('2023-01-01'));
+  });
+  test('should not change year for double grid with startPeriod "previous" on December', () => {
+    const value = { start: { date: '2023-12-15', time: '00:00' }, end: { date: '', time: '' } };
+    const result = findYearToDisplay(value, false, 'previous');
+    expect(result).toEqual(createDate('2022-01-01'));
   });
   test('should prioritize start date over end date', () => {
     const value = { start: { date: '2023-03-15', time: '00:00' }, end: { date: '2024-07-20', time: '00:00' } };
-    const result = findYearToDisplay(value, true);
+    const result = findYearToDisplay(value, true, 'current');
     expect(result).toEqual(createDate('2023-01-01'));
   });
   test('should handle end of year dates', () => {
     const value = { start: { date: '2023-12-31', time: '23:59' }, end: { date: '', time: '' } };
-    const result = findYearToDisplay(value, true);
+    const result = findYearToDisplay(value, true, 'current');
     expect(result).toEqual(createDate('2023-01-01'));
   });
   test('should handle start of year dates', () => {
     const value = { start: { date: '2023-01-01', time: '00:00' }, end: { date: '', time: '' } };
-    const result = findYearToDisplay(value, true);
+    const result = findYearToDisplay(value, true, 'current');
     expect(result).toEqual(createDate('2023-01-01'));
+  });
+  test('should handle current date of first day of month: current', () => {
+    MockDate.set(new Date('2026-04-01'));
+    const value = { start: { date: '', time: '' }, end: { date: '', time: '' } };
+    const result = findYearToDisplay(value, false, 'current');
+    expect(result).toEqual(createDate('2026-01-01'));
+  });
+  test('should handle current date of first day of month: auto', () => {
+    MockDate.set(new Date('2026-04-01'));
+    const value = { start: { date: '', time: '' }, end: { date: '', time: '' } };
+    const result = findYearToDisplay(value, false, 'auto');
+    expect(result).toEqual(createDate('2025-01-01'));
+  });
+  test('should handle current date of first day of month: previous', () => {
+    MockDate.set(new Date('2026-04-01'));
+    const value = { start: { date: '', time: '' }, end: { date: '', time: '' } };
+    const result = findYearToDisplay(value, false, 'previous');
+    expect(result).toEqual(createDate('2025-01-01'));
   });
 });

--- a/src/date-range-picker/calendar/grids/index.tsx
+++ b/src/date-range-picker/calendar/grids/index.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { addMonths, addYears, isAfter, isBefore, isSameMonth, isSameYear, max, min } from 'date-fns';
+import { addMonths, addYears, isAfter, isSameMonth, isSameYear, max, min } from 'date-fns';
 
 import { CalendarProps } from '../../../calendar/interfaces';
 import {
@@ -36,9 +36,9 @@ function isVisible(date: Date, baseDate: Date, isSingleGrid: boolean, granularit
     return isSame(date, baseDate);
   }
 
-  const previous = add(baseDate, -1);
+  const next = add(baseDate, 1);
 
-  return isSame(date, previous) || isSame(date, baseDate);
+  return isSame(date, baseDate) || isSame(date, next);
 }
 
 export const Grids = ({
@@ -90,12 +90,12 @@ export const Grids = ({
 
   useEffect(() => {
     if (focusedDate && !isVisible(focusedDate, baseDate, isSingleGrid, granularity)) {
-      const direction = isAfter(focusedDate, baseDate) ? -1 : 1;
+      const direction = isAfter(focusedDate, baseDate) ? 0 : -1;
 
       const newPage = !isSingleGrid && direction === -1 ? addPages(baseDate, -1) : baseDate;
       const nearestBaseDate = getBase(newPage, isDateFocusable);
 
-      const newFocusedDate = findDateToFocus(focusedDate, nearestBaseDate, isDateFocusable);
+      const newFocusedDate = findDateToFocus(focusedDate, nearestBaseDate, isDateFocusable, isSingleGrid);
 
       onFocusedDateChange(newFocusedDate);
     }
@@ -132,8 +132,8 @@ export const Grids = ({
     const updatedDateIsVisible = isVisible(updatedFocusDate, baseDate, isSingleGrid, granularity);
 
     if (!updatedDateIsVisible) {
-      const newPageIsOnLeftSide = !isSingleGrid && isBefore(updatedFocusDate, baseDate);
-      onPageChange(newPageIsOnLeftSide ? addPages(updatedFocusDate, 1) : updatedFocusDate);
+      const newPageIsOnRightSide = !isSingleGrid && isAfter(updatedFocusDate, baseDate);
+      onPageChange(newPageIsOnRightSide ? addPages(updatedFocusDate, -1) : updatedFocusDate);
     }
     onFocusedDateChange(updatedFocusDate);
   };
@@ -195,7 +195,7 @@ export const Grids = ({
             {...sharedGridProps}
             padDates={'before'}
             className={testutilStyles['first-grid']}
-            baseDate={addPages(baseDate, -1)}
+            baseDate={baseDate}
             ariaLabelledby={`${headingIdPrefix}-prev${pageUnit}`}
             referrerId={referrerId}
           />
@@ -204,7 +204,7 @@ export const Grids = ({
           {...sharedGridProps}
           padDates={'after'}
           className={testutilStyles['second-grid']}
-          baseDate={baseDate}
+          baseDate={addPages(baseDate, 1)}
           ariaLabelledby={`${headingIdPrefix}-current${pageUnit}`}
           referrerId={referrerId}
         />

--- a/src/date-range-picker/calendar/grids/index.tsx
+++ b/src/date-range-picker/calendar/grids/index.tsx
@@ -190,24 +190,24 @@ export const Grids = ({
   return (
     <div ref={containerRef} onFocus={onGridFocus} onBlur={onGridBlur}>
       <InternalSpaceBetween size="xs" direction="horizontal">
+        <Grid
+          {...sharedGridProps}
+          padDates={'before'}
+          className={testutilStyles['first-grid']}
+          baseDate={baseDate}
+          ariaLabelledby={`${headingIdPrefix}-prev${pageUnit}`}
+          referrerId={referrerId}
+        />
         {!isSingleGrid && (
           <Grid
             {...sharedGridProps}
-            padDates={'before'}
-            className={testutilStyles['first-grid']}
-            baseDate={baseDate}
-            ariaLabelledby={`${headingIdPrefix}-prev${pageUnit}`}
+            padDates={'after'}
+            className={testutilStyles['second-grid']}
+            baseDate={addPages(baseDate, 1)}
+            ariaLabelledby={`${headingIdPrefix}-current${pageUnit}`}
             referrerId={referrerId}
           />
         )}
-        <Grid
-          {...sharedGridProps}
-          padDates={'after'}
-          className={testutilStyles['second-grid']}
-          baseDate={addPages(baseDate, 1)}
-          ariaLabelledby={`${headingIdPrefix}-current${pageUnit}`}
-          referrerId={referrerId}
-        />
       </InternalSpaceBetween>
     </div>
   );

--- a/src/date-range-picker/calendar/header/index.tsx
+++ b/src/date-range-picker/calendar/header/index.tsx
@@ -36,11 +36,11 @@ export default function CalendarHeader({
   const i18n = useInternalI18n('date-range-picker');
   const isMonthPicker = granularity === 'month';
   const renderLabel = isMonthPicker ? renderYear : renderMonthAndYear;
-  const prevPageHeaderLabel = renderLabel(
+  const firstPageHeaderLabel = renderLabel(locale, baseDate);
+  const secondPageHeaderLabel = renderLabel(
     locale,
-    add(baseDate, granularity === 'month' ? { years: -1 } : { months: -1 })
+    add(baseDate, granularity === 'month' ? { years: 1 } : { months: 1 })
   );
-  const currentPageHeaderLabel = renderLabel(locale, baseDate);
   const pageUnit = isMonthPicker ? 'year' : 'month';
 
   return (
@@ -56,11 +56,11 @@ export default function CalendarHeader({
         <h2 className={styles['calendar-header-pages-wrapper']}>
           {!isSingleGrid && (
             <span className={styles['calendar-header-page']} id={`${headingIdPrefix}-prev${pageUnit}`}>
-              {prevPageHeaderLabel}
+              {firstPageHeaderLabel}
             </span>
           )}
           <span className={styles['calendar-header-page']} id={`${headingIdPrefix}-current${pageUnit}`}>
-            {currentPageHeaderLabel}
+            {secondPageHeaderLabel}
           </span>
         </h2>
         <NextPageButton
@@ -72,7 +72,7 @@ export default function CalendarHeader({
         />
       </div>
       <InternalLiveRegion hidden={true}>
-        {isSingleGrid ? currentPageHeaderLabel : `${prevPageHeaderLabel}, ${currentPageHeaderLabel}`}
+        {isSingleGrid ? secondPageHeaderLabel : `${firstPageHeaderLabel}, ${secondPageHeaderLabel}`}
       </InternalLiveRegion>
     </>
   );

--- a/src/date-range-picker/calendar/header/index.tsx
+++ b/src/date-range-picker/calendar/header/index.tsx
@@ -54,14 +54,14 @@ export default function CalendarHeader({
           onChangePage={onChangePage}
         />
         <h2 className={styles['calendar-header-pages-wrapper']}>
+          <span className={styles['calendar-header-page']} id={`${headingIdPrefix}-prev${pageUnit}`}>
+            {firstPageHeaderLabel}
+          </span>
           {!isSingleGrid && (
-            <span className={styles['calendar-header-page']} id={`${headingIdPrefix}-prev${pageUnit}`}>
-              {firstPageHeaderLabel}
+            <span className={styles['calendar-header-page']} id={`${headingIdPrefix}-current${pageUnit}`}>
+              {secondPageHeaderLabel}
             </span>
           )}
-          <span className={styles['calendar-header-page']} id={`${headingIdPrefix}-current${pageUnit}`}>
-            {secondPageHeaderLabel}
-          </span>
         </h2>
         <NextPageButton
           ariaLabel={i18n(

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -53,6 +53,7 @@ export default function DateRangePickerCalendar({
   customAbsoluteRangeControl,
   granularity = 'day',
   referrerId,
+  multiGridStartPeriod,
 }: DateRangePickerCalendarProps) {
   const isSingleGrid = useMobile();
   const isMonthPicker = granularity === 'month';
@@ -67,24 +68,24 @@ export default function DateRangePickerCalendar({
   const addPage = isMonthPicker ? addYears : addMonths;
   const startOfPage = isMonthPicker ? startOfYear : startOfMonth;
   const findItemToFocus = isMonthPicker ? findMonthToFocus : findDateToFocus;
-  const [currentPage, setCurrentPage] = useState(() => findPageToDisplay(value, isSingleGrid));
+  const [currentPage, setCurrentPage] = useState(() => findPageToDisplay(value, isSingleGrid, multiGridStartPeriod));
   const [focusedDate, setFocusedDate] = useState<Date | null>(() => {
     if (value.start.date) {
       const startDate = parseDate(value.start.date);
       if (isSamePage(startDate, currentPage)) {
         return startDate;
       }
-      if (!isSingleGrid && isSamePage(startDate, addPage(currentPage, -1))) {
+      if (!isSingleGrid && isSamePage(startDate, addPage(currentPage, 1))) {
         return startDate;
       }
     }
-    return findItemToFocus(parseDate(value.start.date), currentPage, isDateEnabled);
+    return findItemToFocus(parseDate(value.start.date), currentPage, isDateEnabled, isSingleGrid);
   });
 
   const updateCurrentPage = (startDate: string) => {
     if ((isMonthPicker && startDate.length >= 4) || startDate.length >= 8) {
       const newCurrentPage = startOfPage(parseDate(startDate));
-      setCurrentPage(isSingleGrid ? newCurrentPage : addPage(newCurrentPage, 1));
+      setCurrentPage(newCurrentPage);
     }
   };
 

--- a/src/date-range-picker/calendar/interfaces.ts
+++ b/src/date-range-picker/calendar/interfaces.ts
@@ -56,6 +56,7 @@ export interface DateRangePickerCalendarProps
   setValue: React.Dispatch<React.SetStateAction<DateRangePickerProps.PendingAbsoluteValue>>;
   i18nStrings?: RangeCalendarI18nStrings;
   referrerId?: string;
+  multiGridStartPeriod: DateRangePickerProps.StartPeriod;
 }
 
 export interface RangeInputsProps

--- a/src/date-range-picker/calendar/utils.ts
+++ b/src/date-range-picker/calendar/utils.ts
@@ -6,16 +6,30 @@ import { parseDate } from '../../internal/utils/date-time';
 import { DateRangePickerProps } from '../interfaces';
 import { RangeCalendarI18nStrings } from './interfaces';
 
+function isVisibleMonth(dateLeft: number | Date, dateRight: number | Date, isSingleGrid: boolean) {
+  if (isSingleGrid) {
+    return isSameMonth(dateLeft, dateRight);
+  }
+  return isSameMonth(dateLeft, dateRight) || isSameMonth(dateLeft, addMonths(dateRight, 1));
+}
+function isVisibleYear(dateLeft: number | Date, dateRight: number | Date, isSingleGrid: boolean) {
+  if (isSingleGrid) {
+    return isSameYear(dateLeft, dateRight);
+  }
+  return isSameYear(dateLeft, dateRight) || isSameYear(dateLeft, addYears(dateRight, 1));
+}
+
 export function findDateToFocus(
   selected: Date | null,
   baseDate: Date,
-  isDateEnabled: DateRangePickerProps.IsDateEnabledFunction
+  isDateEnabled: DateRangePickerProps.IsDateEnabledFunction,
+  isSingleGrid: boolean
 ) {
-  if (selected && isDateEnabled(selected) && isSameMonth(selected, baseDate)) {
+  if (selected && isDateEnabled(selected) && isVisibleMonth(selected, baseDate, isSingleGrid)) {
     return selected;
   }
   const today = new Date();
-  if (isDateEnabled(today) && isSameMonth(today, baseDate)) {
+  if (isDateEnabled(today) && isVisibleMonth(today, baseDate, isSingleGrid)) {
     return today;
   }
   if (isDateEnabled(baseDate)) {
@@ -27,14 +41,15 @@ export function findDateToFocus(
 export function findMonthToFocus(
   selected: Date | null,
   baseDate: Date,
-  isMonthEnabled: DateRangePickerProps.IsDateEnabledFunction
+  isMonthEnabled: DateRangePickerProps.IsDateEnabledFunction,
+  isSingleGrid: boolean
 ) {
-  if (selected && isMonthEnabled(selected) && isSameYear(selected, baseDate)) {
+  if (selected && isMonthEnabled(selected) && isVisibleYear(selected, baseDate, isSingleGrid)) {
     return selected;
   }
 
   const today = new Date();
-  if (isMonthEnabled(today) && isSameYear(today, baseDate)) {
+  if (isMonthEnabled(today) && isVisibleYear(today, baseDate, isSingleGrid)) {
     return today;
   }
   if (isMonthEnabled(baseDate)) {
@@ -43,32 +58,74 @@ export function findMonthToFocus(
   return null;
 }
 
-export function findMonthToDisplay(value: DateRangePickerProps.PendingAbsoluteValue, isSingleGrid: boolean) {
-  if (value.start.date) {
+function calculateEffectiveStartPeriod(
+  startPeriod: DateRangePickerProps.StartPeriod,
+  value: DateRangePickerProps.PendingAbsoluteValue,
+  isSamePeriod: (date1: Date, date2: Date) => boolean
+): 'current' | 'previous' {
+  if (startPeriod === 'current') {
+    return 'current';
+  }
+
+  // 'auto' always resolves to 'current' when a date is selected
+  if ((value.start.date || value.end.date) && startPeriod === 'auto') {
+    return 'current';
+  }
+
+  // Override 'previous' to 'current' when the range spans multiple periods
+  // to ensure as much of the range is visible as possible
+  if (value.start.date && value.end.date) {
     const startDate = parseDate(value.start.date);
-    if (isSingleGrid) {
-      return startOfMonth(startDate);
+    const endDate = parseDate(value.end.date);
+    if (!isSamePeriod(startDate, endDate)) {
+      return 'current';
     }
-    return startOfMonth(addMonths(startDate, 1));
   }
-  if (value.end.date) {
-    return startOfMonth(parseDate(value.end.date));
-  }
-  return startOfMonth(Date.now());
+
+  return 'previous';
 }
 
-export function findYearToDisplay(value: DateRangePickerProps.PendingAbsoluteValue, isSingleGrid: boolean) {
-  if (value.start.date) {
-    const startDate = parseDate(value.start.date);
-    if (isSingleGrid) {
-      return startOfYear(startDate);
-    }
-    return startOfYear(addYears(startDate, 1));
+function calculateDisplayOffset(isSingleGrid: boolean, startPeriod: DateRangePickerProps.StartPeriod): number {
+  if (isSingleGrid) {
+    return 0;
   }
-  if (value.end.date) {
-    return startOfYear(parseDate(value.end.date));
-  }
-  return startOfYear(Date.now());
+
+  return startPeriod === 'current' ? 0 : -1;
+}
+
+/**
+ * Generic function to find which period (month or year) to display in the calendar.
+ */
+function findPeriodToDisplay(
+  value: DateRangePickerProps.PendingAbsoluteValue,
+  isSingleGrid: boolean,
+  startPeriod: DateRangePickerProps.StartPeriod,
+  addPeriods: (date: Date | number, amount: number) => Date,
+  startOfPeriod: (date: Date) => Date,
+  isSamePeriod: (date1: Date, date2: Date) => boolean
+): Date {
+  const effectiveStartPeriod = calculateEffectiveStartPeriod(startPeriod, value, isSamePeriod);
+  const offset = calculateDisplayOffset(isSingleGrid, effectiveStartPeriod);
+  const date =
+    (value.start.date && parseDate(value.start.date)) || (value.end.date && parseDate(value.end.date)) || Date.now();
+
+  return startOfPeriod(addPeriods(date, offset));
+}
+
+export function findMonthToDisplay(
+  value: DateRangePickerProps.PendingAbsoluteValue,
+  isSingleGrid: boolean,
+  startPeriod: DateRangePickerProps.StartPeriod
+) {
+  return findPeriodToDisplay(value, isSingleGrid, startPeriod, addMonths, startOfMonth, isSameMonth);
+}
+
+export function findYearToDisplay(
+  value: DateRangePickerProps.PendingAbsoluteValue,
+  isSingleGrid: boolean,
+  startPeriod: DateRangePickerProps.StartPeriod
+) {
+  return findPeriodToDisplay(value, isSingleGrid, startPeriod, addYears, startOfYear, isSameYear);
 }
 
 export const generateI18NFallbackKey = (isMonthPicker: boolean, isDateOnly: boolean) => {

--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -52,8 +52,9 @@ interface DateRangePickerDropdownProps
         | 'i18nStrings'
         | 'customRelativeRangeUnits'
         | 'dateDisabledReason'
+        | 'absoluteMultiGridStartPeriod'
       >,
-      'absoluteFormat' | 'timeInputFormat'
+      'absoluteFormat' | 'timeInputFormat' | 'absoluteMultiGridStartPeriod'
     >,
     Pick<CalendarProps, 'granularity'> {
   onClear: () => void;
@@ -93,6 +94,7 @@ export function DateRangePickerDropdown({
   renderRelativeRangeContent,
   granularity = 'day',
   referrerId,
+  absoluteMultiGridStartPeriod,
 }: DateRangePickerDropdownProps) {
   const i18n = useInternalI18n('date-range-picker');
   const isMonthPicker = granularity === 'month';
@@ -219,6 +221,7 @@ export function DateRangePickerDropdown({
                       customAbsoluteRangeControl={customAbsoluteRangeControl}
                       granularity={granularity}
                       referrerId={referrerId}
+                      multiGridStartPeriod={absoluteMultiGridStartPeriod}
                     />
                   )}
 

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -117,6 +117,7 @@ const DateRangePicker = React.forwardRef(
       customRelativeRangeUnits,
       renderRelativeRangeContent,
       granularity = 'day',
+      absoluteMultiGridStartPeriod = 'auto',
       ...rest
     }: DateRangePickerProps,
     ref: Ref<DateRangePickerProps.Ref>
@@ -362,6 +363,7 @@ const DateRangePicker = React.forwardRef(
                   renderRelativeRangeContent={renderRelativeRangeContent}
                   granularity={granularity}
                   referrerId={referrerId}
+                  absoluteMultiGridStartPeriod={absoluteMultiGridStartPeriod}
                 />
               )}
             </ResetContextsForModal>

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -213,6 +213,15 @@ export interface DateRangePickerProps
    * Adds `aria-label` to the trigger and dropdown.
    */
   ariaLabel?: string;
+
+  /**
+   * Specifies whether to start with the previous or current period (month or year)
+   * when multiple calendar grids are displayed in absolute mode.
+   *
+   * Defaults to 'auto', which starts with previous if no date is selected,
+   * or current if a selection is present.
+   */
+  absoluteMultiGridStartPeriod?: DateRangePickerProps.StartPeriod;
 }
 
 export namespace DateRangePickerProps {
@@ -609,6 +618,8 @@ export namespace DateRangePickerProps {
   export type DateInputFormat = EditableDateFormat | undefined;
 
   export type TimeInputFormat = TimeInputProps.Format;
+
+  export type StartPeriod = 'previous' | 'current' | 'auto';
 }
 
 export type DayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;


### PR DESCRIPTION
### Description

Allow switching between showing previous or next month alongside the current/selected month, when in 2-grid mode.

Related links, issue #, if available: AWSUI-41171

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
