### PR TITLE
feat: add children slot for custom content to top navigation

### DIFF
--- a/pages/top-navigation/custom-content.permutations.page.tsx
+++ b/pages/top-navigation/custom-content.permutations.page.tsx
@@ -1,0 +1,242 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Badge from '~components/badge';
+import Button from '~components/button';
+import ButtonDropdown from '~components/button-dropdown';
+import Input from '~components/input';
+import Link from '~components/link';
+import Select from '~components/select';
+import SpaceBetween from '~components/space-between';
+import StatusIndicator from '~components/status-indicator';
+import TopNavigation, { TopNavigationProps } from '~components/top-navigation';
+
+import { SimplePage } from '../app/templates';
+import logo from './logos/simple-logo.svg';
+
+const navStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  paddingInline: 16,
+  height: 48,
+  gap: 16,
+};
+
+const trailingStyle: React.CSSProperties = { marginInlineStart: 'auto', display: 'flex', alignItems: 'center', gap: 8 };
+
+const Brand = ({ title }: { title: string }) => (
+  <>
+    <img src={logo} alt={title} style={{ height: 24 }} />
+    <span style={{ fontWeight: 700 }}>{title}</span>
+  </>
+);
+
+function useCustomContents(): Array<{ label: string; content: React.ReactNode }> {
+  const [searchValue, setSearchValue] = useState('');
+  const [environment, setEnvironment] = useState<{ value: string; label: string } | null>({
+    value: 'prod',
+    label: 'Production',
+  });
+
+  return [
+    {
+      label: 'Badge, status indicator and buttons',
+      content: (
+        <div style={navStyle}>
+          <Brand title="My Service" />
+          <div style={trailingStyle}>
+            <StatusIndicator type="success">Operational</StatusIndicator>
+            <Badge color="blue">3 updates</Badge>
+            <Button variant="link" href="#">
+              Docs
+            </Button>
+            <Button variant="primary">Sign in</Button>
+          </div>
+        </div>
+      ),
+    },
+    {
+      label: 'Button dropdown variants',
+      content: (
+        <div style={navStyle}>
+          <Brand title="My Service" />
+          <div style={trailingStyle}>
+            <ButtonDropdown
+              items={[
+                { id: 'us-east-1', text: 'US East (N. Virginia)' },
+                { id: 'us-west-2', text: 'US West (Oregon)' },
+                { id: 'eu-west-1', text: 'Europe (Ireland)' },
+              ]}
+            >
+              Region
+            </ButtonDropdown>
+            <ButtonDropdown
+              expandableGroups={true}
+              items={[
+                {
+                  id: 'docs-group',
+                  text: 'Documentation',
+                  items: [
+                    { id: 'api', text: 'API reference', href: '#', external: true },
+                    { id: 'guides', text: 'Developer guides', href: '#', external: true },
+                  ],
+                },
+                {
+                  id: 'support-group',
+                  text: 'Support',
+                  items: [
+                    { id: 'contact', text: 'Contact us' },
+                    { id: 'feedback', text: 'Send feedback' },
+                  ],
+                },
+              ]}
+            >
+              Help
+            </ButtonDropdown>
+            <ButtonDropdown
+              variant="primary"
+              items={[
+                { id: 'instance', text: 'Launch instance', iconName: 'add-plus' },
+                { id: 'volume', text: 'Create volume', iconName: 'add-plus' },
+              ]}
+            >
+              Create
+            </ButtonDropdown>
+          </div>
+        </div>
+      ),
+    },
+    {
+      label: 'Select and button',
+      content: (
+        <div style={navStyle}>
+          <Brand title="My Service" />
+          <div style={trailingStyle}>
+            <Select
+              selectedOption={environment}
+              onChange={({ detail }) => setEnvironment(detail.selectedOption as { value: string; label: string })}
+              options={[
+                { value: 'prod', label: 'Production' },
+                { value: 'dev', label: 'Development' },
+              ]}
+              ariaLabel="Environment selector"
+            />
+            <Button variant="primary" iconName="add-plus">
+              Create
+            </Button>
+          </div>
+        </div>
+      ),
+    },
+    {
+      label: 'Cloudscape',
+      content: (
+        <div style={navStyle}>
+          <Button variant="icon" iconName="menu" ariaLabel="Open navigation" />
+          <Brand title="Cloudscape" />
+          <nav style={{ display: 'flex', alignItems: 'center', gap: 16, flex: 1, justifyContent: 'center' }}>
+            <Link href="#">Get started</Link>
+            <Link href="#">Foundation</Link>
+            <Link href="#">Components</Link>
+            <Link href="#">Patterns</Link>
+            <Link href="#">Demos</Link>
+          </nav>
+          <div style={trailingStyle}>
+            <Input
+              type="search"
+              placeholder="Search"
+              value={searchValue}
+              onChange={({ detail }) => setSearchValue(detail.value)}
+              ariaLabel="Search"
+            />
+            <Button variant="icon" iconName="light-dark" ariaLabel="Theme" />
+          </div>
+        </div>
+      ),
+    },
+    {
+      label: 'Taller top navigation',
+      content: (
+        <div style={{ ...navStyle, height: 72 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <img src={logo} alt="My Service" style={{ height: 32 }} />
+            <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.3 }}>
+              <span style={{ fontWeight: 700, fontSize: 16 }}>My Service</span>
+              <span style={{ fontSize: 12, opacity: 0.7 }}>Production workspace</span>
+            </div>
+          </div>
+          <div style={{ flex: 1, maxWidth: 480, marginInline: 'auto' }}>
+            <Input
+              type="search"
+              placeholder="Search resources, docs, and settings..."
+              value={searchValue}
+              onChange={({ detail }) => setSearchValue(detail.value)}
+              ariaLabel="Search"
+            />
+          </div>
+          <div style={trailingStyle}>
+            <StatusIndicator type="success">Connected</StatusIndicator>
+            <ButtonDropdown
+              variant="icon"
+              ariaLabel="Account menu"
+              items={[
+                { id: 'profile', text: 'Your profile' },
+                { id: 'settings', text: 'Settings' },
+                { id: 'signout', text: 'Sign out' },
+              ]}
+            >
+              Jane Doe
+            </ButtonDropdown>
+          </div>
+        </div>
+      ),
+    },
+    {
+      label: 'Centered brand with navigation and auth actions',
+      content: (
+        <div style={navStyle}>
+          <div style={{ flex: 1 }}>
+            <SpaceBetween direction="horizontal" size="m" alignItems="center">
+              <Link href="#">Download</Link>
+              <Link href="#">Pricing</Link>
+              <Link href="#">Help center</Link>
+            </SpaceBetween>
+          </div>
+          <Brand title="Steep" />
+          <div style={{ flex: 1, display: 'flex', justifyContent: 'flex-end' }}>
+            <SpaceBetween direction="horizontal" size="xs" alignItems="center">
+              <Link href="#">Request a demo</Link>
+              <Button variant="link" href="#">
+                Log in
+              </Button>
+              <Button variant="primary">Get started</Button>
+            </SpaceBetween>
+          </div>
+        </div>
+      ),
+    },
+  ];
+}
+
+const visualContexts: Array<TopNavigationProps['visualContext']> = ['top-navigation', 'none'];
+
+export default function CustomContentPermutationsPage() {
+  const customContents = useCustomContents();
+
+  return (
+    <SimplePage title="TopNavigation customContent permutations" screenshotArea={{}}>
+      {visualContexts.map(visualContext => (
+        <div key={visualContext}>
+          <h2>visualContext=&quot;{visualContext}&quot;</h2>
+          {customContents.map(({ label, content }) => (
+            <div key={label} style={{ marginBottom: 16 }}>
+              <h3>{label}</h3>
+              <TopNavigation visualContext={visualContext}>{content}</TopNavigation>
+            </div>
+          ))}
+        </div>
+      ))}
+    </SimplePage>
+  );
+}

--- a/pages/top-navigation/custom-content.permutations.page.tsx
+++ b/pages/top-navigation/custom-content.permutations.page.tsx
@@ -18,12 +18,19 @@ import logo from './logos/simple-logo.svg';
 const navStyle: React.CSSProperties = {
   display: 'flex',
   alignItems: 'center',
+  flexWrap: 'wrap',
   paddingInline: 16,
-  height: 48,
+  minHeight: 48,
   gap: 16,
 };
 
-const trailingStyle: React.CSSProperties = { marginInlineStart: 'auto', display: 'flex', alignItems: 'center', gap: 8 };
+const trailingStyle: React.CSSProperties = {
+  marginInlineStart: 'auto',
+  display: 'flex',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+  gap: 8,
+};
 
 const Brand = ({ title }: { title: string }) => (
   <>
@@ -135,7 +142,16 @@ function useCustomContents(): Array<{ label: string; content: React.ReactNode }>
         <div style={navStyle}>
           <Button variant="icon" iconName="menu" ariaLabel="Open navigation" />
           <Brand title="Cloudscape" />
-          <div style={{ display: 'flex', alignItems: 'center', gap: 16, flex: 1, justifyContent: 'center' }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+              gap: 16,
+              flex: 1,
+              justifyContent: 'center',
+            }}
+          >
             <Link href="#">Get started</Link>
             <Link href="#">Foundation</Link>
             <Link href="#">Components</Link>
@@ -158,7 +174,7 @@ function useCustomContents(): Array<{ label: string; content: React.ReactNode }>
     {
       label: 'Taller top navigation',
       content: (
-        <div style={{ ...navStyle, height: 72 }}>
+        <div style={{ ...navStyle, minHeight: 72 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
             <img src={logo} alt="My Service" style={{ height: 32 }} />
             <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.3 }}>

--- a/pages/top-navigation/custom-content.permutations.page.tsx
+++ b/pages/top-navigation/custom-content.permutations.page.tsx
@@ -135,13 +135,13 @@ function useCustomContents(): Array<{ label: string; content: React.ReactNode }>
         <div style={navStyle}>
           <Button variant="icon" iconName="menu" ariaLabel="Open navigation" />
           <Brand title="Cloudscape" />
-          <nav style={{ display: 'flex', alignItems: 'center', gap: 16, flex: 1, justifyContent: 'center' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 16, flex: 1, justifyContent: 'center' }}>
             <Link href="#">Get started</Link>
             <Link href="#">Foundation</Link>
             <Link href="#">Components</Link>
             <Link href="#">Patterns</Link>
             <Link href="#">Demos</Link>
-          </nav>
+          </div>
           <div style={trailingStyle}>
             <Input
               type="search"

--- a/pages/top-navigation/custom-content.permutations.page.tsx
+++ b/pages/top-navigation/custom-content.permutations.page.tsx
@@ -13,6 +13,8 @@ import StatusIndicator from '~components/status-indicator';
 import TopNavigation, { TopNavigationProps } from '~components/top-navigation';
 
 import { SimplePage } from '../app/templates';
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
 import logo from './logos/simple-logo.svg';
 
 const navStyle: React.CSSProperties = {
@@ -39,220 +41,212 @@ const Brand = ({ title }: { title: string }) => (
   </>
 );
 
-function useCustomContents(): Array<{ label: string; content: React.ReactNode }> {
+function useCustomContents(): Record<string, React.ReactNode> {
   const [searchValue, setSearchValue] = useState('');
   const [environment, setEnvironment] = useState<{ value: string; label: string } | null>({
     value: 'prod',
     label: 'Production',
   });
 
-  return [
-    {
-      label: 'Badge, status indicator and buttons',
-      content: (
-        <div style={navStyle}>
-          <Brand title="My Service" />
-          <div style={trailingStyle}>
-            <StatusIndicator type="success">Operational</StatusIndicator>
-            <Badge color="blue">3 updates</Badge>
-            <Button variant="link" href="#">
-              Docs
-            </Button>
-            <Button variant="primary">Sign in</Button>
-          </div>
+  return {
+    'Badge, status indicator and buttons': (
+      <div style={navStyle}>
+        <Brand title="My Service" />
+        <div style={trailingStyle}>
+          <StatusIndicator type="success">Operational</StatusIndicator>
+          <Badge color="blue">3 updates</Badge>
+          <Button variant="link" href="#">
+            Docs
+          </Button>
+          <Button variant="primary">Sign in</Button>
         </div>
-      ),
-    },
-    {
-      label: 'Button dropdown variants',
-      content: (
-        <div style={navStyle}>
-          <Brand title="My Service" />
-          <div style={trailingStyle}>
-            <ButtonDropdown
-              items={[
-                { id: 'us-east-1', text: 'US East (N. Virginia)' },
-                { id: 'us-west-2', text: 'US West (Oregon)' },
-                { id: 'eu-west-1', text: 'Europe (Ireland)' },
-              ]}
-            >
-              Region
-            </ButtonDropdown>
-            <ButtonDropdown
-              expandableGroups={true}
-              items={[
-                {
-                  id: 'docs-group',
-                  text: 'Documentation',
-                  items: [
-                    { id: 'api', text: 'API reference', href: '#', external: true },
-                    { id: 'guides', text: 'Developer guides', href: '#', external: true },
-                  ],
-                },
-                {
-                  id: 'support-group',
-                  text: 'Support',
-                  items: [
-                    { id: 'contact', text: 'Contact us' },
-                    { id: 'feedback', text: 'Send feedback' },
-                  ],
-                },
-              ]}
-            >
-              Help
-            </ButtonDropdown>
-            <ButtonDropdown
-              variant="primary"
-              items={[
-                { id: 'instance', text: 'Launch instance', iconName: 'add-plus' },
-                { id: 'volume', text: 'Create volume', iconName: 'add-plus' },
-              ]}
-            >
-              Create
-            </ButtonDropdown>
-          </div>
-        </div>
-      ),
-    },
-    {
-      label: 'Select and button',
-      content: (
-        <div style={navStyle}>
-          <Brand title="My Service" />
-          <div style={trailingStyle}>
-            <Select
-              selectedOption={environment}
-              onChange={({ detail }) => setEnvironment(detail.selectedOption as { value: string; label: string })}
-              options={[
-                { value: 'prod', label: 'Production' },
-                { value: 'dev', label: 'Development' },
-              ]}
-              ariaLabel="Environment selector"
-            />
-            <Button variant="primary" iconName="add-plus">
-              Create
-            </Button>
-          </div>
-        </div>
-      ),
-    },
-    {
-      label: 'Cloudscape',
-      content: (
-        <div style={navStyle}>
-          <Button variant="icon" iconName="menu" ariaLabel="Open navigation" />
-          <Brand title="Cloudscape" />
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              flexWrap: 'wrap',
-              gap: 16,
-              flex: 1,
-              justifyContent: 'center',
-            }}
+      </div>
+    ),
+    'Button dropdown variants': (
+      <div style={navStyle}>
+        <Brand title="My Service" />
+        <div style={trailingStyle}>
+          <ButtonDropdown
+            items={[
+              { id: 'us-east-1', text: 'US East (N. Virginia)' },
+              { id: 'us-west-2', text: 'US West (Oregon)' },
+              { id: 'eu-west-1', text: 'Europe (Ireland)' },
+            ]}
           >
-            <Link href="#">Get started</Link>
-            <Link href="#">Foundation</Link>
-            <Link href="#">Components</Link>
-            <Link href="#">Patterns</Link>
-            <Link href="#">Demos</Link>
-          </div>
-          <div style={trailingStyle}>
-            <Input
-              type="search"
-              placeholder="Search"
-              value={searchValue}
-              onChange={({ detail }) => setSearchValue(detail.value)}
-              ariaLabel="Search"
-            />
-            <Button variant="icon" iconName="light-dark" ariaLabel="Theme" />
+            Region
+          </ButtonDropdown>
+          <ButtonDropdown
+            expandableGroups={true}
+            items={[
+              {
+                id: 'docs-group',
+                text: 'Documentation',
+                items: [
+                  { id: 'api', text: 'API reference', href: '#', external: true },
+                  { id: 'guides', text: 'Developer guides', href: '#', external: true },
+                ],
+              },
+              {
+                id: 'support-group',
+                text: 'Support',
+                items: [
+                  { id: 'contact', text: 'Contact us' },
+                  { id: 'feedback', text: 'Send feedback' },
+                ],
+              },
+            ]}
+          >
+            Help
+          </ButtonDropdown>
+          <ButtonDropdown
+            variant="primary"
+            items={[
+              { id: 'instance', text: 'Launch instance', iconName: 'add-plus' },
+              { id: 'volume', text: 'Create volume', iconName: 'add-plus' },
+            ]}
+          >
+            Create
+          </ButtonDropdown>
+        </div>
+      </div>
+    ),
+    'Select and button': (
+      <div style={navStyle}>
+        <Brand title="My Service" />
+        <div style={trailingStyle}>
+          <Select
+            selectedOption={environment}
+            onChange={({ detail }) => setEnvironment(detail.selectedOption as { value: string; label: string })}
+            options={[
+              { value: 'prod', label: 'Production' },
+              { value: 'dev', label: 'Development' },
+            ]}
+            ariaLabel="Environment selector"
+          />
+          <Button variant="primary" iconName="add-plus">
+            Create
+          </Button>
+        </div>
+      </div>
+    ),
+    Cloudscape: (
+      <div style={navStyle}>
+        <Button variant="icon" iconName="menu" ariaLabel="Open navigation" />
+        <Brand title="Cloudscape" />
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: 16,
+            flex: 1,
+            justifyContent: 'center',
+          }}
+        >
+          <Link href="#">Get started</Link>
+          <Link href="#">Foundation</Link>
+          <Link href="#">Components</Link>
+          <Link href="#">Patterns</Link>
+          <Link href="#">Demos</Link>
+        </div>
+        <div style={trailingStyle}>
+          <Input
+            type="search"
+            placeholder="Search"
+            value={searchValue}
+            onChange={({ detail }) => setSearchValue(detail.value)}
+            ariaLabel="Search"
+          />
+          <Button variant="icon" iconName="light-dark" ariaLabel="Theme" />
+        </div>
+      </div>
+    ),
+    'Taller top navigation': (
+      <div style={{ ...navStyle, minHeight: 72 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <img src={logo} alt="My Service" style={{ height: 32 }} />
+          <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.3 }}>
+            <span style={{ fontWeight: 700, fontSize: 16 }}>My Service</span>
+            <span style={{ fontSize: 12, opacity: 0.7 }}>Production workspace</span>
           </div>
         </div>
-      ),
-    },
-    {
-      label: 'Taller top navigation',
-      content: (
-        <div style={{ ...navStyle, minHeight: 72 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-            <img src={logo} alt="My Service" style={{ height: 32 }} />
-            <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.3 }}>
-              <span style={{ fontWeight: 700, fontSize: 16 }}>My Service</span>
-              <span style={{ fontSize: 12, opacity: 0.7 }}>Production workspace</span>
-            </div>
-          </div>
-          <div style={{ flex: 1, maxWidth: 480, marginInline: 'auto' }}>
-            <Input
-              type="search"
-              placeholder="Search resources, docs, and settings..."
-              value={searchValue}
-              onChange={({ detail }) => setSearchValue(detail.value)}
-              ariaLabel="Search"
-            />
-          </div>
-          <div style={trailingStyle}>
-            <StatusIndicator type="success">Connected</StatusIndicator>
-            <ButtonDropdown
-              variant="icon"
-              ariaLabel="Account menu"
-              items={[
-                { id: 'profile', text: 'Your profile' },
-                { id: 'settings', text: 'Settings' },
-                { id: 'signout', text: 'Sign out' },
-              ]}
-            >
-              Jane Doe
-            </ButtonDropdown>
-          </div>
+        <div style={{ flex: 1, maxWidth: 480, marginInline: 'auto' }}>
+          <Input
+            type="search"
+            placeholder="Search resources, docs, and settings..."
+            value={searchValue}
+            onChange={({ detail }) => setSearchValue(detail.value)}
+            ariaLabel="Search"
+          />
         </div>
-      ),
-    },
-    {
-      label: 'Centered brand with navigation and auth actions',
-      content: (
-        <div style={navStyle}>
-          <div style={{ flex: 1 }}>
-            <SpaceBetween direction="horizontal" size="m" alignItems="center">
-              <Link href="#">Download</Link>
-              <Link href="#">Pricing</Link>
-              <Link href="#">Help center</Link>
-            </SpaceBetween>
-          </div>
-          <Brand title="Steep" />
-          <div style={{ flex: 1, display: 'flex', justifyContent: 'flex-end' }}>
-            <SpaceBetween direction="horizontal" size="xs" alignItems="center">
-              <Link href="#">Request a demo</Link>
-              <Button variant="link" href="#">
-                Log in
-              </Button>
-              <Button variant="primary">Get started</Button>
-            </SpaceBetween>
-          </div>
+        <div style={trailingStyle}>
+          <StatusIndicator type="success">Connected</StatusIndicator>
+          <ButtonDropdown
+            variant="icon"
+            ariaLabel="Account menu"
+            items={[
+              { id: 'profile', text: 'Your profile' },
+              { id: 'settings', text: 'Settings' },
+              { id: 'signout', text: 'Sign out' },
+            ]}
+          >
+            Jane Doe
+          </ButtonDropdown>
         </div>
-      ),
-    },
-  ];
+      </div>
+    ),
+    'Centered brand with navigation and auth actions': (
+      <div style={navStyle}>
+        <div style={{ flex: 1 }}>
+          <SpaceBetween direction="horizontal" size="m" alignItems="center">
+            <Link href="#">Download</Link>
+            <Link href="#">Pricing</Link>
+            <Link href="#">Help center</Link>
+          </SpaceBetween>
+        </div>
+        <Brand title="Steep" />
+        <div style={{ flex: 1, display: 'flex', justifyContent: 'flex-end' }}>
+          <SpaceBetween direction="horizontal" size="xs" alignItems="center">
+            <Link href="#">Request a demo</Link>
+            <Button variant="link" href="#">
+              Log in
+            </Button>
+            <Button variant="primary">Get started</Button>
+          </SpaceBetween>
+        </div>
+      </div>
+    ),
+  };
 }
 
-const visualContexts: Array<TopNavigationProps['visualContext']> = ['top-navigation', 'none'];
+interface Permutation {
+  visualContext: TopNavigationProps['visualContext'];
+  label: string;
+}
 
 export default function CustomContentPermutationsPage() {
   const customContents = useCustomContents();
 
+  const permutations = createPermutations<Permutation>([
+    {
+      visualContext: ['top-navigation', 'none'],
+      label: Object.keys(customContents),
+    },
+  ]);
+
   return (
     <SimplePage title="TopNavigation customContent permutations" screenshotArea={{}}>
-      {visualContexts.map(visualContext => (
-        <div key={visualContext}>
-          <h2>visualContext=&quot;{visualContext}&quot;</h2>
-          {customContents.map(({ label, content }) => (
-            <div key={label} style={{ marginBottom: 16 }}>
-              <h3>{label}</h3>
-              <TopNavigation visualContext={visualContext}>{content}</TopNavigation>
-            </div>
-          ))}
-        </div>
-      ))}
+      <PermutationsView
+        permutations={permutations}
+        render={({ visualContext, label }) => (
+          <div style={{ marginBottom: 16 }}>
+            <h2>
+              visualContext=&quot;{visualContext}&quot; — {label}
+            </h2>
+            <TopNavigation visualContext={visualContext}>{customContents[label]}</TopNavigation>
+          </div>
+        )}
+      />
     </SimplePage>
   );
 }

--- a/pages/top-navigation/integ.page.tsx
+++ b/pages/top-navigation/integ.page.tsx
@@ -6,10 +6,14 @@ import { NonCancelableCustomEvent } from '~components';
 import Input, { InputProps } from '~components/input';
 import TopNavigation from '~components/top-navigation';
 
+import { useAppContext } from '../app/app-context';
 import ScreenshotArea from '../utils/screenshot-area';
 import { I18N_STRINGS } from './common';
 
 export default function () {
+  const {
+    urlParams: { hideIdentity },
+  } = useAppContext<'hideIdentity'>();
   const inputRef = useRef<InputProps.Ref>(null);
   const [inputValue, setInputValue] = useState<string>('');
   const [events, setEvents] = useState<string[]>([]);
@@ -22,10 +26,14 @@ export default function () {
       <ScreenshotArea>
         <TopNavigation
           i18nStrings={I18N_STRINGS}
-          identity={{
-            href: '#',
-            title: 'Title with an href',
-          }}
+          identity={
+            hideIdentity
+              ? undefined
+              : {
+                  href: '#',
+                  title: 'Title with an href',
+                }
+          }
           search={
             <Input
               ref={inputRef}

--- a/pages/top-navigation/optional-props.permutations.page.tsx
+++ b/pages/top-navigation/optional-props.permutations.page.tsx
@@ -1,0 +1,93 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Input from '~components/input';
+import TopNavigation, { TopNavigationProps } from '~components/top-navigation';
+
+import { SimplePage } from '../app/templates';
+import { I18N_STRINGS } from './common';
+import logo from './logos/simple-logo.svg';
+
+const utilities: TopNavigationProps['utilities'] = [
+  { type: 'button', iconName: 'notification', ariaLabel: 'Notifications', badge: true },
+  { type: 'button', text: 'Settings', iconName: 'settings' },
+  {
+    type: 'menu-dropdown',
+    text: 'Jane Doe',
+    description: 'jane.doe@example.com',
+    iconName: 'user-profile',
+    items: [
+      { id: 'profile', text: 'Profile' },
+      { id: 'signout', text: 'Sign out' },
+    ],
+  },
+];
+
+const identity: TopNavigationProps['identity'] = {
+  href: '#',
+  title: 'My Service',
+  logo: { src: logo, alt: 'Logo' },
+};
+
+const search = <Input type="search" placeholder="Search..." value="" onChange={() => {}} ariaLabel="Search" />;
+
+interface Permutation {
+  label: string;
+  props: TopNavigationProps;
+}
+
+const permutations: Permutation[] = [
+  {
+    label: 'Identity + search + utilities',
+    props: { identity, search, utilities, i18nStrings: I18N_STRINGS },
+  },
+  {
+    label: 'Identity + utilities (no search)',
+    props: { identity, utilities, i18nStrings: I18N_STRINGS },
+  },
+  {
+    label: 'Identity + search (no utilities)',
+    props: { identity, search, i18nStrings: I18N_STRINGS },
+  },
+  {
+    label: 'Identity only',
+    props: { identity, i18nStrings: I18N_STRINGS },
+  },
+  {
+    label: 'Utilities only (no identity)',
+    props: { utilities, i18nStrings: I18N_STRINGS },
+  },
+  {
+    label: 'Search + utilities (no identity)',
+    props: { search, utilities, i18nStrings: I18N_STRINGS },
+  },
+  {
+    label: 'Search only (no identity, no utilities)',
+    props: { search, i18nStrings: I18N_STRINGS },
+  },
+  {
+    label: 'Empty (no identity, no search, no utilities)',
+    props: { i18nStrings: I18N_STRINGS },
+  },
+];
+
+const visualContexts: Array<TopNavigationProps['visualContext']> = ['top-navigation', 'none'];
+
+export default function OptionalPropsPermutations() {
+  return (
+    <SimplePage title="TopNavigation optional props permutations" screenshotArea={{}}>
+      {visualContexts.map(visualContext => (
+        <div key={visualContext} style={{ marginBottom: 32 }}>
+          <h2>visualContext=&quot;{visualContext}&quot;</h2>
+          {permutations.map(({ label, props }) => (
+            <div key={label} style={{ marginBottom: 16 }}>
+              <h3>{label}</h3>
+              <TopNavigation {...props} visualContext={visualContext} />
+            </div>
+          ))}
+        </div>
+      ))}
+    </SimplePage>
+  );
+}

--- a/pages/top-navigation/optional-props.permutations.page.tsx
+++ b/pages/top-navigation/optional-props.permutations.page.tsx
@@ -6,6 +6,8 @@ import Input from '~components/input';
 import TopNavigation, { TopNavigationProps } from '~components/top-navigation';
 
 import { SimplePage } from '../app/templates';
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
 import { I18N_STRINGS } from './common';
 import logo from './logos/simple-logo.svg';
 
@@ -32,62 +34,38 @@ const identity: TopNavigationProps['identity'] = {
 
 const search = <Input type="search" placeholder="Search..." value="" onChange={() => {}} ariaLabel="Search" />;
 
-interface Permutation {
-  label: string;
-  props: TopNavigationProps;
-}
+const contentPermutations: Record<string, TopNavigationProps> = {
+  'Identity + search + utilities': { identity, search, utilities, i18nStrings: I18N_STRINGS },
+  'Identity + utilities (no search)': { identity, utilities, i18nStrings: I18N_STRINGS },
+  'Identity + search (no utilities)': { identity, search, i18nStrings: I18N_STRINGS },
+  'Identity only': { identity, i18nStrings: I18N_STRINGS },
+  'Utilities only (no identity)': { utilities, i18nStrings: I18N_STRINGS },
+  'Search + utilities (no identity)': { search, utilities, i18nStrings: I18N_STRINGS },
+  'Search only (no identity, no utilities)': { search, i18nStrings: I18N_STRINGS },
+  'Empty (no identity, no search, no utilities)': { i18nStrings: I18N_STRINGS },
+};
 
-const permutations: Permutation[] = [
+const permutations = createPermutations<{ visualContext: TopNavigationProps['visualContext']; label: string }>([
   {
-    label: 'Identity + search + utilities',
-    props: { identity, search, utilities, i18nStrings: I18N_STRINGS },
+    visualContext: ['top-navigation', 'none'],
+    label: Object.keys(contentPermutations),
   },
-  {
-    label: 'Identity + utilities (no search)',
-    props: { identity, utilities, i18nStrings: I18N_STRINGS },
-  },
-  {
-    label: 'Identity + search (no utilities)',
-    props: { identity, search, i18nStrings: I18N_STRINGS },
-  },
-  {
-    label: 'Identity only',
-    props: { identity, i18nStrings: I18N_STRINGS },
-  },
-  {
-    label: 'Utilities only (no identity)',
-    props: { utilities, i18nStrings: I18N_STRINGS },
-  },
-  {
-    label: 'Search + utilities (no identity)',
-    props: { search, utilities, i18nStrings: I18N_STRINGS },
-  },
-  {
-    label: 'Search only (no identity, no utilities)',
-    props: { search, i18nStrings: I18N_STRINGS },
-  },
-  {
-    label: 'Empty (no identity, no search, no utilities)',
-    props: { i18nStrings: I18N_STRINGS },
-  },
-];
-
-const visualContexts: Array<TopNavigationProps['visualContext']> = ['top-navigation', 'none'];
+]);
 
 export default function OptionalPropsPermutations() {
   return (
     <SimplePage title="TopNavigation optional props permutations" screenshotArea={{}}>
-      {visualContexts.map(visualContext => (
-        <div key={visualContext} style={{ marginBottom: 32 }}>
-          <h2>visualContext=&quot;{visualContext}&quot;</h2>
-          {permutations.map(({ label, props }) => (
-            <div key={label} style={{ marginBottom: 16 }}>
-              <h3>{label}</h3>
-              <TopNavigation {...props} visualContext={visualContext} />
-            </div>
-          ))}
-        </div>
-      ))}
+      <PermutationsView
+        permutations={permutations}
+        render={({ visualContext, label }) => (
+          <div style={{ marginBottom: 16 }}>
+            <h2>
+              visualContext=&quot;{visualContext}&quot; — {label}
+            </h2>
+            <TopNavigation {...contentPermutations[label]} visualContext={visualContext} />
+          </div>
+        )}
+      />
     </SimplePage>
   );
 }

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -32647,7 +32647,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
         "type": "object",
       },
       "name": "identity",
-      "optional": false,
+      "optional": true,
       "type": "TopNavigationProps.Identity",
     },
     {
@@ -32709,6 +32709,12 @@ The following properties are supported across all utility types:
     },
   ],
   "regions": [
+    {
+      "description": "Specifies custom navigation content.
+When provided, replaces all structured content (identity, search, utilities are ignored).",
+      "isDefault": true,
+      "name": "children",
+    },
     {
       "description": "Use with an input or autosuggest control for a global search query.",
       "isDefault": false,
@@ -45033,10 +45039,23 @@ Searches within this tooltip's scope to avoid conflicts with popovers.",
     {
       "methods": [
         {
+          "name": "findContent",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
           "name": "findIdentityLink",
           "parameters": [],
           "returnType": {
-            "isNullable": false,
+            "isNullable": true,
             "name": "ElementWrapper",
             "typeArguments": [
               {
@@ -53979,6 +53998,14 @@ Searches within this tooltip's scope to avoid conflicts with popovers.",
     },
     {
       "methods": [
+        {
+          "name": "findContent",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
         {
           "name": "findIdentityLink",
           "parameters": [],

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -32713,7 +32713,7 @@ The following properties are supported across all utility types:
     {
       "description": "Specifies custom navigation content.
 When provided, replaces all structured content (identity, search, utilities are ignored).",
-      "displayName": "custom content",
+      "displayName": "customContent",
       "isDefault": true,
       "name": "children",
     },

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -32692,6 +32692,7 @@ The following properties are supported across all utility types:
       "type": "ReadonlyArray<TopNavigationProps.Utility>",
     },
     {
+      "defaultValue": "'top-navigation'",
       "description": "Visual context applied to the navigation bar.
 - "top-navigation": Applies the top-navigation visual context. The component maintains a dark appearance regardless of the page's light/dark mode setting. Child components automatically adapt their colors to work on this dark background.
 - "none": No visual context applied. The component and its children use the same colors as the rest of the page and respond to the global light/dark mode normally.",
@@ -32712,6 +32713,7 @@ The following properties are supported across all utility types:
     {
       "description": "Specifies custom navigation content.
 When provided, replaces all structured content (identity, search, utilities are ignored).",
+      "displayName": "custom content",
       "isDefault": true,
       "name": "children",
     },

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -722,6 +722,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_root_1u26h",
   ],
   "top-navigation": [
+    "awsui_custom-content_1oq04",
     "awsui_hidden_k5dlb",
     "awsui_identity_k5dlb",
     "awsui_logo_k5dlb",

--- a/src/test-utils/dom/top-navigation/index.ts
+++ b/src/test-utils/dom/top-navigation/index.ts
@@ -9,12 +9,17 @@ import LinkWrapper from '../link';
 import buttonDropdownStyles from '../../../button-dropdown/styles.selectors.js';
 import menuDropdownStyles from '../../../internal/components/menu-dropdown/styles.selectors.js';
 import styles from '../../../top-navigation/styles.selectors.js';
+import testUtilStyles from '../../../top-navigation/test-classes/styles.selectors.js';
 
 export default class TopNavigationWrapper extends ComponentWrapper {
   static rootSelector = `${styles['top-navigation']}:not(.${styles.hidden})`;
 
-  findIdentityLink(): ElementWrapper {
-    return this.find(`.${styles.identity} a`)!;
+  findContent(): ElementWrapper | null {
+    return this.find(`.${testUtilStyles['custom-content']}`);
+  }
+
+  findIdentityLink(): ElementWrapper | null {
+    return this.find(`.${styles.identity} a`);
   }
 
   findLogo(): ElementWrapper | null {

--- a/src/top-navigation/__integ__/top-navigation.test.ts
+++ b/src/top-navigation/__integ__/top-navigation.test.ts
@@ -14,9 +14,9 @@ class TopNavigationPage extends BasePageObject {
   }
 }
 
-const setupTest = (pageWidth: number, testFn: (page: TopNavigationPage) => Promise<void>) => {
+const setupTest = (pageWidth: number, testFn: (page: TopNavigationPage) => Promise<void>, urlParams = '') => {
   return useBrowser(async browser => {
-    await browser.url('#/light/top-navigation/integ');
+    await browser.url(`#/light/top-navigation/integ${urlParams}`);
     const page = new TopNavigationPage(browser);
     await page.setWindowSize({ width: pageWidth, height: 600 });
     await page.waitForVisible(wrapper.toSelector());
@@ -232,4 +232,37 @@ describe('Top navigation', () => {
       await expect(page.isFocused(searchInputSelector)).resolves.toBe(true);
     })
   );
+
+  describe('without identity', () => {
+    const urlParams = '?hideIdentity=true';
+
+    test(
+      'displays all utilities and the search slot when there is enough space',
+      setupTest(
+        1100,
+        async page => {
+          await expect(page.isExisting(wrapper.findIdentityLink().toSelector())).resolves.toBe(false);
+          await expect(page.isExisting(wrapper.findTitle().toSelector())).resolves.toBe(false);
+          await expect(page.isExisting(wrapper.findSearch().findInput().toSelector())).resolves.toBe(true);
+          await expect(page.getText(wrapper.findUtility(1).toSelector())).resolves.toBe('New thing');
+        },
+        urlParams
+      )
+    );
+
+    test(
+      'collapses the search slot and moves utilities into the overflow menu at a narrow viewport',
+      setupTest(
+        300,
+        async page => {
+          // The inline search slot collapses into a search utility button.
+          await expect(page.isExisting(wrapper.findSearch().findInput().toSelector())).resolves.toBe(false);
+          await expect(page.isExisting(wrapper.findSearchButton().toSelector())).resolves.toBe(true);
+          // Utilities move into the overflow menu.
+          await expect(page.getText(wrapper.findOverflowMenuButton().toSelector())).resolves.toBe('More');
+        },
+        urlParams
+      )
+    );
+  });
 });

--- a/src/top-navigation/__tests__/common.tsx
+++ b/src/top-navigation/__tests__/common.tsx
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import createWrapper from '../../../lib/components/test-utils/dom';
+import TopNavigation, { TopNavigationProps } from '../../../lib/components/top-navigation';
+
+export const I18N_STRINGS: TopNavigationProps.I18nStrings = {
+  searchIconAriaLabel: 'Search',
+  searchDismissIconAriaLabel: 'Close search',
+  overflowMenuTriggerText: 'More',
+  overflowMenuTitleText: 'All',
+  overflowMenuBackIconAriaLabel: 'Back',
+  overflowMenuDismissIconAriaLabel: 'Close',
+};
+
+type PickPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+export const renderTopNavigation = (props: PickPartial<TopNavigationProps, 'i18nStrings'>) => {
+  const { container } = render(<TopNavigation i18nStrings={I18N_STRINGS} {...props} />);
+  return createWrapper(container).findTopNavigation()!;
+};

--- a/src/top-navigation/__tests__/common.tsx
+++ b/src/top-navigation/__tests__/common.tsx
@@ -6,7 +6,7 @@ import { render } from '@testing-library/react';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import TopNavigation, { TopNavigationProps } from '../../../lib/components/top-navigation';
 
-export const I18N_STRINGS: TopNavigationProps.I18nStrings = {
+const I18N_STRINGS: TopNavigationProps.I18nStrings = {
   searchIconAriaLabel: 'Search',
   searchDismissIconAriaLabel: 'Close search',
   overflowMenuTriggerText: 'More',

--- a/src/top-navigation/__tests__/top-navigation-custom-content.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation-custom-content.test.tsx
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+
+import { TopNavigationProps } from '../../../lib/components/top-navigation';
+import { renderTopNavigation } from './common';
+
+jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
+  ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
+  warnOnce: jest.fn(),
+}));
+
+afterEach(() => {
+  (warnOnce as jest.Mock).mockReset();
+});
+
+const structuredProps: Pick<TopNavigationProps, 'identity' | 'search' | 'utilities'> = {
+  identity: { href: '#', title: 'Structured' },
+  search: <input placeholder="Search" />,
+  utilities: [{ type: 'button', text: 'Help' }],
+};
+
+const children = <div>Custom Nav</div>;
+
+describe('custom content - children', () => {
+  test('renders children and ignores structured elements when both are provided', () => {
+    const wrapper = renderTopNavigation({ ...structuredProps, children });
+
+    expect(wrapper.findContent()!.getElement()).toHaveTextContent('Custom Nav');
+    expect(wrapper.findTitle()).toBeNull();
+    expect(wrapper.findIdentityLink()).toBeNull();
+    expect(wrapper.findSearch()).toBeNull();
+    expect(wrapper.findUtilities()).toHaveLength(0);
+  });
+
+  test('warns when children are provided alongside structured props', () => {
+    renderTopNavigation({ ...structuredProps, children });
+
+    expect(warnOnce).toHaveBeenCalledTimes(1);
+    expect(warnOnce).toHaveBeenCalledWith('TopNavigation', expect.stringContaining('structured props'));
+  });
+
+  test('does not warn when only children are provided', () => {
+    renderTopNavigation({ children });
+    expect(warnOnce).not.toHaveBeenCalled();
+  });
+
+  test('does not warn for the structured variant', () => {
+    renderTopNavigation(structuredProps);
+    expect(warnOnce).not.toHaveBeenCalled();
+  });
+});

--- a/src/top-navigation/__tests__/top-navigation-responsiveness.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation-responsiveness.test.tsx
@@ -4,6 +4,7 @@ import { TopNavigationProps } from '../../../lib/components/top-navigation/inter
 import {
   determineBestResponsiveState,
   generateResponsiveStateKeys,
+  getOptionalElementWidth,
   TopNavigationSizeConfiguration,
 } from '../../../lib/components/top-navigation/use-top-navigation';
 
@@ -187,5 +188,22 @@ describe('TopNavigation responsiveness', () => {
 
     expect(possibleStates).toEqual([{}, { hideTitle: true, hideUtilityText: true }]);
     expect(responsiveState).toEqual({});
+  });
+});
+
+describe('getOptionalElementWidth', () => {
+  it('returns 0 when the element is not present', () => {
+    const parent = document.createElement('div');
+    expect(getOptionalElementWidth(parent, '.missing')).toBe(0);
+  });
+
+  it('returns the element width when present', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('div');
+    child.className = 'present';
+    jest.spyOn(child, 'getBoundingClientRect').mockReturnValue({ width: 123 } as DOMRect);
+    parent.appendChild(child);
+
+    expect(getOptionalElementWidth(parent, '.present')).toBe(123);
   });
 });

--- a/src/top-navigation/__tests__/top-navigation-responsiveness.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation-responsiveness.test.tsx
@@ -4,7 +4,6 @@ import { TopNavigationProps } from '../../../lib/components/top-navigation/inter
 import {
   determineBestResponsiveState,
   generateResponsiveStateKeys,
-  getOptionalElementWidth,
   TopNavigationSizeConfiguration,
 } from '../../../lib/components/top-navigation/use-top-navigation';
 
@@ -188,22 +187,5 @@ describe('TopNavigation responsiveness', () => {
 
     expect(possibleStates).toEqual([{}, { hideTitle: true, hideUtilityText: true }]);
     expect(responsiveState).toEqual({});
-  });
-});
-
-describe('getOptionalElementWidth', () => {
-  it('returns 0 when the element is not present', () => {
-    const parent = document.createElement('div');
-    expect(getOptionalElementWidth(parent, '.missing')).toBe(0);
-  });
-
-  it('returns the element width when present', () => {
-    const parent = document.createElement('div');
-    const child = document.createElement('div');
-    child.className = 'present';
-    jest.spyOn(child, 'getBoundingClientRect').mockReturnValue({ width: 123 } as DOMRect);
-    parent.appendChild(child);
-
-    expect(getOptionalElementWidth(parent, '.present')).toBe(123);
   });
 });

--- a/src/top-navigation/__tests__/top-navigation.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation.test.tsx
@@ -69,7 +69,7 @@ describe('TopNavigation Component', () => {
 
   test('has a link', () => {
     const topNavigation = renderTopNavigation({ identity: { href: '#', title: 'Application Title' } });
-    expect(topNavigation.findIdentityLink().getElement()).toHaveAttribute('href', '#');
+    expect(topNavigation.findIdentityLink()!.getElement()).toHaveAttribute('href', '#');
   });
 
   test('fires follow event when the title is clicked', () => {
@@ -82,7 +82,7 @@ describe('TopNavigation Component', () => {
         onFollow: event => onFollowSpy(event.detail),
       },
     });
-    const identityLink = topNavigation.findIdentityLink().getElement();
+    const identityLink = topNavigation.findIdentityLink()!.getElement();
     identityLink.click();
     expect(onFollowSpy).toHaveBeenCalledWith({});
   });
@@ -97,7 +97,7 @@ describe('TopNavigation Component', () => {
         onFollow: event => onFollowSpy(event.detail),
       },
     });
-    const identityLink = topNavigation.findIdentityLink();
+    const identityLink = topNavigation.findIdentityLink()!;
     identityLink.click({ ctrlKey: true });
     identityLink.click({ altKey: true });
     identityLink.click({ shiftKey: true });
@@ -269,7 +269,7 @@ describe('URL sanitization', () => {
   describe('for the identity', () => {
     test('does not throw an error when a safe javascript: URL is passed', () => {
       const element = renderTopNavigation({ identity: { href: 'javascript:void(0)' } });
-      expect((element.findIdentityLink().getElement() as HTMLAnchorElement).href).toBe('javascript:void(0)');
+      expect((element.findIdentityLink()!.getElement() as HTMLAnchorElement).href).toBe('javascript:void(0)');
 
       expect(warnOnce).toHaveBeenCalledTimes(0);
     });
@@ -424,18 +424,50 @@ describe('URL sanitization', () => {
 
 describe('visualContext', () => {
   test('defaults to top-navigation visual context', () => {
-    renderTopNavigation({ identity: { href: '#', title: 'Structured' } });
-    expect(createWrapper().findAll('[class*="awsui-context-top-navigation"]')).toHaveLength(1);
+    const { container } = render(
+      <>
+        <TopNavigation identity={{ href: '#', title: 'Structured' }} />
+        <TopNavigation>custom</TopNavigation>
+      </>
+    );
+    expect(createWrapper(container).findAll('[class*="awsui-context-top-navigation"]')).toHaveLength(2);
   });
 
   test('uses top-navigation visual context explicitly', () => {
-    renderTopNavigation({ identity: { href: '#', title: 'Structured' }, visualContext: 'top-navigation' });
-    expect(createWrapper().findAll('[class*="awsui-context-top-navigation"]')).toHaveLength(1);
+    const { container } = render(
+      <>
+        <TopNavigation visualContext="top-navigation" identity={{ href: '#', title: 'Structured' }} />
+        <TopNavigation visualContext="top-navigation">custom</TopNavigation>
+      </>
+    );
+    expect(createWrapper(container).findAll('[class*="awsui-context-top-navigation"]')).toHaveLength(2);
   });
 
   test('uses no visual context', () => {
-    renderTopNavigation({ identity: { href: '#', title: 'Structured' }, visualContext: 'none' });
-    expect(createWrapper().findAll('[class*="awsui-context-top-navigation"]')).toHaveLength(0);
+    const { container } = render(
+      <>
+        <TopNavigation visualContext="none" identity={{ href: '#', title: 'Structured' }} />
+        <TopNavigation visualContext="none">custom</TopNavigation>
+      </>
+    );
+    expect(createWrapper(container).findAll('[class*="awsui-context-top-navigation"]')).toHaveLength(0);
+  });
+});
+
+describe('custom content - children', () => {
+  test('renders custom content and replaces structured elements when children are provided', () => {
+    const wrapper = renderTopNavigation({
+      identity: { href: '#', title: 'Should Not Render' },
+      search: <input placeholder="Search" />,
+      utilities: [{ type: 'button', text: 'Help' }],
+      children: <div data-testid="custom">Custom Nav</div>,
+    });
+    expect(wrapper.findContent()).not.toBeNull();
+    expect(wrapper.findContent()!.getElement()).toHaveTextContent('Custom Nav');
+    expect(wrapper.findTitle()).toBeNull();
+    expect(wrapper.findIdentityLink()).toBeNull();
+    expect(wrapper.findSearch()).toBeNull();
+    expect(wrapper.findUtilities()).toHaveLength(0);
   });
 });
 

--- a/src/top-navigation/__tests__/top-navigation.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation.test.tsx
@@ -87,6 +87,25 @@ describe('TopNavigation Component', () => {
     expect(onFollowSpy).toHaveBeenCalledWith({});
   });
 
+  test('does not throw when the identity is clicked without an onFollow handler', () => {
+    const topNavigation = renderTopNavigation({
+      identity: { href: '#', title: 'Application Title' },
+    });
+    expect(() => topNavigation.findIdentityLink()!.click()).not.toThrow();
+  });
+
+  test('renders the structured variant without an identity', () => {
+    const wrapper = renderTopNavigation({
+      search: <Input value="" onChange={() => {}} />,
+      utilities: [{ type: 'button', text: 'Help' }],
+    });
+    expect(wrapper.findIdentityLink()).toBeNull();
+    expect(wrapper.findTitle()).toBeNull();
+    expect(wrapper.findLogo()).toBeNull();
+    expect(wrapper.findUtilities()).toHaveLength(1);
+    expect(warnOnce).not.toHaveBeenCalled();
+  });
+
   test('does not fire a follow event when the item is clicked with a modifier', () => {
     const onFollowSpy = jest.fn();
 
@@ -468,6 +487,11 @@ describe('custom content - children', () => {
     expect(wrapper.findIdentityLink()).toBeNull();
     expect(wrapper.findSearch()).toBeNull();
     expect(wrapper.findUtilities()).toHaveLength(0);
+  });
+
+  test('does not render custom content for the structured variant', () => {
+    const wrapper = renderTopNavigation({ identity: { href: '#', title: 'Structured' } });
+    expect(wrapper.findContent()).toBeNull();
   });
 });
 

--- a/src/top-navigation/__tests__/top-navigation.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation.test.tsx
@@ -11,9 +11,10 @@ import createWrapper from '../../../lib/components/test-utils/dom';
 import TopNavigationWrapper, {
   OverflowMenu as OverflowMenuWrapper,
 } from '../../../lib/components/test-utils/dom/top-navigation';
-import TopNavigation, { TopNavigationProps } from '../../../lib/components/top-navigation';
+import TopNavigation from '../../../lib/components/top-navigation';
 import OverflowMenu from '../../../lib/components/top-navigation/parts/overflow-menu';
 import { useTopNavigation } from '../../../lib/components/top-navigation/use-top-navigation';
+import { renderTopNavigation } from './common';
 
 jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
   ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
@@ -38,22 +39,6 @@ const actualUseTopNavigation = jest.requireActual(
 afterEach(() => {
   (warnOnce as jest.Mock).mockReset();
 });
-
-const I18N_STRINGS: TopNavigationProps.I18nStrings = {
-  searchIconAriaLabel: 'Search',
-  searchDismissIconAriaLabel: 'Close search',
-  overflowMenuTriggerText: 'More',
-  overflowMenuTitleText: 'All',
-  overflowMenuBackIconAriaLabel: 'Back',
-  overflowMenuDismissIconAriaLabel: 'Close',
-};
-
-type PickPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
-
-const renderTopNavigation = (props: PickPartial<TopNavigationProps, 'i18nStrings'>) => {
-  const { container } = render(<TopNavigation i18nStrings={I18N_STRINGS} {...props} />);
-  return createWrapper(container).findTopNavigation()!;
-};
 
 describe('TopNavigation Component', () => {
   test('has title', () => {
@@ -470,28 +455,6 @@ describe('visualContext', () => {
       </>
     );
     expect(createWrapper(container).findAll('[class*="awsui-context-top-navigation"]')).toHaveLength(0);
-  });
-});
-
-describe('custom content - children', () => {
-  test('renders custom content and replaces structured elements when children are provided', () => {
-    const wrapper = renderTopNavigation({
-      identity: { href: '#', title: 'Should Not Render' },
-      search: <input placeholder="Search" />,
-      utilities: [{ type: 'button', text: 'Help' }],
-      children: <div data-testid="custom">Custom Nav</div>,
-    });
-    expect(wrapper.findContent()).not.toBeNull();
-    expect(wrapper.findContent()!.getElement()).toHaveTextContent('Custom Nav');
-    expect(wrapper.findTitle()).toBeNull();
-    expect(wrapper.findIdentityLink()).toBeNull();
-    expect(wrapper.findSearch()).toBeNull();
-    expect(wrapper.findUtilities()).toHaveLength(0);
-  });
-
-  test('does not render custom content for the structured variant', () => {
-    const wrapper = renderTopNavigation({ identity: { href: '#', title: 'Structured' } });
-    expect(wrapper.findContent()).toBeNull();
   });
 });
 

--- a/src/top-navigation/index.tsx
+++ b/src/top-navigation/index.tsx
@@ -10,9 +10,15 @@ import InternalTopNavigation from './internal';
 
 export { TopNavigationProps };
 
-export default function TopNavigation({ utilities = [], ...restProps }: TopNavigationProps) {
+export default function TopNavigation({
+  utilities = [],
+  visualContext = 'top-navigation',
+  ...restProps
+}: TopNavigationProps) {
   const baseComponentProps = useBaseComponent('TopNavigation');
-  return <InternalTopNavigation {...baseComponentProps} utilities={utilities} {...restProps} />;
+  return (
+    <InternalTopNavigation {...baseComponentProps} utilities={utilities} visualContext={visualContext} {...restProps} />
+  );
 }
 
 applyDisplayName(TopNavigation, 'TopNavigation');

--- a/src/top-navigation/interfaces.ts
+++ b/src/top-navigation/interfaces.ts
@@ -20,7 +20,7 @@ export interface TopNavigationProps extends BaseComponentProps {
   /**
    * Specifies custom navigation content.
    * When provided, replaces all structured content (identity, search, utilities are ignored).
-   * @displayname custom content
+   * @displayname customContent
    */
   children?: React.ReactNode;
 

--- a/src/top-navigation/interfaces.ts
+++ b/src/top-navigation/interfaces.ts
@@ -20,6 +20,7 @@ export interface TopNavigationProps extends BaseComponentProps {
   /**
    * Specifies custom navigation content.
    * When provided, replaces all structured content (identity, search, utilities are ignored).
+   * @displayname custom content
    */
   children?: React.ReactNode;
 

--- a/src/top-navigation/interfaces.ts
+++ b/src/top-navigation/interfaces.ts
@@ -15,7 +15,13 @@ export interface TopNavigationProps extends BaseComponentProps {
    * * `href` (string) - Specifies the `href` that the header links to.
    * * `onFollow` (() => void) - Specifies the event handler called when the identity is clicked without any modifier keys.
    */
-  identity: TopNavigationProps.Identity;
+  identity?: TopNavigationProps.Identity;
+
+  /**
+   * Specifies custom navigation content.
+   * When provided, replaces all structured content (identity, search, utilities are ignored).
+   */
+  children?: React.ReactNode;
 
   /**
    * Visual context applied to the navigation bar.

--- a/src/top-navigation/internal.tsx
+++ b/src/top-navigation/internal.tsx
@@ -18,6 +18,7 @@ import Utility from './parts/utility';
 import { useTopNavigation } from './use-top-navigation.js';
 
 import styles from './styles.css.js';
+import testUtilStyles from './test-classes/styles.css.js';
 
 type InternalTopNavigationProps = SomeRequired<TopNavigationProps, 'utilities'> & InternalBaseComponentProps;
 
@@ -27,15 +28,46 @@ function wrapWithVisualContext(content: React.ReactNode, visualContext: TopNavig
 
 export default function InternalTopNavigation({
   __internalRootRef,
+  children,
+  visualContext = 'top-navigation',
+  ...restProps
+}: InternalTopNavigationProps) {
+  const baseProps = getBaseProps(restProps);
+
+  if (children !== undefined) {
+    return (
+      <div {...baseProps} ref={__internalRootRef}>
+        {wrapWithVisualContext(
+          <header className={styles['top-navigation']}>
+            <div className={testUtilStyles['custom-content']}>{children}</div>
+          </header>,
+          visualContext
+        )}
+      </div>
+    );
+  }
+
+  return <StructuredTopNavigation __internalRootRef={__internalRootRef} visualContext={visualContext} {...restProps} />;
+}
+
+interface StructuredTopNavigationProps extends Omit<InternalTopNavigationProps, 'children'> {
+  visualContext: TopNavigationProps.VisualContext;
+}
+
+function StructuredTopNavigation({
+  __internalRootRef,
   identity,
   i18nStrings,
   utilities,
   search,
-  visualContext = 'top-navigation',
+  visualContext,
   ...restProps
-}: InternalTopNavigationProps) {
-  checkSafeUrl('TopNavigation', identity.href);
+}: StructuredTopNavigationProps) {
+  if (identity) {
+    checkSafeUrl('TopNavigation', identity.href);
+  }
   const baseProps = getBaseProps(restProps);
+
   const { mainRef, virtualRef, breakpoint, responsiveState, isSearchExpanded, onSearchUtilityClick } = useTopNavigation(
     { identity, search, utilities }
   );
@@ -46,16 +78,7 @@ export default function InternalTopNavigation({
   const isLargeViewport = breakpoint === 's';
   const i18n = useInternalI18n('top-navigation');
 
-  const onIdentityClick = (event: React.MouseEvent) => {
-    if (isPlainLeftClick(event)) {
-      fireCancelableEvent(identity.onFollow, {}, event);
-    }
-  };
-
-  const toggleOverflowMenu = () => {
-    setOverflowMenuOpen(overflowMenuOpen => !overflowMenuOpen);
-  };
-
+  // const hasCollapsibleUtilities = utilities.some(u => !u.disableUtilityCollapse);
   const menuTriggerVisible = !isSearchExpanded && responsiveState.hideUtilities;
 
   useEffect(() => {
@@ -68,12 +91,22 @@ export default function InternalTopNavigation({
     }
   }, [overflowMenuOpen]);
 
+  const onIdentityClick = (event: React.MouseEvent) => {
+    if (isPlainLeftClick(event)) {
+      fireCancelableEvent(identity?.onFollow, {}, event);
+    }
+  };
+
+  const toggleOverflowMenu = () => {
+    setOverflowMenuOpen(overflowMenuOpen => !overflowMenuOpen);
+  };
+
   // Render the top nav twice; once as the top nav that users can see, and another
   // "virtual" top nav used just for calculations. The virtual top nav doesn't react to
   // layout changes and renders two sets of utilities: one with labels and one without.
   const content = (isVirtual: boolean) => {
     const Wrapper = isVirtual ? 'div' : 'header';
-    const showIdentity = isVirtual || !isSearchExpanded;
+    const showIdentity = !!identity && (isVirtual || !isSearchExpanded);
     const showTitle = isVirtual || !responsiveState.hideTitle;
     const showSearchSlot = search && (isVirtual || !responsiveState.hideSearch || isSearchExpanded);
     const showSearchUtility = isVirtual || (search && responsiveState.hideSearch);
@@ -92,14 +125,14 @@ export default function InternalTopNavigation({
         })}
       >
         <div className={styles['padding-box']}>
-          {showIdentity && (
+          {showIdentity && identity && (
             <div className={clsx(styles.identity, !identity.logo && styles['no-logo'])}>
               <a className={styles['identity-link']} href={identity.href} onClick={onIdentityClick}>
                 {identity.logo && (
                   <img
                     role="img"
-                    src={identity.logo?.src}
-                    alt={identity.logo?.alt}
+                    src={identity.logo.src}
+                    alt={identity.logo.alt}
                     className={clsx(styles.logo, {
                       [styles.narrow]: isNarrowViewport,
                     })}

--- a/src/top-navigation/internal.tsx
+++ b/src/top-navigation/internal.tsx
@@ -12,7 +12,6 @@ import VisualContext from '../internal/components/visual-context';
 import { fireCancelableEvent, isPlainLeftClick } from '../internal/events';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useEffectOnUpdate } from '../internal/hooks/use-effect-on-update';
-import { isDevelopment } from '../internal/is-development';
 import { SomeRequired } from '../internal/types';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
 import { TopNavigationProps } from './interfaces';
@@ -23,7 +22,8 @@ import { useTopNavigation } from './use-top-navigation.js';
 import styles from './styles.css.js';
 import testUtilStyles from './test-classes/styles.css.js';
 
-type InternalTopNavigationProps = SomeRequired<TopNavigationProps, 'utilities'> & InternalBaseComponentProps;
+type InternalTopNavigationProps = SomeRequired<TopNavigationProps, 'utilities' | 'visualContext'> &
+  InternalBaseComponentProps;
 
 function wrapWithVisualContext(content: React.ReactNode, visualContext: TopNavigationProps.VisualContext) {
   return visualContext === 'none' ? content : <VisualContext contextName={visualContext}>{content}</VisualContext>;
@@ -32,7 +32,7 @@ function wrapWithVisualContext(content: React.ReactNode, visualContext: TopNavig
 export default function InternalTopNavigation({
   __internalRootRef,
   children,
-  visualContext = 'top-navigation',
+  visualContext,
   ...restProps
 }: InternalTopNavigationProps) {
   if (children !== undefined) {
@@ -46,27 +46,20 @@ export default function InternalTopNavigation({
   return <StructuredTopNavigation __internalRootRef={__internalRootRef} visualContext={visualContext} {...restProps} />;
 }
 
-interface CustomContentTopNavigationProps extends InternalTopNavigationProps {
-  visualContext: TopNavigationProps.VisualContext;
-}
-
 function CustomContentTopNavigation({
   __internalRootRef,
   children,
   visualContext,
   ...restProps
-}: CustomContentTopNavigationProps) {
+}: InternalTopNavigationProps) {
   const baseProps = getBaseProps(restProps);
 
-  if (isDevelopment) {
-    const { identity, search, utilities } = restProps;
-    if (identity || search || (utilities && utilities.length > 0)) {
-      warnOnce(
-        'TopNavigation',
-        'You have provided `children` along with structured props (`identity`, `search`, and/or `utilities`). ' +
-          'When `children` is set, the structured props are ignored.'
-      );
-    }
+  const { identity, search, utilities } = restProps;
+  if (identity || search || (utilities && utilities.length > 0)) {
+    warnOnce(
+      'TopNavigation',
+      'When children is set, the structured props (identity, search, and utilities) are ignored'
+    );
   }
 
   return (
@@ -81,9 +74,7 @@ function CustomContentTopNavigation({
   );
 }
 
-interface StructuredTopNavigationProps extends Omit<InternalTopNavigationProps, 'children'> {
-  visualContext: TopNavigationProps.VisualContext;
-}
+type StructuredTopNavigationProps = Omit<InternalTopNavigationProps, 'children'>;
 
 function StructuredTopNavigation({
   __internalRootRef,

--- a/src/top-navigation/internal.tsx
+++ b/src/top-navigation/internal.tsx
@@ -3,6 +3,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+
 import { useInternalI18n } from '../i18n/context';
 import { getBaseProps } from '../internal/base-component';
 import { ButtonTrigger } from '../internal/components/menu-dropdown';
@@ -10,6 +12,7 @@ import VisualContext from '../internal/components/visual-context';
 import { fireCancelableEvent, isPlainLeftClick } from '../internal/events';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useEffectOnUpdate } from '../internal/hooks/use-effect-on-update';
+import { isDevelopment } from '../internal/is-development';
 import { SomeRequired } from '../internal/types';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
 import { TopNavigationProps } from './interfaces';
@@ -32,22 +35,50 @@ export default function InternalTopNavigation({
   visualContext = 'top-navigation',
   ...restProps
 }: InternalTopNavigationProps) {
-  const baseProps = getBaseProps(restProps);
-
   if (children !== undefined) {
     return (
-      <div {...baseProps} ref={__internalRootRef}>
-        {wrapWithVisualContext(
-          <header className={styles['top-navigation']}>
-            <div className={testUtilStyles['custom-content']}>{children}</div>
-          </header>,
-          visualContext
-        )}
-      </div>
+      <CustomContentTopNavigation __internalRootRef={__internalRootRef} visualContext={visualContext} {...restProps}>
+        {children}
+      </CustomContentTopNavigation>
     );
   }
 
   return <StructuredTopNavigation __internalRootRef={__internalRootRef} visualContext={visualContext} {...restProps} />;
+}
+
+interface CustomContentTopNavigationProps extends InternalTopNavigationProps {
+  visualContext: TopNavigationProps.VisualContext;
+}
+
+function CustomContentTopNavigation({
+  __internalRootRef,
+  children,
+  visualContext,
+  ...restProps
+}: CustomContentTopNavigationProps) {
+  const baseProps = getBaseProps(restProps);
+
+  if (isDevelopment) {
+    const { identity, search, utilities } = restProps;
+    if (identity || search || (utilities && utilities.length > 0)) {
+      warnOnce(
+        'TopNavigation',
+        'You have provided `children` along with structured props (`identity`, `search`, and/or `utilities`). ' +
+          'When `children` is set, the structured props are ignored.'
+      );
+    }
+  }
+
+  return (
+    <div {...baseProps} ref={__internalRootRef}>
+      {wrapWithVisualContext(
+        <header className={styles['top-navigation']}>
+          <div className={testUtilStyles['custom-content']}>{children}</div>
+        </header>,
+        visualContext
+      )}
+    </div>
+  );
 }
 
 interface StructuredTopNavigationProps extends Omit<InternalTopNavigationProps, 'children'> {
@@ -78,7 +109,6 @@ function StructuredTopNavigation({
   const isLargeViewport = breakpoint === 's';
   const i18n = useInternalI18n('top-navigation');
 
-  // const hasCollapsibleUtilities = utilities.some(u => !u.disableUtilityCollapse);
   const menuTriggerVisible = !isSearchExpanded && responsiveState.hideUtilities;
 
   useEffect(() => {

--- a/src/top-navigation/test-classes/styles.scss
+++ b/src/top-navigation/test-classes/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.custom-content {
+  /* used in test-utils */
+}

--- a/src/top-navigation/use-top-navigation.ts
+++ b/src/top-navigation/use-top-navigation.ts
@@ -59,7 +59,7 @@ export function useTopNavigation({ identity, search, utilities }: UseTopNavigati
   // The component works by calculating the possible resize states that it can
   // be in, and having a state variable to track which state we're currently in.
   const hasSearch = !!search;
-  const hasTitleWithLogo = identity && !!identity.logo && !!identity.title;
+  const hasTitleWithLogo = !!identity && !!identity.logo && !!identity.title;
   const responsiveStates = useMemo<ReadonlyArray<ResponsiveState>>(() => {
     return generateResponsiveStateKeys(utilities, hasSearch, hasTitleWithLogo);
   }, [utilities, hasSearch, hasTitleWithLogo]);
@@ -93,7 +93,7 @@ export function useTopNavigation({ identity, search, utilities }: UseTopNavigati
       availableWidth,
 
       // Get widths from the hidden top navigation
-      fullIdentityWidth: virtualRef.current.querySelector(`.${styles.identity}`)!.getBoundingClientRect().width,
+      fullIdentityWidth: virtualRef.current.querySelector(`.${styles.identity}`)?.getBoundingClientRect().width ?? 0,
       titleWidth: virtualRef.current.querySelector(`.${styles.title}`)?.getBoundingClientRect().width ?? 0,
       searchSlotWidth: virtualRef.current.querySelector(`.${styles.search}`)?.getBoundingClientRect().width ?? 0,
       searchUtilityWidth: virtualRef.current.querySelector('[data-utility-special="search"]')!.getBoundingClientRect()

--- a/src/top-navigation/use-top-navigation.ts
+++ b/src/top-navigation/use-top-navigation.ts
@@ -172,12 +172,10 @@ function getContentBoxWidth(element: Element): number {
 }
 
 /**
- * Measures the width of an optional element. Returns 0 when the element is not rendered
- * (e.g. there is no `identity`, `title` or `search`). The `number` return type makes the
- * zero fallback part of the contract, so a missing element can never leak `undefined` into
- * the responsive-width math (which would turn it into `NaN` and collapse the layout).
+ * Measures the width of an optional element, returning 0 when it is not rendered
+ * (e.g. there is no `identity`, `title` or `search`).
  */
-export function getOptionalElementWidth(parent: Element, selector: string): number {
+function getOptionalElementWidth(parent: Element, selector: string): number {
   return parent.querySelector(selector)?.getBoundingClientRect().width ?? 0;
 }
 

--- a/src/top-navigation/use-top-navigation.ts
+++ b/src/top-navigation/use-top-navigation.ts
@@ -175,7 +175,7 @@ function getContentBoxWidth(element: Element): number {
  * Measures the width of an optional element, returning 0 when it is not rendered
  * (e.g. there is no `identity`, `title` or `search`).
  */
-function getOptionalElementWidth(parent: Element, selector: string): number {
+export function getOptionalElementWidth(parent: Element, selector: string): number {
   return parent.querySelector(selector)?.getBoundingClientRect().width ?? 0;
 }
 

--- a/src/top-navigation/use-top-navigation.ts
+++ b/src/top-navigation/use-top-navigation.ts
@@ -93,9 +93,9 @@ export function useTopNavigation({ identity, search, utilities }: UseTopNavigati
       availableWidth,
 
       // Get widths from the hidden top navigation
-      fullIdentityWidth: virtualRef.current.querySelector(`.${styles.identity}`)?.getBoundingClientRect().width ?? 0,
-      titleWidth: virtualRef.current.querySelector(`.${styles.title}`)?.getBoundingClientRect().width ?? 0,
-      searchSlotWidth: virtualRef.current.querySelector(`.${styles.search}`)?.getBoundingClientRect().width ?? 0,
+      fullIdentityWidth: getOptionalElementWidth(virtualRef.current, `.${styles.identity}`),
+      titleWidth: getOptionalElementWidth(virtualRef.current, `.${styles.title}`),
+      searchSlotWidth: getOptionalElementWidth(virtualRef.current, `.${styles.search}`),
       searchUtilityWidth: virtualRef.current.querySelector('[data-utility-special="search"]')!.getBoundingClientRect()
         .width,
       utilitiesLeftPadding: parseFloat(
@@ -169,6 +169,16 @@ function getContentBoxWidth(element: Element): number {
   return (
     parseFloat(style.width || '0px') - parseFloat(style.paddingLeft || '0px') - parseFloat(style.paddingRight || '0px')
   );
+}
+
+/**
+ * Measures the width of an optional element. Returns 0 when the element is not rendered
+ * (e.g. there is no `identity`, `title` or `search`). The `number` return type makes the
+ * zero fallback part of the contract, so a missing element can never leak `undefined` into
+ * the responsive-width math (which would turn it into `NaN` and collapse the layout).
+ */
+export function getOptionalElementWidth(parent: Element, selector: string): number {
+  return parent.querySelector(selector)?.getBoundingClientRect().width ?? 0;
 }
 
 /**


### PR DESCRIPTION
### Description
Adds a children slot to TopNavigation that lets consumers render fully custom navigation content, replacing the structured layout (identity, search, utilities).
```typescript []
<TopNavigation>
  <MyCustomNav />
</TopNavigation>
```
When children is provided, the component renders the custom content inside the navigation bar and skips the structured layout entirely. It still respects the visualContext prop, so custom content adapts to the dark/branded context or uses page colors with visualContext="none".

**Note**: Depends on the [visualContext PR](https://github.com/cloudscape-design/components/pull/4631)

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

- Unit tests for custom content rendering, structured fallback, and visualContext across both modes
- Snapshot updates for the new prop

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
