### PR TITLE
fix: propagate one-theme class to portaled content

### DIFF
--- a/src/breadcrumb-group/__tests__/widgetized-breadcrumbs.test.tsx
+++ b/src/breadcrumb-group/__tests__/widgetized-breadcrumbs.test.tsx
@@ -47,6 +47,7 @@ function getResourceTypeElements(container: HTMLElement) {
 
 jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => ({
   useVisualRefresh: jest.fn().mockReturnValue(false),
+  useOneTheme: jest.fn().mockReturnValue(false),
 }));
 
 describe('Classic design', () => {

--- a/src/container/__tests__/sticky-header.test.tsx
+++ b/src/container/__tests__/sticky-header.test.tsx
@@ -12,6 +12,7 @@ jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
 }));
 jest.mock('../../internal/hooks/use-visual-mode', () => ({
   useVisualRefresh: jest.fn().mockReturnValue(true),
+  useOneTheme: jest.fn().mockReturnValue(false),
 }));
 
 jest.mock('@cloudscape-design/component-toolkit/dom', () => ({

--- a/src/content-layout/__tests__/content-layout.test.tsx
+++ b/src/content-layout/__tests__/content-layout.test.tsx
@@ -13,6 +13,7 @@ import styles from '../../../lib/components/content-layout/styles.selectors.js';
 
 jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => ({
   useVisualRefresh: jest.fn().mockReturnValue(false),
+  useOneTheme: jest.fn().mockReturnValue(false),
 }));
 
 function renderContentLayout(props: ContentLayoutProps = {}) {

--- a/src/header/__tests__/sticky-responsiveness.test.tsx
+++ b/src/header/__tests__/sticky-responsiveness.test.tsx
@@ -12,6 +12,7 @@ import styles from '../../../lib/components/header/styles.css.js';
 
 jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => ({
   useVisualRefresh: jest.fn().mockReturnValue(false),
+  useOneTheme: jest.fn().mockReturnValue(false),
 }));
 
 function renderHeader(jsx: React.ReactElement) {

--- a/src/internal/hooks/use-portal-mode-classes/__tests__/use-portal-mode-classes.test.tsx
+++ b/src/internal/hooks/use-portal-mode-classes/__tests__/use-portal-mode-classes.test.tsx
@@ -42,6 +42,24 @@ describe('usePortalModeClasses', () => {
     expect(screen.getByTestId('subject')).toHaveClass('awsui-visual-refresh', { exact: true });
   });
 
+  test('should detect one theme mode', () => {
+    document.body.classList.add('awsui-one-theme');
+
+    render(<RenderTest refClasses="" />);
+    expect(screen.getByTestId('subject')).toHaveClass('awsui-one-theme', { exact: true });
+    // Must not stamp the VR class, which would override One Theme tokens on portaled content.
+    expect(screen.getByTestId('subject')).not.toHaveClass('awsui-visual-refresh');
+  });
+
+  test('should let one theme win when visual refresh is also active', () => {
+    globalWithFlags[Symbol.for('awsui-visual-refresh-flag')] = () => true;
+    document.body.classList.add('awsui-one-theme');
+
+    render(<RenderTest refClasses="" />);
+    expect(screen.getByTestId('subject')).toHaveClass('awsui-one-theme', { exact: true });
+    expect(screen.getByTestId('subject')).not.toHaveClass('awsui-visual-refresh');
+  });
+
   test('should detect contexts', () => {
     render(
       <VisualContext contextName="content-header">

--- a/src/internal/hooks/use-portal-mode-classes/index.ts
+++ b/src/internal/hooks/use-portal-mode-classes/index.ts
@@ -7,18 +7,20 @@ import { useCurrentMode, useDensityMode } from '@cloudscape-design/component-too
 
 import { useVisualContext } from '../../components/visual-context';
 import { ALWAYS_VISUAL_REFRESH } from '../../environment';
-import { useVisualRefresh } from '../use-visual-mode';
+import { useOneTheme, useVisualRefresh } from '../use-visual-mode';
 
 export function usePortalModeClasses(ref: React.RefObject<HTMLElement>, options?: { resetVisualContext?: boolean }) {
   const colorMode = useCurrentMode(ref);
   const densityMode = useDensityMode(ref);
   const context = useVisualContext(ref);
-  const visualRefreshWithClass = useVisualRefresh() && !ALWAYS_VISUAL_REFRESH;
+  const oneTheme = useOneTheme();
+  const visualRefreshWithClass = useVisualRefresh() && !ALWAYS_VISUAL_REFRESH && !oneTheme;
 
   return clsx({
     'awsui-polaris-dark-mode awsui-dark-mode': colorMode === 'dark',
     'awsui-polaris-compact-mode awsui-compact-mode': densityMode === 'compact',
     'awsui-visual-refresh': visualRefreshWithClass,
+    'awsui-one-theme': oneTheme,
     [`awsui-context-${context}`]: context && !options?.resetVisualContext,
   });
 }

--- a/src/internal/hooks/use-visual-mode/index.ts
+++ b/src/internal/hooks/use-visual-mode/index.ts
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useRuntimeVisualRefresh } from '@cloudscape-design/component-toolkit/internal';
+import { isThemeActive, Theme, useRuntimeVisualRefresh } from '@cloudscape-design/component-toolkit/internal';
 
 import { ALWAYS_VISUAL_REFRESH } from '../../environment';
 
 export const useVisualRefresh = ALWAYS_VISUAL_REFRESH ? () => true : useRuntimeVisualRefresh;
+
+export const useOneTheme = () => isThemeActive(Theme.OneTheme);

--- a/src/internal/widgets/__tests__/widgets.test.tsx
+++ b/src/internal/widgets/__tests__/widgets.test.tsx
@@ -20,6 +20,7 @@ function findContent(container: HTMLElement) {
 
 jest.mock('../../../../lib/components/internal/hooks/use-visual-mode', () => ({
   useVisualRefresh: jest.fn().mockReturnValue(false),
+  useOneTheme: jest.fn().mockReturnValue(false),
 }));
 
 describe('Classic design', () => {

--- a/src/split-panel/__tests__/widgetized-panel.test.tsx
+++ b/src/split-panel/__tests__/widgetized-panel.test.tsx
@@ -43,6 +43,7 @@ const defaultProps: SplitPanelImplementationProps = {
 
 jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => ({
   useVisualRefresh: jest.fn().mockReturnValue(false),
+  useOneTheme: jest.fn().mockReturnValue(false),
 }));
 
 describe('Classic design', () => {

--- a/src/wizard/__tests__/analytics-metadata.test.tsx
+++ b/src/wizard/__tests__/analytics-metadata.test.tsx
@@ -26,6 +26,7 @@ import labels from '../../../lib/components/wizard/analytics-metadata/styles.css
 
 jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => ({
   useVisualRefresh: jest.fn().mockReturnValue(false),
+  useOneTheme: jest.fn().mockReturnValue(false),
 }));
 
 const steps: WizardProps['steps'] = [


### PR DESCRIPTION
### Description

Propagates `.awsui-one-theme` to portaled content.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
