### PR TITLE
fix: Prevent height hook from running in token-mode when value prop changes

### DIFF
--- a/src/prompt-input/__tests__/prompt-input-token-mode.test.tsx
+++ b/src/prompt-input/__tests__/prompt-input-token-mode.test.tsx
@@ -7952,3 +7952,82 @@ describe('IME composition handling', () => {
     expect(onChange.mock.calls[0][0].detail.value).toBe('가나');
   });
 });
+
+describe('tokens takes precedence over value', () => {
+  test('empty tokens array still activates token mode, ignoring value', () => {
+    const { wrapper } = renderTokenMode({ props: { value: 'hello' } });
+    expect(wrapper.findContentEditableElement()).not.toBeNull();
+    expect(getValue(wrapper)).toBe('');
+  });
+
+  test('content is derived from tokens, not value, when both are provided', () => {
+    const { wrapper } = renderTokenMode({
+      props: { tokens: [{ type: 'text', value: 'from-tokens' }], value: 'from-value' },
+    });
+    expect(getValue(wrapper)).toBe('from-tokens');
+  });
+
+  test('onAction fires with tokens-derived value, not the value prop', () => {
+    const onAction = jest.fn();
+    const { wrapper } = renderTokenMode({
+      props: {
+        onAction,
+        tokens: [{ type: 'text', value: 'from-tokens' }],
+        value: 'from-value',
+      },
+    });
+    wrapper.findActionButton()!.click();
+    expect(onAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ value: 'from-tokens' }),
+      })
+    );
+  });
+
+  test('updating the value prop does not trigger the token-mode height effect', () => {
+    const rafSpy = jest.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 0);
+    try {
+      const tokens: PromptInputProps['tokens'] = [{ type: 'text', value: 'hello' }];
+      const { rerender } = renderTokenMode({ props: { tokens, value: 'initial' } });
+      const callsAfterMount = rafSpy.mock.calls.length;
+      expect(callsAfterMount).toBeGreaterThan(0);
+
+      rerender(
+        <PromptInput
+          tokens={tokens}
+          value="changed"
+          menus={defaultMenus}
+          actionButtonIconName="send"
+          i18nStrings={defaultI18nStrings}
+          ariaLabel="Chat input"
+        />
+      );
+
+      expect(rafSpy.mock.calls.length).toBe(callsAfterMount);
+    } finally {
+      rafSpy.mockRestore();
+    }
+  });
+
+  test('updating tokens still triggers the token-mode height effect', () => {
+    const rafSpy = jest.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 0);
+    try {
+      const { rerender } = renderTokenMode({ props: { tokens: [{ type: 'text', value: 'hello' }] } });
+      const callsAfterMount = rafSpy.mock.calls.length;
+
+      rerender(
+        <PromptInput
+          tokens={[{ type: 'text', value: 'hello world' }]}
+          menus={defaultMenus}
+          actionButtonIconName="send"
+          i18nStrings={defaultI18nStrings}
+          ariaLabel="Chat input"
+        />
+      );
+
+      expect(rafSpy.mock.calls.length).toBeGreaterThan(callsAfterMount);
+    } finally {
+      rafSpy.mockRestore();
+    }
+  });
+});

--- a/src/prompt-input/internal.tsx
+++ b/src/prompt-input/internal.tsx
@@ -116,7 +116,9 @@ const InternalPromptInput = React.forwardRef(
       ),
     };
 
-    const isTokenMode = !!tokens && supportsTokenMode;
+    // Empty tokens array is valid token-mode state; only fall back to
+    // textarea mode when the prop is absent.
+    const isTokenMode = tokens !== undefined && supportsTokenMode;
 
     if (isDevelopment) {
       if ((menus || tokens) && !supportsTokenMode) {
@@ -173,13 +175,20 @@ const InternalPromptInput = React.forwardRef(
       }
     });
 
+    // Height is adjusted per-mode. `value` must not be a dependency in token
+    // mode — it's unused there, and re-running the effect on `value` changes
+    // resets the contentEditable caret to offset 0.
     useEffect(() => {
       if (isTokenMode) {
         requestAnimationFrame(() => adjustInputHeight());
-      } else {
+      }
+    }, [isTokenMode, tokens, adjustInputHeight, isCompactMode, placeholder]);
+
+    useEffect(() => {
+      if (!isTokenMode) {
         adjustInputHeight();
       }
-    }, [isTokenMode, tokens, adjustInputHeight, value, isCompactMode, placeholder]);
+    }, [isTokenMode, value, adjustInputHeight, isCompactMode, placeholder]);
 
     const plainTextValue = isTokenMode
       ? tokensToText


### PR DESCRIPTION
### Description
When providing both `value` and `tokens`, updating the value prop results in the adjustHeight hook running and affecting the caret position. This PR separates the useEffect so it can run independently when in either mode, this way value updates don't affect token mode and vice versa.

Related links, issue #, if available: `AWSUI-61987`

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
