### PR TITLE
feat: Release dropdown and radio-button for all systems

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -12587,9 +12587,6 @@ scrolling dropdown content.",
     },
   ],
   "releaseStatus": "stable",
-  "systemTags": [
-    "core",
-  ],
 }
 `;
 
@@ -23644,9 +23641,6 @@ For more details, see the [MDN documentation](https://developer.mozilla.org/en-U
     },
   ],
   "releaseStatus": "stable",
-  "systemTags": [
-    "core",
-  ],
 }
 `;
 

--- a/src/dropdown/index.tsx
+++ b/src/dropdown/index.tsx
@@ -10,9 +10,6 @@ import InternalDropdown from './internal';
 
 export { DropdownProps };
 
-/**
- * @awsuiSystem core
- */
 export default function Dropdown({ style, ...props }: DropdownProps) {
   const baseComponentProps = useBaseComponent('Dropdown');
   return <InternalDropdown {...props} style={style} {...baseComponentProps} />;

--- a/src/radio-button/index.tsx
+++ b/src/radio-button/index.tsx
@@ -29,7 +29,4 @@ const RadioButton = React.forwardRef((props: RadioButtonProps, ref: React.Ref<HT
 
 applyDisplayName(RadioButton, 'RadioButton');
 
-/**
- * @awsuiSystem core
- */
 export default RadioButton;


### PR DESCRIPTION
### Description

Remove `@awsuiSystem core` annotation from the default exports of dropdown and radio-button, making them available in console and external builds.

Style API props (`style`) and `nativeInputAttributes` remain gated to core-only.

### How has this been tested?

- Build passes (`npm run build`)
- Documenter snapshots updated (systemTags removed from both components)
- Lint passes

<details>
   <summary>Review checklist</summary>

#### Correctness

- _No documentation updates needed — component docs auto-filter via systemTags._
- _Changes are backward-compatible — additive only (components become available in more builds)._
- _No new browser features._
- _No accessibility changes — components are unchanged, just available in more builds._

#### Security

- _No URL handling changes._

#### Testing

- _Existing unit tests continue to pass._
- _Integration tests will be ungated separately (CR-276119711) after this merges._
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.