### PR TITLE
test: Update analytics metadata tests for description extraction

### DIFF
--- a/src/button/__tests__/analytics-metadata.test.tsx
+++ b/src/button/__tests__/analytics-metadata.test.tsx
@@ -21,7 +21,7 @@ function renderButton(props: ButtonProps = {}) {
   return createWrapper(renderResult.container).findButton()!;
 }
 
-const getMetadata = (label: string, variant: string, disabled?: boolean) => {
+const getMetadata = (label: string, variant: string, disabled?: boolean, description?: string) => {
   const metadata: GeneratedAnalyticsMetadataFragment = {
     contexts: [
       {
@@ -29,6 +29,7 @@ const getMetadata = (label: string, variant: string, disabled?: boolean) => {
         detail: {
           name: 'awsui.Button',
           label,
+          ...(description ? { description } : {}),
           properties: {
             variant,
             disabled: disabled ? 'true' : 'false',
@@ -62,7 +63,7 @@ describe('Button renders correct analytics metadata', () => {
     const wrapper = renderButton({ children: 'inline button text', disabled: true, disabledReason: 'reason' });
     validateComponentNameAndLabels(wrapper.getElement(), labels);
     expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual(
-      getMetadata('inline button text', 'normal', true)
+      getMetadata('inline button text', 'normal', true, 'reason')
     );
   });
   test('when it has text content and aria label', () => {

--- a/src/flashbar/__tests__/analytics-metadata.test.tsx
+++ b/src/flashbar/__tests__/analytics-metadata.test.tsx
@@ -77,6 +77,7 @@ const getMetadata = (itemPosition?: number, stackItems = false, expanded?: boole
         detail: {
           name: 'awsui.Flashbar',
           label: 'Notifications',
+          ...(stackItems && itemsCount > 0 ? { description: 'Notifications bar11110' } : {}),
           properties: {
             stackItems: `${!!stackItems}`,
             itemsCount: `${itemsCount}`,


### PR DESCRIPTION
### Description

Update button and flashbar analytics metadata tests to account for the new `description` field extracted via `aria-describedby` from component-toolkit PR #220.

- **Button**: `disabledReason` is now surfaced as `description` in component metadata
- **Flashbar**: collapsible (stackItems=true) list's `aria-describedby` pointing to the item counter is now extracted as `description`

Related links, issue #, if available: https://github.com/cloudscape-design/component-toolkit/pull/220

### How has this been tested?

All 37 analytics-metadata test suites pass (286 tests).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes are test-only, no production code affected._

#### Security

- _N/A — test changes only._

</details>