### PR TITLE
fix: Update deprecated code editor test util documentation

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -38230,7 +38230,7 @@ Returns the current value of the input.",
           },
         },
         {
-          "description": "Sets the value of the component and calls the \`onChange\` handler",
+          "description": "Sets the value of the component and calls the \`onDelayedChange\` handler",
           "name": "setValue",
           "parameters": [
             {

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -196,11 +196,20 @@ describe('Code editor component', () => {
   });
 
   it('sets value with test-util', () => {
+    jest.useFakeTimers();
     const ace = jest.requireActual('ace-builds');
     const { wrapper } = renderCodeEditor({ ace, value: 'value-initial' });
     expect(defaultProps.onChange).not.toHaveBeenCalled();
+    expect(defaultProps.onDelayedChange).not.toHaveBeenCalled();
     act(() => wrapper.setValue('value-final'));
     expect(defaultProps.onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { value: 'value-final' } }));
+    act(() => {
+      jest.advanceTimersByTime(1); // Minimal delay to let onDelayedChange fire
+    });
+    expect(defaultProps.onDelayedChange).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { value: 'value-final' } })
+    );
+    jest.useRealTimers();
   });
 
   it('fails silently while setting value on loading or error state', () => {

--- a/src/code-editor/__tests__/util.tsx
+++ b/src/code-editor/__tests__/util.tsx
@@ -74,6 +74,7 @@ export const defaultProps: CodeEditorProps = {
   value: 'const pi = 3.14;',
   language: 'javascript',
   onChange: jest.fn(),
+  onDelayedChange: jest.fn(),
   onValidate: jest.fn(),
   onPreferencesChange: jest.fn(),
   onRecoveryClick: jest.fn(),

--- a/src/test-utils/dom/code-editor/index.ts
+++ b/src/test-utils/dom/code-editor/index.ts
@@ -47,7 +47,7 @@ export default class CodeEditorWrapper extends ComponentWrapper {
   }
 
   /**
-   * Sets the value of the component and calls the `onChange` handler
+   * Sets the value of the component and calls the `onDelayedChange` handler
    *
    * @param value The value the input is set to.
    */


### PR DESCRIPTION
### Description

Updated test util doc to refer to `onDelayedChange` instead of deprecated `onChange`

Ticket: `D461825569`

### How has this been tested?

Updated tests to cover `onDelayedChange` actually being called.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
