### PR TITLE
chore: Table Column Groups Followups

### DIFF
--- a/pages/table/column-groups.page.tsx
+++ b/pages/table/column-groups.page.tsx
@@ -200,7 +200,6 @@ type DemoContext = React.Context<
     lastSticky: number;
     wrapLines: boolean;
     stripedRows: boolean;
-    contentDensity: 'comfortable' | 'compact' | undefined;
     enableKeyboardNavigation: boolean;
     loading: boolean;
     empty: boolean;
@@ -222,7 +221,6 @@ export default function ColumnGroupsPage() {
       lastSticky = 0,
       wrapLines = false,
       stripedRows = false,
-      contentDensity = 'comfortable',
       enableKeyboardNavigation = true,
       loading = false,
       empty = false,
@@ -350,18 +348,6 @@ export default function ColumnGroupsPage() {
             <Toggle checked={stickyHeader} onChange={({ detail }) => setUrlParams({ stickyHeader: detail.checked })}>
               Sticky header
             </Toggle>
-            <Toggle checked={wrapLines} onChange={({ detail }) => setUrlParams({ wrapLines: detail.checked })}>
-              Wrap lines
-            </Toggle>
-            <Toggle checked={stripedRows} onChange={({ detail }) => setUrlParams({ stripedRows: detail.checked })}>
-              Striped rows
-            </Toggle>
-            <Toggle
-              checked={contentDensity === 'compact'}
-              onChange={({ detail }) => setUrlParams({ contentDensity: detail.checked ? 'compact' : 'comfortable' })}
-            >
-              Compact mode
-            </Toggle>
             <Toggle
               checked={enableKeyboardNavigation}
               onChange={({ detail }) => setUrlParams({ enableKeyboardNavigation: detail.checked })}
@@ -400,7 +386,6 @@ export default function ColumnGroupsPage() {
         enableKeyboardNavigation={enableKeyboardNavigation}
         wrapLines={wrapLines}
         stripedRows={stripedRows}
-        contentDensity={contentDensity}
         cellVerticalAlign={cellVerticalAlign}
         sortingDisabled={sortingDisabled}
         loading={loading}
@@ -422,7 +407,7 @@ export default function ColumnGroupsPage() {
         pagination={<Pagination {...paginationProps} />}
         preferences={
           <CollectionPreferences
-            preferences={{ contentDisplay: columnDisplay, wrapLines, stripedRows, contentDensity }}
+            preferences={{ contentDisplay: columnDisplay, wrapLines, stripedRows }}
             onConfirm={({ detail }) => {
               if (detail.contentDisplay) {
                 setColumnDisplay([...detail.contentDisplay]);
@@ -430,12 +415,10 @@ export default function ColumnGroupsPage() {
               setUrlParams({
                 wrapLines: detail.wrapLines ?? false,
                 stripedRows: detail.stripedRows ?? false,
-                contentDensity: detail.contentDensity ?? 'comfortable',
               });
             }}
             wrapLinesPreference={{}}
             stripedRowsPreference={{}}
-            contentDensityPreference={{}}
             contentDisplayPreference={{
               options: [
                 { id: 'id', label: 'Instance ID', alwaysVisible: true },

--- a/pages/table/column-groups.page.tsx
+++ b/pages/table/column-groups.page.tsx
@@ -23,10 +23,6 @@ import {
 import AppContext, { AppContextType } from '../app/app-context';
 import { SimplePage } from '../app/templates';
 
-// ============================================================================
-// Data
-// ============================================================================
-
 interface Instance {
   id: string;
   name: string;
@@ -57,10 +53,6 @@ const allInstances: Instance[] = Array.from({ length: 35 }, (_, i) => ({
   cost: +(Math.random() * 500).toFixed(2),
 }));
 
-// ============================================================================
-// Column & group definitions
-// ============================================================================
-
 const columnDefinitions: TableProps.ColumnDefinition<Instance>[] = [
   {
     id: 'id',
@@ -86,10 +78,6 @@ const groupDefinitions: TableProps.GroupDefinition[] = [
   { id: 'network', header: 'Network' },
   { id: 'metrics', header: 'Metrics' },
 ];
-
-// ============================================================================
-// Column display presets
-// ============================================================================
 
 type GroupingPreset = 'flat' | 'single-level' | 'nested' | 'single-child-groups';
 
@@ -199,10 +187,6 @@ const presetOptions = [
   { value: 'single-child-groups', label: 'Single-child groups' },
   { value: 'flat', label: 'Without grouping' },
 ];
-
-// ============================================================================
-// Page component
-// ============================================================================
 
 type DemoContext = React.Context<
   AppContextType<{

--- a/pages/table/column-groups.page.tsx
+++ b/pages/table/column-groups.page.tsx
@@ -220,7 +220,7 @@ type DemoContext = React.Context<
     enableKeyboardNavigation: boolean;
     loading: boolean;
     empty: boolean;
-    cellVerticalAlign: string;
+    cellVerticalAlign?: TableProps.VerticalAlign;
     sortingDisabled: boolean;
   }>
 >;
@@ -321,7 +321,9 @@ export default function ColumnGroupsPage() {
                   { value: 'middle', label: 'middle' },
                   { value: 'top', label: 'top' },
                 ]}
-                onChange={({ detail }) => setUrlParams({ cellVerticalAlign: detail.selectedOption.value! })}
+                onChange={({ detail }) =>
+                  setUrlParams({ cellVerticalAlign: detail.selectedOption.value as TableProps.VerticalAlign })
+                }
                 ariaLabel="Cell vertical align"
               />
             </FormField>
@@ -415,7 +417,7 @@ export default function ColumnGroupsPage() {
         wrapLines={wrapLines}
         stripedRows={stripedRows}
         contentDensity={contentDensity}
-        cellVerticalAlign={cellVerticalAlign as 'middle' | 'top'}
+        cellVerticalAlign={cellVerticalAlign}
         sortingDisabled={sortingDisabled}
         loading={loading}
         loadingText="Loading..."

--- a/pages/table/column-groups.page.tsx
+++ b/pages/table/column-groups.page.tsx
@@ -6,6 +6,7 @@ import { useCollection } from '@cloudscape-design/collection-hooks';
 
 import {
   Box,
+  CollectionPreferences,
   FormField,
   Header,
   Input,
@@ -215,7 +216,7 @@ type DemoContext = React.Context<
     lastSticky: number;
     wrapLines: boolean;
     stripedRows: boolean;
-    contentDensity: string;
+    contentDensity: 'comfortable' | 'compact' | undefined;
     enableKeyboardNavigation: boolean;
     loading: boolean;
     empty: boolean;
@@ -413,7 +414,7 @@ export default function ColumnGroupsPage() {
         enableKeyboardNavigation={enableKeyboardNavigation}
         wrapLines={wrapLines}
         stripedRows={stripedRows}
-        contentDensity={contentDensity as 'comfortable' | 'compact'}
+        contentDensity={contentDensity}
         cellVerticalAlign={cellVerticalAlign as 'middle' | 'top'}
         sortingDisabled={sortingDisabled}
         loading={loading}
@@ -433,6 +434,47 @@ export default function ColumnGroupsPage() {
           />
         }
         pagination={<Pagination {...paginationProps} />}
+        preferences={
+          <CollectionPreferences
+            preferences={{ contentDisplay: columnDisplay, wrapLines, stripedRows, contentDensity }}
+            onConfirm={({ detail }) => {
+              if (detail.contentDisplay) {
+                setColumnDisplay([...detail.contentDisplay]);
+              }
+              setUrlParams({
+                wrapLines: detail.wrapLines ?? false,
+                stripedRows: detail.stripedRows ?? false,
+                contentDensity: detail.contentDensity ?? 'comfortable',
+              });
+            }}
+            wrapLinesPreference={{}}
+            stripedRowsPreference={{}}
+            contentDensityPreference={{}}
+            contentDisplayPreference={{
+              options: [
+                { id: 'id', label: 'Instance ID', alwaysVisible: true },
+                { id: 'name', label: 'Name' },
+                { id: 'type', label: 'Type' },
+                { id: 'az', label: 'AZ' },
+                { id: 'state', label: 'State' },
+                { id: 'cpu', label: 'CPU (%)' },
+                { id: 'memory', label: 'Memory (%)' },
+                { id: 'netIn', label: 'Network in' },
+                { id: 'netOut', label: 'Network out' },
+                { id: 'cost', label: 'Cost ($)' },
+              ],
+              groups:
+                groupingPreset === 'flat'
+                  ? undefined
+                  : [
+                      { id: 'config', label: 'Configuration' },
+                      { id: 'performance', label: 'Performance' },
+                      { id: 'network', label: 'Network' },
+                      { id: 'metrics', label: 'Metrics' },
+                    ],
+            }}
+          />
+        }
         empty={<Box textAlign="center">No instances</Box>}
       />
     </SimplePage>

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -71,7 +71,7 @@ $cell-horizontal-padding: awsui.$space-scaled-l;
   }
 
   &-sticky {
-    border-block-end: awsui.$border-table-sticky-width solid awsui.$color-border-divider-default;
+    border-block-end: awsui.$border-table-sticky-width solid awsui.$color-border-divider-interactive-default;
   }
   &-stuck:not(.header-cell-variant-full-page) {
     border-block-end-color: transparent;


### PR DESCRIPTION
Following up on #4482 

Fix missing highcontrast horizontal line divider between levels.
- fix: use higher-contrast border color for sticky table header divider

Unintended less contract color divider.
<img width="1176" height="359" alt="image" src="https://github.com/user-attachments/assets/00265281-a15d-44a6-b21d-b66643bdb075" />

What we want consistently for all table feature combinations
<img width="1176" height="359" alt="image" src="https://github.com/user-attachments/assets/965e726a-7ba4-4014-b666-15c577d943eb" />


Updating the Test Page to include collection prefs on the grouped table dev page
- **chore: add CollectionPreferences to column-groups dev page**

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
