### PR TITLE
feat: Create colorBorderButtonGroupDivider design token

### DIFF
--- a/src/button-group/styles.scss
+++ b/src/button-group/styles.scss
@@ -23,7 +23,7 @@
 }
 
 .divider {
-  background-color: awsui.$color-border-divider-default;
+  background-color: awsui.$color-border-button-group-divider;
   inline-size: awsui.$border-divider-section-width;
   margin-block: awsui.$space-static-xs;
 }

--- a/style-dictionary/classic/colors.ts
+++ b/style-dictionary/classic/colors.ts
@@ -170,6 +170,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorIconActionCardHover: { light: '{colorPrimary900}', dark: '{colorPrimary300}' },
   colorIconActionCardActive: { light: '{colorPrimary900}', dark: '{colorPrimary300}' },
   colorIconActionCardDisabled: { light: '{colorNeutral400}', dark: '{colorNeutral600}' },
+  colorBorderButtonGroupDivider: '{colorBorderDividerDefault}',
 };
 
 const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = merge(

--- a/style-dictionary/utils/token-names.ts
+++ b/style-dictionary/utils/token-names.ts
@@ -655,6 +655,7 @@ export type ColorsTokenName =
   | 'colorBorderControlDefault'
   | 'colorBorderControlDisabled'
   | 'colorBorderDividerActive'
+  | 'colorBorderButtonGroupDivider'
   | 'colorBorderDividerDefault'
   | 'colorBorderDividerSecondary'
   | 'colorBorderDividerPanelBottom'
@@ -838,7 +839,8 @@ export type ColorsTokenName =
   | 'colorIconActionCardDefault'
   | 'colorIconActionCardHover'
   | 'colorIconActionCardActive'
-  | 'colorIconActionCardDisabled';
+  | 'colorIconActionCardDisabled'
+  | 'colorBorderButtonGroupDivider';
 export type TypographyTokenName =
   | 'fontBoxValueLargeWeight'
   | 'fontButtonLetterSpacing'

--- a/style-dictionary/visual-refresh/colors.ts
+++ b/style-dictionary/visual-refresh/colors.ts
@@ -337,6 +337,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorIconActionCardDisabled: { light: '{colorNeutral400}', dark: '{colorNeutral600}' },
   colorBackgroundSkeleton: { light: '{colorNeutral250}', dark: '{colorNeutral750}' },
   colorBackgroundSkeletonWave: { light: '{colorNeutral150}', dark: '{colorNeutral700}' },
+  colorBorderButtonGroupDivider: '{colorBorderDividerDefault}',
 };
 
 const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = expandColorDictionary(tokens);

--- a/style-dictionary/visual-refresh/metadata/colors.ts
+++ b/style-dictionary/visual-refresh/metadata/colors.ts
@@ -1109,6 +1109,11 @@ const metadata: StyleDictionary.MetadataIndex = {
     public: false,
     themeable: true,
   },
+  colorBorderButtonGroupDivider: {
+    description: 'The border color of the button group divider.',
+    public: true,
+    themeable: true,
+  },
 };
 
 export default metadata;


### PR DESCRIPTION
### Description
Creates a new design token for the divider in button group and makes it public + themeable.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
