### PR TITLE
fix: Removes core-only annotations from the internal drawer interface

### DIFF
--- a/src/drawer/interfaces.ts
+++ b/src/drawer/interfaces.ts
@@ -60,11 +60,10 @@ export interface NextDrawerProps extends DrawerProps {
   /**
    * Specifies the CSS positioning mode of the drawer, and supports the following options:
    * * `static` (default) - The drawer is positioned in the normal document flow.
-   * * `sticky` - The drawer sticks to its nearest scrolling ancestor. Only meaningful with `placement="top"` or `placement="bottom"`. Using `sticky` with `placement="start"` or `placement="end"` falls back to `static`.
+   * * `sticky` - The drawer sticks to its nearest scrolling ancestor. Only meaningful with `placement="top"` or `placement="bottom"`.
+   * Using `sticky` with `placement="start"` or `placement="end"` falls back to `static`.
    * * `absolute` - The drawer is positioned relative to its nearest positioned ancestor.
    * * `fixed` - The drawer is positioned relative to the viewport.
-   *
-   * @awsuiSystem core
    */
   position?: NextDrawerProps.Position;
 
@@ -74,8 +73,6 @@ export interface NextDrawerProps extends DrawerProps {
    * * `end` - (default) Anchored to the inline-end edge.
    * * `top` - Anchored to the top edge.
    * * `bottom` - Anchored to the bottom edge.
-   *
-   * @awsuiSystem core
    */
   placement?: NextDrawerProps.Placement;
 
@@ -87,8 +84,6 @@ export interface NextDrawerProps extends DrawerProps {
    * * `end` - Distance from the inline-end edge. Not applicable when `placement` is `"start"`.
    * * `top` - Distance from the top edge. Not applicable when `placement` is `"bottom"`.
    * * `bottom` - Distance from the bottom edge. Not applicable when `placement` is `"top"`.
-   *
-   * @awsuiSystem core
    */
   offset?: NextDrawerProps.Offset;
 
@@ -98,8 +93,6 @@ export interface NextDrawerProps extends DrawerProps {
    * * Supported properties:
    * * `top` - Distance from the top of the scrolling container.
    * * `bottom` - Distance from the bottom of the scrolling container.
-   *
-   * @awsuiSystem core
    */
   stickyOffset?: NextDrawerProps.StickyOffset;
 
@@ -108,8 +101,6 @@ export interface NextDrawerProps extends DrawerProps {
    * overlaps other positioned elements on the page.
    *
    * Applicable when using `position="sticky"`, `position="absolute"`, or `position="fixed"`.
-   *
-   * @awsuiSystem core
    */
   zIndex?: number;
 }


### PR DESCRIPTION
### Description

The core-only annotations cause compilation errors in console packages as they are removed from interfaces by the documenter. See build: 7799754897.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
