### PR TITLE
fix: Prompt input issue on switching from string to token mode

### DIFF
--- a/pages/prompt-input/feature-flag-mode-switch.page.tsx
+++ b/pages/prompt-input/feature-flag-mode-switch.page.tsx
@@ -1,0 +1,123 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useState } from 'react';
+
+import { Checkbox, FormField, KeyValuePairs, PromptInput, PromptInputProps, SpaceBetween } from '~components';
+
+import { SimplePage } from '../app/templates';
+
+const menus: PromptInputProps.MenuDefinition[] = [
+  {
+    id: 'mentions',
+    trigger: '@',
+    options: [
+      { value: 'alice', label: 'Alice' },
+      { value: 'bob', label: 'Bob' },
+    ],
+    filteringType: 'auto',
+    empty: 'No mentions found',
+  },
+];
+
+const tokensToText = (tokens: readonly PromptInputProps.InputToken[]) => tokens.map(token => token.value).join('');
+
+export default function FeatureFlagModeSwitchPage() {
+  // Simulated async feature flag: starts false, becomes true after a delay.
+  const [tokenModeEnabled, setTokenModeEnabled] = useState(false);
+  // Auto-flip the flag shortly after mount to mimic the async API resolution.
+  const [autoFlip, setAutoFlip] = useState(true);
+
+  const [value, setValue] = useState('');
+  const [tokens, setTokens] = useState<readonly PromptInputProps.InputToken[]>([]);
+
+  useEffect(() => {
+    if (!autoFlip || tokenModeEnabled) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      setTokenModeEnabled(true);
+      // Carry the text typed in string mode over into token mode.
+      setTokens(prev => (prev.length > 0 ? prev : value ? [{ type: 'text', value }] : []));
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [autoFlip, tokenModeEnabled, value]);
+
+  const resetToStringMode = () => {
+    setTokenModeEnabled(false);
+    setTokens([]);
+    setValue('');
+  };
+
+  return (
+    <SimplePage title="PromptInput – feature flag mode switch">
+      <SpaceBetween size="l">
+        <FormField label="Settings">
+          <Checkbox checked={autoFlip} onChange={({ detail }) => setAutoFlip(detail.checked)}>
+            Auto-flip feature flag ~1.5s after mount (simulates async API)
+          </Checkbox>
+          <Checkbox
+            checked={tokenModeEnabled}
+            onChange={({ detail }) => {
+              setTokenModeEnabled(detail.checked);
+              if (detail.checked) {
+                setTokens(prev => (prev.length > 0 ? prev : value ? [{ type: 'text', value }] : []));
+              }
+            }}
+          >
+            Token mode enabled (the &quot;feature flag&quot;)
+          </Checkbox>
+        </FormField>
+
+        <button id="reset-button" onClick={resetToStringMode}>
+          Reset to string mode (remount in string mode)
+        </button>
+
+        <KeyValuePairs
+          columns={2}
+          items={[
+            { label: 'Resolved mode', value: tokenModeEnabled ? 'token mode' : 'string mode' },
+            {
+              label: tokenModeEnabled ? 'Current tokens' : 'Current value',
+              value: (
+                <code style={{ whiteSpace: 'pre-wrap' }}>
+                  {tokenModeEnabled ? JSON.stringify(tokens, null, 2) : JSON.stringify(value)}
+                </code>
+              ),
+            },
+          ]}
+        />
+
+        <FormField label="User prompt">
+          {tokenModeEnabled ? (
+            <PromptInput
+              data-testid="prompt-input"
+              ariaLabel="Chat input (token mode)"
+              actionButtonIconName="send"
+              actionButtonAriaLabel="Submit prompt"
+              placeholder="Type here after the flag flips…"
+              tokens={tokens}
+              tokensToText={tokensToText}
+              menus={menus}
+              onChange={event => {
+                setTokens(event.detail.tokens ?? []);
+                setValue(event.detail.value ?? '');
+              }}
+              onAction={({ detail }) => window.alert(`Submitted: ${detail.value ?? ''}`)}
+            />
+          ) : (
+            <PromptInput
+              data-testid="prompt-input"
+              ariaLabel="Chat input (string mode)"
+              actionButtonIconName="send"
+              actionButtonAriaLabel="Submit prompt"
+              placeholder="Type here (string mode)…"
+              value={value}
+              onChange={event => setValue(event.detail.value)}
+              onAction={({ detail }) => window.alert(`Submitted: ${detail.value ?? ''}`)}
+            />
+          )}
+        </FormField>
+      </SpaceBetween>
+    </SimplePage>
+  );
+}

--- a/src/prompt-input/__tests__/prompt-input-token-mode.test.tsx
+++ b/src/prompt-input/__tests__/prompt-input-token-mode.test.tsx
@@ -8050,4 +8050,113 @@ describe('tokens takes precedence over value', () => {
       rafSpy.mockRestore();
     }
   });
+  describe('switching between textarea mode and token mode after mount', () => {
+    test('initializes token-mode editing when switching from value to tokens after mount', () => {
+      const onChange = jest.fn();
+      const ref = React.createRef<PromptInputProps.Ref>();
+
+      // Mount in textarea (non-token) mode — no contentEditable element exists yet.
+      const { container, rerender } = render(
+        <PromptInput
+          value="hello"
+          actionButtonIconName="send"
+          i18nStrings={defaultI18nStrings}
+          ariaLabel="Chat input"
+          onChange={onChange}
+          ref={ref}
+        />
+      );
+      expect(createWrapper(container).findPromptInput()!.findContentEditableElement()).toBeNull();
+
+      // Switch to token mode after mount.
+      act(() => {
+        rerender(
+          <PromptInput
+            tokens={[{ type: 'text', value: 'hello' }]}
+            menus={defaultMenus}
+            actionButtonIconName="send"
+            i18nStrings={defaultI18nStrings}
+            ariaLabel="Chat input"
+            onChange={onChange}
+            ref={ref}
+          />
+        );
+      });
+
+      const wrapper = createWrapper(container).findPromptInput()!;
+      expect(wrapper.findContentEditableElement()).not.toBeNull();
+
+      onChange.mockClear();
+
+      // insertText is a no-op unless the CaretController was built. Before the fix it
+      // was never constructed on a post-mount switch, so this stayed silent.
+      act(() => {
+        ref.current!.focus();
+      });
+      act(() => {
+        ref.current!.insertText(' world');
+      });
+
+      expect(onChange).toHaveBeenCalled();
+      const lastTokens = onChange.mock.calls[onChange.mock.calls.length - 1][0].detail.tokens;
+      const text = lastTokens
+        .filter((t: any) => t.type === 'text')
+        .map((t: any) => t.value)
+        .join('');
+      expect(text).toContain('world');
+    });
+
+    test('re-initializes editing when toggling token mode off and back on', () => {
+      const onChange = jest.fn();
+      const ref = React.createRef<PromptInputProps.Ref>();
+
+      const tokenModeElement = (
+        <PromptInput
+          tokens={[]}
+          menus={defaultMenus}
+          actionButtonIconName="send"
+          i18nStrings={defaultI18nStrings}
+          ariaLabel="Chat input"
+          onChange={onChange}
+          ref={ref}
+        />
+      );
+      const textareaModeElement = (
+        <PromptInput
+          value=""
+          actionButtonIconName="send"
+          i18nStrings={defaultI18nStrings}
+          ariaLabel="Chat input"
+          onChange={onChange}
+          ref={ref}
+        />
+      );
+
+      // Start in token mode.
+      const { container, rerender } = render(tokenModeElement);
+      expect(createWrapper(container).findPromptInput()!.findContentEditableElement()).not.toBeNull();
+
+      // Switch to textarea mode — contentEditable unmounts and its controller is dropped.
+      act(() => {
+        rerender(textareaModeElement);
+      });
+      expect(createWrapper(container).findPromptInput()!.findContentEditableElement()).toBeNull();
+
+      // Switch back to token mode — a fresh controller and listeners must be built.
+      act(() => {
+        rerender(tokenModeElement);
+      });
+      const wrapper = createWrapper(container).findPromptInput()!;
+      expect(wrapper.findContentEditableElement()).not.toBeNull();
+
+      onChange.mockClear();
+      act(() => {
+        ref.current!.focus();
+      });
+      act(() => {
+        ref.current!.insertText('again');
+      });
+      expect(onChange).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/prompt-input/index.tsx
+++ b/src/prompt-input/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
+import { supportsTokenMode } from './core/token-renderer';
 import { PromptInputProps } from './interfaces';
 import InternalPromptInput from './internal';
 
@@ -39,8 +40,12 @@ const PromptInput = React.forwardRef(
         maxRows,
       },
     });
+
+    const isTokenMode = props.tokens !== undefined && supportsTokenMode;
+
     return (
       <InternalPromptInput
+        key={isTokenMode ? 'token-mode' : 'string-mode'}
         readOnly={readOnly}
         autoComplete={autoComplete}
         autoFocus={autoFocus}


### PR DESCRIPTION
### Description
Hotfixes [AWSUI-62103] by changing the key of the internal prompt input.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
