### PR TITLE
feat: Release prompt input customPrimaryAction for all systems

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -21883,9 +21883,6 @@ If this is provided then any other \`actionButton*\` properties will be ignored.
 Note that you should still provide an \`onAction\` function in order to handle keyboard submission.",
       "isDefault": false,
       "name": "customPrimaryAction",
-      "systemTags": [
-        "core",
-      ],
     },
     {
       "description": "Use this slot to add secondary actions to the prompt input.",

--- a/src/prompt-input/interfaces.ts
+++ b/src/prompt-input/interfaces.ts
@@ -173,8 +173,6 @@ export interface PromptInputProps
    * Use this to replace the primary action.
    * If this is provided then any other `actionButton*` properties will be ignored.
    * Note that you should still provide an `onAction` function in order to handle keyboard submission.
-   *
-   * @awsuiSystem core
    */
   customPrimaryAction?: React.ReactNode;
 


### PR DESCRIPTION
### Description

Remove `@awsuiSystem core` annotation from `prompt-input.customPrimaryAction`, making it available for all systems.

Slot prop for a custom primary action button. The component manages focus and keyboard handling regardless of system.

Related links, issue #, if available: n/a

### How has this been tested?

- Existing unit and integration tests continue to pass
- Snapshot tests updated via `npx jest -c jest.unit.config.js -u documenter`

<details>
   <summary>Review checklist</summary>

#### Correctness

- Changes include appropriate documentation updates.
- Changes are backward-compatible.
- Changes do not include unsupported browser features.
- N/A for accessibility (annotation-only change).

#### Security

- N/A (no URL handling changes).

#### Testing

- Existing tests cover this prop.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.