### PR TITLE
feat: Support JSX content in CopyToClipboard component's textToDisplay prop

### DIFF
--- a/pages/copy-to-clipboard/permutations.page.tsx
+++ b/pages/copy-to-clipboard/permutations.page.tsx
@@ -32,6 +32,7 @@ const permutations = createPermutations<CopyToClipboardProps>([
     ],
     disabled: [false, true],
     variant: ['inline'],
+    copyButtonText: ['Copy to clipboard'],
     textToCopy: ['Lorem ipsum dolor sit amet.'],
     copySuccessText: ['Text copied successfully'],
     copyErrorText: ['Copy failed.'],

--- a/pages/copy-to-clipboard/permutations.page.tsx
+++ b/pages/copy-to-clipboard/permutations.page.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import { CopyToClipboard, CopyToClipboardProps } from '~components';
+import { CopyToClipboard, CopyToClipboardProps, Popover } from '~components';
 
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
@@ -20,6 +20,21 @@ const permutations = createPermutations<CopyToClipboardProps>([
     textToDisplay: ['Lorem ipsum dolor sit amet consectetur adipiscing elit'],
     copyErrorText: ['Copy failed.'],
     copyButtonText: ['Copy to clipboard'],
+  },
+  {
+    textToDisplay: [
+      <Popover key={1} content="Popover" triggerType="text">
+        Inline block popover
+      </Popover>,
+      <Popover key={2} content="Popover" triggerType="text-inline">
+        Inline text popover
+      </Popover>,
+    ],
+    disabled: [false, true],
+    variant: ['inline'],
+    textToCopy: ['Lorem ipsum dolor sit amet.'],
+    copySuccessText: ['Text copied successfully'],
+    copyErrorText: ['Copy failed.'],
   },
 ]);
 

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -10031,12 +10031,6 @@ Enable this setting if you need the popover to ignore its parent stacking contex
       "type": "string",
     },
     {
-      "description": "The text content to display next to the copy button when \`variant="inline"\`. If not provided, \`textToCopy\` will be displayed instead.",
-      "name": "textToDisplay",
-      "optional": true,
-      "type": "string",
-    },
-    {
       "defaultValue": "'button'",
       "description": "Determines the general styling of the copy button as follows:
 
@@ -10059,7 +10053,13 @@ Defaults to \`button\`.",
       "type": "string",
     },
   ],
-  "regions": [],
+  "regions": [
+    {
+      "description": "The text content to display next to the copy button when \`variant="inline"\`. If not provided, \`textToCopy\` will be displayed instead.",
+      "isDefault": false,
+      "name": "textToDisplay",
+    },
+  ],
   "releaseStatus": "stable",
 }
 `;

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -10055,7 +10055,7 @@ Defaults to \`button\`.",
   ],
   "regions": [
     {
-      "description": "The text content to display next to the copy button when \`variant="inline"\`. If not provided, \`textToCopy\` will be displayed instead.",
+      "description": "The content to display next to the copy button when \`variant="inline"\`. If not provided, \`textToCopy\` will be displayed instead.",
       "isDefault": false,
       "name": "textToDisplay",
     },

--- a/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
+++ b/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
@@ -77,6 +77,37 @@ describe('CopyToClipboard', () => {
     expect(wrapper.findTextToCopy()!.getElement().textContent).toBe('Text to copy');
   });
 
+  test('renders JSX in textToDisplay when variant="inline"', () => {
+    const { container } = render(
+      <CopyToClipboard
+        {...defaultProps}
+        variant="inline"
+        textToDisplay={
+          <>
+            styled <strong>content</strong>
+          </>
+        }
+      />
+    );
+    const wrapper = createWrapper(container).findCopyToClipboard()!;
+    const displayedEl = wrapper.findDisplayedText()!.getElement();
+    expect(displayedEl.innerHTML).toBe('styled <strong>content</strong>');
+  });
+
+  test('renders textToCopy for variant="inline" when textToDisplay is explicitly undefined', () => {
+    const { container } = render(<CopyToClipboard {...defaultProps} variant="inline" textToDisplay={undefined} />);
+    const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+    expect(wrapper.findDisplayedText()!.getElement().textContent).toBe('Text to copy');
+  });
+
+  test('renders null for variant="inline" when textToDisplay is explicitly null', () => {
+    const { container } = render(<CopyToClipboard {...defaultProps} variant="inline" textToDisplay={null} />);
+    const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+    expect(wrapper.findDisplayedText()!.getElement().textContent).toBe('');
+  });
+
   test('renders an inline button with custom text to display and separate text to copy', () => {
     const mockedWriteText = jest.fn().mockResolvedValue(act(() => new Promise(() => {}))); // The act here is just to prevent console warnings when tests run
 

--- a/src/copy-to-clipboard/interfaces.ts
+++ b/src/copy-to-clipboard/interfaces.ts
@@ -34,7 +34,7 @@ export interface CopyToClipboardProps extends BaseComponentProps {
   /**
    * The text content to display next to the copy button when `variant="inline"`. If not provided, `textToCopy` will be displayed instead.
    */
-  textToDisplay?: string;
+  textToDisplay?: React.ReactNode;
 
   /**
    * The message shown when the text is copied successfully.
@@ -59,6 +59,7 @@ export interface CopyToClipboardProps extends BaseComponentProps {
    * Renders the copy to clipboard button as disabled and prevents clicks.
    */
   disabled?: boolean;
+
   /**
    * Provides a reason why the copy to clipboard button is disabled (only when `disabled` is `true`).
    * If provided, the copy to clipboard button becomes focusable.

--- a/src/copy-to-clipboard/interfaces.ts
+++ b/src/copy-to-clipboard/interfaces.ts
@@ -32,7 +32,7 @@ export interface CopyToClipboardProps extends BaseComponentProps {
   textToCopy: string;
 
   /**
-   * The text content to display next to the copy button when `variant="inline"`. If not provided, `textToCopy` will be displayed instead.
+   * The content to display next to the copy button when `variant="inline"`. If not provided, `textToCopy` will be displayed instead.
    */
   textToDisplay?: React.ReactNode;
 

--- a/src/copy-to-clipboard/internal.tsx
+++ b/src/copy-to-clipboard/internal.tsx
@@ -122,7 +122,7 @@ export default function InternalCopyToClipboard({
         <span className={styles['inline-container']}>
           <span className={styles['inline-container-trigger']}>{trigger}</span>
           <span className={clsx(testStyles['text-to-display'], testStyles['text-to-copy'])}>
-            {textToDisplay ?? textToCopy}
+            {textToDisplay !== undefined ? textToDisplay : textToCopy}
           </span>
         </span>
       ) : (


### PR DESCRIPTION
### Description

See issue for context; people want to put more complex things (i.e. popovers) inside of the inline copy-to-clipboard's content slot. I guess if the button is blue, it's enough of an affordance for sighted users that it's distinctly clickable from the thing in the slot — and for popovers specifically, I guess the fact that the underline doesn't include the icon works. There are definitely ways of making this visually confusing and inaccessible (e.g. secondary or button links) but it is what it is; the solution is just to not put a thing in there that makes it inaccessible (usage guideline addition, maybe, but popover with its underline and body text really is a special case).

Related links, issue #, if available: AWSUI-61686

### How has this been tested?

Added some unit tests. Added a permutation test specifically for the popover use-case, just in case.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
