### PR TITLE
chore: Update one-theme button-link and alert styles

### DIFF
--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -63,7 +63,7 @@ const InternalLink = React.forwardRef(
     const isButton = !href;
     const { defaultVariant } = useContext(LinkDefaultVariantContext);
     const variant = providedVariant || defaultVariant;
-    const specialStyles = ['top-navigation', 'link', 'recovery'];
+    const specialStyles = ['top-navigation', 'link', 'recovery', 'info'];
     const hasSpecialStyle = specialStyles.indexOf(variant) > -1;
 
     const i18n = useInternalI18n('link');

--- a/src/link/styles.scss
+++ b/src/link/styles.scss
@@ -10,6 +10,7 @@
 @use './constants' as constants;
 @use '../internal/generated/custom-css-properties/index.scss' as custom-props;
 @use '../internal/styles/foundation' as foundation;
+@use '../internal/styles/utils/theming' as theming;
 
 .link {
   @include styles.styles-reset;
@@ -38,6 +39,21 @@
   &.button {
     @include styles.font-smoothing;
     @include styles.link-variant-style(map.get(constants.$link-styles, 'button'));
+
+    @include theming.one-theme-only {
+      @include styles.link-variant-style(map.get(constants.$link-variants, 'primary'));
+      & {
+        font-weight: inherit;
+        letter-spacing: normal;
+      }
+      &.color-inverted {
+        color: awsui.$color-text-notification-default;
+        text-decoration-color: currentColor;
+        &:hover {
+          color: awsui.$color-text-link-inverted-hover;
+        }
+      }
+    }
   }
 
   &.color-inverted {

--- a/style-dictionary/one-theme/colors.ts
+++ b/style-dictionary/one-theme/colors.ts
@@ -97,7 +97,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorTextLinkSecondaryDefault: { light: '{colorNeutral600}', dark: '{colorNeutral450}' },
   colorTextLinkSecondaryHover: { light: '{colorPrimary600}', dark: '{colorPrimary400}' },
   colorTextLinkInfoDefault: { light: '{colorPrimary600}', dark: '{colorPrimary400}' },
-  colorTextLinkInfoHover: { light: '{colorPrimary600}', dark: '{colorPrimary400}' },
+  colorTextLinkInfoHover: { light: '{colorPrimary800}', dark: '{colorPrimary300}' },
   colorTextAccent: { light: '{colorPrimary600}', dark: '{colorPrimary400}' },
   colorTextLinkDecorationDefault: { light: '{colorNeutral650}', dark: '{colorNeutral600}' },
 

--- a/style-dictionary/one-theme/contexts/alert.ts
+++ b/style-dictionary/one-theme/contexts/alert.ts
@@ -7,9 +7,9 @@ import { StyleDictionary } from '../../utils/interfaces.js';
 
 const tokens: StyleDictionary.ColorsDictionary = {
   colorBackgroundStatusInfo: { light: '{colorInfo50}', dark: '#161a2d' },
-  colorBackgroundStatusWarning: { light: '{colorWarning50}', dark: '#fbd33210' },
-  colorBackgroundStatusError: { light: '{colorError50}', dark: '#ff7a7a10' },
-  colorBackgroundStatusSuccess: { light: '{colorSuccess50}', dark: '#2bb53410' },
+  colorBackgroundStatusWarning: { light: '{colorWarning50}', dark: '#191100' },
+  colorBackgroundStatusError: { light: '{colorError50}', dark: '#1f0000' },
+  colorBackgroundStatusSuccess: { light: '{colorSuccess50}', dark: '#001401' },
   colorTextStatusInfo: { light: '{colorInfo600}', dark: '{colorInfo500}' },
   colorBorderStatusInfo: { light: '{colorInfo600}', dark: '{colorInfo500}' },
   colorTextStatusSuccess: { light: '{colorSuccess600}', dark: '{colorSuccess500}' },


### PR DESCRIPTION
### Description
This PR 1) removes opacity from the alert background that caused accessibility color contrast issue when they are displayed on a gradient background, 2) updates button-link link component style for one-theme.

These changes make visual changes only for one-theme.


<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
