### PR TITLE
fix: Fixes custom steps connector lines

### DIFF
--- a/src/steps/internal.tsx
+++ b/src/steps/internal.tsx
@@ -37,18 +37,35 @@ const CustomStep = ({
 }) => {
   const { status, statusIconAriaLabel } = step;
   const { header, details, icon } = renderStep(step);
-  return (
-    <li className={styles.container}>
-      <div className={styles.header}>
-        {icon ? icon : <InternalStatusIcon type={status} iconAriaLabel={statusIconAriaLabel} />}
-        {orientation === 'vertical' ? header : <hr className={styles.connector} role="none" />}
-      </div>
-      {orientation === 'vertical' ? (
-        <hr className={styles.connector} role="none" />
-      ) : (
+  const iconNode = icon ? icon : <InternalStatusIcon type={status} iconAriaLabel={statusIconAriaLabel} />;
+
+  if (orientation === 'horizontal') {
+    return (
+      <li className={styles.container}>
+        <div className={styles.header}>
+          {iconNode}
+          <hr className={styles.connector} role="none" />
+        </div>
         <div className={styles['horizontal-header']}>{header}</div>
-      )}
-      {details && <div className={styles.details}>{details}</div>}
+        {details && <div className={styles.details}>{details}</div>}
+      </li>
+    );
+  }
+
+  // Vertical orientation: render the icon and the connector together in a column-1 "rail" so the
+  // connector starts directly beneath the icon and stretches the full height of the step. Unlike
+  // placing the header in the same row as the icon, this keeps the vertical line continuous even
+  // when the custom header wraps onto multiple lines.
+  return (
+    <li className={clsx(styles.container, styles['custom-vertical'])}>
+      <div className={styles.rail}>
+        {iconNode}
+        <hr className={styles.connector} role="none" />
+      </div>
+      <div className={styles.content}>
+        <div className={styles.header}>{header}</div>
+        {details && <div className={styles.details}>{details}</div>}
+      </div>
     </li>
   );
 };

--- a/src/steps/styles.scss
+++ b/src/steps/styles.scss
@@ -116,3 +116,42 @@
     }
   }
 }
+
+// Vertical custom steps: a column-1 "rail" stacks the icon above a connector that grows to fill
+// the full height of the step (header + details), keeping the vertical line continuous and
+// connecting consecutive steps regardless of header height. Placed after `.horizontal` so
+// selectors stay in ascending specificity order.
+.root > .list > .container.custom-vertical {
+  // The rail stretches to the row height (default `align-items: stretch`), which is driven by the
+  // content column, so the connector always spans the full step.
+  > .rail {
+    grid-column: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    > .connector {
+      grid-row: auto;
+      grid-column: auto;
+      flex: 1 1 auto;
+      background-color: awsui.$color-border-divider-default;
+      border-block: 0;
+      border-inline: 0;
+      inline-size: awsui.$border-divider-list-width;
+      block-size: auto;
+      min-block-size: awsui.$space-static-xs;
+      inset-inline-end: 0;
+      margin-block: awsui.$space-static-xxs 0;
+    }
+  }
+
+  > .content {
+    grid-column: 2;
+    // Allow long header/details text to wrap instead of stretching the grid column.
+    min-inline-size: 0;
+  }
+}
+
+.root > .list > .container.custom-vertical:last-of-type > .rail > .connector {
+  display: none;
+}


### PR DESCRIPTION
### Description

Fixes vertical steps with custom content.

Before:
<img width="418" height="204" alt="Screenshot 2026-06-15 at 13 09 31" src="https://github.com/user-attachments/assets/94c82a29-d7da-40ff-b3e5-2ce914fb18d8" />

After:
<img width="418" height="181" alt="Screenshot 2026-06-15 at 13 33 06" src="https://github.com/user-attachments/assets/925f3525-5123-4058-a7d9-5c506ea97372" />


Rel: AWSUI-62077

### How has this been tested?

* Tested in permutation pages

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
