### PR TITLE
feat: Make action card design token public + themeable

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
@@ -93,6 +93,22 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$description": "The border radius of tutorials inside a tutorial panel.",
           "$value": "2px",
         },
+        "border-width-action-card-active": {
+          "$description": "The border width of action cards in active state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-default": {
+          "$description": "The border width of action cards in default state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-disabled": {
+          "$description": "The border width of action cards in disabled state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-hover": {
+          "$description": "The border width of action cards in hover state.",
+          "$value": "1px",
+        },
         "border-width-alert": {
           "$description": "The border width of alerts.",
           "$value": "1px",
@@ -164,6 +180,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         "border-width-token": {
           "$description": "The border width of tokens.",
           "$value": "1px",
+        },
+        "color-background-action-card-active": {
+          "$description": "The background color of action cards in active state.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-action-card-default": {
+          "$description": "The default background color of action cards.",
+          "$value": {
+            "dark": "#1a2029",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-disabled": {
+          "$description": "The background color of action cards in disabled state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#eaeded",
+          },
+        },
+        "color-background-action-card-hover": {
+          "$description": "The background color of action cards in hover state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#f1faff",
+          },
         },
         "color-background-avatar-default": {
           "$description": "The default background color of avatars.",
@@ -667,6 +711,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#0073bb",
             "light": "#99cbe4",
+          },
+        },
+        "color-border-action-card-active": {
+          "$description": "The border color of action cards in active state.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#002b66",
+          },
+        },
+        "color-border-action-card-default": {
+          "$description": "The default border color of action cards.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#0073bb",
+          },
+        },
+        "color-border-action-card-disabled": {
+          "$description": "The border color of action cards in disabled state.",
+          "$value": {
+            "dark": "#687078",
+            "light": "#aab7b8",
+          },
+        },
+        "color-border-action-card-hover": {
+          "$description": "The border color of action cards in hover state.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#002b66",
           },
         },
         "color-border-button-link-disabled": {
@@ -2069,6 +2141,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#0073bb",
           },
         },
+        "color-text-action-card-disabled": {
+          "$description": "The text color of action cards in disabled state.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#879596",
+          },
+        },
         "color-text-avatar": {
           "$description": "The text and icon color of avatars.",
           "$value": {
@@ -2883,6 +2962,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "comfortable": "32px",
             "compact": "28px",
+          },
+        },
+        "space-action-card-horizontal-default": {
+          "$description": "The default horizontal padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-action-card-horizontal-embedded": {
+          "$description": "The horizontal padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "10px",
+          },
+        },
+        "space-action-card-vertical-default": {
+          "$description": "The default vertical padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "16px",
+          },
+        },
+        "space-action-card-vertical-embedded": {
+          "$description": "The vertical padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "10px",
+            "compact": "8px",
           },
         },
         "space-alert-vertical": {
@@ -3208,6 +3315,22 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$description": "The border radius of tutorials inside a tutorial panel.",
           "$value": "2px",
         },
+        "border-width-action-card-active": {
+          "$description": "The border width of action cards in active state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-default": {
+          "$description": "The border width of action cards in default state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-disabled": {
+          "$description": "The border width of action cards in disabled state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-hover": {
+          "$description": "The border width of action cards in hover state.",
+          "$value": "1px",
+        },
         "border-width-alert": {
           "$description": "The border width of alerts.",
           "$value": "1px",
@@ -3279,6 +3402,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         "border-width-token": {
           "$description": "The border width of tokens.",
           "$value": "1px",
+        },
+        "color-background-action-card-active": {
+          "$description": "The background color of action cards in active state.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-action-card-default": {
+          "$description": "The default background color of action cards.",
+          "$value": {
+            "dark": "#1a2029",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-disabled": {
+          "$description": "The background color of action cards in disabled state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#eaeded",
+          },
+        },
+        "color-background-action-card-hover": {
+          "$description": "The background color of action cards in hover state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#f1faff",
+          },
         },
         "color-background-avatar-default": {
           "$description": "The default background color of avatars.",
@@ -3782,6 +3933,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#0073bb",
             "light": "#99cbe4",
+          },
+        },
+        "color-border-action-card-active": {
+          "$description": "The border color of action cards in active state.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#002b66",
+          },
+        },
+        "color-border-action-card-default": {
+          "$description": "The default border color of action cards.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#0073bb",
+          },
+        },
+        "color-border-action-card-disabled": {
+          "$description": "The border color of action cards in disabled state.",
+          "$value": {
+            "dark": "#687078",
+            "light": "#aab7b8",
+          },
+        },
+        "color-border-action-card-hover": {
+          "$description": "The border color of action cards in hover state.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#002b66",
           },
         },
         "color-border-button-link-disabled": {
@@ -5182,6 +5361,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#44b9d6",
             "light": "#0073bb",
+          },
+        },
+        "color-text-action-card-disabled": {
+          "$description": "The text color of action cards in disabled state.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#879596",
           },
         },
         "color-text-avatar": {
@@ -6000,6 +6186,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "compact": "28px",
           },
         },
+        "space-action-card-horizontal-default": {
+          "$description": "The default horizontal padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-action-card-horizontal-embedded": {
+          "$description": "The horizontal padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "10px",
+          },
+        },
+        "space-action-card-vertical-default": {
+          "$description": "The default vertical padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "16px",
+          },
+        },
+        "space-action-card-vertical-embedded": {
+          "$description": "The vertical padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "10px",
+            "compact": "8px",
+          },
+        },
         "space-alert-vertical": {
           "$description": "The vertical padding inside alert components.",
           "$value": {
@@ -6323,6 +6537,22 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$description": "The border radius of tutorials inside a tutorial panel.",
           "$value": "2px",
         },
+        "border-width-action-card-active": {
+          "$description": "The border width of action cards in active state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-default": {
+          "$description": "The border width of action cards in default state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-disabled": {
+          "$description": "The border width of action cards in disabled state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-hover": {
+          "$description": "The border width of action cards in hover state.",
+          "$value": "1px",
+        },
         "border-width-alert": {
           "$description": "The border width of alerts.",
           "$value": "1px",
@@ -6394,6 +6624,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         "border-width-token": {
           "$description": "The border width of tokens.",
           "$value": "1px",
+        },
+        "color-background-action-card-active": {
+          "$description": "The background color of action cards in active state.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-action-card-default": {
+          "$description": "The default background color of action cards.",
+          "$value": {
+            "dark": "#1a2029",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-disabled": {
+          "$description": "The background color of action cards in disabled state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#eaeded",
+          },
+        },
+        "color-background-action-card-hover": {
+          "$description": "The background color of action cards in hover state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#f1faff",
+          },
         },
         "color-background-avatar-default": {
           "$description": "The default background color of avatars.",
@@ -6897,6 +7155,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#0073bb",
             "light": "#99cbe4",
+          },
+        },
+        "color-border-action-card-active": {
+          "$description": "The border color of action cards in active state.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#002b66",
+          },
+        },
+        "color-border-action-card-default": {
+          "$description": "The default border color of action cards.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#0073bb",
+          },
+        },
+        "color-border-action-card-disabled": {
+          "$description": "The border color of action cards in disabled state.",
+          "$value": {
+            "dark": "#687078",
+            "light": "#aab7b8",
+          },
+        },
+        "color-border-action-card-hover": {
+          "$description": "The border color of action cards in hover state.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#002b66",
           },
         },
         "color-border-button-link-disabled": {
@@ -8297,6 +8583,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#44b9d6",
             "light": "#0073bb",
+          },
+        },
+        "color-text-action-card-disabled": {
+          "$description": "The text color of action cards in disabled state.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#879596",
           },
         },
         "color-text-avatar": {
@@ -9115,6 +9408,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "compact": "28px",
           },
         },
+        "space-action-card-horizontal-default": {
+          "$description": "The default horizontal padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-action-card-horizontal-embedded": {
+          "$description": "The horizontal padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "10px",
+          },
+        },
+        "space-action-card-vertical-default": {
+          "$description": "The default vertical padding inside an action card.",
+          "$value": {
+            "comfortable": "16px",
+            "compact": "16px",
+          },
+        },
+        "space-action-card-vertical-embedded": {
+          "$description": "The vertical padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "10px",
+            "compact": "8px",
+          },
+        },
         "space-alert-vertical": {
           "$description": "The vertical padding inside alert components.",
           "$value": {
@@ -9438,6 +9759,22 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$description": "The border radius of tutorials inside a tutorial panel.",
           "$value": "2px",
         },
+        "border-width-action-card-active": {
+          "$description": "The border width of action cards in active state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-default": {
+          "$description": "The border width of action cards in default state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-disabled": {
+          "$description": "The border width of action cards in disabled state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-hover": {
+          "$description": "The border width of action cards in hover state.",
+          "$value": "1px",
+        },
         "border-width-alert": {
           "$description": "The border width of alerts.",
           "$value": "1px",
@@ -9509,6 +9846,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         "border-width-token": {
           "$description": "The border width of tokens.",
           "$value": "1px",
+        },
+        "color-background-action-card-active": {
+          "$description": "The background color of action cards in active state.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-action-card-default": {
+          "$description": "The default background color of action cards.",
+          "$value": {
+            "dark": "#1a2029",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-disabled": {
+          "$description": "The background color of action cards in disabled state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#eaeded",
+          },
+        },
+        "color-background-action-card-hover": {
+          "$description": "The background color of action cards in hover state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#f1faff",
+          },
         },
         "color-background-avatar-default": {
           "$description": "The default background color of avatars.",
@@ -10014,6 +10379,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#99cbe4",
           },
         },
+        "color-border-action-card-active": {
+          "$description": "The border color of action cards in active state.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#002b66",
+          },
+        },
+        "color-border-action-card-default": {
+          "$description": "The default border color of action cards.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#0073bb",
+          },
+        },
+        "color-border-action-card-disabled": {
+          "$description": "The border color of action cards in disabled state.",
+          "$value": {
+            "dark": "#687078",
+            "light": "#aab7b8",
+          },
+        },
+        "color-border-action-card-hover": {
+          "$description": "The border color of action cards in hover state.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#002b66",
+          },
+        },
         "color-border-button-link-disabled": {
           "$description": "The border color of link buttons in disabled state.",
           "$value": {
@@ -11414,6 +11807,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#0073bb",
           },
         },
+        "color-text-action-card-disabled": {
+          "$description": "The text color of action cards in disabled state.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#879596",
+          },
+        },
         "color-text-avatar": {
           "$description": "The text and icon color of avatars.",
           "$value": {
@@ -12230,6 +12630,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "compact": "28px",
           },
         },
+        "space-action-card-horizontal-default": {
+          "$description": "The default horizontal padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-action-card-horizontal-embedded": {
+          "$description": "The horizontal padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "10px",
+          },
+        },
+        "space-action-card-vertical-default": {
+          "$description": "The default vertical padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "16px",
+          },
+        },
+        "space-action-card-vertical-embedded": {
+          "$description": "The vertical padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "10px",
+            "compact": "8px",
+          },
+        },
         "space-alert-vertical": {
           "$description": "The vertical padding inside alert components.",
           "$value": {
@@ -12553,6 +12981,22 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$description": "The border radius of tutorials inside a tutorial panel.",
           "$value": "2px",
         },
+        "border-width-action-card-active": {
+          "$description": "The border width of action cards in active state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-default": {
+          "$description": "The border width of action cards in default state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-disabled": {
+          "$description": "The border width of action cards in disabled state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-hover": {
+          "$description": "The border width of action cards in hover state.",
+          "$value": "1px",
+        },
         "border-width-alert": {
           "$description": "The border width of alerts.",
           "$value": "1px",
@@ -12624,6 +13068,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         "border-width-token": {
           "$description": "The border width of tokens.",
           "$value": "1px",
+        },
+        "color-background-action-card-active": {
+          "$description": "The background color of action cards in active state.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-action-card-default": {
+          "$description": "The default background color of action cards.",
+          "$value": {
+            "dark": "#1a2029",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-disabled": {
+          "$description": "The background color of action cards in disabled state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#eaeded",
+          },
+        },
+        "color-background-action-card-hover": {
+          "$description": "The background color of action cards in hover state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#f1faff",
+          },
         },
         "color-background-avatar-default": {
           "$description": "The default background color of avatars.",
@@ -13129,6 +13601,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#99cbe4",
           },
         },
+        "color-border-action-card-active": {
+          "$description": "The border color of action cards in active state.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#002b66",
+          },
+        },
+        "color-border-action-card-default": {
+          "$description": "The default border color of action cards.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#0073bb",
+          },
+        },
+        "color-border-action-card-disabled": {
+          "$description": "The border color of action cards in disabled state.",
+          "$value": {
+            "dark": "#687078",
+            "light": "#aab7b8",
+          },
+        },
+        "color-border-action-card-hover": {
+          "$description": "The border color of action cards in hover state.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#002b66",
+          },
+        },
         "color-border-button-link-disabled": {
           "$description": "The border color of link buttons in disabled state.",
           "$value": {
@@ -14529,6 +15029,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#0073bb",
           },
         },
+        "color-text-action-card-disabled": {
+          "$description": "The text color of action cards in disabled state.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#879596",
+          },
+        },
         "color-text-avatar": {
           "$description": "The text and icon color of avatars.",
           "$value": {
@@ -15345,6 +15852,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "compact": "28px",
           },
         },
+        "space-action-card-horizontal-default": {
+          "$description": "The default horizontal padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-action-card-horizontal-embedded": {
+          "$description": "The horizontal padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "10px",
+          },
+        },
+        "space-action-card-vertical-default": {
+          "$description": "The default vertical padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "16px",
+          },
+        },
+        "space-action-card-vertical-embedded": {
+          "$description": "The vertical padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "10px",
+            "compact": "8px",
+          },
+        },
         "space-alert-vertical": {
           "$description": "The vertical padding inside alert components.",
           "$value": {
@@ -15668,6 +16203,22 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$description": "The border radius of tutorials inside a tutorial panel.",
           "$value": "2px",
         },
+        "border-width-action-card-active": {
+          "$description": "The border width of action cards in active state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-default": {
+          "$description": "The border width of action cards in default state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-disabled": {
+          "$description": "The border width of action cards in disabled state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-hover": {
+          "$description": "The border width of action cards in hover state.",
+          "$value": "1px",
+        },
         "border-width-alert": {
           "$description": "The border width of alerts.",
           "$value": "1px",
@@ -15739,6 +16290,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         "border-width-token": {
           "$description": "The border width of tokens.",
           "$value": "1px",
+        },
+        "color-background-action-card-active": {
+          "$description": "The background color of action cards in active state.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#414750",
+          },
+        },
+        "color-background-action-card-default": {
+          "$description": "The default background color of action cards.",
+          "$value": {
+            "dark": "#1a2029",
+            "light": "#1a2029",
+          },
+        },
+        "color-background-action-card-disabled": {
+          "$description": "The background color of action cards in disabled state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#21252c",
+          },
+        },
+        "color-background-action-card-hover": {
+          "$description": "The background color of action cards in hover state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#21252c",
+          },
         },
         "color-background-avatar-default": {
           "$description": "The default background color of avatars.",
@@ -16242,6 +16821,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#0073bb",
             "light": "#0073bb",
+          },
+        },
+        "color-border-action-card-active": {
+          "$description": "The border color of action cards in active state.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#44b9d6",
+          },
+        },
+        "color-border-action-card-default": {
+          "$description": "The default border color of action cards.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#00a1c9",
+          },
+        },
+        "color-border-action-card-disabled": {
+          "$description": "The border color of action cards in disabled state.",
+          "$value": {
+            "dark": "#687078",
+            "light": "#687078",
+          },
+        },
+        "color-border-action-card-hover": {
+          "$description": "The border color of action cards in hover state.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#44b9d6",
           },
         },
         "color-border-button-link-disabled": {
@@ -17642,6 +18249,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#44b9d6",
             "light": "#44b9d6",
+          },
+        },
+        "color-text-action-card-disabled": {
+          "$description": "The text color of action cards in disabled state.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#879596",
           },
         },
         "color-text-avatar": {
@@ -18460,6 +19074,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "compact": "28px",
           },
         },
+        "space-action-card-horizontal-default": {
+          "$description": "The default horizontal padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-action-card-horizontal-embedded": {
+          "$description": "The horizontal padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "10px",
+          },
+        },
+        "space-action-card-vertical-default": {
+          "$description": "The default vertical padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "16px",
+          },
+        },
+        "space-action-card-vertical-embedded": {
+          "$description": "The vertical padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "10px",
+            "compact": "8px",
+          },
+        },
         "space-alert-vertical": {
           "$description": "The vertical padding inside alert components.",
           "$value": {
@@ -18783,6 +19425,22 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
       "$description": "The border radius of tutorials inside a tutorial panel.",
       "$value": "2px",
     },
+    "border-width-action-card-active": {
+      "$description": "The border width of action cards in active state.",
+      "$value": "1px",
+    },
+    "border-width-action-card-default": {
+      "$description": "The border width of action cards in default state.",
+      "$value": "1px",
+    },
+    "border-width-action-card-disabled": {
+      "$description": "The border width of action cards in disabled state.",
+      "$value": "1px",
+    },
+    "border-width-action-card-hover": {
+      "$description": "The border width of action cards in hover state.",
+      "$value": "1px",
+    },
     "border-width-alert": {
       "$description": "The border width of alerts.",
       "$value": "1px",
@@ -18854,6 +19512,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
     "border-width-token": {
       "$description": "The border width of tokens.",
       "$value": "1px",
+    },
+    "color-background-action-card-active": {
+      "$description": "The background color of action cards in active state.",
+      "$value": {
+        "dark": "#414750",
+        "light": "#d1f1ff",
+      },
+    },
+    "color-background-action-card-default": {
+      "$description": "The default background color of action cards.",
+      "$value": {
+        "dark": "#1a2029",
+        "light": "#ffffff",
+      },
+    },
+    "color-background-action-card-disabled": {
+      "$description": "The background color of action cards in disabled state.",
+      "$value": {
+        "dark": "#21252c",
+        "light": "#eaeded",
+      },
+    },
+    "color-background-action-card-hover": {
+      "$description": "The background color of action cards in hover state.",
+      "$value": {
+        "dark": "#21252c",
+        "light": "#f1faff",
+      },
     },
     "color-background-avatar-default": {
       "$description": "The default background color of avatars.",
@@ -19357,6 +20043,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
       "$value": {
         "dark": "#0073bb",
         "light": "#99cbe4",
+      },
+    },
+    "color-border-action-card-active": {
+      "$description": "The border color of action cards in active state.",
+      "$value": {
+        "dark": "#44b9d6",
+        "light": "#002b66",
+      },
+    },
+    "color-border-action-card-default": {
+      "$description": "The default border color of action cards.",
+      "$value": {
+        "dark": "#00a1c9",
+        "light": "#0073bb",
+      },
+    },
+    "color-border-action-card-disabled": {
+      "$description": "The border color of action cards in disabled state.",
+      "$value": {
+        "dark": "#687078",
+        "light": "#aab7b8",
+      },
+    },
+    "color-border-action-card-hover": {
+      "$description": "The border color of action cards in hover state.",
+      "$value": {
+        "dark": "#44b9d6",
+        "light": "#002b66",
       },
     },
     "color-border-button-link-disabled": {
@@ -20757,6 +21471,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
       "$value": {
         "dark": "#44b9d6",
         "light": "#0073bb",
+      },
+    },
+    "color-text-action-card-disabled": {
+      "$description": "The text color of action cards in disabled state.",
+      "$value": {
+        "dark": "#879596",
+        "light": "#879596",
       },
     },
     "color-text-avatar": {
@@ -21575,6 +22296,34 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         "compact": "28px",
       },
     },
+    "space-action-card-horizontal-default": {
+      "$description": "The default horizontal padding inside an action card.",
+      "$value": {
+        "comfortable": "20px",
+        "compact": "20px",
+      },
+    },
+    "space-action-card-horizontal-embedded": {
+      "$description": "The horizontal padding inside an embedded action card.",
+      "$value": {
+        "comfortable": "12px",
+        "compact": "10px",
+      },
+    },
+    "space-action-card-vertical-default": {
+      "$description": "The default vertical padding inside an action card.",
+      "$value": {
+        "comfortable": "20px",
+        "compact": "16px",
+      },
+    },
+    "space-action-card-vertical-embedded": {
+      "$description": "The vertical padding inside an embedded action card.",
+      "$value": {
+        "comfortable": "10px",
+        "compact": "8px",
+      },
+    },
     "space-alert-vertical": {
       "$description": "The vertical padding inside alert components.",
       "$value": {
@@ -21903,6 +22652,22 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$description": "The border radius of tutorials inside a tutorial panel.",
           "$value": "8px",
         },
+        "border-width-action-card-active": {
+          "$description": "The border width of action cards in active state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-default": {
+          "$description": "The border width of action cards in default state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-disabled": {
+          "$description": "The border width of action cards in disabled state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-hover": {
+          "$description": "The border width of action cards in hover state.",
+          "$value": "1px",
+        },
         "border-width-alert": {
           "$description": "The border width of alerts.",
           "$value": "2px",
@@ -21974,6 +22739,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "border-width-token": {
           "$description": "The border width of tokens.",
           "$value": "2px",
+        },
+        "color-background-action-card-active": {
+          "$description": "The background color of action cards in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-action-card-default": {
+          "$description": "The default background color of action cards.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-disabled": {
+          "$description": "The background color of action cards in disabled state.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-hover": {
+          "$description": "The background color of action cards in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#f0fbff",
+          },
         },
         "color-background-avatar-default": {
           "$description": "The default background color of avatars.",
@@ -22477,6 +23270,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#006ce0",
             "light": "#d1f1ff",
+          },
+        },
+        "color-border-action-card-active": {
+          "$description": "The border color of action cards in active state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#002b66",
+          },
+        },
+        "color-border-action-card-default": {
+          "$description": "The default border color of action cards.",
+          "$value": {
+            "dark": "#42b4ff",
+            "light": "#006ce0",
+          },
+        },
+        "color-border-action-card-disabled": {
+          "$description": "The border color of action cards in disabled state.",
+          "$value": {
+            "dark": "#656871",
+            "light": "#b4b4bb",
+          },
+        },
+        "color-border-action-card-hover": {
+          "$description": "The border color of action cards in hover state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#002b66",
           },
         },
         "color-border-button-link-disabled": {
@@ -23879,6 +24700,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#006ce0",
           },
         },
+        "color-text-action-card-disabled": {
+          "$description": "The text color of action cards in disabled state.",
+          "$value": {
+            "dark": "#8c8c94",
+            "light": "#8c8c94",
+          },
+        },
         "color-text-avatar": {
           "$description": "The text and icon color of avatars.",
           "$value": {
@@ -24695,6 +25523,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "compact": "28px",
           },
         },
+        "space-action-card-horizontal-default": {
+          "$description": "The default horizontal padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-action-card-horizontal-embedded": {
+          "$description": "The horizontal padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "10px",
+          },
+        },
+        "space-action-card-vertical-default": {
+          "$description": "The default vertical padding inside an action card.",
+          "$value": {
+            "comfortable": "16px",
+            "compact": "12px",
+          },
+        },
+        "space-action-card-vertical-embedded": {
+          "$description": "The vertical padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "10px",
+            "compact": "8px",
+          },
+        },
         "space-alert-vertical": {
           "$description": "The vertical padding inside alert components.",
           "$value": {
@@ -25018,6 +25874,22 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$description": "The border radius of tutorials inside a tutorial panel.",
           "$value": "8px",
         },
+        "border-width-action-card-active": {
+          "$description": "The border width of action cards in active state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-default": {
+          "$description": "The border width of action cards in default state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-disabled": {
+          "$description": "The border width of action cards in disabled state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-hover": {
+          "$description": "The border width of action cards in hover state.",
+          "$value": "1px",
+        },
         "border-width-alert": {
           "$description": "The border width of alerts.",
           "$value": "2px",
@@ -25089,6 +25961,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "border-width-token": {
           "$description": "The border width of tokens.",
           "$value": "2px",
+        },
+        "color-background-action-card-active": {
+          "$description": "The background color of action cards in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#333843",
+          },
+        },
+        "color-background-action-card-default": {
+          "$description": "The default background color of action cards.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#161d26",
+          },
+        },
+        "color-background-action-card-disabled": {
+          "$description": "The background color of action cards in disabled state.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#161d26",
+          },
+        },
+        "color-background-action-card-hover": {
+          "$description": "The background color of action cards in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#1b232d",
+          },
         },
         "color-background-avatar-default": {
           "$description": "The default background color of avatars.",
@@ -25592,6 +26492,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#006ce0",
             "light": "#006ce0",
+          },
+        },
+        "color-border-action-card-active": {
+          "$description": "The border color of action cards in active state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#75cfff",
+          },
+        },
+        "color-border-action-card-default": {
+          "$description": "The default border color of action cards.",
+          "$value": {
+            "dark": "#42b4ff",
+            "light": "#42b4ff",
+          },
+        },
+        "color-border-action-card-disabled": {
+          "$description": "The border color of action cards in disabled state.",
+          "$value": {
+            "dark": "#656871",
+            "light": "#656871",
+          },
+        },
+        "color-border-action-card-hover": {
+          "$description": "The border color of action cards in hover state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#75cfff",
           },
         },
         "color-border-button-link-disabled": {
@@ -26992,6 +27920,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#42b4ff",
             "light": "#42b4ff",
+          },
+        },
+        "color-text-action-card-disabled": {
+          "$description": "The text color of action cards in disabled state.",
+          "$value": {
+            "dark": "#8c8c94",
+            "light": "#8c8c94",
           },
         },
         "color-text-avatar": {
@@ -27810,6 +28745,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "compact": "28px",
           },
         },
+        "space-action-card-horizontal-default": {
+          "$description": "The default horizontal padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-action-card-horizontal-embedded": {
+          "$description": "The horizontal padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "10px",
+          },
+        },
+        "space-action-card-vertical-default": {
+          "$description": "The default vertical padding inside an action card.",
+          "$value": {
+            "comfortable": "16px",
+            "compact": "12px",
+          },
+        },
+        "space-action-card-vertical-embedded": {
+          "$description": "The vertical padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "10px",
+            "compact": "8px",
+          },
+        },
         "space-alert-vertical": {
           "$description": "The vertical padding inside alert components.",
           "$value": {
@@ -28133,6 +29096,22 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$description": "The border radius of tutorials inside a tutorial panel.",
           "$value": "8px",
         },
+        "border-width-action-card-active": {
+          "$description": "The border width of action cards in active state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-default": {
+          "$description": "The border width of action cards in default state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-disabled": {
+          "$description": "The border width of action cards in disabled state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-hover": {
+          "$description": "The border width of action cards in hover state.",
+          "$value": "1px",
+        },
         "border-width-alert": {
           "$description": "The border width of alerts.",
           "$value": "2px",
@@ -28204,6 +29183,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "border-width-token": {
           "$description": "The border width of tokens.",
           "$value": "2px",
+        },
+        "color-background-action-card-active": {
+          "$description": "The background color of action cards in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-action-card-default": {
+          "$description": "The default background color of action cards.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-disabled": {
+          "$description": "The background color of action cards in disabled state.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-hover": {
+          "$description": "The background color of action cards in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#f0fbff",
+          },
         },
         "color-background-avatar-default": {
           "$description": "The default background color of avatars.",
@@ -28707,6 +29714,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#006ce0",
             "light": "#d1f1ff",
+          },
+        },
+        "color-border-action-card-active": {
+          "$description": "The border color of action cards in active state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#002b66",
+          },
+        },
+        "color-border-action-card-default": {
+          "$description": "The default border color of action cards.",
+          "$value": {
+            "dark": "#42b4ff",
+            "light": "#006ce0",
+          },
+        },
+        "color-border-action-card-disabled": {
+          "$description": "The border color of action cards in disabled state.",
+          "$value": {
+            "dark": "#656871",
+            "light": "#b4b4bb",
+          },
+        },
+        "color-border-action-card-hover": {
+          "$description": "The border color of action cards in hover state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#002b66",
           },
         },
         "color-border-button-link-disabled": {
@@ -30107,6 +31142,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#42b4ff",
             "light": "#006ce0",
+          },
+        },
+        "color-text-action-card-disabled": {
+          "$description": "The text color of action cards in disabled state.",
+          "$value": {
+            "dark": "#8c8c94",
+            "light": "#8c8c94",
           },
         },
         "color-text-avatar": {
@@ -30925,6 +31967,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "compact": "28px",
           },
         },
+        "space-action-card-horizontal-default": {
+          "$description": "The default horizontal padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-action-card-horizontal-embedded": {
+          "$description": "The horizontal padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "10px",
+          },
+        },
+        "space-action-card-vertical-default": {
+          "$description": "The default vertical padding inside an action card.",
+          "$value": {
+            "comfortable": "16px",
+            "compact": "12px",
+          },
+        },
+        "space-action-card-vertical-embedded": {
+          "$description": "The vertical padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "10px",
+            "compact": "8px",
+          },
+        },
         "space-alert-vertical": {
           "$description": "The vertical padding inside alert components.",
           "$value": {
@@ -31248,6 +32318,22 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$description": "The border radius of tutorials inside a tutorial panel.",
           "$value": "8px",
         },
+        "border-width-action-card-active": {
+          "$description": "The border width of action cards in active state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-default": {
+          "$description": "The border width of action cards in default state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-disabled": {
+          "$description": "The border width of action cards in disabled state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-hover": {
+          "$description": "The border width of action cards in hover state.",
+          "$value": "1px",
+        },
         "border-width-alert": {
           "$description": "The border width of alerts.",
           "$value": "2px",
@@ -31319,6 +32405,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "border-width-token": {
           "$description": "The border width of tokens.",
           "$value": "2px",
+        },
+        "color-background-action-card-active": {
+          "$description": "The background color of action cards in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-action-card-default": {
+          "$description": "The default background color of action cards.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-disabled": {
+          "$description": "The background color of action cards in disabled state.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-hover": {
+          "$description": "The background color of action cards in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#f0fbff",
+          },
         },
         "color-background-avatar-default": {
           "$description": "The default background color of avatars.",
@@ -31822,6 +32936,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#006ce0",
             "light": "#d1f1ff",
+          },
+        },
+        "color-border-action-card-active": {
+          "$description": "The border color of action cards in active state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#002b66",
+          },
+        },
+        "color-border-action-card-default": {
+          "$description": "The default border color of action cards.",
+          "$value": {
+            "dark": "#42b4ff",
+            "light": "#006ce0",
+          },
+        },
+        "color-border-action-card-disabled": {
+          "$description": "The border color of action cards in disabled state.",
+          "$value": {
+            "dark": "#656871",
+            "light": "#b4b4bb",
+          },
+        },
+        "color-border-action-card-hover": {
+          "$description": "The border color of action cards in hover state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#002b66",
           },
         },
         "color-border-button-link-disabled": {
@@ -33222,6 +34364,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#42b4ff",
             "light": "#006ce0",
+          },
+        },
+        "color-text-action-card-disabled": {
+          "$description": "The text color of action cards in disabled state.",
+          "$value": {
+            "dark": "#8c8c94",
+            "light": "#8c8c94",
           },
         },
         "color-text-avatar": {
@@ -34040,6 +35189,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "compact": "28px",
           },
         },
+        "space-action-card-horizontal-default": {
+          "$description": "The default horizontal padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-action-card-horizontal-embedded": {
+          "$description": "The horizontal padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "10px",
+          },
+        },
+        "space-action-card-vertical-default": {
+          "$description": "The default vertical padding inside an action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "12px",
+          },
+        },
+        "space-action-card-vertical-embedded": {
+          "$description": "The vertical padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "10px",
+            "compact": "8px",
+          },
+        },
         "space-alert-vertical": {
           "$description": "The vertical padding inside alert components.",
           "$value": {
@@ -34363,6 +35540,22 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$description": "The border radius of tutorials inside a tutorial panel.",
           "$value": "8px",
         },
+        "border-width-action-card-active": {
+          "$description": "The border width of action cards in active state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-default": {
+          "$description": "The border width of action cards in default state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-disabled": {
+          "$description": "The border width of action cards in disabled state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-hover": {
+          "$description": "The border width of action cards in hover state.",
+          "$value": "1px",
+        },
         "border-width-alert": {
           "$description": "The border width of alerts.",
           "$value": "2px",
@@ -34434,6 +35627,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "border-width-token": {
           "$description": "The border width of tokens.",
           "$value": "2px",
+        },
+        "color-background-action-card-active": {
+          "$description": "The background color of action cards in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-action-card-default": {
+          "$description": "The default background color of action cards.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-disabled": {
+          "$description": "The background color of action cards in disabled state.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-hover": {
+          "$description": "The background color of action cards in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#f0fbff",
+          },
         },
         "color-background-avatar-default": {
           "$description": "The default background color of avatars.",
@@ -34939,6 +36160,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#d1f1ff",
           },
         },
+        "color-border-action-card-active": {
+          "$description": "The border color of action cards in active state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#002b66",
+          },
+        },
+        "color-border-action-card-default": {
+          "$description": "The default border color of action cards.",
+          "$value": {
+            "dark": "#42b4ff",
+            "light": "#006ce0",
+          },
+        },
+        "color-border-action-card-disabled": {
+          "$description": "The border color of action cards in disabled state.",
+          "$value": {
+            "dark": "#656871",
+            "light": "#b4b4bb",
+          },
+        },
+        "color-border-action-card-hover": {
+          "$description": "The border color of action cards in hover state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#002b66",
+          },
+        },
         "color-border-button-link-disabled": {
           "$description": "The border color of link buttons in disabled state.",
           "$value": {
@@ -36339,6 +37588,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#006ce0",
           },
         },
+        "color-text-action-card-disabled": {
+          "$description": "The text color of action cards in disabled state.",
+          "$value": {
+            "dark": "#8c8c94",
+            "light": "#8c8c94",
+          },
+        },
         "color-text-avatar": {
           "$description": "The text and icon color of avatars.",
           "$value": {
@@ -37155,6 +38411,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "compact": "28px",
           },
         },
+        "space-action-card-horizontal-default": {
+          "$description": "The default horizontal padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-action-card-horizontal-embedded": {
+          "$description": "The horizontal padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "10px",
+          },
+        },
+        "space-action-card-vertical-default": {
+          "$description": "The default vertical padding inside an action card.",
+          "$value": {
+            "comfortable": "16px",
+            "compact": "12px",
+          },
+        },
+        "space-action-card-vertical-embedded": {
+          "$description": "The vertical padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "10px",
+            "compact": "8px",
+          },
+        },
         "space-alert-vertical": {
           "$description": "The vertical padding inside alert components.",
           "$value": {
@@ -37478,6 +38762,22 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$description": "The border radius of tutorials inside a tutorial panel.",
           "$value": "8px",
         },
+        "border-width-action-card-active": {
+          "$description": "The border width of action cards in active state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-default": {
+          "$description": "The border width of action cards in default state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-disabled": {
+          "$description": "The border width of action cards in disabled state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-hover": {
+          "$description": "The border width of action cards in hover state.",
+          "$value": "1px",
+        },
         "border-width-alert": {
           "$description": "The border width of alerts.",
           "$value": "2px",
@@ -37549,6 +38849,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "border-width-token": {
           "$description": "The border width of tokens.",
           "$value": "2px",
+        },
+        "color-background-action-card-active": {
+          "$description": "The background color of action cards in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#d1f1ff",
+          },
+        },
+        "color-background-action-card-default": {
+          "$description": "The default background color of action cards.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-disabled": {
+          "$description": "The background color of action cards in disabled state.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-action-card-hover": {
+          "$description": "The background color of action cards in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#f0fbff",
+          },
         },
         "color-background-avatar-default": {
           "$description": "The default background color of avatars.",
@@ -38054,6 +39382,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#d1f1ff",
           },
         },
+        "color-border-action-card-active": {
+          "$description": "The border color of action cards in active state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#002b66",
+          },
+        },
+        "color-border-action-card-default": {
+          "$description": "The default border color of action cards.",
+          "$value": {
+            "dark": "#42b4ff",
+            "light": "#006ce0",
+          },
+        },
+        "color-border-action-card-disabled": {
+          "$description": "The border color of action cards in disabled state.",
+          "$value": {
+            "dark": "#656871",
+            "light": "#b4b4bb",
+          },
+        },
+        "color-border-action-card-hover": {
+          "$description": "The border color of action cards in hover state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#002b66",
+          },
+        },
         "color-border-button-link-disabled": {
           "$description": "The border color of link buttons in disabled state.",
           "$value": {
@@ -39454,6 +40810,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#006ce0",
           },
         },
+        "color-text-action-card-disabled": {
+          "$description": "The text color of action cards in disabled state.",
+          "$value": {
+            "dark": "#8c8c94",
+            "light": "#8c8c94",
+          },
+        },
         "color-text-avatar": {
           "$description": "The text and icon color of avatars.",
           "$value": {
@@ -40270,6 +41633,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "compact": "28px",
           },
         },
+        "space-action-card-horizontal-default": {
+          "$description": "The default horizontal padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-action-card-horizontal-embedded": {
+          "$description": "The horizontal padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "10px",
+          },
+        },
+        "space-action-card-vertical-default": {
+          "$description": "The default vertical padding inside an action card.",
+          "$value": {
+            "comfortable": "16px",
+            "compact": "12px",
+          },
+        },
+        "space-action-card-vertical-embedded": {
+          "$description": "The vertical padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "10px",
+            "compact": "8px",
+          },
+        },
         "space-alert-vertical": {
           "$description": "The vertical padding inside alert components.",
           "$value": {
@@ -40593,6 +41984,22 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$description": "The border radius of tutorials inside a tutorial panel.",
           "$value": "8px",
         },
+        "border-width-action-card-active": {
+          "$description": "The border width of action cards in active state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-default": {
+          "$description": "The border width of action cards in default state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-disabled": {
+          "$description": "The border width of action cards in disabled state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-hover": {
+          "$description": "The border width of action cards in hover state.",
+          "$value": "1px",
+        },
         "border-width-alert": {
           "$description": "The border width of alerts.",
           "$value": "2px",
@@ -40664,6 +42071,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "border-width-token": {
           "$description": "The border width of tokens.",
           "$value": "2px",
+        },
+        "color-background-action-card-active": {
+          "$description": "The background color of action cards in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#333843",
+          },
+        },
+        "color-background-action-card-default": {
+          "$description": "The default background color of action cards.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#161d26",
+          },
+        },
+        "color-background-action-card-disabled": {
+          "$description": "The background color of action cards in disabled state.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#161d26",
+          },
+        },
+        "color-background-action-card-hover": {
+          "$description": "The background color of action cards in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#1b232d",
+          },
         },
         "color-background-avatar-default": {
           "$description": "The default background color of avatars.",
@@ -41167,6 +42602,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#006ce0",
             "light": "#006ce0",
+          },
+        },
+        "color-border-action-card-active": {
+          "$description": "The border color of action cards in active state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#75cfff",
+          },
+        },
+        "color-border-action-card-default": {
+          "$description": "The default border color of action cards.",
+          "$value": {
+            "dark": "#42b4ff",
+            "light": "#42b4ff",
+          },
+        },
+        "color-border-action-card-disabled": {
+          "$description": "The border color of action cards in disabled state.",
+          "$value": {
+            "dark": "#656871",
+            "light": "#656871",
+          },
+        },
+        "color-border-action-card-hover": {
+          "$description": "The border color of action cards in hover state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#75cfff",
           },
         },
         "color-border-button-link-disabled": {
@@ -42567,6 +44030,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#42b4ff",
             "light": "#42b4ff",
+          },
+        },
+        "color-text-action-card-disabled": {
+          "$description": "The text color of action cards in disabled state.",
+          "$value": {
+            "dark": "#8c8c94",
+            "light": "#8c8c94",
           },
         },
         "color-text-avatar": {
@@ -43385,6 +44855,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "compact": "28px",
           },
         },
+        "space-action-card-horizontal-default": {
+          "$description": "The default horizontal padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-action-card-horizontal-embedded": {
+          "$description": "The horizontal padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "10px",
+          },
+        },
+        "space-action-card-vertical-default": {
+          "$description": "The default vertical padding inside an action card.",
+          "$value": {
+            "comfortable": "16px",
+            "compact": "12px",
+          },
+        },
+        "space-action-card-vertical-embedded": {
+          "$description": "The vertical padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "10px",
+            "compact": "8px",
+          },
+        },
         "space-alert-vertical": {
           "$description": "The vertical padding inside alert components.",
           "$value": {
@@ -43708,6 +45206,22 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$description": "The border radius of tutorials inside a tutorial panel.",
           "$value": "8px",
         },
+        "border-width-action-card-active": {
+          "$description": "The border width of action cards in active state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-default": {
+          "$description": "The border width of action cards in default state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-disabled": {
+          "$description": "The border width of action cards in disabled state.",
+          "$value": "1px",
+        },
+        "border-width-action-card-hover": {
+          "$description": "The border width of action cards in hover state.",
+          "$value": "1px",
+        },
         "border-width-alert": {
           "$description": "The border width of alerts.",
           "$value": "2px",
@@ -43779,6 +45293,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "border-width-token": {
           "$description": "The border width of tokens.",
           "$value": "2px",
+        },
+        "color-background-action-card-active": {
+          "$description": "The background color of action cards in active state.",
+          "$value": {
+            "dark": "#333843",
+            "light": "#333843",
+          },
+        },
+        "color-background-action-card-default": {
+          "$description": "The default background color of action cards.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#161d26",
+          },
+        },
+        "color-background-action-card-disabled": {
+          "$description": "The background color of action cards in disabled state.",
+          "$value": {
+            "dark": "#161d26",
+            "light": "#161d26",
+          },
+        },
+        "color-background-action-card-hover": {
+          "$description": "The background color of action cards in hover state.",
+          "$value": {
+            "dark": "#1b232d",
+            "light": "#1b232d",
+          },
         },
         "color-background-avatar-default": {
           "$description": "The default background color of avatars.",
@@ -44282,6 +45824,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#006ce0",
             "light": "#006ce0",
+          },
+        },
+        "color-border-action-card-active": {
+          "$description": "The border color of action cards in active state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#75cfff",
+          },
+        },
+        "color-border-action-card-default": {
+          "$description": "The default border color of action cards.",
+          "$value": {
+            "dark": "#42b4ff",
+            "light": "#42b4ff",
+          },
+        },
+        "color-border-action-card-disabled": {
+          "$description": "The border color of action cards in disabled state.",
+          "$value": {
+            "dark": "#656871",
+            "light": "#656871",
+          },
+        },
+        "color-border-action-card-hover": {
+          "$description": "The border color of action cards in hover state.",
+          "$value": {
+            "dark": "#75cfff",
+            "light": "#75cfff",
           },
         },
         "color-border-button-link-disabled": {
@@ -45684,6 +47254,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#42b4ff",
           },
         },
+        "color-text-action-card-disabled": {
+          "$description": "The text color of action cards in disabled state.",
+          "$value": {
+            "dark": "#8c8c94",
+            "light": "#8c8c94",
+          },
+        },
         "color-text-avatar": {
           "$description": "The text and icon color of avatars.",
           "$value": {
@@ -46500,6 +48077,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "compact": "28px",
           },
         },
+        "space-action-card-horizontal-default": {
+          "$description": "The default horizontal padding inside an action card.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-action-card-horizontal-embedded": {
+          "$description": "The horizontal padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "10px",
+          },
+        },
+        "space-action-card-vertical-default": {
+          "$description": "The default vertical padding inside an action card.",
+          "$value": {
+            "comfortable": "16px",
+            "compact": "12px",
+          },
+        },
+        "space-action-card-vertical-embedded": {
+          "$description": "The vertical padding inside an embedded action card.",
+          "$value": {
+            "comfortable": "10px",
+            "compact": "8px",
+          },
+        },
         "space-alert-vertical": {
           "$description": "The vertical padding inside alert components.",
           "$value": {
@@ -46823,6 +48428,22 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
       "$description": "The border radius of tutorials inside a tutorial panel.",
       "$value": "8px",
     },
+    "border-width-action-card-active": {
+      "$description": "The border width of action cards in active state.",
+      "$value": "1px",
+    },
+    "border-width-action-card-default": {
+      "$description": "The border width of action cards in default state.",
+      "$value": "1px",
+    },
+    "border-width-action-card-disabled": {
+      "$description": "The border width of action cards in disabled state.",
+      "$value": "1px",
+    },
+    "border-width-action-card-hover": {
+      "$description": "The border width of action cards in hover state.",
+      "$value": "1px",
+    },
     "border-width-alert": {
       "$description": "The border width of alerts.",
       "$value": "2px",
@@ -46894,6 +48515,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
     "border-width-token": {
       "$description": "The border width of tokens.",
       "$value": "2px",
+    },
+    "color-background-action-card-active": {
+      "$description": "The background color of action cards in active state.",
+      "$value": {
+        "dark": "#333843",
+        "light": "#d1f1ff",
+      },
+    },
+    "color-background-action-card-default": {
+      "$description": "The default background color of action cards.",
+      "$value": {
+        "dark": "#161d26",
+        "light": "#ffffff",
+      },
+    },
+    "color-background-action-card-disabled": {
+      "$description": "The background color of action cards in disabled state.",
+      "$value": {
+        "dark": "#161d26",
+        "light": "#ffffff",
+      },
+    },
+    "color-background-action-card-hover": {
+      "$description": "The background color of action cards in hover state.",
+      "$value": {
+        "dark": "#1b232d",
+        "light": "#f0fbff",
+      },
     },
     "color-background-avatar-default": {
       "$description": "The default background color of avatars.",
@@ -47397,6 +49046,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
       "$value": {
         "dark": "#006ce0",
         "light": "#d1f1ff",
+      },
+    },
+    "color-border-action-card-active": {
+      "$description": "The border color of action cards in active state.",
+      "$value": {
+        "dark": "#75cfff",
+        "light": "#002b66",
+      },
+    },
+    "color-border-action-card-default": {
+      "$description": "The default border color of action cards.",
+      "$value": {
+        "dark": "#42b4ff",
+        "light": "#006ce0",
+      },
+    },
+    "color-border-action-card-disabled": {
+      "$description": "The border color of action cards in disabled state.",
+      "$value": {
+        "dark": "#656871",
+        "light": "#b4b4bb",
+      },
+    },
+    "color-border-action-card-hover": {
+      "$description": "The border color of action cards in hover state.",
+      "$value": {
+        "dark": "#75cfff",
+        "light": "#002b66",
       },
     },
     "color-border-button-link-disabled": {
@@ -48799,6 +50476,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "light": "#006ce0",
       },
     },
+    "color-text-action-card-disabled": {
+      "$description": "The text color of action cards in disabled state.",
+      "$value": {
+        "dark": "#8c8c94",
+        "light": "#8c8c94",
+      },
+    },
     "color-text-avatar": {
       "$description": "The text and icon color of avatars.",
       "$value": {
@@ -49613,6 +51297,34 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
       "$value": {
         "comfortable": "32px",
         "compact": "28px",
+      },
+    },
+    "space-action-card-horizontal-default": {
+      "$description": "The default horizontal padding inside an action card.",
+      "$value": {
+        "comfortable": "20px",
+        "compact": "20px",
+      },
+    },
+    "space-action-card-horizontal-embedded": {
+      "$description": "The horizontal padding inside an embedded action card.",
+      "$value": {
+        "comfortable": "12px",
+        "compact": "10px",
+      },
+    },
+    "space-action-card-vertical-default": {
+      "$description": "The default vertical padding inside an action card.",
+      "$value": {
+        "comfortable": "16px",
+        "compact": "12px",
+      },
+    },
+    "space-action-card-vertical-embedded": {
+      "$description": "The vertical padding inside an embedded action card.",
+      "$value": {
+        "comfortable": "10px",
+        "compact": "8px",
       },
     },
     "space-alert-vertical": {

--- a/style-dictionary/visual-refresh/metadata/borders.ts
+++ b/style-dictionary/visual-refresh/metadata/borders.ts
@@ -219,6 +219,26 @@ const metadata: StyleDictionary.MetadataIndex = {
     public: true,
     themeable: true,
   },
+  borderWidthActionCardDefault: {
+    description: 'The border width of action cards in default state.',
+    public: true,
+    themeable: true,
+  },
+  borderWidthActionCardHover: {
+    description: 'The border width of action cards in hover state.',
+    public: true,
+    themeable: true,
+  },
+  borderWidthActionCardActive: {
+    description: 'The border width of action cards in active state.',
+    public: true,
+    themeable: true,
+  },
+  borderWidthActionCardDisabled: {
+    description: 'The border width of action cards in disabled state.',
+    public: true,
+    themeable: true,
+  },
 };
 
 export default metadata;

--- a/style-dictionary/visual-refresh/metadata/colors.ts
+++ b/style-dictionary/visual-refresh/metadata/colors.ts
@@ -994,6 +994,51 @@ const metadata: StyleDictionary.MetadataIndex = {
     themeable: true,
     public: true,
   },
+  colorBackgroundActionCardDefault: {
+    description: 'The default background color of action cards.',
+    themeable: true,
+    public: true,
+  },
+  colorBackgroundActionCardHover: {
+    description: 'The background color of action cards in hover state.',
+    themeable: true,
+    public: true,
+  },
+  colorBackgroundActionCardActive: {
+    description: 'The background color of action cards in active state.',
+    themeable: true,
+    public: true,
+  },
+  colorBackgroundActionCardDisabled: {
+    description: 'The background color of action cards in disabled state.',
+    themeable: true,
+    public: true,
+  },
+  colorBorderActionCardDefault: {
+    description: 'The default border color of action cards.',
+    themeable: true,
+    public: true,
+  },
+  colorBorderActionCardHover: {
+    description: 'The border color of action cards in hover state.',
+    themeable: true,
+    public: true,
+  },
+  colorBorderActionCardActive: {
+    description: 'The border color of action cards in active state.',
+    themeable: true,
+    public: true,
+  },
+  colorBorderActionCardDisabled: {
+    description: 'The border color of action cards in disabled state.',
+    themeable: true,
+    public: true,
+  },
+  colorTextActionCardDisabled: {
+    description: 'The text color of action cards in disabled state.',
+    themeable: true,
+    public: true,
+  },
   colorTextIconSubtle: {
     description: 'The color of subtle icons. For example: secondary icons with lower visual emphasis.',
     public: true,

--- a/style-dictionary/visual-refresh/metadata/spacing.ts
+++ b/style-dictionary/visual-refresh/metadata/spacing.ts
@@ -134,6 +134,26 @@ const metadata: StyleDictionary.MetadataIndex = {
     public: true,
     themeable: true,
   },
+  spaceActionCardHorizontalDefault: {
+    description: 'The default horizontal padding inside an action card.',
+    public: true,
+    themeable: true,
+  },
+  spaceActionCardHorizontalEmbedded: {
+    description: 'The horizontal padding inside an embedded action card.',
+    public: true,
+    themeable: true,
+  },
+  spaceActionCardVerticalDefault: {
+    description: 'The default vertical padding inside an action card.',
+    public: true,
+    themeable: true,
+  },
+  spaceActionCardVerticalEmbedded: {
+    description: 'The vertical padding inside an embedded action card.',
+    public: true,
+    themeable: true,
+  },
   spaceContainerHorizontal: {
     description: 'The horizontal padding inside a container.',
     public: true,


### PR DESCRIPTION
### Description
This PR exposes the action card design tokens by making them public and themeable. This includes:
- borderWidthActionCardActive
- borderWidthActionCardDefault
- borderWidthActionCardDisabled
- borderWidthActionCardHover
- colorBackgroundActionCardActive
- colorBackgroundActionCardDefault
- colorBackgroundActionCardDisabled
- colorBackgroundActionCardHover
- colorBorderActionCardActive
- colorBorderActionCardDefault
- colorBorderActionCardDisabled
- colorBorderActionCardHover
- colorTextActionCardDisabled
- spaceActionCardHorizontalDefault
- spaceActionCardHorizontalEmbedded
- spaceActionCardVerticalDefault
- spaceActionCardVerticalEmbedded


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
