### PR TITLE
chore: Don't apply aria-expanded to side navigation links

### DIFF
--- a/src/side-navigation/__tests__/side-navigation.test.tsx
+++ b/src/side-navigation/__tests__/side-navigation.test.tsx
@@ -962,31 +962,6 @@ describe('SideNavigation', () => {
       expect(wrapper.findItemByIndex(1)?.findExpandableLinkGroup()?.findExpandedContent()).not.toBeTruthy();
     });
 
-    it('decorates the link with the accurate aria-expanded attribute', () => {
-      const wrapper = renderSideNavigation({
-        items: [
-          {
-            type: 'expandable-link-group',
-            text: 'Expandable Link Group',
-            href: '#/something',
-            defaultExpanded: true,
-            items: [],
-          },
-          {
-            type: 'expandable-link-group',
-            text: 'Expandable Link Group',
-            href: '#/something/else',
-            defaultExpanded: false,
-            items: [],
-          },
-        ],
-      });
-
-      expect(wrapper.findItemByIndex(1)?.findLink()?.getElement()).toHaveAttribute('aria-expanded', 'true');
-
-      expect(wrapper.findItemByIndex(2)?.findLink()?.getElement()).toHaveAttribute('aria-expanded', 'false');
-    });
-
     describe('when clicking on the title link', () => {
       it('gets expanded', () => {
         const wrapper = renderSideNavigation({

--- a/src/side-navigation/parts.tsx
+++ b/src/side-navigation/parts.tsx
@@ -266,10 +266,9 @@ function Divider({ variant = 'default', isPresentational = false }: DividerProps
 
 interface LinkProps extends BaseItemComponentProps {
   definition: SideNavigationProps.Link;
-  expanded?: boolean;
 }
 
-function Link({ definition, expanded, activeHref, fireFollow, position }: LinkProps) {
+function Link({ definition, activeHref, fireFollow, position }: LinkProps) {
   checkSafeUrl('SideNavigation', definition.href);
   const isActive = definition.href === activeHref;
   const i18n = useInternalI18n('link');
@@ -302,7 +301,6 @@ function Link({ definition, expanded, activeHref, fireFollow, position }: LinkPr
         className={clsx(styles.link, { [styles['link-active']]: isActive })}
         target={definition.external ? '_blank' : undefined}
         rel={definition.external ? 'noopener noreferrer' : undefined}
-        aria-expanded={expanded}
         aria-current={definition.href === activeHref ? 'page' : undefined}
         onClick={onClick}
         {...getAnalyticsMetadataAttribute(clickActionAnalyticsMetadata)}
@@ -482,7 +480,6 @@ function ExpandableLinkGroup({
       headerText={
         <Link
           definition={{ type: 'link', href: definition.href, text: definition.text }}
-          expanded={userExpanded ?? expanded}
           fireFollow={onHeaderFollow}
           fireChange={fireChange}
           activeHref={activeHref}


### PR DESCRIPTION
### Description

See ticket. The aria-expanded attribute is still applied to the expand/collapse icon button, so the information is still conveyed. The link doesn't control the aria-expanded state, so it's confusing.

Related links, issue #, if available: AWSUI-61885

### How has this been tested?

Removed a test. I don't want to add a test for a negative.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
