### PR TITLE
chore: Refactor colorNeutral color tokens

### DIFF
--- a/style-dictionary/one-theme/colors.ts
+++ b/style-dictionary/one-theme/colors.ts
@@ -12,61 +12,61 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorGreyOpaque70: { light: 'rgba(0, 0, 0, 0.7)', dark: 'rgba(0, 0, 0, 0.7)' },
 
   // ── Body text ─────────────────────────────────────────────────────────────
-  colorTextBodyDefault: { light: '{colorNeutralGrey850}', dark: '{colorNeutralGrey350}' },
-  colorTextBodySecondary: { light: '{colorNeutralGrey600}', dark: '{colorNeutralGrey450}' },
+  colorTextBodyDefault: { light: '{colorNeutral850}', dark: '{colorNeutral350}' },
+  colorTextBodySecondary: { light: '{colorNeutral600}', dark: '{colorNeutral450}' },
 
   // ── Container / layout ────────────────────────────────────────────────────
-  colorBackgroundLayoutMain: { light: '{colorNeutralGrey50}', dark: '{colorNeutralGrey1000}' },
-  colorBackgroundLayoutPanelContent: { light: '{colorNeutralGrey50}', dark: '{colorNeutralGrey1000}' },
+  colorBackgroundLayoutMain: { light: '{colorNeutral50}', dark: '{colorNeutral1000}' },
+  colorBackgroundLayoutPanelContent: { light: '{colorNeutral50}', dark: '{colorNeutral1000}' },
 
-  colorBackgroundContainerHeader: { light: '{colorWhite}', dark: '{colorNeutralGrey950}' },
-  colorBackgroundContainerContent: { light: '{colorWhite}', dark: '{colorNeutralGrey950}' },
-  colorBorderDividerDefault: { light: '{colorNeutralGrey300}', dark: '{colorNeutralGrey750}' },
-  colorBorderDividerInteractiveDefault: { light: '{colorNeutralGrey300}', dark: '{colorNeutralGrey750}' },
-  colorBorderDividerSecondary: { light: '{colorNeutralGrey250}', dark: '{colorNeutralGrey800}' },
-  colorBorderDividerTableGroup: { light: '{colorNeutralGrey500}', dark: '{colorNeutralGrey600}' },
-  colorBorderLayout: { light: '{colorNeutralGrey300}', dark: '{colorNeutralGrey750}' },
-  colorGapGlobalDrawer: { light: '{colorNeutralGrey250}', dark: '{colorBlack}' },
+  colorBackgroundContainerHeader: { light: '{colorWhite}', dark: '{colorNeutral950}' },
+  colorBackgroundContainerContent: { light: '{colorWhite}', dark: '{colorNeutral950}' },
+  colorBorderDividerDefault: { light: '{colorNeutral300}', dark: '{colorNeutral750}' },
+  colorBorderDividerInteractiveDefault: { light: '{colorNeutral300}', dark: '{colorNeutral750}' },
+  colorBorderDividerSecondary: { light: '{colorNeutral250}', dark: '{colorNeutral800}' },
+  colorBorderDividerTableGroup: { light: '{colorNeutral500}', dark: '{colorNeutral600}' },
+  colorBorderLayout: { light: '{colorNeutral300}', dark: '{colorNeutral750}' },
+  colorGapGlobalDrawer: { light: '{colorNeutral250}', dark: '{colorBlack}' },
   colorBackgroundModalOverlay: '{colorGreyOpaque70}',
 
   // ── Normal button ─────────────────────────────────────────────────────────
-  colorBorderButtonNormalDefault: { light: '{colorNeutralGrey500}', dark: '{colorNeutralGrey600}' },
-  colorBorderButtonNormalHover: { light: '{colorNeutralGrey600}', dark: '{colorNeutralGrey500}' },
-  colorBorderButtonNormalActive: { light: '{colorNeutralGrey400}', dark: '{colorNeutralGrey500}' },
-  colorBorderButtonNormalDisabled: { light: '{colorNeutralGrey400}', dark: '{colorNeutralGrey700}' },
-  colorBackgroundButtonNormalDefault: { light: '{colorNeutralGrey100}', dark: '{colorNeutralGrey850}' },
-  colorBackgroundButtonNormalHover: { light: '{colorNeutralGrey150}', dark: '{colorNeutralGrey800}' },
-  colorBackgroundButtonNormalActive: { light: '{colorNeutralGrey200}', dark: '{colorNeutralGrey850}' },
-  colorBackgroundButtonNormalDisabled: { light: '{colorWhite}', dark: '{colorNeutralGrey950}' },
-  colorTextButtonNormalDefault: { light: '{colorNeutralGrey700}', dark: '{colorNeutralGrey350}' },
-  colorTextButtonNormalHover: { light: '{colorNeutralGrey850}', dark: '{colorNeutralGrey250}' },
-  colorTextButtonNormalActive: { light: '{colorNeutralGrey850}', dark: '{colorNeutralGrey350}' },
-  colorTextButtonNormalDisabled: { light: '{colorNeutralGrey450}', dark: '{colorNeutralGrey600}' },
+  colorBorderButtonNormalDefault: { light: '{colorNeutral500}', dark: '{colorNeutral600}' },
+  colorBorderButtonNormalHover: { light: '{colorNeutral600}', dark: '{colorNeutral500}' },
+  colorBorderButtonNormalActive: { light: '{colorNeutral400}', dark: '{colorNeutral500}' },
+  colorBorderButtonNormalDisabled: { light: '{colorNeutral400}', dark: '{colorNeutral700}' },
+  colorBackgroundButtonNormalDefault: { light: '{colorNeutral100}', dark: '{colorNeutral850}' },
+  colorBackgroundButtonNormalHover: { light: '{colorNeutral150}', dark: '{colorNeutral800}' },
+  colorBackgroundButtonNormalActive: { light: '{colorNeutral200}', dark: '{colorNeutral850}' },
+  colorBackgroundButtonNormalDisabled: { light: '{colorWhite}', dark: '{colorNeutral950}' },
+  colorTextButtonNormalDefault: { light: '{colorNeutral700}', dark: '{colorNeutral350}' },
+  colorTextButtonNormalHover: { light: '{colorNeutral850}', dark: '{colorNeutral250}' },
+  colorTextButtonNormalActive: { light: '{colorNeutral850}', dark: '{colorNeutral350}' },
+  colorTextButtonNormalDisabled: { light: '{colorNeutral450}', dark: '{colorNeutral600}' },
 
   // ── Tertiary button ─────────────────────────────────────────────────────────
   colorBackgroundButtonLinkDefault: { light: 'transparent', dark: 'transparent' },
-  colorBackgroundButtonLinkHover: { light: '{colorNeutralGrey150}', dark: '{colorNeutralGrey800}' },
-  colorBackgroundButtonLinkActive: { light: '{colorNeutralGrey250}', dark: '{colorNeutralGrey850}' },
+  colorBackgroundButtonLinkHover: { light: '{colorNeutral150}', dark: '{colorNeutral800}' },
+  colorBackgroundButtonLinkActive: { light: '{colorNeutral250}', dark: '{colorNeutral850}' },
   colorBackgroundButtonLinkDisabled: { light: 'transparent', dark: 'transparent' },
-  colorTextButtonLinkDefault: { light: '{colorNeutralGrey700}', dark: '{colorNeutralGrey350}' },
-  colorTextButtonLinkHover: { light: '{colorNeutralGrey700}', dark: '{colorNeutralGrey250}' },
-  colorTextButtonLinkActive: { light: '{colorNeutralGrey700}', dark: '{colorNeutralGrey300}' },
-  colorTextButtonLinkDisabled: { light: '{colorNeutralGrey500}', dark: '{colorNeutralGrey650}' },
+  colorTextButtonLinkDefault: { light: '{colorNeutral700}', dark: '{colorNeutral350}' },
+  colorTextButtonLinkHover: { light: '{colorNeutral700}', dark: '{colorNeutral250}' },
+  colorTextButtonLinkActive: { light: '{colorNeutral700}', dark: '{colorNeutral300}' },
+  colorTextButtonLinkDisabled: { light: '{colorNeutral500}', dark: '{colorNeutral650}' },
 
   // ── Primary button ────────────────────────────────────────────────────────
-  colorBackgroundButtonPrimaryDefault: { light: '{colorNeutralGrey800}', dark: '{colorNeutralGrey300}' },
-  colorBackgroundButtonPrimaryHover: { light: '{colorNeutralGrey700}', dark: '{colorNeutralGrey200}' },
-  colorBackgroundButtonPrimaryActive: { light: '{colorNeutralGrey800}', dark: '{colorNeutralGrey300}' },
-  colorBackgroundButtonPrimaryDisabled: { light: '{colorNeutralGrey400}', dark: '{colorNeutralGrey700}' },
-  colorTextButtonPrimaryDefault: { light: '{colorNeutralGrey100}', dark: '{colorNeutralGrey950}' },
-  colorTextButtonPrimaryHover: { light: '{colorNeutralGrey50}', dark: '{colorNeutralGrey950}' },
-  colorTextButtonPrimaryActive: { light: '{colorNeutralGrey50}', dark: '{colorNeutralGrey950}' },
-  colorTextButtonPrimaryDisabled: { light: '{colorNeutralGrey100}', dark: '{colorNeutralGrey950}' },
+  colorBackgroundButtonPrimaryDefault: { light: '{colorNeutral800}', dark: '{colorNeutral300}' },
+  colorBackgroundButtonPrimaryHover: { light: '{colorNeutral700}', dark: '{colorNeutral200}' },
+  colorBackgroundButtonPrimaryActive: { light: '{colorNeutral800}', dark: '{colorNeutral300}' },
+  colorBackgroundButtonPrimaryDisabled: { light: '{colorNeutral400}', dark: '{colorNeutral700}' },
+  colorTextButtonPrimaryDefault: { light: '{colorNeutral100}', dark: '{colorNeutral950}' },
+  colorTextButtonPrimaryHover: { light: '{colorNeutral50}', dark: '{colorNeutral950}' },
+  colorTextButtonPrimaryActive: { light: '{colorNeutral50}', dark: '{colorNeutral950}' },
+  colorTextButtonPrimaryDisabled: { light: '{colorNeutral100}', dark: '{colorNeutral950}' },
 
   // ── Toggle button ─────────────────────────────────────────────────────────
-  colorBackgroundToggleButtonNormalPressed: { light: '{colorWhite}', dark: '{colorNeutralGrey1000}' },
+  colorBackgroundToggleButtonNormalPressed: { light: '{colorWhite}', dark: '{colorNeutral1000}' },
   colorBorderToggleButtonNormalPressed: { light: '{colorPrimary600}', dark: '{colorPrimary500}' },
-  colorTextToggleButtonNormalPressed: { light: '{colorNeutralGrey900}', dark: '{colorWhite}' },
+  colorTextToggleButtonNormalPressed: { light: '{colorNeutral900}', dark: '{colorWhite}' },
 
   // ── Toggle ─────────────────────────────────────────────────────────
   colorBackgroundToggleCheckedDisabled: {
@@ -76,35 +76,35 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorBackgroundToggleDefault: { light: '{colorNeutral650}', dark: '{colorNeutral500}' },
 
   // ── Input / form ──────────────────────────────────────────────────────────
-  colorBackgroundInputDefault: { light: '{colorWhite}', dark: '{colorNeutralGrey950}' },
-  colorBackgroundInputDisabled: { light: '{colorNeutralGrey250}', dark: '{colorNeutralGrey800}' },
-  colorBorderInputDefault: { light: '{colorNeutralGrey500}', dark: '{colorNeutralGrey600}' },
-  colorTextFormLabel: { light: '{colorNeutralGrey850}', dark: '{colorNeutralGrey350}' },
-  colorTextFormSecondary: { light: '{colorNeutralGrey600}', dark: '{colorNeutralGrey500}' },
-  colorTextLabel: { light: '{colorNeutralGrey600}', dark: '{colorNeutralGrey500}' },
-  colorTextKeyValuePairsValue: { light: '{colorNeutralGrey950}', dark: '{colorNeutralGrey350}' },
+  colorBackgroundInputDefault: { light: '{colorWhite}', dark: '{colorNeutral950}' },
+  colorBackgroundInputDisabled: { light: '{colorNeutral250}', dark: '{colorNeutral800}' },
+  colorBorderInputDefault: { light: '{colorNeutral500}', dark: '{colorNeutral600}' },
+  colorTextFormLabel: { light: '{colorNeutral850}', dark: '{colorNeutral350}' },
+  colorTextFormSecondary: { light: '{colorNeutral600}', dark: '{colorNeutral500}' },
+  colorTextLabel: { light: '{colorNeutral600}', dark: '{colorNeutral500}' },
+  colorTextKeyValuePairsValue: { light: '{colorNeutral950}', dark: '{colorNeutral350}' },
   colorBorderInputFocused: { light: '{colorIndigo600}', dark: '{colorIndigo400}' },
 
   // ── Controls ──────────────────────────────────────────────────────────────
   colorBackgroundControlChecked: { light: '{colorIndigo600}', dark: '{colorIndigo500}' },
-  colorBackgroundControlDefault: { light: '{colorWhite}', dark: '{colorNeutralGrey950}' },
-  colorBackgroundControlDisabled: { light: '{colorNeutralGrey300}', dark: '{colorNeutralGrey650}' },
-  colorBorderControlDefault: { light: '{colorNeutralGrey500}', dark: '{colorNeutralGrey600}' },
+  colorBackgroundControlDefault: { light: '{colorWhite}', dark: '{colorNeutral950}' },
+  colorBackgroundControlDisabled: { light: '{colorNeutral300}', dark: '{colorNeutral650}' },
+  colorBorderControlDefault: { light: '{colorNeutral500}', dark: '{colorNeutral600}' },
 
   // ── Links ─────────────────────────────────────────────────────────────────
-  colorTextLinkDefault: { light: '{colorNeutralGrey850}', dark: '{colorNeutralGrey350}' },
+  colorTextLinkDefault: { light: '{colorNeutral850}', dark: '{colorNeutral350}' },
   colorTextLinkHover: { light: '{colorPrimary600}', dark: '{colorPrimary400}' },
-  colorTextLinkSecondaryDefault: { light: '{colorNeutralGrey600}', dark: '{colorNeutralGrey450}' },
+  colorTextLinkSecondaryDefault: { light: '{colorNeutral600}', dark: '{colorNeutral450}' },
   colorTextLinkSecondaryHover: { light: '{colorPrimary600}', dark: '{colorPrimary400}' },
   colorTextLinkInfoDefault: { light: '{colorPrimary600}', dark: '{colorPrimary400}' },
   colorTextLinkInfoHover: { light: '{colorPrimary600}', dark: '{colorPrimary400}' },
   colorTextAccent: { light: '{colorPrimary600}', dark: '{colorPrimary400}' },
-  colorTextLinkDecorationDefault: { light: '{colorNeutralGrey650}', dark: '{colorNeutralGrey600}' },
+  colorTextLinkDecorationDefault: { light: '{colorNeutral650}', dark: '{colorNeutral600}' },
 
   // ── Selection / focus ─────────────────────────────────────────────────────
   colorBorderItemFocused: { light: '{colorPrimary600}', dark: '{colorPrimary500}' },
   colorBorderItemSelected: { light: '{colorPrimary600}', dark: '{colorPrimary500}' },
-  colorBackgroundItemSelected: { light: '{colorNeutralGrey150}', dark: '{colorNeutralGrey1000}' },
+  colorBackgroundItemSelected: { light: '{colorNeutral150}', dark: '{colorNeutral1000}' },
   colorBackgroundLayoutToggleSelectedDefault: { light: '{colorPrimary100}', dark: '#5c7fff20' },
   colorBackgroundLayoutToggleSelectedHover: { light: '{colorPrimary200}', dark: '#5c7fff40' },
   colorBackgroundLayoutToggleSelectedActive: { light: '{colorPrimary100}', dark: '{colorPrimary1000}' },
@@ -112,10 +112,10 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorItemSelected: { light: '{colorIndigo600}', dark: '{colorIndigo400}' },
 
   // ── Segmented control ─────────────────────────────────────────────────────
-  colorBackgroundSegmentActive: { light: '{colorNeutralGrey800}', dark: '{colorNeutralGrey300}' },
+  colorBackgroundSegmentActive: { light: '{colorNeutral800}', dark: '{colorNeutral300}' },
   colorBackgroundSegmentDefault: { light: 'transparent', dark: 'transparent' },
-  colorTextSegmentActive: { light: '{colorNeutralGrey200}', dark: '{colorNeutralGrey950}' },
-  colorTextSegmentDefault: { light: '{colorNeutralGrey600}', dark: '{colorNeutralGrey300}' },
+  colorTextSegmentActive: { light: '{colorNeutral200}', dark: '{colorNeutral950}' },
+  colorTextSegmentDefault: { light: '{colorNeutral600}', dark: '{colorNeutral300}' },
   colorTextSegmentHover: '{colorTextButtonNormalHover}',
 
   // ── Slider / progress ─────────────────────────────────────────────────────
@@ -128,37 +128,37 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorBackgroundNotificationBlue: { light: '{colorInfo600}', dark: '{colorInfo900}' },
   colorBackgroundNotificationRed: { light: '{colorError600}', dark: '{colorError800}' },
   colorBackgroundNotificationYellow: { light: '{colorWarning400}', dark: '{colorWarning900}' },
-  colorTextNotificationDefault: { light: '{colorNeutralGrey100}', dark: '{colorNeutralGrey100}' },
+  colorTextNotificationDefault: { light: '{colorNeutral100}', dark: '{colorNeutral100}' },
 
   // ── Status text ───────────────────────────────────────────────────────────
   colorTextStatusInfo: { light: '{colorInfo600}', dark: '{colorInfo300}' },
   colorTextStatusSuccess: { light: '{colorSuccess600}', dark: '{colorSuccess200}' },
   colorTextStatusWarning: { light: '{colorWarning800}', dark: '{colorWarning300}' },
   colorTextStatusError: { light: '{colorError600}', dark: '{colorError400}' },
-  colorTextStatusInactive: { light: '{colorNeutralGrey650}', dark: '{colorNeutralGrey450}' },
+  colorTextStatusInactive: { light: '{colorNeutral650}', dark: '{colorNeutral450}' },
 
   // ── Dropdown ─────────────────────────────────────────────────
   colorTextDropdownItemFilterMatch: { light: '{colorPrimary600}', dark: '{colorPrimary500}' },
-  colorBackgroundDropdownItemFilterMatch: { light: '{colorNeutralGrey200}', dark: '{colorNeutralGrey1000}' },
-  colorBackgroundDropdownItemDefault: { light: '{colorWhite}', dark: '{colorNeutralGrey800}' },
-  colorBackgroundDropdownItemHover: { light: '{colorNeutralGrey200}', dark: '{colorNeutralGrey900}' },
+  colorBackgroundDropdownItemFilterMatch: { light: '{colorNeutral200}', dark: '{colorNeutral1000}' },
+  colorBackgroundDropdownItemDefault: { light: '{colorWhite}', dark: '{colorNeutral800}' },
+  colorBackgroundDropdownItemHover: { light: '{colorNeutral200}', dark: '{colorNeutral900}' },
 
   // ── Status indicator backgrounds (alpha values — no palette token available) ──
   colorBackgroundStatusIndicatorInfo: { light: '{colorInfo50}', dark: '#5c7fff20' },
   colorBackgroundStatusIndicatorWarning: { light: '{colorWarning50}', dark: '#fbd33220' },
   colorBackgroundStatusIndicatorSuccess: { light: '{colorSuccess50}', dark: '#2bb53420' },
   colorBackgroundStatusIndicatorError: { light: '{colorError50}', dark: '#ff7a7a20' },
-  colorBackgroundStatusIndicatorNeutral: { light: '{colorNeutralGrey250}', dark: '{colorNeutralGrey800}' },
+  colorBackgroundStatusIndicatorNeutral: { light: '{colorNeutral250}', dark: '{colorNeutral800}' },
 
   // ── Table ─────────────────────────────────────────────────────────────────
-  colorBackgroundCellShaded: { light: '{colorNeutralGrey150}', dark: '{colorNeutralGrey900}' },
-  colorBorderCellShaded: { light: '{colorNeutralGrey300}', dark: '{colorNeutralGrey700}' },
+  colorBackgroundCellShaded: { light: '{colorNeutral150}', dark: '{colorNeutral900}' },
+  colorBorderCellShaded: { light: '{colorNeutral300}', dark: '{colorNeutral700}' },
 
   // ── Breadcrumb ────────────────────────────────────────────────────────────
-  colorTextBreadcrumbCurrent: { light: '{colorNeutralGrey950}', dark: '{colorNeutralGrey250}' },
+  colorTextBreadcrumbCurrent: { light: '{colorNeutral950}', dark: '{colorNeutral250}' },
 
   // ── Tile ─────────────────────────────────────────────────────────────────
-  colorBackgroundTilesDisabled: { light: '{colorNeutralGrey250}', dark: '{colorNeutralGrey800}' },
+  colorBackgroundTilesDisabled: { light: '{colorNeutral250}', dark: '{colorNeutral800}' },
 
   // ── Dropzone ──────────────────────────────────────────────────────────────
   colorDropzoneBackgroundDefault: { light: '{colorWhite}', dark: '{colorNeutral850}' },
@@ -169,7 +169,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorDropzoneBorderHover: { light: '{colorPrimary900}', dark: '{colorPrimary300}' },
 
   // ── Code view ─────────────────────────────────────────────────────────────
-  colorBackgroundCodeView: { light: '{colorNeutralGrey200}', dark: '{colorNeutralGrey700}' },
+  colorBackgroundCodeView: { light: '{colorNeutral200}', dark: '{colorNeutral700}' },
 };
 
 const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = merge(

--- a/style-dictionary/one-theme/colors.ts
+++ b/style-dictionary/one-theme/colors.ts
@@ -83,10 +83,10 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorTextFormSecondary: { light: '{colorNeutral600}', dark: '{colorNeutral500}' },
   colorTextLabel: { light: '{colorNeutral600}', dark: '{colorNeutral500}' },
   colorTextKeyValuePairsValue: { light: '{colorNeutral950}', dark: '{colorNeutral350}' },
-  colorBorderInputFocused: { light: '{colorIndigo600}', dark: '{colorIndigo400}' },
+  colorBorderInputFocused: { light: '{colorPrimary600}', dark: '{colorPrimary400}' },
 
   // ── Controls ──────────────────────────────────────────────────────────────
-  colorBackgroundControlChecked: { light: '{colorIndigo600}', dark: '{colorIndigo500}' },
+  colorBackgroundControlChecked: { light: '{colorPrimary600}', dark: '{colorPrimary500}' },
   colorBackgroundControlDefault: { light: '{colorWhite}', dark: '{colorNeutral950}' },
   colorBackgroundControlDisabled: { light: '{colorNeutral300}', dark: '{colorNeutral650}' },
   colorBorderControlDefault: { light: '{colorNeutral500}', dark: '{colorNeutral600}' },
@@ -109,7 +109,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorBackgroundLayoutToggleSelectedHover: { light: '{colorPrimary200}', dark: '#5c7fff40' },
   colorBackgroundLayoutToggleSelectedActive: { light: '{colorPrimary100}', dark: '{colorPrimary1000}' },
   colorTextLayoutToggleSelected: { light: '{colorPrimary600}', dark: '{colorPrimary300}' },
-  colorItemSelected: { light: '{colorIndigo600}', dark: '{colorIndigo400}' },
+  colorItemSelected: { light: '{colorPrimary600}', dark: '{colorPrimary400}' },
 
   // ── Segmented control ─────────────────────────────────────────────────────
   colorBackgroundSegmentActive: { light: '{colorNeutral800}', dark: '{colorNeutral300}' },
@@ -137,11 +137,13 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorTextStatusError: { light: '{colorError600}', dark: '{colorError400}' },
   colorTextStatusInactive: { light: '{colorNeutral650}', dark: '{colorNeutral450}' },
 
-  // ── Dropdown ─────────────────────────────────────────────────
+  // ── Dropdown & Popover ─────────────────────────────────────────────────
   colorTextDropdownItemFilterMatch: { light: '{colorPrimary600}', dark: '{colorPrimary500}' },
   colorBackgroundDropdownItemFilterMatch: { light: '{colorNeutral200}', dark: '{colorNeutral1000}' },
   colorBackgroundDropdownItemDefault: { light: '{colorWhite}', dark: '{colorNeutral800}' },
   colorBackgroundDropdownItemHover: { light: '{colorNeutral200}', dark: '{colorNeutral900}' },
+  colorBackgroundPopover: { light: '{colorWhite}', dark: '{colorNeutral800}' },
+  colorBorderPopover: { light: '{colorNeutral400}', dark: '{colorNeutral600}' },
 
   // ── Status indicator backgrounds (alpha values — no palette token available) ──
   colorBackgroundStatusIndicatorInfo: { light: '{colorInfo50}', dark: '#5c7fff20' },

--- a/style-dictionary/one-theme/contexts/alert.ts
+++ b/style-dictionary/one-theme/contexts/alert.ts
@@ -15,7 +15,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorTextStatusSuccess: { light: '{colorSuccess600}', dark: '{colorSuccess500}' },
   colorBorderStatusSuccess: { light: '{colorSuccess600}', dark: '{colorSuccess500}' },
   colorBackgroundButtonNormalDefault: { light: 'transparent', dark: 'transparent' },
-  colorBorderDividerDefault: { light: '{colorNeutralGrey350}', dark: '{colorNeutralGrey600}' },
+  colorBorderDividerDefault: { light: '{colorNeutral350}', dark: '{colorNeutral600}' },
 };
 
 const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = expandColorDictionary(merge({}, tokens));

--- a/style-dictionary/one-theme/contexts/app-layout-toolbar.ts
+++ b/style-dictionary/one-theme/contexts/app-layout-toolbar.ts
@@ -6,10 +6,10 @@ import { expandColorDictionary } from '../../utils/index.js';
 import { StyleDictionary } from '../../utils/interfaces.js';
 
 const tokens: StyleDictionary.ColorsDictionary = {
-  colorBackgroundLayoutMain: { light: '{colorNeutralGrey50}', dark: '{colorNeutralGrey1000}' },
-  colorBackgroundLayoutPanelContent: { light: '{colorNeutralGrey50}', dark: '{colorNeutralGrey1000}' },
-  colorBackgroundLayoutToolbar: { light: '{colorNeutralGrey50}', dark: '{colorNeutralGrey1000}' },
-  colorGapGlobalDrawer: { light: '{colorNeutralGrey250}', dark: '{colorNeutralGrey1000}' },
+  colorBackgroundLayoutMain: { light: '{colorNeutral50}', dark: '{colorNeutral1000}' },
+  colorBackgroundLayoutPanelContent: { light: '{colorNeutral50}', dark: '{colorNeutral1000}' },
+  colorBackgroundLayoutToolbar: { light: '{colorNeutral50}', dark: '{colorNeutral1000}' },
+  colorGapGlobalDrawer: { light: '{colorNeutral250}', dark: '{colorNeutral1000}' },
 };
 
 const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = expandColorDictionary(merge({}, tokens));

--- a/style-dictionary/one-theme/contexts/flashbar-warning.ts
+++ b/style-dictionary/one-theme/contexts/flashbar-warning.ts
@@ -6,23 +6,30 @@ import { expandColorDictionary } from '../../utils/index.js';
 import { StyleDictionary } from '../../utils/interfaces.js';
 
 const tokens: StyleDictionary.ColorsDictionary = {
-  colorTextNotificationYellow: { light: '{colorNeutralGrey900}', dark: '{colorWhite}' },
-  colorTextNotificationDefault: { light: '{colorNeutralGrey900}', dark: '{colorWhite}' },
-  colorTextInteractiveInvertedDefault: { light: '{colorNeutralGrey900}', dark: '{colorWhite}' },
-  colorBorderDividerDefault: '{colorNeutralGrey900}',
+  colorTextNotificationYellow: { light: '{colorNeutral900}', dark: '{colorWhite}' },
+  colorTextNotificationDefault: { light: '{colorNeutral900}', dark: '{colorWhite}' },
+  colorTextInteractiveInvertedDefault: { light: '{colorNeutral900}', dark: '{colorWhite}' },
+  colorBorderDividerDefault: '{colorNeutral900}',
 
   // Button
-  colorBorderButtonNormalDefault: { light: '{colorNeutralGrey800}', dark: '{colorWhite}' },
-  colorBorderButtonNormalHover: { light: '{colorNeutralGrey800}', dark: '{colorWhite}' },
-  colorBorderButtonNormalActive: { light: '{colorNeutralGrey800}', dark: '{colorWhite}' },
+  colorBorderButtonNormalDefault: { light: '{colorNeutral800}', dark: '{colorWhite}' },
+  colorBorderButtonNormalHover: { light: '{colorNeutral800}', dark: '{colorWhite}' },
+  colorBorderButtonNormalActive: { light: '{colorNeutral800}', dark: '{colorWhite}' },
 
   colorBackgroundButtonNormalDefault: { light: 'transparent', dark: 'transparent' },
   colorBackgroundButtonNormalHover: { light: 'rgba(0, 7, 22, 0.08)', dark: 'rgba(255, 255, 255, 0.06)' },
   colorBackgroundButtonNormalActive: { light: 'rgba(0, 7, 22, 0.1)', dark: 'rgba(255, 255, 255, 0.1)' },
 
-  colorTextButtonNormalDefault: { light: '{colorNeutralGrey900}', dark: '{colorWhite}' },
-  colorTextButtonNormalHover: { light: '{colorNeutralGrey900}', dark: '{colorWhite}' },
-  colorTextButtonNormalActive: { light: '{colorNeutralGrey900}', dark: '{colorWhite}' },
+  colorTextButtonNormalDefault: { light: '{colorNeutral900}', dark: '{colorWhite}' },
+  colorTextButtonNormalHover: { light: '{colorNeutral900}', dark: '{colorWhite}' },
+  colorTextButtonNormalActive: { light: '{colorNeutral900}', dark: '{colorWhite}' },
+
+  // Expandable section
+  colorTextExpandableSectionDefault: { light: '{colorNeutral900}', dark: '{colorNeutral100}' },
+  colorTextExpandableSectionHover: { light: '{colorNeutral1000}', dark: '{colorWhite}' },
+  colorTextHeadingSecondary: { light: '{colorNeutral700}', dark: '{colorNeutral100}' },
+  colorBorderExpandableSectionDefault: { light: '{colorNeutral900}', dark: '{colorWhite}' },
+  colorTextBodyDefault: { light: '{colorNeutral700}', dark: '{colorNeutral100}' },
 };
 
 const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = expandColorDictionary(merge({}, tokens));

--- a/style-dictionary/one-theme/contexts/flashbar.ts
+++ b/style-dictionary/one-theme/contexts/flashbar.ts
@@ -6,8 +6,8 @@ import { expandColorDictionary } from '../../utils/index.js';
 import { StyleDictionary } from '../../utils/interfaces.js';
 
 const tokens: StyleDictionary.ColorsDictionary = {
-  colorTextButtonNormalDefault: '{colorNeutralGrey100}',
-  colorBorderButtonNormalDefault: '{colorNeutralGrey100}',
+  colorTextButtonNormalDefault: '{colorNeutral100}',
+  colorBorderButtonNormalDefault: '{colorNeutral100}',
   colorBackgroundButtonNormalDefault: 'transparent',
   colorTextButtonNormalHover: '{colorWhite}',
   colorBorderButtonNormalHover: '{colorWhite}',
@@ -15,21 +15,21 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorTextButtonNormalActive: '{colorWhite}',
   colorBorderButtonNormalActive: '{colorWhite}',
   colorBackgroundButtonNormalActive: 'rgba(0, 7, 22, 0.2)',
-  colorBorderItemFocused: '{colorNeutralGrey100}',
-  colorTextExpandableSectionDefault: '{colorNeutralGrey100}',
+  colorBorderItemFocused: '{colorNeutral100}',
+  colorTextExpandableSectionDefault: '{colorNeutral100}',
   colorTextExpandableSectionHover: '{colorWhite}',
-  colorTextBodyDefault: '{colorNeutralGrey100}',
-  colorTextBodySecondary: '{colorNeutralGrey100}',
-  colorTextHeadingSecondary: '{colorNeutralGrey100}',
-  colorBorderDividerDefault: '{colorNeutralGrey100}',
-  colorTextTutorialHotspotDefault: '{colorNeutralGrey300}',
-  colorTextTutorialHotspotHover: '{colorNeutralGrey100}',
+  colorTextBodyDefault: '{colorNeutral100}',
+  colorTextBodySecondary: '{colorNeutral100}',
+  colorTextHeadingSecondary: '{colorNeutral100}',
+  colorBorderDividerDefault: '{colorNeutral100}',
+  colorTextTutorialHotspotDefault: '{colorNeutral300}',
+  colorTextTutorialHotspotHover: '{colorNeutral100}',
   colorBackgroundInlineCode: 'rgba(0, 0, 0, 0.2)',
   // Key-value pairs
-  colorTextLabel: '{colorNeutralGrey100}',
+  colorTextLabel: '{colorNeutral100}',
 
   // Info links
-  colorTextLinkDefault: '{colorNeutralGrey100}',
+  colorTextLinkDefault: '{colorNeutral100}',
   colorTextLinkHover: '{colorWhite}',
 
   // Progress Bar

--- a/style-dictionary/one-theme/contexts/header.ts
+++ b/style-dictionary/one-theme/contexts/header.ts
@@ -11,7 +11,7 @@ import { tokens as parentShadowsTokens } from '../shadows.js';
 // All values are mode-invariant (single string = same in light and dark).
 
 const colorTokens: StyleDictionary.ColorsDictionary = {
-  colorBackgroundLayoutMain: '{colorNeutralGrey800}',
+  colorBackgroundLayoutMain: '{colorNeutral800}',
 };
 
 const darkColorValues = pickState(parentColorTokens, 'dark');

--- a/style-dictionary/one-theme/contexts/top-navigation.ts
+++ b/style-dictionary/one-theme/contexts/top-navigation.ts
@@ -8,16 +8,16 @@ import { tokens as vrParentTokens } from '../../visual-refresh/colors.js';
 import { tokens as oneThemeParentTokens } from '../colors.js';
 
 const tokens: StyleDictionary.ColorsDictionary = {
-  colorBackgroundContainerContent: '{colorNeutralGrey950}',
-  colorBorderDividerDefault: '{colorNeutralGrey750}',
-  colorBackgroundPopover: '{colorNeutralGrey800}',
+  colorBackgroundContainerContent: '{colorNeutral950}',
+  colorBorderDividerDefault: '{colorNeutral750}',
+  colorBackgroundPopover: '{colorNeutral800}',
 
   colorTextButtonInlineIconDefault: '{colorIndigo400}',
   colorTextButtonInlineIconHover: '{colorIndigo300}',
 
-  colorBackgroundDropdownItemDefault: '{colorNeutralGrey800}',
-  colorBackgroundDropdownItemHover: '{colorNeutralGrey700}',
-  colorBackgroundInputDefault: '{colorNeutralGrey950}',
+  colorBackgroundDropdownItemDefault: '{colorNeutral800}',
+  colorBackgroundDropdownItemHover: '{colorNeutral700}',
+  colorBackgroundInputDefault: '{colorNeutral950}',
 
   colorBorderItemFocused: '{colorIndigo500}',
   colorBorderInputFocused: '{colorIndigo500}',


### PR DESCRIPTION
### Description
This PR 1) replaces hardcoded tokens like `colorNeutralGrey*` with reference tokens like `colorNeutral*`, and 2) address `flashbar-warning` context style issue. All changes are for one-theme and create no changes on VR.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
