### PR TITLE
chore: Apply a proper space token for flashbar collapse button

### DIFF
--- a/src/flashbar/collapsible.scss
+++ b/src/flashbar/collapsible.scss
@@ -16,7 +16,7 @@ $notification-bar-top-overlap: (
   'expanded': awsui.$space-scaled-s,
 );
 $notification-bar-line-height: awsui.$line-height-body-m;
-$notification-bar-padding-vertical: styles.$control-padding-vertical;
+$notification-bar-padding-vertical: awsui.$space-button-vertical;
 $notification-bar-collapsed-item-overflow: (
   'x': 10px,
   'y': 8px,


### PR DESCRIPTION
### Description
This PR applies a proper space token `spaceButtonVertical` to the button in the stacked Flashbar to open and collapse the stacked Flashbar. 

<img width="600" height="110" alt="Screenshot 2026-04-22 at 18 13 07" src="https://github.com/user-attachments/assets/267bfa96-ee52-4c1f-952c-ff6596b7986c" />


<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
