### PR TITLE
chore: Fix date range picker test failing when previous month does not start on Sunday

### DIFF
--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -606,7 +606,7 @@ describe('renderTriggerContent', () => {
 });
 
 describe('disabled reason behavior', () => {
-  const findDate = (wrapper: DateRangePickerWrapper) => wrapper.findDropdown()!.findDateAt('left', 1, 1);
+  const findDate = (wrapper: DateRangePickerWrapper) => wrapper.findDropdown()!.findDateAt('left', 2, 1);
 
   test('clicking on disabled reason does not close the calendar', () => {
     const { wrapper } = renderDateRangePicker({


### PR DESCRIPTION
### Description

A previously added test had an implicit time-sensitive dependency. The line

```
wrapper.findDropdown()!.findDateAt('left', 1, 1);
```

tries to pick the top left item of the calendar grid for the previous month. In April 2026, using en-US locale which lets the months start on Sunday, this worked because March started on Sunday. The first line of the March calendar grid looks like this:

<img width="235" height="29" alt="Screenshot 2026-05-04 at 10 43 24" src="https://github.com/user-attachments/assets/cc359423-ab7d-4de6-8462-4db7d4ecde6b" />

But now in May, the first item of the first line of the previous month (April) grid does not contain a selectable date:

<img width="239" height="30" alt="Screenshot 2026-05-04 at 10 43 19" src="https://github.com/user-attachments/assets/78bd3469-5533-4acd-9038-2adcd6857148" />

so the call errors out.

This PR addresses this by selecting the first item from the second row, which will always exist.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
