### PR TITLE
fix: associate selection inputs with section content

### DIFF
--- a/src/cards/__tests__/selection.test.tsx
+++ b/src/cards/__tests__/selection.test.tsx
@@ -7,6 +7,8 @@ import range from 'lodash/range';
 import Cards, { CardsProps } from '../../../lib/components/cards';
 import { CardsWrapper } from '../../../lib/components/test-utils/dom';
 
+import styles from '../../../lib/components/cards/styles.css.js';
+
 interface Item {
   description: string;
 }
@@ -88,6 +90,79 @@ describe('Cards selection', () => {
     it('should display radios', () => {
       wrapper = renderCards(<Cards<Item> {...props} selectionType={'single'} />).wrapper;
       expect(getCard(0)?.findSelectionArea()?.find('input[type="radio"]')).toBeTruthy();
+    });
+
+    describe('aria-describedby for section content', () => {
+      const cardDefinitionWithSections: CardsProps.CardDefinition<Item> = {
+        header: item => item.description,
+        sections: [
+          { id: 'desc', header: 'Description', content: item => `Description: ${item.description}` },
+          { id: 'extra', header: 'Extra', content: item => `Extra: ${item.description}` },
+        ],
+      };
+
+      it('adds aria-describedby to radio input pointing to section content elements', () => {
+        wrapper = renderCards(
+          <Cards<Item> {...props} selectionType={'single'} cardDefinition={cardDefinitionWithSections} />
+        ).wrapper;
+        const card = getCard(0);
+        const input = card.findSelectionArea()?.find('input')?.getElement();
+        const ariaDescribedby = input?.getAttribute('aria-describedby');
+        expect(ariaDescribedby).toBeTruthy();
+
+        // Each id in aria-describedby should correspond to a section-content element
+        const ids = ariaDescribedby!.split(' ');
+        expect(ids).toHaveLength(2);
+        ids.forEach(id => {
+          const el = document.getElementById(id);
+          expect(el).not.toBeNull();
+          expect(el).toHaveClass(styles['section-content']);
+        });
+      });
+
+      it('each card has its own unique section content IDs', () => {
+        wrapper = renderCards(
+          <Cards<Item> {...props} selectionType={'single'} cardDefinition={cardDefinitionWithSections} />
+        ).wrapper;
+        const card0Input = getCard(0).findSelectionArea()?.find('input')?.getElement();
+        const card1Input = getCard(1).findSelectionArea()?.find('input')?.getElement();
+
+        const ids0 = card0Input?.getAttribute('aria-describedby')?.split(' ') ?? [];
+        const ids1 = card1Input?.getAttribute('aria-describedby')?.split(' ') ?? [];
+
+        // IDs must not overlap between cards
+        const allIds = [...ids0, ...ids1];
+        expect(new Set(allIds).size).toBe(allIds.length);
+      });
+
+      it('does not add aria-describedby when there are no sections with content', () => {
+        const noContentDefinition: CardsProps.CardDefinition<Item> = {
+          header: item => item.description,
+          sections: [{ id: 'hdr', header: 'Only header' }],
+        };
+        wrapper = renderCards(
+          <Cards<Item> {...props} selectionType={'single'} cardDefinition={noContentDefinition} />
+        ).wrapper;
+        const input = getCard(0).findSelectionArea()?.find('input')?.getElement();
+        expect(input?.getAttribute('aria-describedby')).toBeFalsy();
+      });
+
+      it('does not add aria-describedby when there are no sections at all', () => {
+        wrapper = renderCards(<Cards<Item> {...props} selectionType={'single'} />).wrapper;
+        const input = getCard(0).findSelectionArea()?.find('input')?.getElement();
+        expect(input?.getAttribute('aria-describedby')).toBeFalsy();
+      });
+
+      it('does not set id on section-content divs when there is no selectionType', () => {
+        wrapper = renderCards(
+          <Cards<Item> {...props} selectionType={undefined} cardDefinition={cardDefinitionWithSections} />
+        ).wrapper;
+        // Section content elements should have no id attribute
+        const contentDivs = wrapper.getElement().querySelectorAll(`.${styles['section-content']}`);
+        contentDivs.forEach(div => {
+          expect(div.getAttribute('id')).toBeNull();
+        });
+      });
     });
 
     it('should deselect previous card on selection', () => {

--- a/src/cards/__tests__/selection.test.tsx
+++ b/src/cards/__tests__/selection.test.tsx
@@ -115,7 +115,25 @@ describe('Cards selection', () => {
         expect(ids).toHaveLength(1);
         const el = document.getElementById(ids[0]);
         expect(el).not.toBeNull();
-        expect(el).toHaveClass(styles['section-content']);
+        expect(el).toHaveClass(styles.section);
+      });
+
+      it('uses the first section with content even when preceded by a header-only section', () => {
+        const headerFirstDefinition: CardsProps.CardDefinition<Item> = {
+          header: (item: Item) => item.description,
+          sections: [
+            { id: 'hdr', header: 'Header only' },
+            { id: 'desc', header: 'Description', content: (item: Item) => `Description: ${item.description}` },
+          ],
+        };
+        wrapper = renderCards(
+          <Cards<Item> {...props} selectionType={'single'} cardDefinition={headerFirstDefinition} />
+        ).wrapper;
+        const input = getCard(0).findSelectionArea()?.find('input')?.getElement();
+        const ids = input?.getAttribute('aria-describedby')?.split(' ') ?? [];
+        expect(ids).toHaveLength(1);
+        const el = document.getElementById(ids[0]);
+        expect(el).toHaveClass(styles.section);
       });
 
       it('each card has its own unique section content ID', () => {
@@ -148,13 +166,13 @@ describe('Cards selection', () => {
         expect(input?.getAttribute('aria-describedby')).toBeFalsy();
       });
 
-      it('does not set id on section-content divs when there is no selectionType', () => {
+      it('does not set id on section divs when there is no selectionType', () => {
         wrapper = renderCards(
           <Cards<Item> {...props} selectionType={undefined} cardDefinition={cardDefinitionWithSections} />
         ).wrapper;
-        // Section content elements should have no id attribute
-        const contentDivs = wrapper.getElement().querySelectorAll(`.${styles['section-content']}`);
-        contentDivs.forEach(div => {
+        // Section outer divs should have no id attribute when not selectable
+        const sectionDivs = wrapper.getElement().querySelectorAll(`.${styles.section}`);
+        sectionDivs.forEach(div => {
           expect(div.getAttribute('id')).toBeNull();
         });
       });

--- a/src/cards/__tests__/selection.test.tsx
+++ b/src/cards/__tests__/selection.test.tsx
@@ -101,7 +101,7 @@ describe('Cards selection', () => {
         ],
       };
 
-      it('adds aria-describedby to radio input pointing to section content elements', () => {
+      it('adds aria-describedby to radio input pointing to the first section content element', () => {
         wrapper = renderCards(
           <Cards<Item> {...props} selectionType={'single'} cardDefinition={cardDefinitionWithSections} />
         ).wrapper;
@@ -110,29 +110,24 @@ describe('Cards selection', () => {
         const ariaDescribedby = input?.getAttribute('aria-describedby');
         expect(ariaDescribedby).toBeTruthy();
 
-        // Each id in aria-describedby should correspond to a section-content element
+        // aria-describedby should reference exactly one element — the first section with content
         const ids = ariaDescribedby!.split(' ');
-        expect(ids).toHaveLength(2);
-        ids.forEach(id => {
-          const el = document.getElementById(id);
-          expect(el).not.toBeNull();
-          expect(el).toHaveClass(styles['section-content']);
-        });
+        expect(ids).toHaveLength(1);
+        const el = document.getElementById(ids[0]);
+        expect(el).not.toBeNull();
+        expect(el).toHaveClass(styles['section-content']);
       });
 
-      it('each card has its own unique section content IDs', () => {
+      it('each card has its own unique section content ID', () => {
         wrapper = renderCards(
           <Cards<Item> {...props} selectionType={'single'} cardDefinition={cardDefinitionWithSections} />
         ).wrapper;
-        const card0Input = getCard(0).findSelectionArea()?.find('input')?.getElement();
-        const card1Input = getCard(1).findSelectionArea()?.find('input')?.getElement();
+        const card0Id = getCard(0).findSelectionArea()?.find('input')?.getElement().getAttribute('aria-describedby');
+        const card1Id = getCard(1).findSelectionArea()?.find('input')?.getElement().getAttribute('aria-describedby');
 
-        const ids0 = card0Input?.getAttribute('aria-describedby')?.split(' ') ?? [];
-        const ids1 = card1Input?.getAttribute('aria-describedby')?.split(' ') ?? [];
-
-        // IDs must not overlap between cards
-        const allIds = [...ids0, ...ids1];
-        expect(new Set(allIds).size).toBe(allIds.length);
+        expect(card0Id).toBeTruthy();
+        expect(card1Id).toBeTruthy();
+        expect(card0Id).not.toEqual(card1Id);
       });
 
       it('does not add aria-describedby when there are no sections with content', () => {

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -373,18 +373,18 @@ const CardItem = <T,>({
       >
         {visibleSectionsDefinition.length > 0 &&
           visibleSectionsDefinition.map(({ width = 100, header, content, id }, sectionIndex) => (
-            <div key={id || sectionIndex} className={styles.section} style={{ width: `${width}%` }}>
+            <div
+              key={id || sectionIndex}
+              id={
+                selectionProps && sectionIndex === firstContentSectionIndex
+                  ? `${cardId}-section-${sectionIndex}`
+                  : undefined
+              }
+              className={styles.section}
+              style={{ width: `${width}%` }}
+            >
               {header ? <div className={styles['section-header']}>{header}</div> : ''}
-              {content ? (
-                <div
-                  id={selectionProps ? `${cardId}-section-${sectionIndex}` : undefined}
-                  className={styles['section-content']}
-                >
-                  {content(item)}
-                </div>
-              ) : (
-                ''
-              )}
+              {content ? <div className={styles['section-content']}>{content(item)}</div> : ''}
             </div>
           ))}
       </InternalItemCard>

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -291,7 +291,7 @@ const CardItem = <T,>({
   moveFocusUp,
   onFocus,
 }: CardItemProps<T>) => {
-  const cardId = useUniqueId('card-');
+  const cardId = useUniqueId('card:');
   const selected = isItemSelected(item);
   const disabled = selectionProps && selectionProps.disabled;
 

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -305,6 +305,7 @@ const CardsList = <T,>({
         const selectionProps = getItemSelectionProps ? getItemSelectionProps(item) : null;
         const selected = isItemSelected(item);
         const disabled = selectionProps && selectionProps.disabled;
+        const cardId = `card-${key}`;
         const selectionAnalyticsMetadata:
           | GeneratedAnalyticsMetadataCardsSelect
           | GeneratedAnalyticsMetadataCardsDeselect = {
@@ -318,6 +319,14 @@ const CardsList = <T,>({
             item: `${key}`,
           },
         };
+
+        const sectionContentIds = selectionProps
+          ? visibleSectionsDefinition
+              .map(({ content }, sectionIndex) => (content ? `${cardId}-section-${sectionIndex}` : null))
+              .filter((id): id is string => id !== null)
+          : [];
+        const ariaDescribedby = sectionContentIds.length > 0 ? sectionContentIds.join(' ') : undefined;
+
         return (
           <li
             className={clsx(styles.card, {
@@ -357,7 +366,12 @@ const CardsList = <T,>({
                         ? getAnalyticsMetadataAttribute(selectionAnalyticsMetadata)
                         : {})}
                     >
-                      <SelectionControl onFocusDown={moveFocusDown} onFocusUp={moveFocusUp} {...selectionProps} />
+                      <SelectionControl
+                        onFocusDown={moveFocusDown}
+                        onFocusUp={moveFocusUp}
+                        {...selectionProps}
+                        ariaDescribedby={ariaDescribedby}
+                      />
                     </div>
                   )}
                 </div>
@@ -376,10 +390,19 @@ const CardsList = <T,>({
               }
             >
               {visibleSectionsDefinition.length > 0 &&
-                visibleSectionsDefinition.map(({ width = 100, header, content, id }, index) => (
-                  <div key={id || index} className={styles.section} style={{ width: `${width}%` }}>
+                visibleSectionsDefinition.map(({ width = 100, header, content, id }, sectionIndex) => (
+                  <div key={id || sectionIndex} className={styles.section} style={{ width: `${width}%` }}>
                     {header ? <div className={styles['section-header']}>{header}</div> : ''}
-                    {content ? <div className={styles['section-content']}>{content(item)}</div> : ''}
+                    {content ? (
+                      <div
+                        id={selectionProps ? `${cardId}-section-${sectionIndex}` : undefined}
+                        className={styles['section-content']}
+                      >
+                        {content(item)}
+                      </div>
+                    ) : (
+                      ''
+                    )}
                   </div>
                 ))}
             </InternalItemCard>

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -5,7 +5,7 @@ import React, { FocusEventHandler, useCallback, useImperativeHandle, useRef } fr
 import clsx from 'clsx';
 
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
-import { useMergeRefs } from '@cloudscape-design/component-toolkit/internal';
+import { useMergeRefs, useUniqueId } from '@cloudscape-design/component-toolkit/internal';
 import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 import { InternalContainerAsSubstep } from '../container/internal';
@@ -247,6 +247,153 @@ const Cards = React.forwardRef(function <T = any>(
 
 export default Cards;
 
+interface CardsListProps<T>
+  extends Pick<
+    CardsProps<T>,
+    'items' | 'cardDefinition' | 'trackBy' | 'selectionType' | 'visibleSections' | 'entireCardClickable'
+  > {
+  columns: number | null;
+  isItemSelected: (item: T) => boolean;
+  getItemSelectionProps?: (item: T) => SelectionControlProps;
+  onFocus: FocusEventHandler<HTMLElement>;
+  ariaLabel?: string;
+  ariaLabelledby?: string;
+}
+
+interface CardItemProps<T> {
+  item: T;
+  index: number;
+  itemKey: string;
+  cardDefinition: CardsProps.CardDefinition<T>;
+  selectable: boolean;
+  canClickEntireCard: boolean;
+  selectionProps: SelectionControlProps | null;
+  isItemSelected: (item: T) => boolean;
+  visibleSectionsDefinition: ReadonlyArray<CardsProps.SectionDefinition<T>>;
+  listItemRole: 'presentation' | undefined;
+  moveFocusDown: React.KeyboardEventHandler | undefined;
+  moveFocusUp: React.KeyboardEventHandler | undefined;
+  onFocus: FocusEventHandler<HTMLElement>;
+}
+
+const CardItem = <T,>({
+  item,
+  index,
+  itemKey,
+  cardDefinition,
+  selectable,
+  canClickEntireCard,
+  selectionProps,
+  isItemSelected,
+  visibleSectionsDefinition,
+  listItemRole,
+  moveFocusDown,
+  moveFocusUp,
+  onFocus,
+}: CardItemProps<T>) => {
+  const cardId = useUniqueId('card-');
+  const selected = isItemSelected(item);
+  const disabled = selectionProps && selectionProps.disabled;
+
+  const selectionAnalyticsMetadata: GeneratedAnalyticsMetadataCardsSelect | GeneratedAnalyticsMetadataCardsDeselect = {
+    action: selected ? 'deselect' : 'select',
+    detail: {
+      label: {
+        selector: `.${analyticsSelectors['cards-list']} li:nth-child(${index + 1}) .${analyticsSelectors['card-header']}`,
+        root: 'component',
+      },
+      position: `${index + 1}`,
+      item: `${itemKey}`,
+    },
+  };
+
+  const sectionContentIds = selectionProps
+    ? visibleSectionsDefinition
+        .map(({ content }, sectionIndex) => (content ? `${cardId}-section-${sectionIndex}` : null))
+        .filter((id): id is string => id !== null)
+    : [];
+  const ariaDescribedby = sectionContentIds.length > 0 ? sectionContentIds.join(' ') : undefined;
+
+  return (
+    <li
+      className={clsx(styles.card, {
+        [styles['card-selected']]: selectable && selected,
+      })}
+      onFocus={onFocus}
+      {...(focusMarkers && focusMarkers.item)}
+      role={listItemRole}
+      {...getAnalyticsMetadataAttribute({
+        component: {
+          innerContext: {
+            position: `${index + 1}`,
+            item: `${itemKey}`,
+          },
+        },
+      })}
+    >
+      <InternalItemCard
+        fullHeight={true}
+        highlighted={selectable && selected}
+        header={
+          <div className={styles['card-header']}>
+            <div
+              className={clsx(
+                styles['card-header-inner'],
+                selectable && styles['card-header-inner-selectable'],
+                analyticsSelectors['card-header']
+              )}
+            >
+              {cardDefinition.header ? cardDefinition.header(item) : ''}
+            </div>
+            {selectionProps && (
+              <div
+                className={styles['selection-control']}
+                {...(!canClickEntireCard && !disabled ? getAnalyticsMetadataAttribute(selectionAnalyticsMetadata) : {})}
+              >
+                <SelectionControl
+                  onFocusDown={moveFocusDown}
+                  onFocusUp={moveFocusUp}
+                  {...selectionProps}
+                  ariaDescribedby={ariaDescribedby}
+                />
+              </div>
+            )}
+          </div>
+        }
+        metadataAttributes={
+          canClickEntireCard && !disabled ? getAnalyticsMetadataAttribute(selectionAnalyticsMetadata) : {}
+        }
+        onClick={
+          canClickEntireCard
+            ? event => {
+                selectionProps?.onChange();
+                // Manually move focus to the native input (checkbox or radio button)
+                event.currentTarget.querySelector('input')?.focus();
+              }
+            : undefined
+        }
+      >
+        {visibleSectionsDefinition.length > 0 &&
+          visibleSectionsDefinition.map(({ width = 100, header, content, id }, sectionIndex) => (
+            <div key={id || sectionIndex} className={styles.section} style={{ width: `${width}%` }}>
+              {header ? <div className={styles['section-header']}>{header}</div> : ''}
+              {content ? (
+                <div
+                  id={selectionProps ? `${cardId}-section-${sectionIndex}` : undefined}
+                  className={styles['section-content']}
+                >
+                  {content(item)}
+                </div>
+              ) : (
+                ''
+              )}
+            </div>
+          ))}
+      </InternalItemCard>
+    </li>
+  );
+};
+
 const CardsList = <T,>({
   items,
   cardDefinition,
@@ -260,20 +407,9 @@ const CardsList = <T,>({
   ariaLabelledby,
   ariaLabel,
   entireCardClickable,
-}: Pick<
-  CardsProps<T>,
-  'items' | 'cardDefinition' | 'trackBy' | 'selectionType' | 'visibleSections' | 'entireCardClickable'
-> & {
-  columns: number | null;
-  isItemSelected: (item: T) => boolean;
-  getItemSelectionProps?: (item: T) => SelectionControlProps;
-  onFocus: FocusEventHandler<HTMLElement>;
-  ariaLabel?: string;
-  ariaLabelledby?: string;
-  ariaDescribedby?: string;
-}) => {
+}: CardsListProps<T>) => {
   const selectable = !!selectionType;
-  const canClickEntireCard = selectable && entireCardClickable;
+  const canClickEntireCard = selectable && !!entireCardClickable;
 
   const { moveFocusDown, moveFocusUp } = useSelectionFocusMove(selectionType, items.length);
 
@@ -303,110 +439,23 @@ const CardsList = <T,>({
       {items.map((item, index) => {
         const key = getItemKey(trackBy, item, index);
         const selectionProps = getItemSelectionProps ? getItemSelectionProps(item) : null;
-        const selected = isItemSelected(item);
-        const disabled = selectionProps && selectionProps.disabled;
-        const cardId = `card-${key}`;
-        const selectionAnalyticsMetadata:
-          | GeneratedAnalyticsMetadataCardsSelect
-          | GeneratedAnalyticsMetadataCardsDeselect = {
-          action: selected ? 'deselect' : 'select',
-          detail: {
-            label: {
-              selector: `.${analyticsSelectors['cards-list']} li:nth-child(${index + 1}) .${analyticsSelectors['card-header']}`,
-              root: 'component',
-            },
-            position: `${index + 1}`,
-            item: `${key}`,
-          },
-        };
-
-        const sectionContentIds = selectionProps
-          ? visibleSectionsDefinition
-              .map(({ content }, sectionIndex) => (content ? `${cardId}-section-${sectionIndex}` : null))
-              .filter((id): id is string => id !== null)
-          : [];
-        const ariaDescribedby = sectionContentIds.length > 0 ? sectionContentIds.join(' ') : undefined;
-
         return (
-          <li
-            className={clsx(styles.card, {
-              [styles['card-selected']]: selectable && selected,
-            })}
+          <CardItem
             key={key}
+            item={item}
+            index={index}
+            itemKey={key}
+            cardDefinition={cardDefinition}
+            selectable={selectable}
+            canClickEntireCard={canClickEntireCard}
+            selectionProps={selectionProps}
+            isItemSelected={isItemSelected}
+            visibleSectionsDefinition={visibleSectionsDefinition}
+            listItemRole={listItemRole}
+            moveFocusDown={moveFocusDown}
+            moveFocusUp={moveFocusUp}
             onFocus={onFocus}
-            {...(focusMarkers && focusMarkers.item)}
-            role={listItemRole}
-            {...getAnalyticsMetadataAttribute({
-              component: {
-                innerContext: {
-                  position: `${index + 1}`,
-                  item: `${key}`,
-                },
-              },
-            })}
-          >
-            <InternalItemCard
-              fullHeight={true}
-              highlighted={selectable && selected}
-              header={
-                <div className={styles['card-header']}>
-                  <div
-                    className={clsx(
-                      styles['card-header-inner'],
-                      selectable && styles['card-header-inner-selectable'],
-                      analyticsSelectors['card-header']
-                    )}
-                  >
-                    {cardDefinition.header ? cardDefinition.header(item) : ''}
-                  </div>
-                  {selectionProps && (
-                    <div
-                      className={styles['selection-control']}
-                      {...(!canClickEntireCard && !disabled
-                        ? getAnalyticsMetadataAttribute(selectionAnalyticsMetadata)
-                        : {})}
-                    >
-                      <SelectionControl
-                        onFocusDown={moveFocusDown}
-                        onFocusUp={moveFocusUp}
-                        {...selectionProps}
-                        ariaDescribedby={ariaDescribedby}
-                      />
-                    </div>
-                  )}
-                </div>
-              }
-              metadataAttributes={
-                canClickEntireCard && !disabled ? getAnalyticsMetadataAttribute(selectionAnalyticsMetadata) : {}
-              }
-              onClick={
-                canClickEntireCard
-                  ? event => {
-                      selectionProps?.onChange();
-                      // Manually move focus to the native input (checkbox or radio button)
-                      event.currentTarget.querySelector('input')?.focus();
-                    }
-                  : undefined
-              }
-            >
-              {visibleSectionsDefinition.length > 0 &&
-                visibleSectionsDefinition.map(({ width = 100, header, content, id }, sectionIndex) => (
-                  <div key={id || sectionIndex} className={styles.section} style={{ width: `${width}%` }}>
-                    {header ? <div className={styles['section-header']}>{header}</div> : ''}
-                    {content ? (
-                      <div
-                        id={selectionProps ? `${cardId}-section-${sectionIndex}` : undefined}
-                        className={styles['section-content']}
-                      >
-                        {content(item)}
-                      </div>
-                    ) : (
-                      ''
-                    )}
-                  </div>
-                ))}
-            </InternalItemCard>
-          </li>
+          />
         );
       })}
     </ol>

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -307,12 +307,10 @@ const CardItem = <T,>({
     },
   };
 
-  const sectionContentIds = selectionProps
-    ? visibleSectionsDefinition
-        .map(({ content }, sectionIndex) => (content ? `${cardId}-section-${sectionIndex}` : null))
-        .filter((id): id is string => id !== null)
-    : [];
-  const ariaDescribedby = sectionContentIds.length > 0 ? sectionContentIds.join(' ') : undefined;
+  const firstContentSectionIndex = selectionProps
+    ? visibleSectionsDefinition.findIndex(({ content }) => !!content)
+    : -1;
+  const ariaDescribedby = firstContentSectionIndex >= 0 ? `${cardId}-section-${firstContentSectionIndex}` : undefined;
 
   return (
     <li

--- a/src/table/__tests__/group-selection.test.tsx
+++ b/src/table/__tests__/group-selection.test.tsx
@@ -114,7 +114,7 @@ describe('selection control labels', () => {
       `${selectedItemsCount} of ${itemsCount} ${item.name} selected`,
     itemLoaderSelectionLabel: (_, item) => (item ? `${item.name} loader` : 'Root loader'),
   };
-  const getRowSelector = (w: TableWrapper, i: number) => w.findRowSelectionArea(i)!.getElement();
+  const getRowSelector = (w: TableWrapper, i: number) => w.findRowSelectionArea(i)!.find('input')!.getElement();
 
   test('adds allItemsSelectionLabel to select-all checkbox', () => {
     const { wrapper, rerender } = renderTable({
@@ -124,7 +124,10 @@ describe('selection control labels', () => {
       ariaLabels,
     });
     expect(getSelectionA11yHeader(wrapper)).toBe(null);
-    expect(wrapper.findSelectAllTrigger()!.getElement()).toHaveAttribute('aria-label', '2(2) of 3 selected');
+    expect(wrapper.findSelectAllTrigger()!.find('input')!.getElement()).toHaveAttribute(
+      'aria-label',
+      '2(2) of 3 selected'
+    );
 
     rerender({
       expandableRows: createExpandableRows({
@@ -133,7 +136,10 @@ describe('selection control labels', () => {
         totalSelectedItemsCount: 8,
       }),
     });
-    expect(wrapper.findSelectAllTrigger()!.getElement()).toHaveAttribute('aria-label', '8(2) of 12 selected');
+    expect(wrapper.findSelectAllTrigger()!.find('input')!.getElement()).toHaveAttribute(
+      'aria-label',
+      '8(2) of 12 selected'
+    );
   });
 
   test('leaves the controls without labels, when ariaLabels is omitted', () => {

--- a/src/table/__tests__/selection.test.tsx
+++ b/src/table/__tests__/selection.test.tsx
@@ -66,12 +66,17 @@ describe('selection control labels', () => {
     itemSelectionLabel: ({ selectedItems }, item) =>
       `${item.name} is ${selectedItems.indexOf(item) < 0 ? 'not ' : ''}selected`,
   };
-  const getRowSelector = (w: TableWrapper, i: number) => w.findRowSelectionArea(i)!.getElement();
+  const getRowLabel = (w: TableWrapper, i: number) => w.findRowSelectionArea(i)!.getElement();
+  const getRowInput = (w: TableWrapper, i: number) => w.findRowSelectionArea(i)!.find('input')!.getElement();
 
   test('adds allItemsSelectionLabel to select-all checkbox', () => {
     const { wrapper } = renderTable({ selectionType: 'multi', selectedItems: [items[0]], ariaLabels });
     expect(getSelectionA11yHeader(wrapper)).toBe(null);
     expect(wrapper.findSelectAllTrigger()!.getElement()).toHaveAttribute('aria-label', '1(1) of 3 selected');
+    expect(wrapper.findSelectAllTrigger()!.find('input')!.getElement()).toHaveAttribute(
+      'aria-label',
+      '1(1) of 3 selected'
+    );
   });
 
   test('adds selectionGroupLabel to single selection column header', () => {
@@ -87,16 +92,22 @@ describe('selection control labels', () => {
       } else {
         expect(wrapper.findSelectAllTrigger()!.getElement()).not.toHaveAttribute('aria-label');
       }
-      expect(getRowSelector(wrapper, 1)).not.toHaveAttribute('aria-label');
-      expect(getRowSelector(wrapper, 2)).not.toHaveAttribute('aria-label');
-      expect(getRowSelector(wrapper, 3)).not.toHaveAttribute('aria-label');
+      expect(getRowLabel(wrapper, 1)).not.toHaveAttribute('aria-label');
+      expect(getRowLabel(wrapper, 2)).not.toHaveAttribute('aria-label');
+      expect(getRowLabel(wrapper, 3)).not.toHaveAttribute('aria-label');
+      expect(getRowInput(wrapper, 1)).not.toHaveAttribute('aria-label');
+      expect(getRowInput(wrapper, 2)).not.toHaveAttribute('aria-label');
+      expect(getRowInput(wrapper, 3)).not.toHaveAttribute('aria-label');
     });
 
     test('adds selectionGroupLabel and itemSelectionLabel to row selection control', () => {
       const { wrapper } = renderTable({ selectionType, selectedItems: [items[1]], ariaLabels });
-      expect(getRowSelector(wrapper, 1)).toHaveAttribute('aria-label', 'Apples is not selected');
-      expect(getRowSelector(wrapper, 2)).toHaveAttribute('aria-label', 'Oranges is selected');
-      expect(getRowSelector(wrapper, 3)).toHaveAttribute('aria-label', 'Bananas is not selected');
+      expect(getRowLabel(wrapper, 1)).toHaveAttribute('aria-label', 'Apples is not selected');
+      expect(getRowLabel(wrapper, 2)).toHaveAttribute('aria-label', 'Oranges is selected');
+      expect(getRowLabel(wrapper, 3)).toHaveAttribute('aria-label', 'Bananas is not selected');
+      expect(getRowInput(wrapper, 1)).toHaveAttribute('aria-label', 'Apples is not selected');
+      expect(getRowInput(wrapper, 2)).toHaveAttribute('aria-label', 'Oranges is selected');
+      expect(getRowInput(wrapper, 3)).toHaveAttribute('aria-label', 'Bananas is not selected');
     });
   });
 });

--- a/src/table/selection/interfaces.ts
+++ b/src/table/selection/interfaces.ts
@@ -10,6 +10,7 @@ export interface ItemSelectionProps {
   onChange: () => void;
   onShiftToggle?: (value: boolean) => void;
   ariaLabel?: string;
+  ariaDescribedby?: string;
   selectionGroupLabel?: string;
 }
 

--- a/src/table/selection/selection-control.tsx
+++ b/src/table/selection/selection-control.tsx
@@ -83,6 +83,14 @@ export function SelectionControl({
     nativeInput?.focus();
   };
 
+  const nativeInputAttributes: Record<string, string> = {};
+  if (ariaLabel) {
+    nativeInputAttributes['aria-label'] = ariaLabel;
+  }
+  if (ariaDescribedby) {
+    nativeInputAttributes['aria-describedby'] = ariaDescribedby;
+  }
+
   const selector = isMultiSelection ? (
     <InternalCheckbox
       {...sharedProps}
@@ -91,6 +99,7 @@ export function SelectionControl({
       controlId={controlId}
       data-focus-id="selection-control"
       indeterminate={indeterminate}
+      ariaLabel={ariaLabel}
       ariaDescribedby={ariaDescribedby}
     />
   ) : (
@@ -100,7 +109,7 @@ export function SelectionControl({
       name={name}
       value={''}
       onSelect={onChange}
-      nativeInputAttributes={ariaDescribedby ? { 'aria-describedby': ariaDescribedby } : undefined}
+      nativeInputAttributes={Object.keys(nativeInputAttributes).length > 0 ? nativeInputAttributes : undefined}
     />
   );
 

--- a/src/table/selection/selection-control.tsx
+++ b/src/table/selection/selection-control.tsx
@@ -33,6 +33,7 @@ export function SelectionControl({
   onFocusDown,
   name,
   ariaLabel,
+  ariaDescribedby,
   focusedComponent,
   rowIndex,
   itemKey,
@@ -90,9 +91,17 @@ export function SelectionControl({
       controlId={controlId}
       data-focus-id="selection-control"
       indeterminate={indeterminate}
+      ariaDescribedby={ariaDescribedby}
     />
   ) : (
-    <RadioButton {...sharedProps} controlId={controlId} name={name} value={''} onSelect={onChange} />
+    <RadioButton
+      {...sharedProps}
+      controlId={controlId}
+      name={name}
+      value={''}
+      onSelect={onChange}
+      nativeInputAttributes={ariaDescribedby ? { 'aria-describedby': ariaDescribedby } : undefined}
+    />
   );
 
   return (


### PR DESCRIPTION
### Description

Selectable cards had no programmatic link between the checkbox input and the card's body content, so screen readers couldn't announce the section text when the input was focused.

Each section content element now gets a unique `id`, and the selection input's `aria-describedby` is set to those IDs. To generate the IDs using `useUniqueId`, we extract the internal `CardItem` component.


Related links, issue #, if available: `AWSUI-61870`

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
