### PR TITLE
fix: One-theme left panel styles

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
@@ -285,6 +285,10 @@ $ai-drawer-heider-height: 42px;
       grid-column: 1 / span 1;
       background-color: awsui.$color-background-layout-panel-content;
 
+      @include theming.one-theme-only {
+        border-start-end-radius: 0;
+      }
+
       @include desktop-only {
         border-start-end-radius: awsui.$space-xxs;
       }
@@ -325,6 +329,14 @@ $ai-drawer-heider-height: 42px;
               }
             }
 
+            @include theming.dark-mode-only('.awsui-one-theme') {
+              @include desktop-only {
+                &:has(+ .drawer-back-to-console-slot) {
+                  border-start-end-radius: 0;
+                }
+              }
+            }
+
             > .drawer-actions {
               display: flex;
             }
@@ -356,6 +368,11 @@ $ai-drawer-heider-height: 42px;
 
             &:after {
               background-color: awsui.$color-background-layout-panel-content;
+
+              @include theming.one-theme-only {
+                border-start-end-radius: 0;
+              }
+
               border-start-end-radius: awsui.$space-xxs;
             }
 
@@ -406,6 +423,10 @@ $ai-drawer-heider-height: 42px;
 
     &:not(.drawer-expanded) {
       > .drawer-content-container {
+        @include theming.one-theme-only {
+          clip-path: none;
+        }
+
         @include desktop-only {
           clip-path: inset(0 0 -9999px 0 round 0 awsui.$space-xxs 0 0);
 

--- a/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
@@ -240,6 +240,10 @@
 .pseudo-toolbar-content {
   position: relative;
 
+  @include theming.dark-mode-only('.awsui-one-theme') {
+    border-start-start-radius: 0;
+  }
+
   @include theming.dark-mode-only {
     border-block-start: awsui.$border-divider-section-width solid awsui.$color-border-layout;
     border-start-start-radius: awsui.$space-xxs;
@@ -247,6 +251,10 @@
 
   &:before,
   &:after {
+    @include theming.one-theme-only {
+      display: none;
+    }
+
     content: '';
     position: absolute;
     inset-block-start: 0;

--- a/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
@@ -25,6 +25,10 @@ $toolbar-height: 42px;
   &.with-ai-drawer:not(:has(.universal-toolbar-ai-custom)) {
     &:before,
     &:after {
+      @include theming.one-theme-only {
+        border-start-start-radius: 0;
+      }
+
       content: '';
       position: absolute;
       inset-block-start: 0;
@@ -54,6 +58,10 @@ $toolbar-height: 42px;
     &:after {
       background-color: awsui.$color-background-layout-toolbar;
       border-start-start-radius: awsui.$space-xxs;
+
+      @include theming.one-theme-only {
+        border-start-start-radius: 0;
+      }
 
       @include theming.dark-mode-only {
         display: none;
@@ -125,6 +133,12 @@ $toolbar-height: 42px;
       &.with-ai-drawer {
         border-start-start-radius: awsui.$space-xxs;
         border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-layout;
+      }
+    }
+
+    @include theming.dark-mode-only('.awsui-one-theme') {
+      &.with-ai-drawer {
+        border-start-start-radius: 0;
       }
     }
 


### PR DESCRIPTION
### Description

Removed border radiuses for left panel and AppLayout toolbar in one theme.

Before:
<img width="496" height="238" alt="image" src="https://github.com/user-attachments/assets/a304f357-33f3-48d4-ac32-685c03c8da02" />
After:
<img width="627" height="215" alt="image" src="https://github.com/user-attachments/assets/c2bfa45c-fa13-4994-aba1-642a720bf1b9" />
 
(same for the dark theme)

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
