### PR TITLE
fix: stabilize flaky resizable-columns integration test

### DIFF
--- a/src/table/__integ__/resizable-columns.test.ts
+++ b/src/table/__integ__/resizable-columns.test.ts
@@ -345,8 +345,7 @@ test(
     await page.resizeColumn(2, 100);
     const oldWidth = await page.getColumnWidth(2);
     await page.click('#reset-state');
-    const newWidth = await page.getColumnWidth(2);
-    expect(oldWidth).toEqual(newWidth);
+    await page.assertColumnWidth(2, oldWidth);
   })
 );
 


### PR DESCRIPTION
### Description
The "should recover column widths when the inner state is reset" test reads column width immediately after clicking `#reset-state`. React hasn't finished re-rendering at that point, so the test intermittently reads the default width instead of the recovered one.

Fix: replace the immediate read with `assertColumnWidth`, which polls via `waitUntil` (1s timeout). Same pattern used by adjacent tests in the file.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: 8ODfAlKbid05

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
