### PR TITLE
refactor: make one-theme a standalone theme

### DIFF
--- a/style-dictionary/one-theme/borders.ts
+++ b/style-dictionary/one-theme/borders.ts
@@ -1,8 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { StyleDictionary } from '../utils/interfaces.js';
+import merge from 'lodash/merge.js';
 
-export const tokens: StyleDictionary.BordersDictionary = {
+import { StyleDictionary } from '../utils/interfaces.js';
+import { tokens as parentTokens } from '../visual-refresh/borders.js';
+
+const tokens: StyleDictionary.BordersDictionary = {
   // ── Border widths ─────────────────────────────────────────────────────────
   borderWidthButton: '1px',
   borderWidthToken: '1px',
@@ -35,3 +38,7 @@ export const tokens: StyleDictionary.BordersDictionary = {
   borderRadiusTutorialPanelItem: '4px',
   borderRadiusStatusIndicator: '2px',
 };
+
+const expandedTokens: StyleDictionary.ExpandedGlobalScopeDictionary = merge({}, parentTokens, tokens);
+
+export { expandedTokens as tokens };

--- a/style-dictionary/one-theme/color-palette.ts
+++ b/style-dictionary/one-theme/color-palette.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import merge from 'lodash/merge.js';
 import pick from 'lodash/pick.js';
 
 import { ReferenceTokens } from '@cloudscape-design/theming-build';
@@ -7,6 +8,7 @@ import { ReferenceTokens } from '@cloudscape-design/theming-build';
 import { paletteTokens as brand } from '../core/color-palette.js';
 import { expandColorDictionary, expandReferenceTokens } from '../utils/index.js';
 import { StyleDictionary } from '../utils/interfaces.js';
+import { referenceTokens as vrReferenceTokens, tokens as parentTokens } from '../visual-refresh/color-palette.js';
 
 /**
  * @deprecated These color palette tokens are deprecated and may be removed in a future version.
@@ -166,8 +168,12 @@ const referenceTokens: ReferenceTokens = {
   },
 };
 
-const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = expandColorDictionary(tokens);
-const expandedReferenceTokens: ReferenceTokens = expandReferenceTokens(referenceTokens);
+const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = merge(
+  {},
+  parentTokens,
+  expandColorDictionary(tokens)
+);
+const expandedReferenceTokens: ReferenceTokens = expandReferenceTokens(merge({}, vrReferenceTokens, referenceTokens));
 
 export const mode: StyleDictionary.ModeIdentifier = 'color';
 export { expandedTokens as tokens };

--- a/style-dictionary/one-theme/colors.ts
+++ b/style-dictionary/one-theme/colors.ts
@@ -1,10 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import merge from 'lodash/merge.js';
+
 import { expandColorDictionary } from '../utils/index.js';
 import { StyleDictionary } from '../utils/interfaces.js';
+import { tokens as parentTokens } from '../visual-refresh/colors.js';
 
-// One Theme color overrides on top of the visual-refresh baseline.
-// Tokens not listed here fall back to the visual-refresh value via ThemeBuilder.addTokens in ./index.ts.
+// One Theme color overrides. The full visual-refresh color set is merged in as the
+// base (parentTokens) and the entries below override it. This keeps One Theme a
+// standalone theme (no runtime buildVisualRefresh layering) — same pattern as classic.
 const tokens: StyleDictionary.ColorsDictionary = {
   // ── Body text ─────────────────────────────────────────────────────────────
   colorTextBodyDefault: { light: '{colorNeutralGrey950}', dark: '{colorNeutralGrey350}' },
@@ -135,7 +139,11 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorTextBreadcrumbCurrent: { light: '{colorNeutralGrey600}', dark: '{colorNeutralGrey500}' },
 };
 
-const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = expandColorDictionary(tokens);
+const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = merge(
+  {},
+  parentTokens,
+  expandColorDictionary(tokens)
+);
 
 export { expandedTokens as tokens };
 export const mode: StyleDictionary.ModeIdentifier = 'color';

--- a/style-dictionary/one-theme/colors.ts
+++ b/style-dictionary/one-theme/colors.ts
@@ -6,9 +6,7 @@ import { expandColorDictionary } from '../utils/index.js';
 import { StyleDictionary } from '../utils/interfaces.js';
 import { tokens as parentTokens } from '../visual-refresh/colors.js';
 
-// One Theme color overrides. The full visual-refresh color set is merged in as the
-// base (parentTokens) and the entries below override it. This keeps One Theme a
-// standalone theme (no runtime buildVisualRefresh layering) — same pattern as classic.
+// One Theme color overrides; the full visual-refresh color set (parentTokens) is the base.
 const tokens: StyleDictionary.ColorsDictionary = {
   // ── Body text ─────────────────────────────────────────────────────────────
   colorTextBodyDefault: { light: '{colorNeutralGrey950}', dark: '{colorNeutralGrey350}' },

--- a/style-dictionary/one-theme/index.ts
+++ b/style-dictionary/one-theme/index.ts
@@ -2,17 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ThemeBuilder } from '@cloudscape-design/theming-build';
 
+// visual-refresh/color-palette and core/color-palette form an import cycle (core re-exports
+// visual-refresh's reference tokens, while visual-refresh consumes core's `brand` palette).
+// The cycle resolves correctly only when visual-refresh/color-palette is evaluated first.
+// one-theme/color-palette.ts imports both modules, and import sorting forces the core import
+// first, which would trigger a temporal-dead-zone error on `brand`. Evaluating
+// visual-refresh/color-palette here first guarantees the safe order (the same ordering the
+// previous buildVisualRefresh import used to provide).
+import '../visual-refresh/color-palette.js';
 import {
   createAlertContext,
   createAppLayoutToolbarContext,
+  createCompactTableContext,
   createFlashbarContext,
   createFlashbarWarningContext,
+  createHeaderAlertContext,
   createHeaderContext,
   createTopNavigationContext,
 } from '../utils/contexts.js';
 import { StyleDictionary } from '../utils/interfaces.js';
 import { createColorMode, createDensityMode, createMotionMode } from '../utils/modes.js';
-import { buildVisualRefresh } from '../visual-refresh/index.js';
 
 const modes = [
   createColorMode('.awsui-dark-mode'),
@@ -20,23 +29,22 @@ const modes = [
   createMotionMode('.awsui-motion-disabled'),
 ];
 
-// One Theme starts from the full visual-refresh token set and layers overrides on top.
-const overrides = [
+const tokenCategories: Array<StyleDictionary.CategoryModule> = [
   await import('./color-palette.js'),
+  await import('../visual-refresh/color-charts.js'),
+  await import('../visual-refresh/color-severity.js'),
   await import('./colors.js'),
   await import('./typography.js'),
   await import('./borders.js'),
-  await import('./spacing.js'),
+  await import('../visual-refresh/motion.js'),
   await import('./sizes.js'),
-] as Array<StyleDictionary.CategoryModule>;
+  await import('./spacing.js'),
+  await import('../visual-refresh/shadows.js'),
+];
 
 const builder = new ThemeBuilder('one-theme', '.awsui-one-theme', modes);
 
-// Layer 1: visual refresh baseline (full token set + contexts).
-await buildVisualRefresh(builder);
-
-// Layer 2: One Theme token overrides.
-overrides.forEach(({ tokens, mode: modeId, referenceTokens }) => {
+tokenCategories.forEach(({ tokens, mode: modeId, referenceTokens }) => {
   const mode = modes.find(m => m.id === modeId);
   if (referenceTokens) {
     builder.addReferenceTokens(referenceTokens, mode);
@@ -44,7 +52,8 @@ overrides.forEach(({ tokens, mode: modeId, referenceTokens }) => {
   builder.addTokens(tokens, mode);
 });
 
-// Layer 3: One Theme context overrides (replace the VR contexts added in layer 1).
+builder.addContext(createCompactTableContext((await import('../visual-refresh/contexts/compact-table.js')).tokens));
+builder.addContext(createHeaderAlertContext((await import('../visual-refresh/contexts/header-alert.js')).tokens));
 builder.addContext(createAppLayoutToolbarContext((await import('./contexts/app-layout-toolbar.js')).tokens));
 builder.addContext(createTopNavigationContext((await import('./contexts/top-navigation.js')).tokens));
 builder.addContext(createHeaderContext((await import('./contexts/header.js')).tokens));

--- a/style-dictionary/one-theme/index.ts
+++ b/style-dictionary/one-theme/index.ts
@@ -2,13 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ThemeBuilder } from '@cloudscape-design/theming-build';
 
-// visual-refresh/color-palette and core/color-palette form an import cycle (core re-exports
-// visual-refresh's reference tokens, while visual-refresh consumes core's `brand` palette).
-// The cycle resolves correctly only when visual-refresh/color-palette is evaluated first.
-// one-theme/color-palette.ts imports both modules, and import sorting forces the core import
-// first, which would trigger a temporal-dead-zone error on `brand`. Evaluating
-// visual-refresh/color-palette here first guarantees the safe order (the same ordering the
-// previous buildVisualRefresh import used to provide).
+// visual-refresh/color-palette and core/color-palette form an import cycle; evaluating
+// visual-refresh first ensures core's `brand` is initialized before one-theme/color-palette.ts.
 import '../visual-refresh/color-palette.js';
 import {
   createAlertContext,

--- a/style-dictionary/one-theme/sizes.ts
+++ b/style-dictionary/one-theme/sizes.ts
@@ -1,13 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import merge from 'lodash/merge.js';
+
 import { expandDensityDictionary } from '../utils/index.js';
 import { StyleDictionary } from '../utils/interfaces.js';
+import { tokens as parentTokens } from '../visual-refresh/sizes.js';
 
 const tokens: StyleDictionary.SizesDictionary = {
   sizeVerticalInput: { comfortable: '30px', compact: '26px' },
 };
 
-const expandedTokens: StyleDictionary.ExpandedDensityScopeDictionary = expandDensityDictionary(tokens);
+const expandedTokens: StyleDictionary.ExpandedDensityScopeDictionary = merge(
+  {},
+  parentTokens,
+  expandDensityDictionary(tokens)
+);
 
 export { expandedTokens as tokens };
 export const mode: StyleDictionary.ModeIdentifier = 'density';

--- a/style-dictionary/one-theme/spacing.ts
+++ b/style-dictionary/one-theme/spacing.ts
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import merge from 'lodash/merge.js';
+
 import { expandDensityDictionary } from '../utils/index.js';
 import { StyleDictionary } from '../utils/interfaces.js';
+import { tokens as parentTokens } from '../visual-refresh/spacing.js';
 
 const tokens: StyleDictionary.SpacingDictionary = {
   spaceAlertVertical: '6px',
@@ -13,7 +16,11 @@ const tokens: StyleDictionary.SpacingDictionary = {
   spaceStatusIndicatorPaddingHorizontal: '2px',
 };
 
-const expandedTokens: StyleDictionary.ExpandedDensityScopeDictionary = expandDensityDictionary(tokens);
+const expandedTokens: StyleDictionary.ExpandedDensityScopeDictionary = merge(
+  {},
+  parentTokens,
+  expandDensityDictionary(tokens)
+);
 
 export { expandedTokens as tokens };
 export const mode: StyleDictionary.ModeIdentifier = 'density';

--- a/style-dictionary/one-theme/typography.ts
+++ b/style-dictionary/one-theme/typography.ts
@@ -1,8 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { StyleDictionary } from '../utils/interfaces.js';
+import merge from 'lodash/merge.js';
 
-export const tokens: StyleDictionary.TypographyDictionary = {
+import { StyleDictionary } from '../utils/interfaces.js';
+import { tokens as parentTokens } from '../visual-refresh/typography.js';
+
+const tokens: StyleDictionary.TypographyDictionary = {
   fontFamilyBase: "'Ember Modern Text UI', 'Amazon Ember', Roboto, Arial, sans-serif",
 
   // ── Headings ──────────────────────────────────────────────────────────────
@@ -52,3 +55,7 @@ export const tokens: StyleDictionary.TypographyDictionary = {
   // ── Breadcrumb ────────────────────────────────────────────────────────────
   fontWeightBreadcrumbCurrent: '400',
 };
+
+const expandedTokens: StyleDictionary.ExpandedGlobalScopeDictionary = merge({}, parentTokens, tokens);
+
+export { expandedTokens as tokens };


### PR DESCRIPTION
### Description

Changes the one theme build to use a fresh builder instance instead of using the existing visual refresh builder. This also fixes reference tokens which got overridden by visual refresh builder.

Related links, issue #, if available: n/a

### How has this been tested?

Locally.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
