### PR TITLE
fix: Table groups wrong offset set with sticky column

### DIFF
--- a/src/table/header-cell/group-header-cell.tsx
+++ b/src/table/header-cell/group-header-cell.tsx
@@ -8,9 +8,7 @@ import { useUniqueId } from '@cloudscape-design/component-toolkit/internal';
 
 import { TableProps } from '../interfaces';
 import { Divider, Resizer } from '../resizer';
-import { useStickyCellStyles } from '../sticky-columns';
 import { DEFAULT_COLUMN_WIDTH, useColumnWidths } from '../use-column-widths';
-import { getStickyClassNames } from '../utils';
 import { BaseHeaderCellProps } from './common-props';
 import { TableThElement } from './th-element';
 
@@ -74,18 +72,6 @@ export function TableGroupHeaderCell({
   const clickableHeaderRef = useRef<HTMLDivElement>(null);
   const { tabIndex: clickableHeaderTabIndex } = useSingleTabStopNavigation(clickableHeaderRef, { tabIndex });
 
-  // Subscribe to the boundary column's sticky state to inherit shadow/clip-path classes.
-  // The offset/position comes from stickyColumnId (first child); this only adds boundary classes.
-  const boundaryStyles = useStickyCellStyles({
-    stickyColumns: stickyState,
-    columnId: stickyBoundaryColumnId ?? stickyColumnId ?? groupId,
-    getClassName: props => getStickyClassNames(styles, props),
-  });
-
-  // boundaryStyles.className is populated by scroll/intersection observers in the browser.
-  // In JSDOM these observers don't fire, so this branch is only exercised in integration tests.
-  const boundaryClassName = stickyBoundaryColumnId && boundaryStyles.className ? boundaryStyles.className : undefined;
-
   return (
     <TableThElement
       resizableStyle={resizableStyle}
@@ -97,6 +83,7 @@ export function TableGroupHeaderCell({
       stripedRows={stripedRows}
       colIndex={colIndex}
       columnId={stickyColumnId ?? groupId}
+      stickyBoundaryColumnId={stickyBoundaryColumnId}
       stickyState={stickyState}
       tableRole={tableRole}
       variant={variant}
@@ -106,8 +93,6 @@ export function TableGroupHeaderCell({
       scope="colgroup"
       isLast={isLast}
       columnGroupId={columnGroupId}
-      className={boundaryClassName}
-      boundaryRef={stickyBoundaryColumnId ? boundaryStyles.ref : undefined}
     >
       <div
         ref={clickableHeaderRef}

--- a/src/table/header-cell/th-element.tsx
+++ b/src/table/header-cell/th-element.tsx
@@ -43,10 +43,11 @@ export interface TableThElementProps {
   scope?: 'col' | 'colgroup';
   columnGroupId?: string;
   isLast?: boolean;
-  /** Additional className to merge (e.g. boundary shadow classes from a secondary sticky subscription). */
-  className?: string;
-  /** Additional ref for boundary sticky subscription (imperatively updates shadow classes). */
-  boundaryRef?: React.RefCallback<HTMLElement>;
+  /**
+   * For cells that span multiple columns (group headers): the column id of the boundary leaf
+   * whose sticky shadow this cell should inherit. The cell's position still comes from `columnId`.
+   */
+  stickyBoundaryColumnId?: PropertyKey;
 }
 
 export function TableThElement({
@@ -74,8 +75,7 @@ export function TableThElement({
   scope,
   columnGroupId,
   isLast,
-  className,
-  boundaryRef,
+  stickyBoundaryColumnId,
   ...props
 }: TableThElementProps) {
   const isVisualRefresh = useVisualRefresh();
@@ -84,10 +84,11 @@ export function TableThElement({
     stickyColumns: stickyState,
     columnId,
     getClassName: props => getStickyClassNames(styles, props),
+    boundaryColumnId: stickyBoundaryColumnId,
   });
 
   const cellRefObject = useRef<HTMLTableCellElement>(null);
-  const mergedRef = useMergeRefs(stickyStyles.ref, cellRef, cellRefObject, boundaryRef);
+  const mergedRef = useMergeRefs(stickyStyles.ref, cellRef, cellRefObject);
   const { tabIndex: cellTabIndex } = useSingleTabStopNavigation(cellRefObject);
 
   return (
@@ -115,8 +116,7 @@ export function TableThElement({
           [styles['header-cell-spans-rows']]: (rowSpan ?? 1) > 1,
           [styles['header-cell-grouped']]: !!columnGroupId,
         },
-        stickyStyles.className,
-        className
+        stickyStyles.className
       )}
       colSpan={colSpan}
       rowSpan={rowSpan}

--- a/src/table/sticky-columns/__tests__/use-sticky-columns.test.tsx
+++ b/src/table/sticky-columns/__tests__/use-sticky-columns.test.tsx
@@ -325,3 +325,83 @@ test('updateCellOffsets element widths fallback to 0 when elements are missing',
   expect(offsets.get('a')).toEqual({ first: 0, last: 0 });
   expect(offsets.get('c')).toEqual({ first: 0, last: 0 });
 });
+
+describe('useStickyCellStyles boundaryColumnId', () => {
+  // Stub store lets us toggle the boundary leaf's `lastInsetInlineEnd` while keeping the
+  // position leaf's flag false — a state the real store never produces (it only ever sets
+  // the flag on one leaf), but exactly the situation a group header relies on.
+  const cellState = (overrides: { lastInsetInlineEnd?: boolean; offset?: { insetInlineEnd: number } } = {}) => ({
+    padInlineStart: false,
+    lastInsetInlineStart: false,
+    lastInsetInlineEnd: false,
+    offset: { insetInlineEnd: 100 },
+    ...overrides,
+  });
+  function stubModel(initial: Map<PropertyKey, any>) {
+    const listeners: Array<(n: any, p: any) => void> = [];
+    let state = { cellState: initial, wrapperState: { scrollPaddingInlineStart: 0, scrollPaddingInlineEnd: 0 } };
+    return {
+      model: {
+        store: {
+          get: () => state,
+          subscribe: (_: any, l: any) => (listeners.push(l), () => {}),
+          unsubscribe: () => {},
+        },
+        style: { wrapper: {} },
+        refs: { table: () => {}, wrapper: () => {}, cell: () => {} },
+      } as unknown as StickyColumnsModel,
+      setCellState: (next: Map<PropertyKey, any>) => {
+        const prev = state;
+        state = { ...state, cellState: next };
+        listeners.forEach(l => l(state, prev));
+      },
+    };
+  }
+
+  test("OR-merges boundary leaf's shadow flag into className but keeps position leaf's offset", () => {
+    const { model } = stubModel(
+      new Map<PropertyKey, any>([
+        ['pos', cellState({ offset: { insetInlineEnd: 120 } })],
+        ['boundary', cellState({ lastInsetInlineEnd: true, offset: { insetInlineEnd: 240 } })],
+      ])
+    );
+    const getClassName = jest.fn(state => ({ 'last-end': !!state?.lastInsetInlineEnd }));
+    const { result } = renderHook(() =>
+      useStickyCellStyles({ stickyColumns: model, columnId: 'pos', boundaryColumnId: 'boundary', getClassName })
+    );
+    expect(getClassName).toHaveBeenLastCalledWith(expect.objectContaining({ lastInsetInlineEnd: true }));
+    expect(result.current.className).toBe('last-end');
+    expect(result.current.style).toEqual({ insetInlineEnd: 120 });
+  });
+
+  test("scroll updates merge boundary shadow class without touching position leaf's offset", () => {
+    const th = document.createElement('th');
+    const pos = cellState({ offset: { insetInlineEnd: 120 } });
+    const { model, setCellState } = stubModel(
+      new Map<PropertyKey, any>([
+        ['pos', pos],
+        ['boundary', cellState({ offset: { insetInlineEnd: 240 } })],
+      ])
+    );
+    const styles = { 'sticky-cell': 'sticky-cell', 'sticky-cell-last-inline-end': 'sticky-cell-last-inline-end' };
+    const { result } = renderHook(() =>
+      useStickyCellStyles({
+        stickyColumns: model,
+        columnId: 'pos',
+        boundaryColumnId: 'boundary',
+        getClassName: state => getStickyClassNames(styles, state),
+      })
+    );
+    result.current.ref(th);
+    expect(th).not.toHaveClass('sticky-cell-last-inline-end');
+
+    setCellState(
+      new Map<PropertyKey, any>([
+        ['pos', pos],
+        ['boundary', cellState({ lastInsetInlineEnd: true, offset: { insetInlineEnd: 240 } })],
+      ])
+    );
+    expect(th).toHaveClass('sticky-cell-last-inline-end');
+    expect(th.style.insetInlineEnd).toBe('120px');
+  });
+});

--- a/src/table/sticky-columns/use-sticky-columns.ts
+++ b/src/table/sticky-columns/use-sticky-columns.ts
@@ -139,6 +139,12 @@ interface UseStickyCellStylesProps {
   stickyColumns: StickyColumnsModel;
   columnId: PropertyKey;
   getClassName: (styles: null | StickyColumnsCellState) => Record<string, boolean>;
+  // Optional column to inherit the boundary shadow flags from. Used by group header cells
+  // that span multiple leaves: the cell's offset is owned by `columnId` (one of its child
+  // leaves), but the boundary shadow lives on a different leaf (the group's boundary child).
+  // The hook keeps a single subscription/writer and merges the boundary leaf's
+  // `lastInsetInlineStart` / `lastInsetInlineEnd` into the cell state passed to getClassName.
+  boundaryColumnId?: PropertyKey;
 }
 
 interface StickyCellStyles {
@@ -147,10 +153,33 @@ interface StickyCellStyles {
   style?: React.CSSProperties;
 }
 
+// Merges the boundary leaf's shadow flags into the position leaf's cell state.
+// Returns the position state untouched when there is no boundary column or no boundary state.
+function mergeBoundaryShadow(
+  positionState: null | StickyColumnsCellState,
+  boundaryState: null | StickyColumnsCellState
+): null | StickyColumnsCellState {
+  if (!positionState || !boundaryState) {
+    return positionState;
+  }
+  if (
+    positionState.lastInsetInlineStart === boundaryState.lastInsetInlineStart &&
+    positionState.lastInsetInlineEnd === boundaryState.lastInsetInlineEnd
+  ) {
+    return positionState;
+  }
+  return {
+    ...positionState,
+    lastInsetInlineStart: positionState.lastInsetInlineStart || boundaryState.lastInsetInlineStart,
+    lastInsetInlineEnd: positionState.lastInsetInlineEnd || boundaryState.lastInsetInlineEnd,
+  };
+}
+
 export function useStickyCellStyles({
   stickyColumns,
   columnId,
   getClassName,
+  boundaryColumnId,
 }: UseStickyCellStylesProps): StickyCellStyles {
   const setCell = stickyColumns.refs.cell;
 
@@ -169,7 +198,11 @@ export function useStickyCellStyles({
       setCell(columnId, cellElement);
 
       // Update cell styles imperatively to avoid unnecessary re-renders.
-      const selector = (state: StickyColumnsState) => state.cellState.get(columnId) ?? null;
+      const selector = (state: StickyColumnsState) => {
+        const positionState = state.cellState.get(columnId) ?? null;
+        const boundaryState = boundaryColumnId !== undefined ? (state.cellState.get(boundaryColumnId) ?? null) : null;
+        return mergeBoundaryShadow(positionState, boundaryState);
+      };
 
       const updateCellStyles = (state: null | StickyColumnsCellState, prev: null | StickyColumnsCellState) => {
         if (isCellStatesEqual(state, prev)) {
@@ -203,15 +236,18 @@ export function useStickyCellStyles({
 
     // getClassName is expected to be pure
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [columnId, setCell, stickyColumns.store]
+    [columnId, boundaryColumnId, setCell, stickyColumns.store]
   );
 
   // Provide cell styles as props so that a re-render won't cause invalidation.
-  const cellStyles = stickyColumns.store.get().cellState.get(columnId);
+  const storeState = stickyColumns.store.get();
+  const positionStyles = storeState.cellState.get(columnId) ?? null;
+  const boundaryStyles = boundaryColumnId !== undefined ? (storeState.cellState.get(boundaryColumnId) ?? null) : null;
+  const mergedStyles = mergeBoundaryShadow(positionStyles, boundaryStyles);
   return {
     ref: refCallback,
-    className: cellStyles ? clsx(getClassName(cellStyles)) : undefined,
-    style: cellStyles?.offset ?? undefined,
+    className: mergedStyles ? clsx(getClassName(mergedStyles)) : undefined,
+    style: positionStyles?.offset ?? undefined,
   };
 }
 

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -331,6 +331,7 @@ const Thead = React.forwardRef(
                         resizerTooltipText={resizerTooltipText}
                         isLast={rightColIndex + rightColspan === totalColumns}
                         stickyColumnId={!isSplitFirst ? childIds[childIds.length - 1] : undefined}
+                        stickyBoundaryColumnId={!isSplitFirst ? rightChildIds[0] : undefined}
                       />
                     </React.Fragment>
                   );


### PR DESCRIPTION
### Description

Fix for AWSUI-62074. With column groups + `stickyColumns={{ last: 3 }}`, the group header renders correctly but becomes misaligned with its columns after scrolling horizontally and back.

Add a read-only `useStickyCellBoundary` hook that returns only the `className` (no ref, no offset writes). The group header uses it for shadow classes, leaving the primary subscription as the sole owner of position. Also removes the now-unused `boundaryRef` from `th-element.tsx`.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->
In the test pages: go to /#/table/column-groups

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
