### PR TITLE
feat: Exposes more public design tokens for expandable section

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
@@ -2594,6 +2594,27 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#687078",
           },
         },
+        "color-text-expandable-section-default": {
+          "$description": "The default color of the expandable section header text.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#545b64",
+          },
+        },
+        "color-text-expandable-section-hover": {
+          "$description": "The color of the expandable section header text in hover state.",
+          "$value": {
+            "dark": "#fafafa",
+            "light": "#16191f",
+          },
+        },
+        "color-text-expandable-section-navigation-icon-default": {
+          "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#879596",
+          },
+        },
         "color-text-form-default": {
           "$description": "The default color of form field labels and values. For example: the label in form fields, checkboxes, radio buttons, toggles, and the value in inputs and text areas.",
           "$value": {
@@ -6071,6 +6092,27 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#d5dbdb",
             "light": "#687078",
+          },
+        },
+        "color-text-expandable-section-default": {
+          "$description": "The default color of the expandable section header text.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#545b64",
+          },
+        },
+        "color-text-expandable-section-hover": {
+          "$description": "The color of the expandable section header text in hover state.",
+          "$value": {
+            "dark": "#fafafa",
+            "light": "#16191f",
+          },
+        },
+        "color-text-expandable-section-navigation-icon-default": {
+          "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#879596",
           },
         },
         "color-text-form-default": {
@@ -9552,6 +9594,27 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#687078",
           },
         },
+        "color-text-expandable-section-default": {
+          "$description": "The default color of the expandable section header text.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#545b64",
+          },
+        },
+        "color-text-expandable-section-hover": {
+          "$description": "The color of the expandable section header text in hover state.",
+          "$value": {
+            "dark": "#fafafa",
+            "light": "#16191f",
+          },
+        },
+        "color-text-expandable-section-navigation-icon-default": {
+          "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#879596",
+          },
+        },
         "color-text-form-default": {
           "$description": "The default color of form field labels and values. For example: the label in form fields, checkboxes, radio buttons, toggles, and the value in inputs and text areas.",
           "$value": {
@@ -13029,6 +13092,27 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#d5dbdb",
             "light": "#687078",
+          },
+        },
+        "color-text-expandable-section-default": {
+          "$description": "The default color of the expandable section header text.",
+          "$value": {
+            "dark": "#fafafa",
+            "light": "#fafafa",
+          },
+        },
+        "color-text-expandable-section-hover": {
+          "$description": "The color of the expandable section header text in hover state.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#ffffff",
+          },
+        },
+        "color-text-expandable-section-navigation-icon-default": {
+          "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#879596",
           },
         },
         "color-text-form-default": {
@@ -16510,6 +16594,27 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#687078",
           },
         },
+        "color-text-expandable-section-default": {
+          "$description": "The default color of the expandable section header text.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#16191f",
+          },
+        },
+        "color-text-expandable-section-hover": {
+          "$description": "The color of the expandable section header text in hover state.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#16191f",
+          },
+        },
+        "color-text-expandable-section-navigation-icon-default": {
+          "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#879596",
+          },
+        },
         "color-text-form-default": {
           "$description": "The default color of form field labels and values. For example: the label in form fields, checkboxes, radio buttons, toggles, and the value in inputs and text areas.",
           "$value": {
@@ -19989,6 +20094,27 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#d5dbdb",
           },
         },
+        "color-text-expandable-section-default": {
+          "$description": "The default color of the expandable section header text.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#d5dbdb",
+          },
+        },
+        "color-text-expandable-section-hover": {
+          "$description": "The color of the expandable section header text in hover state.",
+          "$value": {
+            "dark": "#fafafa",
+            "light": "#fafafa",
+          },
+        },
+        "color-text-expandable-section-navigation-icon-default": {
+          "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#95a5a6",
+          },
+        },
         "color-text-form-default": {
           "$description": "The default color of form field labels and values. For example: the label in form fields, checkboxes, radio buttons, toggles, and the value in inputs and text areas.",
           "$value": {
@@ -23466,6 +23592,27 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
       "$value": {
         "dark": "#d5dbdb",
         "light": "#687078",
+      },
+    },
+    "color-text-expandable-section-default": {
+      "$description": "The default color of the expandable section header text.",
+      "$value": {
+        "dark": "#d5dbdb",
+        "light": "#545b64",
+      },
+    },
+    "color-text-expandable-section-hover": {
+      "$description": "The color of the expandable section header text in hover state.",
+      "$value": {
+        "dark": "#fafafa",
+        "light": "#16191f",
+      },
+    },
+    "color-text-expandable-section-navigation-icon-default": {
+      "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
+      "$value": {
+        "dark": "#95a5a6",
+        "light": "#879596",
       },
     },
     "color-text-form-default": {
@@ -26952,6 +27099,27 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#656871",
           },
         },
+        "color-text-expandable-section-default": {
+          "$description": "The default color of the expandable section header text.",
+          "$value": {
+            "dark": "#dedee3",
+            "light": "#424650",
+          },
+        },
+        "color-text-expandable-section-hover": {
+          "$description": "The color of the expandable section header text in hover state.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#0f141a",
+          },
+        },
+        "color-text-expandable-section-navigation-icon-default": {
+          "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
+          "$value": {
+            "dark": "#dedee3",
+            "light": "#424650",
+          },
+        },
         "color-text-form-default": {
           "$description": "The default color of form field labels and values. For example: the label in form fields, checkboxes, radio buttons, toggles, and the value in inputs and text areas.",
           "$value": {
@@ -30426,6 +30594,27 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
+          "$value": {
+            "dark": "#dedee3",
+            "light": "#dedee3",
+          },
+        },
+        "color-text-expandable-section-default": {
+          "$description": "The default color of the expandable section header text.",
+          "$value": {
+            "dark": "#dedee3",
+            "light": "#dedee3",
+          },
+        },
+        "color-text-expandable-section-hover": {
+          "$description": "The color of the expandable section header text in hover state.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#ffffff",
+          },
+        },
+        "color-text-expandable-section-navigation-icon-default": {
+          "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
           "$value": {
             "dark": "#dedee3",
             "light": "#dedee3",
@@ -33910,6 +34099,27 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#656871",
           },
         },
+        "color-text-expandable-section-default": {
+          "$description": "The default color of the expandable section header text.",
+          "$value": {
+            "dark": "#dedee3",
+            "light": "#0f141a",
+          },
+        },
+        "color-text-expandable-section-hover": {
+          "$description": "The color of the expandable section header text in hover state.",
+          "$value": {
+            "dark": "#42b4ff",
+            "light": "#006ce0",
+          },
+        },
+        "color-text-expandable-section-navigation-icon-default": {
+          "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
+          "$value": {
+            "dark": "#dedee3",
+            "light": "#424650",
+          },
+        },
         "color-text-form-default": {
           "$description": "The default color of form field labels and values. For example: the label in form fields, checkboxes, radio buttons, toggles, and the value in inputs and text areas.",
           "$value": {
@@ -37387,6 +37597,27 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#dedee3",
             "light": "#656871",
+          },
+        },
+        "color-text-expandable-section-default": {
+          "$description": "The default color of the expandable section header text.",
+          "$value": {
+            "dark": "#dedee3",
+            "light": "#0f141a",
+          },
+        },
+        "color-text-expandable-section-hover": {
+          "$description": "The color of the expandable section header text in hover state.",
+          "$value": {
+            "dark": "#42b4ff",
+            "light": "#006ce0",
+          },
+        },
+        "color-text-expandable-section-navigation-icon-default": {
+          "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
+          "$value": {
+            "dark": "#dedee3",
+            "light": "#424650",
           },
         },
         "color-text-form-default": {
@@ -40868,6 +41099,27 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#656871",
           },
         },
+        "color-text-expandable-section-default": {
+          "$description": "The default color of the expandable section header text.",
+          "$value": {
+            "dark": "#f9f9fa",
+            "light": "#f9f9fa",
+          },
+        },
+        "color-text-expandable-section-hover": {
+          "$description": "The color of the expandable section header text in hover state.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#ffffff",
+          },
+        },
+        "color-text-expandable-section-navigation-icon-default": {
+          "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
+          "$value": {
+            "dark": "#dedee3",
+            "light": "#424650",
+          },
+        },
         "color-text-form-default": {
           "$description": "The default color of form field labels and values. For example: the label in form fields, checkboxes, radio buttons, toggles, and the value in inputs and text areas.",
           "$value": {
@@ -44347,6 +44599,27 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#656871",
           },
         },
+        "color-text-expandable-section-default": {
+          "$description": "The default color of the expandable section header text.",
+          "$value": {
+            "dark": "#0f141a",
+            "light": "#0f141a",
+          },
+        },
+        "color-text-expandable-section-hover": {
+          "$description": "The color of the expandable section header text in hover state.",
+          "$value": {
+            "dark": "#0f141a",
+            "light": "#0f141a",
+          },
+        },
+        "color-text-expandable-section-navigation-icon-default": {
+          "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
+          "$value": {
+            "dark": "#dedee3",
+            "light": "#424650",
+          },
+        },
         "color-text-form-default": {
           "$description": "The default color of form field labels and values. For example: the label in form fields, checkboxes, radio buttons, toggles, and the value in inputs and text areas.",
           "$value": {
@@ -47821,6 +48094,27 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         },
         "color-text-empty": {
           "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
+          "$value": {
+            "dark": "#dedee3",
+            "light": "#dedee3",
+          },
+        },
+        "color-text-expandable-section-default": {
+          "$description": "The default color of the expandable section header text.",
+          "$value": {
+            "dark": "#dedee3",
+            "light": "#dedee3",
+          },
+        },
+        "color-text-expandable-section-hover": {
+          "$description": "The color of the expandable section header text in hover state.",
+          "$value": {
+            "dark": "#42b4ff",
+            "light": "#42b4ff",
+          },
+        },
+        "color-text-expandable-section-navigation-icon-default": {
+          "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
           "$value": {
             "dark": "#dedee3",
             "light": "#dedee3",
@@ -51305,6 +51599,27 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#dedee3",
           },
         },
+        "color-text-expandable-section-default": {
+          "$description": "The default color of the expandable section header text.",
+          "$value": {
+            "dark": "#dedee3",
+            "light": "#dedee3",
+          },
+        },
+        "color-text-expandable-section-hover": {
+          "$description": "The color of the expandable section header text in hover state.",
+          "$value": {
+            "dark": "#42b4ff",
+            "light": "#42b4ff",
+          },
+        },
+        "color-text-expandable-section-navigation-icon-default": {
+          "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
+          "$value": {
+            "dark": "#dedee3",
+            "light": "#dedee3",
+          },
+        },
         "color-text-form-default": {
           "$description": "The default color of form field labels and values. For example: the label in form fields, checkboxes, radio buttons, toggles, and the value in inputs and text areas.",
           "$value": {
@@ -54782,6 +55097,27 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
       "$value": {
         "dark": "#dedee3",
         "light": "#656871",
+      },
+    },
+    "color-text-expandable-section-default": {
+      "$description": "The default color of the expandable section header text.",
+      "$value": {
+        "dark": "#dedee3",
+        "light": "#0f141a",
+      },
+    },
+    "color-text-expandable-section-hover": {
+      "$description": "The color of the expandable section header text in hover state.",
+      "$value": {
+        "dark": "#42b4ff",
+        "light": "#006ce0",
+      },
+    },
+    "color-text-expandable-section-navigation-icon-default": {
+      "$description": "The default color of the expand icon in the navigation variant of the expandable section.",
+      "$value": {
+        "dark": "#dedee3",
+        "light": "#424650",
       },
     },
     "color-text-form-default": {

--- a/style-dictionary/visual-refresh/metadata/colors.ts
+++ b/style-dictionary/visual-refresh/metadata/colors.ts
@@ -803,6 +803,21 @@ const metadata: StyleDictionary.MetadataIndex = {
     public: true,
     themeable: true,
   },
+  colorTextExpandableSectionDefault: {
+    description: 'The default color of the expandable section header text.',
+    public: true,
+    themeable: true,
+  },
+  colorTextExpandableSectionHover: {
+    description: 'The color of the expandable section header text in hover state.',
+    public: true,
+    themeable: true,
+  },
+  colorTextExpandableSectionNavigationIconDefault: {
+    description: 'The default color of the expand icon in the navigation variant of the expandable section.',
+    public: true,
+    themeable: true,
+  },
   colorTextFormDefault: {
     description:
       'The default color of form field labels and values. For example: the label in form fields, checkboxes, radio buttons, toggles, and the value in inputs and text areas.',


### PR DESCRIPTION
### Description

Makes 3 existing design tokens public and themeable.

Rel: AWSUI-62085

### How has this been tested?

Tested manually in `/theming/integration` page by adding an expandable section with variant navigation and using exposed tokens in the runtime theme.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
