### PR TITLE
fix: Exclude skeleton rows from table test-utils findRows()

### DIFF
--- a/src/table/__tests__/skeleton.test.tsx
+++ b/src/table/__tests__/skeleton.test.tsx
@@ -66,8 +66,8 @@ describe('Table skeleton loading', () => {
       const table = wrapper.findTable()!;
       const allRows = table.findRows();
       const skeletonRows = wrapper.findAll('tr[aria-hidden="true"]');
-      // 3 data + 3 skeleton = 6 rows with .row class
-      expect(allRows).toHaveLength(6);
+      // findRows() returns only data rows, not skeleton rows
+      expect(allRows).toHaveLength(3);
       expect(skeletonRows).toHaveLength(3);
       expect(wrapper.findAllSkeletons()).toHaveLength(6); // 2 columns × 3 rows
       expect(table.findBodyCell(1, 2)!.getElement().textContent).toBe('Apples');

--- a/src/test-utils/dom/table/index.ts
+++ b/src/test-utils/dom/table/index.ts
@@ -102,7 +102,7 @@ export default class TableWrapper extends ComponentWrapper {
   }
 
   findRows(): Array<ElementWrapper> {
-    return this.findNativeTable().findAllByClassName(styles.row);
+    return this.findNativeTable().findAll(`tr.${styles.row}:not([aria-hidden])`);
   }
 
   findSelectedRows(): Array<ElementWrapper> {


### PR DESCRIPTION
## Description

`findRows()` was returning skeleton rows (which have `aria-hidden="true"`) alongside data rows. This is unexpected for consumers who use `findRows()` to count or interact with actual table data.

## Changes

- `findRows()` now uses `tr.row:not([aria-hidden])` to exclude skeleton rows
- Updated skeleton unit test assertion to expect only data rows from `findRows()`

## How has this been tested?

- 430 table unit tests pass
- Skeleton-specific tests verify that `findRows()` returns 3 (data only) while skeleton rows are separately queryable via `tr[aria-hidden="true"]`
