### PR TITLE
feat(theming): Release referenceTokens for all systems

### DIFF
--- a/src/internal/generated/theming/index.d.ts
+++ b/src/internal/generated/theming/index.d.ts
@@ -12,9 +12,6 @@ import {
 export interface TypedOverride extends Override {
   tokens: Partial<Record<string, GlobalValue | TypedModeValueOverride>>;
 
-  /**
-   * @awsuiSystem core
-   */
   referenceTokens?: ReferenceTokens;
 }
 export declare const preset: ThemePreset;


### PR DESCRIPTION
Remove @awsuiSystem core annotation. Doc-only change — already works at runtime for all systems.