### PR TITLE
feat: property filter custom operator support

### DIFF
--- a/pages/property-filter/property-filter-custom-operator.page.tsx
+++ b/pages/property-filter/property-filter-custom-operator.page.tsx
@@ -1,0 +1,205 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { useCollection } from '@cloudscape-design/collection-hooks';
+
+import { I18nProvider } from '~components/i18n';
+import messages from '~components/i18n/messages/all.en';
+import PropertyFilter from '~components/property-filter';
+import { PropertyFilterProps } from '~components/property-filter/interfaces';
+
+interface Item {
+  name: string;
+  env: string;
+  owner: string;
+  created: string;
+  priority: number;
+}
+
+const allItems: Item[] = [
+  { name: 'app-web-prod', env: 'production', owner: 'alice', created: '2025-01-15', priority: 1 },
+  { name: 'app-api-prod', env: 'production', owner: 'bob', created: '2025-03-20', priority: 2 },
+  { name: 'app-worker-staging', env: 'staging', owner: 'alice', created: '2025-06-01', priority: 3 },
+  { name: 'app-web-dev', env: 'development', owner: 'charlie', created: '2025-08-10', priority: 1 },
+  { name: 'svc-auth-prod', env: 'production', owner: 'bob', created: '2024-11-05', priority: 2 },
+  { name: 'svc-data-staging', env: 'staging', owner: 'charlie', created: '2025-02-28', priority: 3 },
+];
+
+const filteringProperties: PropertyFilterProps.FilteringProperty[] = [
+  // Demo 1: Custom symbolic operators (~, !~)
+  {
+    key: 'name',
+    propertyLabel: 'Name',
+    groupValuesLabel: 'Name values',
+    operators: [
+      '=',
+      '!=',
+      ':',
+      '!:',
+      {
+        operator: '~',
+        match: (itemValue: unknown, tokenValue: unknown) => {
+          try {
+            return new RegExp(String(tokenValue)).test(String(itemValue));
+          } catch {
+            return String(itemValue).toLowerCase().includes(String(tokenValue).toLowerCase());
+          }
+        },
+        description: 'Matches regular expression',
+      },
+      {
+        operator: '!~',
+        match: (itemValue: unknown, tokenValue: unknown) => {
+          try {
+            return !new RegExp(String(tokenValue)).test(String(itemValue));
+          } catch {
+            return !String(itemValue).toLowerCase().includes(String(tokenValue).toLowerCase());
+          }
+        },
+        description: 'Does not match regular expression',
+      },
+    ],
+  },
+  // Demo 2: Description override on predefined operators (> = "After", < = "Before")
+  {
+    key: 'created',
+    propertyLabel: 'Created',
+    groupValuesLabel: 'Created values',
+    operators: [
+      { operator: '=', description: 'On' },
+      { operator: '>', description: 'After', match: 'date' as const },
+      { operator: '<', description: 'Before', match: 'date' as const },
+      { operator: '>=', description: 'On or after', match: 'date' as const },
+      { operator: '<=', description: 'On or before', match: 'date' as const },
+    ],
+  },
+  // Demo 3: Text-based operators (in, NOT IN)
+  {
+    key: 'env',
+    propertyLabel: 'Environment',
+    groupValuesLabel: 'Environment values',
+    operators: [
+      '=',
+      '!=',
+      {
+        operator: 'in',
+        match: (itemValue: unknown, tokenValue: unknown) => {
+          const values = String(tokenValue)
+            .split(',')
+            .map(v => v.trim().toLowerCase());
+          return values.includes(String(itemValue).toLowerCase());
+        },
+        description: 'Is one of',
+      },
+      {
+        operator: 'NOT IN',
+        match: (itemValue: unknown, tokenValue: unknown) => {
+          const values = String(tokenValue)
+            .split(',')
+            .map(v => v.trim().toLowerCase());
+          return !values.includes(String(itemValue).toLowerCase());
+        },
+        description: 'Is not one of',
+      },
+    ],
+  },
+  {
+    key: 'owner',
+    propertyLabel: 'Owner',
+    groupValuesLabel: 'Owner values',
+    operators: ['=', '!='],
+  },
+  {
+    key: 'priority',
+    propertyLabel: 'Priority',
+    groupValuesLabel: 'Priority values',
+    operators: ['=', '!=', '>', '<', '>=', '<='],
+  },
+];
+
+const filteringOptions: PropertyFilterProps.FilteringOption[] = [...new Set(allItems.map(i => i.name))]
+  .map(v => ({ propertyKey: 'name', value: v }))
+  .concat([...new Set(allItems.map(i => i.env))].map(v => ({ propertyKey: 'env', value: v })))
+  .concat([...new Set(allItems.map(i => i.owner))].map(v => ({ propertyKey: 'owner', value: v })))
+  .concat([...new Set(allItems.map(i => String(i.priority)))].map(v => ({ propertyKey: 'priority', value: v })));
+
+export default function CustomOperatorDemo() {
+  const { items, propertyFilterProps } = useCollection(allItems, {
+    propertyFiltering: {
+      filteringProperties,
+    },
+  });
+
+  return (
+    <I18nProvider locale="en" messages={[messages]}>
+      <div style={{ padding: 20 }}>
+        <h1>Property Filter — Custom Operator Demo</h1>
+
+        <PropertyFilter
+          {...propertyFilterProps}
+          filteringOptions={filteringOptions}
+          freeTextFiltering={{ operators: [':', '!:', '~', 'in'] }}
+          i18nStrings={{
+            filteringAriaLabel: 'Filter instances',
+            dismissAriaLabel: 'Dismiss',
+            filteringPlaceholder: 'Filter instances',
+            groupValuesText: 'Values',
+            groupPropertiesText: 'Properties',
+            operatorsText: 'Operators',
+            operationAndText: 'and',
+            operationOrText: 'or',
+            operatorLessText: 'Less than',
+            operatorLessOrEqualText: 'Less than or equal',
+            operatorGreaterText: 'Greater than',
+            operatorGreaterOrEqualText: 'Greater than or equal',
+            operatorContainsText: 'Contains',
+            operatorDoesNotContainText: 'Does not contain',
+            operatorEqualsText: 'Equals',
+            operatorDoesNotEqualText: 'Does not equal',
+            operatorStartsWithText: 'Starts with',
+            operatorDoesNotStartWithText: 'Does not start with',
+            editTokenHeader: 'Edit filter',
+            propertyText: 'Property',
+            operatorText: 'Operator',
+            valueText: 'Value',
+            cancelActionText: 'Cancel',
+            applyActionText: 'Apply',
+            clearFiltersText: 'Clear filters',
+            removeTokenButtonAriaLabel: token =>
+              `Remove filter, ${token.propertyLabel} ${token.operator} ${token.value}`,
+            enteredTextLabel: text => `Use: "${text}"`,
+          }}
+        />
+
+        <h2>
+          Filtered items ({items.length} / {allItems.length})
+        </h2>
+        <h3>Current query</h3>
+        <pre>{JSON.stringify(propertyFilterProps.query, null, 2)}</pre>
+        <table style={{ borderCollapse: 'collapse', width: '100%', marginTop: 8 }}>
+          <thead>
+            <tr>
+              <th style={{ border: '1px solid #ccc', padding: 8, textAlign: 'left' }}>Name</th>
+              <th style={{ border: '1px solid #ccc', padding: 8, textAlign: 'left' }}>Environment</th>
+              <th style={{ border: '1px solid #ccc', padding: 8, textAlign: 'left' }}>Owner</th>
+              <th style={{ border: '1px solid #ccc', padding: 8, textAlign: 'left' }}>Created</th>
+              <th style={{ border: '1px solid #ccc', padding: 8, textAlign: 'left' }}>Priority</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item, i) => (
+              <tr key={i}>
+                <td style={{ border: '1px solid #ccc', padding: 8 }}>{item.name}</td>
+                <td style={{ border: '1px solid #ccc', padding: 8 }}>{item.env}</td>
+                <td style={{ border: '1px solid #ccc', padding: 8 }}>{item.owner}</td>
+                <td style={{ border: '1px solid #ccc', padding: 8 }}>{item.created}</td>
+                <td style={{ border: '1px solid #ccc', padding: 8 }}>{item.priority}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </I18nProvider>
+  );
+}

--- a/pages/property-filter/property-filter-editor-permutations.page.tsx
+++ b/pages/property-filter/property-filter-editor-permutations.page.tsx
@@ -35,6 +35,7 @@ const nameProperty: InternalFilteringProperty = {
   getTokenType: () => 'value',
   getValueFormatter: () => null,
   getValueFormRenderer: () => null,
+  getOperatorDescription: () => null,
   externalProperty,
 };
 
@@ -47,6 +48,7 @@ const stateProperty: InternalFilteringProperty = {
   getTokenType: () => 'enum',
   getValueFormatter: () => null,
   getValueFormRenderer: () => null,
+  getOperatorDescription: () => null,
   externalProperty,
 };
 
@@ -65,6 +67,7 @@ const dateProperty: InternalFilteringProperty = {
         <DatePicker value={value ? format(value, 'yyyy-MM-dd') : ''} openCalendarAriaLabel={openCalendarAriaLabel} />
       </FormField>
     ),
+  getOperatorDescription: () => null,
   externalProperty,
 };
 
@@ -88,6 +91,7 @@ const dateTimeProperty: InternalFilteringProperty = {
         </FormField>
       </div>
     ),
+  getOperatorDescription: () => null,
   externalProperty,
 };
 

--- a/src/property-filter/__tests__/common.tsx
+++ b/src/property-filter/__tests__/common.tsx
@@ -146,7 +146,7 @@ export function toInternalProperties(properties: FilteringProperty[]): InternalF
       getValueFormatter: () => null,
       getValueFormRenderer: () => null,
       getOperatorDescription: (operator?: string) =>
-        operator ? extendedOperators.get(operator)?.description ?? null : null,
+        operator ? (extendedOperators.get(operator)?.description ?? null) : null,
       externalProperty: property,
     };
   });

--- a/src/property-filter/__tests__/common.tsx
+++ b/src/property-filter/__tests__/common.tsx
@@ -123,18 +123,33 @@ export const createDefaultProps = (
 });
 
 export function toInternalProperties(properties: FilteringProperty[]): InternalFilteringProperty[] {
-  return properties.map(property => ({
-    propertyKey: property.key,
-    propertyLabel: property.propertyLabel,
-    groupValuesLabel: property.groupValuesLabel,
-    propertyGroup: property.group,
-    operators: (property.operators ?? []).map(op => (typeof op === 'string' ? op : op.operator)),
-    defaultOperator: property.defaultOperator ?? '=',
-    getTokenType: () => 'value',
-    getValueFormatter: () => null,
-    getValueFormRenderer: () => null,
-    externalProperty: property,
-  }));
+  return properties.map(property => {
+    const ops = property.operators ?? [];
+    const operatorStrings: string[] = [];
+    const extendedOperators = new Map<string, any>();
+    for (const op of ops) {
+      if (typeof op === 'object') {
+        operatorStrings.push(op.operator);
+        extendedOperators.set(op.operator, op);
+      } else {
+        operatorStrings.push(op);
+      }
+    }
+    return {
+      propertyKey: property.key,
+      propertyLabel: property.propertyLabel,
+      groupValuesLabel: property.groupValuesLabel,
+      propertyGroup: property.group,
+      operators: operatorStrings,
+      defaultOperator: property.defaultOperator ?? '=',
+      getTokenType: () => 'value',
+      getValueFormatter: () => null,
+      getValueFormRenderer: () => null,
+      getOperatorDescription: (operator?: string) =>
+        operator ? extendedOperators.get(operator)?.description ?? null : null,
+      externalProperty: property,
+    };
+  });
 }
 
 export function StatefulPropertyFilter(props: PropertyFilterProps) {

--- a/src/property-filter/__tests__/property-filter-controller.test.ts
+++ b/src/property-filter/__tests__/property-filter-controller.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getAllowedOperators, getAutosuggestOptions, parseText } from '../controller';
+import { operatorToDescription } from '../i18n-utils';
 import { ComparisonOperator, FilteringProperty, GroupText } from '../interfaces';
 import { InternalFilteringProperty, InternalFreeTextFiltering, ParsedText } from '../internal-interfaces';
 import { i18nStrings, toInternalProperties } from './common';
@@ -46,6 +47,20 @@ const filteringProperties = toInternalProperties([
     propertyLabel: 'custom column',
     defaultOperator: ':',
     groupValuesLabel: 'Custom column values',
+  },
+  // supports custom operator
+  {
+    key: 'custom-op',
+    propertyLabel: 'custom-op',
+    operators: ['=', { operator: '~', description: 'Matches regex' }],
+    groupValuesLabel: 'Custom op values',
+  },
+  // supports text-based custom operator
+  {
+    key: 'text-op',
+    propertyLabel: 'status',
+    operators: ['=', '!=', 'in' as ComparisonOperator, 'NOT IN' as ComparisonOperator],
+    groupValuesLabel: 'Status values',
   },
 ]);
 
@@ -99,8 +114,17 @@ describe('getAllowedOperators', () => {
       ['=', '!=', ':', '!:', '>=', '<=', '<', '>'],
     ],
     ['removes duplicates', getFilteringProperty(['=', { operator: '=' }]), ['=']],
-    ['removes unsupported', getFilteringProperty(['<>' as ComparisonOperator, '>', '=']), ['=', '>']],
+    [
+      'preserves custom operators after known ones',
+      getFilteringProperty(['<>' as ComparisonOperator, '>', '=']),
+      ['=', '>', '<>'],
+    ],
     ['adds default custom operator', getFilteringProperty(undefined, ':'), [':']],
+    [
+      'preserves custom operator with description',
+      getFilteringProperty([{ operator: '~', description: 'Matches regex' }]),
+      ['=', '~'],
+    ],
   ];
   test.each<TestCase>(cases)('%s', (__description, input, expected) => {
     expect(getAllowedOperators(input)).toEqual(expected);
@@ -235,6 +259,30 @@ describe('parseText', () => {
       defaultFreeTextFiltering,
       { step: 'operator', operatorPrefix: '', property: filteringProperties[0] },
     ],
+    [
+      'custom operator',
+      'custom-op~value',
+      defaultFreeTextFiltering,
+      { step: 'property', value: 'value', operator: '~', property: filteringProperties[6] },
+    ],
+    [
+      'text-based operator with space',
+      'status in active, pending',
+      defaultFreeTextFiltering,
+      { step: 'property', value: 'active, pending', operator: 'in', property: filteringProperties[7] },
+    ],
+    [
+      'text-based operator case-insensitive',
+      'status NOT IN active',
+      defaultFreeTextFiltering,
+      { step: 'property', value: 'active', operator: 'NOT IN', property: filteringProperties[7] },
+    ],
+    [
+      'text-based operator not matched when part of value',
+      'status =internal',
+      defaultFreeTextFiltering,
+      { step: 'property', value: 'internal', operator: '=', property: filteringProperties[7] },
+    ],
   ];
   test.each<TestCase>(cases)('%s', (__description, input, disableFreeTextFiltering, expected) => {
     expect(parseText(input, filteringProperties, disableFreeTextFiltering)).toEqual(expected);
@@ -253,6 +301,8 @@ describe('getAutosuggestOptions', () => {
         { label: 'default', value: 'default', keepOpenOnSelect: true },
         { label: 'string!=', value: 'string!=', keepOpenOnSelect: true },
         { label: 'custom column', value: 'custom column', keepOpenOnSelect: true },
+        { label: 'custom-op', value: 'custom-op', keepOpenOnSelect: true },
+        { label: 'status', value: 'status', keepOpenOnSelect: true },
       ],
     },
     { options: [{ label: 'range', value: 'range', keepOpenOnSelect: true }], label: 'Group properties' },
@@ -412,5 +462,95 @@ describe('getAutosuggestOptions', () => {
       i18nStrings
     );
     expect(actual).toEqual(expected);
+  });
+  test('returns custom operator with description in operator suggestions', () => {
+    const parsedText: ParsedText = {
+      step: 'operator',
+      operatorPrefix: '',
+      property: filteringProperties[6],
+    };
+    const actual = getAutosuggestOptions(
+      parsedText,
+      filteringProperties,
+      filteringOptions,
+      customGroupText,
+      i18nStrings
+    );
+    const operatorGroup = actual.options.find(group => group.label === 'Operators');
+    expect(operatorGroup?.options).toEqual([
+      { value: 'custom-op = ', label: 'custom-op =', description: 'Equals', keepOpenOnSelect: true },
+      { value: 'custom-op ~ ', label: 'custom-op ~', description: 'Matches regex', keepOpenOnSelect: true },
+    ]);
+  });
+  test('custom description overrides built-in i18n for predefined operators', () => {
+    const overrideProperties = toInternalProperties([
+      {
+        key: 'date',
+        propertyLabel: 'date',
+        operators: [{ operator: '>', description: 'After' }, { operator: '<', description: 'Before' }, '='],
+        groupValuesLabel: 'Date values',
+      },
+    ]);
+    const parsedText: ParsedText = {
+      step: 'operator',
+      operatorPrefix: '',
+      property: overrideProperties[0],
+    };
+    const actual = getAutosuggestOptions(parsedText, overrideProperties, [], customGroupText, i18nStrings);
+    const operatorGroup = actual.options.find(group => group.label === 'Operators');
+    expect(operatorGroup?.options).toEqual([
+      { value: 'date = ', label: 'date =', description: 'Equals', keepOpenOnSelect: true },
+      { value: 'date < ', label: 'date <', description: 'Before', keepOpenOnSelect: true },
+      { value: 'date > ', label: 'date >', description: 'After', keepOpenOnSelect: true },
+    ]);
+  });
+});
+
+describe('operatorToDescription', () => {
+  test('returns built-in i18n for known operators without custom description', () => {
+    const property = toInternalProperties([
+      { key: 'k', propertyLabel: 'k', operators: ['=', '>'], groupValuesLabel: '' },
+    ])[0];
+    expect(operatorToDescription('=', i18nStrings, property)).toBe('Equals');
+    expect(operatorToDescription('>', i18nStrings, property)).toBe('Greater than');
+  });
+  test('custom description overrides built-in i18n for known operators', () => {
+    const property = toInternalProperties([
+      {
+        key: 'k',
+        propertyLabel: 'k',
+        operators: [
+          { operator: '=', description: 'Exactly matches' },
+          { operator: '>', description: 'After' },
+        ],
+        groupValuesLabel: '',
+      },
+    ])[0];
+    expect(operatorToDescription('=', i18nStrings, property)).toBe('Exactly matches');
+    expect(operatorToDescription('>', i18nStrings, property)).toBe('After');
+  });
+  test('returns custom description for unknown operators', () => {
+    const property = toInternalProperties([
+      {
+        key: 'k',
+        propertyLabel: 'k',
+        operators: [{ operator: '~', description: 'Matches regex' }],
+        groupValuesLabel: '',
+      },
+    ])[0];
+    expect(operatorToDescription('~', i18nStrings, property)).toBe('Matches regex');
+  });
+  test('returns empty string for unknown operators without description', () => {
+    const property = toInternalProperties([
+      { key: 'k', propertyLabel: 'k', operators: ['~' as ComparisonOperator], groupValuesLabel: '' },
+    ])[0];
+    expect(operatorToDescription('~', i18nStrings, property)).toBe('');
+  });
+  test('returns built-in i18n when no property is provided', () => {
+    expect(operatorToDescription('=', i18nStrings, undefined)).toBe('Equals');
+    expect(operatorToDescription(':', i18nStrings, undefined)).toBe('Contains');
+  });
+  test('returns empty string for unknown operator when no property is provided', () => {
+    expect(operatorToDescription('~', i18nStrings, undefined)).toBe('');
   });
 });

--- a/src/property-filter/__tests__/utils.test.ts
+++ b/src/property-filter/__tests__/utils.test.ts
@@ -21,7 +21,8 @@ const filteringProperties = toInternalProperties([
   },
 ]);
 
-const operators: ComparisonOperator[] = ['!:', ':', 'contains', 'does not contain'] as any;
+const operators = ['!:', ':', 'contains', 'does not contain'] as ComparisonOperator[];
+const textOperators = ['=', '!=', 'in', 'NOT IN', ':'] as ComparisonOperator[];
 
 describe('matchFilteringProperty', () => {
   test('should match property by label when filtering text equals to it', () => {
@@ -82,6 +83,30 @@ describe('matchOperator', () => {
   test('should not match operator when filtering text has leading space', () => {
     const operator = matchOperator(operators, ' :');
     expect(operator).toBe(null);
+  });
+  test('should not match text operator when followed by non-space character', () => {
+    const operator = matchOperator(textOperators, 'internal-server');
+    expect(operator).toBe(null);
+  });
+  test('should match text operator when followed by space', () => {
+    const operator = matchOperator(textOperators, 'in value1, value2');
+    expect(operator).toBe('in');
+  });
+  test('should match text operator when at end of string', () => {
+    const operator = matchOperator(textOperators, 'in');
+    expect(operator).toBe('in');
+  });
+  test('should match text operator case-insensitively', () => {
+    const operator = matchOperator(textOperators, 'not in value');
+    expect(operator).toBe('NOT IN');
+  });
+  test('should prefer longer text operator match', () => {
+    const operator = matchOperator(textOperators, 'NOT IN value');
+    expect(operator).toBe('NOT IN');
+  });
+  test('should still match symbolic operators without word boundary', () => {
+    const operator = matchOperator(textOperators, '!=value');
+    expect(operator).toBe('!=');
   });
 });
 

--- a/src/property-filter/controller.ts
+++ b/src/property-filter/controller.ts
@@ -91,20 +91,20 @@ export const getQueryActions = ({
 
 const knownOperatorOrder = ['=', '!=', ':', '!:', '^', '!^', '>=', '<=', '<', '>'] as const;
 
+function orderOperators(operatorSet: Set<ComparisonOperator>): ComparisonOperator[] {
+  const knownOperators = knownOperatorOrder.filter(op => operatorSet.has(op));
+  const customOperators = [...operatorSet].filter(op => !(knownOperatorOrder as readonly string[]).includes(op));
+  return [...knownOperators, ...customOperators];
+}
+
 export const getAllowedOperators = (property: InternalFilteringProperty): ComparisonOperator[] => {
   const { operators = [], defaultOperator } = property;
-  const operatorSet = new Set([defaultOperator, ...operators]);
-  const knownOperators = knownOperatorOrder.filter(op => operatorSet.has(op));
-  const customOperators = operators.filter(op => !(knownOperatorOrder as readonly string[]).includes(op));
-  return [...knownOperators, ...customOperators];
+  return orderOperators(new Set([defaultOperator, ...operators]));
 };
 
 export const getAllowedFreeTextOperators = (freeText: InternalFreeTextFiltering): ComparisonOperator[] => {
   const operators = freeText.operators.map(op => (typeof op === 'string' ? op : op.operator));
-  const operatorSet = new Set(operators);
-  const knownOperators = knownOperatorOrder.filter(op => operatorSet.has(op));
-  const customOperators = operators.filter(op => !(knownOperatorOrder as readonly string[]).includes(op));
-  return [...knownOperators, ...customOperators];
+  return orderOperators(new Set(operators));
 };
 
 /*

--- a/src/property-filter/controller.ts
+++ b/src/property-filter/controller.ts
@@ -89,17 +89,22 @@ export const getQueryActions = ({
   return { addToken, updateToken, updateOperation, removeToken, removeAllTokens };
 };
 
-const operatorOrder = ['=', '!=', ':', '!:', '^', '!^', '>=', '<=', '<', '>'] as const;
+const knownOperatorOrder = ['=', '!=', ':', '!:', '^', '!^', '>=', '<=', '<', '>'] as const;
 
 export const getAllowedOperators = (property: InternalFilteringProperty): ComparisonOperator[] => {
   const { operators = [], defaultOperator } = property;
   const operatorSet = new Set([defaultOperator, ...operators]);
-  return operatorOrder.filter(op => operatorSet.has(op));
+  const knownOperators = knownOperatorOrder.filter(op => operatorSet.has(op));
+  const customOperators = operators.filter(op => !(knownOperatorOrder as readonly string[]).includes(op));
+  return [...knownOperators, ...customOperators];
 };
 
 export const getAllowedFreeTextOperators = (freeText: InternalFreeTextFiltering): ComparisonOperator[] => {
-  const operatorSet = new Set(freeText.operators);
-  return operatorOrder.filter(op => operatorSet.has(op));
+  const operators = freeText.operators.map(op => (typeof op === 'string' ? op : op.operator));
+  const operatorSet = new Set(operators);
+  const knownOperators = knownOperatorOrder.filter(op => operatorSet.has(op));
+  const customOperators = operators.filter(op => !(knownOperatorOrder as readonly string[]).includes(op));
+  return [...knownOperators, ...customOperators];
 };
 
 /*
@@ -286,7 +291,7 @@ export const getAutosuggestOptions = (
             options: getAllowedOperators(parsedText.property).map(value => ({
               value: parsedText.property.propertyLabel + ' ' + value + ' ',
               label: parsedText.property.propertyLabel + ' ' + value,
-              description: operatorToDescription(value, i18nStrings),
+              description: operatorToDescription(value, i18nStrings, parsedText.property),
               keepOpenOnSelect: true,
             })),
             label: i18nStrings.operatorsText,

--- a/src/property-filter/i18n-utils.ts
+++ b/src/property-filter/i18n-utils.ts
@@ -3,7 +3,7 @@
 
 import { useInternalI18n } from '../i18n/context';
 import { ComparisonOperator, FormattedToken, I18nStrings } from './interfaces';
-import { InternalToken, InternalTokenGroup } from './internal-interfaces';
+import { InternalFilteringProperty, InternalToken, InternalTokenGroup } from './internal-interfaces';
 import { tokenGroupToTokens } from './utils';
 
 export type I18nStringsOperators = Pick<
@@ -113,7 +113,11 @@ export function usePropertyFilterI18n(def: I18nStrings = {}): I18nStringsInterna
     ),
     formatToken: token => {
       const formattedToken = toFormatted(token);
-      return { ...formattedToken, formattedText: formatToken(toFormatted(token)) };
+      const customDescription = token.property?.getOperatorDescription(token.operator);
+      const formattedForAria = customDescription
+        ? { ...formattedToken, operator: customDescription.toLowerCase() }
+        : formattedToken;
+      return { ...formattedToken, formattedText: formatToken(formattedForAria) };
     },
     groupAriaLabel: group => {
       const tokens = tokenGroupToTokens<InternalToken>(group.tokens).map(toFormatted);
@@ -188,7 +192,16 @@ export function usePropertyFilterI18n(def: I18nStrings = {}): I18nStringsInterna
   };
 }
 
-export function operatorToDescription(operator: ComparisonOperator, i18nStrings: I18nStringsOperators) {
+export function operatorToDescription(
+  operator: ComparisonOperator,
+  i18nStrings: I18nStringsOperators,
+  property?: InternalFilteringProperty
+) {
+  const customDescription = property?.getOperatorDescription(operator);
+  if (customDescription !== undefined) {
+    return customDescription;
+  }
+
   switch (operator) {
     case '<':
       return i18nStrings.operatorLessText;
@@ -210,8 +223,6 @@ export function operatorToDescription(operator: ComparisonOperator, i18nStrings:
       return i18nStrings.operatorStartsWithText;
     case '!^':
       return i18nStrings.operatorDoesNotStartWithText;
-    // The line is ignored from coverage because it is not reachable.
-    // The purpose of it is to prevent TS errors if ComparisonOperator type gets extended.
     /* istanbul ignore next */
     default:
       return '';

--- a/src/property-filter/i18n-utils.ts
+++ b/src/property-filter/i18n-utils.ts
@@ -198,7 +198,7 @@ export function operatorToDescription(
   property?: InternalFilteringProperty
 ) {
   const customDescription = property?.getOperatorDescription(operator);
-  if (customDescription !== undefined) {
+  if (customDescription) {
     return customDescription;
   }
 

--- a/src/property-filter/internal-interfaces.ts
+++ b/src/property-filter/internal-interfaces.ts
@@ -23,6 +23,7 @@ export interface InternalFilteringProperty<TokenValue = any> {
   getTokenType: (operator?: PropertyFilterOperator) => PropertyFilterTokenType;
   getValueFormatter: (operator?: PropertyFilterOperator) => null | ((value: any) => string);
   getValueFormRenderer: (operator?: PropertyFilterOperator) => null | PropertyFilterOperatorForm<TokenValue>;
+  getOperatorDescription: (operator?: PropertyFilterOperator) => string | null;
   // Original property used in callbacks.
   externalProperty: PropertyFilterProperty;
 }

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -144,7 +144,8 @@ const PropertyFilterInternal = React.forwardRef(
           getTokenType: operator => (operator ? (extendedOperators.get(operator)?.tokenType ?? 'value') : 'value'),
           getValueFormatter: operator => (operator ? (extendedOperators.get(operator)?.format ?? null) : null),
           getValueFormRenderer: operator => (operator ? (extendedOperators.get(operator)?.form ?? null) : null),
-          getOperatorDescription: operator => (operator ? extendedOperators.get(operator)?.description ?? null : null),
+          getOperatorDescription: operator =>
+            operator ? (extendedOperators.get(operator)?.description ?? null) : null,
           externalProperty: property,
         });
         return acc;

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -144,6 +144,7 @@ const PropertyFilterInternal = React.forwardRef(
           getTokenType: operator => (operator ? (extendedOperators.get(operator)?.tokenType ?? 'value') : 'value'),
           getValueFormatter: operator => (operator ? (extendedOperators.get(operator)?.format ?? null) : null),
           getValueFormRenderer: operator => (operator ? (extendedOperators.get(operator)?.form ?? null) : null),
+          getOperatorDescription: operator => (operator ? extendedOperators.get(operator)?.description ?? null : null),
           externalProperty: property,
         });
         return acc;

--- a/src/property-filter/token-editor-inputs.tsx
+++ b/src/property-filter/token-editor-inputs.tsx
@@ -85,6 +85,7 @@ interface OperatorInputProps {
   onChangeOperator: (operator: ComparisonOperator) => void;
   operator: undefined | ComparisonOperator;
   property: null | InternalFilteringProperty;
+  filteringProperties: readonly InternalFilteringProperty[];
   freeTextFiltering: InternalFreeTextFiltering;
   triggerVariant: 'option' | 'label';
 }
@@ -94,14 +95,24 @@ export function OperatorInput({
   operator,
   onChangeOperator,
   i18nStrings,
+  filteringProperties,
   freeTextFiltering,
   triggerVariant,
 }: OperatorInputProps) {
-  const operators = property ? getAllowedOperators(property) : getAllowedFreeTextOperators(freeTextFiltering);
-  const operatorOptions = operators.map(operator => ({
-    value: operator,
-    label: operator,
-    description: operatorToDescription(operator, i18nStrings),
+  const getDescription = (op: ComparisonOperator) => {
+    if (property) {
+      return operatorToDescription(op, i18nStrings, property);
+    }
+    const freeTextProperty = filteringProperties.find(prop => prop.getOperatorDescription(op) !== null);
+    return operatorToDescription(op, i18nStrings, freeTextProperty);
+  };
+
+  const operatorOptions = (
+    property ? getAllowedOperators(property) : getAllowedFreeTextOperators(freeTextFiltering)
+  ).map(op => ({
+    value: op,
+    label: op,
+    description: getDescription(op) ?? undefined,
   }));
   return (
     <InternalSelect
@@ -112,7 +123,7 @@ export function OperatorInput({
           ? {
               value: operator,
               label: operator,
-              description: operatorToDescription(operator, i18nStrings),
+              description: getDescription(operator) ?? undefined,
             }
           : null
       }

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -163,6 +163,7 @@ export function TokenEditor({
             operator={groups[index].operator}
             onChangeOperator={groups[index].onChangeOperator}
             i18nStrings={i18nStrings}
+            filteringProperties={filteringProperties}
             freeTextFiltering={freeTextFiltering}
             triggerVariant={supportsGroups ? 'label' : 'option'}
           />

--- a/src/property-filter/utils.ts
+++ b/src/property-filter/utils.ts
@@ -48,14 +48,23 @@ export function matchOperator(
   allowedOperators: readonly ComparisonOperator[],
   filteringText: string
 ): null | ComparisonOperator {
-  filteringText = filteringText.toLowerCase();
+  const lowerText = filteringText.toLowerCase();
 
   let maxLength = 0;
   let matchedOperator: null | ComparisonOperator = null;
 
   for (const operator of allowedOperators) {
-    if (operator.length > maxLength && startsWith(filteringText, operator.toLowerCase())) {
-      maxLength = operator.length;
+    const lowerOp = operator.toLowerCase();
+    if (lowerOp.length > maxLength && startsWith(lowerText, lowerOp)) {
+      // Text-based operators (containing letters) require a word boundary after the match
+      // to avoid matching the operator as a prefix of a value (e.g. "in" matching "internal").
+      if (/[a-zA-Z]/.test(operator)) {
+        const charAfter = lowerText[lowerOp.length];
+        if (charAfter !== undefined && charAfter !== ' ') {
+          continue;
+        }
+      }
+      maxLength = lowerOp.length;
       matchedOperator = operator;
     }
   }


### PR DESCRIPTION
  ### Description

  Adds end-to-end support for custom operators in the Property Filter component. Consumers can define their own operator strings with custom matching logic, display descriptions, and accessible labels.

  Key changes:
  - `getAllowedOperators` now preserves custom operators (appended after known operators in standard display order)
  - `getAllowedFreeTextOperators` updated to handle extended operator objects and preserve custom operators
  - `operatorToDescription` checks custom `description` before built-in i18n, allowing consumers to override predefined operator labels (e.g. `>` described as "After" for date properties)
  - `matchOperator` requires word boundary after text-based operators to prevent false matches (e.g. "in" not matching "internal")
  - Token editor resolves custom operator descriptions from filtering properties when in free-text mode
  - Added `getOperatorDescription` accessor to `InternalFilteringProperty`

  Depends on: https://github.com/cloudscape-design/collection-hooks/pull/151

  Related links, issue #, if available: n/a

  ### How has this been tested?

  - Unit tests for `operatorToDescription` (custom description override, fallback to i18n, unknown operators)
  - Unit tests for `getAllowedOperators` (custom operators preserved, ordering, duplicates)
  - Unit tests for `matchOperator` (text-based operator word boundary, case-insensitive matching, symbolic operators unaffected)
  - Unit tests for `parseText` (text-based operators with space, case-insensitive, no false match on value prefix)
  - Integration test for autosuggest options (custom description in dropdown, override of predefined operator descriptions)
  - Demo page at `/#/light/property-filter/property-filter-custom-operator` exercising all scenarios

  <details>
     <summary>Review checklist</summary>

  _The following items are to be evaluated by the author(s) and the reviewer(s)._

  #### Correctness

  - _Changes include appropriate documentation updates._
  - _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
  - _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
  - _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

  #### Security

  - _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

  #### Testing
  
  - _Changes are covered with new/existing unit tests?_
  - _Changes are covered with new/existing integration tests?_
  </details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
