### PR TITLE
chore: Adds disable dismiss auto-focus for internal chart tooltip

### DIFF
--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -56,6 +56,9 @@ export interface ChartPopoverProps extends PopoverProps {
 
   /** Popover footer */
   footer?: React.ReactNode;
+
+  /** Prevents dismiss button auto-focus */
+  disableDismissAutoFocus?: boolean;
 }
 
 export default React.forwardRef(ChartPopover);
@@ -67,6 +70,7 @@ function ChartPopover(
     fixedWidth = false,
     dismissButton = false,
     dismissAriaLabel,
+    disableDismissAutoFocus,
 
     children,
     footer,
@@ -157,6 +161,7 @@ function ChartPopover(
         <PopoverBody
           dismissButton={dismissButton}
           dismissAriaLabel={dismissAriaLabel}
+          disableDismissAutoFocus={disableDismissAutoFocus}
           header={<span className={testClasses.header}>{title}</span>}
           onDismiss={() => onDismiss()}
           overflowVisible="content"

--- a/src/popover/__tests__/popover-body.test.tsx
+++ b/src/popover/__tests__/popover-body.test.tsx
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import PopoverBody from '../../../lib/components/popover/body';
+
+function renderPopoverBody(disableDismissAutoFocus = false) {
+  return render(
+    <PopoverBody
+      dismissButton={true}
+      dismissAriaLabel="Close"
+      disableDismissAutoFocus={disableDismissAutoFocus}
+      onDismiss={() => {}}
+      header={undefined}
+    >
+      Content
+    </PopoverBody>
+  );
+}
+
+describe('disableDismissAutoFocus', () => {
+  it('focuses the dismiss button by default when dismissButton is true', () => {
+    const { container } = renderPopoverBody();
+    const dismissButton = container.querySelector('button[aria-label="Close"]');
+    expect(document.activeElement).toBe(dismissButton);
+  });
+
+  it('does not focus the dismiss button when disableDismissAutoFocus is true', () => {
+    const { container } = renderPopoverBody(true);
+    const dismissButton = container.querySelector('button[aria-label="Close"]');
+    expect(document.activeElement).not.toBe(dismissButton);
+  });
+});

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -18,6 +18,7 @@ import styles from './styles.css.js';
 export interface PopoverBodyProps {
   dismissButton: boolean;
   dismissAriaLabel: string | undefined;
+  disableDismissAutoFocus?: boolean;
   onDismiss: ((method?: 'escape' | 'close-button') => void) | undefined;
   onBlur?: (event: React.FocusEvent) => void;
 
@@ -37,6 +38,7 @@ const PopoverBody = React.forwardRef(
     {
       dismissButton: showDismissButton,
       dismissAriaLabel,
+      disableDismissAutoFocus = false,
       header,
       children,
       onDismiss,
@@ -68,11 +70,11 @@ const PopoverBody = React.forwardRef(
     // because we also want to focus the dismiss button when it
     // is added dynamically (e.g. in chart popovers)
     useEffect(() => {
-      if (showDismissButton && !dismissButtonFocused.current) {
+      if (showDismissButton && !disableDismissAutoFocus && !dismissButtonFocused.current) {
         dismissButtonRef.current?.focus({ preventScroll: true });
       }
       dismissButtonFocused.current = showDismissButton;
-    }, [showDismissButton]);
+    }, [showDismissButton, disableDismissAutoFocus]);
 
     const dismissButton = (showDismissButton ?? null) && (
       <div


### PR DESCRIPTION
### Description

This change is required to support https://github.com/cloudscape-design/chart-components/pull/217, where the use case requires the dismiss button to appear, while the focus stays on the legend item - this is different from the conventional popover use with click activation or charts use, where the tooltip does not have a dismiss button unless pinned.

### How has this been tested?

* New unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
