### PR TITLE
feat: make colorBorderLayout themeable

### DIFF
--- a/src/wizard/styles.scss
+++ b/src/wizard/styles.scss
@@ -211,7 +211,7 @@
     }
 
     > li:not(:last-child) {
-      border-block-end: awsui.$border-divider-list-width solid awsui.$color-border-layout;
+      border-block-end: awsui.$border-divider-list-width solid awsui.$color-border-divider-default;
     }
   }
   /* stylelint-enable selector-max-type */

--- a/style-dictionary/visual-refresh/metadata/colors.ts
+++ b/style-dictionary/visual-refresh/metadata/colors.ts
@@ -551,6 +551,11 @@ const metadata: StyleDictionary.MetadataIndex = {
     public: true,
     themeable: true,
   },
+  colorBorderLayout: {
+    description: 'The border color of layout elements. For example: toolbar, panel dividers.',
+    public: false,
+    themeable: true,
+  },
   colorBorderTutorial: { description: 'The border color of tutorials in the tutorials list in the tutorial panel.' },
   colorForegroundControlDefault: {
     description:


### PR DESCRIPTION
### Description

Makes `colorBorderLayout` themable

Related links, issue #, if available: n/a

### How has this been tested?

Locally.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
