### PR TITLE
feat: add one theme style dictionary

### DIFF
--- a/build-tools/tasks/generate-environment.js
+++ b/build-tools/tasks/generate-environment.js
@@ -6,6 +6,7 @@ const themes = require('../utils/themes');
 const workspace = require('../utils/workspace');
 
 const ALWAYS_VISUAL_REFRESH = process.env.ALWAYS_VISUAL_REFRESH === 'true';
+const INCLUDE_ONE_THEME = process.env.NODE_ENV !== 'production';
 
 function writeEnvironmentFile(theme) {
   const filepath = 'internal/environment';
@@ -16,6 +17,7 @@ function writeEnvironmentFile(theme) {
     THEME: theme.name,
     SYSTEM: 'core',
     ALWAYS_VISUAL_REFRESH: !!theme.alwaysVisualRefresh || ALWAYS_VISUAL_REFRESH,
+    INCLUDE_ONE_THEME: INCLUDE_ONE_THEME,
   };
   const basePath = path.join(theme.outputPath, filepath);
 

--- a/build-tools/tasks/generate-environment.js
+++ b/build-tools/tasks/generate-environment.js
@@ -6,7 +6,7 @@ const themes = require('../utils/themes');
 const workspace = require('../utils/workspace');
 
 const ALWAYS_VISUAL_REFRESH = process.env.ALWAYS_VISUAL_REFRESH === 'true';
-const INCLUDE_ONE_THEME = process.env.NODE_ENV !== 'production';
+const INCLUDE_ONE_THEME = process.env.INCLUDE_ONE_THEME === 'true';
 
 function writeEnvironmentFile(theme) {
   const filepath = 'internal/environment';

--- a/build-tools/utils/themes.js
+++ b/build-tools/utils/themes.js
@@ -3,6 +3,9 @@
 const path = require('path');
 const workspace = require('./workspace');
 
+// One Theme is gated on NODE_ENV so it does not ship in published packages yet.
+const INCLUDE_ONE_THEME = process.env.NODE_ENV !== 'production';
+
 const themes = [
   // This is the default Cloudscape theme, which is best used with Visual Refresh enabled (by default)
   {
@@ -13,7 +16,10 @@ const themes = [
     designTokensPackageJson: { name: '@cloudscape-design/design-tokens' },
     outputPath: path.join(workspace.targetPath, 'components'),
     primaryThemePath: './classic/index.js',
-    secondaryThemePaths: ['./visual-refresh-secondary/index.js', './one-theme/index.js'],
+    secondaryThemePaths: [
+      './visual-refresh-secondary/index.js',
+      ...(INCLUDE_ONE_THEME ? ['./one-theme/index.js'] : []),
+    ],
   },
 ];
 

--- a/build-tools/utils/themes.js
+++ b/build-tools/utils/themes.js
@@ -13,7 +13,7 @@ const themes = [
     designTokensPackageJson: { name: '@cloudscape-design/design-tokens' },
     outputPath: path.join(workspace.targetPath, 'components'),
     primaryThemePath: './classic/index.js',
-    secondaryThemePaths: ['./visual-refresh-secondary/index.js'],
+    secondaryThemePaths: ['./visual-refresh-secondary/index.js', './one-theme/index.js'],
   },
 ];
 

--- a/build-tools/utils/themes.js
+++ b/build-tools/utils/themes.js
@@ -3,7 +3,6 @@
 const path = require('path');
 const workspace = require('./workspace');
 
-// One Theme is gated on this env var so it does not ship in published packages.
 const INCLUDE_ONE_THEME = process.env.INCLUDE_ONE_THEME === 'true';
 
 const themes = [

--- a/build-tools/utils/themes.js
+++ b/build-tools/utils/themes.js
@@ -3,8 +3,8 @@
 const path = require('path');
 const workspace = require('./workspace');
 
-// One Theme is gated on NODE_ENV so it does not ship in published packages yet.
-const INCLUDE_ONE_THEME = process.env.NODE_ENV !== 'production';
+// One Theme is gated on this env var so it does not ship in published packages.
+const INCLUDE_ONE_THEME = process.env.INCLUDE_ONE_THEME === 'true';
 
 const themes = [
   // This is the default Cloudscape theme, which is best used with Visual Refresh enabled (by default)

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     {
       "path": "lib/components/internal/widget-exports.js",
       "brotli": false,
-      "limit": "1285 kB",
+      "limit": "1400 kB",
       "ignore": "react-dom"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     {
       "path": "lib/components/internal/widget-exports.js",
       "brotli": false,
-      "limit": "1400 kB",
+      "limit": "1285 kB",
       "ignore": "react-dom"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://cloudscape.design",
   "files": [],
   "scripts": {
-    "quick-build": "gulp quick-build",
+    "quick-build": "cross-env INCLUDE_ONE_THEME=true gulp quick-build",
     "build": "cross-env NODE_ENV=production gulp build",
     "test": "TZ=UTC gulp test",
     "test:unit": "TZ=UTC gulp test:unit",
@@ -20,7 +20,7 @@
     "lint:stylelint": "stylelint --ignore-path .gitignore '{src,pages}/**/*.{css,scss}'",
     "build:react18": "cross-env NODE_ENV=production REACT_VERSION=18 gulp build",
     "start": "npm-run-all --parallel start:watch start:dev",
-    "start:watch": "gulp watch",
+    "start:watch": "cross-env INCLUDE_ONE_THEME=true gulp watch",
     "start:dev": "cross-env NODE_ENV=development webpack serve --config pages/webpack.config.cjs",
     "start:integ": "cross-env NODE_ENV=development webpack serve --config pages/webpack.config.integ.cjs",
     "start:react18": "npm-run-all --parallel start:watch start:react18:dev",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://cloudscape.design",
   "files": [],
   "scripts": {
-    "quick-build": "cross-env INCLUDE_ONE_THEME=true gulp quick-build",
+    "quick-build": "cross-env gulp quick-build",
     "build": "cross-env NODE_ENV=production gulp build",
     "test": "TZ=UTC gulp test",
     "test:unit": "TZ=UTC gulp test:unit",
@@ -20,7 +20,7 @@
     "lint:stylelint": "stylelint --ignore-path .gitignore '{src,pages}/**/*.{css,scss}'",
     "build:react18": "cross-env NODE_ENV=production REACT_VERSION=18 gulp build",
     "start": "npm-run-all --parallel start:watch start:dev",
-    "start:watch": "cross-env INCLUDE_ONE_THEME=true gulp watch",
+    "start:watch": "cross-env gulp watch",
     "start:dev": "cross-env NODE_ENV=development webpack serve --config pages/webpack.config.cjs",
     "start:integ": "cross-env NODE_ENV=development webpack serve --config pages/webpack.config.integ.cjs",
     "start:react18": "npm-run-all --parallel start:watch start:react18:dev",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://cloudscape.design",
   "files": [],
   "scripts": {
-    "quick-build": "cross-env gulp quick-build",
+    "quick-build": "gulp quick-build",
     "build": "cross-env NODE_ENV=production gulp build",
     "test": "TZ=UTC gulp test",
     "test:unit": "TZ=UTC gulp test:unit",
@@ -20,7 +20,7 @@
     "lint:stylelint": "stylelint --ignore-path .gitignore '{src,pages}/**/*.{css,scss}'",
     "build:react18": "cross-env NODE_ENV=production REACT_VERSION=18 gulp build",
     "start": "npm-run-all --parallel start:watch start:dev",
-    "start:watch": "cross-env gulp watch",
+    "start:watch": "gulp watch",
     "start:dev": "cross-env NODE_ENV=development webpack serve --config pages/webpack.config.cjs",
     "start:integ": "cross-env NODE_ENV=development webpack serve --config pages/webpack.config.integ.cjs",
     "start:react18": "npm-run-all --parallel start:watch start:react18:dev",

--- a/pages/app/app-context.tsx
+++ b/pages/app/app-context.tsx
@@ -12,6 +12,7 @@ interface AppUrlParams {
   density: Density;
   direction: 'ltr' | 'rtl';
   visualRefresh: boolean;
+  oneTheme: boolean;
   motionDisabled: boolean;
   appLayoutWidget: boolean;
   mode?: Mode;
@@ -32,6 +33,7 @@ const appContextDefaults: AppContextType = {
     density: Density.Comfortable,
     direction: 'ltr',
     visualRefresh: THEME === 'default',
+    oneTheme: false,
     motionDisabled: false,
     appLayoutWidget: false,
   },

--- a/pages/app/components/theme-switcher.tsx
+++ b/pages/app/components/theme-switcher.tsx
@@ -21,7 +21,7 @@ export default function ThemeSwitcher() {
     vrSwitchProps.checked = true;
     vrSwitchProps.readOnly = true;
   } else {
-    vrSwitchProps.checked = urlParams.visualRefresh;
+    vrSwitchProps.checked = urlParams.visualRefresh && !urlParams.oneTheme;
     vrSwitchProps.onChange = event => {
       setUrlParams(event.target.checked ? { visualRefresh: true, oneTheme: false } : { visualRefresh: false });
       window.location.reload();

--- a/pages/app/components/theme-switcher.tsx
+++ b/pages/app/components/theme-switcher.tsx
@@ -12,7 +12,6 @@ import AppContext from '../app-context';
 export default function ThemeSwitcher() {
   const { mode, urlParams, setUrlParams, setMode } = useContext(AppContext);
 
-  // Three mutually-exclusive themes drive both URL params at once.
   function activateTheme(theme: 'visualRefresh' | 'oneTheme' | 'classic') {
     setUrlParams({
       visualRefresh: theme === 'visualRefresh',

--- a/pages/app/components/theme-switcher.tsx
+++ b/pages/app/components/theme-switcher.tsx
@@ -12,6 +12,15 @@ import AppContext from '../app-context';
 export default function ThemeSwitcher() {
   const { mode, urlParams, setUrlParams, setMode } = useContext(AppContext);
 
+  // Three mutually-exclusive themes drive both URL params at once.
+  function activateTheme(theme: 'visualRefresh' | 'oneTheme' | 'classic') {
+    setUrlParams({
+      visualRefresh: theme === 'visualRefresh',
+      oneTheme: theme === 'oneTheme',
+    });
+    window.location.reload();
+  }
+
   const vrSwitchProps: React.InputHTMLAttributes<HTMLInputElement> = {
     id: 'visual-refresh-toggle',
     type: 'checkbox',
@@ -22,10 +31,7 @@ export default function ThemeSwitcher() {
     vrSwitchProps.readOnly = true;
   } else {
     vrSwitchProps.checked = urlParams.visualRefresh && !urlParams.oneTheme;
-    vrSwitchProps.onChange = event => {
-      setUrlParams(event.target.checked ? { visualRefresh: true, oneTheme: false } : { visualRefresh: false });
-      window.location.reload();
-    };
+    vrSwitchProps.onChange = event => activateTheme(event.target.checked ? 'visualRefresh' : 'classic');
   }
 
   return (
@@ -40,10 +46,7 @@ export default function ThemeSwitcher() {
             id="one-theme-toggle"
             type="checkbox"
             checked={urlParams.oneTheme}
-            onChange={event => {
-              setUrlParams(event.target.checked ? { oneTheme: true, visualRefresh: false } : { oneTheme: false });
-              window.location.reload();
-            }}
+            onChange={event => activateTheme(event.target.checked ? 'oneTheme' : 'classic')}
           />
           One theme
         </label>

--- a/pages/app/components/theme-switcher.tsx
+++ b/pages/app/components/theme-switcher.tsx
@@ -4,7 +4,7 @@ import React, { useContext } from 'react';
 
 import { Density, Mode } from '@cloudscape-design/global-styles';
 
-import { ALWAYS_VISUAL_REFRESH } from '~components/internal/environment';
+import { ALWAYS_VISUAL_REFRESH, INCLUDE_ONE_THEME } from '~components/internal/environment';
 import SpaceBetween from '~components/space-between';
 
 import AppContext from '../app-context';
@@ -23,7 +23,7 @@ export default function ThemeSwitcher() {
   } else {
     vrSwitchProps.checked = urlParams.visualRefresh;
     vrSwitchProps.onChange = event => {
-      setUrlParams({ visualRefresh: event.target.checked });
+      setUrlParams(event.target.checked ? { visualRefresh: true, oneTheme: false } : { visualRefresh: false });
       window.location.reload();
     };
   }
@@ -34,6 +34,20 @@ export default function ThemeSwitcher() {
         <input {...vrSwitchProps} />
         Visual refresh
       </label>
+      {INCLUDE_ONE_THEME && (
+        <label>
+          <input
+            id="one-theme-toggle"
+            type="checkbox"
+            checked={urlParams.oneTheme}
+            onChange={event => {
+              setUrlParams(event.target.checked ? { oneTheme: true, visualRefresh: false } : { oneTheme: false });
+              window.location.reload();
+            }}
+          />
+          One theme
+        </label>
+      )}
       <label>
         <input
           id="mode-toggle"

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -95,7 +95,7 @@ function App() {
 }
 
 const history = createHashHistory();
-const { direction, visualRefresh, appLayoutWidget, appLayoutToolbar, appLayoutDelayedWidget } = parseQuery(
+const { direction, visualRefresh, oneTheme, appLayoutWidget, appLayoutToolbar, appLayoutDelayedWidget } = parseQuery(
   history.location.search
 );
 
@@ -110,6 +110,14 @@ if (!window[awsuiCustomFlagsSymbol]) {
 window[awsuiGlobalFlagsSymbol].appLayoutWidget = appLayoutWidget;
 window[awsuiGlobalFlagsSymbol].appLayoutToolbar = appLayoutToolbar;
 window[awsuiCustomFlagsSymbol].appLayoutDelayedWidget = appLayoutDelayedWidget;
+
+// Removes .awsui-visual-refresh when one theme is active and vice verca
+if (oneTheme) {
+  document.body.classList.add('awsui-one-theme');
+  document.body.classList.remove('awsui-visual-refresh');
+} else {
+  document.body.classList.remove('awsui-one-theme');
+}
 
 // Apply the direction value to the HTML element dir attribute
 document.documentElement.setAttribute('dir', direction);

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -100,7 +100,7 @@ const { direction, visualRefresh, oneTheme, appLayoutWidget, appLayoutToolbar, a
 );
 
 // The VR class needs to be set before any React rendering occurs.
-window[awsuiVisualRefreshFlag] = () => visualRefresh;
+window[awsuiVisualRefreshFlag] = () => visualRefresh && !oneTheme;
 if (!window[awsuiGlobalFlagsSymbol]) {
   window[awsuiGlobalFlagsSymbol] = {};
 }
@@ -111,13 +111,10 @@ window[awsuiGlobalFlagsSymbol].appLayoutWidget = appLayoutWidget;
 window[awsuiGlobalFlagsSymbol].appLayoutToolbar = appLayoutToolbar;
 window[awsuiCustomFlagsSymbol].appLayoutDelayedWidget = appLayoutDelayedWidget;
 
-// Removes .awsui-visual-refresh when one theme is active and vice verca
-if (oneTheme) {
-  document.body.classList.add('awsui-one-theme');
-  document.body.classList.remove('awsui-visual-refresh');
-} else {
-  document.body.classList.remove('awsui-one-theme');
-}
+// Visual Refresh and One Theme are mutually exclusive — manage both classes here so they never coexist.
+// useRuntimeVisualRefresh() detects .awsui-visual-refresh on body and short-circuits before its Symbol fallback.
+document.body.classList.toggle('awsui-one-theme', oneTheme);
+document.body.classList.toggle('awsui-visual-refresh', visualRefresh && !oneTheme);
 
 // Apply the direction value to the HTML element dir attribute
 document.documentElement.setAttribute('dir', direction);

--- a/style-dictionary/one-theme/colors.ts
+++ b/style-dictionary/one-theme/colors.ts
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { expandColorDictionary } from '../utils/index.js';
+import { StyleDictionary } from '../utils/interfaces.js';
+
+// Anything not listed here falls back to the visual-refresh value via ThemeBuilder.addTokens in ./index.ts.
+const tokens: StyleDictionary.ColorsDictionary = {
+  colorBackgroundButtonPrimaryDefault: '{colorBlack}',
+};
+
+const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = expandColorDictionary(tokens);
+
+export { expandedTokens as tokens };
+export const mode: StyleDictionary.ModeIdentifier = 'color';

--- a/style-dictionary/one-theme/index.ts
+++ b/style-dictionary/one-theme/index.ts
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ThemeBuilder } from '@cloudscape-design/theming-build';
+
+import { StyleDictionary } from '../utils/interfaces.js';
+import { createColorMode, createDensityMode, createMotionMode } from '../utils/modes.js';
+import { buildVisualRefresh } from '../visual-refresh/index.js';
+
+const modes = [
+  createColorMode('.awsui-dark-mode'),
+  createDensityMode('.awsui-compact-mode'),
+  createMotionMode('.awsui-motion-disabled'),
+];
+
+// One Theme starts from the full visual-refresh token set and layers overrides on top.
+const overrides: Array<StyleDictionary.CategoryModule> = [await import('./colors.js')];
+
+const builder = new ThemeBuilder('one-theme', '.awsui-one-theme', modes);
+
+// Layer 1: visual refresh baseline (full token set + contexts).
+await buildVisualRefresh(builder);
+
+// Layer 2: One Theme overrides.
+overrides.forEach(({ tokens, mode: modeId, referenceTokens }) => {
+  const mode = modes.find(m => m.id === modeId);
+  if (referenceTokens) {
+    builder.addReferenceTokens(referenceTokens, mode);
+  }
+  builder.addTokens(tokens, mode);
+});
+
+const theme = builder.build();
+export default theme;

--- a/style-dictionary/one-theme/metadata.ts
+++ b/style-dictionary/one-theme/metadata.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import metadata from '../visual-refresh/metadata/index.js';
+
+export default metadata;


### PR DESCRIPTION
### Description

Adds One Theme as a overlay on visual-refresh, gated behind `INCLUDE_ONE_THEME=true`. Set on dev scripts, not on build, so published packages don't include it. Dev page theme switcher has a new toggle for local testing.

Related links, issue #, if available:`aQokArCTx9ab` 

### How has this been tested?

- Verified in local workspace that build output does not include any one theme references.
- Changes wend through pipeline.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
