### PR TITLE
fix: Support pressedIconSvg in button group

### DIFF
--- a/src/app-layout/runtime-drawer/index.tsx
+++ b/src/app-layout/runtime-drawer/index.tsx
@@ -95,7 +95,7 @@ function mapRuntimeHeaderActionsToHeaderActions(
       // eslint-disable-next-line no-restricted-syntax -- Runtime plugin API: property not in TS type
       ...('pressedIconSvg' in runtimeHeaderAction &&
         runtimeHeaderAction.pressedIconSvg && {
-          iconSvg: convertRuntimeTriggerToReactNode(runtimeHeaderAction.pressedIconSvg),
+          pressedIconSvg: convertRuntimeTriggerToReactNode(runtimeHeaderAction.pressedIconSvg),
         }),
     };
   });

--- a/src/button-group/__tests__/button-group.test.tsx
+++ b/src/button-group/__tests__/button-group.test.tsx
@@ -107,61 +107,60 @@ describe('ButtonGroup Style API', () => {
 });
 
 test('icon-toggle-button maintains correct icon on state change', () => {
-    const { rerender } = render(
-      <ButtonGroup
-        variant="icon"
-        ariaLabel="Test"
-        items={[
-          {
-            type: 'icon-toggle-button',
-            id: 'test-toggle-state',
-            text: 'Toggle State',
-            pressed: false,
-            iconSvg: (
-              <svg className="default-state-icon" focusable="false" viewBox="0 0 16 16">
-                <circle cx="8" cy="8" r="7" />
-              </svg>
-            ),
-            pressedIconSvg: (
-              <svg className="pressed-state-icon" focusable="false" viewBox="0 0 16 16">
-                <circle cx="8" cy="8" r="8" fill="currentColor" />
-              </svg>
-            ),
-          },
-        ]}
-      />
-    );
-    
-    expect(wrapper.findToggleButtonById('test-toggle-state')!.find('.default-icon')).toBeTruthy();
-    expect(wrapper.findToggleButtonById('test-toggle-state')!.find('.pressed-icon')).toBeFalsy();
-    
+  const { rerender } = render(
+    <ButtonGroup
+      variant="icon"
+      ariaLabel="Test"
+      items={[
+        {
+          type: 'icon-toggle-button',
+          id: 'test-toggle-state',
+          text: 'Toggle State',
+          pressed: false,
+          iconSvg: (
+            <svg className="default-state-icon" focusable="false" viewBox="0 0 16 16">
+              <circle cx="8" cy="8" r="7" />
+            </svg>
+          ),
+          pressedIconSvg: (
+            <svg className="pressed-state-icon" focusable="false" viewBox="0 0 16 16">
+              <circle cx="8" cy="8" r="8" fill="currentColor" />
+            </svg>
+          ),
+        },
+      ]}
+    />
+  );
 
-    // Rerender with pressed state
-    rerender(
-      <ButtonGroup
-        variant="icon"
-        ariaLabel="Test"
-        items={[
-          {
-            type: 'icon-toggle-button',
-            id: 'test-toggle-state',
-            text: 'Toggle State',
-            pressed: true,
-            iconSvg: (
-              <svg className="default-state-icon" focusable="false" viewBox="0 0 16 16">
-                <circle cx="8" cy="8" r="7" />
-              </svg>
-            ),
-            pressedIconSvg: (
-              <svg className="pressed-state-icon" focusable="false" viewBox="0 0 16 16">
-                <circle cx="8" cy="8" r="8" fill="currentColor" />
-              </svg>
-            ),
-          },
-        ]}
-      />
-    );
+  expect(wrapper.findToggleButtonById('test-toggle-state')!.find('.default-icon')).toBeTruthy();
+  expect(wrapper.findToggleButtonById('test-toggle-state')!.find('.pressed-icon')).toBeFalsy();
 
-    expect(wrapper.findToggleButtonById('test-toggle-state')!.find('.default-icon')).toBeFalsy();
-    expect(wrapper.findToggleButtonById('test-toggle-state')!.find('.pressed-icon')).toBeTruthy();
-  });
+  // Rerender with pressed state
+  rerender(
+    <ButtonGroup
+      variant="icon"
+      ariaLabel="Test"
+      items={[
+        {
+          type: 'icon-toggle-button',
+          id: 'test-toggle-state',
+          text: 'Toggle State',
+          pressed: true,
+          iconSvg: (
+            <svg className="default-state-icon" focusable="false" viewBox="0 0 16 16">
+              <circle cx="8" cy="8" r="7" />
+            </svg>
+          ),
+          pressedIconSvg: (
+            <svg className="pressed-state-icon" focusable="false" viewBox="0 0 16 16">
+              <circle cx="8" cy="8" r="8" fill="currentColor" />
+            </svg>
+          ),
+        },
+      ]}
+    />
+  );
+
+  expect(wrapper.findToggleButtonById('test-toggle-state')!.find('.default-icon')).toBeFalsy();
+  expect(wrapper.findToggleButtonById('test-toggle-state')!.find('.pressed-icon')).toBeTruthy();
+});

--- a/src/button-group/__tests__/button-group.test.tsx
+++ b/src/button-group/__tests__/button-group.test.tsx
@@ -107,7 +107,7 @@ describe('ButtonGroup Style API', () => {
 });
 
 test('icon-toggle-button maintains correct icon on state change', () => {
-  const { rerender } = render(
+  const { rerender, container } = render(
     <ButtonGroup
       variant="icon"
       ariaLabel="Test"
@@ -131,6 +131,7 @@ test('icon-toggle-button maintains correct icon on state change', () => {
       ]}
     />
   );
+  const wrapper = createWrapper(container).findButtonGroup()!;
 
   expect(wrapper.findToggleButtonById('test-toggle-state')!.find('.default-icon')).toBeTruthy();
   expect(wrapper.findToggleButtonById('test-toggle-state')!.find('.pressed-icon')).toBeFalsy();

--- a/src/button-group/__tests__/button-group.test.tsx
+++ b/src/button-group/__tests__/button-group.test.tsx
@@ -118,12 +118,12 @@ test('icon-toggle-button maintains correct icon on state change', () => {
           text: 'Toggle State',
           pressed: false,
           iconSvg: (
-            <svg className="default-state-icon" focusable="false" viewBox="0 0 16 16">
+            <svg className="default-icon" focusable="false" viewBox="0 0 16 16">
               <circle cx="8" cy="8" r="7" />
             </svg>
           ),
           pressedIconSvg: (
-            <svg className="pressed-state-icon" focusable="false" viewBox="0 0 16 16">
+            <svg className="pressed-icon" focusable="false" viewBox="0 0 16 16">
               <circle cx="8" cy="8" r="8" fill="currentColor" />
             </svg>
           ),

--- a/src/button-group/__tests__/button-group.test.tsx
+++ b/src/button-group/__tests__/button-group.test.tsx
@@ -105,3 +105,198 @@ describe('ButtonGroup Style API', () => {
     expect(getComputedStyle(itemElement).getPropertyValue(customCssProps.styleFocusRingBorderWidth)).toBe('2px');
   });
 });
+
+describe('ButtonGroup Icon Toggle Button with SVG icons', () => {
+  test('renders icon-toggle-button with pressedIconSvg when pressed', () => {
+    const defaultSvg = (
+      <svg className="default-icon" focusable="false" viewBox="0 0 16 16">
+        <circle cx="8" cy="8" r="7" />
+      </svg>
+    );
+    const pressedSvg = (
+      <svg className="pressed-icon" focusable="false" viewBox="0 0 16 16">
+        <circle cx="8" cy="8" r="8" fill="currentColor" />
+      </svg>
+    );
+
+    const wrapper = renderButtonGroup({
+      variant: 'icon',
+      ariaLabel: 'Test',
+      items: [
+        {
+          type: 'icon-toggle-button',
+          id: 'test-toggle',
+          text: 'Toggle Button',
+          pressed: true,
+          iconSvg: defaultSvg,
+          pressedIconSvg: pressedSvg,
+        },
+      ],
+    });
+
+    const toggleButton = wrapper.findToggleButtonById('test-toggle');
+    expect(toggleButton).toBeTruthy();
+
+    // Verify the pressed SVG is rendered
+    const element = toggleButton!.getElement();
+    const pressedIconElement = element.querySelector('.pressed-icon');
+    expect(pressedIconElement).toBeTruthy();
+  });
+
+  test('renders icon-toggle-button with default iconSvg when not pressed', () => {
+    const defaultSvg = (
+      <svg className="default-icon" focusable="false" viewBox="0 0 16 16">
+        <circle cx="8" cy="8" r="7" />
+      </svg>
+    );
+    const pressedSvg = (
+      <svg className="pressed-icon" focusable="false" viewBox="0 0 16 16">
+        <circle cx="8" cy="8" r="8" fill="currentColor" />
+      </svg>
+    );
+
+    const wrapper = renderButtonGroup({
+      variant: 'icon',
+      ariaLabel: 'Test',
+      items: [
+        {
+          type: 'icon-toggle-button',
+          id: 'test-toggle',
+          text: 'Toggle Button',
+          pressed: false,
+          iconSvg: defaultSvg,
+          pressedIconSvg: pressedSvg,
+        },
+      ],
+    });
+
+    const toggleButton = wrapper.findToggleButtonById('test-toggle');
+    expect(toggleButton).toBeTruthy();
+
+    // Verify the default SVG is rendered when not pressed
+    const element = toggleButton!.getElement();
+    const defaultIconElement = element.querySelector('.default-icon');
+    expect(defaultIconElement).toBeTruthy();
+  });
+
+  test('icon-toggle-button with pressedIconUrl shows correct icon when pressed', () => {
+    const pressedUrl = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"%3E%3Ccircle cx="8" cy="8" r="8"%3E%3C/circle%3E%3C/svg%3E';
+
+    const wrapper = renderButtonGroup({
+      variant: 'icon',
+      ariaLabel: 'Test',
+      items: [
+        {
+          type: 'icon-toggle-button',
+          id: 'test-toggle-url',
+          text: 'Toggle with URL',
+          pressed: true,
+          iconName: 'star',
+          pressedIconUrl: pressedUrl,
+        },
+      ],
+    });
+
+    const toggleButton = wrapper.findToggleButtonById('test-toggle-url');
+    expect(toggleButton).toBeTruthy();
+  });
+
+  test('icon-toggle-button with all icon types prioritizes SVG correctly', () => {
+    const pressedSvg = (
+      <svg className="pressed-svg-test" focusable="false" viewBox="0 0 16 16">
+        <circle cx="8" cy="8" r="8" />
+      </svg>
+    );
+
+    const wrapper = renderButtonGroup({
+      variant: 'icon',
+      ariaLabel: 'Test',
+      items: [
+        {
+          type: 'icon-toggle-button',
+          id: 'test-toggle-all',
+          text: 'Toggle with all icons',
+          pressed: true,
+          iconName: 'star',
+          pressedIconName: 'star-filled',
+          iconUrl: 'data:image/svg+xml,%3Csvg%3E%3C/svg%3E',
+          pressedIconUrl: 'data:image/svg+xml,%3Csvg%3E%3C/svg%3E',
+          iconSvg: (
+            <svg className="default-svg-test" focusable="false" viewBox="0 0 16 16">
+              <circle cx="8" cy="8" r="7" />
+            </svg>
+          ),
+          pressedIconSvg: pressedSvg,
+        },
+      ],
+    });
+
+    const toggleButton = wrapper.findToggleButtonById('test-toggle-all');
+    expect(toggleButton).toBeTruthy();
+
+    // SVG should take precedence when present in pressed state
+    const element = toggleButton!.getElement();
+    const pressedSvgElement = element.querySelector('.pressed-svg-test');
+    expect(pressedSvgElement).toBeTruthy();
+  });
+
+  test('icon-toggle-button maintains correct icon on state change', () => {
+    const { rerender } = render(
+      <ButtonGroup
+        variant="icon"
+        ariaLabel="Test"
+        items={[
+          {
+            type: 'icon-toggle-button',
+            id: 'test-toggle-state',
+            text: 'Toggle State',
+            pressed: false,
+            iconSvg: (
+              <svg className="default-state-icon" focusable="false" viewBox="0 0 16 16">
+                <circle cx="8" cy="8" r="7" />
+              </svg>
+            ),
+            pressedIconSvg: (
+              <svg className="pressed-state-icon" focusable="false" viewBox="0 0 16 16">
+                <circle cx="8" cy="8" r="8" fill="currentColor" />
+              </svg>
+            ),
+          },
+        ]}
+      />
+    );
+
+    const container = document.querySelector('.awsui-button-group');
+    let iconElement = container?.querySelector('.default-state-icon');
+    expect(iconElement).toBeTruthy();
+
+    // Rerender with pressed state
+    rerender(
+      <ButtonGroup
+        variant="icon"
+        ariaLabel="Test"
+        items={[
+          {
+            type: 'icon-toggle-button',
+            id: 'test-toggle-state',
+            text: 'Toggle State',
+            pressed: true,
+            iconSvg: (
+              <svg className="default-state-icon" focusable="false" viewBox="0 0 16 16">
+                <circle cx="8" cy="8" r="7" />
+              </svg>
+            ),
+            pressedIconSvg: (
+              <svg className="pressed-state-icon" focusable="false" viewBox="0 0 16 16">
+                <circle cx="8" cy="8" r="8" fill="currentColor" />
+              </svg>
+            ),
+          },
+        ]}
+      />
+    );
+
+    iconElement = container?.querySelector('.pressed-state-icon');
+    expect(iconElement).toBeTruthy();
+  });
+});

--- a/src/button-group/__tests__/button-group.test.tsx
+++ b/src/button-group/__tests__/button-group.test.tsx
@@ -106,141 +106,7 @@ describe('ButtonGroup Style API', () => {
   });
 });
 
-describe('ButtonGroup Icon Toggle Button with SVG icons', () => {
-  test('renders icon-toggle-button with pressedIconSvg when pressed', () => {
-    const defaultSvg = (
-      <svg className="default-icon" focusable="false" viewBox="0 0 16 16">
-        <circle cx="8" cy="8" r="7" />
-      </svg>
-    );
-    const pressedSvg = (
-      <svg className="pressed-icon" focusable="false" viewBox="0 0 16 16">
-        <circle cx="8" cy="8" r="8" fill="currentColor" />
-      </svg>
-    );
-
-    const wrapper = renderButtonGroup({
-      variant: 'icon',
-      ariaLabel: 'Test',
-      items: [
-        {
-          type: 'icon-toggle-button',
-          id: 'test-toggle',
-          text: 'Toggle Button',
-          pressed: true,
-          iconSvg: defaultSvg,
-          pressedIconSvg: pressedSvg,
-        },
-      ],
-    });
-
-    const toggleButton = wrapper.findToggleButtonById('test-toggle');
-    expect(toggleButton).toBeTruthy();
-
-    // Verify the pressed SVG is rendered
-    const element = toggleButton!.getElement();
-    const pressedIconElement = element.querySelector('.pressed-icon');
-    expect(pressedIconElement).toBeTruthy();
-  });
-
-  test('renders icon-toggle-button with default iconSvg when not pressed', () => {
-    const defaultSvg = (
-      <svg className="default-icon" focusable="false" viewBox="0 0 16 16">
-        <circle cx="8" cy="8" r="7" />
-      </svg>
-    );
-    const pressedSvg = (
-      <svg className="pressed-icon" focusable="false" viewBox="0 0 16 16">
-        <circle cx="8" cy="8" r="8" fill="currentColor" />
-      </svg>
-    );
-
-    const wrapper = renderButtonGroup({
-      variant: 'icon',
-      ariaLabel: 'Test',
-      items: [
-        {
-          type: 'icon-toggle-button',
-          id: 'test-toggle',
-          text: 'Toggle Button',
-          pressed: false,
-          iconSvg: defaultSvg,
-          pressedIconSvg: pressedSvg,
-        },
-      ],
-    });
-
-    const toggleButton = wrapper.findToggleButtonById('test-toggle');
-    expect(toggleButton).toBeTruthy();
-
-    // Verify the default SVG is rendered when not pressed
-    const element = toggleButton!.getElement();
-    const defaultIconElement = element.querySelector('.default-icon');
-    expect(defaultIconElement).toBeTruthy();
-  });
-
-  test('icon-toggle-button with pressedIconUrl shows correct icon when pressed', () => {
-    const pressedUrl = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"%3E%3Ccircle cx="8" cy="8" r="8"%3E%3C/circle%3E%3C/svg%3E';
-
-    const wrapper = renderButtonGroup({
-      variant: 'icon',
-      ariaLabel: 'Test',
-      items: [
-        {
-          type: 'icon-toggle-button',
-          id: 'test-toggle-url',
-          text: 'Toggle with URL',
-          pressed: true,
-          iconName: 'star',
-          pressedIconUrl: pressedUrl,
-        },
-      ],
-    });
-
-    const toggleButton = wrapper.findToggleButtonById('test-toggle-url');
-    expect(toggleButton).toBeTruthy();
-  });
-
-  test('icon-toggle-button with all icon types prioritizes SVG correctly', () => {
-    const pressedSvg = (
-      <svg className="pressed-svg-test" focusable="false" viewBox="0 0 16 16">
-        <circle cx="8" cy="8" r="8" />
-      </svg>
-    );
-
-    const wrapper = renderButtonGroup({
-      variant: 'icon',
-      ariaLabel: 'Test',
-      items: [
-        {
-          type: 'icon-toggle-button',
-          id: 'test-toggle-all',
-          text: 'Toggle with all icons',
-          pressed: true,
-          iconName: 'star',
-          pressedIconName: 'star-filled',
-          iconUrl: 'data:image/svg+xml,%3Csvg%3E%3C/svg%3E',
-          pressedIconUrl: 'data:image/svg+xml,%3Csvg%3E%3C/svg%3E',
-          iconSvg: (
-            <svg className="default-svg-test" focusable="false" viewBox="0 0 16 16">
-              <circle cx="8" cy="8" r="7" />
-            </svg>
-          ),
-          pressedIconSvg: pressedSvg,
-        },
-      ],
-    });
-
-    const toggleButton = wrapper.findToggleButtonById('test-toggle-all');
-    expect(toggleButton).toBeTruthy();
-
-    // SVG should take precedence when present in pressed state
-    const element = toggleButton!.getElement();
-    const pressedSvgElement = element.querySelector('.pressed-svg-test');
-    expect(pressedSvgElement).toBeTruthy();
-  });
-
-  test('icon-toggle-button maintains correct icon on state change', () => {
+test('icon-toggle-button maintains correct icon on state change', () => {
     const { rerender } = render(
       <ButtonGroup
         variant="icon"
@@ -265,10 +131,10 @@ describe('ButtonGroup Icon Toggle Button with SVG icons', () => {
         ]}
       />
     );
-
-    const container = document.querySelector('.awsui-button-group');
-    let iconElement = container?.querySelector('.default-state-icon');
-    expect(iconElement).toBeTruthy();
+    
+    expect(wrapper.findToggleButtonById('test-toggle-state')!.find('.default-icon')).toBeTruthy();
+    expect(wrapper.findToggleButtonById('test-toggle-state')!.find('.pressed-icon')).toBeFalsy();
+    
 
     // Rerender with pressed state
     rerender(
@@ -296,7 +162,6 @@ describe('ButtonGroup Icon Toggle Button with SVG icons', () => {
       />
     );
 
-    iconElement = container?.querySelector('.pressed-state-icon');
-    expect(iconElement).toBeTruthy();
+    expect(wrapper.findToggleButtonById('test-toggle-state')!.find('.default-icon')).toBeFalsy();
+    expect(wrapper.findToggleButtonById('test-toggle-state')!.find('.pressed-icon')).toBeTruthy();
   });
-});

--- a/src/button-group/__tests__/button-group.test.tsx
+++ b/src/button-group/__tests__/button-group.test.tsx
@@ -148,12 +148,12 @@ test('icon-toggle-button maintains correct icon on state change', () => {
           text: 'Toggle State',
           pressed: true,
           iconSvg: (
-            <svg className="default-state-icon" focusable="false" viewBox="0 0 16 16">
+            <svg className="default-icon" focusable="false" viewBox="0 0 16 16">
               <circle cx="8" cy="8" r="7" />
             </svg>
           ),
           pressedIconSvg: (
-            <svg className="pressed-state-icon" focusable="false" viewBox="0 0 16 16">
+            <svg className="pressed-icon" focusable="false" viewBox="0 0 16 16">
               <circle cx="8" cy="8" r="8" fill="currentColor" />
             </svg>
           ),

--- a/src/button-group/icon-toggle-button-item.tsx
+++ b/src/button-group/icon-toggle-button-item.tsx
@@ -55,7 +55,7 @@ const IconToggleButtonItem = forwardRef(
           iconSvg={item.iconSvg}
           pressedIconName={hasIcon ? item.pressedIconName : 'close'}
           pressedIconUrl={item.pressedIconUrl}
-          pressedIconSvg={item.pressedIconUrl}
+          pressedIconSvg={item.pressedIconSvg}
           ariaLabel={item.text}
           onChange={event => fireCancelableEvent(onItemClick, { id: item.id, pressed: event.detail.pressed })}
           ref={ref}


### PR DESCRIPTION
### Description

Self explanatory

Related links, issue #, if available: n/a

### How has this been tested?

n/a

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
