### PR TITLE
chore: Fix regression on #4588 - Scope trigger flex alignment to one-theme only

### DIFF
--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -3,13 +3,14 @@
 import React, { useEffect, useImperativeHandle, useRef } from 'react';
 import clsx from 'clsx';
 
-import { useUniqueId, warnOnce } from '@cloudscape-design/component-toolkit/internal';
+import { isThemeActive, Theme, useUniqueId, warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 import InternalBox from '../box/internal';
 import { ButtonProps } from '../button/interfaces';
 import { InternalButton, InternalButtonProps } from '../button/internal';
 import Dropdown from '../dropdown/internal';
+import { IconProps } from '../icon/interfaces';
 import { useFunnel } from '../internal/analytics/hooks/use-funnel.js';
 import { getBaseProps } from '../internal/base-component';
 import OptionsList from '../internal/components/options-list';
@@ -141,13 +142,14 @@ const InternalButtonDropdown = React.forwardRef(
     const canBeFullWidth = !!fullWidth && (variant === 'primary' || variant === 'normal');
 
     const triggerVariant = variant === 'navigation' ? undefined : variant === 'inline-icon' ? 'inline-icon' : variant;
-    const iconProps: Partial<ButtonProps & { __iconClass?: string }> =
+    const iconProps: Partial<ButtonProps & { __iconClass?: string; __iconSize?: IconProps.Size }> =
       variant === 'icon' || variant === 'inline-icon'
         ? {
             iconName: 'ellipsis',
           }
         : {
-            iconName: 'caret-down-filled',
+            iconName: isThemeActive(Theme.OneTheme) ? 'angle-down' : 'caret-down-filled',
+            __iconSize: isThemeActive(Theme.OneTheme) ? 'x-small' : 'normal',
             iconAlign: 'right',
             __iconClass: spinWhenOpen(styles, 'rotate', canBeOpened && isOpen),
           };
@@ -155,6 +157,7 @@ const InternalButtonDropdown = React.forwardRef(
     const baseTriggerProps: InternalButtonProps = {
       className: clsx(
         styles['trigger-button'],
+        isThemeActive(Theme.OneTheme) && styles['one-theme'],
         styles['test-utils-button-trigger'],
         analyticsSelectors['trigger-label']
       ),

--- a/src/button-dropdown/styles.scss
+++ b/src/button-dropdown/styles.scss
@@ -50,6 +50,10 @@ $dropdown-trigger-icon-offset: 2px;
 }
 
 .trigger-button {
+  &.one-theme {
+    display: flex;
+    align-items: center;
+  }
   &.full-width {
     display: grid;
     grid-template-columns: 1fr auto;


### PR DESCRIPTION


### Description
Fixes a visual-refresh regression introduced in #4588.

`display: flex; align-items: center;` was added to `.trigger-button` in `styles.scss` without being scoped to one-theme. 
This changed the layout of button-dropdown trigger buttons in visual-refresh mode unconditionally.

#### Root cause: 
The flex alignment was needed for icon vertical centering in one-theme, but the CSS rule had no theme guard, so it applied globally across all themes.

#### Fix:
- Moved display: flex; align-items: center; inside a .one-theme modifier on .trigger-button in the SCSS
- Added isThemeActive(Theme.OneTheme) && styles['one-theme'] to the trigger button className in 
`internal.tsx` so the class is only applied when one-theme is active
No behavior change in visual-refresh. One-theme icon alignment is preserved.

Related links: #4588
<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
