### PR TITLE
fix: Typescript type import backwards-compatibility issue

### DIFF
--- a/src/action-card/index.tsx
+++ b/src/action-card/index.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { getExternalProps } from '../internal/utils/external-props';
-import { type ActionCardProps } from './interfaces';
+import { ActionCardProps } from './interfaces';
 import InternalActionCard from './internal';
 
 export { ActionCardProps };

--- a/src/action-card/internal.tsx
+++ b/src/action-card/internal.tsx
@@ -11,7 +11,7 @@ import { fireCancelableEvent } from '../internal/events';
 import useForwardFocus from '../internal/hooks/forward-focus';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import WithNativeAttributes from '../internal/utils/with-native-attributes';
-import { type ActionCardProps } from './interfaces';
+import { ActionCardProps } from './interfaces';
 
 import styles from './styles.css.js';
 import testStyles from './test-classes/styles.css.js';


### PR DESCRIPTION
### Description
This PR makes our ActionCard backwards compatible with typescript version <= 4.5.

Related links, issue #, if available: n/a

### How has this been tested?
- Local testing

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
