### PR TITLE
feat: Release theming referenceTokens for all systems

### DIFF
--- a/src/internal/generated/theming/index.d.ts
+++ b/src/internal/generated/theming/index.d.ts
@@ -12,9 +12,6 @@ import {
 export interface TypedOverride extends Override {
   tokens: Partial<Record<string, GlobalValue | TypedModeValueOverride>>;
 
-  /**
-   * @awsuiSystem core
-   */
   referenceTokens?: ReferenceTokens;
 }
 export declare const preset: ThemePreset;


### PR DESCRIPTION
### Description

Remove `@awsuiSystem core` annotation from `theming.referenceTokens`, making it available for all systems.

Doc-only change — `referenceTokens` already works at runtime for all systems. No runtime gating exists for this prop.

Related links, issue #, if available: n/a

### How has this been tested?

- Existing unit and integration tests continue to pass
- Snapshot tests updated via `npx jest -c jest.unit.config.js -u documenter`

<details>
   <summary>Review checklist</summary>

#### Correctness

- Changes include appropriate documentation updates.
- Changes are backward-compatible.
- Changes do not include unsupported browser features.
- N/A for accessibility (annotation-only change).

#### Security

- N/A (no URL handling changes).

#### Testing

- Existing tests cover this prop.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.