### PR TITLE
revert: Revert "fix: Prevent copy button in inline copy-to-clipboard from wrapping on its own line"

### DIFF
--- a/pages/copy-to-clipboard/simple.page.tsx
+++ b/pages/copy-to-clipboard/simple.page.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import { Box, CopyToClipboard, Popover, SpaceBetween } from '~components';
+import { Box, CopyToClipboard, SpaceBetween } from '~components';
 
 import ScreenshotArea from '../utils/screenshot-area';
 
@@ -14,7 +14,7 @@ const paragraphs = [
 
 const sentence = paragraphs[0].split('.')[0];
 
-export default function CopyToClipboardScenarios() {
+export default function DateInputScenario() {
   return (
     <ScreenshotArea>
       <Box>
@@ -81,21 +81,6 @@ export default function CopyToClipboardScenarios() {
                 copyErrorText="Lorem ipsum sentence failed to copy"
               />
             </div>
-          </div>
-
-          <div style={{ width: '200px' }}>
-            <CopyToClipboard
-              variant="inline"
-              copyButtonAriaLabel="Copy lorem ipsum sentence"
-              textToCopy="Relatively long text that we don't want to wrap"
-              copySuccessText="Lorem ipsum sentence copied"
-              copyErrorText="Lorem ipsum sentence failed to copy"
-              textToDisplay={
-                <Popover wrapTriggerText={false} content="Popover content.">
-                  Relatively long trigger text that we don&apos;t want to wrap
-                </Popover>
-              }
-            />
           </div>
         </SpaceBetween>
       </Box>

--- a/src/copy-to-clipboard/internal.tsx
+++ b/src/copy-to-clipboard/internal.tsx
@@ -120,11 +120,7 @@ export default function InternalCopyToClipboard({
     <span {...baseProps} ref={__internalRootRef} className={clsx(baseProps.className, styles.root, testStyles.root)}>
       {isInline ? (
         <span className={styles['inline-container']}>
-          <span className={styles['inline-container-trigger']}>
-            {trigger}
-            {/* "Word Joiner" (WJ): Zero-width character to indicate that a line break shouldn't happen at this point. */}
-            &#8288;
-          </span>
+          <span className={styles['inline-container-trigger']}>{trigger}</span>
           <span className={clsx(testStyles['text-to-display'], testStyles['text-to-copy'])}>
             {textToDisplay !== undefined ? textToDisplay : textToCopy}
           </span>

--- a/src/copy-to-clipboard/styles.scss
+++ b/src/copy-to-clipboard/styles.scss
@@ -13,7 +13,6 @@
   word-break: break-all;
 
   &-trigger {
-    white-space: nowrap;
     margin-inline-end: awsui.$space-scaled-xxs;
   }
 }


### PR DESCRIPTION
Reverts cloudscape-design/components#4496