### PR TITLE
feat: add visualContext prop to top navigation

### DIFF
--- a/pages/top-navigation/simple.page.tsx
+++ b/pages/top-navigation/simple.page.tsx
@@ -63,6 +63,16 @@ export default function TopNavigationPage() {
           title: 'Tall logo, resized to fit',
         }}
       />
+      <br />
+      <TopNavigation
+        visualContext="none"
+        i18nStrings={I18N_STRINGS}
+        identity={{
+          href: '#',
+          title: 'Light mode with logo',
+          logo: { src: logo, alt: 'Logo' },
+        }}
+      />
     </article>
   );
 }

--- a/pages/top-navigation/utilities.page.tsx
+++ b/pages/top-navigation/utilities.page.tsx
@@ -79,6 +79,34 @@ const simpleActions = [
 
 export default function TopNavigationPage() {
   const { urlParams, setUrlParams } = useContext(AppContext as PageContext);
+
+  const badgedUtilities = [
+    {
+      type: 'menu-dropdown' as const,
+      text: 'Settings',
+      iconName: 'settings' as const,
+      badge: true,
+      items: simpleActions,
+    },
+    {
+      type: 'menu-dropdown' as const,
+      ariaLabel: 'Notifications',
+      title: 'Notifications',
+      iconName: 'notification' as const,
+      items: notificationActions,
+      disableUtilityCollapse: true,
+      badge: true,
+    },
+    {
+      type: 'menu-dropdown' as const,
+      text: 'Jane Doe',
+      description: 'jane.doe@example.com',
+      iconName: 'envelope' as const,
+      items: profileActions,
+      expandableGroups: urlParams.expandableGroups,
+    },
+  ];
+
   return (
     <article>
       <h1>Simple TopNavigation</h1>
@@ -146,30 +174,16 @@ export default function TopNavigationPage() {
       <br />
       <TopNavigation
         i18nStrings={I18N_STRINGS}
-        identity={{
-          href: '#',
-          title: 'Title with an href',
-        }}
-        utilities={[
-          { type: 'menu-dropdown', text: 'Settings', iconName: 'settings', badge: true, items: simpleActions },
-          {
-            type: 'menu-dropdown',
-            ariaLabel: 'Notifications',
-            title: 'Notifications',
-            iconName: 'notification',
-            items: notificationActions,
-            disableUtilityCollapse: true,
-            badge: true,
-          },
-          {
-            type: 'menu-dropdown',
-            text: 'Jane Doe',
-            description: 'jane.doe@example.com',
-            iconName: 'envelope',
-            items: profileActions,
-            expandableGroups: urlParams.expandableGroups,
-          },
-        ]}
+        identity={{ href: '#', title: 'Title with an href' }}
+        utilities={badgedUtilities}
+      />
+      <br />
+      <TopNavigation
+        i18nStrings={I18N_STRINGS}
+        identity={{ href: '#', title: 'Title with an href' }}
+        visualContext="none"
+        search={<Input ariaLabel="Input field" value="" onChange={() => {}} />}
+        utilities={badgedUtilities}
       />
     </article>
   );

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -32691,6 +32691,22 @@ The following properties are supported across all utility types:
       "optional": true,
       "type": "ReadonlyArray<TopNavigationProps.Utility>",
     },
+    {
+      "description": "Visual context applied to the navigation bar.
+- "top-navigation": Applies the top-navigation visual context. The component maintains a dark appearance regardless of the page's light/dark mode setting. Child components automatically adapt their colors to work on this dark background.
+- "none": No visual context applied. The component and its children use the same colors as the rest of the page and respond to the global light/dark mode normally.",
+      "inlineType": {
+        "name": "TopNavigationProps.VisualContext",
+        "type": "union",
+        "values": [
+          "none",
+          "top-navigation",
+        ],
+      },
+      "name": "visualContext",
+      "optional": true,
+      "type": "string",
+    },
   ],
   "regions": [
     {

--- a/src/top-navigation/__tests__/top-navigation.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation.test.tsx
@@ -13,11 +13,27 @@ import TopNavigationWrapper, {
 } from '../../../lib/components/test-utils/dom/top-navigation';
 import TopNavigation, { TopNavigationProps } from '../../../lib/components/top-navigation';
 import OverflowMenu from '../../../lib/components/top-navigation/parts/overflow-menu';
+import { useTopNavigation } from '../../../lib/components/top-navigation/use-top-navigation';
 
 jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
   ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
   warnOnce: jest.fn(),
 }));
+
+// The hook defaults to the real implementation so existing tests are unaffected.
+// Individual tests can override the return value to force a specific responsive state.
+jest.mock('../../../lib/components/top-navigation/use-top-navigation', () => {
+  const actual = jest.requireActual('../../../lib/components/top-navigation/use-top-navigation');
+  return {
+    __esModule: true,
+    ...actual,
+    useTopNavigation: jest.fn(actual.useTopNavigation),
+  };
+});
+
+const actualUseTopNavigation = jest.requireActual(
+  '../../../lib/components/top-navigation/use-top-navigation'
+).useTopNavigation;
 
 afterEach(() => {
   (warnOnce as jest.Mock).mockReset();
@@ -420,5 +436,52 @@ describe('visualContext', () => {
   test('uses no visual context', () => {
     renderTopNavigation({ identity: { href: '#', title: 'Structured' }, visualContext: 'none' });
     expect(createWrapper().findAll('[class*="awsui-context-top-navigation"]')).toHaveLength(0);
+  });
+});
+
+describe('overflow menu', () => {
+  afterEach(() => {
+    // Restore the real hook implementation for any subsequent tests.
+    (useTopNavigation as jest.Mock).mockImplementation(actualUseTopNavigation);
+  });
+
+  // The overflow drawer only renders once utilities are collapsed, which depends on layout
+  // measurements unavailable in JSDOM. We mock the hook to force that state. The behavior itself
+  // is verified end to end in __integ__/top-navigation.test.ts ("all collapsable utilities collapsed").
+  const renderWithCollapsedUtilities = () => {
+    (useTopNavigation as jest.Mock).mockReturnValue({
+      mainRef: { current: null },
+      virtualRef: { current: null },
+      responsiveState: { hideUtilities: [0], hideUtilityText: true },
+      breakpoint: 'default',
+      isSearchExpanded: false,
+      onSearchUtilityClick: jest.fn(),
+    });
+
+    return renderTopNavigation({
+      identity: { href: '#', title: 'Application' },
+      utilities: [
+        { type: 'button', text: 'Settings', iconName: 'settings' },
+        { type: 'button', text: 'User', iconName: 'user-profile' },
+      ],
+    });
+  };
+
+  test('opens and closes the overflow drawer when the menu trigger is clicked', () => {
+    const topNavigation = renderWithCollapsedUtilities();
+    const trigger = topNavigation.findOverflowMenuButton()!;
+    expect(trigger).not.toBeNull();
+
+    // Drawer is closed initially.
+    expect(topNavigation.findOverflowMenu()).toBeNull();
+
+    // Open the drawer.
+    act(() => trigger.click());
+    expect(topNavigation.findOverflowMenu()).not.toBeNull();
+
+    // Close the drawer; focus returns to the trigger.
+    act(() => trigger.click());
+    expect(topNavigation.findOverflowMenu()).toBeNull();
+    expect(trigger.getElement()).toHaveFocus();
   });
 });

--- a/src/top-navigation/__tests__/top-navigation.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation.test.tsx
@@ -405,3 +405,20 @@ describe('URL sanitization', () => {
     });
   });
 });
+
+describe('visualContext', () => {
+  test('defaults to top-navigation visual context', () => {
+    renderTopNavigation({ identity: { href: '#', title: 'Structured' } });
+    expect(createWrapper().findAll('[class*="awsui-context-top-navigation"]')).toHaveLength(1);
+  });
+
+  test('uses top-navigation visual context explicitly', () => {
+    renderTopNavigation({ identity: { href: '#', title: 'Structured' }, visualContext: 'top-navigation' });
+    expect(createWrapper().findAll('[class*="awsui-context-top-navigation"]')).toHaveLength(1);
+  });
+
+  test('uses no visual context', () => {
+    renderTopNavigation({ identity: { href: '#', title: 'Structured' }, visualContext: 'none' });
+    expect(createWrapper().findAll('[class*="awsui-context-top-navigation"]')).toHaveLength(0);
+  });
+});

--- a/src/top-navigation/interfaces.ts
+++ b/src/top-navigation/interfaces.ts
@@ -18,6 +18,13 @@ export interface TopNavigationProps extends BaseComponentProps {
   identity: TopNavigationProps.Identity;
 
   /**
+   * Visual context applied to the navigation bar.
+   * - "top-navigation": Applies the top-navigation visual context. The component maintains a dark appearance regardless of the page's light/dark mode setting. Child components automatically adapt their colors to work on this dark background.
+   * - "none": No visual context applied. The component and its children use the same colors as the rest of the page and respond to the global light/dark mode normally.
+   */
+  visualContext?: TopNavigationProps.VisualContext;
+
+  /**
    * Use with an input or autosuggest control for a global search query.
    */
   search?: React.ReactNode;
@@ -126,4 +133,6 @@ export namespace TopNavigationProps {
     overflowMenuTriggerText?: string;
     overflowMenuTitleText?: string;
   }
+
+  export type VisualContext = 'top-navigation' | 'none';
 }

--- a/src/top-navigation/internal.tsx
+++ b/src/top-navigation/internal.tsx
@@ -21,12 +21,17 @@ import styles from './styles.css.js';
 
 type InternalTopNavigationProps = SomeRequired<TopNavigationProps, 'utilities'> & InternalBaseComponentProps;
 
+function wrapWithVisualContext(content: React.ReactNode, visualContext: TopNavigationProps.VisualContext) {
+  return visualContext === 'none' ? content : <VisualContext contextName={visualContext}>{content}</VisualContext>;
+}
+
 export default function InternalTopNavigation({
   __internalRootRef,
   identity,
   i18nStrings,
   utilities,
   search,
+  visualContext = 'top-navigation',
   ...restProps
 }: InternalTopNavigationProps) {
   checkSafeUrl('TopNavigation', identity.href);
@@ -222,30 +227,34 @@ export default function InternalTopNavigation({
     );
   };
 
+  const structuredContent = (
+    <>
+      {/* Render virtual content first to ensure React refs for content will be assigned on the actual nodes. */}
+      {content(true)}
+
+      {content(false)}
+
+      {menuTriggerVisible && overflowMenuOpen && (
+        <div className={styles['overflow-menu-drawer']}>
+          <OverflowMenu
+            headerText={i18nStrings?.overflowMenuTitleText}
+            dismissIconAriaLabel={i18nStrings?.overflowMenuDismissIconAriaLabel}
+            backIconAriaLabel={i18nStrings?.overflowMenuBackIconAriaLabel}
+            items={utilities.filter(
+              (utility, i) =>
+                (!responsiveState.hideUtilities || responsiveState.hideUtilities.indexOf(i) !== -1) &&
+                !utility.disableUtilityCollapse
+            )}
+            onClose={toggleOverflowMenu}
+          />
+        </div>
+      )}
+    </>
+  );
+
   return (
     <div {...baseProps} ref={__internalRootRef}>
-      <VisualContext contextName="top-navigation">
-        {/* Render virtual content first to ensure React refs for content will be assigned on the actual nodes. */}
-        {content(true)}
-
-        {content(false)}
-
-        {menuTriggerVisible && overflowMenuOpen && (
-          <div className={styles['overflow-menu-drawer']}>
-            <OverflowMenu
-              headerText={i18nStrings?.overflowMenuTitleText}
-              dismissIconAriaLabel={i18nStrings?.overflowMenuDismissIconAriaLabel}
-              backIconAriaLabel={i18nStrings?.overflowMenuBackIconAriaLabel}
-              items={utilities.filter(
-                (utility, i) =>
-                  (!responsiveState.hideUtilities || responsiveState.hideUtilities.indexOf(i) !== -1) &&
-                  !utility.disableUtilityCollapse
-              )}
-              onClose={toggleOverflowMenu}
-            />
-          </div>
-        )}
-      </VisualContext>
+      {wrapWithVisualContext(structuredContent, visualContext)}
     </div>
   );
 }


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
Adds a visualContext prop to TopNavigation that controls whether the dark visual context is applied.
- "top-navigation" (default): maintains the existing dark appearance regardless of light/dark mode
- "none": no visual context applied, the component uses the same colors as the rest of the page

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?
Unit tests, and test pages

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
