### PR TITLE
feat: Make color-background-badge-icon token public and themeable

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
@@ -232,7 +232,7 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           },
         },
         "color-background-badge-icon": {
-          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$description": "The background color of the badge indicator on navigation and panel buttons.",
           "$value": {
             "dark": "#ff5d64",
             "light": "#d13212",
@@ -3623,7 +3623,7 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           },
         },
         "color-background-badge-icon": {
-          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$description": "The background color of the badge indicator on navigation and panel buttons.",
           "$value": {
             "dark": "#ff5d64",
             "light": "#d13212",
@@ -7014,7 +7014,7 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           },
         },
         "color-background-badge-icon": {
-          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$description": "The background color of the badge indicator on navigation and panel buttons.",
           "$value": {
             "dark": "#ff5d64",
             "light": "#d13212",
@@ -10405,7 +10405,7 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           },
         },
         "color-background-badge-icon": {
-          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$description": "The background color of the badge indicator on navigation and panel buttons.",
           "$value": {
             "dark": "#ff5d64",
             "light": "#d13212",
@@ -13796,7 +13796,7 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           },
         },
         "color-background-badge-icon": {
-          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$description": "The background color of the badge indicator on navigation and panel buttons.",
           "$value": {
             "dark": "#ff5d64",
             "light": "#d13212",
@@ -17187,7 +17187,7 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           },
         },
         "color-background-badge-icon": {
-          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$description": "The background color of the badge indicator on navigation and panel buttons.",
           "$value": {
             "dark": "#ff5d64",
             "light": "#ff5d64",
@@ -20578,7 +20578,7 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
       },
     },
     "color-background-badge-icon": {
-      "$description": "The background color of the badge indicator on icons and icon buttons.",
+      "$description": "The background color of the badge indicator on navigation and panel buttons.",
       "$value": {
         "dark": "#ff5d64",
         "light": "#d13212",
@@ -23974,7 +23974,7 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           },
         },
         "color-background-badge-icon": {
-          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$description": "The background color of the badge indicator on navigation and panel buttons.",
           "$value": {
             "dark": "#ff7a7a",
             "light": "#db0000",
@@ -27365,7 +27365,7 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           },
         },
         "color-background-badge-icon": {
-          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$description": "The background color of the badge indicator on navigation and panel buttons.",
           "$value": {
             "dark": "#ff7a7a",
             "light": "#ff7a7a",
@@ -30756,7 +30756,7 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           },
         },
         "color-background-badge-icon": {
-          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$description": "The background color of the badge indicator on navigation and panel buttons.",
           "$value": {
             "dark": "#ff7a7a",
             "light": "#db0000",
@@ -34147,7 +34147,7 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           },
         },
         "color-background-badge-icon": {
-          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$description": "The background color of the badge indicator on navigation and panel buttons.",
           "$value": {
             "dark": "#ff7a7a",
             "light": "#db0000",
@@ -37538,7 +37538,7 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           },
         },
         "color-background-badge-icon": {
-          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$description": "The background color of the badge indicator on navigation and panel buttons.",
           "$value": {
             "dark": "#ff7a7a",
             "light": "#db0000",
@@ -40929,7 +40929,7 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           },
         },
         "color-background-badge-icon": {
-          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$description": "The background color of the badge indicator on navigation and panel buttons.",
           "$value": {
             "dark": "#ff7a7a",
             "light": "#db0000",
@@ -44320,7 +44320,7 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           },
         },
         "color-background-badge-icon": {
-          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$description": "The background color of the badge indicator on navigation and panel buttons.",
           "$value": {
             "dark": "#ff7a7a",
             "light": "#ff7a7a",
@@ -47711,7 +47711,7 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           },
         },
         "color-background-badge-icon": {
-          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$description": "The background color of the badge indicator on navigation and panel buttons.",
           "$value": {
             "dark": "#ff7a7a",
             "light": "#ff7a7a",
@@ -51102,7 +51102,7 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
       },
     },
     "color-background-badge-icon": {
-      "$description": "The background color of the badge indicator on icons and icon buttons.",
+      "$description": "The background color of the badge indicator on navigation and panel buttons.",
       "$value": {
         "dark": "#ff7a7a",
         "light": "#db0000",

--- a/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
@@ -231,6 +231,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-badge-icon": {
+          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$value": {
+            "dark": "#ff5d64",
+            "light": "#d13212",
+          },
+        },
         "color-background-button-link-active": {
           "$description": "The background color of link buttons in active state.",
           "$value": {
@@ -3613,6 +3620,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
+          },
+        },
+        "color-background-badge-icon": {
+          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$value": {
+            "dark": "#ff5d64",
+            "light": "#d13212",
           },
         },
         "color-background-button-link-active": {
@@ -6999,6 +7013,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-badge-icon": {
+          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$value": {
+            "dark": "#ff5d64",
+            "light": "#d13212",
+          },
+        },
         "color-background-button-link-active": {
           "$description": "The background color of link buttons in active state.",
           "$value": {
@@ -10381,6 +10402,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
+          },
+        },
+        "color-background-badge-icon": {
+          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$value": {
+            "dark": "#ff5d64",
+            "light": "#d13212",
           },
         },
         "color-background-button-link-active": {
@@ -13767,6 +13795,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-badge-icon": {
+          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$value": {
+            "dark": "#ff5d64",
+            "light": "#d13212",
+          },
+        },
         "color-background-button-link-active": {
           "$description": "The background color of link buttons in active state.",
           "$value": {
@@ -17151,6 +17186,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-badge-icon": {
+          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$value": {
+            "dark": "#ff5d64",
+            "light": "#ff5d64",
+          },
+        },
         "color-background-button-link-active": {
           "$description": "The background color of link buttons in active state.",
           "$value": {
@@ -20533,6 +20575,13 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
       "$value": {
         "dark": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
         "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
+      },
+    },
+    "color-background-badge-icon": {
+      "$description": "The background color of the badge indicator on icons and icon buttons.",
+      "$value": {
+        "dark": "#ff5d64",
+        "light": "#d13212",
       },
     },
     "color-background-button-link-active": {
@@ -23924,6 +23973,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-badge-icon": {
+          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$value": {
+            "dark": "#ff7a7a",
+            "light": "#db0000",
+          },
+        },
         "color-background-button-link-active": {
           "$description": "The background color of link buttons in active state.",
           "$value": {
@@ -27306,6 +27362,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
+          },
+        },
+        "color-background-badge-icon": {
+          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$value": {
+            "dark": "#ff7a7a",
+            "light": "#ff7a7a",
           },
         },
         "color-background-button-link-active": {
@@ -30692,6 +30755,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-badge-icon": {
+          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$value": {
+            "dark": "#ff7a7a",
+            "light": "#db0000",
+          },
+        },
         "color-background-button-link-active": {
           "$description": "The background color of link buttons in active state.",
           "$value": {
@@ -34074,6 +34144,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
+          },
+        },
+        "color-background-badge-icon": {
+          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$value": {
+            "dark": "#ff7a7a",
+            "light": "#db0000",
           },
         },
         "color-background-button-link-active": {
@@ -37460,6 +37537,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-badge-icon": {
+          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$value": {
+            "dark": "#ff7a7a",
+            "light": "#db0000",
+          },
+        },
         "color-background-button-link-active": {
           "$description": "The background color of link buttons in active state.",
           "$value": {
@@ -40842,6 +40926,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
+          },
+        },
+        "color-background-badge-icon": {
+          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$value": {
+            "dark": "#ff7a7a",
+            "light": "#db0000",
           },
         },
         "color-background-button-link-active": {
@@ -44228,6 +44319,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-badge-icon": {
+          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$value": {
+            "dark": "#ff7a7a",
+            "light": "#ff7a7a",
+          },
+        },
         "color-background-button-link-active": {
           "$description": "The background color of link buttons in active state.",
           "$value": {
@@ -47612,6 +47710,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
           },
         },
+        "color-background-badge-icon": {
+          "$description": "The background color of the badge indicator on icons and icon buttons.",
+          "$value": {
+            "dark": "#ff7a7a",
+            "light": "#ff7a7a",
+          },
+        },
         "color-background-button-link-active": {
           "$description": "The background color of link buttons in active state.",
           "$value": {
@@ -50994,6 +51099,13 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
       "$value": {
         "dark": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
         "light": "radial-gradient(circle farthest-corner at top right, #b8e7ff 0%, #0099ff 25%, #5c7fff 40% , #8575ff 60%, #962eff 80%)",
+      },
+    },
+    "color-background-badge-icon": {
+      "$description": "The background color of the badge indicator on icons and icon buttons.",
+      "$value": {
+        "dark": "#ff7a7a",
+        "light": "#db0000",
       },
     },
     "color-background-button-link-active": {

--- a/style-dictionary/visual-refresh/metadata/colors.ts
+++ b/style-dictionary/visual-refresh/metadata/colors.ts
@@ -321,7 +321,7 @@ const metadata: StyleDictionary.MetadataIndex = {
     themeable: true,
   },
   colorBackgroundBadgeIcon: {
-    description: 'The background color of the badge indicator on icons and icon buttons.',
+    description: 'The background color of the badge indicator on navigation and panel buttons.',
     themeable: true,
     public: true,
   },

--- a/style-dictionary/visual-refresh/metadata/colors.ts
+++ b/style-dictionary/visual-refresh/metadata/colors.ts
@@ -320,6 +320,11 @@ const metadata: StyleDictionary.MetadataIndex = {
     public: true,
     themeable: true,
   },
+  colorBackgroundBadgeIcon: {
+    description: 'The background color of the badge indicator on icons and icon buttons.',
+    themeable: true,
+    public: true,
+  },
   colorBackgroundToggleCheckedDisabled: {
     description: 'The background color of checked toggles in disabled state.',
     themeable: true,


### PR DESCRIPTION
### Description

For core theme — the top navigation is going to be white, and the red dot doesn't meet contrast. So for the new theme to be applied, it needs to be themeable.

Related links, issue #, if available: D460257194

### How has this been tested?

Updated snapshots

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
