### PR TITLE
fix: Autosuggest custom rendering group and use-entered text not rendering correctly

### DIFF
--- a/src/autosuggest/__tests__/render-option.test.tsx
+++ b/src/autosuggest/__tests__/render-option.test.tsx
@@ -231,7 +231,7 @@ describe('Autosuggest renderOption', () => {
         );
       });
 
-      test('does not render custom content for entered-text option', () => {
+      test('renders custom content for entered-text option', () => {
         const renderOption = jest.fn(props => {
           if (props.item.type === 'entered-text') {
             return <div>Use custom: {props.item.option.value}</div>;
@@ -248,8 +248,7 @@ describe('Autosuggest renderOption', () => {
 
         const enteredTextOption = wrapper.findEnteredTextOption();
         expect(enteredTextOption).not.toBe(null);
-        // entered-text options always use option.label, ignoring renderOption
-        expect(enteredTextOption!.getElement()).toHaveTextContent('Use value');
+        expect(enteredTextOption!.getElement()).toHaveTextContent('Use custom: custom-value');
       });
 
       test('maintains option index in item properties', () => {

--- a/src/autosuggest/autosuggest-option.tsx
+++ b/src/autosuggest/autosuggest-option.tsx
@@ -150,12 +150,12 @@ const AutosuggestOption = (
 
   let optionContent;
   if (useEntered) {
-    optionContent = option.label;
+    optionContent = renderResult ?? option.label;
     // we don't want fancy generated content for screenreader for the "Use..." option,
     // just the visible text is fine
     screenReaderContent = undefined;
   } else if (isParent) {
-    optionContent = option.label;
+    optionContent = renderResult ?? option.label;
   } else {
     const a11yProperties: AutosuggestOptionProps['nativeAttributes'] = {};
     if (nativeAttributes['aria-label']) {


### PR DESCRIPTION
### Description

Addresses a rendering issue with option groups and use-entered text in Autosuggest.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
