### PR TITLE
chore: Add components overview page

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,11 @@
   "devDependencies": {
     "@babel/core": "^7.23.7",
     "@babel/plugin-syntax-typescript": "^7.23.3",
+    "@cloudscape-design/board-components": "^3.0.191",
     "@cloudscape-design/browser-test-tools": "^3.0.0",
     "@cloudscape-design/build-tools": "github:cloudscape-design/build-tools#main",
+    "@cloudscape-design/chat-components": "^1.0.140",
+    "@cloudscape-design/code-view": "^3.0.142",
     "@cloudscape-design/documenter": "^1.0.0",
     "@cloudscape-design/global-styles": "^1.0.0",
     "@cloudscape-design/jest-preset": "^2.0.0",

--- a/pages/components-overview/board-section.tsx
+++ b/pages/components-overview/board-section.tsx
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Board from '@cloudscape-design/board-components/board';
+import BoardItem from '@cloudscape-design/board-components/board-item';
+
+import Header from '~components/header';
+import SpaceBetween from '~components/space-between';
+
+import { Section } from './utils';
+
+export default function BoardSection() {
+  return (
+    <Section header="Board components" level="h2" description="Imported from @cloudscape-design/board-components">
+      <Board
+        items={[
+          { id: '1', columnSpan: 1, rowSpan: 2, data: { title: 'Widget 1', content: 'First board item content' } },
+          { id: '2', columnSpan: 1, rowSpan: 2, data: { title: 'Widget 2', content: 'Second board item content' } },
+          { id: '3', columnSpan: 1, rowSpan: 2, data: { title: 'Widget 3', content: 'Third board item content' } },
+        ]}
+        renderItem={item => (
+          <BoardItem
+            header={<Header variant="h3">{item.data.title}</Header>}
+            i18nStrings={{
+              dragHandleAriaLabel: 'Drag handle',
+              dragHandleAriaDescription: 'Use arrow keys to move, space to confirm, escape to cancel',
+              resizeHandleAriaLabel: 'Resize handle',
+              resizeHandleAriaDescription: 'Use arrow keys to resize, space to confirm, escape to cancel',
+            }}
+          >
+            <SpaceBetween size="s">{item.data.content}</SpaceBetween>
+          </BoardItem>
+        )}
+        onItemsChange={() => {}}
+        empty="No items"
+        i18nStrings={{
+          liveAnnouncementDndStarted: () => '',
+          liveAnnouncementDndItemReordered: () => '',
+          liveAnnouncementDndItemResized: () => '',
+          liveAnnouncementDndItemInserted: () => '',
+          liveAnnouncementDndCommitted: () => '',
+          liveAnnouncementDndDiscarded: () => '',
+          liveAnnouncementItemRemoved: () => '',
+          navigationAriaLabel: 'Board navigation',
+          navigationAriaDescription: 'Click on non-empty item to move focus',
+          navigationItemAriaLabel: () => '',
+        }}
+      />
+    </Section>
+  );
+}

--- a/pages/components-overview/buttons-inputs-dropdowns.tsx
+++ b/pages/components-overview/buttons-inputs-dropdowns.tsx
@@ -1,0 +1,361 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Autosuggest from '~components/autosuggest';
+import Box from '~components/box';
+import Button from '~components/button';
+import ButtonDropdown from '~components/button-dropdown';
+import ButtonGroup from '~components/button-group';
+import Container from '~components/container';
+import DatePicker from '~components/date-picker';
+import DateRangePicker, { DateRangePickerProps } from '~components/date-range-picker';
+import Grid from '~components/grid';
+import Header from '~components/header';
+import Modal from '~components/modal';
+import Multiselect, { MultiselectProps } from '~components/multiselect';
+import Popover from '~components/popover';
+import PropertyFilter, { PropertyFilterProps } from '~components/property-filter';
+import SegmentedControl from '~components/segmented-control';
+import SpaceBetween from '~components/space-between';
+import StatusIndicator from '~components/status-indicator';
+import ToggleButton from '~components/toggle-button';
+
+import { generateDropdownOptions } from './component-data';
+
+function Buttons() {
+  const [selectedSegment, setSelectedSegment] = useState('seg-1');
+  const [toggle1, setToggle1] = useState(true);
+  const [toggle2, setToggle2] = useState(false);
+  const [toggle3, setToggle3] = useState(false);
+  const [toggle4, setToggle4] = useState(true);
+  const [toggle5, setToggle5] = useState(false);
+  const [toggle6, setToggle6] = useState(true);
+
+  return (
+    <SpaceBetween size="l">
+      <SpaceBetween direction="horizontal" size="m" alignItems="center">
+        <Button variant="primary">Primary button</Button>
+        <Button variant="normal">Secondary button</Button>
+        <Button iconName="refresh" ariaLabel="Icon in normal button" />
+        <Button variant="link">Tertiary button</Button>
+      </SpaceBetween>
+      <SpaceBetween direction="horizontal" size="m" alignItems="center">
+        <Button variant="primary" disabled={true}>
+          Primary button
+        </Button>
+        <Button variant="normal" disabled={true}>
+          Secondary button
+        </Button>
+        <Button iconName="refresh" disabled={true} ariaLabel="Disabled refresh button" />
+        <Button variant="link" disabled={true}>
+          Tertiary button
+        </Button>
+      </SpaceBetween>
+      <SpaceBetween direction="horizontal" size="m" alignItems="center">
+        <Button variant="inline-icon" iconName="copy" ariaLabel="Inline icon button" />
+        <Button variant="icon" iconName="add-plus" ariaLabel="Icon button" />
+        <ButtonGroup
+          ariaLabel="Button group"
+          items={[
+            { type: 'icon-button', id: 'copy', iconName: 'upload', text: 'Upload files' },
+            { type: 'icon-button', id: 'expand', iconName: 'expand', text: 'Go full page' },
+          ]}
+          variant="icon"
+        />
+      </SpaceBetween>
+      <SpaceBetween direction="horizontal" size="m" alignItems="center">
+        <ToggleButton
+          onChange={({ detail }) => setToggle1(detail.pressed)}
+          pressed={toggle1}
+          iconName="star"
+          pressedIconName="star-filled"
+        >
+          Toggle button
+        </ToggleButton>
+        <ToggleButton
+          onChange={({ detail }) => setToggle2(detail.pressed)}
+          pressed={toggle2}
+          iconName="star"
+          pressedIconName="star-filled"
+        >
+          Toggle button
+        </ToggleButton>
+        <ToggleButton
+          onChange={({ detail }) => setToggle3(detail.pressed)}
+          pressed={toggle3}
+          iconName="star"
+          pressedIconName="star-filled"
+          ariaLabel="Toggle button"
+        />
+        <ToggleButton
+          onChange={({ detail }) => setToggle4(detail.pressed)}
+          pressed={toggle4}
+          iconName="star"
+          pressedIconName="star-filled"
+          ariaLabel="Toggle button pressed"
+        />
+        <ToggleButton
+          variant="icon"
+          onChange={({ detail }) => setToggle5(detail.pressed)}
+          pressed={toggle5}
+          iconName="star"
+          pressedIconName="star-filled"
+          ariaLabel="Toggle button icon"
+        />
+        <ToggleButton
+          variant="icon"
+          onChange={({ detail }) => setToggle6(detail.pressed)}
+          pressed={toggle6}
+          iconName="star"
+          pressedIconName="star-filled"
+          ariaLabel="Toggle button icon pressed"
+        />
+      </SpaceBetween>
+      <SegmentedControl
+        selectedId={selectedSegment}
+        onChange={({ detail }) => setSelectedSegment(detail.selectedId)}
+        label="Default segmented control"
+        options={[
+          { text: 'Segment 1', id: 'seg-1' },
+          { text: 'Segment 2', id: 'seg-2' },
+          { text: 'Segment 3', id: 'seg-3' },
+        ]}
+      />
+    </SpaceBetween>
+  );
+}
+
+function Inputs() {
+  const multiSelectOptions = generateDropdownOptions() as MultiselectProps.Options;
+  const [selectedItems, setSelectedItems] = useState([
+    multiSelectOptions[1],
+    multiSelectOptions[3],
+  ] as MultiselectProps.Options);
+  const [dateValue, setDateValue] = useState('2018-01-02');
+  const [dateRangeValue, setDateRangeValue] = useState<DateRangePickerProps['value']>(null);
+  const [autosuggestValue, setAutosuggestValue] = useState('');
+
+  return (
+    <Grid>
+      <SpaceBetween size="s" direction="horizontal">
+        <Multiselect
+          options={multiSelectOptions}
+          placeholder="Multiselect"
+          selectedOptions={selectedItems}
+          onChange={({ detail }) => setSelectedItems(detail.selectedOptions)}
+        />
+        <Multiselect disabled={true} placeholder="Disabled multi-select" selectedOptions={selectedItems} />
+        <Multiselect readOnly={true} placeholder="Read-only multi-select" selectedOptions={selectedItems} />
+      </SpaceBetween>
+      <SpaceBetween size="s" direction="horizontal">
+        <Autosuggest
+          value={autosuggestValue}
+          onChange={({ detail }) => setAutosuggestValue(detail.value)}
+          options={[
+            { value: 'us-east-1', label: 'US East (N. Virginia)' },
+            { value: 'us-west-2', label: 'US West (Oregon)' },
+            { value: 'eu-west-1', label: 'Europe (Ireland)' },
+          ]}
+          placeholder="Autosuggest"
+          ariaLabel="Autosuggest example"
+        />
+        <Autosuggest
+          value="Disabled"
+          onChange={() => {}}
+          options={[]}
+          disabled={true}
+          placeholder="Disabled"
+          ariaLabel="Disabled autosuggest"
+        />
+        <Autosuggest
+          value="Read-only"
+          onChange={() => {}}
+          options={[]}
+          readOnly={true}
+          placeholder="Read-only"
+          ariaLabel="Read-only autosuggest"
+        />
+      </SpaceBetween>
+      <SpaceBetween direction="horizontal" size="l">
+        <DatePicker
+          value={dateValue}
+          placeholder="Datepicker"
+          openCalendarAriaLabel={() => 'Open calendar'}
+          onChange={({ detail }) => setDateValue(detail.value)}
+        />
+        <DateRangePicker
+          value={dateRangeValue}
+          onChange={({ detail }) => setDateRangeValue(detail.value)}
+          relativeOptions={[
+            { key: 'previous-5-minutes', amount: 5, unit: 'minute', type: 'relative' },
+            { key: 'previous-30-minutes', amount: 30, unit: 'minute', type: 'relative' },
+            { key: 'previous-1-hour', amount: 1, unit: 'hour', type: 'relative' },
+          ]}
+          isValidRange={range => {
+            if (range?.type === 'absolute') {
+              const [startDateWithoutTime] = range.startDate.split('T');
+              const [endDateWithoutTime] = range.endDate.split('T');
+              if (!startDateWithoutTime || !endDateWithoutTime) {
+                return { valid: false, errorMessage: 'The selected date range is incomplete.' };
+              }
+            }
+            return { valid: true };
+          }}
+          i18nStrings={{}}
+          placeholder="Filter by a date and time range"
+        />
+      </SpaceBetween>
+    </Grid>
+  );
+}
+
+export default function ButtonsInputsDropdowns() {
+  const [query, setQuery] = React.useState<PropertyFilterProps.Query>({ tokens: [], operation: 'and' });
+  const [modalVisible, setModalVisible] = React.useState(false);
+  return (
+    <SpaceBetween size="s">
+      <Header variant="h2">Buttons, inputs, and dropdowns</Header>
+      <Box>
+        <Container variant="stacked">
+          <SpaceBetween size="l">
+            <Grid gridDefinition={[{ colspan: { default: 12, xxs: 6 } }, { colspan: { default: 12, xxs: 6 } }]}>
+              <Buttons />
+              <Inputs />
+            </Grid>
+            <PropertyFilter
+              query={query}
+              onChange={({ detail }) => setQuery(detail)}
+              countText="5 matches"
+              enableTokenGroups={true}
+              expandToViewport={true}
+              filteringAriaLabel="Find distributions"
+              filteringOptions={[
+                { propertyKey: 'instanceid', value: 'i-2dc5ce28a0328391' },
+                { propertyKey: 'instanceid', value: 'i-d0312e022392efa0' },
+                { propertyKey: 'state', value: 'Stopped' },
+                { propertyKey: 'state', value: 'Running' },
+                { propertyKey: 'instancetype', value: 't3.small' },
+                { propertyKey: 'instancetype', value: 't2.small' },
+              ]}
+              filteringPlaceholder="Find distributions"
+              filteringProperties={[
+                {
+                  key: 'instanceid',
+                  operators: ['=', '!=', ':', '!:'],
+                  propertyLabel: 'Instance ID',
+                  groupValuesLabel: 'Instance ID values',
+                },
+                {
+                  key: 'state',
+                  operators: [{ operator: '=', tokenType: 'enum' }, { operator: '!=', tokenType: 'enum' }, ':', '!:'],
+                  propertyLabel: 'State',
+                  groupValuesLabel: 'State values',
+                },
+                {
+                  key: 'instancetype',
+                  operators: [{ operator: '=', tokenType: 'enum' }, { operator: '!=', tokenType: 'enum' }, ':', '!:'],
+                  propertyLabel: 'Instance type',
+                  groupValuesLabel: 'Instance type values',
+                },
+              ]}
+            />
+          </SpaceBetween>
+        </Container>
+        <Container variant="stacked">
+          <Grid
+            gridDefinition={[
+              { colspan: { default: 12, xxs: 4 } },
+              { colspan: { default: 12, xxs: 4 } },
+              { colspan: { default: 12, xxs: 4 } },
+            ]}
+          >
+            <SpaceBetween size="s">
+              <ButtonDropdown
+                items={[
+                  { text: 'Edit', id: 'edit', iconName: 'edit' },
+                  { text: 'Delete', id: 'delete', iconName: 'remove' },
+                  { text: 'Duplicate', id: 'duplicate', iconName: 'copy' },
+                  {
+                    text: 'More actions',
+                    id: 'more',
+                    items: [
+                      { text: 'Export', id: 'export' },
+                      { text: 'Share', id: 'share' },
+                    ],
+                  },
+                ]}
+              >
+                Actions
+              </ButtonDropdown>
+              <ButtonDropdown
+                items={[
+                  { text: 'Edit', id: 'edit' },
+                  { text: 'Delete', id: 'delete', disabled: true },
+                ]}
+                variant="primary"
+              >
+                Primary dropdown
+              </ButtonDropdown>
+              <ButtonDropdown
+                items={[
+                  { text: 'Edit', id: 'edit' },
+                  { text: 'Delete', id: 'delete' },
+                ]}
+                disabled={true}
+              >
+                Disabled dropdown
+              </ButtonDropdown>
+            </SpaceBetween>
+
+            <SpaceBetween size="s">
+              <Popover
+                header="Memory usage"
+                content="This instance is using 72% of its allocated memory."
+                triggerType="custom"
+              >
+                <StatusIndicator type="warning">High memory</StatusIndicator>
+              </Popover>
+              <Popover
+                header="Latency info"
+                content="Average latency over the last 5 minutes is 42ms."
+                triggerType="custom"
+              >
+                <StatusIndicator type="success">Normal latency</StatusIndicator>
+              </Popover>
+              <StatusIndicator type="info">Normal latency</StatusIndicator>
+              <StatusIndicator type="error">Error latency</StatusIndicator>
+              <StatusIndicator type="pending">Pending instance</StatusIndicator>
+              <Popover dismissButton={false} position="top" size="small" content="Copied!" triggerType="custom">
+                <Button iconName="copy" variant="inline-icon" ariaLabel="Copy" />
+              </Popover>
+            </SpaceBetween>
+
+            <SpaceBetween size="s">
+              <Button onClick={() => setModalVisible(true)}>Open modal</Button>
+              <Modal
+                visible={modalVisible}
+                onDismiss={() => setModalVisible(false)}
+                header="Delete resource"
+                footer={
+                  <Box float="right">
+                    <SpaceBetween direction="horizontal" size="xs">
+                      <Button variant="link" onClick={() => setModalVisible(false)}>
+                        Cancel
+                      </Button>
+                      <Button variant="primary" onClick={() => setModalVisible(false)}>
+                        Delete
+                      </Button>
+                    </SpaceBetween>
+                  </Box>
+                }
+              >
+                Are you sure you want to delete this resource? This action cannot be undone.
+              </Modal>
+            </SpaceBetween>
+          </Grid>
+        </Container>
+      </Box>
+    </SpaceBetween>
+  );
+}

--- a/pages/components-overview/charts.tsx
+++ b/pages/components-overview/charts.tsx
@@ -1,0 +1,155 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import BarChart from '~components/bar-chart';
+import Box from '~components/box';
+import Button from '~components/button';
+import ColumnLayout from '~components/column-layout';
+import LineChart from '~components/line-chart';
+import PieChart from '~components/pie-chart';
+
+import { Section, SubSection } from './utils';
+
+const formatLargeNumber = (value: number): string => {
+  if (Math.abs(value) >= 1e6) {
+    return (value / 1e6).toFixed(1).replace(/\.0$/, '') + 'M';
+  }
+  if (Math.abs(value) >= 1e3) {
+    return (value / 1e3).toFixed(1).replace(/\.0$/, '') + 'K';
+  }
+  return value.toFixed(2);
+};
+
+const formatDateTick = (date: Date): string =>
+  date
+    .toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric', hour12: false })
+    .split(',')
+    .join('\n');
+
+const emptyState = (
+  <Box textAlign="center" color="inherit">
+    <b>No data available</b>
+    <Box variant="p" color="inherit">
+      There is no data available
+    </Box>
+  </Box>
+);
+
+const noMatchState = (
+  <Box textAlign="center" color="inherit">
+    <b>No matching data</b>
+    <Box variant="p" color="inherit">
+      There is no matching data to display
+    </Box>
+    <Button>Clear filter</Button>
+  </Box>
+);
+
+const barChartDates = [
+  new Date(1601071200000),
+  new Date(1601078400000),
+  new Date(1601085600000),
+  new Date(1601092800000),
+  new Date(1601100000000),
+];
+
+const lineChartDomain: [Date, Date] = [new Date(1600984800000), new Date(1601013600000)];
+
+const lineChartSite1 = [
+  { x: new Date(1600984800000), y: 58020 },
+  { x: new Date(1600988400000), y: 125021 },
+  { x: new Date(1600992000000), y: 274021 },
+  { x: new Date(1600995600000), y: 257306 },
+  { x: new Date(1600999200000), y: 486039 },
+  { x: new Date(1601002800000), y: 298028 },
+  { x: new Date(1601006400000), y: 102839 },
+  { x: new Date(1601010000000), y: 183570 },
+  { x: new Date(1601013600000), y: 293910 },
+];
+
+const lineChartSite2 = [
+  { x: new Date(1600984800000), y: 151023 },
+  { x: new Date(1600988400000), y: 149130 },
+  { x: new Date(1600992000000), y: 154091 },
+  { x: new Date(1600995600000), y: 181635 },
+  { x: new Date(1600999200000), y: 220516 },
+  { x: new Date(1601002800000), y: 172331 },
+  { x: new Date(1601006400000), y: 194091 },
+  { x: new Date(1601010000000), y: 179130 },
+  { x: new Date(1601013600000), y: 157299 },
+];
+
+export default function Charts() {
+  return (
+    <Section header="Charts" level="h2">
+      <ColumnLayout columns={3}>
+        <SubSection header="Stacked bar chart">
+          <BarChart
+            series={[
+              { title: 'Severe', type: 'bar', data: barChartDates.map((x, i) => ({ x, y: [12, 18, 15, 9, 18][i] })) },
+              { title: 'Moderate', type: 'bar', data: barChartDates.map((x, i) => ({ x, y: [8, 11, 12, 11, 13][i] })) },
+              { title: 'Low', type: 'bar', data: barChartDates.map((x, i) => ({ x, y: [7, 9, 8, 7, 5][i] })) },
+              {
+                title: 'Unclassified',
+                type: 'bar',
+                data: barChartDates.map((x, i) => ({ x, y: [14, 8, 6, 4, 6][i] })),
+              },
+            ]}
+            xDomain={barChartDates}
+            yDomain={[0, 50]}
+            i18nStrings={{ xTickFormatter: formatDateTick }}
+            ariaLabel="Stacked bar chart"
+            height={300}
+            stackedBars={true}
+            xTitle="Time (UTC)"
+            yTitle="Error count"
+            empty={emptyState}
+            noMatch={noMatchState}
+          />
+        </SubSection>
+
+        <SubSection header="Line chart">
+          <LineChart
+            series={[
+              { title: 'Site 1', type: 'line', data: lineChartSite1, valueFormatter: formatLargeNumber },
+              { title: 'Site 2', type: 'line', data: lineChartSite2, valueFormatter: formatLargeNumber },
+              { title: 'Performance goal', type: 'threshold', y: 250000, valueFormatter: formatLargeNumber },
+            ]}
+            xDomain={lineChartDomain}
+            yDomain={[0, 500000]}
+            i18nStrings={{ xTickFormatter: formatDateTick, yTickFormatter: formatLargeNumber }}
+            ariaLabel="Multiple data series line chart"
+            height={300}
+            xScaleType="time"
+            xTitle="Time (UTC)"
+            yTitle="Bytes transferred"
+            empty={emptyState}
+            noMatch={noMatchState}
+          />
+        </SubSection>
+
+        <SubSection header="Pie chart">
+          <PieChart
+            data={[
+              { title: 'Running', value: 60, lastUpdate: 'Dec 7, 2020' },
+              { title: 'Failed', value: 30, lastUpdate: 'Dec 6, 2020' },
+              { title: 'In-progress', value: 10, lastUpdate: 'Dec 6, 2020' },
+              { title: 'Pending', value: 0, lastUpdate: 'Dec 7, 2020' },
+            ]}
+            detailPopoverContent={(datum, sum) => [
+              { key: 'Resource count', value: datum.value },
+              { key: 'Percentage', value: `${((datum.value / sum) * 100).toFixed(0)}%` },
+              { key: 'Last update on', value: datum.lastUpdate },
+            ]}
+            segmentDescription={(datum, sum) => `${datum.value} units, ${((datum.value / sum) * 100).toFixed(0)}%`}
+            ariaDescription="Pie chart showing resource states."
+            ariaLabel="Pie chart"
+            empty={emptyState}
+            noMatch={noMatchState}
+          />
+        </SubSection>
+      </ColumnLayout>
+    </Section>
+  );
+}

--- a/pages/components-overview/chat.tsx
+++ b/pages/components-overview/chat.tsx
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Avatar from '@cloudscape-design/chat-components/avatar';
+import ChatBubble from '@cloudscape-design/chat-components/chat-bubble';
+import SupportPromptGroup from '@cloudscape-design/chat-components/support-prompt-group';
+
+import Box from '~components/box';
+import ButtonGroup from '~components/button-group';
+import FileTokenGroup from '~components/file-token-group';
+import Grid from '~components/grid';
+import PromptInput from '~components/prompt-input';
+import SpaceBetween from '~components/space-between';
+
+import { Section } from './utils';
+
+export default function Chat() {
+  const [value, setValue] = useState('');
+  const [files, setFiles] = React.useState([
+    new File([new Blob(['Test content'])], 'file-1.pdf', { type: 'application/pdf', lastModified: 1590962400000 }),
+    new File([new Blob(['Test content'])], 'file-2.pdf', { type: 'application/pdf', lastModified: 1590962400000 }),
+  ]);
+  return (
+    <Section header="Chat components" level="h2" description="Imported from @cloudscape-design/chat-components">
+      <Grid
+        gridDefinition={[
+          { colspan: { default: 12, xxs: 3 } },
+          { colspan: { default: 12, xxs: 3 } },
+          { colspan: { default: 12, xxs: 6 } },
+        ]}
+      >
+        <SpaceBetween size="s">
+          <ChatBubble
+            avatar={<Avatar initials="JD" tooltipText="Jane Doe" ariaLabel="Jane Doe" />}
+            ariaLabel="Jane Doe message"
+            type="outgoing"
+          >
+            This is an outgoing message from a user.
+          </ChatBubble>
+          <ChatBubble
+            avatar={<Avatar color="gen-ai" iconName="gen-ai" tooltipText="AI Assistant" ariaLabel="AI Assistant" />}
+            ariaLabel="AI Assistant message"
+            type="incoming"
+          >
+            This is an incoming message from the AI assistant.
+          </ChatBubble>
+          <ChatBubble
+            ariaLabel="Generative AI assistant loading"
+            showLoadingBar={true}
+            type="incoming"
+            avatar={
+              <Avatar
+                loading={true}
+                color="gen-ai"
+                iconName="gen-ai"
+                ariaLabel="Generative AI assistant"
+                tooltipText="Generative AI assistant"
+              />
+            }
+          >
+            <Box color="text-status-inactive">Generating response</Box>
+          </ChatBubble>
+        </SpaceBetween>
+
+        <SpaceBetween size="xs">
+          <SupportPromptGroup
+            ariaLabel="Support prompts"
+            items={[
+              { text: 'How can I help you today?', id: 'help' },
+              { text: 'Tell me more about this topic', id: 'more' },
+              { text: 'Show me an example', id: 'example' },
+            ]}
+            onItemClick={() => {}}
+          />
+        </SpaceBetween>
+
+        <PromptInput
+          onChange={({ detail }) => setValue(detail.value)}
+          value={value}
+          actionButtonAriaLabel="Send message"
+          actionButtonIconName="send"
+          disableSecondaryActionsPaddings={true}
+          placeholder="Ask a question"
+          ariaLabel="Prompt input with files"
+          secondaryActions={
+            <Box padding={{ left: 'xxs', top: 'xs' }}>
+              <ButtonGroup
+                ariaLabel="Chat actions"
+                items={[
+                  { type: 'icon-button', id: 'upload', iconName: 'upload', text: 'Upload files' },
+                  { type: 'icon-button', id: 'expand', iconName: 'expand', text: 'Go full page' },
+                ]}
+                variant="icon"
+              />
+            </Box>
+          }
+          secondaryContent={
+            <FileTokenGroup
+              items={files.map(file => ({ file }))}
+              onDismiss={({ detail }) => setFiles(f => f.filter((_, i) => i !== detail.fileIndex))}
+              alignment="horizontal"
+              showFileSize={true}
+              showFileLastModified={true}
+              showFileThumbnail={true}
+              i18nStrings={{
+                removeFileAriaLabel: () => 'Remove file',
+                limitShowFewer: 'Show fewer files',
+                limitShowMore: 'Show more files',
+                errorIconAriaLabel: 'Error',
+                warningIconAriaLabel: 'Warning',
+              }}
+            />
+          }
+        />
+      </Grid>
+    </Section>
+  );
+}

--- a/pages/components-overview/code-view-section.tsx
+++ b/pages/components-overview/code-view-section.tsx
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import CodeView from '@cloudscape-design/code-view/code-view';
+
+import { Section } from './utils';
+
+const codeSnippet = `import { applyTheme } from '@cloudscape-design/components/theming';
+
+applyTheme({
+  theme: {
+    tokens: {
+      colorBackgroundLayoutMain: '#f5f5f5',
+      borderRadiusContainer: '8px',
+    },
+  },
+});`;
+
+export default function CodeViewSection() {
+  return (
+    <Section header="Code view" level="h2" description="Imported from @cloudscape-design/code-view">
+      <CodeView content={codeSnippet} lineNumbers={true} />
+    </Section>
+  );
+}

--- a/pages/components-overview/component-data.tsx
+++ b/pages/components-overview/component-data.tsx
@@ -1,0 +1,143 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { FlashbarProps } from '~components/flashbar';
+import { MultiselectProps } from '~components/multiselect';
+import ProgressBar from '~components/progress-bar';
+import { SelectProps } from '~components/select';
+
+let seed = 1;
+export default function pseudoRandom() {
+  const x = Math.sin(seed++) * 10000;
+  return x - Math.floor(x);
+}
+
+export interface RandomData {
+  description: string;
+  name: string;
+  amount: string;
+  increase: boolean;
+}
+
+const collectionData: RandomData[] = [
+  {
+    description: 'volutpat. Nulla dignissim. Maecenas ornare egestas ligula.',
+    name: 'Velit Egestas LLP',
+    amount: '$68.54',
+    increase: true,
+  },
+  {
+    description: 'vestibulum lorem, sit amet ultricies sem magna nec quam.',
+    name: 'Mattis Velit Justo Company',
+    amount: '$80.38',
+    increase: true,
+  },
+  {
+    description: 'aliquet odio. Etiam ligula tortor, dictum eu, placerat eget.',
+    name: 'Tempor LLP',
+    amount: '$1.66',
+    increase: false,
+  },
+  {
+    description: 'ridiculus mus. Donec dignissim magna a tortor. Nunc commodo.',
+    name: 'Egestas Hendrerit Neque Corporation',
+    amount: '$31.74',
+    increase: true,
+  },
+  {
+    description: 'Vivamus molestie dapibus ligula. Aliquam erat volutpat.',
+    name: 'Aenean Incorporated',
+    amount: '$53.61',
+    increase: true,
+  },
+  {
+    description: 'Cras sed leo. Cras vehicula aliquet libero. Integer in magna.',
+    name: 'Proin Ltd',
+    amount: '$42.19',
+    increase: false,
+  },
+  {
+    description: 'Phasellus at augue id ante dictum cursus. Nunc mauris elit.',
+    name: 'Nulla Facilisi Foundation',
+    amount: '$97.03',
+    increase: true,
+  },
+  {
+    description: 'Sed nec metus facilisis lorem tristique aliquet.',
+    name: 'Donec Vitae Corp',
+    amount: '$15.88',
+    increase: false,
+  },
+];
+
+export const cardItems = collectionData.slice(0, 2);
+export const tableItems = collectionData;
+
+export const flashbarItems: FlashbarProps.MessageDefinition[] = [
+  {
+    header: 'Success',
+    type: 'success',
+    content: 'This is a success message.',
+    dismissible: true,
+    dismissLabel: 'Dismiss success message',
+    id: 'success',
+  },
+  {
+    header: 'Warning',
+    type: 'warning',
+    content: 'This is a warning message.',
+    dismissible: true,
+    dismissLabel: 'Dismiss warning message',
+    id: 'warning',
+  },
+  {
+    header: 'Error',
+    type: 'error',
+    content: 'This is an error message.',
+    dismissible: true,
+    dismissLabel: 'Dismiss error message',
+    id: 'error',
+  },
+  {
+    header: 'Info',
+    type: 'info',
+    content: 'This is an info message.',
+    dismissible: true,
+    dismissLabel: 'Dismiss info message',
+    id: 'info',
+  },
+  {
+    header: 'In-progress',
+    type: 'in-progress',
+    content: (
+      <>
+        This is an in-progress flash.
+        <ProgressBar value={37} variant="flash" />
+      </>
+    ),
+    dismissible: true,
+    dismissLabel: 'Dismiss in-progress message',
+    id: 'in-progress',
+  },
+  {
+    header: 'Loading',
+    type: 'in-progress',
+    loading: true,
+    content: 'This is a loading flash.',
+    dismissible: true,
+    dismissLabel: 'Dismiss loading message',
+    id: 'loading',
+  },
+];
+
+export const generateDropdownOptions = (count = 25): SelectProps.Options | MultiselectProps.Options => {
+  return [...Array(count).keys()].map(n => {
+    const numberToDisplay = (n + 1).toString();
+    const baseOption = { id: numberToDisplay, value: numberToDisplay, label: `Option ${numberToDisplay}` };
+    if (n === 0 || n === 24 || n === 49) {
+      return { ...baseOption, disabled: true, disabledReason: 'disabled reason' };
+    }
+    return baseOption;
+  });
+};

--- a/pages/components-overview/components-overview.page.tsx
+++ b/pages/components-overview/components-overview.page.tsx
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Box from '~components/box';
+import SpaceBetween from '~components/space-between';
+
+import BoardSection from './board-section';
+import ButtonsInputsDropdowns from './buttons-inputs-dropdowns';
+import Charts from './charts';
+import Chat from './chat';
+import CodeViewSection from './code-view-section';
+import FormControls from './form-controls';
+import KvpForm from './kvp-form';
+import NavigationComponents from './navigation-components';
+import OverlaysAndPatterns from './overlays-and-patterns';
+import StatusComponents from './status-components';
+import TableAndCards from './table-and-cards';
+import Typography from './typography';
+
+export default function ComponentsOverviewPage() {
+  return (
+    <div style={{ inlineSize: '90%', marginInline: 'auto' }}>
+      <SpaceBetween direction="vertical" size="xl">
+        <Box variant="h1" padding={{ top: 'l' }}>
+          Components overview page
+        </Box>
+        <div id="typography">
+          <Typography />
+        </div>
+        <div id="buttons-inputs-dropdowns">
+          <ButtonsInputsDropdowns />
+        </div>
+        <div id="form-controls">
+          <FormControls />
+        </div>
+        <div id="navigation-components">
+          <NavigationComponents />
+        </div>
+        <div id="table-and-cards">
+          <TableAndCards />
+        </div>
+        <div id="charts">
+          <Charts />
+        </div>
+        <div id="overlays-and-patterns">
+          <OverlaysAndPatterns />
+        </div>
+        <div id="code-view">
+          <CodeViewSection />
+        </div>
+        <div id="chat">
+          <Chat />
+        </div>
+        <div id="board">
+          <BoardSection />
+        </div>
+        <div id="status-components">
+          <StatusComponents />
+        </div>
+        <div id="kvp-form">
+          <KvpForm />
+        </div>
+      </SpaceBetween>
+    </div>
+  );
+}

--- a/pages/components-overview/form-controls.tsx
+++ b/pages/components-overview/form-controls.tsx
@@ -1,0 +1,144 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Checkbox from '~components/checkbox';
+import ColumnLayout from '~components/column-layout';
+import Grid from '~components/grid';
+import RadioGroup from '~components/radio-group';
+import Slider from '~components/slider';
+import SpaceBetween from '~components/space-between';
+import Tiles from '~components/tiles';
+import Toggle from '~components/toggle';
+
+import { Section } from './utils';
+
+export default function FormControls() {
+  return (
+    <Section header="Form controls">
+      <Grid
+        gridDefinition={[
+          { colspan: { default: 12, l: 6 } },
+          { colspan: { default: 12, l: 6 } },
+          { colspan: { default: 12, xxs: 12 } },
+        ]}
+      >
+        <Grid
+          gridDefinition={[
+            { colspan: { default: 12, xxs: 4 } },
+            { colspan: { default: 12, xxs: 4 } },
+            { colspan: { default: 12, xxs: 4 } },
+          ]}
+        >
+          <SpaceBetween size="xxs">
+            <Checkbox checked={true} ariaLabel="Checked">
+              Checked
+            </Checkbox>
+            <Checkbox checked={false} ariaLabel="Unchecked">
+              Unchecked
+            </Checkbox>
+            <Checkbox checked={true} disabled={true} ariaLabel="Disabled checked">
+              Disabled
+            </Checkbox>
+            <Checkbox checked={false} disabled={true} ariaLabel="Disabled unchecked">
+              Disabled
+            </Checkbox>
+            <Checkbox checked={true} readOnly={true} ariaLabel="Read-only checked">
+              Read-only
+            </Checkbox>
+            <Checkbox checked={false} readOnly={true} ariaLabel="Read-only unchecked">
+              Read-only
+            </Checkbox>
+          </SpaceBetween>
+
+          <SpaceBetween size="xxs">
+            <RadioGroup
+              items={[
+                { value: '1', label: 'Checked' },
+                { value: '2', label: 'Unchecked' },
+              ]}
+              value={'1'}
+              ariaLabel="Default radio group"
+            />
+            <RadioGroup
+              items={[
+                { value: '1', label: 'Disabled', disabled: true },
+                { value: '2', label: 'Disabled', disabled: true },
+              ]}
+              value={'1'}
+              ariaLabel="Disabled radio group"
+            />
+            <RadioGroup
+              items={[
+                { value: '1', label: 'Read-only' },
+                { value: '2', label: 'Read-only' },
+              ]}
+              readOnly={true}
+              value={'1'}
+              ariaLabel="Read-only radio group"
+            />
+          </SpaceBetween>
+
+          <SpaceBetween size="xxs">
+            <Toggle checked={true} ariaLabel="Checked">
+              Checked
+            </Toggle>
+            <Toggle checked={false} ariaLabel="Unchecked">
+              Unchecked
+            </Toggle>
+            <Toggle checked={true} disabled={true} ariaLabel="Disabled checked">
+              Disabled
+            </Toggle>
+            <Toggle checked={false} disabled={true} ariaLabel="Disabled unchecked">
+              Disabled
+            </Toggle>
+            <Toggle checked={true} readOnly={true} ariaLabel="Read-only checked">
+              Read-only
+            </Toggle>
+            <Toggle checked={false} readOnly={true} ariaLabel="Read-only unchecked">
+              Read-only
+            </Toggle>
+          </SpaceBetween>
+        </Grid>
+
+        <ColumnLayout columns={2}>
+          <SpaceBetween size="xs">
+            <Tiles
+              value="item1"
+              items={[
+                { label: 'Selected', value: 'item1', description: 'This is a description for item 1' },
+                { label: 'Unselected', value: 'item2', description: 'This is a description for item 2' },
+              ]}
+              ariaLabel="Default tiles"
+            />
+            <Tiles
+              value="item1"
+              items={[
+                { label: 'Disabled', value: 'item1', disabled: true, description: 'This is a description for item 1' },
+                { label: 'Disabled', value: 'item2', disabled: true, description: 'This is a description for item 2' },
+              ]}
+              ariaLabel="Disabled tiles"
+            />
+          </SpaceBetween>
+          <SpaceBetween size="xs">
+            <Tiles
+              value="item1"
+              readOnly={true}
+              items={[
+                { label: 'Read-only', value: 'item1', description: 'This is a description for item 1' },
+                { label: 'Read-only', value: 'item2', description: 'This is a description for item 2' },
+              ]}
+              ariaLabel="Read-only tiles"
+            />
+          </SpaceBetween>
+        </ColumnLayout>
+
+        <ColumnLayout columns={3}>
+          <Slider value={50} max={100} min={0} ariaLabel="Default slider" />
+          <Slider value={50} max={100} min={0} disabled={true} ariaLabel="Disabled slider" />
+          <Slider value={50} max={100} min={0} readOnly={true} ariaLabel="Read-only slider" />
+        </ColumnLayout>
+      </Grid>
+    </Section>
+  );
+}

--- a/pages/components-overview/kvp-form.tsx
+++ b/pages/components-overview/kvp-form.tsx
@@ -1,0 +1,132 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Box from '~components/box';
+import Button from '~components/button';
+import ColumnLayout from '~components/column-layout';
+import CopyToClipboard from '~components/copy-to-clipboard';
+import Form from '~components/form';
+import FormField from '~components/form-field';
+import Grid from '~components/grid';
+import Header from '~components/header';
+import Icon from '~components/icon';
+import Input from '~components/input';
+import KeyValuePairs from '~components/key-value-pairs';
+import Link from '~components/link';
+import SpaceBetween from '~components/space-between';
+import StatusIndicator from '~components/status-indicator';
+import Textarea from '~components/textarea';
+import Tiles from '~components/tiles';
+
+import { Section } from './utils';
+
+export default function KvpForm() {
+  const [value, setValue] = React.useState('standard');
+  return (
+    <Section header="Key-value pairs & Form" level="h2">
+      <ColumnLayout borders="horizontal">
+        <Box padding={{ bottom: 'xl' }}>
+          <SpaceBetween size="l">
+            <Header variant="h2">General configuration</Header>
+            <KeyValuePairs
+              columns={3}
+              items={[
+                { label: 'Distribution ID', value: 'SLCCSMWOHOFUY0' },
+                {
+                  label: 'Domain name',
+                  value: 'd111111abcdef8.cloudfront.net',
+                  info: (
+                    <Link variant="info" href="#">
+                      Info
+                    </Link>
+                  ),
+                },
+                { label: 'Status', value: <StatusIndicator type="success">Available</StatusIndicator> },
+                { label: 'Price class', value: 'Use only US, Canada, Europe, and Asia' },
+                { label: 'CNAMEs', value: <Link href="#">example.com</Link> },
+                {
+                  label: 'ARN',
+                  value: (
+                    <CopyToClipboard
+                      copyButtonAriaLabel="Copy ARN"
+                      copyErrorText="ARN failed to copy"
+                      copySuccessText="ARN copied"
+                      textToCopy="arn:service23G24::111122223333:distribution/23E1WG1ZNPRXT0D4"
+                      variant="inline"
+                    />
+                  ),
+                },
+              ]}
+            />
+          </SpaceBetween>
+        </Box>
+
+        <Box margin={{ top: 'xl' }}>
+          <SpaceBetween size="l">
+            <Form
+              actions={
+                <SpaceBetween direction="horizontal" size="xs">
+                  <Button variant="link">Cancel</Button>
+                  <Button variant="primary">Submit</Button>
+                </SpaceBetween>
+              }
+              header={<Header variant="h2">Create instance</Header>}
+            >
+              <SpaceBetween size="l">
+                <Grid gridDefinition={[{ colspan: { default: 12, xxs: 8 } }, { colspan: { default: 12, xxs: 4 } }]}>
+                  <SpaceBetween size="l">
+                    <FormField label="Cache policy">
+                      <Tiles
+                        value={value}
+                        onChange={e => setValue(e.detail.value)}
+                        columns={4}
+                        items={[
+                          {
+                            value: 'standard',
+                            label: 'Standard',
+                            description: 'Recommended for most workloads',
+                            image: <Icon name="settings" size="large" />,
+                          },
+                          {
+                            value: 'optimized',
+                            label: 'Optimized',
+                            description: 'Best for dynamic content',
+                            image: <Icon name="star" size="large" />,
+                          },
+                          {
+                            value: 'custom',
+                            label: 'Custom',
+                            description: 'Configure your own policy',
+                            image: <Icon name="edit" size="large" />,
+                          },
+                          {
+                            value: 'disabled',
+                            label: 'Disabled',
+                            description: 'No caching applied',
+                            image: <Icon name="close" size="large" />,
+                          },
+                        ]}
+                        ariaLabel="Cache policy"
+                      />
+                    </FormField>
+                    <FormField label="Origin domain name" description="The domain name of the resource.">
+                      <Input value="example-bucket.s3.amazonaws.com" ariaLabel="Origin domain name" />
+                    </FormField>
+                    <FormField label="Origin path" constraintText="Must begin with / and must not end with /.">
+                      <Input value="/production" ariaLabel="Origin path" />
+                    </FormField>
+                    <FormField label="Comment">
+                      <Textarea value="Production distribution" ariaLabel="Comment" />
+                    </FormField>
+                  </SpaceBetween>
+                  <div />
+                </Grid>
+              </SpaceBetween>
+            </Form>
+          </SpaceBetween>
+        </Box>
+      </ColumnLayout>
+    </Section>
+  );
+}

--- a/pages/components-overview/navigation-components.tsx
+++ b/pages/components-overview/navigation-components.tsx
@@ -1,0 +1,93 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import AnchorNavigation from '~components/anchor-navigation';
+import BreadcrumbGroup from '~components/breadcrumb-group';
+import Grid from '~components/grid';
+import Link from '~components/link';
+import SideNavigation from '~components/side-navigation';
+import SpaceBetween from '~components/space-between';
+import Tabs from '~components/tabs';
+
+import { Section } from './utils';
+
+export default function NavigationComponents() {
+  const [activeTabId, setActiveTabId] = useState('tab1');
+  const [activeHref, setActiveHref] = useState('#/parent-page/child-page1');
+
+  return (
+    <Section header="Navigation components">
+      <Grid
+        gridDefinition={[
+          { colspan: { default: 2, s: 2 } },
+          { colspan: { default: 4, m: 2 } },
+          { colspan: { default: 4, m: 4 } },
+          { colspan: { default: 6, m: 4 } },
+        ]}
+      >
+        <AnchorNavigation
+          activeHref="#section2"
+          anchors={[
+            { text: 'Section 1', href: '#section1', level: 1 },
+            { text: 'Section 2', href: '#section2', level: 1 },
+            { text: 'Section 3', href: '#section3', level: 1 },
+            { text: 'Section 4', href: '#section4', level: 1 },
+          ]}
+        />
+
+        <SideNavigation
+          activeHref={activeHref}
+          header={{ href: '#/', text: 'Side navigation' }}
+          onFollow={event => {
+            if (!event.detail.external) {
+              event.preventDefault();
+              setActiveHref(event.detail.href);
+            }
+          }}
+          items={[
+            { type: 'link', text: 'Page 1', href: '#/page1' },
+            {
+              type: 'expandable-link-group',
+              text: 'Parent page',
+              href: '#/parent-page',
+              items: [
+                { type: 'link', text: 'Child page 1', href: '#/parent-page/child-page1' },
+                { type: 'link', text: 'Child page 2', href: '#/parent-page/child-page2' },
+              ],
+            },
+            { type: 'link', text: 'Page 2', href: '#/page2' },
+            { type: 'link', text: 'Page 3', href: '#/page3' },
+          ]}
+        />
+
+        <Tabs
+          activeTabId={activeTabId}
+          onChange={({ detail }) => setActiveTabId(detail.activeTabId)}
+          tabs={[
+            { id: 'tab1', label: 'Tab 1', content: 'Tab 1 Content' },
+            { id: 'tab2', label: 'Tab 2', content: 'Tab 2 Content' },
+            { id: 'tab3', label: 'Tab 3', content: 'Tab 3 Content', disabled: true },
+          ]}
+        />
+
+        <SpaceBetween size="s">
+          <BreadcrumbGroup
+            items={[
+              { text: 'Home', href: '#' },
+              { text: 'Another page', href: '#' },
+              { text: 'Testing', href: '#' },
+            ]}
+          />
+          <Link href="#" variant="primary">
+            Primary anchor link
+          </Link>
+          <Link href="#" variant="secondary">
+            Secondary anchor link
+          </Link>
+          <Link onFollow={() => {}}>Button link</Link>
+        </SpaceBetween>
+      </Grid>
+    </Section>
+  );
+}

--- a/pages/components-overview/overlays-and-patterns.tsx
+++ b/pages/components-overview/overlays-and-patterns.tsx
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Box from '~components/box';
+import ColumnLayout from '~components/column-layout';
+import TokenGroup from '~components/token-group';
+import Wizard from '~components/wizard';
+
+import { Section, SubSection } from './utils';
+
+export default function OverlaysAndPatterns() {
+  const [tokens, setTokens] = useState([
+    { label: 'us-east-1', dismissLabel: 'Remove us-east-1' },
+    { label: 'eu-west-1', dismissLabel: 'Remove eu-west-1' },
+    { label: 'ap-southeast-1', dismissLabel: 'Remove ap-southeast-1' },
+  ]);
+  const [activeWizardStep, setActiveWizardStep] = useState(0);
+
+  return (
+    <Section header="Tokens & patterns" level="h2">
+      <>
+        <SubSection header="Token group">
+          <ColumnLayout columns={2}>
+            <TokenGroup
+              items={tokens}
+              onDismiss={({ detail }) => setTokens(tokens.filter((_, i) => i !== detail.itemIndex))}
+            />
+            <TokenGroup
+              items={[{ label: 'Read-only token 1' }, { label: 'Read-only token 2' }, { label: 'Read-only token 3' }]}
+              readOnly={true}
+            />
+          </ColumnLayout>
+        </SubSection>
+
+        <SubSection header="Wizard">
+          <Box padding={{ vertical: 's' }}>
+            <Wizard
+              i18nStrings={{
+                stepNumberLabel: stepNumber => `Step ${stepNumber}`,
+                collapsedStepsLabel: (stepNumber, stepsCount) => `Step ${stepNumber} of ${stepsCount}`,
+                cancelButton: 'Cancel',
+                previousButton: 'Previous',
+                nextButton: 'Next',
+                submitButton: 'Create distribution',
+                optional: 'optional',
+              }}
+              activeStepIndex={activeWizardStep}
+              onNavigate={({ detail }) => setActiveWizardStep(detail.requestedStepIndex)}
+              steps={[
+                {
+                  title: 'Choose origin',
+                  description: 'Select the origin for your distribution.',
+                  content: (
+                    <Box padding={{ vertical: 's' }}>
+                      Configure the origin settings for your CloudFront distribution.
+                    </Box>
+                  ),
+                },
+                {
+                  title: 'Configure behaviors',
+                  description: 'Set up cache behaviors and path patterns.',
+                  content: (
+                    <Box padding={{ vertical: 's' }}>
+                      Define how CloudFront handles requests for different URL paths.
+                    </Box>
+                  ),
+                },
+                {
+                  title: 'Review and create',
+                  description: 'Review your configuration before creating.',
+                  content: (
+                    <Box padding={{ vertical: 's' }}>Review all settings and confirm the distribution creation.</Box>
+                  ),
+                },
+              ]}
+            />
+          </Box>
+        </SubSection>
+      </>
+    </Section>
+  );
+}

--- a/pages/components-overview/status-components.tsx
+++ b/pages/components-overview/status-components.tsx
@@ -1,0 +1,249 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Alert from '~components/alert';
+import Badge from '~components/badge';
+import Button from '~components/button';
+import ButtonGroup from '~components/button-group';
+import ColumnLayout from '~components/column-layout';
+import FileTokenGroup from '~components/file-token-group';
+import Flashbar, { FlashbarProps } from '~components/flashbar';
+import FormField from '~components/form-field';
+import Grid from '~components/grid';
+import Input from '~components/input';
+import ProgressBar from '~components/progress-bar';
+import Slider from '~components/slider';
+import SpaceBetween from '~components/space-between';
+import Spinner from '~components/spinner';
+import StatusIndicator from '~components/status-indicator';
+import Steps from '~components/steps';
+
+import { flashbarItems } from './component-data';
+import { Section, SubSection } from './utils';
+
+export default function StatusComponents() {
+  return (
+    <Section header="Status components" level="h2">
+      <>
+        <SubSection header="Errors">
+          <ColumnLayout columns={3}>
+            <Flashbar items={[flashbarItems.find(item => item.type === 'error') as FlashbarProps.MessageDefinition]} />
+            <Alert
+              type="error"
+              dismissible={true}
+              i18nStrings={{ dismissAriaLabel: 'Dismiss error alert' }}
+              header="Error"
+            >
+              This is an error alert.
+            </Alert>
+            <Slider value={50} invalid={true} max={100} min={0} ariaLabel="Invalid slider" />
+            <Input value="Invalid input" invalid={true} ariaLabel="Invalid input" />
+            <FormField
+              constraintText="Requirements and constraints."
+              description="This is a description."
+              errorText="This is an error message."
+              label="Form field label"
+            >
+              <Input value="Hello" />
+            </FormField>
+            <Grid gridDefinition={[{ colspan: { default: 6, xxs: 4 } }, { colspan: { default: 6, xxs: 4 } }]}>
+              <Steps
+                steps={[
+                  { status: 'error', header: 'Error step', statusIconAriaLabel: 'Error' },
+                  { status: 'error', header: 'Error step', statusIconAriaLabel: 'Error' },
+                  { status: 'error', header: 'Error step', statusIconAriaLabel: 'Error' },
+                ]}
+              />
+              <SpaceBetween size="xs">
+                <StatusIndicator type="error">Error Status</StatusIndicator>
+                <Badge color="red">Badge</Badge>
+              </SpaceBetween>
+            </Grid>
+          </ColumnLayout>
+        </SubSection>
+
+        <SubSection header="Warnings">
+          <ColumnLayout columns={3}>
+            <Flashbar
+              items={[flashbarItems.find(item => item.type === 'warning') as FlashbarProps.MessageDefinition]}
+            />
+            <Alert
+              type="warning"
+              dismissible={true}
+              i18nStrings={{ dismissAriaLabel: 'Dismiss warning alert' }}
+              header="Warning"
+            >
+              This is a warning alert.
+            </Alert>
+            <Slider value={50} warning={true} max={100} min={0} ariaLabel="Warning slider" />
+            <Input value="Warning input" warning={true} ariaLabel="Warning input" />
+            <FormField
+              constraintText="Requirements and constraints."
+              description="This is a description."
+              warningText="This is a warning message."
+              label="Form field label"
+            >
+              <Input value="Hello" />
+            </FormField>
+            <Grid gridDefinition={[{ colspan: { default: 6, xxs: 4 } }, { colspan: { default: 6, xxs: 4 } }]}>
+              <Steps
+                steps={[
+                  { status: 'warning', header: 'Warning step', statusIconAriaLabel: 'Warning' },
+                  { status: 'warning', header: 'Warning step', statusIconAriaLabel: 'Warning' },
+                ]}
+              />
+              <StatusIndicator type="warning">Warning Status</StatusIndicator>
+            </Grid>
+          </ColumnLayout>
+        </SubSection>
+
+        <SubSection header="Success">
+          <ColumnLayout columns={3}>
+            <Flashbar
+              items={[flashbarItems.find(item => item.type === 'success') as FlashbarProps.MessageDefinition]}
+            />
+            <Alert
+              type="success"
+              dismissible={true}
+              i18nStrings={{ dismissAriaLabel: 'Dismiss success alert' }}
+              header="Success"
+            >
+              This is a success alert.
+            </Alert>
+            <Grid gridDefinition={[{ colspan: { default: 6, xxs: 4 } }, { colspan: { default: 6, xxs: 4 } }]}>
+              <Steps
+                steps={[
+                  { status: 'success', header: 'Success step', statusIconAriaLabel: 'Success' },
+                  { status: 'success', header: 'Success step', statusIconAriaLabel: 'Success' },
+                ]}
+              />
+              <SpaceBetween size="xs">
+                <StatusIndicator type="success">Success Status</StatusIndicator>
+                <Badge color="green">Badge</Badge>
+              </SpaceBetween>
+            </Grid>
+          </ColumnLayout>
+        </SubSection>
+
+        <SubSection header="Info">
+          <ColumnLayout columns={3}>
+            <Flashbar items={[flashbarItems.find(item => item.type === 'info') as FlashbarProps.MessageDefinition]} />
+            <Alert
+              type="info"
+              dismissible={true}
+              i18nStrings={{ dismissAriaLabel: 'Dismiss info alert' }}
+              header="Info"
+            >
+              This is an info alert.
+            </Alert>
+            <Grid gridDefinition={[{ colspan: { default: 6, xxs: 4 } }, { colspan: { default: 6, xxs: 4 } }]}>
+              <Steps
+                steps={[
+                  { status: 'info', header: 'Info step', statusIconAriaLabel: 'Info' },
+                  { status: 'info', header: 'Info step', statusIconAriaLabel: 'Info' },
+                ]}
+              />
+              <SpaceBetween size="xs">
+                <StatusIndicator type="info">Info Status</StatusIndicator>
+                <Badge color="blue">Badge</Badge>
+              </SpaceBetween>
+            </Grid>
+          </ColumnLayout>
+        </SubSection>
+
+        <SubSection header="Loading & in-progress">
+          <ColumnLayout columns={3}>
+            <Flashbar
+              items={[
+                {
+                  type: 'in-progress',
+                  header: 'In-progress',
+                  content: (
+                    <>
+                      This is an in-progress flash.
+                      <ProgressBar value={37} variant="flash" ariaLabel="Progress bar in flash" />
+                    </>
+                  ),
+                  dismissible: true,
+                  dismissLabel: 'Dismiss in-progress message',
+                  id: 'in-progress',
+                },
+                {
+                  header: 'Loading',
+                  type: 'in-progress',
+                  loading: true,
+                  content: 'This is a loading flash.',
+                  dismissible: true,
+                  dismissLabel: 'Dismiss loading message',
+                  id: 'loading',
+                },
+              ]}
+            />
+            <SpaceBetween size="s">
+              <FileTokenGroup
+                items={[
+                  {
+                    file: new File([new Blob(['Test content'])], 'file-1.pdf', {
+                      type: 'application/pdf',
+                      lastModified: 1590962400000,
+                    }),
+                    loading: true,
+                  },
+                ]}
+                onDismiss={() => {}}
+              />
+              <ProgressBar value={60} label="Progress" ariaLabel="Progress bar" />
+              <SpaceBetween direction="horizontal" size="s">
+                <Button variant="primary" loading={true}>
+                  Loading
+                </Button>
+                <Button loading={true}>Loading</Button>
+                <Button loading={true} iconName="refresh" ariaLabel="Loading button" />
+                <Button variant="link" loading={true}>
+                  Loading
+                </Button>
+              </SpaceBetween>
+              <SpaceBetween direction="horizontal" size="s">
+                <Spinner size="normal" />
+                <Spinner size="big" />
+                <Button variant="icon" loading={true} ariaLabel="Loading icon button" />
+                <ButtonGroup
+                  ariaLabel="Loading button group"
+                  items={[
+                    {
+                      type: 'icon-button',
+                      id: 'copy',
+                      iconName: 'upload',
+                      text: 'Upload files',
+                      loading: true,
+                      loadingText: 'Loading',
+                    },
+                  ]}
+                  variant="icon"
+                />
+              </SpaceBetween>
+            </SpaceBetween>
+            <Grid gridDefinition={[{ colspan: { default: 6, xs: 4 } }, { colspan: { default: 6, xs: 4 } }]}>
+              <Steps
+                steps={[
+                  { status: 'in-progress', header: 'In-progress step', statusIconAriaLabel: 'In-progress' },
+                  { status: 'loading', header: 'Loading step', statusIconAriaLabel: 'Loading' },
+                  { status: 'stopped', header: 'Stopped step', statusIconAriaLabel: 'Stopped' },
+                  { status: 'pending', header: 'Pending step', statusIconAriaLabel: 'Pending' },
+                ]}
+              />
+              <SpaceBetween size="xs">
+                <StatusIndicator type="in-progress">In-progress Status</StatusIndicator>
+                <StatusIndicator type="loading">Loading</StatusIndicator>
+                <StatusIndicator type="stopped">Stopped Status</StatusIndicator>
+                <StatusIndicator type="pending">Pending Status</StatusIndicator>
+                <Badge color="grey">Badge</Badge>
+              </SpaceBetween>
+            </Grid>
+          </ColumnLayout>
+        </SubSection>
+      </>
+    </Section>
+  );
+}

--- a/pages/components-overview/table-and-cards.tsx
+++ b/pages/components-overview/table-and-cards.tsx
@@ -1,0 +1,184 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Badge from '~components/badge';
+import Cards from '~components/cards';
+import CollectionPreferences from '~components/collection-preferences';
+import Header from '~components/header';
+import KeyValuePairs from '~components/key-value-pairs';
+import Link from '~components/link';
+import Pagination from '~components/pagination';
+import SpaceBetween from '~components/space-between';
+import Table from '~components/table';
+import TextFilter from '~components/text-filter';
+
+import { cardItems, RandomData, tableItems } from './component-data';
+import { Section } from './utils';
+
+export default function TableAndCards() {
+  const [selectedItems, setSelectedItems] = useState({
+    table: [tableItems[2]],
+    cards: [cardItems[1]],
+  });
+  const [filteringText, setFilteringText] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [preferences, setPreferences] = useState({
+    pageSize: 5,
+    visibleContent: ['name', 'category', 'description'],
+  });
+
+  return (
+    <SpaceBetween size="xxs">
+      <Section header="Cards" container={false}>
+        <Cards
+          items={cardItems}
+          cardsPerRow={[{ cards: 1 }, { minWidth: 500, cards: 2 }]}
+          cardDefinition={{
+            header: (item: RandomData) => (
+              <Link href="#" fontSize="heading-m">
+                {item.name}
+              </Link>
+            ),
+            sections: [
+              {
+                id: 'key-value-pairs',
+                content: item => (
+                  <KeyValuePairs
+                    columns={2}
+                    items={[
+                      { label: 'Description', value: item.description },
+                      { label: 'Cost', value: item.amount },
+                    ]}
+                  />
+                ),
+              },
+            ],
+          }}
+          selectionType="multi"
+          selectedItems={selectedItems.cards}
+          onSelectionChange={({ detail }) => setSelectedItems(prev => ({ ...prev, cards: detail.selectedItems }))}
+          ariaLabels={{
+            itemSelectionLabel: (e, item) => `Select ${item.name}`,
+            selectionGroupLabel: 'Item selection',
+          }}
+        />
+      </Section>
+      <Section header="Table" container={false}>
+        <Table
+          items={tableItems}
+          header={
+            <Header
+              description="Description"
+              counter={`(${tableItems.length})`}
+              info={
+                <Link variant="info" href="#">
+                  Info
+                </Link>
+              }
+            >
+              Table with common features
+            </Header>
+          }
+          filter={
+            <TextFilter
+              filteringText={filteringText}
+              filteringPlaceholder="Find resources"
+              filteringAriaLabel="Filter resources"
+              onChange={({ detail }) => setFilteringText(detail.filteringText)}
+            />
+          }
+          pagination={
+            <Pagination
+              currentPageIndex={currentPage}
+              pagesCount={2}
+              onChange={({ detail }) => setCurrentPage(detail.currentPageIndex)}
+              ariaLabels={{
+                nextPageLabel: 'Next page',
+                previousPageLabel: 'Previous page',
+                pageLabel: pageNumber => `Page ${pageNumber}`,
+              }}
+            />
+          }
+          preferences={
+            <CollectionPreferences
+              title="Preferences"
+              confirmLabel="Confirm"
+              cancelLabel="Cancel"
+              preferences={preferences}
+              onConfirm={({ detail }) =>
+                setPreferences({
+                  pageSize: detail.pageSize ?? 5,
+                  visibleContent: (detail.visibleContent as string[]) ?? [],
+                })
+              }
+              pageSizePreference={{
+                title: 'Page size',
+                options: [
+                  { value: 5, label: '5 resources' },
+                  { value: 10, label: '10 resources' },
+                ],
+              }}
+              visibleContentPreference={{
+                title: 'Select visible content',
+                options: [
+                  {
+                    label: 'Main properties',
+                    options: [
+                      { id: 'name', label: 'Name' },
+                      { id: 'category', label: 'Category' },
+                      { id: 'description', label: 'Description' },
+                    ],
+                  },
+                ],
+              }}
+            />
+          }
+          resizableColumns={true}
+          columnDefinitions={[
+            {
+              id: 'name',
+              header: 'Name',
+              cell: (item: RandomData) => (
+                <Link variant="primary" href="#">
+                  {item.name}
+                </Link>
+              ),
+              sortingField: 'name',
+              width: 200,
+              minWidth: 150,
+            },
+            {
+              id: 'category',
+              header: 'Category',
+              cell: (item: RandomData) => {
+                const categories = ['green', 'grey', 'blue'] as const;
+                const labels = ['Serverless', 'Security', 'Agentic AI'];
+                const index = item.name.length % 3;
+                return <Badge color={categories[index]}>{labels[index]}</Badge>;
+              },
+              sortingField: 'category',
+              width: 150,
+              minWidth: 100,
+            },
+            {
+              id: 'description',
+              header: 'Description',
+              cell: (item: RandomData) => item.description,
+              width: 300,
+              minWidth: 200,
+            },
+          ]}
+          selectionType="single"
+          selectedItems={selectedItems.table}
+          onSelectionChange={({ detail }) => setSelectedItems(prev => ({ ...prev, table: detail.selectedItems }))}
+          ariaLabels={{
+            itemSelectionLabel: (e, item) => `Select ${item.name}`,
+            allItemsSelectionLabel: () => 'Select all items',
+            selectionGroupLabel: 'Item selection',
+          }}
+        />
+      </Section>
+    </SpaceBetween>
+  );
+}

--- a/pages/components-overview/typography.tsx
+++ b/pages/components-overview/typography.tsx
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Box from '~components/box';
+import ColumnLayout from '~components/column-layout';
+import Container from '~components/container';
+import Header from '~components/header';
+import Icon from '~components/icon';
+import Link from '~components/link';
+import SpaceBetween from '~components/space-between';
+import TextContent from '~components/text-content';
+import Toggle from '~components/toggle';
+
+export default function Typography() {
+  const [longText, setLongText] = useState(false);
+  return (
+    <>
+      <Box padding={{ bottom: 's' }}>
+        <Header
+          variant="h2"
+          actions={
+            <Toggle onChange={({ detail }) => setLongText(detail.checked)} checked={longText}>
+              Long text
+            </Toggle>
+          }
+        >
+          Typography & Iconography
+        </Header>
+      </Box>
+      <Container>
+        <TextContent>
+          <SpaceBetween size="xs">
+            {longText ? (
+              <>
+                <h1>Heading 1: The instance type you specify determines the hardware of the host computer.</h1>
+                <h2>Heading 2: The instance type you specify determines the hardware of the host computer.</h2>
+                <h3>Heading 3: The instance type you specify determines the hardware of the host computer.</h3>
+                <h4>Heading 4: The instance type you specify determines the hardware of the host computer.</h4>
+                <h5>Heading 5: The instance type you specify determines the hardware of the host computer.</h5>
+              </>
+            ) : (
+              <>
+                <h1>Heading 1</h1>
+                <h2>Heading 2</h2>
+                <h3>Heading 3</h3>
+                <h4>Heading 4</h4>
+                <h5>Heading 5</h5>
+              </>
+            )}
+          </SpaceBetween>
+        </TextContent>
+        <Box variant="p" padding={{ top: 'm' }}>
+          {longText ? (
+            <>
+              Paragraph - The instance type you specify determines the hardware of the host computer used for your
+              instance. Each instance type offers different compute, memory, and storage capabilities.{' '}
+              <Link variant="primary" href="#">
+                Amazon EC2
+              </Link>{' '}
+              provides each instance with a consistent and predictable amount of CPU capacity, regardless of its{' '}
+              <Link variant="primary" href="#">
+                underlying hardware
+              </Link>
+              .
+            </>
+          ) : (
+            <>
+              Paragraph -{' '}
+              <Link variant="primary" href="#">
+                Amazon EC2
+              </Link>{' '}
+              provides each instance with a consistent and predictable amount of CPU capacity, regardless of its{' '}
+              <Link variant="primary" href="#">
+                underlying hardware
+              </Link>
+              .
+            </>
+          )}
+        </Box>
+        <Box variant="small" color="text-body-secondary" padding={{ top: 's' }}>
+          {longText ? (
+            <>Small - Daily instance hours by instance type, aggregated across all regions and availability zones.</>
+          ) : (
+            <>Small - Requirements and constraints for the field.</>
+          )}
+        </Box>
+        <Box padding={{ bottom: 'xxs', top: 'm' }}>
+          <Box padding={{ vertical: 'xs' }}>Icon - Normal size</Box>
+          <ColumnLayout columns={8}>
+            <Icon name="add-plus" />
+            <Icon name="thumbs-up" />
+            <Icon name="settings" />
+            <Icon name="close" />
+            <Icon name="check" />
+            <Icon name="star" />
+            <Icon name="send" />
+            <Icon name="refresh" />
+            <Icon name="edit" />
+            <Icon name="remove" />
+            <Icon name="copy" />
+            <Icon name="share" />
+            <Icon name="lock-private" />
+            <Icon name="anchor-link" />
+            <Icon name="folder" />
+            <Icon name="file" />
+            <Icon name="user-profile" />
+            <Icon name="status-info" />
+          </ColumnLayout>
+        </Box>
+      </Container>
+    </>
+  );
+}

--- a/pages/components-overview/utils.tsx
+++ b/pages/components-overview/utils.tsx
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { ReactElement } from 'react';
+
+import Box from '~components/box';
+import Container from '~components/container';
+import Header from '~components/header';
+import SpaceBetween from '~components/space-between';
+
+interface SectionProps {
+  header?: string;
+  description?: string;
+  level?: 'h2' | 'h3';
+  container?: boolean;
+  children: ReactElement;
+}
+
+export const Section = ({ header, description, level = 'h2', container = true, children }: SectionProps) => {
+  const content = <SpaceBetween size={'m'}>{children}</SpaceBetween>;
+  return (
+    <SpaceBetween size={'s'}>
+      {header && (
+        <Header variant={level} description={description}>
+          {header}
+        </Header>
+      )}
+      {container ? <Container>{content}</Container> : content}
+    </SpaceBetween>
+  );
+};
+
+export const SubSection = ({ header, level = 'h3', children }: SectionProps) => {
+  return (
+    <SpaceBetween size={'s'}>
+      {header && <Box variant={level}>{header}</Box>}
+      <SpaceBetween size={'s'}>{children}</SpaceBetween>
+    </SpaceBetween>
+  );
+};

--- a/pages/webpack.config.base.cjs
+++ b/pages/webpack.config.base.cjs
@@ -153,6 +153,7 @@ module.exports = ({
       }),
       replaceModule(/~components/, componentsPath),
       replaceModule(/~design-tokens/, designTokensPath),
+      replaceModule(/@cloudscape-design\/components(?!\w)/, componentsPath),
       globalStylesPath
         ? replaceModule(/@cloudscape-design\/global-styles\/index\.css/, `${globalStylesPath}/${globalStylesIndex}.css`)
         : noop,


### PR DESCRIPTION
### Description
This PR adds components overview page including components that are imported from:
- @cloudscape-design/chat-components
- @cloudscape-design/board-components
- @cloudscape-design/code-view

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
