### PR TITLE
chore: bump component-toolkit version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ vendor/generated-*.txt
 .vscode
 # System
 .DS_Store
+.worktrees

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@cloudscape-design/collection-hooks": "^1.0.0",
-        "@cloudscape-design/component-toolkit": "^1.0.0-beta",
+        "@cloudscape-design/component-toolkit": "^1.0.0-beta.164",
         "@cloudscape-design/test-utils-core": "^1.0.0",
         "@cloudscape-design/theming-runtime": "^1.0.0",
         "@dnd-kit/core": "^6.0.8",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@cloudscape-design/collection-hooks": "^1.0.0",
-    "@cloudscape-design/component-toolkit": "^1.0.0-beta",
+    "@cloudscape-design/component-toolkit": "^1.0.0-beta.164",
     "@cloudscape-design/test-utils-core": "^1.0.0",
     "@cloudscape-design/theming-runtime": "^1.0.0",
     "@dnd-kit/core": "^6.0.8",


### PR DESCRIPTION
### Description

Bumps version of component-toolkit because of api changes.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
