### PR TITLE
chore: Make the selected border within dropdown themeable

### DIFF
--- a/src/internal/components/selectable-item/styles.scss
+++ b/src/internal/components/selectable-item/styles.scss
@@ -7,7 +7,8 @@
 @use '../../styles/tokens' as awsui;
 
 // Box-shadow spread values for simulating borders without layout shifts
-$border-offset: awsui.$border-item-width;
+$border-offset: awsui.$border-width-item-selected;
+$border-offset-double: calc(2 * #{$border-offset});
 $border-offset-double: calc(2 * awsui.$border-width-item-selected);
 
 // Divider widths (and negative) for reuse

--- a/src/internal/components/selectable-item/styles.scss
+++ b/src/internal/components/selectable-item/styles.scss
@@ -62,14 +62,14 @@ $neg-divider-w: calc(-1 * #{$divider-w});
 }
 
 @mixin selected-shadow {
-  box-shadow: inset 0 0 0 $border-offset awsui.$color-border-dropdown-item-selected;
+  box-shadow: inset 0 0 0 awsui.$border-width-item-selected awsui.$color-border-dropdown-item-selected;
   &.highlighted {
     box-shadow:
-      inset 0 0 0 $border-offset awsui.$color-border-dropdown-item-selected,
+      inset 0 0 0 awsui.$border-width-item-selected awsui.$color-border-dropdown-item-selected,
       inset 0 0 0 $border-offset-double awsui.$color-border-dropdown-item-hover;
     &.is-keyboard {
       box-shadow:
-        inset 0 0 0 $border-offset awsui.$color-border-dropdown-item-selected,
+        inset 0 0 0 awsui.$border-width-item-selected awsui.$color-border-dropdown-item-selected,
         inset 0 0 0 $border-offset-double awsui.$color-border-dropdown-item-focused;
     }
   }

--- a/src/internal/components/selectable-item/styles.scss
+++ b/src/internal/components/selectable-item/styles.scss
@@ -9,7 +9,6 @@
 // Box-shadow spread values for simulating borders without layout shifts
 $border-offset: awsui.$border-width-item-selected;
 $border-offset-double: calc(2 * #{$border-offset});
-$border-offset-double: calc(2 * awsui.$border-width-item-selected);
 
 // Divider widths (and negative) for reuse
 $divider-w: awsui.$border-divider-list-width;

--- a/src/internal/components/selectable-item/styles.scss
+++ b/src/internal/components/selectable-item/styles.scss
@@ -8,7 +8,7 @@
 
 // Box-shadow spread values for simulating borders without layout shifts
 $border-offset: awsui.$border-item-width;
-$border-offset-double: calc(2 * #{awsui.$border-item-width});
+$border-offset-double: calc(2 * awsui.$border-width-item-selected);
 
 // Divider widths (and negative) for reuse
 $divider-w: awsui.$border-divider-list-width;

--- a/src/internal/components/selectable-item/styles.scss
+++ b/src/internal/components/selectable-item/styles.scss
@@ -62,14 +62,14 @@ $neg-divider-w: calc(-1 * #{$divider-w});
 }
 
 @mixin selected-shadow {
-  box-shadow: inset 0 0 0 awsui.$border-width-item-selected awsui.$color-border-dropdown-item-selected;
+  box-shadow: inset 0 0 0 $border-offset awsui.$color-border-dropdown-item-selected;
   &.highlighted {
     box-shadow:
-      inset 0 0 0 awsui.$border-width-item-selected awsui.$color-border-dropdown-item-selected,
+      inset 0 0 0 $border-offset awsui.$color-border-dropdown-item-selected,
       inset 0 0 0 $border-offset-double awsui.$color-border-dropdown-item-hover;
     &.is-keyboard {
       box-shadow:
-        inset 0 0 0 awsui.$border-width-item-selected awsui.$color-border-dropdown-item-selected,
+        inset 0 0 0 $border-offset awsui.$color-border-dropdown-item-selected,
         inset 0 0 0 $border-offset-double awsui.$color-border-dropdown-item-focused;
     }
   }


### PR DESCRIPTION
### Description
This PR makes the border width of selected borders in dropdowns.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
