### PR TITLE
feat: Add `stretch` option to space between's `alignItems` property

### DIFF
--- a/pages/space-between/alignment.permutations.page.tsx
+++ b/pages/space-between/alignment.permutations.page.tsx
@@ -49,7 +49,7 @@ const permutations = createPermutations<Pick<SpaceBetweenProps, 'direction' | 'a
   {
     children: [ExampleChildren, NestedExample],
     direction: ['vertical', 'horizontal'],
-    alignItems: [undefined, 'center', 'start', 'end'],
+    alignItems: [undefined, 'center', 'start', 'end', 'stretch'],
   },
 ]);
 

--- a/pages/space-between/styles.scss
+++ b/pages/space-between/styles.scss
@@ -7,11 +7,13 @@
 
 .border-box-outer,
 .box {
+  block-size: 100%;
   border-block: 1px solid tokens.$color-border-status-info;
   border-inline: 1px solid tokens.$color-border-status-info;
 }
 
 .border-box-inner {
+  block-size: 100%;
   border-block: 1px solid tokens.$color-border-status-error;
   border-inline: 1px solid tokens.$color-border-status-error;
 }

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -26931,6 +26931,7 @@ exports[`Components definition for space-between matches the snapshot: space-bet
           "center",
           "end",
           "start",
+          "stretch",
         ],
       },
       "name": "alignItems",

--- a/src/space-between/__tests__/space-between.test.tsx
+++ b/src/space-between/__tests__/space-between.test.tsx
@@ -85,6 +85,29 @@ describe('SpaceBetween', () => {
     expect(content[0].getElement()).toHaveAttribute('id', 'button-one');
     expect(content[1].getElement()).toHaveAttribute('id', 'button-two');
   });
+
+  it.each(['center', 'start', 'end', 'stretch'] as const)('applies align-%s class', alignItems => {
+    const { container } = render(
+      <SpaceBetween size="s" alignItems={alignItems}>
+        <button />
+        <button />
+      </SpaceBetween>
+    );
+    expect(container.firstChild).toHaveClass(styles[`align-${alignItems}`]);
+  });
+
+  it('does not apply an alignment class when alignItems is undefined', () => {
+    const { container } = render(
+      <SpaceBetween size="s">
+        <button />
+        <button />
+      </SpaceBetween>
+    );
+    expect(container.firstChild).not.toHaveClass(styles['align-center']);
+    expect(container.firstChild).not.toHaveClass(styles['align-start']);
+    expect(container.firstChild).not.toHaveClass(styles['align-end']);
+    expect(container.firstChild).not.toHaveClass(styles['align-stretch']);
+  });
 });
 
 describe('native attributes', () => {

--- a/src/space-between/interfaces.ts
+++ b/src/space-between/interfaces.ts
@@ -45,5 +45,5 @@ export namespace SpaceBetweenProps {
 
   export type Size = 'xxxs' | 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl';
 
-  export type AlignItems = 'center' | 'start' | 'end';
+  export type AlignItems = 'center' | 'start' | 'end' | 'stretch';
 }

--- a/src/space-between/styles.scss
+++ b/src/space-between/styles.scss
@@ -80,3 +80,7 @@ $sizes-vertical: (
 .align-end {
   align-items: end;
 }
+
+.align-stretch {
+  align-items: stretch;
+}


### PR DESCRIPTION
### Description
This change adds a new option of `"stretch"` to the `alignItems` property on space between.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
