### PR TITLE
feat: Release container disableFooterPaddings for all systems

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -9643,9 +9643,6 @@ exports[`Components definition for container matches the snapshot: container 1`]
       "description": "Determines whether the container footer has padding. If \`true\`, removes the default padding from the footer.",
       "name": "disableFooterPaddings",
       "optional": true,
-      "systemTags": [
-        "core",
-      ],
       "type": "boolean",
     },
     {

--- a/src/container/interfaces.ts
+++ b/src/container/interfaces.ts
@@ -69,7 +69,6 @@ export interface ContainerProps extends BaseComponentProps {
 
   /**
    * Determines whether the container footer has padding. If `true`, removes the default padding from the footer.
-   * @awsuiSystem core
    */
   disableFooterPaddings?: boolean;
 


### PR DESCRIPTION
### Description

Remove `@awsuiSystem core` annotation from `container.disableFooterPaddings`, making it available for all systems.

This is a simple boolean prop with no runtime risk. No new code — only the JSDoc annotation is removed.

Related links, issue #, if available: n/a

### How has this been tested?

- Existing unit and integration tests continue to pass
- Snapshot tests updated via `npx jest -c jest.unit.config.js -u documenter`

<details>
   <summary>Review checklist</summary>

#### Correctness

- Changes include appropriate documentation updates.
- Changes are backward-compatible.
- Changes do not include unsupported browser features.
- N/A for accessibility (annotation-only change).

#### Security

- N/A (no URL handling changes).

#### Testing

- Existing tests cover this prop.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.