### PR TITLE
fix: Prevent focus from being lost when pagination previous/next buttons are disabled

### DIFF
--- a/pages/pagination/simple.page.tsx
+++ b/pages/pagination/simple.page.tsx
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import I18nProvider from '~components/i18n';
+import messages from '~components/i18n/messages/all.en';
+import Pagination, { PaginationProps } from '~components/pagination';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+const paginationLabels: PaginationProps.Labels = {
+  nextPageLabel: 'Next page',
+  previousPageLabel: 'Previous page',
+  pageLabel: pageNumber => `Page ${pageNumber} of all pages`,
+  jumpToPageButton: 'Go to page',
+};
+
+const i18nStrings: PaginationProps.I18nStrings = {
+  jumpToPageInputLabel: 'Page number',
+  jumpToPageError: 'Enter a valid page number',
+  jumpToPageLoadingText: 'Loading page',
+};
+
+export default function PaginationSimplePage() {
+  const [basicPageIndex, setBasicPageIndex] = useState(1);
+  const [jumpPageIndex, setJumpPageIndex] = useState(1);
+
+  return (
+    <I18nProvider messages={[messages]} locale="en">
+      <h1>Pagination simple</h1>
+      <ScreenshotArea>
+        <h2>Basic pagination with 20 pages</h2>
+        <Pagination
+          currentPageIndex={basicPageIndex}
+          pagesCount={20}
+          ariaLabels={paginationLabels}
+          onChange={event => setBasicPageIndex(event.detail.currentPageIndex)}
+        />
+
+        <h2>Basic pagination with jump to page</h2>
+        <Pagination
+          currentPageIndex={jumpPageIndex}
+          pagesCount={20}
+          ariaLabels={paginationLabels}
+          i18nStrings={i18nStrings}
+          jumpToPage={{}}
+          onChange={event => setJumpPageIndex(event.detail.currentPageIndex)}
+        />
+      </ScreenshotArea>
+    </I18nProvider>
+  );
+}

--- a/src/pagination/__tests__/pagination.test.tsx
+++ b/src/pagination/__tests__/pagination.test.tsx
@@ -47,24 +47,24 @@ test('should re-render component correctly after current page state change', () 
 
 test('should have both arrows disabled when there is only one page', () => {
   const { wrapper } = renderPagination(<Pagination currentPageIndex={1} pagesCount={1} />);
-  expect(wrapper.findPreviousPageButton().getElement()).toBeDisabled();
-  expect(wrapper.findNextPageButton().getElement()).toBeDisabled();
+  expect(wrapper.findPreviousPageButton().getElement()).toHaveAttribute('aria-disabled', 'true');
+  expect(wrapper.findNextPageButton().getElement()).toHaveAttribute('aria-disabled', 'true');
   expect(wrapper.findPageNumberByIndex(1)!.getElement()).toHaveTextContent('1');
   expect(getItemsContent(wrapper)).toEqual(['1']);
 });
 
 test('should have both arrows disabled when there are no pages', () => {
   const { wrapper } = renderPagination(<Pagination currentPageIndex={1} pagesCount={0} />);
-  expect(wrapper.findPreviousPageButton().getElement()).toBeDisabled();
-  expect(wrapper.findNextPageButton().getElement()).toBeDisabled();
+  expect(wrapper.findPreviousPageButton().getElement()).toHaveAttribute('aria-disabled', 'true');
+  expect(wrapper.findNextPageButton().getElement()).toHaveAttribute('aria-disabled', 'true');
   expect(wrapper.findPageNumberByIndex(1)!.getElement()).toHaveTextContent('1');
   expect(getItemsContent(wrapper)).toEqual(['1']);
 });
 
 test('should show all buttons when middle page selected', () => {
   const { wrapper } = renderPagination(<Pagination currentPageIndex={5} pagesCount={9} />);
-  expect(wrapper.findPreviousPageButton().getElement()).toBeEnabled();
-  expect(wrapper.findNextPageButton().getElement()).toBeEnabled();
+  expect(wrapper.findPreviousPageButton().getElement()).not.toHaveAttribute('aria-disabled');
+  expect(wrapper.findNextPageButton().getElement()).not.toHaveAttribute('aria-disabled');
   expect(wrapper.findCurrentPage().getElement()).toHaveTextContent('5');
   expect(getItemsContent(wrapper)).toEqual(['1', '2', '3', '4', '5', '6', '7', '8', '9']);
 });
@@ -86,8 +86,8 @@ test('should not fire nextPageClick event when clicking next page with the last 
     test('should disable `previous` button when first page selected', () => {
       const { wrapper } = renderPagination(<Pagination currentPageIndex={1} pagesCount={10} openEnd={openEnd} />);
 
-      expect(wrapper.findPreviousPageButton().getElement()).toBeDisabled();
-      expect(wrapper.findNextPageButton().getElement()).toBeEnabled();
+      expect(wrapper.findPreviousPageButton().getElement()).toHaveAttribute('aria-disabled', 'true');
+      expect(wrapper.findNextPageButton().getElement()).not.toHaveAttribute('aria-disabled');
       expect(wrapper.findCurrentPage().getElement()).toHaveTextContent('1');
     });
 
@@ -189,8 +189,8 @@ test('should not fire nextPageClick event when clicking next page with the last 
       );
 
       expect(wrapper.isDisabled()).toBe(true);
-      expect(wrapper.findPreviousPageButton().getElement()).toBeDisabled();
-      expect(wrapper.findNextPageButton().getElement()).toBeDisabled();
+      expect(wrapper.findPreviousPageButton().getElement()).toHaveAttribute('aria-disabled', 'true');
+      expect(wrapper.findNextPageButton().getElement()).toHaveAttribute('aria-disabled', 'true');
 
       wrapper.findPreviousPageButton().click();
       expect(onChange).not.toHaveBeenCalled();

--- a/src/pagination/internal.tsx
+++ b/src/pagination/internal.tsx
@@ -47,6 +47,9 @@ function PageButton({
   ...rest
 }: PageButtonProps) {
   function handleClick(event: React.MouseEvent) {
+    if (disabled) {
+      return;
+    }
     event.preventDefault();
     onClick(pageIndex);
   }
@@ -61,7 +64,8 @@ function PageButton({
         )}
         type="button"
         aria-label={ariaLabel}
-        disabled={disabled}
+        aria-disabled={disabled}
+        tabIndex={disabled ? -1 : 0}
         onClick={handleClick}
         aria-current={isCurrent}
         {...(disabled

--- a/src/pagination/internal.tsx
+++ b/src/pagination/internal.tsx
@@ -64,7 +64,7 @@ function PageButton({
         )}
         type="button"
         aria-label={ariaLabel}
-        aria-disabled={disabled}
+        aria-disabled={disabled ? true : undefined}
         tabIndex={disabled ? -1 : 0}
         onClick={handleClick}
         aria-current={isCurrent}

--- a/src/table/__tests__/hooks-integration.test.tsx
+++ b/src/table/__tests__/hooks-integration.test.tsx
@@ -82,10 +82,10 @@ test('should apply filtering and display no-match state', () => {
 test('should navigate through pagination', () => {
   const { tableWrapper, paginationWrapper } = renderDemo(<Demo />);
   expect(tableWrapper.findBodyCell(1, 1)!.getElement().textContent).toEqual('1');
-  expect(paginationWrapper.findPreviousPageButton().getElement()).toBeDisabled();
+  expect(paginationWrapper.findPreviousPageButton().getElement()).toHaveAttribute('aria-disabled', 'true');
   paginationWrapper.findNextPageButton().click();
   expect(tableWrapper.findBodyCell(1, 1)!.getElement().textContent).toEqual('11');
-  expect(paginationWrapper.findPreviousPageButton().getElement()).toBeEnabled();
+  expect(paginationWrapper.findPreviousPageButton().getElement()).not.toHaveAttribute('aria-disabled');
   paginationWrapper.findPageNumberByIndex(4)!.click();
   expect(tableWrapper.findBodyCell(1, 1)!.getElement().textContent).toEqual('31');
 });
@@ -95,7 +95,7 @@ test('pagination should work when filtering is applied', () => {
   expect(tableWrapper.findBodyCell(1, 1)!.getElement().textContent).toEqual('1');
   expect(paginationWrapper.findPageNumbers()).toHaveLength(2);
   paginationWrapper.findNextPageButton().click();
-  expect(paginationWrapper.findNextPageButton().getElement()).toBeDisabled();
+  expect(paginationWrapper.findNextPageButton().getElement()).toHaveAttribute('aria-disabled', 'true');
   expect(tableWrapper.findBodyCell(1, 1)!.getElement().textContent).toEqual('19');
 });
 


### PR DESCRIPTION
### Description

The pagination left/right buttons disable themselves when there's no previous or next page after the current page. But this could happen while you're still focused on the left/right navigation buttons, so when you hit the first/last page, the focus could get kicked out while you're still on the button.

Related links, issue #, if available: D460257192

### How has this been tested?

Updated unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
