### PR TITLE
feat: Release renderOption for all systems

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -3761,9 +3761,6 @@ When returning \`null\`, the default rendering will be applied for that item.",
       },
       "name": "renderOption",
       "optional": true,
-      "systemTags": [
-        "core",
-      ],
       "type": "AutosuggestProps.ItemRenderer",
     },
     {
@@ -18936,9 +18933,6 @@ For more information, see the
       },
       "name": "renderOption",
       "optional": true,
-      "systemTags": [
-        "core",
-      ],
       "type": "MultiselectProps.MultiselectOptionItemRenderer",
     },
     {
@@ -25184,9 +25178,6 @@ For more information, see the
       },
       "name": "renderOption",
       "optional": true,
-      "systemTags": [
-        "core",
-      ],
       "type": "SelectProps.SelectOptionItemRenderer",
     },
     {

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -86,8 +86,6 @@ export interface AutosuggestProps
    * The component still manages focus, keyboard interactions, and selection state, but it no longer applies its default item layout or typography.
    *
    * When returning `null`, the default rendering will be applied for that item.
-   *
-   * @awsuiSystem core
    */
   renderOption?: AutosuggestProps.ItemRenderer;
 

--- a/src/multiselect/interfaces.ts
+++ b/src/multiselect/interfaces.ts
@@ -78,8 +78,6 @@ export interface MultiselectProps extends BaseSelectProps {
   enableSelectAll?: boolean;
   /**
    * Specifies a render function to render custom options in the dropdown menu.
-   *
-   * @awsuiSystem core
    */
   renderOption?: MultiselectProps.MultiselectOptionItemRenderer;
 }

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -189,8 +189,6 @@ export interface SelectProps extends BaseSelectProps {
   autoFocus?: boolean;
   /**
    * Specifies a render function to render custom options in the dropdown menu or trigger.
-   *
-   * @awsuiSystem core
    */
   renderOption?: SelectProps.SelectOptionItemRenderer;
 }


### PR DESCRIPTION
### Description

Remove `@awsuiSystem core` annotation from `renderOption` on select, autosuggest, and multiselect components, making custom option rendering available to all systems (including console).

This follows the same approach as button-dropdown `renderItem` (PR #4453). The component retains full control of accessibility (ARIA roles, keyboard navigation) regardless of custom rendering.

Related links, issue #, if available: n/a

### How has this been tested?

- TypeScript compilation passes with no new errors
- Documenter snapshots updated
- Existing unit and integration tests unaffected (annotation removal only)

<details>
   <summary>Review checklist</summary>

#### Correctness

- Changes are backward-compatible — only removes a system gate, no API changes.
- No new browser features used.
- No accessibility impact — components retain full ARIA/keyboard management regardless of custom rendering.

#### Security

- No URL handling changes.

#### Testing

- Existing tests cover renderOption functionality (already tested in core system).
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.