### PR TITLE
feat: Allow arbitrary background colors in item card

### DIFF
--- a/src/item-card/styles.scss
+++ b/src/item-card/styles.scss
@@ -61,7 +61,7 @@ $action-padding-horizontal: awsui.$space-xxs;
   @include styles.styles-reset();
   box-sizing: border-box;
   position: relative;
-  background-color: var(#{custom-props.$styleItemCardBackgroundDefault}, awsui.$color-background-item-card);
+  background: var(#{custom-props.$styleItemCardBackgroundDefault}, awsui.$color-background-item-card);
   min-inline-size: 0;
   box-shadow: var(#{custom-props.$styleItemCardBoxShadowDefault}, awsui.$shadow-item-card);
 
@@ -85,7 +85,7 @@ $action-padding-horizontal: awsui.$space-xxs;
   }
 
   &.highlighted {
-    background-color: awsui.$color-background-item-selected;
+    background: awsui.$color-background-item-selected;
 
     &:before {
       border-block: solid awsui.$border-width-item-card-highlighted awsui.$color-border-item-card-highlighted;


### PR DESCRIPTION
### Description
This PR changes the `background-color` css prop to `background` to allow arbitrary background colors, e.g., `linear-gradient`.

Related links, issue #, if available: n/a

### How has this been tested?
- Manual tests
<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
