### PR TITLE
fix: PromptInput adjusted height

### DIFF
--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -134,8 +134,9 @@ const InternalPromptInput = React.forwardRef(
     const caretControllerRef = useRef<CaretController | null>(null);
 
     const isRefresh = useVisualRefresh();
-    useDensityMode(textareaRef);
-    useDensityMode(editableElementRef);
+    const textareaDensityMode = useDensityMode(textareaRef);
+    const editableDensityMode = useDensityMode(editableElementRef);
+    const isCompactMode = (isTokenMode ? editableDensityMode : textareaDensityMode) === 'compact';
 
     const PADDING = isRefresh ? designTokens.spaceXxs : designTokens.spaceXxxs;
     const LINE_HEIGHT = designTokens.lineHeightBodyM;
@@ -154,18 +155,16 @@ const InternalPromptInput = React.forwardRef(
       }
 
       const scrollTop = element.scrollTop;
+      // this is required so the scrollHeight becomes dynamic, otherwise it will be locked at the highest value for the size it reached e.g. 500px
       element.style.height = 'auto';
 
-      const minRowsHeight = isTokenMode
-        ? `calc(${minRows} * (${LINE_HEIGHT} + ${PADDING} / 2) + ${PADDING})`
-        : `calc(${LINE_HEIGHT} + ${designTokens.spaceScaledXxs} * 2)`;
+      const minRowsHeight = `calc(${LINE_HEIGHT} +  ${designTokens.spaceScaledXxs} * 2)`;
       const scrollHeight = `calc(${element.scrollHeight}px)`;
 
       if (maxRows === -1) {
         element.style.height = `max(${scrollHeight}, ${minRowsHeight})`;
       } else {
-        const effectiveMaxRows = maxRows <= 0 ? DEFAULT_MAX_ROWS : maxRows;
-        const maxRowsHeight = `calc(${effectiveMaxRows} * (${LINE_HEIGHT} + ${PADDING} / 2) + ${PADDING})`;
+        const maxRowsHeight = `calc(${maxRows <= 0 ? DEFAULT_MAX_ROWS : maxRows} * (${LINE_HEIGHT} + ${PADDING} / 2) + ${PADDING})`;
         element.style.height = `min(max(${scrollHeight}, ${minRowsHeight}), ${maxRowsHeight})`;
       }
 
@@ -180,7 +179,7 @@ const InternalPromptInput = React.forwardRef(
       } else {
         adjustInputHeight();
       }
-    }, [isTokenMode, tokens, adjustInputHeight, value]);
+    }, [isTokenMode, tokens, adjustInputHeight, value, isCompactMode]);
 
     const plainTextValue = isTokenMode
       ? tokensToText

--- a/src/prompt-input/styles.scss
+++ b/src/prompt-input/styles.scss
@@ -168,6 +168,7 @@ $invalid-border-offset: constants.$invalid-control-left-padding;
   padding-inline: styles.$control-padding-horizontal;
 
   color: var(#{custom-props.$promptInputStyleColorDefault}, awsui.$color-text-body-default);
+  max-inline-size: 100%;
   inline-size: 100%;
   display: block;
   box-sizing: border-box;


### PR DESCRIPTION
### Description

Restores height calculations to match the original version before shortcuts were introduced

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
