### PR TITLE
fix: Support IME character composition in prompt input with shortcuts

### DIFF
--- a/src/internal/hooks/use-ime-composition/__tests__/use-ime-composition.test.tsx
+++ b/src/internal/hooks/use-ime-composition/__tests__/use-ime-composition.test.tsx
@@ -182,3 +182,60 @@ describe('useIMEComposition', () => {
     expect(hook.isComposing()).toBe(false);
   });
 });
+
+describe('onCompositionStart callback and composing state', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+      setTimeout(() => cb(performance.now()), 0);
+      return 1;
+    });
+  });
+
+  test('onCompositionStart is called when composition begins', () => {
+    const onCompositionStart = jest.fn();
+    const { result } = renderHook(() => {
+      const mockInput = document.createElement('input');
+      const inputRef = { current: mockInput };
+      return { hook: useIMEComposition(inputRef, { onCompositionStart }), inputElement: mockInput };
+    });
+
+    result.current.inputElement.dispatchEvent(new CompositionEvent('compositionstart'));
+    expect(onCompositionStart).toHaveBeenCalledTimes(1);
+  });
+
+  test('onCompositionEnd is called when composition ends', () => {
+    const onCompositionEnd = jest.fn();
+    const { result } = renderHook(() => {
+      const mockInput = document.createElement('input');
+      const inputRef = { current: mockInput };
+      return { hook: useIMEComposition(inputRef, { onCompositionEnd }), inputElement: mockInput };
+    });
+
+    const { inputElement } = result.current;
+    inputElement.dispatchEvent(new CompositionEvent('compositionstart'));
+    inputElement.dispatchEvent(new CompositionEvent('compositionend', { data: '가' }));
+    expect(onCompositionEnd).toHaveBeenCalledTimes(1);
+  });
+
+  test('isComposing() is still true when onCompositionEnd fires (spurious Enter guard)', () => {
+    let isComposingDuringCallback = false;
+    const { result } = renderHook(() => {
+      const mockInput = document.createElement('input');
+      const inputRef = { current: mockInput };
+      // Use a ref to capture the hook's isComposing function after it's created.
+      const hookRef = { current: null as ReturnType<typeof useIMEComposition> | null };
+      const hook = useIMEComposition(inputRef, {
+        onCompositionEnd: () => {
+          isComposingDuringCallback = hookRef.current!.isComposing();
+        },
+      });
+      hookRef.current = hook;
+      return { hook, inputElement: mockInput };
+    });
+
+    result.current.inputElement.dispatchEvent(new CompositionEvent('compositionstart'));
+    result.current.inputElement.dispatchEvent(new CompositionEvent('compositionend', { data: '가' }));
+    expect(isComposingDuringCallback).toBe(true);
+  });
+});

--- a/src/internal/hooks/use-ime-composition/index.ts
+++ b/src/internal/hooks/use-ime-composition/index.ts
@@ -3,6 +3,16 @@
 
 import { useEffect, useRef } from 'react';
 
+export interface UseIMECompositionOptions {
+  /**
+   * Called synchronously when composition ends (i.e. the user commits a composed character).
+   * At the point this fires, isComposing() still returns true — which blocks the spurious
+   * Enter keydown that some browsers fire immediately after compositionend. The flag is
+   * cleared after the next animation frame.
+   */
+  onCompositionEnd?: () => void;
+}
+
 /**
  * Custom hook to handle IME composition state for preventing IME race conditions when pressing enter to end composition.
  *
@@ -11,16 +21,27 @@ import { useEffect, useRef } from 'react';
  * 2. Second Enter: Triggers normal action (isComposing=false)
  *
  * This hook tracks composition lifecycle to prevent the second Enter during the brief window.
+ *
+ * The optional `onCompositionEnd` callback fires synchronously when composition commits,
+ * allowing callers to process the final composed text (e.g. trigger detection in token mode).
  */
-export function useIMEComposition(elementRef: React.RefObject<HTMLInputElement>) {
+export function useIMEComposition(
+  elementRef: React.RefObject<HTMLElement>,
+  { onCompositionEnd }: UseIMECompositionOptions = {}
+) {
   const wasComposingRef = useRef(false);
+  const onCompositionEndRef = useRef(onCompositionEnd);
+  onCompositionEndRef.current = onCompositionEnd;
 
   const handleCompositionStart = () => {
     wasComposingRef.current = true;
   };
 
   const handleCompositionEnd = () => {
-    // Keep flag true briefly to catch immediate post-composition Enter events
+    // Fire the callback while wasComposing is still true — this blocks the spurious
+    // Enter keydown that fires synchronously after compositionend in some browsers.
+    onCompositionEndRef.current?.();
+    // Keep flag true briefly to catch immediate post-composition Enter events.
     requestAnimationFrame(() => {
       wasComposingRef.current = false;
     });

--- a/src/internal/hooks/use-ime-composition/index.ts
+++ b/src/internal/hooks/use-ime-composition/index.ts
@@ -5,6 +5,10 @@ import { useEffect, useRef } from 'react';
 
 export interface UseIMECompositionOptions {
   /**
+   * Called synchronously when composition starts.
+   */
+  onCompositionStart?: () => void;
+  /**
    * Called synchronously when composition ends (i.e. the user commits a composed character).
    * At the point this fires, isComposing() still returns true — which blocks the spurious
    * Enter keydown that some browsers fire immediately after compositionend. The flag is
@@ -27,14 +31,17 @@ export interface UseIMECompositionOptions {
  */
 export function useIMEComposition(
   elementRef: React.RefObject<HTMLElement>,
-  { onCompositionEnd }: UseIMECompositionOptions = {}
+  { onCompositionStart, onCompositionEnd }: UseIMECompositionOptions = {}
 ) {
   const wasComposingRef = useRef(false);
+  const onCompositionStartRef = useRef(onCompositionStart);
+  onCompositionStartRef.current = onCompositionStart;
   const onCompositionEndRef = useRef(onCompositionEnd);
   onCompositionEndRef.current = onCompositionEnd;
 
   const handleCompositionStart = () => {
     wasComposingRef.current = true;
+    onCompositionStartRef.current?.();
   };
 
   const handleCompositionEnd = () => {

--- a/src/prompt-input/__tests__/prompt-input-token-mode.test.tsx
+++ b/src/prompt-input/__tests__/prompt-input-token-mode.test.tsx
@@ -7,6 +7,8 @@ import PromptInput, { PromptInputProps } from '../../../lib/components/prompt-in
 import createWrapper, { PromptInputWrapper } from '../../../lib/components/test-utils/dom';
 import { KeyCode, KeyCodeA, KeyCodeDelete } from '../../internal/keycode';
 
+import promptInputStyles from '../../../lib/components/prompt-input/styles.css.js';
+
 jest.mock('@cloudscape-design/component-toolkit', () => ({
   ...jest.requireActual('@cloudscape-design/component-toolkit'),
   useContainerQuery: () => [800, () => {}],
@@ -7747,5 +7749,206 @@ describe('select-all deletion with root-level selection range', () => {
     const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0].detail;
     expect(lastCall.value).toBe('');
     expect(getValue(wrapper)).toBe('');
+  });
+});
+
+describe('IME composition handling', () => {
+  // Helpers to dispatch composition events on the contentEditable element.
+  function startComposition(el: HTMLElement) {
+    act(() => {
+      el.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    });
+  }
+
+  function endComposition(el: HTMLElement, data: string) {
+    act(() => {
+      el.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data }));
+    });
+  }
+
+  function dispatchInput(el: HTMLElement) {
+    act(() => {
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }
+
+  test('input events during composition do not trigger onChange', () => {
+    const onChange = jest.fn();
+    const { wrapper } = renderTokenMode({ props: { tokens: [{ type: 'text', value: '' }], onChange } });
+    const el = wrapper.findContentEditableElement()!.getElement();
+
+    startComposition(el);
+
+    // Simulate intermediate input events that fire during CJK composition.
+    // Each one should be ignored because isComposing() returns true.
+    const p = el.querySelector('p')!;
+    p.textContent = 'ㄱ';
+    dispatchInput(el);
+    expect(onChange).not.toHaveBeenCalled();
+
+    p.textContent = '가';
+    dispatchInput(el);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('onChange is called once when composition ends', () => {
+    const onChange = jest.fn();
+    const { wrapper } = renderTokenMode({ props: { tokens: [{ type: 'text', value: '' }], onChange } });
+    const el = wrapper.findContentEditableElement()!.getElement();
+
+    startComposition(el);
+
+    // Intermediate input events are suppressed.
+    const p = el.querySelector('p')!;
+    p.textContent = '가';
+    dispatchInput(el);
+    expect(onChange).not.toHaveBeenCalled();
+
+    // compositionend commits the text — onChange should fire exactly once.
+    endComposition(el, '가');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const detail = onChange.mock.calls[0][0].detail;
+    expect(detail.value).toBe('가');
+  });
+
+  test('trigger detection runs after composition ends, not during', () => {
+    const onChange = jest.fn();
+    const { wrapper } = renderTokenMode({ props: { tokens: [], onChange } });
+    const el = wrapper.findContentEditableElement()!.getElement();
+
+    // Ensure there is a paragraph to type into.
+    const p =
+      el.querySelector('p') ??
+      (() => {
+        const newP = document.createElement('p');
+        el.appendChild(newP);
+        return newP;
+      })();
+
+    startComposition(el);
+
+    // Simulate typing '@' as part of a composition (should not open menu).
+    p.textContent = '@';
+    dispatchInput(el);
+    expect(wrapper.isMenuOpen()).toBe(false);
+
+    // After composition ends with a plain character, no trigger should be detected.
+    p.textContent = '안';
+    endComposition(el, '안');
+    expect(wrapper.isMenuOpen()).toBe(false);
+  });
+
+  test('placeholder reappears after composing then deleting all content', () => {
+    const { wrapper } = renderStatefulTokenMode({
+      props: { tokens: [], placeholder: 'Type a message', menus: defaultMenus },
+    });
+    const el = wrapper.findContentEditableElement()!.getElement();
+    const placeholderVisibleClass = promptInputStyles['placeholder-visible'];
+
+    // Placeholder is visible initially.
+    expect(el.classList.contains(placeholderVisibleClass)).toBe(true);
+
+    // Simulate a full IME composition cycle that commits '가'.
+    startComposition(el);
+    const p = el.querySelector('p')!;
+    p.textContent = '가';
+    endComposition(el, '가');
+
+    // Placeholder is hidden because tokens now contain the committed text.
+    expect(el.classList.contains(placeholderVisibleClass)).toBe(false);
+
+    // User deletes the committed text — input is empty again.
+    p.textContent = '';
+    dispatchInput(el);
+
+    // Placeholder should reappear.
+    expect(el.classList.contains(placeholderVisibleClass)).toBe(true);
+  });
+
+  test('placeholder is hidden during composition and reappears when input is empty after composing', () => {
+    const { wrapper } = renderTokenMode({
+      props: { tokens: [], placeholder: 'Type a message', menus: defaultMenus },
+    });
+    const el = wrapper.findContentEditableElement()!.getElement();
+    const placeholderVisibleClass = promptInputStyles['placeholder-visible'];
+
+    // Placeholder is visible initially.
+    expect(el.classList.contains(placeholderVisibleClass)).toBe(true);
+
+    // Placeholder hides when composition starts.
+    act(() => {
+      el.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    });
+    expect(el.classList.contains(placeholderVisibleClass)).toBe(false);
+
+    // Placeholder reappears after compositionend when the input is still empty
+    // (e.g. the user cancelled composition without committing any text).
+    act(() => {
+      el.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '가' }));
+    });
+    expect(el.classList.contains(placeholderVisibleClass)).toBe(true);
+  });
+
+  test('Enter key immediately after compositionend does not submit', () => {
+    // Some browsers fire a spurious Enter keydown with isComposing=false immediately
+    // after compositionend. The isComposing() ref stays true until the next animation
+    // frame, blocking this spurious event from triggering a form submit.
+    const onAction = jest.fn();
+    const { wrapper } = renderTokenMode({
+      props: { tokens: [{ type: 'text', value: '' }], onAction },
+    });
+    const el = wrapper.findContentEditableElement()!.getElement();
+
+    startComposition(el);
+    endComposition(el, '가');
+
+    // Spurious Enter fires synchronously after compositionend, before the next paint.
+    // isComposing() is still true at this point.
+    act(() => {
+      el.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', keyCode: 13, bubbles: true, cancelable: true, isComposing: false })
+      );
+    });
+
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  test('normal input events outside composition still trigger onChange', () => {
+    const onChange = jest.fn();
+    const { wrapper } = renderTokenMode({ props: { tokens: [{ type: 'text', value: '' }], onChange } });
+    const el = wrapper.findContentEditableElement()!.getElement();
+
+    // No composition active — input event should be processed normally.
+    const p = el.querySelector('p')!;
+    p.textContent = 'hello';
+    dispatchInput(el);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0].detail.value).toBe('hello');
+  });
+
+  test('input events after composition ends are processed normally', () => {
+    // After a full composition cycle, a new composition should work correctly.
+    const onChange = jest.fn();
+    const { wrapper } = renderTokenMode({ props: { tokens: [{ type: 'text', value: '' }], onChange } });
+    const el = wrapper.findContentEditableElement()!.getElement();
+
+    // First composition cycle.
+    startComposition(el);
+    const p = el.querySelector('p')!;
+    p.textContent = '가';
+    dispatchInput(el);
+    expect(onChange).not.toHaveBeenCalled();
+    endComposition(el, '가');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    onChange.mockClear();
+
+    // Second composition cycle works independently.
+    startComposition(el);
+    p.textContent = '가나';
+    dispatchInput(el);
+    expect(onChange).not.toHaveBeenCalled();
+    endComposition(el, '나');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0].detail.value).toBe('가나');
   });
 });

--- a/src/prompt-input/core/event-handlers.ts
+++ b/src/prompt-input/core/event-handlers.ts
@@ -52,6 +52,8 @@ export interface KeyboardHandlerProps {
   onChange: (detail: { value: string; tokens: PromptInputProps.InputToken[] }) => void;
   markTokensAsSent: (tokens: readonly PromptInputProps.InputToken[]) => void;
   onKeyDown?: PromptInputProps['onKeyDown'];
+  /** Returns true if an IME composition session is active or just ended (spurious-Enter window). */
+  isComposing?: () => boolean;
 }
 
 /** Handles all keyboard events for the editable element. */
@@ -143,7 +145,7 @@ export function handleEditableKeyDown(event: React.KeyboardEvent<HTMLDivElement>
       handleDeleteAfterTrigger(event, editableElement);
     },
     onShiftEnter: () => {
-      if (event.nativeEvent.isComposing) {
+      if (event.nativeEvent.isComposing || props.isComposing?.()) {
         return;
       }
       event.preventDefault();
@@ -155,7 +157,7 @@ export function handleEditableKeyDown(event: React.KeyboardEvent<HTMLDivElement>
       }
     },
     onEnter: () => {
-      if (event.nativeEvent.isComposing) {
+      if (event.nativeEvent.isComposing || props.isComposing?.()) {
         return;
       }
       if (menuOpen && menuItemsHandlers) {

--- a/src/prompt-input/tokens/use-token-mode.tsx
+++ b/src/prompt-input/tokens/use-token-mode.tsx
@@ -9,6 +9,7 @@ import { useStableCallback, useUniqueId } from '@cloudscape-design/component-too
 
 import { useDropdownStatus } from '../../internal/components/dropdown-status';
 import { fireKeyboardEvent, fireNonCancelableEvent } from '../../internal/events';
+import { useIMEComposition } from '../../internal/hooks/use-ime-composition';
 import { getFirstScrollableParent } from '../../internal/utils/scrollable-containers';
 import Token from '../../token/internal';
 import { calculateTokenPosition, CaretController, getOwnerSelection } from '../core/caret-controller';
@@ -529,6 +530,18 @@ export function useTokenMode(config: UseTokenModeConfig): UseTokenModeResult {
   const menusRef = useRef(menus);
   menusRef.current = menus;
 
+  // Stable ref so the compositionend callback always calls the latest handleInput.
+  const handleInputRef = useRef<() => void>(() => {});
+
+  // Track IME composition state so the onInput handler skips intermediate characters
+  // during CJK (and other) composition sequences. The onCompositionEnd callback
+  // fires synchronously when the user commits a composed character — handleInput
+  // runs unconditionally there, while isComposing() is still true (blocking the
+  // spurious Enter that fires immediately after compositionend in some browsers).
+  const { isComposing } = useIMEComposition(editableElementRef, {
+    onCompositionEnd: () => handleInputRef.current(),
+  });
+
   const handleInput = useCallback(() => {
     if (!editableElementRef.current) {
       return;
@@ -651,6 +664,9 @@ export function useTokenMode(config: UseTokenModeConfig): UseTokenModeResult {
     shortcutsState.triggerElementsRef,
     shortcutsState.cancelledTriggerIds,
   ]);
+
+  // Keep the ref in sync so the compositionend handler always calls the latest version.
+  handleInputRef.current = handleInput;
 
   // Token render effect
   useLayoutEffect(() => {
@@ -1150,7 +1166,15 @@ export function useTokenMode(config: UseTokenModeConfig): UseTokenModeResult {
     menuItemsHandlers,
     menuDropdownStatus,
     shouldRenderMenuDropdown,
-    handleInput,
+    handleInput: () => {
+      // Skip processing during IME composition — intermediate input events fire
+      // for each keystroke during CJK composition and must not trigger token
+      // detection. The onCompositionEnd callback calls handleInput directly
+      // (bypassing this guard) once the final text is committed.
+      if (!isComposing()) {
+        handleInput();
+      }
+    },
     handleLoadMore,
     tokenOperationAnnouncement,
     markTokensAsSent,

--- a/src/prompt-input/tokens/use-token-mode.tsx
+++ b/src/prompt-input/tokens/use-token-mode.tsx
@@ -533,13 +533,23 @@ export function useTokenMode(config: UseTokenModeConfig): UseTokenModeResult {
   // Stable ref so the compositionend callback always calls the latest handleInput.
   const handleInputRef = useRef<() => void>(() => {});
 
+  // `composing` React state drives placeholder visibility — hidden while the user
+  // is actively composing CJK characters so intermediate characters don't flash
+  // the placeholder on and off.
+  const [composing, setComposing] = useState(false);
+
   // Track IME composition state so the onInput handler skips intermediate characters
   // during CJK (and other) composition sequences. The onCompositionEnd callback
   // fires synchronously when the user commits a composed character — handleInput
-  // runs unconditionally there, while isComposing() is still true (blocking the
-  // spurious Enter that fires immediately after compositionend in some browsers).
+  // runs unconditionally there. `isComposing()` stays true briefly after compositionend
+  // (until the next animation frame) to block the spurious Enter keydown that some
+  // browsers fire immediately after compositionend.
   const { isComposing } = useIMEComposition(editableElementRef, {
-    onCompositionEnd: () => handleInputRef.current(),
+    onCompositionStart: () => setComposing(true),
+    onCompositionEnd: () => {
+      setComposing(false);
+      handleInputRef.current();
+    },
   });
 
   const handleInput = useCallback(() => {
@@ -964,6 +974,7 @@ export function useTokenMode(config: UseTokenModeConfig): UseTokenModeResult {
       onChange,
       markTokensAsSent,
       onKeyDown,
+      isComposing,
     });
   });
 
@@ -1084,7 +1095,7 @@ export function useTokenMode(config: UseTokenModeConfig): UseTokenModeResult {
     return !!(menuIsOpen && activeMenu && menuItemsState && triggerVisible);
   }, [menuIsOpen, activeMenu, menuItemsState, triggerVisible]);
 
-  const showPlaceholder = !!(placeholder && (!tokens || tokens.length === 0));
+  const showPlaceholder = !!(placeholder && (!tokens || tokens.length === 0) && !composing);
 
   const editableElementAttributes: React.HTMLAttributes<HTMLDivElement> & { 'data-placeholder'?: string } = {
     'aria-label': ariaLabel,
@@ -1171,7 +1182,11 @@ export function useTokenMode(config: UseTokenModeConfig): UseTokenModeResult {
       // for each keystroke during CJK composition and must not trigger token
       // detection. The onCompositionEnd callback calls handleInput directly
       // (bypassing this guard) once the final text is committed.
-      if (!isComposing()) {
+      // Note: we use `composing` (React state) rather than `isComposing()` (ref)
+      // so that input events after compositionend — such as the user immediately
+      // deleting the committed text — are processed normally. The spurious-Enter
+      // guard in the keyboard handler uses `isComposing()` separately.
+      if (!composing) {
         handleInput();
       }
     },


### PR DESCRIPTION
### Description

Issue: `AWSUI-61979`

Before:


https://github.com/user-attachments/assets/4a442da4-39f0-467a-848a-cee08368f613



After:


https://github.com/user-attachments/assets/02fdd6ba-2769-41d7-9f2f-158ae6541a92



### How has this been tested?

- Added unit tests
- Manually on the existing dev pages, using Korean keyboard input

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
