### PR TITLE
feat: Enable one-theme a11y tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
         env:
           NODE_ENV: production
           REACT_VERSION: ${{ matrix.react }}
+          INCLUDE_ONE_THEME: 'true'
 
       - name: Bundle dev pages
         run: node_modules/.bin/webpack --config pages/webpack.config.integ.cjs --output-path pages/lib/static-default

--- a/src/__a11y__/a11y-onetheme-dark.test.ts
+++ b/src/__a11y__/a11y-onetheme-dark.test.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import runA11yTests from './run-a11y-tests';
+
+runA11yTests('one-theme', 'dark');

--- a/src/__a11y__/a11y-onetheme-light.test.ts
+++ b/src/__a11y__/a11y-onetheme-light.test.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import runA11yTests from './run-a11y-tests';
+
+runA11yTests('one-theme', 'light');

--- a/src/__a11y__/run-a11y-tests.ts
+++ b/src/__a11y__/run-a11y-tests.ts
@@ -6,7 +6,7 @@ import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import { findAllPages } from '../__integ__/utils';
 import A11yPageObject from './a11y-page-object';
 
-type Theme = 'visual-refresh';
+type Theme = 'visual-refresh' | 'one-theme';
 type Mode = 'light' | 'dark';
 
 function setupTest(url: string, testFn: (page: A11yPageObject) => Promise<void>) {
@@ -18,8 +18,9 @@ function setupTest(url: string, testFn: (page: A11yPageObject) => Promise<void>)
   });
 }
 
-function urlFormatter(inputUrl: string, mode: Mode) {
-  return `#/${mode}/${inputUrl}`;
+function urlFormatter(inputUrl: string, mode: Mode, theme: Theme) {
+  const params = theme === 'one-theme' ? '?oneTheme=true' : '';
+  return `#/${mode}/${inputUrl}${params}`;
 }
 
 export default function runA11yTests(theme: Theme, mode: Mode, skip: string[] = []) {
@@ -36,7 +37,7 @@ export default function runA11yTests(theme: Theme, mode: Mode, skip: string[] = 
         'app-layout-toolbar/without-toolbar-nested',
       ];
       const testFunction = skipPages.includes(inputUrl) ? test.skip : test;
-      const url = urlFormatter(inputUrl, mode);
+      const url = urlFormatter(inputUrl, mode, theme);
       testFunction(
         url,
         setupTest(url, page => page.assertNoAxeViolations())


### PR DESCRIPTION
### Description
This PR enable one-theme a11y tests.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
