### PR TITLE
fix: Testing pages without toolbar

### DIFF
--- a/pages/app-layout-toolbar/without-toolbar-nested.page.tsx
+++ b/pages/app-layout-toolbar/without-toolbar-nested.page.tsx
@@ -14,7 +14,7 @@ import appLayoutLabels from '../app-layout/utils/labels';
 import { IframeWrapper } from '../utils/iframe-wrapper';
 import ScreenshotArea from '../utils/screenshot-area';
 
-registerLeftDrawer({ ...leftDrawerPayload, defaultActive: true });
+registerLeftDrawer(leftDrawerPayload);
 
 type DemoContext = React.Context<
   AppContextType<{

--- a/pages/app-layout-toolbar/without-toolbar.page.tsx
+++ b/pages/app-layout-toolbar/without-toolbar.page.tsx
@@ -12,7 +12,7 @@ import { leftDrawerPayload } from '../app-layout/utils/external-global-left-pane
 import appLayoutLabels from '../app-layout/utils/labels';
 import ScreenshotArea from '../utils/screenshot-area';
 
-registerLeftDrawer({ ...leftDrawerPayload, defaultActive: true });
+registerLeftDrawer(leftDrawerPayload);
 
 export default function WithDrawers() {
   const [activeDrawerId, setActiveDrawerId] = useState<string | null>(null);


### PR DESCRIPTION
### Description

Removed `defaultActive: true` for the left panel in testing pages `app-layout-toolbar/without-toolbar(-nested)?`, as it breaks existing testing pages.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
