### PR TITLE
fix: Don't use disabled text color for disabled group titles

### DIFF
--- a/src/internal/components/option/styles.scss
+++ b/src/internal/components/option/styles.scss
@@ -23,7 +23,7 @@
   }
   &.parent {
     font-weight: bold;
-    &:not(.disabled):not(.highlighted) {
+    &:not(.highlighted) {
       color: awsui.$color-text-dropdown-group-label;
     }
   }

--- a/src/internal/components/selectable-item/styles.scss
+++ b/src/internal/components/selectable-item/styles.scss
@@ -125,6 +125,10 @@ $neg-divider-w: calc(-1 * #{$divider-w});
     }
   }
 
+  &.parent > .selectable-item-content {
+    color: awsui.$color-text-dropdown-group-label;
+  }
+
   &.disabled > .selectable-item-content {
     color: awsui.$color-text-dropdown-item-disabled;
   }
@@ -174,11 +178,6 @@ $neg-divider-w: calc(-1 * #{$divider-w});
   }
 
   &.parent {
-    &:not(.disabled) {
-      > .selectable-item-content {
-        color: awsui.$color-text-dropdown-group-label;
-      }
-    }
     &:not(.interactiveGroups) {
       @include divider-shadow(awsui.$color-border-dropdown-group, awsui.$color-border-dropdown-item-default);
       @include content-pad(0, 0);


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
