### PR TITLE
fix: FileToken truncating too early

### DIFF
--- a/src/token/internal.tsx
+++ b/src/token/internal.tsx
@@ -182,7 +182,7 @@ function InternalToken({
             !isInline ? styles['token-box'] : styles['token-box-inline'],
             disabled && styles['token-box-disabled'],
             readOnly && styles['token-box-readonly'],
-            !isInline && !onDismiss && styles['token-box-without-dismiss'],
+            !isInline && !onDismiss && !__customContent && styles['token-box-without-dismiss'],
             disableInnerPadding && styles['disable-padding'],
             __tokenBoxClassName
           )}


### PR DESCRIPTION
### Description

Fixes a minor visual regression where file tokens were truncating too early

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
