### PR TITLE
feat: Add wrapText property to copy to clipboard

### DIFF
--- a/pages/copy-to-clipboard/permutations.page.tsx
+++ b/pages/copy-to-clipboard/permutations.page.tsx
@@ -37,13 +37,36 @@ const permutations = createPermutations<CopyToClipboardProps>([
     copySuccessText: ['Text copied successfully'],
     copyErrorText: ['Copy failed.'],
   },
+  {
+    wrapText: [true, false],
+    variant: ['inline'],
+    textToCopy: [
+      'Lorem ipsum dolor sit amet consectetur adipiscing elit cursus ut pharetra semper litora lobortis sed lacinia.',
+    ],
+    copyButtonText: ['Copy to clipboard'],
+    copySuccessText: ['Text copied successfully'],
+    copyErrorText: ['Copy failed.'],
+  },
+  {
+    wrapText: [true, false],
+    variant: ['inline'],
+    textToDisplay: [
+      <Popover key={1} content="Popover" wrapTriggerText={false}>
+        Inline block popover with relatively long content that should truncate when wrapText is false
+      </Popover>,
+    ],
+    textToCopy: ['Lorem ipsum dolor sit amet.'],
+    copyButtonText: ['Copy to clipboard'],
+    copySuccessText: ['Text copied successfully'],
+    copyErrorText: ['Copy failed.'],
+  },
 ]);
 
 export default function ButtonPermutations() {
   return (
     <>
       <h1>Button permutations</h1>
-      <ScreenshotArea disableAnimations={true}>
+      <ScreenshotArea disableAnimations={true} style={{ maxWidth: 400 }}>
         <PermutationsView permutations={permutations} render={permutation => <CopyToClipboard {...permutation} />} />
       </ScreenshotArea>
     </>

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -10206,6 +10206,14 @@ Defaults to \`button\`.",
       "optional": true,
       "type": "string",
     },
+    {
+      "defaultValue": "true",
+      "description": "Specifies if the \`textToDisplay\` content should wrap. If you set it to false, it prevents the text
+from wrapping and truncates it with an ellipsis. Only applies to \`variant="inline"\`.",
+      "name": "wrapText",
+      "optional": true,
+      "type": "boolean",
+    },
   ],
   "regions": [
     {

--- a/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
+++ b/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
@@ -6,6 +6,8 @@ import { act, render, waitFor } from '@testing-library/react';
 import CopyToClipboard from '../../../lib/components/copy-to-clipboard';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
+import styles from '../../../lib/components/copy-to-clipboard/styles.css.js';
+
 const defaultProps = {
   copyTarget: 'Test content',
   textToCopy: 'Text to copy',
@@ -499,5 +501,20 @@ describe('CopyToClipboard', () => {
       await new Promise(resolve => setTimeout(resolve, 100));
       expect(onCopyFailure).not.toHaveBeenCalled();
     });
+  });
+
+  test('wraps text by default for variant="inline"', () => {
+    const { container } = render(<CopyToClipboard {...defaultProps} variant="inline" />);
+    expect(container.querySelector(`.${styles['inline-container-no-wrap']}`)).toBeNull();
+  });
+
+  test('wraps text when wrapText=undefined', () => {
+    const { container } = render(<CopyToClipboard {...defaultProps} variant="inline" wrapText={undefined} />);
+    expect(container.querySelector(`.${styles['inline-container-no-wrap']}`)).toBeNull();
+  });
+
+  test('does not wrap text when wrapText=false', () => {
+    const { container } = render(<CopyToClipboard {...defaultProps} variant="inline" wrapText={false} />);
+    expect(container.querySelector(`.${styles['inline-container-no-wrap']}`)).not.toBeNull();
   });
 });

--- a/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
+++ b/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { act, render, waitFor } from '@testing-library/react';
 
 import CopyToClipboard from '../../../lib/components/copy-to-clipboard';
+import InternalCopyToClipboard from '../../../lib/components/copy-to-clipboard/internal';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
 import styles from '../../../lib/components/copy-to-clipboard/styles.css.js';
@@ -508,13 +509,18 @@ describe('CopyToClipboard', () => {
     expect(container.querySelector(`.${styles['inline-container-no-wrap']}`)).toBeNull();
   });
 
-  test('wraps text when wrapText=undefined', () => {
-    const { container } = render(<CopyToClipboard {...defaultProps} variant="inline" wrapText={undefined} />);
+  test('InternalCopyToClipboard wraps text by default for variant="inline"', () => {
+    const { container } = render(<InternalCopyToClipboard {...defaultProps} variant="inline" />);
     expect(container.querySelector(`.${styles['inline-container-no-wrap']}`)).toBeNull();
   });
 
   test('does not wrap text when wrapText=false', () => {
     const { container } = render(<CopyToClipboard {...defaultProps} variant="inline" wrapText={false} />);
+    expect(container.querySelector(`.${styles['inline-container-no-wrap']}`)).not.toBeNull();
+  });
+
+  test('InternalCopyToClipboard does not wrap text when wrapText=false', () => {
+    const { container } = render(<InternalCopyToClipboard {...defaultProps} variant="inline" wrapText={false} />);
     expect(container.querySelector(`.${styles['inline-container-no-wrap']}`)).not.toBeNull();
   });
 });

--- a/src/copy-to-clipboard/index.tsx
+++ b/src/copy-to-clipboard/index.tsx
@@ -14,6 +14,7 @@ export { CopyToClipboardProps };
 export default function CopyToClipboard({
   variant = 'button',
   popoverRenderWithPortal = false,
+  wrapText = true,
   ...restProps
 }: CopyToClipboardProps) {
   const baseProps = useBaseComponent('CopyToClipboard', {
@@ -25,6 +26,7 @@ export default function CopyToClipboard({
     <InternalCopyToClipboard
       variant={variant}
       popoverRenderWithPortal={popoverRenderWithPortal}
+      wrapText={wrapText}
       {...baseProps}
       {...filteredProps}
     />

--- a/src/copy-to-clipboard/interfaces.ts
+++ b/src/copy-to-clipboard/interfaces.ts
@@ -37,6 +37,12 @@ export interface CopyToClipboardProps extends BaseComponentProps {
   textToDisplay?: React.ReactNode;
 
   /**
+   * Specifies if the `textToDisplay` content should wrap. If you set it to false, it prevents the text
+   * from wrapping and truncates it with an ellipsis. Only applies to `variant="inline"`.
+   */
+  wrapText?: boolean;
+
+  /**
    * The message shown when the text is copied successfully.
    */
   copySuccessText: string;

--- a/src/copy-to-clipboard/internal.tsx
+++ b/src/copy-to-clipboard/internal.tsx
@@ -24,6 +24,7 @@ export default function InternalCopyToClipboard({
   copyErrorText,
   textToCopy,
   textToDisplay,
+  wrapText = true,
   popoverRenderWithPortal,
   disabled,
   disabledReason,
@@ -119,9 +120,9 @@ export default function InternalCopyToClipboard({
   return (
     <span {...baseProps} ref={__internalRootRef} className={clsx(baseProps.className, styles.root, testStyles.root)}>
       {isInline ? (
-        <span className={styles['inline-container']}>
+        <span className={clsx(styles['inline-container'], !wrapText && styles['inline-container-no-wrap'])}>
           <span className={styles['inline-container-trigger']}>{trigger}</span>
-          <span className={clsx(testStyles['text-to-display'], testStyles['text-to-copy'])}>
+          <span className={clsx(testStyles['text-to-display'], testStyles['text-to-copy'], styles['text-to-display'])}>
             {textToDisplay !== undefined ? textToDisplay : textToCopy}
           </span>
         </span>

--- a/src/copy-to-clipboard/styles.scss
+++ b/src/copy-to-clipboard/styles.scss
@@ -15,4 +15,22 @@
   &-trigger {
     margin-inline-end: awsui.$space-scaled-xxs;
   }
+
+  &-no-wrap {
+    display: inline-flex;
+    align-items: start;
+    max-inline-size: 100%;
+    word-break: normal;
+
+    > .inline-container-trigger {
+      flex-shrink: 0;
+    }
+
+    > .text-to-display {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-inline-size: 0;
+    }
+  }
 }


### PR DESCRIPTION
### Description

Solves a similar problem components like status indicator, popover, and button have, where you want the truncation "boundary" to be inside the component itself, and for the subcomponents (e.g. icon) to wrap predictably. See doc: IYeOAvru29Zv.

Related links, issue #, if available: AWSUI-61955

### How has this been tested?

Unit tests, permutation tests, manual checks (esp. with the popover use-case).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
