### PR TITLE
chore: Auto-approve PRs with only package-lock.json changes

### DIFF
--- a/.github/workflows/auto-approve-lockfile.yml
+++ b/.github/workflows/auto-approve-lockfile.yml
@@ -1,0 +1,31 @@
+name: Auto-approve lockfile-only PRs
+
+on:
+  pull_request:
+    paths:
+      - 'package-lock.json'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if only lockfile changed
+        id: check
+        run: |
+          FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          if [ "$FILES" = "package-lock.json" ]; then
+            echo "lockfile_only=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Auto-approve
+        if: steps.check.outputs.lockfile_only == 'true'
+        run: gh pr review ${{ github.event.pull_request.number }} --approve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
Adds a GitHub Action that auto-approves PRs where package-lock.json is the only changed file.

Requires enabling 'Allow GitHub Actions to approve pull requests' in repo Actions settings.
<img width="716" height="132" alt="image" src="https://github.com/user-attachments/assets/d7cc8837-0d89-4ea2-aa09-7c9e9b703b7c" />

Related links, issue #, if available: N/A

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.