### PR TITLE
fix: Prevent copy button in inline copy-to-clipboard from wrapping on its own line

### DIFF
--- a/pages/copy-to-clipboard/simple.page.tsx
+++ b/pages/copy-to-clipboard/simple.page.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import { Box, CopyToClipboard, SpaceBetween } from '~components';
+import { Box, CopyToClipboard, Popover, SpaceBetween } from '~components';
 
 import ScreenshotArea from '../utils/screenshot-area';
 
@@ -14,7 +14,7 @@ const paragraphs = [
 
 const sentence = paragraphs[0].split('.')[0];
 
-export default function DateInputScenario() {
+export default function CopyToClipboardScenarios() {
   return (
     <ScreenshotArea>
       <Box>
@@ -81,6 +81,21 @@ export default function DateInputScenario() {
                 copyErrorText="Lorem ipsum sentence failed to copy"
               />
             </div>
+          </div>
+
+          <div style={{ width: '200px' }}>
+            <CopyToClipboard
+              variant="inline"
+              copyButtonAriaLabel="Copy lorem ipsum sentence"
+              textToCopy="Relatively long text that we don't want to wrap"
+              copySuccessText="Lorem ipsum sentence copied"
+              copyErrorText="Lorem ipsum sentence failed to copy"
+              textToDisplay={
+                <Popover wrapTriggerText={false} content="Popover content.">
+                  Relatively long trigger text that we don&apos;t want to wrap
+                </Popover>
+              }
+            />
           </div>
         </SpaceBetween>
       </Box>

--- a/src/copy-to-clipboard/internal.tsx
+++ b/src/copy-to-clipboard/internal.tsx
@@ -120,7 +120,11 @@ export default function InternalCopyToClipboard({
     <span {...baseProps} ref={__internalRootRef} className={clsx(baseProps.className, styles.root, testStyles.root)}>
       {isInline ? (
         <span className={styles['inline-container']}>
-          <span className={styles['inline-container-trigger']}>{trigger}</span>
+          <span className={styles['inline-container-trigger']}>
+            {trigger}
+            {/* "Word Joiner" (WJ): Zero-width character to indicate that a line break shouldn't happen at this point. */}
+            &#8288;
+          </span>
           <span className={clsx(testStyles['text-to-display'], testStyles['text-to-copy'])}>
             {textToDisplay !== undefined ? textToDisplay : textToCopy}
           </span>

--- a/src/copy-to-clipboard/styles.scss
+++ b/src/copy-to-clipboard/styles.scss
@@ -13,6 +13,7 @@
   word-break: break-all;
 
   &-trigger {
+    white-space: nowrap;
     margin-inline-end: awsui.$space-scaled-xxs;
   }
 }


### PR DESCRIPTION
### Description

Yay, I get to reuse the same One Weird Trick™ to prevent wrapping that I used in the link component (for the external icon). Now that `textToCopy` can contain arbitrary JSX content, this would cause the two parts (copy icon and content) to break into separate lines before truncate (if the content _can_ truncate). No API changes.

Before:

<img width="683" height="183" alt="Screenshot 2026-05-07 at 16 15 19" src="https://github.com/user-attachments/assets/86e75705-96cb-45c0-b23e-91de7762131b" />

After:

<img width="762" height="133" alt="Screenshot 2026-05-07 at 16 15 45" src="https://github.com/user-attachments/assets/2c77f7eb-1d7a-4bed-a665-a4e82c698727" />


Related links, issue #, if available: AWSUI-61955

### How has this been tested?

Added a scenario to a page that's screenshot-tested. Existing visual tests should continue to pass.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
