### PR TITLE
chore: enable screenshot testing for skeleton components-examples page

### DIFF
--- a/pages/skeleton/components-examples.page.tsx
+++ b/pages/skeleton/components-examples.page.tsx
@@ -15,6 +15,8 @@ import List from '~components/list';
 import Skeleton from '~components/skeleton';
 import SpaceBetween from '~components/space-between';
 
+import { SimplePage } from '../app/templates';
+
 interface DataItem {
   id: string;
   name: string;
@@ -58,22 +60,16 @@ export default function SkeletonComponentsExamples() {
   const [isLoading, setIsLoading] = useState(true);
 
   return (
-    <Box padding="l">
-      <div style={{ position: 'sticky', top: 0, zIndex: 1000, marginBottom: '2em' }}>
-        <Container>
-          <SpaceBetween size="m">
-            <Header
-              variant="h1"
-              description="Demonstrates skeleton loading patterns across different components to minimize layout shift"
-            >
-              Skeleton Component Examples
-            </Header>
-            <Checkbox checked={isLoading} onChange={({ detail }) => setIsLoading(detail.checked)}>
-              Show loading state (Skeleton)
-            </Checkbox>
-          </SpaceBetween>
-        </Container>
-      </div>
+    <SimplePage
+      title="Skeleton Component Examples"
+      subtitle="Demonstrates skeleton loading patterns across different components to minimize layout shift"
+      settings={
+        <Checkbox checked={isLoading} onChange={({ detail }) => setIsLoading(detail.checked)}>
+          Show loading state (Skeleton)
+        </Checkbox>
+      }
+      screenshotArea={{ disableAnimations: true }}
+    >
       <SpaceBetween size="l">
         {/* Cards Example */}
         <Container header={<Header variant="h2">Cards with Skeleton</Header>}>
@@ -333,6 +329,6 @@ export default function SkeletonComponentsExamples() {
           </>
         </Container>
       </SpaceBetween>
-    </Box>
+    </SimplePage>
   );
 }

--- a/pages/skeleton/permutations.page.tsx
+++ b/pages/skeleton/permutations.page.tsx
@@ -4,9 +4,9 @@ import React from 'react';
 
 import Skeleton, { SkeletonProps } from '~components/skeleton';
 
+import { SimplePage } from '../app/templates';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
-import ScreenshotArea from '../utils/screenshot-area';
 
 const permutations = createPermutations<SkeletonProps>([
   // Test all variants with default display and reasonable width
@@ -46,18 +46,15 @@ const permutations = createPermutations<SkeletonProps>([
 
 export default function SkeletonPermutations() {
   return (
-    <>
-      <h1>Skeleton permutations</h1>
-      <ScreenshotArea disableAnimations={true}>
-        <PermutationsView
-          permutations={permutations}
-          render={permutation => (
-            <div style={{ marginBottom: '16px' }}>
-              <Skeleton {...permutation} />
-            </div>
-          )}
-        />
-      </ScreenshotArea>
-    </>
+    <SimplePage title="Skeleton permutations" screenshotArea={{ disableAnimations: true }}>
+      <PermutationsView
+        permutations={permutations}
+        render={permutation => (
+          <div style={{ marginBottom: '16px' }}>
+            <Skeleton {...permutation} />
+          </div>
+        )}
+      />
+    </SimplePage>
   );
 }


### PR DESCRIPTION
### Description
Enable screenshot testing on the skeleton `components-examples.page.tsx` by using the SimplePage template with `screenshotArea={{ disableAnimations: true }}`. Also updates `permutations.page.tsx` to use SimplePage for consistency.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
