### PR TITLE
fix: Fixes reorderable list behaviour when in dropdown

### DIFF
--- a/pages/dropdown/with-list.page.tsx
+++ b/pages/dropdown/with-list.page.tsx
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { useState } from 'react';
+
+import Button from '~components/button';
+import Dropdown from '~components/dropdown';
+import List from '~components/list';
+
+import { SimplePage } from '../app/templates';
+
+export default function DropdownScenario() {
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState([
+    { content: 'Reorderable item 1' },
+    { content: 'Reorderable item 2' },
+    { content: 'Reorderable item 3' },
+    { content: 'Reorderable item 4' },
+    { content: 'Reorderable item 5' },
+  ]);
+  return (
+    <SimplePage title="Dropdown with reorderable list">
+      <Dropdown
+        trigger={<Button onClick={() => setOpen(!open)}>Open dropdown</Button>}
+        open={open}
+        onOutsideClick={() => setOpen(false)}
+        content={
+          <List
+            items={items}
+            sortable={true}
+            ariaLabel="Reorderable list"
+            renderItem={item => ({ id: item.content, content: item.content })}
+            onSortingChange={({ detail }) => setItems([...detail.items])}
+          />
+        }
+      />
+    </SimplePage>
+  );
+}

--- a/src/dropdown/__tests__/dropdown.test.tsx
+++ b/src/dropdown/__tests__/dropdown.test.tsx
@@ -130,6 +130,44 @@ describe('Dropdown Component', () => {
       expect(handleOutsideClick).not.toHaveBeenCalled();
       expect(screen.getByTestId('after-dismiss')).toBeTruthy();
     });
+
+    test('does not fire event when a pointer gesture starts inside the dropdown but is released outside', async () => {
+      const handleOutsideClick = jest.fn();
+      const [, outsideElement] = renderDropdown(
+        <Dropdown
+          trigger={<button />}
+          onOutsideClick={handleOutsideClick}
+          open={true}
+          content={<button data-testid="inside-content">item</button>}
+        />
+      );
+      await runPendingEvents();
+
+      // Gesture begins on an element inside the dropdown (e.g. a drag handle)...
+      fireEvent.mouseDown(screen.getByTestId('inside-content'));
+      // ...and the resulting click resolves outside the dropdown because the pointer moved past its edge.
+      act(() => outsideElement.click());
+
+      expect(handleOutsideClick).not.toHaveBeenCalled();
+    });
+
+    test('still fires event when the pointer gesture starts outside the dropdown', async () => {
+      const handleOutsideClick = jest.fn();
+      const [, outsideElement] = renderDropdown(
+        <Dropdown
+          trigger={<button />}
+          onOutsideClick={handleOutsideClick}
+          open={true}
+          content={<button data-testid="inside-content">item</button>}
+        />
+      );
+      await runPendingEvents();
+
+      fireEvent.mouseDown(outsideElement);
+      act(() => outsideElement.click());
+
+      expect(handleOutsideClick).toHaveBeenCalled();
+    });
   });
 
   describe('dropdown focus events', () => {

--- a/src/dropdown/internal.tsx
+++ b/src/dropdown/internal.tsx
@@ -16,6 +16,7 @@ import { fireNonCancelableEvent, NonCancelableEventHandler } from '../internal/e
 import customCssProps from '../internal/generated/custom-css-properties';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useMobile } from '../internal/hooks/use-mobile';
+import useMouseDownTarget from '../internal/hooks/use-mouse-down-target';
 import { usePortalModeClasses } from '../internal/hooks/use-portal-mode-classes';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { nodeBelongs } from '../internal/utils/node-belongs';
@@ -250,6 +251,11 @@ const InternalDropdown = ({
 
   const isRefresh = useVisualRefresh();
 
+  // Tracks where the most recent pointer gesture started, so a gesture that begins
+  // inside the dropdown but releases outside it (e.g. drag-to-reorder, text selection)
+  // is not mistaken for an outside click.
+  const getMouseDownTarget = useMouseDownTarget();
+
   const dropdownClasses = usePortalModeClasses(triggerRef);
   const [position, setPosition] = useState<DropdownContextProviderProps['position']>('bottom-right');
 
@@ -445,12 +451,21 @@ const InternalDropdown = ({
       // Since the listener is registered on the window, `event.target` will incorrectly point at the
       // shadow root if the component is rendered inside shadow DOM.
       const target = event.composedPath ? event.composedPath()[0] : event.target;
+      // The gesture's origin. A native `click` is dispatched on the common ancestor of the mousedown
+      // and mouseup elements, so a gesture starting inside the dropdown but released just outside it
+      // (drag-to-reorder, text selection, slider drags) resolves to a target outside the dropdown.
+      // Considering the mousedown origin prevents closing the dropdown in those cases.
+      const mouseDownTarget = getMouseDownTarget();
       // For internal triggers, the wrapper div itself counts as outside — only its children are the trigger.
       // For external triggers, the ref is the trigger element directly, so it counts as inside.
       const isOutsideTrigger =
         !nodeBelongs(triggerRef.current, target) || (!externalTriggerRef && target === triggerRef.current);
 
-      if (!nodeBelongs(dropdownRef.current, target) && isOutsideTrigger) {
+      if (
+        !nodeBelongs(dropdownRef.current, target) &&
+        !nodeBelongs(dropdownRef.current, mouseDownTarget) &&
+        isOutsideTrigger
+      ) {
         fireNonCancelableEvent(onOutsideClick);
       }
     };
@@ -459,7 +474,7 @@ const InternalDropdown = ({
     return () => {
       window.removeEventListener('click', clickListener, true);
     };
-  }, [open, onOutsideClick, triggerRef, externalTriggerRef]);
+  }, [open, onOutsideClick, triggerRef, externalTriggerRef, getMouseDownTarget]);
 
   // subscribe to Escape key press
   useEffect(() => {

--- a/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
+++ b/src/internal/components/drag-handle-wrapper/__tests__/drag-handle-wrapper.test.tsx
@@ -148,6 +148,21 @@ test('renders children', () => {
   expect(dragHandle).toBeInTheDocument();
 });
 
+test('associates the portaled UAP overlay with the drag handle via data-awsui-referrer-id', () => {
+  // This association lets outside-click / focus detection (nodeBelongs) treat the portaled UAP
+  // buttons as belonging to wherever the drag handle is mounted (e.g. inside a dropdown).
+  const { dragHandle } = renderDragHandle({ directions: { 'block-start': 'active' } });
+
+  const portalOverlay = document.querySelector<HTMLElement>(`.${styles['portal-overlay']}`)!;
+  const referrerId = portalOverlay.dataset.awsuiReferrerId;
+  expect(referrerId).toBeTruthy();
+
+  const referrer = document.getElementById(referrerId!);
+  expect(referrer).toBeTruthy();
+  // The referenced element lives in the regular DOM and contains the drag handle content.
+  expect(referrer!.contains(dragHandle)).toBe(true);
+});
+
 test('shows tooltip on pointerin', () => {
   const { dragHandle, getTooltip } = renderDragHandle({
     directions: { 'block-start': 'active' },

--- a/src/internal/components/drag-handle-wrapper/index.tsx
+++ b/src/internal/components/drag-handle-wrapper/index.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 import { nodeContains } from '@cloudscape-design/component-toolkit/dom';
-import { getLogicalBoundingClientRect } from '@cloudscape-design/component-toolkit/internal';
+import { getLogicalBoundingClientRect, useUniqueId } from '@cloudscape-design/component-toolkit/internal';
 
 import Tooltip from '../tooltip';
 import DirectionButton from './direction-button';
@@ -35,6 +35,9 @@ export default function DragHandleWrapper({
 }: DragHandleWrapperProps) {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const dragHandleRef = useRef<HTMLDivElement | null>(null);
+  // Links the portaled UAP buttons back to the drag handle's position in the regular DOM,
+  // so outside-click / focus detection treats them as belonging to the handle's container.
+  const referrerId = useUniqueId('drag-handle');
   const [showTooltip, setShowTooltip] = useState(false);
   const [uncontrolledShowButtons, setUncontrolledShowButtons] = useState(initialShowButtons);
 
@@ -244,6 +247,7 @@ export default function DragHandleWrapper({
           <div
             className={clsx(styles['drag-handle'], wrapperClassName)}
             ref={dragHandleRef}
+            id={referrerId}
             onPointerDown={onHandlePointerDown}
             onKeyDown={onDragHandleKeyDown}
           >
@@ -258,7 +262,7 @@ export default function DragHandleWrapper({
         </div>
       </div>
 
-      <PortalOverlay track={dragHandleRef} isDisabled={!showButtons}>
+      <PortalOverlay track={dragHandleRef} isDisabled={!showButtons} referrerId={referrerId}>
         {visibleDirections.map(
           (direction, index) =>
             directions[direction] && (

--- a/src/internal/components/drag-handle-wrapper/portal-overlay.tsx
+++ b/src/internal/components/drag-handle-wrapper/portal-overlay.tsx
@@ -15,10 +15,12 @@ import styles from './styles.css.js';
 export default function PortalOverlay({
   track,
   isDisabled,
+  referrerId,
   children,
 }: {
   track: React.RefObject<HTMLElement | null>;
   isDisabled: boolean;
+  referrerId?: string;
   children: React.ReactNode;
 }) {
   const ref = useRef<HTMLSpanElement | null>(null);
@@ -81,7 +83,15 @@ export default function PortalOverlay({
 
   return (
     <Portal container={container}>
-      <span ref={ref} className={clsx(styles['portal-overlay'], isDisabled && styles['portal-overlay-disabled'])}>
+      {/* `data-awsui-referrer-id` links this portaled overlay back to the tracked element in the
+          regular DOM, so outside-click / focus detection (see `nodeBelongs`) treats interactions
+          with the UAP buttons as belonging to wherever the drag handle is mounted (e.g. inside a
+          dropdown), instead of as a click outside it. */}
+      <span
+        ref={ref}
+        data-awsui-referrer-id={referrerId}
+        className={clsx(styles['portal-overlay'], isDisabled && styles['portal-overlay-disabled'])}
+      >
         <span className={styles['portal-overlay-contents']}>{children}</span>
       </span>
     </Portal>

--- a/src/internal/components/drag-handle/styles.scss
+++ b/src/internal/components/drag-handle/styles.scss
@@ -64,7 +64,11 @@
 
   @include focus-visible.when-visible {
     &:not(.hide-focus) {
-      @include styles.focus-highlight(0px);
+      // Render the focus ring above container border overlays. The dropdown content border is
+      // drawn by `dropdown-shadow`'s `::after` at `z-index: 1`; since that `::after` is the
+      // wrapper's generated last child, it paints after (on top of) this deeply-nested ring in
+      // tree order, so the ring must use a strictly higher z-index to win.
+      @include styles.focus-highlight(0px, $z-index: 2);
     }
   }
 }

--- a/src/internal/hooks/use-mouse-down-target.ts
+++ b/src/internal/hooks/use-mouse-down-target.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useRef } from 'react';
+import { useCallback, useRef } from 'react';
 
 import { createSingletonHandler } from '@cloudscape-design/component-toolkit/internal';
 
@@ -29,5 +29,5 @@ export default function useMouseDownTarget() {
   useEventListenersSingleton(target => {
     mouseDownTargetRef.current = target;
   });
-  return () => mouseDownTargetRef.current;
+  return useCallback(() => mouseDownTargetRef.current, []);
 }


### PR DESCRIPTION
### Description

The PR fixes three issues observed when using a re-orderable list inside a dropdown:
1. d&d causes dropdown to close when point-out it outside the dropdown boundaries;
2. d&d with drag handle's UAP button is not possible: the dropdown closes;
3. drag handle's focus outline is partially hidden behind dropdown's edge.

Rel: AWSUI-62076

### How has this been tested?

* New unit tests for features 1, 2
* New test page to verify all fixes including 3

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
