### PR TITLE
fix: allow text in read-only components to be selected

### DIFF
--- a/pages/date-range-picker/common.tsx
+++ b/pages/date-range-picker/common.tsx
@@ -17,6 +17,7 @@ interface DateRangePickerPageSettings {
   showRelativeOptions?: boolean;
   invalid?: boolean;
   warning?: boolean;
+  readOnly?: boolean;
   rangeSelectorMode?: DateRangePickerProps.RangeSelectorMode;
   absoluteFormat?: DateRangePickerProps.AbsoluteFormat;
   dateInputFormat?: DateRangePickerProps['dateInputFormat'];
@@ -36,6 +37,7 @@ const defaultSettings: Required<DateRangePickerPageSettings> = {
   showRelativeOptions: true,
   invalid: false,
   warning: false,
+  readOnly: false,
   rangeSelectorMode: 'default',
   absoluteFormat: 'iso',
   dateInputFormat: 'iso',
@@ -81,6 +83,7 @@ export function useDateRangePickerSettings(
   const showRelativeOptions = parseBoolean(def('showRelativeOptions'), urlParams.showRelativeOptions);
   const invalid = parseBoolean(def('invalid'), urlParams.invalid);
   const warning = parseBoolean(def('warning'), urlParams.warning);
+  const readOnly = parseBoolean(def('readOnly'), urlParams.readOnly);
   const rangeSelectorMode = urlParams.rangeSelectorMode ?? def('rangeSelectorMode');
   const absoluteFormat = urlParams.absoluteFormat ?? def('absoluteFormat');
   const timeInputFormat = urlParams.timeInputFormat ?? def('timeInputFormat');
@@ -98,6 +101,7 @@ export function useDateRangePickerSettings(
     showRelativeOptions,
     invalid,
     warning,
+    readOnly,
     rangeSelectorMode,
     absoluteFormat,
     dateInputFormat,
@@ -204,6 +208,7 @@ export function useDateRangePickerSettings(
     granularity: monthOnly ? 'month' : 'day',
     invalid,
     warning,
+    readOnly,
     rangeSelectorMode,
     absoluteFormat,
     dateInputFormat,
@@ -251,6 +256,7 @@ export function Settings({
     showRelativeOptions,
     invalid,
     warning,
+    readOnly,
     rangeSelectorMode,
     absoluteFormat,
     dateInputFormat,
@@ -380,6 +386,9 @@ export function Settings({
         </Checkbox>
         <Checkbox checked={warning} onChange={({ detail }) => setSettings({ warning: detail.checked })}>
           Warning
+        </Checkbox>
+        <Checkbox checked={readOnly} onChange={({ detail }) => setSettings({ readOnly: detail.checked })}>
+          Read-only
         </Checkbox>
         <Checkbox
           checked={expandToViewport}

--- a/pages/file-token-group/permutations.page.tsx
+++ b/pages/file-token-group/permutations.page.tsx
@@ -38,6 +38,11 @@ const permutations = createPermutations<Omit<FileTokenGroupProps, 'onDismiss'>>(
     alignment: ['horizontal', 'vertical'],
     limit: [undefined, 0],
   },
+  {
+    items: [[{ file: file1 }, { file: file2 }]],
+    readOnly: [true],
+    alignment: ['horizontal', 'vertical'],
+  },
 ]);
 
 export default function FileTokenGroupPermutations() {

--- a/pages/multiselect/multiselect.sync.example.page.tsx
+++ b/pages/multiselect/multiselect.sync.example.page.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import Box from '~components/box';
+import Checkbox from '~components/checkbox';
 import { NonCancelableCustomEvent } from '~components/interfaces';
 import Multiselect, { MultiselectProps } from '~components/multiselect';
 import { SelectProps } from '~components/select';
@@ -37,10 +38,16 @@ export default function MultiselectPage() {
     selectableOptions[15],
   ]);
   const [selectedOptions2, setSelectedOptions2] = React.useState<MultiselectProps.Options>([]);
+  const [readOnly, setReadOnly] = React.useState(false);
 
   return (
     <article>
       <Box padding="l">
+        <Box padding="s">
+          <Checkbox checked={readOnly} onChange={({ detail }) => setReadOnly(detail.checked)}>
+            Read-only
+          </Checkbox>
+        </Box>
         <Box padding="s">
           <Box variant="h1">Multiselect with filteringType = none</Box>
           <Box margin={{ bottom: 'xxs' }} color="text-label">
@@ -59,6 +66,7 @@ export default function MultiselectPage() {
             noMatch={<b>No match</b>}
             loadingText="Fetching equipment"
             selectedAriaLabel="Selected"
+            readOnly={readOnly}
             onBlur={onBlur}
             onFocus={onFocus}
             onLoadItems={onLoadItems}
@@ -91,6 +99,7 @@ export default function MultiselectPage() {
             noMatch={<b>No match</b>}
             loadingText="Fetching equipment"
             selectedAriaLabel="Selected"
+            readOnly={readOnly}
             onBlur={onBlur}
             onFocus={onFocus}
             onLoadItems={onLoadItems}

--- a/pages/select/select.sync.example.page.tsx
+++ b/pages/select/select.sync.example.page.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import Box from '~components/box';
+import Checkbox from '~components/checkbox';
 import Select from '~components/select';
 
 import { generateOptions } from './generate-options';
@@ -24,10 +25,16 @@ const onBlur = () => {
 export default function SelectPage() {
   const [selectedOption1, setSelectedOption1] = React.useState(null);
   const [selectedOption2, setSelectedOption2] = React.useState(null);
+  const [readOnly, setReadOnly] = React.useState(false);
 
   return (
     <article>
       <Box padding="l">
+        <Box padding="s">
+          <Checkbox checked={readOnly} onChange={({ detail }) => setReadOnly(detail.checked)}>
+            Read-only
+          </Checkbox>
+        </Box>
         <Box padding="s">
           <Box variant="h1">Select with filteringType = none</Box>
           <Box margin={{ bottom: 'xxs' }} color="text-label">
@@ -46,6 +53,7 @@ export default function SelectPage() {
             noMatch={<b>No match</b>}
             loadingText="Fetching equipment"
             selectedAriaLabel="Selected"
+            readOnly={readOnly}
             onBlur={onBlur}
             onFocus={onFocus}
             onLoadItems={onLoadItems}
@@ -75,6 +83,7 @@ export default function SelectPage() {
             noMatch={<b>No match</b>}
             loadingText="Fetching equipment"
             selectedAriaLabel="Selected"
+            readOnly={readOnly}
             onBlur={onBlur}
             onFocus={onFocus}
             onLoadItems={onLoadItems}

--- a/pages/token-group/simple.page.tsx
+++ b/pages/token-group/simple.page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 
 import Box from '~components/box';
+import Checkbox from '~components/checkbox';
 import TokenGroup, { TokenGroupProps } from '~components/token-group';
 
 const generateItems = (numberOfItems: number) => {
@@ -20,6 +21,7 @@ const i18nStrings: TokenGroupProps.I18nStrings = {
 
 export default function TokenGroupPage() {
   const [items, setItems] = useState(generateItems(10));
+  const [readOnly, setReadOnly] = useState(false);
 
   const onDismiss = (event: { detail: { itemIndex: number } }) => {
     const newItems = [...items];
@@ -30,7 +32,11 @@ export default function TokenGroupPage() {
   return (
     <Box padding="xl">
       <h1>Token Group</h1>
-      <TokenGroup items={items} onDismiss={onDismiss} i18nStrings={i18nStrings} limit={5} />
+      <Checkbox checked={readOnly} onChange={({ detail }) => setReadOnly(detail.checked)}>
+        Read-only
+      </Checkbox>
+      <br />
+      <TokenGroup items={items} onDismiss={onDismiss} i18nStrings={i18nStrings} limit={5} readOnly={readOnly} />
     </Box>
   );
 }

--- a/src/date-range-picker/__integ__/date-range-picker.test.ts
+++ b/src/date-range-picker/__integ__/date-range-picker.test.ts
@@ -98,4 +98,38 @@ describe('Date Range Picker', () => {
       }, granularity)
     );
   });
+
+  describe('Read-only mode', () => {
+    const setupReadOnlyTest = (testFn: (page: DateRangePickerPage, browser: WebdriverIO.Browser) => Promise<void>) => {
+      return useBrowser(async browser => {
+        const params = new URLSearchParams({ readOnly: 'true' });
+        const page = new DateRangePickerPage(createWrapper().findDateRangePicker().getElement(), browser);
+        await browser.url(`#/light/date-range-picker/with-value?${params}`);
+        await page.waitForLoad();
+        await testFn(page, browser);
+      });
+    };
+
+    test(
+      'trigger text is selectable',
+      setupReadOnlyTest(async (page, browser) => {
+        const triggerSelector = page.dateRangePickerTrigger;
+        const triggerText = await page.getTriggerText();
+        expect(triggerText).toContain('2018-01-09');
+
+        // Simulate a real user selection. Unlike programmatically adding a
+        // Range via the Selection API (which works regardless of CSS
+        // `user-select`), a double-click is gated by `user-select: text`
+        // and therefore actually exercises the fix.
+        const element = await browser.$(triggerSelector);
+        await element.doubleClick();
+
+        // Double-click selects a single word, so for a value like
+        // `2018-01-09T00:00:00Z` the selected text will just be `2018`.
+        const selectedText = await browser.execute(() => window.getSelection()?.toString());
+        expect(selectedText).not.toBeFalsy();
+        expect(triggerText).toContain(selectedText);
+      })
+    );
+  });
 });

--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -127,6 +127,10 @@ $calendar-header-color: awsui.$color-text-body-default;
 
 .label-text {
   @include styles.form-placeholder;
+  // Placeholder text is purely decorative and not intended to be interacted
+  // with. Disable selection so that it doesn't become selectable inside the
+  // read-only trigger (which enables text selection).
+  user-select: none;
 }
 
 .label-token-nowrap {

--- a/src/file-token-group/styles.scss
+++ b/src/file-token-group/styles.scss
@@ -138,9 +138,9 @@
   &.read-only {
     border-color: awsui.$color-border-input-disabled;
     background-color: awsui.$color-background-container-content;
-    pointer-events: none;
 
     > .dismiss-button {
+      pointer-events: none;
       color: awsui.$color-text-button-inline-icon-disabled;
 
       &:hover {

--- a/src/internal/components/button-trigger/styles.scss
+++ b/src/internal/components/button-trigger/styles.scss
@@ -105,6 +105,7 @@ $padding-block-inner-filtering-token: 0px;
   // should retain standard borders, only the icon changes
   &.readonly:not(&.disabled):not(&.in-filtering-token) {
     @include styles.form-readonly-element;
+    user-select: text;
   }
 
   &:focus {

--- a/src/internal/components/button-trigger/styles.scss
+++ b/src/internal/components/button-trigger/styles.scss
@@ -105,6 +105,12 @@ $padding-block-inner-filtering-token: 0px;
   // should retain standard borders, only the icon changes
   &.readonly:not(&.disabled):not(&.in-filtering-token) {
     @include styles.form-readonly-element;
+  }
+
+  // Allow selecting text (e.g. to copy the selected value) in all read-only
+  // button-triggers, including those inside filtering tokens. Individual
+  // placeholder elements opt out via `user-select: none`.
+  &.readonly:not(&.disabled) {
     user-select: text;
   }
 

--- a/src/select/parts/styles.scss
+++ b/src/select/parts/styles.scss
@@ -10,6 +10,10 @@
 
 .placeholder {
   @include styles.form-placeholder;
+  // Placeholder text is purely decorative and not intended to be interacted
+  // with. Disable selection so that it doesn't become selectable inside
+  // read-only triggers (which enable text selection).
+  user-select: none;
 }
 
 $checkbox-size: awsui.$size-control;

--- a/src/token/styles.scss
+++ b/src/token/styles.scss
@@ -109,10 +109,9 @@
 
 .token-box-readonly,
 .token-box-disabled {
-  pointer-events: none;
-
   > .dismiss-button {
     cursor: initial;
+    pointer-events: none;
   }
 }
 
@@ -126,6 +125,7 @@
 }
 
 .token-box-disabled {
+  pointer-events: none;
   border-color: var(#{custom-props.$tokenStyleBorderColorDisabled}, awsui.$color-border-control-disabled);
   background: var(#{custom-props.$tokenStyleBackgroundDisabled}, awsui.$color-background-container-content);
   color: awsui.$color-text-disabled;


### PR DESCRIPTION
Fixes #4411

This PR modifies the styles on `DateRangePicker`, `FileTokenGroup`, `Select` and `Multiselect` to make text selectable.

#### Testing

I've added a read-only toggle to the demo pages and was able to manually test each of these.

- _Changes are covered with new/existing unit tests?_ No
- _Changes are covered with new/existing integration tests?_ No

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
