### PR TITLE
chore: Use quick build for faster deployments

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -16,7 +16,6 @@ permissions:
   actions: read
   contents: read
   security-events: write
-  deployments: write
 
 jobs:
   build:
@@ -27,19 +26,4 @@ jobs:
     uses: cloudscape-design/actions/.github/workflows/build-lint-test.yml@main
     secrets: inherit
     with:
-      artifact-path: pages/lib/static-default
-      artifact-name: dev-pages-react${{ matrix.react }}
-      react-version: ${{ matrix.react }}   
-  deploy:
-    needs: build
-    name: deploy${{ matrix.react != 16 && format(' (React {0})', matrix.react) || '' }}
-    # skip this job for external contributions as they aren't supported and cause the job's failure
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    strategy:
-      matrix:
-        react: [16, 18]
-    uses: cloudscape-design/actions/.github/workflows/deploy.yml@main
-    secrets: inherit
-    with:
-      artifact-name: dev-pages-react${{ matrix.react }}
-      deployment-path: pages/lib/static-default
+      react-version: ${{ matrix.react }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,67 @@
+name: Deploy
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  actions: read
+  contents: read
+  deployments: write
+
+jobs:
+  # Quick build: compiles source and bundles dev pages without running tests.
+  # Produces the artifact consumed by deploy, allowing it to start
+  # before the full build+test job finishes.
+  quick-build:
+    name: quick-build${{ matrix.react != 16 && format(' (React {0})', matrix.react) || '' }}
+    # skip this job for external contributions
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    strategy:
+      matrix:
+        react: [16, 18]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Quick build
+        run: npm run quick-build
+        env:
+          NODE_ENV: production
+          REACT_VERSION: ${{ matrix.react }}
+
+      - name: Bundle dev pages
+        run: node_modules/.bin/webpack --config pages/webpack.config.integ.cjs --output-path pages/lib/static-default
+        env:
+          NODE_ENV: production
+          REACT_VERSION: ${{ matrix.react }}
+
+      - name: Upload dev pages artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-pages-react${{ matrix.react }}
+          path: pages/lib/static-default
+
+  deploy:
+    needs: quick-build
+    name: deploy${{ matrix.react != 16 && format(' (React {0})', matrix.react) || '' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    strategy:
+      matrix:
+        react: [16, 18]
+    uses: cloudscape-design/actions/.github/workflows/deploy.yml@main
+    secrets: inherit
+    with:
+      artifact-name: dev-pages-react${{ matrix.react }}
+      deployment-path: pages/lib/static-default


### PR DESCRIPTION
### Description

The deployment workflow does not need a full build including unit tests. The quick build is enough.

### How has this been tested?

- Checked the build times for the React 18 branch:
  - In the previous PR, the deployment PR had to wait for a full build that took [11min 16s for React 16](https://github.com/cloudscape-design/components/actions/runs/25740991536/job/75609150649) and [10min 27s for React 18](https://github.com/cloudscape-design/components/actions/runs/25740991536/job/75609150855).
  - In this PR, the quick build took [2min 43s for React 16 and 2m 47s](https://github.com/cloudscape-design/components/actions/runs/25800167380/job/75787708665) and [2min 47s for React 18](https://github.com/cloudscape-design/components/actions/runs/25800167380/job/75787708647)
- Manually checked deployment pages

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
