### PR TITLE
revert: "fix: re-export from internal path"

### DIFF
--- a/src/internal/components/dropdown/interfaces.ts
+++ b/src/internal/components/dropdown/interfaces.ts
@@ -1,3 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-export { OptionsFilteringType, OptionsLoadItemsDetail } from '../../../dropdown/interfaces';


### PR DESCRIPTION
Reverts cloudscape-design/components#4394. Packages in live should import from the public path now.