### PR TITLE
fix: suppress aria-label override warning in SelectionControl radio button

### DIFF
--- a/src/internal/components/radio-button/index.tsx
+++ b/src/internal/components/radio-button/index.tsx
@@ -11,12 +11,16 @@ import { getBaseProps } from '../../base-component';
 import AbstractSwitch from '../../components/abstract-switch';
 import { fireNonCancelableEvent } from '../../events';
 import { InternalBaseComponentProps } from '../../hooks/use-base-component';
-import WithNativeAttributes from '../../utils/with-native-attributes';
+import WithNativeAttributes, { SkipWarnings } from '../../utils/with-native-attributes';
 import { RadioButtonProps } from './interfaces';
 import { getAbstractSwitchStyles, getInnerCircleStyle, getOuterCircleStyle } from './style';
 
 import styles from './styles.css.js';
 import testUtilStyles from './test-classes/styles.css.js';
+
+export interface InternalRadioButtonProps extends RadioButtonProps, InternalBaseComponentProps {
+  __skipNativeAttributesWarnings?: SkipWarnings;
+}
 
 export default React.forwardRef(function RadioButton(
   {
@@ -32,8 +36,9 @@ export default React.forwardRef(function RadioButton(
     style,
     nativeInputAttributes,
     onSelect,
+    __skipNativeAttributesWarnings,
     ...rest
-  }: RadioButtonProps & InternalBaseComponentProps,
+  }: InternalRadioButtonProps,
   ref: React.Ref<HTMLInputElement>
 ) {
   const radioButtonRef = useRef<HTMLInputElement>(null);
@@ -62,6 +67,7 @@ export default React.forwardRef(function RadioButton(
           tag="input"
           componentName="RadioButton"
           nativeAttributes={nativeInputAttributes}
+          skipWarnings={__skipNativeAttributesWarnings}
           tabIndex={tabIndex}
           type="radio"
           ref={mergedRefs}

--- a/src/table/selection/selection-control.tsx
+++ b/src/table/selection/selection-control.tsx
@@ -110,6 +110,7 @@ export function SelectionControl({
       value={''}
       onSelect={onChange}
       nativeInputAttributes={Object.keys(nativeInputAttributes).length > 0 ? nativeInputAttributes : undefined}
+      __skipNativeAttributesWarnings={['aria-label', 'aria-describedby']}
     />
   );
 


### PR DESCRIPTION
### Description
Add support for skipping native attribute warnings in RadioButton so SelectionControl can silence the aria-label collision.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-61930

### How has this been tested?

Tested by running locally, and checking that the warning are not showing any more for both Cards, and Table.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
