### PR TITLE
fix: Allow skip-to navigation to adjacent step when current step is optional

### DIFF
--- a/src/wizard/__tests__/analytics-metadata.test.tsx
+++ b/src/wizard/__tests__/analytics-metadata.test.tsx
@@ -164,7 +164,15 @@ describe.each([true, false])('with visualrefresh=%s', isVR => {
       });
 
       const thirdLink = wrapper.findMenuNavigationLink(3)!.getElement();
-      expect(getGeneratedAnalyticsMetadata(thirdLink)).toEqual(getMetadata(1));
+      expect(getGeneratedAnalyticsMetadata(thirdLink)).toEqual({
+        action: 'navigate',
+        detail: {
+          label: 'Step 3',
+          reason: 'step',
+          targetStepIndex: '2',
+        },
+        ...getMetadata(1),
+      });
     });
     test('with analyticsMetadata', () => {
       const analyticsMetadata: WizardProps['analyticsMetadata'] = {

--- a/src/wizard/__tests__/wizard.test.tsx
+++ b/src/wizard/__tests__/wizard.test.tsx
@@ -364,6 +364,15 @@ describe('Navigation', () => {
       expect.objectContaining({ detail: { requestedStepIndex: 2, reason: 'step' } })
     );
   });
+
+  test('enables adjacent required step in navigation when current step is optional', () => {
+    const onNavigate = jest.fn();
+    const [wrapper] = renderDefaultWizard({ activeStepIndex: 1, onNavigate, allowSkipTo: true });
+    wrapper.findMenuNavigationLink(3)!.click();
+    expect(onNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { requestedStepIndex: 2, reason: 'skip' } })
+    );
+  });
 });
 
 describe('Form', () => {

--- a/src/wizard/wizard-step-list.tsx
+++ b/src/wizard/wizard-step-list.tsx
@@ -49,12 +49,12 @@ export function getStepStatus(
     return StepStatusValues.Visited;
   }
   if (allowSkipTo && index > activeStepIndex) {
-    // Can we skip to this step? (all steps between current and this one are optional)
+    // All steps between current and target are optional — can skip over them
     if (canSkip(activeStepIndex + 1, index, steps)) {
       return StepStatusValues.Next;
     }
-    // Immediate next step is also navigable if it's optional
-    if (index === activeStepIndex + 1 && steps[index]?.isOptional) {
+    // If either the current step or the next step is optional, we can navigate to it
+    if (index === activeStepIndex + 1 && (steps[index]?.isOptional || steps[activeStepIndex]?.isOptional)) {
       return StepStatusValues.Next;
     }
   }


### PR DESCRIPTION
### Description
Fixes an inconsistency in the wizard's allowSkipTo navigation where the immediately-next step was unreachable from an optional step, even though it was reachable from earlier steps. 

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: https://github.com/cloudscape-design/components/issues/4551, AWSUI-62034

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing
Unit test + Manual testing with a wizard where steps 2 and 3 are optional and step 4 is required. Verified step 4 is clickable from all preceding steps.
- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
