### PR TITLE
feat: Add truncated text component and built-in tooltips for button+icon

### DIFF
--- a/build-tools/utils/pluralize.js
+++ b/build-tools/utils/pluralize.js
@@ -92,6 +92,7 @@ const pluralizationMap = {
   Tooltip: 'Tooltips',
   TopNavigation: 'TopNavigations',
   TreeView: 'TreeViews',
+  TruncatedText: 'TruncatedTexts',
   TutorialPanel: 'TutorialPanels',
   Wizard: 'Wizards',
 };

--- a/pages/truncated-text/simple.page.tsx
+++ b/pages/truncated-text/simple.page.tsx
@@ -1,0 +1,101 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+
+import Box from '~components/box';
+import CopyToClipboard from '~components/copy-to-clipboard';
+import Link from '~components/link';
+import SpaceBetween from '~components/space-between';
+import StatusIndicator from '~components/status-indicator';
+import TruncatedText from '~components/truncated-text';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+const containerStyle: React.CSSProperties = {
+  maxWidth: '320px',
+  padding: '8px 12px',
+  border: '1px solid #d5dbdb',
+  borderRadius: '4px',
+};
+
+export default function TruncatedTextSimple() {
+  return (
+    <ScreenshotArea>
+      <h1>TruncatedText examples</h1>
+      <SpaceBetween size="m">
+        <Box>
+          <Box variant="awsui-key-label">Truncated plain text</Box>
+          <div style={containerStyle}>
+            <TruncatedText>arn:aws:lambda:us-east-1:123456789012:function:my-function</TruncatedText>
+          </div>
+        </Box>
+
+        <Box>
+          <Box variant="awsui-key-label">Non-truncated plain text</Box>
+          <div style={containerStyle}>
+            <TruncatedText>arn:aws:lambda</TruncatedText>
+          </div>
+        </Box>
+
+        <Box>
+          <Box variant="awsui-key-label">Truncated with interactive child (uses tooltipText)</Box>
+          <div style={containerStyle}>
+            <TruncatedText tooltipText="ResourceName-421492941223_may-be-truncated">
+              <Link href="#">ResourceName-421492941223_may-be-truncated</Link>
+            </TruncatedText>
+          </div>
+        </Box>
+
+        <Box>
+          <Box variant="awsui-key-label">Truncated text in a flex container</Box>
+          <div style={{ ...containerStyle, display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <span>Label:</span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <TruncatedText>arn:aws:s3:::my-very-long-bucket-name-with-extra-words</TruncatedText>
+            </div>
+          </div>
+        </Box>
+
+        <Box>
+          <Box variant="awsui-key-label">With StatusIndicator (wrapText=true, default)</Box>
+          <div style={containerStyle}>
+            <TruncatedText>
+              <StatusIndicator type="success">
+                The instance has been running for an extended period of time
+              </StatusIndicator>
+            </TruncatedText>
+          </div>
+        </Box>
+
+        <Box>
+          <Box variant="awsui-key-label">With CopyToClipboard (variant=inline)</Box>
+          <div style={containerStyle}>
+            <TruncatedText tooltipText="arn:aws:iam::123456789012:role/my-very-long-role-name">
+              <CopyToClipboard
+                variant="inline"
+                textToCopy="arn:aws:iam::123456789012:role/my-very-long-role-name"
+                copyButtonAriaLabel="Copy ARN"
+                copySuccessText="ARN copied"
+                copyErrorText="Failed to copy ARN"
+              />
+            </TruncatedText>
+          </div>
+        </Box>
+
+        <Box>
+          <Box variant="awsui-key-label">With CopyToClipboard, internal truncation</Box>
+          <div style={containerStyle}>
+            <CopyToClipboard
+              variant="inline"
+              textToCopy="arn:aws:iam::123456789012:role/my-very-long-role-name"
+              textToDisplay={<TruncatedText>arn:aws:iam::123456789012:role/my-very-long-role-name</TruncatedText>}
+              copyButtonAriaLabel="Copy ARN"
+              copySuccessText="ARN copied"
+              copyErrorText="Failed to copy ARN"
+            />
+          </div>
+        </Box>
+      </SpaceBetween>
+    </ScreenshotArea>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -5885,6 +5885,13 @@ This property only applies when an \`href\` is provided.",
       "type": "string",
     },
     {
+      "description": "The text displayed in a tooltip on hover or focus.
+If \`disabledReason\` is also provided, it takes precedence over \`tooltipText\` when disabled.",
+      "name": "tooltipText",
+      "optional": true,
+      "type": "string",
+    },
+    {
       "defaultValue": "'normal'",
       "description": "Determines the general styling of the button as follows:
 * \`primary\` for primary buttons.
@@ -14817,6 +14824,14 @@ The icon will be vertically centered based on the height.",
       "optional": true,
       "type": "string",
       "visualRefreshTag": "\`medium\` size",
+    },
+    {
+      "description": "Displays a visible label on hover or focus. Only use this property
+if the icon is semantically meaningful or isn't followed by alternative
+text.",
+      "name": "tooltipText",
+      "optional": true,
+      "type": "string",
     },
     {
       "description": "Specifies the URL of a custom icon. Use this property if the icon you want isn't available, and your custom icon cannot be an SVG.
@@ -31676,9 +31691,6 @@ Can return null if the element is not yet mounted or available.",
     },
   ],
   "releaseStatus": "stable",
-  "systemTags": [
-    "core",
-  ],
 }
 `;
 
@@ -32104,6 +32116,51 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
     },
   ],
   "regions": [],
+  "releaseStatus": "stable",
+}
+`;
+
+exports[`Components definition for truncated-text matches the snapshot: truncated-text 1`] = `
+{
+  "dashCaseName": "truncated-text",
+  "events": [],
+  "functions": [],
+  "name": "TruncatedText",
+  "properties": [
+    {
+      "deprecatedTag": "Custom CSS is not supported. For testing and other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
+      "description": "Adds the specified classes to the root element of the component.",
+      "name": "className",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
+use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes). If you must
+use the \`id\` attribute, consider setting it on a parent element instead.",
+      "description": "Adds the specified ID to the root element of the component.",
+      "name": "id",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "description": "The content of the tooltip shown when the text is truncated. By default, the
+tooltip content is the same as the \`children\` slot. Use only if the \`children\`
+slot may contain interactive elements.",
+      "name": "tooltipText",
+      "optional": true,
+      "type": "string",
+    },
+  ],
+  "regions": [
+    {
+      "description": "The inline text to display. If there isn't enough space to render the text
+in a single line, it is truncated with an ellipsis and the full content is
+shown on pointer hover or keyboard focus.",
+      "isDefault": true,
+      "name": "children",
+    },
+  ],
   "releaseStatus": "stable",
 }
 `;
@@ -33012,6 +33069,19 @@ The dismiss button is only rendered when the \`dismissible\` property is set to 
         },
         {
           "name": "findTextRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findTooltip",
           "parameters": [],
           "returnType": {
             "isNullable": true,
@@ -36176,6 +36246,22 @@ To find a specific item use the \`findBreadcrumbLink(n)\` function as chaining \
             "name": "ButtonWrapper.findTextRegion",
           },
           "name": "findTextRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.findTooltip",
+          },
+          "name": "findTooltip",
           "parameters": [],
           "returnType": {
             "isNullable": true,
@@ -44622,6 +44708,19 @@ Supported options:
     {
       "methods": [
         {
+          "name": "findTooltip",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "TooltipWrapper",
+          },
+        },
+      ],
+      "name": "TruncatedTextWrapper",
+    },
+    {
+      "methods": [
+        {
           "name": "findCompletionScreenDescription",
           "parameters": [],
           "returnType": {
@@ -45127,6 +45226,14 @@ The dismiss button is only rendered when the \`dismissible\` property is set to 
         },
         {
           "name": "findTextRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findTooltip",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -47398,6 +47505,17 @@ To find a specific item use the \`findBreadcrumbLink(n)\` function as chaining \
             "name": "ButtonWrapper.findTextRegion",
           },
           "name": "findTextRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "ButtonWrapper.findTooltip",
+          },
+          "name": "findTooltip",
           "parameters": [],
           "returnType": {
             "isNullable": false,
@@ -53351,6 +53469,19 @@ Supported options:
         },
       ],
       "name": "TreeViewItemWrapper",
+    },
+    {
+      "methods": [
+        {
+          "name": "findTooltip",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "TooltipWrapper",
+          },
+        },
+      ],
+      "name": "TruncatedTextWrapper",
     },
     {
       "methods": [

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_content_vjswe",
     "awsui_disabled-reason-tooltip_1ueyk",
     "awsui_icon-left_vjswe",
+    "awsui_tooltip_1ueyk",
   ],
   "button-dropdown": [
     "awsui_button-dropdown_sne0l",
@@ -733,6 +734,9 @@ exports[`test-utils selectors 1`] = `
     "awsui_expanded_1js4f",
     "awsui_root_1js4f",
     "awsui_treeitem_1js4f",
+  ],
+  "truncated-text": [
+    "awsui_root_lwmqr",
   ],
   "tutorial-panel": [
     "awsui_collapse-button_ig8mp",

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-wrappers.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-wrappers.test.tsx.snap
@@ -99,6 +99,7 @@ import TokenGroupWrapper from './token-group';
 import TooltipWrapper from './tooltip';
 import TopNavigationWrapper from './top-navigation';
 import TreeViewWrapper from './tree-view';
+import TruncatedTextWrapper from './truncated-text';
 import TutorialPanelWrapper from './tutorial-panel';
 import WizardWrapper from './wizard';
 
@@ -193,6 +194,7 @@ export { TokenGroupWrapper };
 export { TooltipWrapper };
 export { TopNavigationWrapper };
 export { TreeViewWrapper };
+export { TruncatedTextWrapper };
 export { TutorialPanelWrapper };
 export { WizardWrapper };
 
@@ -2720,6 +2722,34 @@ findAllTreeViews(selector?: string): Array<TreeViewWrapper>;
  */
 findClosestTreeView(): TreeViewWrapper | null;
 /**
+ * Returns the wrapper of the first TruncatedText that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first TruncatedText.
+ * If no matching TruncatedText is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TruncatedTextWrapper | null}
+ */
+findTruncatedText(selector?: string): TruncatedTextWrapper | null;
+
+/**
+ * Returns an array of TruncatedText wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the TruncatedTexts inside the current wrapper.
+ * If no matching TruncatedText is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<TruncatedTextWrapper>}
+ */
+findAllTruncatedTexts(selector?: string): Array<TruncatedTextWrapper>;
+
+/**
+ * Returns the wrapper of the closest parent TruncatedText for the current element,
+ * or the element itself if it is an instance of TruncatedText.
+ * If no TruncatedText is found, returns \`null\`.
+ *
+ * @returns {TruncatedTextWrapper | null}
+ */
+findClosestTruncatedText(): TruncatedTextWrapper | null;
+/**
  * Returns the wrapper of the first TutorialPanel that matches the specified CSS selector.
  * If no CSS selector is specified, returns the wrapper of the first TutorialPanel.
  * If no matching TutorialPanel is found, returns \`null\`.
@@ -3949,6 +3979,19 @@ ElementWrapper.prototype.findTreeView = function(selector) {
 ElementWrapper.prototype.findAllTreeViews = function(selector) {
   return this.findAllComponents(TreeViewWrapper, selector);
 };
+ElementWrapper.prototype.findTruncatedText = function(selector) {
+  let rootSelector = \`.\${TruncatedTextWrapper.rootSelector}\`;
+  if("legacyRootSelector" in TruncatedTextWrapper && TruncatedTextWrapper.legacyRootSelector){
+    rootSelector = \`:is(.\${TruncatedTextWrapper.rootSelector}, .\${TruncatedTextWrapper.legacyRootSelector})\`;
+  }
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TruncatedTextWrapper);
+};
+
+ElementWrapper.prototype.findAllTruncatedTexts = function(selector) {
+  return this.findAllComponents(TruncatedTextWrapper, selector);
+};
 ElementWrapper.prototype.findTutorialPanel = function(selector) {
   let rootSelector = \`.\${TutorialPanelWrapper.rootSelector}\`;
   if("legacyRootSelector" in TutorialPanelWrapper && TutorialPanelWrapper.legacyRootSelector){
@@ -4426,6 +4469,11 @@ ElementWrapper.prototype.findClosestTreeView = function() {
   // https://github.com/microsoft/TypeScript/issues/29132
   return (this as any).findClosestComponent(TreeViewWrapper);
 };
+ElementWrapper.prototype.findClosestTruncatedText = function() {
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findClosestComponent(TruncatedTextWrapper);
+};
 ElementWrapper.prototype.findClosestTutorialPanel = function() {
   // casting to 'any' is needed to avoid this issue with generics
   // https://github.com/microsoft/TypeScript/issues/29132
@@ -4545,6 +4593,7 @@ import TokenGroupWrapper from './token-group';
 import TooltipWrapper from './tooltip';
 import TopNavigationWrapper from './top-navigation';
 import TreeViewWrapper from './tree-view';
+import TruncatedTextWrapper from './truncated-text';
 import TutorialPanelWrapper from './tutorial-panel';
 import WizardWrapper from './wizard';
 
@@ -4639,6 +4688,7 @@ export { TokenGroupWrapper };
 export { TooltipWrapper };
 export { TopNavigationWrapper };
 export { TreeViewWrapper };
+export { TruncatedTextWrapper };
 export { TutorialPanelWrapper };
 export { WizardWrapper };
 
@@ -6176,6 +6226,23 @@ findTreeView(selector?: string): TreeViewWrapper;
  */
 findAllTreeViews(selector?: string): MultiElementWrapper<TreeViewWrapper>;
 /**
+ * Returns a wrapper that matches the TruncatedTexts with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches TruncatedTexts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {TruncatedTextWrapper}
+ */
+findTruncatedText(selector?: string): TruncatedTextWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches TruncatedTexts with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches TruncatedTexts.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<TruncatedTextWrapper>}
+ */
+findAllTruncatedTexts(selector?: string): MultiElementWrapper<TruncatedTextWrapper>;
+/**
  * Returns a wrapper that matches the TutorialPanels with the specified CSS selector.
  * If no CSS selector is specified, returns a wrapper that matches TutorialPanels.
  *
@@ -7382,6 +7449,19 @@ ElementWrapper.prototype.findTreeView = function(selector) {
 
 ElementWrapper.prototype.findAllTreeViews = function(selector) {
   return this.findAllComponents(TreeViewWrapper, selector);
+};
+ElementWrapper.prototype.findTruncatedText = function(selector) {
+  let rootSelector = \`.\${TruncatedTextWrapper.rootSelector}\`;
+  if("legacyRootSelector" in TruncatedTextWrapper && TruncatedTextWrapper.legacyRootSelector){
+    rootSelector = \`:is(.\${TruncatedTextWrapper.rootSelector}, .\${TruncatedTextWrapper.legacyRootSelector})\`;
+  }
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, TruncatedTextWrapper);
+};
+
+ElementWrapper.prototype.findAllTruncatedTexts = function(selector) {
+  return this.findAllComponents(TruncatedTextWrapper, selector);
 };
 ElementWrapper.prototype.findTutorialPanel = function(selector) {
   let rootSelector = \`.\${TutorialPanelWrapper.rootSelector}\`;

--- a/src/button/__tests__/button-tooltip-text.test.tsx
+++ b/src/button/__tests__/button-tooltip-text.test.tsx
@@ -1,0 +1,123 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+
+import Button, { ButtonProps } from '../../../lib/components/button';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+function renderButton(props: Partial<ButtonProps> = {}) {
+  const { container } = render(<Button {...props}>Click me</Button>);
+  return createWrapper(container).findButton()!;
+}
+
+describe('Button tooltipText', () => {
+  test('does not show a tooltip by default', () => {
+    const wrapper = renderButton({ tooltipText: 'Helpful text' });
+    expect(wrapper.findTooltip()).toBeNull();
+  });
+
+  test('shows a tooltip on focus', () => {
+    const wrapper = renderButton({ tooltipText: 'Helpful text' });
+
+    wrapper.getElement().focus();
+
+    const tooltip = wrapper.findTooltip();
+    expect(tooltip).not.toBeNull();
+    expect(tooltip!.getElement()).toHaveTextContent('Helpful text');
+  });
+
+  test('hides the tooltip on blur', () => {
+    const wrapper = renderButton({ tooltipText: 'Helpful text' });
+
+    wrapper.getElement().focus();
+    expect(wrapper.findTooltip()).not.toBeNull();
+
+    wrapper.getElement().blur();
+    expect(wrapper.findTooltip()).toBeNull();
+  });
+
+  test('shows the tooltip on mouse enter and hides on mouse leave', () => {
+    const wrapper = renderButton({ tooltipText: 'Helpful text' });
+
+    fireEvent.mouseEnter(wrapper.getElement());
+    expect(wrapper.findTooltip()).not.toBeNull();
+
+    fireEvent.mouseLeave(wrapper.getElement());
+    expect(wrapper.findTooltip()).toBeNull();
+  });
+
+  test('hides the tooltip on Escape key press', () => {
+    const wrapper = renderButton({ tooltipText: 'Helpful text' });
+
+    wrapper.getElement().focus();
+    expect(wrapper.findTooltip()).not.toBeNull();
+
+    act(() => {
+      document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+
+    expect(wrapper.findTooltip()).toBeNull();
+  });
+
+  test('does not render a tooltip when tooltipText is not provided', () => {
+    const wrapper = renderButton();
+
+    wrapper.getElement().focus();
+    fireEvent.mouseEnter(wrapper.getElement());
+
+    expect(wrapper.findTooltip()).toBeNull();
+  });
+
+  describe('precedence over disabledReason', () => {
+    test('shows disabledReason instead of tooltipText when disabled with reason', () => {
+      const wrapper = renderButton({
+        disabled: true,
+        disabledReason: 'Disabled because of reason',
+        tooltipText: 'Helpful text',
+      });
+
+      wrapper.getElement().focus();
+
+      // disabledReason wins: the disabled-reason tooltip is shown, the tooltipText tooltip is not.
+      expect(wrapper.findDisabledReason()).not.toBeNull();
+      expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('Disabled because of reason');
+      expect(wrapper.findTooltip()).toBeNull();
+    });
+  });
+
+  describe('inactive states', () => {
+    test('does not show tooltip when button is in loading state', () => {
+      const wrapper = renderButton({ loading: true, tooltipText: 'Helpful text' });
+
+      wrapper.getElement().focus();
+      fireEvent.mouseEnter(wrapper.getElement());
+
+      expect(wrapper.findTooltip()).toBeNull();
+    });
+
+    test('does not show tooltip when button is disabled without reason', () => {
+      const wrapper = renderButton({ disabled: true, tooltipText: 'Helpful text' });
+
+      // Disabled buttons can't be focused, but we still verify hover does nothing.
+      fireEvent.mouseEnter(wrapper.getElement());
+
+      expect(wrapper.findTooltip()).toBeNull();
+    });
+  });
+
+  describe('with href', () => {
+    test('shows a tooltip on focus for a link button', () => {
+      const { container } = render(
+        <Button href="#test" tooltipText="Open settings">
+          Settings
+        </Button>
+      );
+      const wrapper = createWrapper(container).findButton()!;
+
+      wrapper.getElement().focus();
+      expect(wrapper.findTooltip()).not.toBeNull();
+      expect(wrapper.findTooltip()!.getElement()).toHaveTextContent('Open settings');
+    });
+  });
+});

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -39,6 +39,7 @@ const Button = React.forwardRef(
       ariaExpanded,
       ariaHaspopup,
       ariaControls,
+      tooltipText,
       fullWidth,
       form,
       i18nStrings,
@@ -83,6 +84,7 @@ const Button = React.forwardRef(
         ariaExpanded={ariaExpanded}
         ariaHaspopup={ariaHaspopup}
         ariaControls={ariaControls}
+        tooltipText={tooltipText}
         fullWidth={fullWidth}
         form={form}
         i18nStrings={i18nStrings}

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -208,6 +208,12 @@ export interface ButtonProps extends BaseComponentProps, BaseButtonProps {
   variant?: ButtonProps.Variant;
 
   /**
+   * The text displayed in a tooltip on hover or focus.
+   * If `disabledReason` is also provided, it takes precedence over `tooltipText` when disabled.
+   */
+  tooltipText?: string;
+
+  /**
    * Specifies alternate text for a custom icon. We recommend that you provide this for accessibility.
    * This property is ignored if you use a predefined icon or if you set your custom icon using the `iconSvg` slot.
    */

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -87,6 +87,7 @@ export const InternalButton = React.forwardRef(
       ariaExpanded,
       ariaHaspopup,
       ariaControls,
+      tooltipText,
       fullWidth,
       badge,
       i18nStrings,
@@ -112,6 +113,10 @@ export const InternalButton = React.forwardRef(
     const isNotInteractive = loading || disabled;
     const isDisabledWithReason =
       (variant === 'normal' || variant === 'primary' || variant === 'icon') && !!disabledReason && disabled;
+
+    // tooltipText is shown on hover/focus when the button is fully interactive. When
+    // the button is disabled-with-reason, disabledReason takes precedence.
+    const hasTooltipText = !!tooltipText && !isNotInteractive && !isDisabledWithReason;
 
     const hasAriaDisabled = (loading && !disabled) || (disabled && __focusable) || isDisabledWithReason;
     const shouldHaveContent =
@@ -293,6 +298,24 @@ export const InternalButton = React.forwardRef(
       </>
     );
 
+    const tooltipTextProps =
+      hasTooltipText && !(disabled && !!disabledReason)
+        ? {
+            onFocus: () => setShowTooltip(true),
+            onBlur: () => setShowTooltip(false),
+            onMouseEnter: () => setShowTooltip(true),
+            onMouseLeave: () => setShowTooltip(false),
+          }
+        : {};
+    const tooltipTextContent = hasTooltipText && showTooltip && (
+      <Tooltip
+        className={testUtilStyles.tooltip}
+        getTrack={() => buttonRef.current}
+        content={tooltipText!}
+        onEscape={() => setShowTooltip(false)}
+      />
+    );
+
     const stylePropertiesAndVariables = getButtonStyles(style);
 
     if (isAnchor) {
@@ -310,6 +333,7 @@ export const InternalButton = React.forwardRef(
           <WithNativeAttributes<HTMLAnchorElement, React.AnchorHTMLAttributes<HTMLAnchorElement>>
             {...buttonProps}
             {...disabledReasonProps}
+            {...tooltipTextProps}
             tag="a"
             componentName="Button"
             nativeAttributes={nativeAnchorAttributes}
@@ -326,6 +350,7 @@ export const InternalButton = React.forwardRef(
           >
             {buttonContent}
             {isDisabledWithReason && disabledReasonContent}
+            {tooltipTextContent}
           </WithNativeAttributes>
           {loading && loadingText && (
             <InternalLiveRegion tagName="span" hidden={true}>
@@ -341,6 +366,7 @@ export const InternalButton = React.forwardRef(
         <WithNativeAttributes<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>
           {...buttonProps}
           {...disabledReasonProps}
+          {...tooltipTextProps}
           tag="button"
           componentName="Button"
           nativeAttributes={nativeButtonAttributes}
@@ -352,6 +378,7 @@ export const InternalButton = React.forwardRef(
         >
           {buttonContent}
           {isDisabledWithReason && disabledReasonContent}
+          {tooltipTextContent}
         </WithNativeAttributes>
         {loading && loadingText && (
           <InternalLiveRegion tagName="span" hidden={true}>

--- a/src/button/test-classes/styles.scss
+++ b/src/button/test-classes/styles.scss
@@ -7,6 +7,10 @@
   /* used in test-utils or tests */
 }
 
+.tooltip {
+  /* used in test-utils or tests */
+}
+
 .external-icon {
   /* used in test-utils or tests */
 }

--- a/src/icon/__tests__/icon-tooltip-text.test.tsx
+++ b/src/icon/__tests__/icon-tooltip-text.test.tsx
@@ -1,0 +1,137 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+
+import Icon from '../../../lib/components/icon';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+function renderIcon(jsx: React.ReactElement) {
+  const { container } = render(jsx);
+  const wrapper = createWrapper(container).findIcon()!;
+  return { container, wrapper, element: wrapper.getElement() };
+}
+
+describe('Icon tooltipText', () => {
+  test('does not show a tooltip by default', () => {
+    const { wrapper } = renderIcon(<Icon name="settings" tooltipText="Settings" />);
+    expect(createWrapper().findTooltip()).toBeNull();
+    expect(wrapper).not.toBeNull();
+  });
+
+  test('does not make the icon focusable when tooltipText is not provided', () => {
+    const { element } = renderIcon(<Icon name="settings" />);
+    expect(element).not.toHaveAttribute('tabIndex');
+  });
+
+  test('makes the icon focusable (tabIndex=0) when tooltipText is provided', () => {
+    const { element } = renderIcon(<Icon name="settings" tooltipText="Settings" />);
+    expect(element).toHaveAttribute('tabIndex', '0');
+  });
+
+  test('sets role="img" and aria-label from tooltipText when ariaLabel is not provided', () => {
+    const { element } = renderIcon(<Icon name="settings" tooltipText="Settings" />);
+    expect(element).toHaveAttribute('role', 'img');
+    expect(element).toHaveAttribute('aria-label', 'Settings');
+  });
+
+  test('explicit ariaLabel takes precedence over tooltipText for aria-label', () => {
+    const { element } = renderIcon(<Icon name="settings" ariaLabel="Open settings" tooltipText="Visible tooltip" />);
+    expect(element).toHaveAttribute('aria-label', 'Open settings');
+  });
+
+  test('shows the tooltip on pointer enter and hides on pointer leave', () => {
+    const { element } = renderIcon(<Icon name="settings" tooltipText="Settings" />);
+
+    fireEvent.pointerEnter(element);
+    let tooltip = createWrapper().findTooltip();
+    expect(tooltip).not.toBeNull();
+    expect(tooltip!.getElement()).toHaveTextContent('Settings');
+
+    fireEvent.pointerLeave(element);
+    tooltip = createWrapper().findTooltip();
+    expect(tooltip).toBeNull();
+  });
+
+  test('shows the tooltip on focus and hides on blur', () => {
+    const { element } = renderIcon(<Icon name="settings" tooltipText="Settings" />);
+
+    fireEvent.focus(element);
+    expect(createWrapper().findTooltip()).not.toBeNull();
+
+    fireEvent.blur(element);
+    expect(createWrapper().findTooltip()).toBeNull();
+  });
+
+  test('hides the tooltip on Escape key press', () => {
+    const { element } = renderIcon(<Icon name="settings" tooltipText="Settings" />);
+
+    fireEvent.pointerEnter(element);
+    expect(createWrapper().findTooltip()).not.toBeNull();
+
+    act(() => {
+      document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+
+    expect(createWrapper().findTooltip()).toBeNull();
+  });
+
+  describe('with svg icon', () => {
+    const svg = (
+      <svg className="test-svg" focusable="false">
+        <circle cx="8" cy="8" r="7" />
+      </svg>
+    );
+
+    test('shows the tooltip on hover and applies aria-label', () => {
+      const { element } = renderIcon(<Icon svg={svg} tooltipText="Custom" />);
+
+      expect(element).toHaveAttribute('aria-label', 'Custom');
+      expect(element).toHaveAttribute('tabIndex', '0');
+
+      fireEvent.pointerEnter(element);
+      const tooltip = createWrapper().findTooltip();
+      expect(tooltip).not.toBeNull();
+      expect(tooltip!.getElement()).toHaveTextContent('Custom');
+    });
+
+    test('still sets aria-hidden=false when tooltipText provides the accessible name', () => {
+      const { element } = renderIcon(<Icon svg={svg} tooltipText="Custom" />);
+      // hasAriaLabel becomes true via tooltipText fallback, so aria-hidden should be false.
+      expect(element).toHaveAttribute('aria-hidden', 'false');
+    });
+  });
+
+  describe('with url icon', () => {
+    const url = 'data:image/png;base64,aaaa';
+
+    test('shows the tooltip on hover and uses tooltipText as the img alt fallback', () => {
+      const { container, element } = renderIcon(<Icon url={url} tooltipText="Custom" />);
+
+      // The wrapper span gets the events / tabIndex but does NOT get aria-label
+      // (the inner <img alt="..."> already provides the accessible name).
+      expect(element).toHaveAttribute('tabIndex', '0');
+      expect(element).not.toHaveAttribute('aria-label');
+
+      const img = container.querySelector('img');
+      expect(img).toHaveAttribute('alt', 'Custom');
+
+      fireEvent.pointerEnter(element);
+      const tooltip = createWrapper().findTooltip();
+      expect(tooltip).not.toBeNull();
+      expect(tooltip!.getElement()).toHaveTextContent('Custom');
+    });
+
+    test('explicit ariaLabel takes precedence over tooltipText for img alt', () => {
+      const { container } = renderIcon(<Icon url={url} ariaLabel="Explicit" tooltipText="Visible" />);
+      const img = container.querySelector('img');
+      expect(img).toHaveAttribute('alt', 'Explicit');
+    });
+
+    test('alt prop is used only when both ariaLabel and tooltipText are absent', () => {
+      const { container } = renderIcon(<Icon url={url} alt="Just alt" />);
+      const img = container.querySelector('img');
+      expect(img).toHaveAttribute('alt', 'Just alt');
+    });
+  });
+});

--- a/src/icon/interfaces.ts
+++ b/src/icon/interfaces.ts
@@ -53,6 +53,13 @@ export interface IconProps extends BaseComponentProps {
   ariaLabel?: string;
 
   /**
+   * Displays a visible label on hover or focus. Only use this property
+   * if the icon is semantically meaningful or isn't followed by alternative
+   * text.
+   */
+  tooltipText?: string;
+
+  /**
    * Specifies the SVG of a custom icon.
    *
    * Use this property if the icon you want isn't available, and you want your custom icon to inherit colors dictated by variant or hover states.

--- a/src/icon/internal.tsx
+++ b/src/icon/internal.tsx
@@ -10,6 +10,7 @@ import { getBaseProps } from '../internal/base-component';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import WithNativeAttributes from '../internal/utils/with-native-attributes';
+import Tooltip from '../tooltip/internal';
 import { IconProps } from './interfaces';
 
 import styles from './styles.css.js';
@@ -47,6 +48,7 @@ const InternalIcon = ({
   url,
   alt,
   ariaLabel,
+  tooltipText,
   svg,
   badge,
   nativeAttributes,
@@ -59,6 +61,7 @@ const InternalIcon = ({
   useVisualRefresh();
   const [parentHeight, setParentHeight] = useState<number | null>(null);
   const [parentFontSize, setParentFontSize] = useState<number | null>(null);
+  const [showTooltip, setShowTooltip] = useState(false);
   const contextualSize = size === 'inherit';
   const iconSize = contextualSize ? iconSizeMap(parentHeight, parentFontSize) : size;
   const inlineStyles = contextualSize && parentHeight !== null ? { height: `${parentHeight}px` } : {};
@@ -91,8 +94,26 @@ const InternalIcon = ({
   });
 
   const mergedRef = useMergeRefs(iconRef, __internalRootRef);
-  const hasAriaLabel = typeof ariaLabel === 'string';
-  const labelAttributes = hasAriaLabel ? { role: 'img', 'aria-label': ariaLabel } : {};
+  // When tooltipText is provided, it serves as the accessible name unless an explicit
+  // ariaLabel is provided. The tooltip itself is purely visual; the aria-label keeps the
+  // information available to assistive technology.
+  const effectiveAriaLabel = ariaLabel ?? tooltipText;
+  const hasAriaLabel = typeof effectiveAriaLabel === 'string';
+  const hasTooltipText = typeof tooltipText === 'string';
+  const labelAttributes = hasAriaLabel ? { role: 'img', 'aria-label': effectiveAriaLabel } : {};
+  // When tooltipText is set, the icon becomes a focusable target.
+  const tooltipTextAttributes = hasTooltipText
+    ? {
+        tabIndex: 0,
+        onPointerEnter: () => setShowTooltip(true),
+        onPointerLeave: () => setShowTooltip(false),
+        onFocus: () => setShowTooltip(true),
+        onBlur: () => setShowTooltip(false),
+      }
+    : {};
+  const tooltipElement = hasTooltipText && showTooltip && (
+    <Tooltip content={tooltipText!} getTrack={() => iconRef.current} onEscape={() => setShowTooltip(false)} />
+  );
 
   if (svg) {
     if (url) {
@@ -102,33 +123,41 @@ const InternalIcon = ({
       );
     }
     return (
-      <WithNativeAttributes
-        {...baseProps}
-        {...labelAttributes}
-        tag="span"
-        componentName="Icon"
-        nativeAttributes={nativeAttributes}
-        ref={mergedRef}
-        aria-hidden={!hasAriaLabel}
-        style={inlineStyles}
-      >
-        {svg}
-      </WithNativeAttributes>
+      <>
+        <WithNativeAttributes
+          {...baseProps}
+          {...labelAttributes}
+          {...tooltipTextAttributes}
+          tag="span"
+          componentName="Icon"
+          nativeAttributes={nativeAttributes}
+          ref={mergedRef}
+          aria-hidden={!hasAriaLabel}
+          style={inlineStyles}
+        >
+          {svg}
+        </WithNativeAttributes>
+        {tooltipElement}
+      </>
     );
   }
 
   if (url) {
     return (
-      <WithNativeAttributes
-        {...baseProps}
-        tag="span"
-        componentName="Icon"
-        nativeAttributes={nativeAttributes}
-        ref={mergedRef}
-        style={inlineStyles}
-      >
-        <img src={url} alt={ariaLabel ?? alt} />
-      </WithNativeAttributes>
+      <>
+        <WithNativeAttributes
+          {...baseProps}
+          {...tooltipTextAttributes}
+          tag="span"
+          componentName="Icon"
+          nativeAttributes={nativeAttributes}
+          ref={mergedRef}
+          style={inlineStyles}
+        >
+          <img src={url} alt={ariaLabel ?? tooltipText ?? alt} />
+        </WithNativeAttributes>
+        {tooltipElement}
+      </>
     );
   }
 
@@ -165,17 +194,21 @@ const InternalIcon = ({
   }
 
   return (
-    <WithNativeAttributes
-      {...baseProps}
-      {...labelAttributes}
-      tag="span"
-      componentName="Icon"
-      nativeAttributes={nativeAttributes}
-      ref={mergedRef}
-      style={inlineStyles}
-    >
-      {validIcon ? iconMap(name) : undefined}
-    </WithNativeAttributes>
+    <>
+      <WithNativeAttributes
+        {...baseProps}
+        {...labelAttributes}
+        {...tooltipTextAttributes}
+        tag="span"
+        componentName="Icon"
+        nativeAttributes={nativeAttributes}
+        ref={mergedRef}
+        style={inlineStyles}
+      >
+        {validIcon ? iconMap(name) : undefined}
+      </WithNativeAttributes>
+      {tooltipElement}
+    </>
   );
 };
 

--- a/src/icon/styles.scss
+++ b/src/icon/styles.scss
@@ -5,6 +5,7 @@
 
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/styles' as styles;
+@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use './mixins' as mixins;
 
 .icon {
@@ -14,6 +15,16 @@
   &-flex-height {
     display: inline-flex;
     align-items: center;
+  }
+
+  // The icon root only becomes focusable when `tooltipText` is provided. Apply focus-visible
+  // styling so keyboard users see a clear indicator when the icon receives focus.
+  &:focus {
+    outline: none;
+  }
+
+  @include focus-visible.when-visible {
+    @include styles.focus-highlight(awsui.$space-button-inline-icon-focus-outline-gutter);
   }
 
   /* stylelint-disable-next-line selector-max-type */

--- a/src/test-utils/dom/button/index.ts
+++ b/src/test-utils/dom/button/index.ts
@@ -25,4 +25,8 @@ export default class ButtonWrapper extends ComponentWrapper<HTMLButtonElement> {
   findDisabledReason(): ElementWrapper | null {
     return createWrapper().find(`.${buttonTestUtilsStyles['disabled-reason-tooltip']}`);
   }
+
+  findTooltip(): ElementWrapper | null {
+    return createWrapper().findByClassName(buttonTestUtilsStyles.tooltip);
+  }
 }

--- a/src/test-utils/dom/truncated-text/index.ts
+++ b/src/test-utils/dom/truncated-text/index.ts
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ComponentWrapper, createWrapper } from '@cloudscape-design/test-utils-core/dom';
+
+import TooltipWrapper from '../tooltip';
+
+import tooltipTestUtilsStyles from '../../../tooltip/test-classes/styles.selectors.js';
+import styles from '../../../truncated-text/test-classes/styles.selectors.js';
+
+export default class TruncatedTextWrapper extends ComponentWrapper<HTMLElement> {
+  static rootSelector: string = styles.root;
+
+  findTooltip(): TooltipWrapper | null {
+    const tooltipElement = createWrapper().findByClassName(tooltipTestUtilsStyles.root);
+    return tooltipElement && new TooltipWrapper(tooltipElement.getElement());
+  }
+}

--- a/src/tooltip/index.tsx
+++ b/src/tooltip/index.tsx
@@ -11,9 +11,6 @@ import InternalTooltip from './internal';
 
 export { TooltipProps };
 
-/**
- * @awsuiSystem core
- */
 export default function Tooltip({ position = 'top', ...rest }: TooltipProps) {
   const baseComponentProps = useBaseComponent('Tooltip', {
     props: { position },

--- a/src/truncated-text/__tests__/truncated-text.test.tsx
+++ b/src/truncated-text/__tests__/truncated-text.test.tsx
@@ -1,0 +1,253 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+
+import '../../__a11y__/to-validate-a11y';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import TruncatedText from '../../../lib/components/truncated-text';
+
+import styles from '../../../lib/components/truncated-text/test-classes/styles.css.js';
+
+// Mock ResizeObserver. Multiple components in a single render (e.g. TruncatedText + the
+// Tooltip it renders) can each create their own observer, so we associate the callback
+// with the observed element rather than overwriting a single global slot.
+const observerCallbacks = new Map<Element, ResizeObserverCallback>();
+const mockResizeObserver = jest.fn().mockImplementation((callback: ResizeObserverCallback) => {
+  let observed: Element | null = null;
+  return {
+    observe: jest.fn((target: Element) => {
+      observed = target;
+      observerCallbacks.set(target, callback);
+    }),
+    unobserve: jest.fn((target: Element) => {
+      if (observerCallbacks.get(target) === callback) {
+        observerCallbacks.delete(target);
+      }
+    }),
+    disconnect: jest.fn(() => {
+      if (observed && observerCallbacks.get(observed) === callback) {
+        observerCallbacks.delete(observed);
+      }
+    }),
+  };
+});
+
+(global as any).ResizeObserver = mockResizeObserver;
+
+beforeEach(() => {
+  mockResizeObserver.mockClear();
+  observerCallbacks.clear();
+});
+
+function setOverflow(element: HTMLElement, isOverflowing: boolean) {
+  Object.defineProperty(element, 'scrollWidth', {
+    configurable: true,
+    value: isOverflowing ? 300 : 100,
+  });
+  Object.defineProperty(element, 'clientWidth', {
+    configurable: true,
+    value: 200,
+  });
+}
+
+function triggerResize(element: HTMLElement) {
+  const callback = observerCallbacks.get(element);
+  if (!callback) {
+    throw new Error('No ResizeObserver callback registered for the given element.');
+  }
+  act(() => {
+    callback(
+      [
+        {
+          target: element,
+          contentRect: { width: 200, height: 20 } as DOMRectReadOnly,
+          borderBoxSize: [{ inlineSize: 200, blockSize: 20 }],
+          contentBoxSize: [{ inlineSize: 200, blockSize: 20 }],
+          devicePixelContentBoxSize: [{ inlineSize: 200, blockSize: 20 }],
+        } as unknown as ResizeObserverEntry,
+      ],
+      {} as ResizeObserver
+    );
+  });
+}
+
+function renderTruncatedText(jsx: React.ReactElement) {
+  const { container } = render(jsx);
+  const wrapper = createWrapper(container).findTruncatedText()!;
+  return { container, wrapper, element: wrapper.getElement() };
+}
+
+describe('TruncatedText', () => {
+  test('renders the children content', () => {
+    const { element } = renderTruncatedText(<TruncatedText>Some text</TruncatedText>);
+    expect(element).toHaveTextContent('Some text');
+  });
+
+  test('applies the test-utils root class', () => {
+    const { element } = renderTruncatedText(<TruncatedText>Some text</TruncatedText>);
+    expect(element).toHaveClass(styles.root);
+  });
+
+  test('forwards baseComponentProps (className, id, data-*)', () => {
+    const { element } = renderTruncatedText(
+      <TruncatedText className="custom-class" id="my-id" data-testid="my-test-id">
+        Hello
+      </TruncatedText>
+    );
+    expect(element).toHaveClass('custom-class');
+    expect(element).toHaveAttribute('id', 'my-id');
+    expect(element).toHaveAttribute('data-testid', 'my-test-id');
+  });
+
+  test('does not show a tooltip when text is not truncated', () => {
+    const { element, wrapper } = renderTruncatedText(<TruncatedText>Short</TruncatedText>);
+    setOverflow(element, false);
+    triggerResize(element);
+    fireEvent.pointerEnter(element);
+    expect(wrapper.findTooltip()).toBeNull();
+  });
+
+  test('does not make the element focusable when not truncated', () => {
+    const { element } = renderTruncatedText(<TruncatedText>Short</TruncatedText>);
+    setOverflow(element, false);
+    triggerResize(element);
+    expect(element).not.toHaveAttribute('tabIndex');
+  });
+
+  test('shows a tooltip on pointer enter when text is truncated', () => {
+    const { element, wrapper } = renderTruncatedText(<TruncatedText>Very long text content</TruncatedText>);
+    setOverflow(element, true);
+    triggerResize(element);
+
+    fireEvent.pointerEnter(element);
+
+    const tooltip = wrapper.findTooltip();
+    expect(tooltip).not.toBeNull();
+    expect(tooltip!.getElement()).toHaveTextContent('Very long text content');
+  });
+
+  test('hides the tooltip on pointer leave', () => {
+    const { element, wrapper } = renderTruncatedText(<TruncatedText>Very long text content</TruncatedText>);
+    setOverflow(element, true);
+    triggerResize(element);
+
+    fireEvent.pointerEnter(element);
+    expect(wrapper.findTooltip()).not.toBeNull();
+
+    fireEvent.pointerLeave(element);
+    expect(wrapper.findTooltip()).toBeNull();
+  });
+
+  test('shows the tooltip on focus when text is truncated', () => {
+    const { element, wrapper } = renderTruncatedText(<TruncatedText>Very long text content</TruncatedText>);
+    setOverflow(element, true);
+    triggerResize(element);
+
+    fireEvent.focus(element);
+    expect(wrapper.findTooltip()).not.toBeNull();
+  });
+
+  test('hides the tooltip on blur', () => {
+    const { element, wrapper } = renderTruncatedText(<TruncatedText>Very long text content</TruncatedText>);
+    setOverflow(element, true);
+    triggerResize(element);
+
+    fireEvent.focus(element);
+    expect(wrapper.findTooltip()).not.toBeNull();
+
+    fireEvent.blur(element);
+    expect(wrapper.findTooltip()).toBeNull();
+  });
+
+  test('hides the tooltip on Escape key press', () => {
+    const { element, wrapper } = renderTruncatedText(<TruncatedText>Very long text content</TruncatedText>);
+    setOverflow(element, true);
+    triggerResize(element);
+
+    fireEvent.pointerEnter(element);
+    expect(wrapper.findTooltip()).not.toBeNull();
+
+    act(() => {
+      document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+
+    expect(wrapper.findTooltip()).toBeNull();
+  });
+
+  test('makes the element focusable (tabIndex=0) only when text is truncated', () => {
+    const { element } = renderTruncatedText(<TruncatedText>Very long text content</TruncatedText>);
+    setOverflow(element, true);
+    triggerResize(element);
+    expect(element).toHaveAttribute('tabIndex', '0');
+  });
+
+  test('uses tooltipText for the tooltip content when provided', () => {
+    const { element, wrapper } = renderTruncatedText(
+      <TruncatedText tooltipText="Custom tooltip text">
+        <a href="#">Link content</a>
+      </TruncatedText>
+    );
+    setOverflow(element, true);
+    triggerResize(element);
+
+    fireEvent.pointerEnter(element);
+
+    const tooltip = wrapper.findTooltip();
+    expect(tooltip).not.toBeNull();
+    expect(tooltip!.getElement()).toHaveTextContent('Custom tooltip text');
+    expect(tooltip!.getElement()).not.toHaveTextContent('Link content');
+  });
+
+  test('falls back to children when tooltipText is not provided', () => {
+    const { element, wrapper } = renderTruncatedText(<TruncatedText>Default text</TruncatedText>);
+    setOverflow(element, true);
+    triggerResize(element);
+
+    fireEvent.pointerEnter(element);
+    expect(wrapper.findTooltip()!.getElement()).toHaveTextContent('Default text');
+  });
+
+  test('renders non-string React children', () => {
+    const { element } = renderTruncatedText(
+      <TruncatedText tooltipText="ResourceName-12345">
+        <a href="#">ResourceName-12345</a>
+      </TruncatedText>
+    );
+    expect(element.querySelector('a')).not.toBeNull();
+    expect(element.querySelector('a')).toHaveTextContent('ResourceName-12345');
+  });
+
+  test('updates truncation status when the resize callback indicates content fits', () => {
+    const { element, wrapper } = renderTruncatedText(<TruncatedText>Some text</TruncatedText>);
+
+    // Start truncated
+    setOverflow(element, true);
+    triggerResize(element);
+    fireEvent.pointerEnter(element);
+    expect(wrapper.findTooltip()).not.toBeNull();
+    fireEvent.pointerLeave(element);
+    expect(wrapper.findTooltip()).toBeNull();
+
+    // Then no longer truncated
+    setOverflow(element, false);
+    triggerResize(element);
+    expect(element).not.toHaveAttribute('tabIndex');
+    fireEvent.pointerEnter(element);
+    expect(wrapper.findTooltip()).toBeNull();
+  });
+
+  test('passes accessibility validation (non-truncated)', async () => {
+    const { container, element } = renderTruncatedText(<TruncatedText>Short text</TruncatedText>);
+    setOverflow(element, false);
+    triggerResize(element);
+    await expect(container).toValidateA11y();
+  });
+
+  test('passes accessibility validation (truncated)', async () => {
+    const { container, element } = renderTruncatedText(<TruncatedText>Very long text content</TruncatedText>);
+    setOverflow(element, true);
+    triggerResize(element);
+    await expect(container).toValidateA11y();
+  });
+});

--- a/src/truncated-text/index.tsx
+++ b/src/truncated-text/index.tsx
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+'use client';
+import React from 'react';
+
+import useBaseComponent from '../internal/hooks/use-base-component';
+import { applyDisplayName } from '../internal/utils/apply-display-name';
+import { getExternalProps } from '../internal/utils/external-props';
+import { TruncatedTextProps } from './interfaces';
+import InternalTruncatedText from './internal';
+
+export { TruncatedTextProps };
+
+export default function TruncatedText({ children, tooltipText, ...rest }: TruncatedTextProps) {
+  const baseComponentProps = useBaseComponent('TruncatedText');
+  const externalProps = getExternalProps(rest);
+  return (
+    <InternalTruncatedText {...externalProps} {...baseComponentProps} tooltipText={tooltipText}>
+      {children}
+    </InternalTruncatedText>
+  );
+}
+
+applyDisplayName(TruncatedText, 'TruncatedText');

--- a/src/truncated-text/interfaces.ts
+++ b/src/truncated-text/interfaces.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { BaseComponentProps } from '../internal/base-component';
+
+export interface TruncatedTextProps extends BaseComponentProps {
+  /**
+   * The inline text to display. If there isn't enough space to render the text
+   * in a single line, it is truncated with an ellipsis and the full content is
+   * shown on pointer hover or keyboard focus.
+   */
+  children?: React.ReactNode;
+
+  /**
+   * The content of the tooltip shown when the text is truncated. By default, the
+   * tooltip content is the same as the `children` slot. Use only if the `children`
+   * slot may contain interactive elements.
+   */
+  tooltipText?: string;
+}

--- a/src/truncated-text/internal.tsx
+++ b/src/truncated-text/internal.tsx
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { HTMLAttributes, useEffect, useRef, useState } from 'react';
+import clsx from 'clsx';
+
+import { useMergeRefs, useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
+
+import { getBaseProps } from '../internal/base-component';
+import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import Tooltip from '../tooltip/internal';
+import { TruncatedTextProps } from './interfaces';
+
+import styles from './styles.css.js';
+import testUtilStyles from './test-classes/styles.css.js';
+
+type InternalTruncatedTextProps = TruncatedTextProps & InternalBaseComponentProps;
+
+export default function InternalTruncatedText({
+  children,
+  tooltipText,
+  __internalRootRef,
+  ...rest
+}: InternalTruncatedTextProps) {
+  const baseProps = getBaseProps(rest);
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const [showTooltip, setShowTooltip] = useState(false);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useResizeObserver(containerRef, () => {
+    const element = containerRef.current;
+    if (element) {
+      // The element uses CSS ellipsis truncation. When the rendered content overflows the
+      // visible box, the browser sets scrollWidth > clientWidth.
+      setIsTruncated(element.scrollWidth > element.clientWidth);
+    }
+  });
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (element) {
+      // useResizeObserver fires initially at layoutEffect-time where the initial calculation
+      // is performed, but the calculation isn't always correct at that stage.
+      setTimeout(() => setIsTruncated(element.scrollWidth > element.clientWidth), 1);
+    }
+  }, []);
+
+  const tooltipEnabledProps: HTMLAttributes<HTMLSpanElement> = isTruncated
+    ? {
+        role: 'group',
+        tabIndex: 0,
+        onPointerEnter: () => setShowTooltip(true),
+        onPointerLeave: () => setShowTooltip(false),
+        // onFocus/onBlur bubble in React, so we only want the wrapper focus to trigger the tooltip.
+        onFocus: event => event.target === event.currentTarget && setShowTooltip(true),
+        onBlur: event => event.target === event.currentTarget && setShowTooltip(false),
+      }
+    : {};
+
+  return (
+    <>
+      <span
+        {...baseProps}
+        {...tooltipEnabledProps}
+        ref={useMergeRefs(__internalRootRef, containerRef)}
+        className={clsx(styles.root, testUtilStyles.root, baseProps.className)}
+      >
+        {children}
+        {isTruncated && showTooltip && (
+          <Tooltip
+            content={tooltipText ?? children}
+            getTrack={() => containerRef.current}
+            onEscape={() => setShowTooltip(false)}
+          />
+        )}
+      </span>
+    </>
+  );
+}

--- a/src/truncated-text/styles.scss
+++ b/src/truncated-text/styles.scss
@@ -1,0 +1,25 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '../internal/styles' as styles;
+@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
+
+.root {
+  @include styles.text-overflow-ellipsis;
+
+  display: block;
+  inline-size: 100%;
+  max-inline-size: 100%;
+  min-inline-size: 0;
+
+  &:focus {
+    outline: none;
+  }
+  @include focus-visible.when-visible {
+    // The border is 2px wide, and since this component is commonly used in scenarios
+    // where the content can be truncated, let's play it safe by pulling in the outline.
+    @include styles.focus-highlight(-2px);
+  }
+}

--- a/src/truncated-text/test-classes/styles.scss
+++ b/src/truncated-text/test-classes/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.root {
+  /* used in test-utils */
+}


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
