### PR TITLE
chore: Update docs for breadcrumb-group

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -5032,7 +5032,7 @@ exports[`Components definition for breadcrumb-group matches the snapshot: breadc
   "events": [
     {
       "cancelable": true,
-      "description": "Called when the user clicks on a breadcrumb item.",
+      "description": "Called when the user clicks on a breadcrumb item. Do not use this handler for navigation, use the \`onFollow\` event instead.",
       "detailInlineType": {
         "name": "BreadcrumbGroupProps.ClickDetail<T>",
         "properties": [

--- a/src/breadcrumb-group/interfaces.ts
+++ b/src/breadcrumb-group/interfaces.ts
@@ -31,7 +31,7 @@ export interface BreadcrumbGroupProps<T extends BreadcrumbGroupProps.Item = Brea
    */
   expandAriaLabel?: string;
   /**
-   * Called when the user clicks on a breadcrumb item.
+   * Called when the user clicks on a breadcrumb item. Do not use this handler for navigation, use the `onFollow` event instead.
    */
   onClick?: CancelableEventHandler<BreadcrumbGroupProps.ClickDetail<T>>;
   /**


### PR DESCRIPTION
### Description

Update docs to make the distinction between `onFollow` and `onClick` clearer.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
