### PR TITLE
chore: ESLint bans augmented ElementWrapper use in test utils

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -210,6 +210,21 @@ export default tsEslint.config(
     },
   },
   {
+    files: ['src/test-utils/dom/**/*.ts'],
+    rules: {
+      '@cloudscape-design/components/ban-files': [
+        'error',
+        [
+          {
+            pattern: './src/test-utils/dom/index.ts',
+            message:
+              "Do not import from the augmented ElementWrapper barrel '{{ path }}'. Use @cloudscape-design/test-utils-core/dom instead.",
+          },
+        ],
+      ],
+    },
+  },
+  {
     files: ['**/__integ__/**', '**/__motion__/**', '**/__a11y__/**'],
     rules: {
       // useBrowser is not a hook

--- a/src/test-utils/dom/hotspot/index.ts
+++ b/src/test-utils/dom/hotspot/index.ts
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { ComponentWrapper, createWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 
 import AnnotationWrapper from '../annotation';
-import createWrapper from '../index';
 
 import annotationStyles from '../../../annotation-context/annotation/styles.selectors.js';
 import hotspotStyles from '../../../hotspot/styles.selectors.js';

--- a/src/test-utils/dom/s3-resource-selector/index.ts
+++ b/src/test-utils/dom/s3-resource-selector/index.ts
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { ComponentWrapper, createWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 import { appendSelector } from '@cloudscape-design/test-utils-core/utils';
 
-import createWrapper from '../';
 import ButtonWrapper from '../button';
 import InputWrapper from '../input';
 import ModalWrapper from '../modal';


### PR DESCRIPTION
### Description

The test-utils wrapper can only use the core ElementWrapper type, but not the augmented version (with injected findButton(), findAllButtons(), findAlert(), etc.). This allows extensions of the library where certain components are removed from the exports and from the ElementWrapper accordingly.

More context here: NM53AzDnq6Bl

### How has this been tested?

* Manually checked the rule works by adding `import { ElementWrapper } from '../index'` to one of the dom wrappers.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
