### PR TITLE
fix: Remove underline from trailing whitespace in external links

### DIFF
--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -194,7 +194,6 @@ const InternalLink = React.forwardRef(
         {children}
         {external && (
           <span className={styles['icon-wrapper']}>
-            &nbsp;
             <span
               className={styles.icon}
               aria-label={renderedExternalIconAriaLabel}

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -194,6 +194,7 @@ const InternalLink = React.forwardRef(
         {children}
         {external && (
           <span className={styles['icon-wrapper']}>
+            &#8288;
             <span
               className={styles.icon}
               aria-label={renderedExternalIconAriaLabel}

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -194,7 +194,7 @@ const InternalLink = React.forwardRef(
         {children}
         {external && (
           <span className={styles['icon-wrapper']}>
-            &#8288;
+            &#xFEFF;
             <span
               className={styles.icon}
               aria-label={renderedExternalIconAriaLabel}

--- a/src/link/styles.scss
+++ b/src/link/styles.scss
@@ -73,6 +73,11 @@
 
 .icon-wrapper {
   white-space: nowrap;
+  /* Add non-breaking space for consistent spacing */
+  &::before {
+    content: '\a0';
+    display: inline-block;
+  }
 }
 
 .icon {

--- a/src/link/styles.scss
+++ b/src/link/styles.scss
@@ -73,13 +73,14 @@
 
 .icon-wrapper {
   white-space: nowrap;
+}
+
+.icon {
+  display: inline-block;
+
   /* Add non-breaking space for consistent spacing */
   &::before {
     content: '\a0';
     display: inline-block;
   }
-}
-
-.icon {
-  display: inline-block;
 }

--- a/src/pie-chart/__integ__/with-links.test.ts
+++ b/src/pie-chart/__integ__/with-links.test.ts
@@ -20,8 +20,8 @@ describe('Pie chart with links in key-value pairs', () => {
         const expectedFocusedText =
           linksIn === 'keys'
             ? // The external link icon adds an extra space at the end
-              'Popularity '
-            : '50% ';
+              'Popularity'
+            : '50%';
         await page.click('#focus-target');
         await page.keys(['Tab']); // Focus the chart
         await page.keys(['Enter']); // Focus the first chart segment

--- a/src/top-navigation/__integ__/top-navigation.test.ts
+++ b/src/top-navigation/__integ__/top-navigation.test.ts
@@ -32,7 +32,7 @@ describe('Top navigation', () => {
       'renders utilities with text',
       setupTest(pageWidth, async page => {
         await expect(page.getText(wrapper.findUtility(1).toSelector())).resolves.toBe('New thing');
-        await expect(page.getText(wrapper.findUtility(2).toSelector())).resolves.toBe('Docs ');
+        await expect(page.getText(wrapper.findUtility(2).toSelector())).resolves.toBe('Docs');
         await expect(page.getText(wrapper.findUtility(4).toSelector())).resolves.toBe('John Doe');
       })
     );
@@ -66,7 +66,7 @@ describe('Top navigation', () => {
         await expect(page.getText(wrapper.findUtility(1).toSelector())).resolves.toBe('New thing');
 
         // Docs shouldn't be collapsed because it doesn't have an icon.
-        await expect(page.getText(wrapper.findUtility(2).toSelector())).resolves.toBe('Docs ');
+        await expect(page.getText(wrapper.findUtility(2).toSelector())).resolves.toBe('Docs');
       })
     );
   });


### PR DESCRIPTION
### Description

Resurrecting a contribution in #3709 that neither I nor the contributor could find a path forward for. While spending time investigating a fix for #4496, I discovered a trick that lets us do this without a space (apparently this character existed for many years now, just hadn't come across it until just now).

Keeping the original commit in there to maintain the attribution to the original contributor who kicked it off.

Related links, issue #, if available: AWSUI-60840

### How has this been tested?

Would definitely show up in screenshot tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
