### PR TITLE
fix: Render navigation trigger, nav panel, and content during SSR

### DIFF
--- a/src/app-layout-toolbar/__tests__/app-layout-toolbar.ssr.test.tsx
+++ b/src/app-layout-toolbar/__tests__/app-layout-toolbar.ssr.test.tsx
@@ -1,0 +1,28 @@
+/**
+ * @jest-environment node
+ */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { clearVisualRefreshState } from '@cloudscape-design/component-toolkit/internal/testing';
+
+import AppLayoutToolbar from '../../../lib/components/app-layout-toolbar';
+
+const globalWithFlags = globalThis as any;
+
+afterEach(() => {
+  delete globalWithFlags[Symbol.for('awsui-visual-refresh-flag')];
+  clearVisualRefreshState();
+});
+
+test('AppLayoutToolbar should render content, breadcrumbs, and navigation during SSR', () => {
+  globalWithFlags[Symbol.for('awsui-visual-refresh-flag')] = () => true;
+  const content = renderToStaticMarkup(
+    <AppLayoutToolbar content="SSR content region" breadcrumbs="SSR breadcrumbs" navigation="SSR navigation" />
+  );
+  expect(content).toContain('SSR content region');
+  expect(content).toContain('SSR breadcrumbs');
+  expect(content).toContain('SSR navigation');
+});

--- a/src/app-layout/__tests__/__snapshots__/widget-contract-old.test.tsx.snap
+++ b/src/app-layout/__tests__/__snapshots__/widget-contract-old.test.tsx.snap
@@ -977,7 +977,7 @@ Map {
       "setToolbarHeight": [Function],
       "setToolbarState": [Function],
       "splitPanelAnimationDisabled": true,
-      "splitPanelControlId": "split-panel6",
+      "splitPanelControlId": "split-panel8",
       "splitPanelFocusControl": {
         "refs": {
           "preferences": {
@@ -1183,7 +1183,7 @@ Map {
       "setToolbarHeight": [Function],
       "setToolbarState": [Function],
       "splitPanelAnimationDisabled": true,
-      "splitPanelControlId": "split-panel6",
+      "splitPanelControlId": "split-panel8",
       "splitPanelFocusControl": {
         "refs": {
           "preferences": {
@@ -1343,7 +1343,7 @@ Map {
       "setToolbarHeight": [Function],
       "setToolbarState": [Function],
       "splitPanelAnimationDisabled": true,
-      "splitPanelControlId": "split-panel6",
+      "splitPanelControlId": "split-panel8",
       "splitPanelFocusControl": {
         "refs": {
           "preferences": {
@@ -1505,7 +1505,7 @@ Map {
       "setToolbarHeight": [Function],
       "setToolbarState": [Function],
       "splitPanelAnimationDisabled": true,
-      "splitPanelControlId": "split-panel6",
+      "splitPanelControlId": "split-panel8",
       "splitPanelFocusControl": {
         "refs": {
           "preferences": {
@@ -1697,7 +1697,7 @@ Map {
       "setToolbarHeight": [Function],
       "setToolbarState": [Function],
       "splitPanelAnimationDisabled": true,
-      "splitPanelControlId": "split-panel6",
+      "splitPanelControlId": "split-panel8",
       "splitPanelFocusControl": {
         "refs": {
           "preferences": {
@@ -1857,7 +1857,7 @@ Map {
       "setToolbarHeight": [Function],
       "setToolbarState": [Function],
       "splitPanelAnimationDisabled": true,
-      "splitPanelControlId": "split-panel6",
+      "splitPanelControlId": "split-panel8",
       "splitPanelFocusControl": {
         "refs": {
           "preferences": {
@@ -2031,7 +2031,7 @@ Map {
       "setToolbarHeight": [Function],
       "setToolbarState": [Function],
       "splitPanelAnimationDisabled": true,
-      "splitPanelControlId": "split-panel8",
+      "splitPanelControlId": "split-panel10",
       "splitPanelFocusControl": {
         "refs": {
           "preferences": {
@@ -2246,7 +2246,7 @@ Map {
       "setToolbarHeight": [Function],
       "setToolbarState": [Function],
       "splitPanelAnimationDisabled": true,
-      "splitPanelControlId": "split-panel8",
+      "splitPanelControlId": "split-panel10",
       "splitPanelFocusControl": {
         "refs": {
           "preferences": {
@@ -2416,7 +2416,7 @@ Map {
       "setToolbarHeight": [Function],
       "setToolbarState": [Function],
       "splitPanelAnimationDisabled": true,
-      "splitPanelControlId": "split-panel8",
+      "splitPanelControlId": "split-panel10",
       "splitPanelFocusControl": {
         "refs": {
           "preferences": {
@@ -2616,7 +2616,7 @@ Map {
       "setToolbarHeight": [Function],
       "setToolbarState": [Function],
       "splitPanelAnimationDisabled": true,
-      "splitPanelControlId": "split-panel8",
+      "splitPanelControlId": "split-panel10",
       "splitPanelFocusControl": {
         "refs": {
           "preferences": {
@@ -2786,7 +2786,7 @@ Map {
       "setToolbarHeight": [Function],
       "setToolbarState": [Function],
       "splitPanelAnimationDisabled": true,
-      "splitPanelControlId": "split-panel8",
+      "splitPanelControlId": "split-panel10",
       "splitPanelFocusControl": {
         "refs": {
           "preferences": {

--- a/src/app-layout/__tests__/app-layout.ssr.test.tsx
+++ b/src/app-layout/__tests__/app-layout.ssr.test.tsx
@@ -9,6 +9,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { clearVisualRefreshState } from '@cloudscape-design/component-toolkit/internal/testing';
 
 import AppLayout from '../../../lib/components/app-layout';
+import AppLayoutToolbar from '../../../lib/components/app-layout-toolbar';
 
 import classicStyles from '../../../lib/components/app-layout/styles.selectors.js';
 import refreshStyles from '../../../lib/components/app-layout/visual-refresh/styles.selectors.js';
@@ -43,11 +44,20 @@ test('should render refresh-toolbar app layout with the toolbar flag', () => {
   const content = renderToStaticMarkup(<AppLayout />);
   expect(content).toContain(refreshToolbarStyles.root);
 });
-test('should render content, breadcrumbs, and navigation during SSR', () => {
+test('AppLayout should not render content during SSR', () => {
   globalWithFlags[Symbol.for('awsui-visual-refresh-flag')] = () => true;
   globalWithFlags[Symbol.for('awsui-global-flags')] = { appLayoutToolbar: true };
   const content = renderToStaticMarkup(
     <AppLayout content="SSR content region" breadcrumbs="SSR breadcrumbs" navigation="SSR navigation" />
+  );
+  expect(content).not.toContain('SSR content region');
+  expect(content).toContain('SSR breadcrumbs');
+  expect(content).toContain('SSR navigation');
+});
+test('AppLayoutToolbar should render content, breadcrumbs, and navigation during SSR', () => {
+  globalWithFlags[Symbol.for('awsui-visual-refresh-flag')] = () => true;
+  const content = renderToStaticMarkup(
+    <AppLayoutToolbar content="SSR content region" breadcrumbs="SSR breadcrumbs" navigation="SSR navigation" />
   );
   expect(content).toContain('SSR content region');
   expect(content).toContain('SSR breadcrumbs');

--- a/src/app-layout/__tests__/app-layout.ssr.test.tsx
+++ b/src/app-layout/__tests__/app-layout.ssr.test.tsx
@@ -43,3 +43,13 @@ test('should render refresh-toolbar app layout with the toolbar flag', () => {
   const content = renderToStaticMarkup(<AppLayout />);
   expect(content).toContain(refreshToolbarStyles.root);
 });
+test('should render content, breadcrumbs, and navigation during SSR', () => {
+  globalWithFlags[Symbol.for('awsui-visual-refresh-flag')] = () => true;
+  globalWithFlags[Symbol.for('awsui-global-flags')] = { appLayoutToolbar: true };
+  const content = renderToStaticMarkup(
+    <AppLayout content="SSR content region" breadcrumbs="SSR breadcrumbs" navigation="SSR navigation" />
+  );
+  expect(content).toContain('SSR content region');
+  expect(content).toContain('SSR breadcrumbs');
+  expect(content).toContain('SSR navigation');
+});

--- a/src/app-layout/__tests__/app-layout.ssr.test.tsx
+++ b/src/app-layout/__tests__/app-layout.ssr.test.tsx
@@ -9,7 +9,6 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { clearVisualRefreshState } from '@cloudscape-design/component-toolkit/internal/testing';
 
 import AppLayout from '../../../lib/components/app-layout';
-import AppLayoutToolbar from '../../../lib/components/app-layout-toolbar';
 
 import classicStyles from '../../../lib/components/app-layout/styles.selectors.js';
 import refreshStyles from '../../../lib/components/app-layout/visual-refresh/styles.selectors.js';
@@ -51,15 +50,6 @@ test('AppLayout should not render content during SSR', () => {
     <AppLayout content="SSR content region" breadcrumbs="SSR breadcrumbs" navigation="SSR navigation" />
   );
   expect(content).not.toContain('SSR content region');
-  expect(content).toContain('SSR breadcrumbs');
-  expect(content).toContain('SSR navigation');
-});
-test('AppLayoutToolbar should render content, breadcrumbs, and navigation during SSR', () => {
-  globalWithFlags[Symbol.for('awsui-visual-refresh-flag')] = () => true;
-  const content = renderToStaticMarkup(
-    <AppLayoutToolbar content="SSR content region" breadcrumbs="SSR breadcrumbs" navigation="SSR navigation" />
-  );
-  expect(content).toContain('SSR content region');
   expect(content).toContain('SSR breadcrumbs');
   expect(content).toContain('SSR navigation');
 });

--- a/src/app-layout/__tests__/skeleton.test.tsx
+++ b/src/app-layout/__tests__/skeleton.test.tsx
@@ -83,10 +83,13 @@ describeEachAppLayout({ themes: ['refresh-toolbar'] }, () => {
       );
       // cannot use wrapper.findNavigation() because our public test utils resolve to nothing in skeleton state
       expect(wrapper.findByClassName(skeletonStyles.navigation)).toBeTruthy();
+      expect(wrapper.findByClassName(skeletonStyles['panel-hidden'])).toBeFalsy();
       rerender(<AppLayout navigation="test nav" navigationOpen={false} onNavigationChange={noop} />);
-      expect(wrapper.findByClassName(skeletonStyles.navigation)).toBeFalsy();
+      expect(wrapper.findByClassName(skeletonStyles.navigation)).toBeTruthy();
+      expect(wrapper.findByClassName(skeletonStyles['panel-hidden'])).toBeTruthy();
       rerender(<AppLayout navigation="test nav" navigationOpen={true} onNavigationChange={noop} />);
       expect(wrapper.findByClassName(skeletonStyles.navigation)).toBeTruthy();
+      expect(wrapper.findByClassName(skeletonStyles['panel-hidden'])).toBeFalsy();
     });
 
     it('toolbar can render conditionally', () => {

--- a/src/app-layout/__tests__/skeleton.test.tsx
+++ b/src/app-layout/__tests__/skeleton.test.tsx
@@ -102,6 +102,11 @@ describeEachAppLayout({ themes: ['refresh-toolbar'] }, () => {
       expect(wrapper.findByClassName(skeletonStyles['toolbar-container'])).toBeFalsy();
     });
 
+    it('renders navigation trigger in skeleton', () => {
+      const { wrapper } = renderComponent(<AppLayout navigation="test nav" />);
+      expect(wrapper.findNavigationToggle()).toBeTruthy();
+    });
+
     it('skeleton toolbar has correct classes for SSR compatibility', () => {
       const { wrapper } = renderComponent(<AppLayout breadcrumbs="test breadcrumbs" />);
       const toolbarContainer = wrapper.findByClassName(skeletonStyles['toolbar-container']);

--- a/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
@@ -46,7 +46,9 @@ export const SkeletonLayout = ({
   toolbarProps,
   skeletonSlotsAttributes,
 }: SkeletonLayoutProps) => {
-  const { contentHeader, content, navigationWidth } = appLayoutProps;
+  const { content, contentHeader, contentType, maxContentWidth, navigationWidth } = appLayoutProps;
+  const isMaxWidth = maxContentWidth === Number.MAX_VALUE || maxContentWidth === Number.MAX_SAFE_INTEGER;
+  const contentTypeCustomWidths: Array<string | undefined> = ['dashboard', 'cards', 'table'];
   const mergedProps: SkeletonPartProps = {
     toolbarProps,
     appLayoutProps,
@@ -69,11 +71,19 @@ export const SkeletonLayout = ({
         ref={appLayoutState.rootRef as React.Ref<HTMLDivElement>}
         data-awsui-app-layout-widget-loaded={isWidgetLoaded}
         {...wrapperElAttributes}
-        className={wrapperElAttributes?.className ?? clsx(styles.root, testutilStyles.root)}
+        className={
+          wrapperElAttributes?.className ??
+          clsx(styles.root, testutilStyles.root, {
+            [styles['has-adaptive-widths-default']]: !contentTypeCustomWidths.includes(contentType),
+            [styles['has-adaptive-widths-dashboard']]: contentType === 'dashboard',
+            [styles['drawer-expanded-mode']]: !!toolbarProps?.expandedDrawerId,
+          })
+        }
         style={
           wrapperElAttributes?.style ?? {
             blockSize: `calc(100vh - ${appLayoutProps.placement.insetBlockStart + appLayoutProps.placement.insetBlockEnd}px)`,
             [customCssProps.navigationWidth]: `${navigationWidth}px`,
+            [customCssProps.maxContentWidth]: isMaxWidth ? '100%' : maxContentWidth ? `${maxContentWidth}px` : '',
           }
         }
       >

--- a/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
@@ -90,7 +90,9 @@ export const SkeletonLayout = ({
             {contentHeader && <div {...contentHeaderElAttributes}>{contentHeader}</div>}
             {/*delay rendering the content until registration of this instance is complete*/}
             <div {...contentElAttributes} className={contentElAttributes?.className ?? testutilStyles.content}>
-              {registered ? <BuiltInErrorBoundary>{content}</BuiltInErrorBoundary> : null}
+              {registered || typeof window === 'undefined' ? (
+                <BuiltInErrorBoundary>{content}</BuiltInErrorBoundary>
+              ) : null}
             </div>
           </div>
           <AppLayoutBottomContentSlot {...mergedProps} />

--- a/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
@@ -61,6 +61,7 @@ export const SkeletonLayout = ({
   } = skeletonSlotsAttributes;
 
   const isWidgetLoaded = isWidgetReady(appLayoutState);
+  const isSSR = typeof window === 'undefined';
 
   return (
     <VisualContext contextName="app-layout-toolbar">
@@ -90,7 +91,7 @@ export const SkeletonLayout = ({
             {contentHeader && <div {...contentHeaderElAttributes}>{contentHeader}</div>}
             {/*delay rendering the content until registration of this instance is complete*/}
             <div {...contentElAttributes} className={contentElAttributes?.className ?? testutilStyles.content}>
-              {registered || typeof window === 'undefined' ? (
+              {registered || isSSR ? (
                 <BuiltInErrorBoundary>{content}</BuiltInErrorBoundary>
               ) : null}
             </div>

--- a/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
@@ -61,7 +61,6 @@ export const SkeletonLayout = ({
   } = skeletonSlotsAttributes;
 
   const isWidgetLoaded = isWidgetReady(appLayoutState);
-  const isSSR = typeof window === 'undefined';
 
   return (
     <VisualContext contextName="app-layout-toolbar">
@@ -91,9 +90,7 @@ export const SkeletonLayout = ({
             {contentHeader && <div {...contentHeaderElAttributes}>{contentHeader}</div>}
             {/*delay rendering the content until registration of this instance is complete*/}
             <div {...contentElAttributes} className={contentElAttributes?.className ?? testutilStyles.content}>
-              {registered || isSSR ? (
-                <BuiltInErrorBoundary>{content}</BuiltInErrorBoundary>
-              ) : null}
+              {registered ? <BuiltInErrorBoundary>{content}</BuiltInErrorBoundary> : null}
             </div>
           </div>
           <AppLayoutBottomContentSlot {...mergedProps} />

--- a/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
@@ -76,7 +76,6 @@ export const SkeletonLayout = ({
           clsx(styles.root, testutilStyles.root, {
             [styles['has-adaptive-widths-default']]: !contentTypeCustomWidths.includes(contentType),
             [styles['has-adaptive-widths-dashboard']]: contentType === 'dashboard',
-            [styles['drawer-expanded-mode']]: !!toolbarProps?.expandedDrawerId,
           })
         }
         style={

--- a/src/app-layout/visual-refresh-toolbar/skeleton/multi-layout.ts
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/multi-layout.ts
@@ -59,11 +59,14 @@ export function useMultiAppLayout(
   }
 
   // During SSR, useLayoutEffect never fires so registration stays null.
-  // Return sensible defaults: treat as a single primary layout.
+  // Treat as a single primary layout. In multi-layout setups this means
+  // every instance renders a toolbar during SSR — client-side hydration
+  // will deduplicate to the actual primary.
   const isSSR = typeof window === 'undefined';
   if (isSSR) {
     return {
       registered: true,
+      // No discovered props during SSR — single layout, nothing to merge.
       toolbarProps: mergeProps(props, []),
     };
   }

--- a/src/app-layout/visual-refresh-toolbar/skeleton/multi-layout.ts
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/multi-layout.ts
@@ -55,6 +55,8 @@ export function useMultiAppLayout(
   if (!isToolbar || isPublicToolbarInSSR) {
     return {
       registered: true,
+      // mergeProps is needed here because the toolbar's behavior depends on reconciliation logic
+      // in this function. For example, navigation trigger visibility
       toolbarProps: mergeProps(props, []),
     };
   }

--- a/src/app-layout/visual-refresh-toolbar/skeleton/multi-layout.ts
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/multi-layout.ts
@@ -1,11 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { useContext, useEffect, useLayoutEffect, useState } from 'react';
 
 import { metrics } from '../../../internal/metrics';
 import { awsuiPluginsInternal } from '../../../internal/plugins/api';
 import { RegistrationState } from '../../../internal/plugins/controllers/app-layout-widget';
 import { useAppLayoutFlagEnabled } from '../../utils/feature-flags';
+import { AppLayoutToolbarPublicContext } from '../contexts';
 import { MergeProps, SharedProps } from '../state/interfaces';
 import { ToolbarProps } from '../toolbar';
 
@@ -49,24 +50,11 @@ export function useMultiAppLayout(
     }
   }, [registration]);
 
-  if (!isToolbar) {
+  const isPublicAppLayout = useContext(AppLayoutToolbarPublicContext);
+  const isPublicToolbarInSSR = isPublicAppLayout && typeof window === 'undefined';
+  if (!isToolbar || isPublicToolbarInSSR) {
     return {
       registered: true,
-      // mergeProps is needed here because the toolbar's behavior depends on reconciliation logic
-      // in this function. For example, navigation trigger visibility
-      toolbarProps: mergeProps(props, []),
-    };
-  }
-
-  // During SSR, useLayoutEffect never fires so registration stays null.
-  // Treat as a single primary layout. In multi-layout setups this means
-  // every instance renders a toolbar during SSR — client-side hydration
-  // will deduplicate to the actual primary.
-  const isSSR = typeof window === 'undefined';
-  if (isSSR) {
-    return {
-      registered: true,
-      // No discovered props during SSR — single layout, nothing to merge.
       toolbarProps: mergeProps(props, []),
     };
   }

--- a/src/app-layout/visual-refresh-toolbar/skeleton/multi-layout.ts
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/multi-layout.ts
@@ -58,6 +58,16 @@ export function useMultiAppLayout(
     };
   }
 
+  // During SSR, useLayoutEffect never fires so registration stays null.
+  // Return sensible defaults: treat as a single primary layout.
+  const isSSR = typeof window === 'undefined';
+  if (isSSR) {
+    return {
+      registered: true,
+      toolbarProps: mergeProps(props, []),
+    };
+  }
+
   return {
     registered: !!registration?.type,
     toolbarProps: registration?.type === 'primary' ? mergeProps(props, registration.discoveredProps) : null,

--- a/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
+import clsx from 'clsx';
 
 import { AppLayoutNotificationsImplementationProps } from '../notifications';
 import { AppLayoutToolbarImplementationProps } from '../toolbar';
@@ -28,7 +29,18 @@ export const BeforeMainSlotSkeleton = React.forwardRef<HTMLElement, SkeletonPart
             ownBreadcrumbs={appLayoutProps.breadcrumbs}
           />
         )}
-        {toolbarProps?.navigationOpen && <div className={styles.navigation}>{appLayoutProps.navigation}</div>}
+        {appLayoutProps.navigation && (
+          <div
+            className={clsx(
+              styles.navigation,
+              !toolbarProps?.navigationOpen && styles['panel-hidden'],
+              !!toolbarProps?.activeDrawerId && styles['unfocusable-mobile'],
+              !!toolbarProps?.expandedDrawerId && styles.hidden
+            )}
+          >
+            {appLayoutProps.navigation}
+          </div>
+        )}
       </>
     );
   }

--- a/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
@@ -21,8 +21,11 @@ export const BeforeMainSlotSkeleton = React.forwardRef<HTMLElement, SkeletonPart
         {!!toolbarProps && (
           <ToolbarSkeletonStructure
             ref={ref}
-            ownBreadcrumbs={appLayoutProps.breadcrumbs}
+            ariaLabels={toolbarProps.ariaLabels}
+            expandedDrawerId={toolbarProps.expandedDrawerId}
             navigation={appLayoutProps.navigation}
+            navigationOpen={toolbarProps.navigationOpen}
+            ownBreadcrumbs={appLayoutProps.breadcrumbs}
           />
         )}
         {toolbarProps?.navigationOpen && <div className={styles.navigation}>{appLayoutProps.navigation}</div>}
@@ -39,9 +42,12 @@ export const ToolbarSkeleton = React.forwardRef<HTMLElement, AppLayoutToolbarImp
   ({ appLayoutInternals }: AppLayoutToolbarImplementationProps, ref) => (
     <ToolbarSkeletonStructure
       ref={ref}
+      ariaLabels={appLayoutInternals.ariaLabels}
+      expandedDrawerId={appLayoutInternals.expandedDrawerId}
+      navigation={appLayoutInternals.navigation}
+      navigationOpen={appLayoutInternals.navigationOpen}
       ownBreadcrumbs={appLayoutInternals.breadcrumbs}
       discoveredBreadcrumbs={appLayoutInternals.discoveredBreadcrumbs}
-      navigation={appLayoutInternals.navigation}
     />
   )
 );

--- a/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
@@ -22,7 +22,7 @@ export const BeforeMainSlotSkeleton = React.forwardRef<HTMLElement, SkeletonPart
           <ToolbarSkeletonStructure
             ref={ref}
             ownBreadcrumbs={appLayoutProps.breadcrumbs}
-            hasNavigation={!!appLayoutProps.navigation}
+            navigation={appLayoutProps.navigation}
           />
         )}
         {toolbarProps?.navigationOpen && <div className={styles.navigation}>{appLayoutProps.navigation}</div>}
@@ -41,7 +41,7 @@ export const ToolbarSkeleton = React.forwardRef<HTMLElement, AppLayoutToolbarImp
       ref={ref}
       ownBreadcrumbs={appLayoutInternals.breadcrumbs}
       discoveredBreadcrumbs={appLayoutInternals.discoveredBreadcrumbs}
-      hasNavigation={!!appLayoutInternals.navigation}
+      navigation={appLayoutInternals.navigation}
     />
   )
 );

--- a/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
@@ -24,12 +24,12 @@ export const BeforeMainSlotSkeleton = React.forwardRef<HTMLElement, SkeletonPart
             ref={ref}
             ariaLabels={toolbarProps.ariaLabels}
             expandedDrawerId={toolbarProps.expandedDrawerId}
-            navigation={appLayoutProps.navigation}
+            hasNavigation={toolbarProps.hasNavigation}
             navigationOpen={toolbarProps.navigationOpen}
             ownBreadcrumbs={appLayoutProps.breadcrumbs}
           />
         )}
-        {appLayoutProps.navigation && (
+        {toolbarProps?.hasNavigation && (
           <div
             className={clsx(
               styles.navigation,
@@ -56,7 +56,6 @@ export const ToolbarSkeleton = React.forwardRef<HTMLElement, AppLayoutToolbarImp
       ref={ref}
       ariaLabels={appLayoutInternals.ariaLabels}
       expandedDrawerId={appLayoutInternals.expandedDrawerId}
-      navigation={appLayoutInternals.navigation}
       navigationOpen={appLayoutInternals.navigationOpen}
       ownBreadcrumbs={appLayoutInternals.breadcrumbs}
       discoveredBreadcrumbs={appLayoutInternals.discoveredBreadcrumbs}

--- a/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
@@ -18,8 +18,14 @@ export const BeforeMainSlotSkeleton = React.forwardRef<HTMLElement, SkeletonPart
   ({ toolbarProps, appLayoutProps }, ref) => {
     return (
       <>
-        {!!toolbarProps && <ToolbarSkeletonStructure ref={ref} ownBreadcrumbs={appLayoutProps.breadcrumbs} />}
-        {toolbarProps?.navigationOpen && <div className={styles.navigation} />}
+        {!!toolbarProps && (
+          <ToolbarSkeletonStructure
+            ref={ref}
+            ownBreadcrumbs={appLayoutProps.breadcrumbs}
+            hasNavigation={!!appLayoutProps.navigation}
+          />
+        )}
+        {toolbarProps?.navigationOpen && <div className={styles.navigation}>{appLayoutProps.navigation}</div>}
       </>
     );
   }
@@ -35,6 +41,7 @@ export const ToolbarSkeleton = React.forwardRef<HTMLElement, AppLayoutToolbarImp
       ref={ref}
       ownBreadcrumbs={appLayoutInternals.breadcrumbs}
       discoveredBreadcrumbs={appLayoutInternals.discoveredBreadcrumbs}
+      hasNavigation={!!appLayoutInternals.navigation}
     />
   )
 );

--- a/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
@@ -17,6 +17,7 @@ import styles from './styles.css.js';
 
 export const BeforeMainSlotSkeleton = React.forwardRef<HTMLElement, SkeletonPartProps>(
   ({ toolbarProps, appLayoutProps }, ref) => {
+    const hasNavigation = toolbarProps ? toolbarProps.hasNavigation : !!appLayoutProps.navigation;
     return (
       <>
         {!!toolbarProps && (
@@ -24,12 +25,12 @@ export const BeforeMainSlotSkeleton = React.forwardRef<HTMLElement, SkeletonPart
             ref={ref}
             ariaLabels={toolbarProps.ariaLabels}
             expandedDrawerId={toolbarProps.expandedDrawerId}
-            hasNavigation={toolbarProps.hasNavigation}
+            hasNavigation={hasNavigation}
             navigationOpen={toolbarProps.navigationOpen}
             ownBreadcrumbs={appLayoutProps.breadcrumbs}
           />
         )}
-        {toolbarProps?.hasNavigation && (
+        {hasNavigation && (
           <div
             className={clsx(
               styles.navigation,

--- a/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
@@ -3,12 +3,14 @@
 import React from 'react';
 import clsx from 'clsx';
 
+import { InternalButton } from '../../../button/internal';
 import { AppLayoutNotificationsImplementationProps } from '../notifications';
 import { AppLayoutToolbarImplementationProps } from '../toolbar';
 import { SkeletonPartProps } from './interfaces';
 import { NotificationsSlot } from './slots';
 import { ToolbarSkeletonStructure } from './toolbar-container';
 
+import navStyles from '../navigation/styles.css.js';
 import styles from './styles.css.js';
 
 /**
@@ -39,7 +41,19 @@ export const BeforeMainSlotSkeleton = React.forwardRef<HTMLElement, SkeletonPart
               !!toolbarProps?.expandedDrawerId && styles.hidden
             )}
           >
-            {appLayoutProps.navigation}
+            <div
+              className={clsx(
+                navStyles['navigation-container'],
+                toolbarProps?.navigationOpen && navStyles['is-navigation-open']
+              )}
+            >
+              <nav className={navStyles.navigation}>
+                <div className={navStyles['hide-navigation']}>
+                  <InternalButton iconName="angle-left" variant="icon" formAction="none" />
+                </div>
+                {appLayoutProps.navigation}
+              </nav>
+            </div>
           </div>
         )}
       </>

--- a/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/skeleton-parts.tsx
@@ -26,7 +26,6 @@ export const BeforeMainSlotSkeleton = React.forwardRef<HTMLElement, SkeletonPart
           <ToolbarSkeletonStructure
             ref={ref}
             ariaLabels={toolbarProps.ariaLabels}
-            expandedDrawerId={toolbarProps.expandedDrawerId}
             hasNavigation={hasNavigation}
             navigationOpen={toolbarProps.navigationOpen}
             ownBreadcrumbs={appLayoutProps.breadcrumbs}
@@ -37,8 +36,7 @@ export const BeforeMainSlotSkeleton = React.forwardRef<HTMLElement, SkeletonPart
             className={clsx(
               styles.navigation,
               !toolbarProps?.navigationOpen && styles['panel-hidden'],
-              !!toolbarProps?.activeDrawerId && styles['unfocusable-mobile'],
-              !!toolbarProps?.expandedDrawerId && styles.hidden
+              !!toolbarProps?.activeDrawerId && styles['unfocusable-mobile']
             )}
           >
             <div

--- a/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
@@ -4,10 +4,12 @@ import React from 'react';
 import clsx from 'clsx';
 
 import { BreadcrumbGroupProps } from '../../../breadcrumb-group/interfaces';
+import Icon from '../../../icon/internal';
 import { BreadcrumbsSlot, ToolbarSlot } from './slots';
 
 import testutilStyles from '../../test-classes/styles.css.js';
 import toolbarStyles from '../toolbar/styles.css.js';
+import triggerButtonStyles from '../toolbar/trigger-button/styles.css.js';
 
 interface ToolbarContainerProps {
   children: React.ReactNode;
@@ -54,14 +56,21 @@ export const ToolbarSkeletonStructure = React.forwardRef<HTMLElement, ToolbarSke
       <ToolbarContainer>
         {hasNavigation && (
           <nav className={toolbarStyles['universal-toolbar-nav']}>
-            <button
-              type="button"
-              className={testutilStyles['navigation-toggle']}
-              aria-label="Open navigation"
-              aria-expanded={false}
-            >
-              <span aria-hidden="true">☰</span>
-            </button>
+            <div className={triggerButtonStyles['trigger-wrapper']}>
+              <button
+                type="button"
+                aria-label="Open navigation"
+                aria-expanded={false}
+                aria-haspopup={true}
+                className={clsx(
+                  triggerButtonStyles.trigger,
+                  triggerButtonStyles.default,
+                  testutilStyles['navigation-toggle']
+                )}
+              >
+                <Icon name="menu" />
+              </button>
+            </div>
           </nav>
         )}
         <ToolbarBreadcrumbsSection

--- a/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
@@ -47,19 +47,19 @@ export function ToolbarBreadcrumbsSection({
 interface ToolbarSkeletonStructureProps {
   ariaLabels?: AppLayoutProps.Labels;
   expandedDrawerId?: string | null;
-  navigation?: React.ReactNode;
+  hasNavigation?: boolean;
   navigationOpen?: boolean;
   ownBreadcrumbs: React.ReactNode;
   discoveredBreadcrumbs?: BreadcrumbGroupProps | null;
 }
 
 export const ToolbarSkeletonStructure = React.forwardRef<HTMLElement, ToolbarSkeletonStructureProps>(
-  ({ ariaLabels, expandedDrawerId, navigation, navigationOpen, ownBreadcrumbs, discoveredBreadcrumbs }, ref) => {
+  ({ ariaLabels, expandedDrawerId, hasNavigation, navigationOpen, ownBreadcrumbs, discoveredBreadcrumbs }, ref) => {
     const drawerExpandedMode = !!expandedDrawerId;
     return (
       <ToolbarSlot ref={ref}>
         <ToolbarContainer>
-          {navigation && (
+          {hasNavigation && (
             <nav className={toolbarStyles['universal-toolbar-nav']}>
               <TriggerButton
                 ariaLabel={ariaLabels?.navigationToggle ?? undefined}

--- a/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
@@ -4,12 +4,11 @@ import React from 'react';
 import clsx from 'clsx';
 
 import { BreadcrumbGroupProps } from '../../../breadcrumb-group/interfaces';
-import Icon from '../../../icon/internal';
 import { BreadcrumbsSlot, ToolbarSlot } from './slots';
+import TriggerButton from '../toolbar/trigger-button';
 
 import testutilStyles from '../../test-classes/styles.css.js';
 import toolbarStyles from '../toolbar/styles.css.js';
-import triggerButtonStyles from '../toolbar/trigger-button/styles.css.js';
 
 interface ToolbarContainerProps {
   children: React.ReactNode;
@@ -56,21 +55,14 @@ export const ToolbarSkeletonStructure = React.forwardRef<HTMLElement, ToolbarSke
       <ToolbarContainer>
         {navigation && (
           <nav className={toolbarStyles['universal-toolbar-nav']}>
-            <div className={triggerButtonStyles['trigger-wrapper']}>
-              <button
-                type="button"
-                aria-label="Open navigation"
-                aria-expanded={false}
-                aria-haspopup={true}
-                className={clsx(
-                  triggerButtonStyles.trigger,
-                  triggerButtonStyles.default,
-                  testutilStyles['navigation-toggle']
-                )}
-              >
-                <Icon name="menu" />
-              </button>
-            </div>
+            <TriggerButton
+              iconName="menu"
+              ariaLabel="Open navigation"
+              ariaExpanded={false}
+              // No-op during SSR — real handler attached after hydration.
+              onClick={() => {}}
+              className={testutilStyles['navigation-toggle']}
+            />
           </nav>
         )}
         <ToolbarBreadcrumbsSection

--- a/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
@@ -47,14 +47,14 @@ export function ToolbarBreadcrumbsSection({
 interface ToolbarSkeletonStructureProps {
   ownBreadcrumbs: React.ReactNode;
   discoveredBreadcrumbs?: BreadcrumbGroupProps | null;
-  hasNavigation?: boolean;
+  navigation?: React.ReactNode;
 }
 
 export const ToolbarSkeletonStructure = React.forwardRef<HTMLElement, ToolbarSkeletonStructureProps>(
-  ({ ownBreadcrumbs, discoveredBreadcrumbs, hasNavigation }, ref) => (
+  ({ ownBreadcrumbs, discoveredBreadcrumbs, navigation }, ref) => (
     <ToolbarSlot ref={ref}>
       <ToolbarContainer>
-        {hasNavigation && (
+        {navigation && (
           <nav className={toolbarStyles['universal-toolbar-nav']}>
             <div className={triggerButtonStyles['trigger-wrapper']}>
               <button

--- a/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
@@ -56,6 +56,8 @@ interface ToolbarSkeletonStructureProps {
 export const ToolbarSkeletonStructure = React.forwardRef<HTMLElement, ToolbarSkeletonStructureProps>(
   ({ ariaLabels, expandedDrawerId, hasNavigation, navigationOpen, ownBreadcrumbs, discoveredBreadcrumbs }, ref) => {
     const drawerExpandedMode = !!expandedDrawerId;
+    // istanbul ignore next: not interactive during SSR
+    const noop = () => {};
     return (
       <ToolbarSlot ref={ref}>
         <ToolbarContainer>
@@ -66,7 +68,7 @@ export const ToolbarSkeletonStructure = React.forwardRef<HTMLElement, ToolbarSke
                 ariaExpanded={!drawerExpandedMode && navigationOpen}
                 iconName="menu"
                 className={testutilStyles['navigation-toggle']}
-                onClick={() => {}}
+                onClick={noop}
                 selected={!drawerExpandedMode && navigationOpen}
               />
             </nav>

--- a/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
@@ -45,12 +45,25 @@ export function ToolbarBreadcrumbsSection({
 interface ToolbarSkeletonStructureProps {
   ownBreadcrumbs: React.ReactNode;
   discoveredBreadcrumbs?: BreadcrumbGroupProps | null;
+  hasNavigation?: boolean;
 }
 
 export const ToolbarSkeletonStructure = React.forwardRef<HTMLElement, ToolbarSkeletonStructureProps>(
-  ({ ownBreadcrumbs, discoveredBreadcrumbs }, ref) => (
+  ({ ownBreadcrumbs, discoveredBreadcrumbs, hasNavigation }, ref) => (
     <ToolbarSlot ref={ref}>
       <ToolbarContainer>
+        {hasNavigation && (
+          <nav className={toolbarStyles['universal-toolbar-nav']}>
+            <button
+              type="button"
+              className={testutilStyles['navigation-toggle']}
+              aria-label="Open navigation"
+              aria-expanded={false}
+            >
+              <span aria-hidden="true">☰</span>
+            </button>
+          </nav>
+        )}
         <ToolbarBreadcrumbsSection
           ownBreadcrumbs={ownBreadcrumbs}
           discoveredBreadcrumbs={discoveredBreadcrumbs}

--- a/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import clsx from 'clsx';
 
+import { AppLayoutProps } from '../../../app-layout/interfaces';
 import { BreadcrumbGroupProps } from '../../../breadcrumb-group/interfaces';
 import { BreadcrumbsSlot, ToolbarSlot } from './slots';
 import TriggerButton from '../toolbar/trigger-button';
@@ -44,34 +45,40 @@ export function ToolbarBreadcrumbsSection({
 }
 
 interface ToolbarSkeletonStructureProps {
+  ariaLabels?: AppLayoutProps.Labels;
+  expandedDrawerId?: string | null;
+  navigation?: React.ReactNode;
+  navigationOpen?: boolean;
   ownBreadcrumbs: React.ReactNode;
   discoveredBreadcrumbs?: BreadcrumbGroupProps | null;
-  navigation?: React.ReactNode;
 }
 
 export const ToolbarSkeletonStructure = React.forwardRef<HTMLElement, ToolbarSkeletonStructureProps>(
-  ({ ownBreadcrumbs, discoveredBreadcrumbs, navigation }, ref) => (
-    <ToolbarSlot ref={ref}>
-      <ToolbarContainer>
-        {navigation && (
-          <nav className={toolbarStyles['universal-toolbar-nav']}>
-            <TriggerButton
-              iconName="menu"
-              ariaLabel="Open navigation"
-              ariaExpanded={false}
-              // No-op during SSR — real handler attached after hydration.
-              onClick={() => {}}
-              className={testutilStyles['navigation-toggle']}
-            />
-          </nav>
-        )}
-        <ToolbarBreadcrumbsSection
-          ownBreadcrumbs={ownBreadcrumbs}
-          discoveredBreadcrumbs={discoveredBreadcrumbs}
-          includeTestUtils={true}
-        />
-        <div className={toolbarStyles['universal-toolbar-drawers']} />
-      </ToolbarContainer>
-    </ToolbarSlot>
-  )
+  ({ ariaLabels, expandedDrawerId, navigation, navigationOpen, ownBreadcrumbs, discoveredBreadcrumbs }, ref) => {
+    const drawerExpandedMode = !!expandedDrawerId;
+    return (
+      <ToolbarSlot ref={ref}>
+        <ToolbarContainer>
+          {navigation && (
+            <nav className={toolbarStyles['universal-toolbar-nav']}>
+              <TriggerButton
+                ariaLabel={ariaLabels?.navigationToggle ?? undefined}
+                ariaExpanded={!drawerExpandedMode && navigationOpen}
+                iconName="menu"
+                className={testutilStyles['navigation-toggle']}
+                onClick={() => {}}
+                selected={!drawerExpandedMode && navigationOpen}
+              />
+            </nav>
+          )}
+          <ToolbarBreadcrumbsSection
+            ownBreadcrumbs={ownBreadcrumbs}
+            discoveredBreadcrumbs={discoveredBreadcrumbs}
+            includeTestUtils={true}
+          />
+          <div className={toolbarStyles['universal-toolbar-drawers']} />
+        </ToolbarContainer>
+      </ToolbarSlot>
+    );
+  }
 );

--- a/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/toolbar-container.tsx
@@ -5,8 +5,8 @@ import clsx from 'clsx';
 
 import { AppLayoutProps } from '../../../app-layout/interfaces';
 import { BreadcrumbGroupProps } from '../../../breadcrumb-group/interfaces';
-import { BreadcrumbsSlot, ToolbarSlot } from './slots';
 import TriggerButton from '../toolbar/trigger-button';
+import { BreadcrumbsSlot, ToolbarSlot } from './slots';
 
 import testutilStyles from '../../test-classes/styles.css.js';
 import toolbarStyles from '../toolbar/styles.css.js';


### PR DESCRIPTION
### Description

Fixes #4450

When rendering `AppLayoutToolbar` with `renderToString`, the main content area, navigation trigger, and navigation panel are all missing from the SSR output. This PR enables the skeleton to render these elements during SSR.

**Live comparison:** [View all demos →](https://piotrekwitkowski.github.io/cloudscape-ssr-nav-repro/)

### Changes

4 files in `src/app-layout/visual-refresh-toolbar/skeleton/`:

- **`multi-layout.ts`** — SSR bypass in `useMultiAppLayout`: during SSR (`typeof window === 'undefined'`), return `{ registered: true, toolbarProps: mergeProps(props, []) }`. Follows the same pattern as the existing `!isToolbar` fallback and the `isSSR` guard in `slots.tsx`. In multi-layout setups, every instance renders a toolbar during SSR — client-side hydration will deduplicate to the actual primary.
- **`index.tsx`** — Bypass the `registered` gate for content rendering during SSR using the same `isSSR` pattern.
- **`skeleton-parts.tsx`** — Pass `navigation` prop through to `ToolbarSkeletonStructure` (consistent with how `ownBreadcrumbs` is passed).
- **`toolbar-container.tsx`** — Render `TriggerButton` with `iconName="menu"` in the skeleton when `navigation` is provided.

### How has this been tested?

- **Reproduction repo:** [cloudscape-ssr-nav-repro](https://github.com/piotrekwitkowski/cloudscape-ssr-nav-repro) with Vite SSR dev server (`npm run dev`) and automated assertions (`npm test`)
- **Static comparison pages** deployed to [GitHub Pages](https://piotrekwitkowski.github.io/cloudscape-ssr-nav-repro/) showing mainline (broken) vs fixed (working) SSR output
- **Hydrated pages** demonstrating SSG + hydration with the fix — fully interactive after hydration
- `npm run quick-build` passes on the fork

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.