### PR TITLE
chore: Avoid using ResizeObserver in useWidthChange if not available

### DIFF
--- a/src/internal/hooks/use-width-change/index.ts
+++ b/src/internal/hooks/use-width-change/index.ts
@@ -18,7 +18,7 @@ export function useWidthChange(elementRef: React.RefObject<HTMLElement>, onWidth
 
   useEffect(() => {
     const node = elementRef.current;
-    if (!node) {
+    if (!node || typeof ResizeObserver === 'undefined') {
       return;
     }
     const observer = new ResizeObserver(() => {


### PR DESCRIPTION
### Description

Add safety condition to prevent the hook to crash in environments where the `ResizeObserver` API is not available.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
