### PR TITLE
feat: Link props for button group buttons

### DIFF
--- a/pages/button-group/item-permutations.page.tsx
+++ b/pages/button-group/item-permutations.page.tsx
@@ -51,6 +51,15 @@ const itemPermutations = createPermutations<ButtonGroupProps.Item>([
       </StatusIndicator>,
     ],
   },
+  // Link (href)
+  {
+    type: ['icon-button'],
+    id: ['test'],
+    iconName: ['external'],
+    text: ['Open in a new tab'],
+    href: ['#'],
+    target: ['_blank'],
+  },
   // Toggle button
   {
     type: ['icon-toggle-button'],

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -6928,6 +6928,10 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
 * \`iconAlt\` (optional, string) - Specifies alternate text for the icon when using \`iconUrl\`.
 * \`iconUrl\` (optional, string) - Specifies the URL of a custom icon.
 * \`iconSvg\` (optional, ReactNode) - Custom SVG icon. Equivalent to the \`svg\` slot of the [icon component](/components/icon/).
+* \`href\` (optional, string) - Renders the button as a link with the specified URL. Use for actions that navigate, such as opening a page in a new browser tab.
+* \`target\` (optional, string) - Specifies where to open the linked URL (for example, \`_blank\` to open in a new tab). This property only applies when \`href\` is set.
+* \`rel\` (optional, string) - Adds a \`rel\` attribute to the link. By default, the component sets \`rel\` to "noopener noreferrer" when \`target\` is \`"_blank"\`. This property only applies when \`href\` is set.
+* \`download\` (optional, boolean | string) - Specifies whether the linked URL, when selected, prompts the user to download instead of navigate. You can provide a string to suggest a file name. This property only applies when \`href\` is set.
 * \`popoverFeedback\` (optional, ReactNode) - Text that appears when the user clicks the button. Use to provide feedback to the user.
 
 ### icon-toggle-button

--- a/src/button-group/__tests__/button-group-href.test.tsx
+++ b/src/button-group/__tests__/button-group-href.test.tsx
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderButtonGroup } from './common';
+
+let mockButtonProps: Record<string, any> | undefined;
+
+// Replace the underlying button with a spy so we can assert which props ButtonGroup forwards.
+// The button's own link behavior (target/rel defaults, external icon, etc.) is covered by the button tests.
+jest.mock('../../../lib/components/button/internal', () => {
+  const actual = jest.requireActual('../../../lib/components/button/internal');
+  return {
+    ...actual,
+    InternalButton: (props: Record<string, any>) => {
+      mockButtonProps = props;
+      return null;
+    },
+  };
+});
+
+// Suppressing console errors to mute React warning on ref forwarding.
+let errorSpy: jest.SpyInstance;
+beforeAll(() => (errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})));
+afterAll(() => errorSpy.mockRestore());
+
+test('forwards link properties to the underlying button', () => {
+  renderButtonGroup({
+    items: [
+      {
+        type: 'icon-button',
+        id: 'open',
+        text: 'Open in a new tab',
+        iconName: 'external',
+        href: 'https://example.com/',
+        target: '_blank',
+        rel: 'nofollow',
+        download: 'report.pdf',
+      },
+    ],
+  });
+
+  expect(mockButtonProps).toEqual(
+    expect.objectContaining({
+      href: 'https://example.com/',
+      target: '_blank',
+      rel: 'nofollow',
+      download: 'report.pdf',
+    })
+  );
+});

--- a/src/button-group/icon-button-item.tsx
+++ b/src/button-group/icon-button-item.tsx
@@ -50,6 +50,10 @@ const IconButtonItem = forwardRef(
           iconSvg={item.iconSvg}
           iconAlt={item.text}
           ariaLabel={item.text}
+          href={item.href}
+          target={item.target}
+          rel={item.rel}
+          download={item.download}
           onClick={event => fireCancelableEvent(onItemClick, { id: item.id }, event)}
           ref={ref}
           data-testid={item.id}

--- a/src/button-group/interfaces.ts
+++ b/src/button-group/interfaces.ts
@@ -48,6 +48,10 @@ export interface ButtonGroupProps extends BaseComponentProps {
    * * `iconAlt` (optional, string) - Specifies alternate text for the icon when using `iconUrl`.
    * * `iconUrl` (optional, string) - Specifies the URL of a custom icon.
    * * `iconSvg` (optional, ReactNode) - Custom SVG icon. Equivalent to the `svg` slot of the [icon component](/components/icon/).
+   * * `href` (optional, string) - Renders the button as a link with the specified URL. Use for actions that navigate, such as opening a page in a new browser tab.
+   * * `target` (optional, string) - Specifies where to open the linked URL (for example, `_blank` to open in a new tab). This property only applies when `href` is set.
+   * * `rel` (optional, string) - Adds a `rel` attribute to the link. By default, the component sets `rel` to "noopener noreferrer" when `target` is `"_blank"`. This property only applies when `href` is set.
+   * * `download` (optional, boolean | string) - Specifies whether the linked URL, when selected, prompts the user to download instead of navigate. You can provide a string to suggest a file name. This property only applies when `href` is set.
    * * `popoverFeedback` (optional, ReactNode) - Text that appears when the user clicks the button. Use to provide feedback to the user.
    *
    * ### icon-toggle-button
@@ -171,6 +175,10 @@ export namespace ButtonGroupProps {
     iconAlt?: string;
     iconUrl?: string;
     iconSvg?: React.ReactNode;
+    href?: string;
+    target?: string;
+    rel?: string;
+    download?: boolean | string;
     popoverFeedback?: React.ReactNode;
   }
 


### PR DESCRIPTION
### Description

Propagates link properties to the icon-button item of the button group.

Rel: AWSUI-61991

### How has this been tested?

* New unit test and permutations page entry

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
