### PR TITLE
feat: Make color background segment wrapper public

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
@@ -564,6 +564,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#fafafa",
           },
         },
+        "color-background-segment-wrapper": {
+          "$description": "The background color of segmented control wrapper.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#ffffff",
+          },
+        },
         "color-background-slider-handle-active": {
           "$description": "The background color of the slider handle in active state.",
           "$value": {
@@ -3649,6 +3656,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#21252c",
             "light": "#fafafa",
+          },
+        },
+        "color-background-segment-wrapper": {
+          "$description": "The background color of segmented control wrapper.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#ffffff",
           },
         },
         "color-background-slider-handle-active": {
@@ -6738,6 +6752,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#fafafa",
           },
         },
+        "color-background-segment-wrapper": {
+          "$description": "The background color of segmented control wrapper.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#ffffff",
+          },
+        },
         "color-background-slider-handle-active": {
           "$description": "The background color of the slider handle in active state.",
           "$value": {
@@ -9823,6 +9844,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "rgba(0, 7, 22, 0.15)",
             "light": "rgba(0, 7, 22, 0.15)",
+          },
+        },
+        "color-background-segment-wrapper": {
+          "$description": "The background color of segmented control wrapper.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#ffffff",
           },
         },
         "color-background-slider-handle-active": {
@@ -12912,6 +12940,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "rgba(0, 7, 22, 0.05)",
           },
         },
+        "color-background-segment-wrapper": {
+          "$description": "The background color of segmented control wrapper.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#ffffff",
+          },
+        },
         "color-background-slider-handle-active": {
           "$description": "The background color of the slider handle in active state.",
           "$value": {
@@ -15999,6 +16034,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#21252c",
           },
         },
+        "color-background-segment-wrapper": {
+          "$description": "The background color of segmented control wrapper.",
+          "$value": {
+            "dark": "#232f3e",
+            "light": "#232f3e",
+          },
+        },
         "color-background-slider-handle-active": {
           "$description": "The background color of the slider handle in active state.",
           "$value": {
@@ -19084,6 +19126,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
       "$value": {
         "dark": "#21252c",
         "light": "#fafafa",
+      },
+    },
+    "color-background-segment-wrapper": {
+      "$description": "The background color of segmented control wrapper.",
+      "$value": {
+        "dark": "#2a2e33",
+        "light": "#ffffff",
       },
     },
     "color-background-slider-handle-active": {
@@ -22178,6 +22227,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "rgba(0, 7, 22, 0.05)",
           },
         },
+        "color-background-segment-wrapper": {
+          "$description": "The background color of segmented control wrapper.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
+          },
+        },
         "color-background-slider-handle-active": {
           "$description": "The background color of the slider handle in active state.",
           "$value": {
@@ -25263,6 +25319,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "rgba(255, 255, 255, 0.1)",
             "light": "rgba(255, 255, 255, 0.1)",
+          },
+        },
+        "color-background-segment-wrapper": {
+          "$description": "The background color of segmented control wrapper.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#161d26",
           },
         },
         "color-background-slider-handle-active": {
@@ -28352,6 +28415,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#f0fbff",
           },
         },
+        "color-background-segment-wrapper": {
+          "$description": "The background color of segmented control wrapper.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
+          },
+        },
         "color-background-slider-handle-active": {
           "$description": "The background color of the slider handle in active state.",
           "$value": {
@@ -31437,6 +31507,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#1b232d",
             "light": "#f0fbff",
+          },
+        },
+        "color-background-segment-wrapper": {
+          "$description": "The background color of segmented control wrapper.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
           },
         },
         "color-background-slider-handle-active": {
@@ -34526,6 +34603,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "rgba(0, 7, 22, 0.15)",
           },
         },
+        "color-background-segment-wrapper": {
+          "$description": "The background color of segmented control wrapper.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
+          },
+        },
         "color-background-slider-handle-active": {
           "$description": "The background color of the slider handle in active state.",
           "$value": {
@@ -37611,6 +37695,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "rgba(0, 7, 22, 0.05)",
             "light": "rgba(0, 7, 22, 0.05)",
+          },
+        },
+        "color-background-segment-wrapper": {
+          "$description": "The background color of segmented control wrapper.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
           },
         },
         "color-background-slider-handle-active": {
@@ -40700,6 +40791,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#1b232d",
           },
         },
+        "color-background-segment-wrapper": {
+          "$description": "The background color of segmented control wrapper.",
+          "$value": {
+            "dark": "#0f141a",
+            "light": "#0f141a",
+          },
+        },
         "color-background-slider-handle-active": {
           "$description": "The background color of the slider handle in active state.",
           "$value": {
@@ -43787,6 +43885,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#1b232d",
           },
         },
+        "color-background-segment-wrapper": {
+          "$description": "The background color of segmented control wrapper.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#161d26",
+          },
+        },
         "color-background-slider-handle-active": {
           "$description": "The background color of the slider handle in active state.",
           "$value": {
@@ -46872,6 +46977,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
       "$value": {
         "dark": "#1b232d",
         "light": "#f0fbff",
+      },
+    },
+    "color-background-segment-wrapper": {
+      "$description": "The background color of segmented control wrapper.",
+      "$value": {
+        "dark": "#161d26",
+        "light": "#ffffff",
       },
     },
     "color-background-slider-handle-active": {

--- a/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
@@ -354,6 +354,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#f2f3f3",
           },
         },
+        "color-background-dropdown-item-selected": {
+          "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#12293b",
+            "light": "#f1faff",
+          },
+        },
         "color-background-home-header": {
           "$description": "The background color of the home header, displayed on the Service's home page.",
           "$value": {
@@ -2258,6 +2265,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#16191f",
           },
         },
+        "color-text-dropdown-item-secondary": {
+          "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#687078",
+          },
+        },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
           "$value": {
@@ -2312,6 +2326,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#d5dbdb",
             "light": "#d5dbdb",
+          },
+        },
+        "color-text-icon-subtle": {
+          "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+          "$value": {
+            "dark": "#aab7b8",
+            "light": "#687078",
           },
         },
         "color-text-input-disabled": {
@@ -3448,6 +3469,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#f2f3f3",
           },
         },
+        "color-background-dropdown-item-selected": {
+          "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#12293b",
+            "light": "#f1faff",
+          },
+        },
         "color-background-home-header": {
           "$description": "The background color of the home header, displayed on the Service's home page.",
           "$value": {
@@ -5352,6 +5380,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#16191f",
           },
         },
+        "color-text-dropdown-item-secondary": {
+          "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#687078",
+          },
+        },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
           "$value": {
@@ -5406,6 +5441,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#d5dbdb",
             "light": "#d5dbdb",
+          },
+        },
+        "color-text-icon-subtle": {
+          "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+          "$value": {
+            "dark": "#aab7b8",
+            "light": "#687078",
           },
         },
         "color-text-input-disabled": {
@@ -6542,6 +6584,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#f2f3f3",
           },
         },
+        "color-background-dropdown-item-selected": {
+          "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#12293b",
+            "light": "#f1faff",
+          },
+        },
         "color-background-home-header": {
           "$description": "The background color of the home header, displayed on the Service's home page.",
           "$value": {
@@ -8446,6 +8495,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#16191f",
           },
         },
+        "color-text-dropdown-item-secondary": {
+          "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#687078",
+          },
+        },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
           "$value": {
@@ -8500,6 +8556,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#d5dbdb",
             "light": "#d5dbdb",
+          },
+        },
+        "color-text-icon-subtle": {
+          "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+          "$value": {
+            "dark": "#aab7b8",
+            "light": "#687078",
           },
         },
         "color-text-input-disabled": {
@@ -9634,6 +9697,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#414750",
             "light": "#f2f3f3",
+          },
+        },
+        "color-background-dropdown-item-selected": {
+          "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#12293b",
+            "light": "#f1faff",
           },
         },
         "color-background-home-header": {
@@ -11540,6 +11610,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#16191f",
           },
         },
+        "color-text-dropdown-item-secondary": {
+          "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#687078",
+          },
+        },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
           "$value": {
@@ -11594,6 +11671,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#d5dbdb",
             "light": "#d5dbdb",
+          },
+        },
+        "color-text-icon-subtle": {
+          "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+          "$value": {
+            "dark": "#aab7b8",
+            "light": "#687078",
           },
         },
         "color-text-input-disabled": {
@@ -12728,6 +12812,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#414750",
             "light": "#f2f3f3",
+          },
+        },
+        "color-background-dropdown-item-selected": {
+          "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#12293b",
+            "light": "#f1faff",
           },
         },
         "color-background-home-header": {
@@ -14634,6 +14725,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#16191f",
           },
         },
+        "color-text-dropdown-item-secondary": {
+          "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#687078",
+          },
+        },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
           "$value": {
@@ -14688,6 +14786,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#d5dbdb",
             "light": "#d5dbdb",
+          },
+        },
+        "color-text-icon-subtle": {
+          "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+          "$value": {
+            "dark": "#aab7b8",
+            "light": "#687078",
           },
         },
         "color-text-input-disabled": {
@@ -15822,6 +15927,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#414750",
             "light": "#414750",
+          },
+        },
+        "color-background-dropdown-item-selected": {
+          "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#12293b",
+            "light": "#12293b",
           },
         },
         "color-background-home-header": {
@@ -17728,6 +17840,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#eaeded",
           },
         },
+        "color-text-dropdown-item-secondary": {
+          "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#95a5a6",
+          },
+        },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
           "$value": {
@@ -17782,6 +17901,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#d5dbdb",
             "light": "#d5dbdb",
+          },
+        },
+        "color-text-icon-subtle": {
+          "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+          "$value": {
+            "dark": "#aab7b8",
+            "light": "#aab7b8",
           },
         },
         "color-text-input-disabled": {
@@ -18916,6 +19042,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
       "$value": {
         "dark": "#414750",
         "light": "#f2f3f3",
+      },
+    },
+    "color-background-dropdown-item-selected": {
+      "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+      "$value": {
+        "dark": "#12293b",
+        "light": "#f1faff",
       },
     },
     "color-background-home-header": {
@@ -20822,6 +20955,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         "light": "#16191f",
       },
     },
+    "color-text-dropdown-item-secondary": {
+      "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+      "$value": {
+        "dark": "#95a5a6",
+        "light": "#687078",
+      },
+    },
     "color-text-empty": {
       "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
       "$value": {
@@ -20876,6 +21016,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
       "$value": {
         "dark": "#d5dbdb",
         "light": "#d5dbdb",
+      },
+    },
+    "color-text-icon-subtle": {
+      "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+      "$value": {
+        "dark": "#aab7b8",
+        "light": "#687078",
       },
     },
     "color-text-input-disabled": {
@@ -22015,6 +22162,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#131920",
             "light": "#f3f3f7",
+          },
+        },
+        "color-background-dropdown-item-selected": {
+          "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#001129",
+            "light": "#f0fbff",
           },
         },
         "color-background-home-header": {
@@ -23921,6 +24075,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#0f141a",
           },
         },
+        "color-text-dropdown-item-secondary": {
+          "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#a4a4ad",
+            "light": "#656871",
+          },
+        },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
           "$value": {
@@ -23975,6 +24136,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#c6c6cd",
             "light": "#c6c6cd",
+          },
+        },
+        "color-text-icon-subtle": {
+          "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+          "$value": {
+            "dark": "#b4b4bb",
+            "light": "#656871",
           },
         },
         "color-text-input-disabled": {
@@ -25109,6 +25277,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#131920",
             "light": "#131920",
+          },
+        },
+        "color-background-dropdown-item-selected": {
+          "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#001129",
+            "light": "#001129",
           },
         },
         "color-background-home-header": {
@@ -27015,6 +27190,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#ebebf0",
           },
         },
+        "color-text-dropdown-item-secondary": {
+          "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#a4a4ad",
+            "light": "#a4a4ad",
+          },
+        },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
           "$value": {
@@ -27069,6 +27251,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#c6c6cd",
             "light": "#c6c6cd",
+          },
+        },
+        "color-text-icon-subtle": {
+          "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+          "$value": {
+            "dark": "#b4b4bb",
+            "light": "#b4b4bb",
           },
         },
         "color-text-input-disabled": {
@@ -28203,6 +28392,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#131920",
             "light": "#f3f3f7",
+          },
+        },
+        "color-background-dropdown-item-selected": {
+          "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#001129",
+            "light": "#f0fbff",
           },
         },
         "color-background-home-header": {
@@ -30109,6 +30305,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#0f141a",
           },
         },
+        "color-text-dropdown-item-secondary": {
+          "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#a4a4ad",
+            "light": "#656871",
+          },
+        },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
           "$value": {
@@ -30163,6 +30366,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#c6c6cd",
             "light": "#c6c6cd",
+          },
+        },
+        "color-text-icon-subtle": {
+          "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+          "$value": {
+            "dark": "#b4b4bb",
+            "light": "#656871",
           },
         },
         "color-text-input-disabled": {
@@ -31297,6 +31507,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#131920",
             "light": "#f3f3f7",
+          },
+        },
+        "color-background-dropdown-item-selected": {
+          "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#001129",
+            "light": "#f0fbff",
           },
         },
         "color-background-home-header": {
@@ -33203,6 +33420,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#0f141a",
           },
         },
+        "color-text-dropdown-item-secondary": {
+          "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#a4a4ad",
+            "light": "#656871",
+          },
+        },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
           "$value": {
@@ -33257,6 +33481,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#c6c6cd",
             "light": "#c6c6cd",
+          },
+        },
+        "color-text-icon-subtle": {
+          "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+          "$value": {
+            "dark": "#b4b4bb",
+            "light": "#656871",
           },
         },
         "color-text-input-disabled": {
@@ -34391,6 +34622,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#131920",
             "light": "#f3f3f7",
+          },
+        },
+        "color-background-dropdown-item-selected": {
+          "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#001129",
+            "light": "#f0fbff",
           },
         },
         "color-background-home-header": {
@@ -36297,6 +36535,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#0f141a",
           },
         },
+        "color-text-dropdown-item-secondary": {
+          "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#a4a4ad",
+            "light": "#656871",
+          },
+        },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
           "$value": {
@@ -36351,6 +36596,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#c6c6cd",
             "light": "#c6c6cd",
+          },
+        },
+        "color-text-icon-subtle": {
+          "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+          "$value": {
+            "dark": "#b4b4bb",
+            "light": "#656871",
           },
         },
         "color-text-input-disabled": {
@@ -37485,6 +37737,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#131920",
             "light": "#f3f3f7",
+          },
+        },
+        "color-background-dropdown-item-selected": {
+          "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#001129",
+            "light": "#f0fbff",
           },
         },
         "color-background-home-header": {
@@ -39391,6 +39650,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#0f141a",
           },
         },
+        "color-text-dropdown-item-secondary": {
+          "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#a4a4ad",
+            "light": "#656871",
+          },
+        },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
           "$value": {
@@ -39445,6 +39711,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#c6c6cd",
             "light": "#c6c6cd",
+          },
+        },
+        "color-text-icon-subtle": {
+          "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+          "$value": {
+            "dark": "#b4b4bb",
+            "light": "#656871",
           },
         },
         "color-text-input-disabled": {
@@ -40581,6 +40854,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#131920",
           },
         },
+        "color-background-dropdown-item-selected": {
+          "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#001129",
+            "light": "#001129",
+          },
+        },
         "color-background-home-header": {
           "$description": "The background color of the home header, displayed on the Service's home page.",
           "$value": {
@@ -42485,6 +42765,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#ebebf0",
           },
         },
+        "color-text-dropdown-item-secondary": {
+          "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#a4a4ad",
+            "light": "#a4a4ad",
+          },
+        },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
           "$value": {
@@ -42539,6 +42826,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#c6c6cd",
             "light": "#c6c6cd",
+          },
+        },
+        "color-text-icon-subtle": {
+          "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+          "$value": {
+            "dark": "#b4b4bb",
+            "light": "#b4b4bb",
           },
         },
         "color-text-input-disabled": {
@@ -43675,6 +43969,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#131920",
           },
         },
+        "color-background-dropdown-item-selected": {
+          "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#001129",
+            "light": "#001129",
+          },
+        },
         "color-background-home-header": {
           "$description": "The background color of the home header, displayed on the Service's home page.",
           "$value": {
@@ -45579,6 +45880,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#ebebf0",
           },
         },
+        "color-text-dropdown-item-secondary": {
+          "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#a4a4ad",
+            "light": "#a4a4ad",
+          },
+        },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
           "$value": {
@@ -45633,6 +45941,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#c6c6cd",
             "light": "#c6c6cd",
+          },
+        },
+        "color-text-icon-subtle": {
+          "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+          "$value": {
+            "dark": "#b4b4bb",
+            "light": "#b4b4bb",
           },
         },
         "color-text-input-disabled": {
@@ -46767,6 +47082,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
       "$value": {
         "dark": "#131920",
         "light": "#f3f3f7",
+      },
+    },
+    "color-background-dropdown-item-selected": {
+      "$description": "The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.",
+      "$value": {
+        "dark": "#001129",
+        "light": "#f0fbff",
       },
     },
     "color-background-home-header": {
@@ -48673,6 +48995,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "light": "#0f141a",
       },
     },
+    "color-text-dropdown-item-secondary": {
+      "$description": "The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.",
+      "$value": {
+        "dark": "#a4a4ad",
+        "light": "#656871",
+      },
+    },
     "color-text-empty": {
       "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
       "$value": {
@@ -48727,6 +49056,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
       "$value": {
         "dark": "#c6c6cd",
         "light": "#c6c6cd",
+      },
+    },
+    "color-text-icon-subtle": {
+      "$description": "The color of subtle icons. For example: secondary icons with lower visual emphasis.",
+      "$value": {
+        "dark": "#b4b4bb",
+        "light": "#656871",
       },
     },
     "color-text-input-disabled": {

--- a/style-dictionary/visual-refresh/metadata/colors.ts
+++ b/style-dictionary/visual-refresh/metadata/colors.ts
@@ -260,7 +260,7 @@ const metadata: StyleDictionary.MetadataIndex = {
   },
   colorBackgroundSegmentWrapper: {
     description: 'The background color of segmented control wrapper.',
-    public: false,
+    public: true,
     themeable: true,
   },
   colorBackgroundSliderHandleDefault: {

--- a/style-dictionary/visual-refresh/metadata/colors.ts
+++ b/style-dictionary/visual-refresh/metadata/colors.ts
@@ -129,6 +129,8 @@ const metadata: StyleDictionary.MetadataIndex = {
   colorBackgroundDropdownItemSelected: {
     description:
       'The background color of selected dropdown items. For example: background of selected items in select, multiselect, autosuggest, and datepicker dropdowns.',
+    public: true,
+    themeable: true,
   },
   colorBackgroundHomeHeader: {
     description: "The background color of the home header, displayed on the Service's home page.",
@@ -721,6 +723,8 @@ const metadata: StyleDictionary.MetadataIndex = {
   colorTextDropdownItemSecondary: {
     description:
       'The text color of secondary information in dropdown items. For example: descriptions and tags text color in a select, multiselect, and autosuggest.',
+    public: true,
+    themeable: true,
   },
   colorTextEmpty: {
     description:
@@ -989,6 +993,11 @@ const metadata: StyleDictionary.MetadataIndex = {
     description: 'The color of file upload dropzone border in hovered state.',
     themeable: true,
     public: true,
+  },
+  colorTextIconSubtle: {
+    description: 'The color of subtle icons. For example: secondary icons with lower visual emphasis.',
+    public: true,
+    themeable: true,
   },
 };
 


### PR DESCRIPTION
### Description  
- Add colorBackgroundDropdownItemSelected token for selected dropdown item backgrounds (select, multiselect, autosuggest, datepicker)
- Add colorBackgroundSegmentWrapper token for segmented control wrapper background
- Add colorTextDropdownItemSecondary token for secondary text in dropdown items (descriptions, tags)
- Add colorTextIconSubtle token for subtle/secondary icons with lower visual emphasis                                                                                                                                                     
                                                                                                                                                                                                                                            
All new tokens are marked public and themeable.    

Related links, issue #, if available: n/a

### How has this been tested?
-- 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
