### PR TITLE
feat: Release icon-provider and navigable-group for all systems

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -16204,9 +16204,6 @@ provider or fall back to their default token-defined stroke-widths.",
     },
   ],
   "releaseStatus": "stable",
-  "systemTags": [
-    "core",
-  ],
 }
 `;
 
@@ -19706,9 +19703,6 @@ need to be direct children of the group:
     },
   ],
   "releaseStatus": "stable",
-  "systemTags": [
-    "core",
-  ],
 }
 `;
 

--- a/src/icon-provider/index.tsx
+++ b/src/icon-provider/index.tsx
@@ -12,9 +12,6 @@ export { IconProviderProps } from './interfaces';
 export { defineIcons } from './define-icons';
 export type { IconRegistry, IconMap } from './interfaces';
 
-/**
- * @awsuiSystem core
- */
 export default function IconProvider(props: IconProviderProps) {
   useBaseComponent('IconProvider');
   return <InternalIconProvider {...props} />;

--- a/src/navigable-group/index.tsx
+++ b/src/navigable-group/index.tsx
@@ -22,7 +22,4 @@ const NavigableGroup = React.forwardRef(({ ...rest }: NavigableGroupProps, ref: 
 
 applyDisplayName(NavigableGroup, 'NavigableGroup');
 
-/**
- * @awsuiSystem core
- */
 export default NavigableGroup;


### PR DESCRIPTION
### Description

Remove `@awsuiSystem core` annotation from the default exports of icon-provider and navigable-group, making them available in console and external builds.

Neither component has gated props (no style API, no nativeAttributes) — this is a clean release with no partial gating needed.

### How has this been tested?

- Build passes (`npm run build`)
- Documenter snapshots updated (systemTags removed from both components)
- Lint passes

<details>
   <summary>Review checklist</summary>

#### Correctness

- _No documentation updates needed — component docs auto-filter via systemTags._
- _Changes are backward-compatible — additive only (components become available in more builds)._
- _No new browser features._
- _No accessibility changes — components are unchanged, just available in more builds._

#### Security

- _No URL handling changes._

#### Testing

- _Existing unit tests continue to pass._
- _Integration tests for these components are not currently gated (no test ungating needed)._
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.