### PR TITLE
refactor: use public namespace-qualified types for onLoadItems event …

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -3077,7 +3077,7 @@ The detail object contains the following properties:
 * \`firstPage\` - Indicates that you should fetch the first page of options that match the \`filteringText\`.
 * \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).",
       "detailInlineType": {
-        "name": "OptionsLoadItemsDetail",
+        "name": "AutosuggestProps.LoadItemsDetail",
         "properties": [
           {
             "name": "filteringText",
@@ -3097,7 +3097,7 @@ The detail object contains the following properties:
         ],
         "type": "object",
       },
-      "detailType": "OptionsLoadItemsDetail",
+      "detailType": "AutosuggestProps.LoadItemsDetail",
       "name": "onLoadItems",
     },
     {
@@ -18428,7 +18428,7 @@ The detail object contains the following properties:
 * \`firstPage\` - Indicates that you should fetch the first page of options that match the \`filteringText\`.
 * \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).",
       "detailInlineType": {
-        "name": "OptionsLoadItemsDetail",
+        "name": "MultiselectProps.LoadItemsDetail",
         "properties": [
           {
             "name": "filteringText",
@@ -18448,7 +18448,7 @@ The detail object contains the following properties:
         ],
         "type": "object",
       },
-      "detailType": "OptionsLoadItemsDetail",
+      "detailType": "MultiselectProps.LoadItemsDetail",
       "name": "onLoadItems",
     },
   ],
@@ -24750,7 +24750,7 @@ The detail object contains the following properties:
 * \`firstPage\` - Indicates that you should fetch the first page of options that match the \`filteringText\`.
 * \`samePage\` - Indicates that you should fetch the same page that you have previously fetched (for example, when the user clicks on the recovery button).",
       "detailInlineType": {
-        "name": "OptionsLoadItemsDetail",
+        "name": "SelectProps.LoadItemsDetail",
         "properties": [
           {
             "name": "filteringText",
@@ -24770,7 +24770,7 @@ The detail object contains the following properties:
         ],
         "type": "object",
       },
-      "detailType": "OptionsLoadItemsDetail",
+      "detailType": "SelectProps.LoadItemsDetail",
       "name": "onLoadItems",
     },
   ],

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -19,6 +19,7 @@ export interface AutosuggestProps
     InputClearLabel,
     FormFieldValidationControlProps,
     DropdownStatusProps {
+  onLoadItems?: NonCancelableEventHandler<AutosuggestProps.LoadItemsDetail>;
   /**
    * Specifies an array of options that are displayed to the user as a dropdown list.
    * The options can be grouped using `OptionGroup` objects.
@@ -179,7 +180,8 @@ export namespace AutosuggestProps {
     label?: string;
     options: ReadonlyArray<Option>;
   }
-  export type LoadItemsDetail = OptionsLoadItemsDetail;
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  export interface LoadItemsDetail extends OptionsLoadItemsDetail {}
   export type StatusType = DropdownStatusProps.StatusType;
   export interface SelectDetail {
     value: string;

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -180,7 +180,9 @@ export namespace AutosuggestProps {
     label?: string;
     options: ReadonlyArray<Option>;
   }
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  /* eslint-disable-next-line @typescript-eslint/no-empty-object-type --
+   * Required to create a distinct named type for the documenter.
+   **/
   export interface LoadItemsDetail extends OptionsLoadItemsDetail {}
   export type StatusType = DropdownStatusProps.StatusType;
   export interface SelectDetail {

--- a/src/multiselect/interfaces.ts
+++ b/src/multiselect/interfaces.ts
@@ -88,7 +88,9 @@ export namespace MultiselectProps {
   export type Option = OptionDefinition;
   export type OptionGroup = OptionGroupDefinition;
   export type Options = ReadonlyArray<Option | OptionGroup>;
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  /* eslint-disable-next-line @typescript-eslint/no-empty-object-type --
+   * Required to create a distinct named type for the documenter.
+   **/
   export interface LoadItemsDetail extends OptionsLoadItemsDetail {}
   export interface MultiselectOptionItem {
     type: 'item';

--- a/src/multiselect/interfaces.ts
+++ b/src/multiselect/interfaces.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ReactNode } from 'react';
 
+import { OptionsLoadItemsDetail } from '../dropdown/interfaces';
 import { OptionDefinition, OptionGroup as OptionGroupDefinition } from '../internal/components/option/interfaces';
 import { NonCancelableEventHandler } from '../internal/events';
 import { BaseSelectProps } from '../select/interfaces';
@@ -49,6 +50,7 @@ export interface MultiselectProps extends BaseSelectProps {
    * @i18n
    */
   i18nStrings?: MultiselectProps.I18nStrings;
+  onLoadItems?: NonCancelableEventHandler<MultiselectProps.LoadItemsDetail>;
   /**
    * Called when the user selects or deselects an option.
    * The event `detail` contains the current `selectedOptions`.
@@ -86,6 +88,8 @@ export namespace MultiselectProps {
   export type Option = OptionDefinition;
   export type OptionGroup = OptionGroupDefinition;
   export type Options = ReadonlyArray<Option | OptionGroup>;
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  export interface LoadItemsDetail extends OptionsLoadItemsDetail {}
   export interface MultiselectOptionItem {
     type: 'item';
     index: number;

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -225,7 +225,9 @@ export namespace SelectProps {
   export type SelectItem = SelectOptionItem | SelectOptionGroupItem | SelectTriggerOptionItem;
   export type SelectOptionItemRenderer = (props: { item: SelectItem; filterText?: string }) => ReactNode | null;
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  /* eslint-disable-next-line @typescript-eslint/no-empty-object-type --
+   * Required to create a distinct named type for the documenter.
+   **/
   export interface LoadItemsDetail extends OptionsLoadItemsDetail {}
 
   export interface ChangeDetail {

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -157,6 +157,7 @@ export interface SelectProps extends BaseSelectProps {
    * For use with collection select filters only.
    */
   inlineLabelText?: string;
+  onLoadItems?: NonCancelableEventHandler<SelectProps.LoadItemsDetail>;
   /**
    * Adds `aria-labelledby` to the component. If you're using this component within a form field,
    * don't set this property because the form field component automatically sets it.
@@ -224,7 +225,8 @@ export namespace SelectProps {
   export type SelectItem = SelectOptionItem | SelectOptionGroupItem | SelectTriggerOptionItem;
   export type SelectOptionItemRenderer = (props: { item: SelectItem; filterText?: string }) => ReactNode | null;
 
-  export type LoadItemsDetail = OptionsLoadItemsDetail;
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  export interface LoadItemsDetail extends OptionsLoadItemsDetail {}
 
   export interface ChangeDetail {
     selectedOption: Option;


### PR DESCRIPTION
### Description

The documenter was outputting OptionsLoadItemsDetail (internal interface) as the event detail type for onLoadItems on select, multiselect, and autosuggest. Builders should see the public namespace-qualified types instead.

Override onLoadItems in each public component interface with a namespace-qualified type (SelectProps.LoadItemsDetail, MultiselectProps.LoadItemsDetail, AutosuggestProps.LoadItemsDetail).

**Before**

<img width="426" height="122" alt="image" src="https://github.com/user-attachments/assets/0652ff0f-5286-43b0-9e81-d111625eb84d" />

**After**

<img width="426" height="122" alt="image" src="https://github.com/user-attachments/assets/9d6cbc92-eccf-4b3e-95c2-0cdfe4730eb7" />


<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: `D421195737`

### How has this been tested?

Change went through pipelines and deployed to website.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
