### PR TITLE
fix: One theme checkbox border radius

### DIFF
--- a/src/internal/components/checkbox-icon/index.tsx
+++ b/src/internal/components/checkbox-icon/index.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import clsx from 'clsx';
 
 import { BaseComponentProps, getBaseProps } from '../../base-component';
-import { useVisualRefresh } from '../../hooks/use-visual-mode';
+import { useOneTheme, useVisualRefresh } from '../../hooks/use-visual-mode';
 
 import styles from './styles.css.js';
 
@@ -33,7 +33,7 @@ interface Dimension {
 }
 
 // Can't use css variables for svg attributes
-const dimensionsByTheme: Record<NonNullable<'default' | 'refresh'>, Dimension> = {
+const dimensionsByTheme: Record<NonNullable<'default' | 'refresh' | 'one'>, Dimension> = {
   default: {
     viewBox: '0 0 14 14',
     indeterminate: '2.5,7 11.5,7',
@@ -50,6 +50,14 @@ const dimensionsByTheme: Record<NonNullable<'default' | 'refresh'>, Dimension> =
     r: 3,
     size: 15,
   },
+  one: {
+    viewBox: '0 0 16 16',
+    indeterminate: '3.5,8 12.5,8',
+    checked: '3.5,8 7,11 12,4',
+    xy: 0.5,
+    r: 2,
+    size: 15,
+  },
 };
 
 const CheckboxIcon = ({
@@ -61,7 +69,8 @@ const CheckboxIcon = ({
   ...restProps
 }: CheckboxIconProps) => {
   const baseProps = getBaseProps(restProps);
-  const theme = useVisualRefresh() ? 'refresh' : 'default';
+  const oneTheme = useOneTheme();
+  const theme = useVisualRefresh() ? (oneTheme ? 'one' : 'refresh') : 'default';
   const dimensions = dimensionsByTheme[theme];
 
   return (


### PR DESCRIPTION
### Description

Aligned checkbox border radius with one theme styles.

Before (3px border radius)
<img width="438" height="78" alt="image" src="https://github.com/user-attachments/assets/b69b9855-6732-41bf-b413-87ccfa793550" />
After (2px border radius)
<img width="483" height="77" alt="image" src="https://github.com/user-attachments/assets/bac47d69-25b2-490c-b9c1-8a120879fa59" />


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
