### PR TITLE
chore: Fix month start in single-calendar DRP

### DIFF
--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -1447,6 +1447,24 @@ describe('Date range picker', () => {
           expect(wrapper.findDropdown()!.findByClassName(testutilStyles['second-grid'])).toBeNull();
         });
 
+        testIf(granularity === 'day')('renders next month crossover days in mobile mode', () => {
+          const { wrapper } = renderDateRangePicker({
+            ...defaultProps,
+            granularity,
+            value: { type: 'absolute', startDate: '2020-03-02T05:00:00+08:45', endDate: '2020-03-12T13:05:21+08:45' },
+          });
+
+          wrapper.findTrigger().click();
+
+          expect(
+            wrapper
+              .findDropdown()!
+              .findAllByClassName(testutilStyles['calendar-week'])[4]
+              .getElement()
+              .querySelector('td:nth-child(6)')?.textContent
+          ).toBe('3April 3, 2020');
+        });
+
         test('header shows only one period in mobile mode', () => {
           const { wrapper } = renderDateRangePicker({
             ...defaultProps,

--- a/src/date-range-picker/calendar/grids/index.tsx
+++ b/src/date-range-picker/calendar/grids/index.tsx
@@ -192,7 +192,7 @@ export const Grids = ({
       <InternalSpaceBetween size="xs" direction="horizontal">
         <Grid
           {...sharedGridProps}
-          padDates={'before'}
+          padDates={isSingleGrid ? 'after' : 'before'}
           className={testutilStyles['first-grid']}
           baseDate={baseDate}
           ariaLabelledby={`${headingIdPrefix}-prev${pageUnit}`}


### PR DESCRIPTION
### Description

Restore previous behavior of date range picker in single-grid mode (#4370 caused a slight change)

Related links, issue #, if available: n/a

### How has this been tested?

Added new unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
