### PR TITLE
chore: Implement one-theme icon

### DIFF
--- a/pages/tree-view/items/basic-page-items.tsx
+++ b/pages/tree-view/items/basic-page-items.tsx
@@ -6,11 +6,14 @@ import Badge from '~components/badge';
 import Popover from '~components/popover';
 import SpaceBetween from '~components/space-between';
 import StatusIndicator from '~components/status-indicator';
+import * as tokens from '~design-tokens';
 
 const progressiveStepContent = (
   <div style={{ display: 'flex' }}>
     <StatusIndicator type="warning">Checked 5 nodes</StatusIndicator>
-    <div style={{ borderLeft: '1px solid grey', marginLeft: '8px', marginRight: '8px' }} />
+    <div
+      style={{ borderLeft: `1px solid ${tokens.colorBorderDividerDefault}`, marginLeft: '8px', marginRight: '8px' }}
+    />
     <SpaceBetween direction="horizontal" size="s">
       <Popover content="There is an item with warning status" dismissButton={false} position="top">
         <StatusIndicator type="warning">1</StatusIndicator>

--- a/pages/tree-view/items/permutations-items.tsx
+++ b/pages/tree-view/items/permutations-items.tsx
@@ -7,6 +7,7 @@ import Box from '~components/box';
 import Icon from '~components/icon';
 import SpaceBetween from '~components/space-between';
 import StatusIndicator from '~components/status-indicator';
+import * as tokens from '~design-tokens';
 
 import { Actions } from '../common';
 
@@ -195,7 +196,9 @@ export const statusIndicatorItems: Item[] = [
     content: (
       <div style={{ display: 'flex' }}>
         <StatusIndicator type="warning">Checked 5 nodes</StatusIndicator>
-        <div style={{ borderLeft: '1px solid grey', marginLeft: '8px', marginRight: '8px' }} />
+        <div
+          style={{ borderLeft: `1px solid ${tokens.colorBorderDividerDefault}`, marginLeft: '8px', marginRight: '8px' }}
+        />
         <SpaceBetween direction="horizontal" size="s">
           <StatusIndicator type="success">1</StatusIndicator>
           <StatusIndicator type="in-progress">1</StatusIndicator>
@@ -252,7 +255,9 @@ export const statusIndicatorItems: Item[] = [
     content: (
       <div style={{ display: 'flex' }}>
         <StatusIndicator type="in-progress">Running automation</StatusIndicator>
-        <div style={{ borderLeft: '1px solid grey', marginLeft: '8px', marginRight: '8px' }} />
+        <div
+          style={{ borderLeft: `1px solid ${tokens.colorBorderDividerDefault}`, marginLeft: '8px', marginRight: '8px' }}
+        />
         <SpaceBetween direction="horizontal" size="s">
           <StatusIndicator type="error">1</StatusIndicator>
           <StatusIndicator type="in-progress">1</StatusIndicator>

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -3,13 +3,14 @@
 import React, { useEffect, useImperativeHandle, useRef } from 'react';
 import clsx from 'clsx';
 
-import { useUniqueId, warnOnce } from '@cloudscape-design/component-toolkit/internal';
+import { isThemeActive, Theme, useUniqueId, warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 import InternalBox from '../box/internal';
 import { ButtonProps } from '../button/interfaces';
 import { InternalButton, InternalButtonProps } from '../button/internal';
 import Dropdown from '../dropdown/internal';
+import { IconProps } from '../icon/interfaces';
 import { useFunnel } from '../internal/analytics/hooks/use-funnel.js';
 import { getBaseProps } from '../internal/base-component';
 import OptionsList from '../internal/components/options-list';
@@ -141,13 +142,14 @@ const InternalButtonDropdown = React.forwardRef(
     const canBeFullWidth = !!fullWidth && (variant === 'primary' || variant === 'normal');
 
     const triggerVariant = variant === 'navigation' ? undefined : variant === 'inline-icon' ? 'inline-icon' : variant;
-    const iconProps: Partial<ButtonProps & { __iconClass?: string }> =
+    const iconProps: Partial<ButtonProps & { __iconClass?: string; __iconSize?: IconProps.Size }> =
       variant === 'icon' || variant === 'inline-icon'
         ? {
             iconName: 'ellipsis',
           }
         : {
-            iconName: 'caret-down-filled',
+            iconName: isThemeActive(Theme.OneTheme) ? 'angle-down' : 'caret-down-filled',
+            __iconSize: isThemeActive(Theme.OneTheme) ? 'x-small' : 'normal',
             iconAlign: 'right',
             __iconClass: spinWhenOpen(styles, 'rotate', canBeOpened && isOpen),
           };

--- a/src/button-dropdown/styles.scss
+++ b/src/button-dropdown/styles.scss
@@ -50,6 +50,8 @@ $dropdown-trigger-icon-offset: 2px;
 }
 
 .trigger-button {
+  display: flex;
+  align-items: center;
   &.full-width {
     display: grid;
     grid-template-columns: 1fr auto;

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -11,6 +11,7 @@ import {
 } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 import { useInternalI18n } from '../i18n/context';
+import { IconProps } from '../icon/interfaces';
 import Icon from '../icon/internal';
 import { FunnelMetrics } from '../internal/analytics';
 import { useFunnel, useFunnelStep, useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
@@ -51,6 +52,7 @@ export type InternalButtonProps = Omit<ButtonProps, 'variant'> & {
   badge?: boolean;
   analyticsAction?: string;
   __iconClass?: string;
+  __iconSize?: IconProps.Size;
   __focusable?: boolean;
   __injectAnalyticsComponentMetadata?: boolean;
   __title?: string;
@@ -64,6 +66,7 @@ export const InternalButton = React.forwardRef(
       children,
       iconName,
       __iconClass,
+      __iconSize,
       onClick,
       onFollow,
       iconAlign = 'left',
@@ -237,7 +240,7 @@ export const InternalButton = React.forwardRef(
       variant,
       badge,
       iconClass: __iconClass,
-      iconSize: variant === 'modal-dismiss' ? 'medium' : 'normal',
+      iconSize: __iconSize ?? (variant === 'modal-dismiss' ? 'medium' : 'normal'),
     };
     const buttonContent = (
       <>

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -3,7 +3,7 @@
 import React, { KeyboardEventHandler, MouseEventHandler, ReactNode } from 'react';
 import clsx from 'clsx';
 
-import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+import { isThemeActive, Theme, warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 import InternalHeader, { Description as HeaderDescription } from '../header/internal';
@@ -108,7 +108,15 @@ const ExpandableDeprecatedHeader = ({
       aria-expanded={expanded}
       {...getExpandActionAnalyticsMetadataAttribute(expanded)}
     >
-      <div className={clsx(styles['icon-container'], styles[`icon-container-${variant}`])}>{icon}</div>
+      <div
+        className={clsx(
+          styles['icon-container'],
+          styles[`icon-container-${variant}`],
+          isThemeActive(Theme.OneTheme) && styles['one-theme']
+        )}
+      >
+        {icon}
+      </div>
       {children}
     </div>
   );
@@ -201,7 +209,15 @@ const ExpandableHeaderTextWrapper = ({
       {...headerButtonListeners}
       {...(headerButtonListeners ? getExpandActionAnalyticsMetadataAttribute(expanded) : {})}
     >
-      <span className={clsx(styles['icon-container'], styles[`icon-container-${variant}`])}>{icon}</span>
+      <span
+        className={clsx(
+          styles['icon-container'],
+          styles[`icon-container-${variant}`],
+          isThemeActive(Theme.OneTheme) && styles['one-theme']
+        )}
+      >
+        {icon}
+      </span>
       <span id={id} className={clsx(styles['header-text'], analyticsSelectors['header-label'])}>
         {children}
       </span>
@@ -267,9 +283,9 @@ export const ExpandableSectionHeader = ({
   const alwaysShowDivider = variantRequiresActionsDivider(variant) && headerActions;
   const icon = (
     <InternalIcon
-      size={variant === 'container' ? 'medium' : 'normal'}
+      size={isThemeActive(Theme.OneTheme) ? 'x-small' : variant === 'container' ? 'medium' : 'normal'}
       className={clsx(styles.icon, expanded && styles.expanded)}
-      name="caret-down-filled"
+      name={isThemeActive(Theme.OneTheme) ? 'angle-down' : 'caret-down-filled'}
     />
   );
   const defaultHeaderProps = {

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -136,7 +136,11 @@ const ExpandableNavigationHeader = ({
   return (
     <div id={id} className={clsx(className, styles['click-target'], analyticsSelectors['header-label'])}>
       <button
-        className={clsx(styles['icon-container'], styles['expand-button'])}
+        className={clsx(
+          styles['icon-container'],
+          styles['expand-button'],
+          isThemeActive(Theme.OneTheme) && styles['one-theme']
+        )}
         aria-labelledby={ariaLabelledBy}
         aria-label={ariaLabel}
         aria-controls={ariaControls}

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -14,6 +14,7 @@ $icon-width-medium: awsui.$size-icon-medium;
 $icon-margin-left: '(#{awsui.$line-height-body-m} - #{$icon-width-normal}) / -2';
 $icon-margin-right-normal: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
 $icon-margin-right-medium: awsui.$space-xs;
+$icon-offset: awsui.$space-xxxs;
 
 // Total space occupied by the expand icon on the left and its margins.
 // Useful to keep elements correctly aligned.
@@ -52,6 +53,18 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
   // For vertical alignment of text in side navigation items
   &-container {
     margin-inline-end: $icon-margin-right-medium;
+    &.one-theme {
+      > .icon {
+        inset-block-start: calc(#{$icon-offset} * 3);
+      }
+    }
+  }
+  &.one-theme {
+    display: inline-flex;
+    align-items: flex-start;
+    > .icon {
+      inset-block-start: $icon-offset;
+    }
   }
 }
 

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -14,7 +14,8 @@ $icon-width-medium: awsui.$size-icon-medium;
 $icon-margin-left: '(#{awsui.$line-height-body-m} - #{$icon-width-normal}) / -2';
 $icon-margin-right-normal: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
 $icon-margin-right-medium: awsui.$space-xs;
-$icon-offset: awsui.$space-xxxs;
+$icon-offset-inline: awsui.$space-xxs;
+$icon-offset-block: awsui.$space-xxxs;
 
 // Total space occupied by the expand icon on the left and its margins.
 // Useful to keep elements correctly aligned.
@@ -54,16 +55,19 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
   &-container {
     margin-inline-end: $icon-margin-right-medium;
     &.one-theme {
+      margin-inline-end: calc(#{$icon-margin-right-medium} + $icon-offset-inline);
+      inset-block-start: $icon-offset-block;
       > .icon {
-        inset-block-start: calc(#{$icon-offset} * 3);
+        inset-block-start: calc(#{$icon-offset-block} * 3); // Double-check
       }
     }
   }
   &.one-theme {
     display: inline-flex;
     align-items: flex-start;
+    margin-inline-end: calc(#{$icon-margin-right-normal} + #{$icon-offset-inline});
     > .icon {
-      inset-block-start: $icon-offset;
+      inset-block-start: $icon-offset-block;
     }
   }
 }

--- a/src/internal/components/button-trigger/index.tsx
+++ b/src/internal/components/button-trigger/index.tsx
@@ -3,6 +3,7 @@
 import React, { ButtonHTMLAttributes } from 'react';
 import clsx from 'clsx';
 
+import { isThemeActive, Theme } from '@cloudscape-design/component-toolkit/internal';
 import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 import InternalIcon from '../../../icon/internal';
@@ -129,8 +130,12 @@ const ButtonTrigger = (
     >
       {children}
       {!hideCaret && (
-        <span className={styles.arrow}>
-          <InternalIcon name="caret-down-filled" variant={disabled || readOnly ? 'disabled' : 'normal'} />
+        <span className={clsx(styles.arrow, isThemeActive(Theme.OneTheme) && styles['one-theme'])}>
+          <InternalIcon
+            name={isThemeActive(Theme.OneTheme) ? 'angle-down' : 'caret-down-filled'}
+            size={isThemeActive(Theme.OneTheme) ? 'x-small' : 'normal'}
+            variant={disabled || readOnly ? 'disabled' : 'normal'}
+          />
         </span>
       )}
     </button>

--- a/src/internal/components/button-trigger/styles.scss
+++ b/src/internal/components/button-trigger/styles.scss
@@ -12,6 +12,7 @@
 
 $padding-inline-inner-filtering-token: styles.$control-padding-horizontal;
 $padding-block-inner-filtering-token: 0px;
+$icon-offset: awsui.$space-xxxs;
 
 .button-trigger {
   @include styles.styles-reset;
@@ -69,6 +70,9 @@ $padding-block-inner-filtering-token: 0px;
     inset-inline-end: styles.$control-icon-horizontal-offset;
     inset-block-start: styles.$control-icon-vertical-offset;
     color: awsui.$color-text-button-inline-icon-default;
+    &.one-theme {
+      inset-block-start: calc(styles.$control-icon-vertical-offset + $icon-offset);
+    }
   }
 
   &:hover {
@@ -80,6 +84,9 @@ $padding-block-inner-filtering-token: 0px;
   &.pressed {
     > .arrow {
       transform: rotate(-180deg);
+      &.one-theme {
+        inset-block-start: calc(styles.$control-icon-vertical-offset - $icon-offset);
+      }
     }
   }
 

--- a/src/internal/components/expand-toggle-button/index.tsx
+++ b/src/internal/components/expand-toggle-button/index.tsx
@@ -4,7 +4,7 @@
 import React, { useRef } from 'react';
 import clsx from 'clsx';
 
-import { useSingleTabStopNavigation } from '@cloudscape-design/component-toolkit/internal';
+import { isThemeActive, Theme, useSingleTabStopNavigation } from '@cloudscape-design/component-toolkit/internal';
 
 import InternalIcon from '../../../icon/internal';
 
@@ -42,8 +42,8 @@ export function ExpandToggleButton({
     >
       {customIcon ?? (
         <InternalIcon
-          size="small"
-          name="caret-down-filled"
+          size={isThemeActive(Theme.OneTheme) ? 'x-small' : 'small'}
+          name={isThemeActive(Theme.OneTheme) ? 'angle-down' : 'caret-down-filled'}
           className={clsx(styles['expand-toggle-icon'], isExpanded && styles['expand-toggle-icon-expanded'])}
         />
       )}

--- a/src/status-indicator/internal.tsx
+++ b/src/status-indicator/internal.tsx
@@ -53,6 +53,7 @@ const typeToIcon: (size: IconProps.Size) => Record<StatusIndicatorProps.Type, JS
 interface InternalStatusIconProps extends Pick<InternalStatusIndicatorProps, 'type' | 'iconAriaLabel'> {
   animate?: InternalStatusIndicatorProps['__animate'];
   size?: InternalStatusIndicatorProps['__size'];
+  display?: InternalStatusIndicatorProps['__display'];
 }
 
 export function InternalStatusIcon({
@@ -117,7 +118,13 @@ export default function StatusIndicator({
           __animate && styles['container-fade-in']
         )}
       >
-        <InternalStatusIcon type={type} iconAriaLabel={iconAriaLabel} animate={__animate} size={__size} />
+        <InternalStatusIcon
+          type={type}
+          iconAriaLabel={iconAriaLabel}
+          animate={__animate}
+          display={__display}
+          size={__size}
+        />
         <span>{children}</span>
       </span>
     </WithNativeAttributes>

--- a/src/status-indicator/internal.tsx
+++ b/src/status-indicator/internal.tsx
@@ -53,7 +53,6 @@ const typeToIcon: (size: IconProps.Size) => Record<StatusIndicatorProps.Type, JS
 interface InternalStatusIconProps extends Pick<InternalStatusIndicatorProps, 'type' | 'iconAriaLabel'> {
   animate?: InternalStatusIndicatorProps['__animate'];
   size?: InternalStatusIndicatorProps['__size'];
-  display?: InternalStatusIndicatorProps['__display'];
 }
 
 export function InternalStatusIcon({
@@ -113,17 +112,12 @@ export default function StatusIndicator({
         className={clsx(
           styles.container,
           styles[`display-${__display}`],
+          isThemeActive(Theme.OneTheme) && styles['one-theme'],
           wrapText === false && styles['overflow-ellipsis'],
           __animate && styles['container-fade-in']
         )}
       >
-        <InternalStatusIcon
-          type={type}
-          iconAriaLabel={iconAriaLabel}
-          animate={__animate}
-          display={__display}
-          size={__size}
-        />
+        <InternalStatusIcon type={type} iconAriaLabel={iconAriaLabel} animate={__animate} size={__size} />
         <span>{children}</span>
       </span>
     </WithNativeAttributes>

--- a/src/status-indicator/internal.tsx
+++ b/src/status-indicator/internal.tsx
@@ -3,6 +3,8 @@
 import React from 'react';
 import clsx from 'clsx';
 
+import { isThemeActive, Theme } from '@cloudscape-design/component-toolkit/internal';
+
 import { IconProps } from '../icon/interfaces';
 import InternalIcon from '../icon/internal';
 import { getBaseProps } from '../internal/base-component';
@@ -63,7 +65,11 @@ export function InternalStatusIcon({
 }: InternalStatusIconProps) {
   return (
     <span
-      className={clsx(styles.icon, animate && styles['icon-shake'])}
+      className={clsx(
+        styles.icon,
+        animate && styles['icon-shake'],
+        isThemeActive(Theme.OneTheme) && styles['one-theme']
+      )}
       aria-label={iconAriaLabel}
       role={iconAriaLabel ? 'img' : undefined}
     >
@@ -82,7 +88,7 @@ export default function StatusIndicator({
   nativeAttributes,
   __animate = false,
   __internalRootRef,
-  __size = 'normal',
+  __size = isThemeActive(Theme.OneTheme) ? 'x-small' : 'normal',
   __display = 'inline-block',
   ...rest
 }: InternalStatusIndicatorProps) {

--- a/src/status-indicator/styles.scss
+++ b/src/status-indicator/styles.scss
@@ -86,8 +86,6 @@ $_background-overrides: (
     > .icon {
       white-space: nowrap;
       &.one-theme {
-        display: inline-flex;
-        align-items: center;
         vertical-align: middle;
       }
     }
@@ -120,4 +118,14 @@ $_background-overrides: (
   text-overflow: ellipsis;
   white-space: nowrap;
   vertical-align: text-bottom;
+
+  &.one-theme {
+    text-overflow: unset;
+
+    > span:last-child {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
 }

--- a/src/status-indicator/styles.scss
+++ b/src/status-indicator/styles.scss
@@ -41,6 +41,14 @@ $_status-backgrounds: (
   'not-started': awsui.$color-background-status-indicator-neutral,
 );
 
+$_background-overrides: (
+  'red': awsui.$color-background-status-indicator-error,
+  'grey': awsui.$color-background-status-indicator-neutral,
+  'blue': awsui.$color-background-status-indicator-info,
+  'green': awsui.$color-background-status-indicator-success,
+  'yellow': awsui.$color-background-status-indicator-warning,
+);
+
 .root {
   @include styles.default-text-style;
   @each $status in map.keys($_status-colors) {
@@ -58,6 +66,11 @@ $_status-backgrounds: (
       background: #{map.get($_status-backgrounds, $status)};
     }
   }
+  @each $color in map.keys($_background-overrides) {
+    &.color-override-#{$color} > .container {
+      background: #{map.get($_background-overrides, $color)};
+    }
+  }
 }
 
 .container {
@@ -72,6 +85,11 @@ $_status-backgrounds: (
 
     > .icon {
       white-space: nowrap;
+      &.one-theme {
+        display: inline-flex;
+        align-items: center;
+        vertical-align: middle;
+      }
     }
   }
 
@@ -79,6 +97,10 @@ $_status-backgrounds: (
     display: inline-block;
     word-wrap: break-word;
     word-break: break-all;
+    &.one-theme {
+      display: inline-flex;
+      align-items: flex-start;
+    }
 
     > .icon {
       padding-inline-end: awsui.$space-xxs;
@@ -86,6 +108,7 @@ $_status-backgrounds: (
       &.one-theme {
         display: inline-flex;
         align-items: center;
+        margin-block-start: awsui.$space-xxxs;
       }
     }
   }

--- a/src/status-indicator/styles.scss
+++ b/src/status-indicator/styles.scss
@@ -82,6 +82,11 @@ $_status-backgrounds: (
 
     > .icon {
       padding-inline-end: awsui.$space-xxs;
+
+      &.one-theme {
+        display: inline-flex;
+        align-items: center;
+      }
     }
   }
 }

--- a/src/tree-view/tree-item/index.tsx
+++ b/src/tree-view/tree-item/index.tsx
@@ -3,6 +3,8 @@
 import React from 'react';
 import clsx from 'clsx';
 
+import { isThemeActive, Theme } from '@cloudscape-design/component-toolkit/internal';
+
 import { useInternalI18n } from '../../i18n/context';
 import { ExpandToggleButton } from '../../internal/components/expand-toggle-button';
 import InternalStructuredItem from '../../internal/components/structured-item';
@@ -86,7 +88,7 @@ const InternalTreeItem = <T,>({
       data-testid={`awsui-treeitem-${id}`}
       data-awsui-tree-item-index={allVisibleItemsIndices[id]}
     >
-      <div className={styles['treeitem-content-wrapper']}>
+      <div className={clsx(styles['treeitem-content-wrapper'], isThemeActive(Theme.OneTheme) && styles['one-theme'])}>
         <div className={styles['expand-toggle-wrapper']}>
           <div className={styles.toggle}>
             {isExpandable ? (

--- a/src/tree-view/tree-item/styles.scss
+++ b/src/tree-view/tree-item/styles.scss
@@ -49,6 +49,16 @@ $item-toggle-column-width: 28px;
       }
     }
 
+    &.one-theme {
+      align-items: center;
+      > .expand-toggle-wrapper {
+        > .toggle {
+          inset-inline-start: 0px;
+          inset-block-start: 3px;
+        }
+      }
+    }
+
     > .structured-item-wrapper {
       grid-column: 2;
       grid-row: 1 / span 2;

--- a/style-dictionary/one-theme/colors.ts
+++ b/style-dictionary/one-theme/colors.ts
@@ -15,7 +15,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorBackgroundContainerHeader: { light: '{colorWhite}', dark: '{colorNeutralGrey950}' },
   colorBackgroundContainerContent: { light: '{colorWhite}', dark: '{colorNeutralGrey950}' },
   colorBorderDividerDefault: { light: '{colorNeutralGrey300}', dark: '{colorNeutralGrey750}' },
-  colorBorderDividerInteractiveDefault: '{colorBorderDividerDefault}',
+  colorBorderDividerInteractiveDefault: { light: '{colorNeutralGrey500}', dark: '{colorNeutralGrey600}' },
   colorBorderDividerSecondary: { light: '{colorNeutralGrey200}', dark: '{colorNeutralGrey800}' },
   colorBorderLayout: { light: '{colorNeutralGrey300}', dark: '{colorNeutralGrey750}' },
   colorGapGlobalDrawer: { light: '{colorNeutralGrey250}', dark: '{colorNeutralGrey1000}' },

--- a/style-dictionary/one-theme/colors.ts
+++ b/style-dictionary/one-theme/colors.ts
@@ -15,6 +15,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorBackgroundContainerHeader: { light: '{colorWhite}', dark: '{colorNeutralGrey950}' },
   colorBackgroundContainerContent: { light: '{colorWhite}', dark: '{colorNeutralGrey950}' },
   colorBorderDividerDefault: { light: '{colorNeutralGrey300}', dark: '{colorNeutralGrey750}' },
+  colorBorderDividerInteractiveDefault: '{colorBorderDividerDefault}',
   colorBorderDividerSecondary: { light: '{colorNeutralGrey200}', dark: '{colorNeutralGrey800}' },
   colorBorderLayout: { light: '{colorNeutralGrey300}', dark: '{colorNeutralGrey750}' },
   colorGapGlobalDrawer: { light: '{colorNeutralGrey250}', dark: '{colorNeutralGrey1000}' },

--- a/style-dictionary/one-theme/spacing.ts
+++ b/style-dictionary/one-theme/spacing.ts
@@ -10,7 +10,7 @@ const tokens: StyleDictionary.SpacingDictionary = {
   spaceTabsVertical: '2px',
   spaceTokenVertical: '1px',
   spaceFieldVertical: { comfortable: '4px', compact: '2px' },
-  spaceStatusIndicatorPaddingHorizontal: '4px',
+  spaceStatusIndicatorPaddingHorizontal: '2px',
 };
 
 const expandedTokens: StyleDictionary.ExpandedDensityScopeDictionary = expandDensityDictionary(tokens);


### PR DESCRIPTION
### Description
This PR implement x-small icon size for OneTheme expand/caret controls:
- Switches caret-down-filled (normal/small size) to angle-down (x-small) for OneTheme across several components, ensuring caret icons are proportionally sized in the OneTheme visual style. Also fixes vertical alignment across affected components.

Component changes:

- button-dropdown — uses angle-down at x-small in OneTheme; adds flex alignment to trigger button
- button-trigger — uses angle-down at x-small in OneTheme; adjusts vertical offset for the caret
- expand-toggle-button — uses angle-down at x-small in OneTheme
- expandable-section — uses angle-down at x-small in OneTheme; adds one-theme class for icon offset/alignment tweaks
- status-indicator — defaults to x-small icon in OneTheme; adds alignment and display fixes for OneTheme; adds color-override background map
- tree-view — adds one-theme class to center-align the content wrapper and adjust toggle position

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
