### PR TITLE
chore: Change styling in copy-to-clipboard to use flex-start

### DIFF
--- a/src/copy-to-clipboard/styles.scss
+++ b/src/copy-to-clipboard/styles.scss
@@ -18,7 +18,7 @@
 
   &-no-wrap {
     display: inline-flex;
-    align-items: start;
+    align-items: flex-start;
     max-inline-size: 100%;
     word-break: normal;
 


### PR DESCRIPTION
### Description

Autoprefixer called this out in one of the consumer packages, that `start` has limited support. It works fine within our support window, but this seemed like an easier option than to open a review against them and ask them to merge a different browserslist.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
