### PR TITLE
revert: Revert "fix: Wizard causing analytics errors when nested components provide errorContext (#4455)"

### DIFF
--- a/src/wizard/__tests__/analytics-metadata.test.tsx
+++ b/src/wizard/__tests__/analytics-metadata.test.tsx
@@ -54,7 +54,6 @@ function renderWizard(props: Partial<WizardProps> = {}) {
 const getMetadata = (
   activeStepIndex: number,
   label = '',
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   { errorContext, ...analyticsMetadata }: WizardProps['analyticsMetadata'] = {}
 ) => {
   const metadata: GeneratedAnalyticsMetadataFragment = {
@@ -68,6 +67,7 @@ const getMetadata = (
             activeStepIndex: `${activeStepIndex}`,
             activeStepLabel: steps[activeStepIndex].title,
             stepsCount: '3',
+            ...errorContext,
             ...analyticsMetadata,
           },
         },

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -156,9 +156,6 @@ export default function InternalWizard({
     );
   }
 
-  // Error context is already included in the AnalyticsFunnel context provider in index.tsx (funnelErrorContext)
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { errorContext, ...analyticsMetadataProperties } = rest.analyticsMetadata || {};
   const componentAnalyticsMetadata: GeneratedAnalyticsMetadataWizardComponent = {
     name: 'awsui.Wizard',
     label: {
@@ -169,7 +166,7 @@ export default function InternalWizard({
       stepsCount: `${(steps || []).length}`,
       activeStepIndex: `${activeStepIndex}`,
       activeStepLabel: `[${DATA_ATTR_FUNNEL_KEY}="${FUNNEL_KEY_STEP_NAME}"]`,
-      ...analyticsMetadataProperties,
+      ...(rest.analyticsMetadata || {}),
     },
   };
 


### PR DESCRIPTION
Revert "fix: Wizard causing analytics errors when nested components provide errorContext (#4455)"

This reverts commit 9372979884750350c90ebb4d99dba899455cc602.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
