### PR TITLE
feat: Release wizard customPrimaryActions for all systems

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -32805,9 +32805,6 @@ Use this if you need to wait for a response from the server before the user can 
       "description": "Specifies right-aligned custom primary actions for the wizard. Overwrites existing buttons (e.g. Cancel, Next, Finish).",
       "isDefault": false,
       "name": "customPrimaryActions",
-      "systemTags": [
-        "core",
-      ],
     },
     {
       "description": "Specifies left-aligned secondary actions for the wizard. Use a button dropdown if multiple actions are required.",

--- a/src/wizard/interfaces.ts
+++ b/src/wizard/interfaces.ts
@@ -105,8 +105,6 @@ export interface WizardProps extends BaseComponentProps {
 
   /**
    * Specifies right-aligned custom primary actions for the wizard. Overwrites existing buttons (e.g. Cancel, Next, Finish).
-   *
-   * @awsuiSystem core
    */
   customPrimaryActions?: React.ReactNode;
 


### PR DESCRIPTION
### Description

Remove `@awsuiSystem core` annotation from `wizard.customPrimaryActions`, making it available for all systems.

Slot prop replacing default primary buttons. Step navigation is still managed by the component.

Related links, issue #, if available: n/a

### How has this been tested?

- Existing unit and integration tests continue to pass
- Snapshot tests updated via `npx jest -c jest.unit.config.js -u documenter`

<details>
   <summary>Review checklist</summary>

#### Correctness

- Changes include appropriate documentation updates.
- Changes are backward-compatible.
- Changes do not include unsupported browser features.
- N/A for accessibility (annotation-only change).

#### Security

- N/A (no URL handling changes).

#### Testing

- Existing tests cover this prop.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.