### PR TITLE
fix: Adds timeout cleanup for button dropdown tooltips

### DIFF
--- a/src/button-dropdown/__tests__/button-dropdown-disabled-reason.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-disabled-reason.test.tsx
@@ -167,7 +167,7 @@ describe('Button Dropdown - Disabled Reason', () => {
     });
   });
 
-  it('does not try to show a tooltip after unmount', () => {
+  it('does not attempt a state update after the component is unmounted', () => {
     const consoleError = jest.spyOn(console, 'error');
     const { wrapper, unmount } = renderOpenButtonDropdown(props);
     const menuItem = getMenuItemForId(wrapper, items[3].id!);
@@ -176,7 +176,7 @@ describe('Button Dropdown - Disabled Reason', () => {
     unmount();
     act(() => jest.advanceTimersByTime(1000));
 
-    // Expect no "Can't perform a React state update on an unmounted component" warning.
+    // Expect no "Can't perform a React state update on an unmounted component" error.
     expect(consoleError).not.toHaveBeenCalled();
     consoleError.mockRestore();
   });

--- a/src/button-dropdown/__tests__/button-dropdown-disabled-reason.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-disabled-reason.test.tsx
@@ -12,8 +12,7 @@ const renderOpenButtonDropdown = (props: ButtonDropdownProps) => {
   const renderResult = render(<ButtonDropdown {...props} />);
   const wrapper = createWrapper(renderResult.container).findButtonDropdown()!;
   wrapper.openDropdown();
-
-  return wrapper;
+  return { ...renderResult, wrapper };
 };
 
 const items: ButtonDropdownProps['items'] = [
@@ -69,27 +68,27 @@ describe('Button Dropdown - Disabled Reason', () => {
   });
 
   it('has no tooltip open by default', () => {
-    const wrapper = renderOpenButtonDropdown(props);
+    const { wrapper } = renderOpenButtonDropdown(props);
     expect(wrapper.findDisabledReason()).toBe(null);
   });
 
   it('has no aria-describedby by default', () => {
     const item = items[0];
-    const wrapper = renderOpenButtonDropdown(props);
+    const { wrapper } = renderOpenButtonDropdown(props);
     const menuItem = getMenuItemForId(wrapper, item.id!);
     expect(menuItem.getElement()).not.toHaveAttribute('aria-describedby');
   });
 
   it('has no aria-describedby without disabledReason', () => {
     const item = items[1];
-    const wrapper = renderOpenButtonDropdown(props);
+    const { wrapper } = renderOpenButtonDropdown(props);
     const menuItem = getMenuItemForId(wrapper, item.id!);
     expect(menuItem.getElement()).not.toHaveAttribute('aria-describedby');
   });
 
   it('has no tooltip without disabledReason', () => {
     const item = items[1];
-    const wrapper = renderOpenButtonDropdown(props);
+    const { wrapper } = renderOpenButtonDropdown(props);
     const menuItem = getMenuItemForId(wrapper, item.id!);
     act(() => {
       menuItem.focus();
@@ -99,7 +98,7 @@ describe('Button Dropdown - Disabled Reason', () => {
 
   it('has no tooltip without disabled flag', () => {
     const item = items[2];
-    const wrapper = renderOpenButtonDropdown(props);
+    const { wrapper } = renderOpenButtonDropdown(props);
     const menuItem = getMenuItemForId(wrapper, item.id!);
     act(() => {
       menuItem.focus();
@@ -121,13 +120,13 @@ describe('Button Dropdown - Disabled Reason', () => {
     });
 
     it('has hidden element with disabledReason', () => {
-      const wrapper = renderOpenButtonDropdown(props);
+      const { wrapper } = renderOpenButtonDropdown(props);
       const span = getItemById(wrapper, item.id!).find('span[hidden]')!;
       expect(span.getElement()).toContainHTML(item.disabledReason!);
     });
 
     it('open tooltip on focus', () => {
-      const wrapper = renderOpenButtonDropdown(props);
+      const { wrapper } = renderOpenButtonDropdown(props);
       const menuItem = getMenuItemForId(wrapper, item.id!);
       act(() => {
         menuItem.focus();
@@ -137,7 +136,7 @@ describe('Button Dropdown - Disabled Reason', () => {
     });
 
     it('closes tooltip on blur', () => {
-      const wrapper = renderOpenButtonDropdown(props);
+      const { wrapper } = renderOpenButtonDropdown(props);
       const menuItem = getMenuItemForId(wrapper, item.id!);
       act(() => {
         menuItem.focus();
@@ -153,7 +152,7 @@ describe('Button Dropdown - Disabled Reason', () => {
     });
 
     it('closes tooltip on Escape', () => {
-      const wrapper = renderOpenButtonDropdown(props);
+      const { wrapper } = renderOpenButtonDropdown(props);
       const menuItem = getMenuItemForId(wrapper, item.id!);
       act(() => {
         menuItem.focus();
@@ -166,6 +165,20 @@ describe('Button Dropdown - Disabled Reason', () => {
       });
       expect(wrapper.findDisabledReason()).toBe(null);
     });
+  });
+
+  it('does not try to show a tooltip after unmount', () => {
+    const consoleError = jest.spyOn(console, 'error');
+    const { wrapper, unmount } = renderOpenButtonDropdown(props);
+    const menuItem = getMenuItemForId(wrapper, items[3].id!);
+
+    act(() => menuItem.focus());
+    unmount();
+    act(() => jest.advanceTimersByTime(1000));
+
+    // Expect no "Can't perform a React state update on an unmounted component" warning.
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 });
 

--- a/src/button-dropdown/tooltip.tsx
+++ b/src/button-dropdown/tooltip.tsx
@@ -59,16 +59,28 @@ export default function Tooltip({ children, content, position = 'right', classNa
 }
 
 function useTooltipOpen(timeout: number) {
-  const timeoutRef = useRef<number>();
   const [isOpen, setIsOpen] = useState(false);
 
-  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+  // The delayed effect is aborted in case the component unmounts. We cannot use the conventional clearTimeout()
+  // as it causes cleanup of a legitimate state update when used with React 18+ strict mode.
+  const timeoutRef = useRef<number>();
+  const timeoutAbortRef = useRef(false);
+  useEffect(() => {
+    timeoutAbortRef.current = false;
+    return () => {
+      timeoutAbortRef.current = true;
+    };
+  }, []);
 
   const close = () => {
     clearTimeout(timeoutRef.current);
     setIsOpen(false);
   };
-  const open = () => setIsOpen(true);
+  const open = () => {
+    if (!timeoutAbortRef.current) {
+      setIsOpen(true);
+    }
+  };
   const openDelayed = () => {
     timeoutRef.current = setTimeout(open, timeout);
   };

--- a/src/button-dropdown/tooltip.tsx
+++ b/src/button-dropdown/tooltip.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { KeyboardEventHandler, useRef, useState } from 'react';
+import React, { KeyboardEventHandler, useEffect, useRef, useState } from 'react';
 
 import { Portal, useReducedMotion } from '@cloudscape-design/component-toolkit/internal';
 
@@ -59,16 +59,18 @@ export default function Tooltip({ children, content, position = 'right', classNa
 }
 
 function useTooltipOpen(timeout: number) {
-  const handle = useRef<number>();
+  const timeoutRef = useRef<number>();
   const [isOpen, setIsOpen] = useState(false);
 
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+
   const close = () => {
-    clearTimeout(handle.current);
+    clearTimeout(timeoutRef.current);
     setIsOpen(false);
   };
   const open = () => setIsOpen(true);
   const openDelayed = () => {
-    handle.current = setTimeout(open, timeout);
+    timeoutRef.current = setTimeout(open, timeout);
   };
   const onKeyDown: KeyboardEventHandler = e => {
     if (isOpen && isEscape(e.key)) {


### PR DESCRIPTION
### Description

The missing cleanup can cause React state update on an already un-mounted component, provoking warnings in test environments. The PR ensures the timeout is cleaned up in case the component un-mounts.

Rel: AWSUI-61903

### How has this been tested?

* New unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
