### PR TITLE
fix: Stop Legacy chart oscllation in Board Components

### DIFF
--- a/src/container/__tests__/accessibility.test.tsx
+++ b/src/container/__tests__/accessibility.test.tsx
@@ -61,8 +61,12 @@ describe('Accessibility: scrollable-region-focusable (fitHeight)', () => {
       expect(contentDiv).not.toHaveAttribute('role');
       expect(contentDiv).not.toHaveAttribute('aria-labelledby');
     } finally {
-      if (origScroll) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', origScroll);
-      if (origClient) Object.defineProperty(HTMLElement.prototype, 'clientHeight', origClient);
+      if (origScroll) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollHeight', origScroll);
+      }
+      if (origClient) {
+        Object.defineProperty(HTMLElement.prototype, 'clientHeight', origClient);
+      }
     }
   });
 });

--- a/src/container/__tests__/accessibility.test.tsx
+++ b/src/container/__tests__/accessibility.test.tsx
@@ -22,7 +22,7 @@ describe('Accessibility: scrollable-region-focusable (fitHeight)', () => {
     expect(contentDiv).not.toHaveAttribute('aria-labelledby');
   });
 
-  test('fitHeight=true with no header: tabIndex=0, no role, no aria-labelledby', () => {
+  test('fitHeight=true with no header and no focusable descendants: tabIndex=0, no role, no aria-labelledby', () => {
     const { wrapper } = renderContainer(<Container fitHeight={true}>content</Container>);
     const contentDiv = wrapper.findByClassName(styles['content-fit-height'])!.getElement();
     expect(contentDiv).toHaveAttribute('tabindex', '0');
@@ -30,22 +30,27 @@ describe('Accessibility: scrollable-region-focusable (fitHeight)', () => {
     expect(contentDiv).not.toHaveAttribute('aria-labelledby');
   });
 
-  test('fitHeight=true with header: tabIndex=0, role="region", aria-labelledby resolves to header wrapper', () => {
-    const { wrapper, container } = renderContainer(
+  test('fitHeight=true with header and no focusable descendants: tabIndex=0, no role, no aria-labelledby', () => {
+    const { wrapper } = renderContainer(
       <Container fitHeight={true} header="My Header">
         content
       </Container>
     );
     const contentDiv = wrapper.findByClassName(styles['content-fit-height'])!.getElement();
     expect(contentDiv).toHaveAttribute('tabindex', '0');
-    expect(contentDiv).toHaveAttribute('role', 'region');
+    expect(contentDiv).not.toHaveAttribute('role');
+    expect(contentDiv).not.toHaveAttribute('aria-labelledby');
+  });
 
-    const labelledById = contentDiv.getAttribute('aria-labelledby');
-    expect(labelledById).toBeTruthy();
-
-    // Verify the referenced element exists in the DOM and is the header wrapper
-    const headerElement = container.querySelector(`#${labelledById}`);
-    expect(headerElement).not.toBeNull();
-    expect(headerElement).toHaveClass(styles.header);
+  test('fitHeight=true with a focusable descendant: no tabIndex, no role, no aria-labelledby', () => {
+    const { wrapper } = renderContainer(
+      <Container fitHeight={true} header="My Header">
+        <button>Click me</button>
+      </Container>
+    );
+    const contentDiv = wrapper.findByClassName(styles['content-fit-height'])!.getElement();
+    expect(contentDiv).not.toHaveAttribute('tabindex');
+    expect(contentDiv).not.toHaveAttribute('role');
+    expect(contentDiv).not.toHaveAttribute('aria-labelledby');
   });
 });

--- a/src/container/__tests__/accessibility.test.tsx
+++ b/src/container/__tests__/accessibility.test.tsx
@@ -13,8 +13,12 @@ function renderContainer(jsx: React.ReactElement) {
   return { wrapper: createWrapper(container).findContainer()!, container };
 }
 
+// Regression: Container's fit-height wrapper must be keyboard-reachable when it
+// actually scrolls AND has no focusable descendant (axe scrollable-region-focusable),
+// but must not insert an extra tab stop otherwise (breaks downstream tab order in
+// consumers such as board-components widget items).
 describe('Accessibility: scrollable-region-focusable (fitHeight)', () => {
-  test('fitHeight=false renders no tabIndex, role, or aria-labelledby on the content wrapper', () => {
+  test('fitHeight=false renders no tabIndex on the content wrapper', () => {
     const { wrapper } = renderContainer(<Container header="Header">content</Container>);
     const contentDiv = wrapper.findByClassName(styles.content)!.getElement();
     expect(contentDiv).not.toHaveAttribute('tabindex');
@@ -22,35 +26,43 @@ describe('Accessibility: scrollable-region-focusable (fitHeight)', () => {
     expect(contentDiv).not.toHaveAttribute('aria-labelledby');
   });
 
-  test('fitHeight=true with no header and no focusable descendants: tabIndex=0, no role, no aria-labelledby', () => {
+  test('fitHeight=true but not actually scrolling: no tabIndex (JSDOM reports zero scroll dimensions)', () => {
     const { wrapper } = renderContainer(<Container fitHeight={true}>content</Container>);
     const contentDiv = wrapper.findByClassName(styles['content-fit-height'])!.getElement();
-    expect(contentDiv).toHaveAttribute('tabindex', '0');
+    expect(contentDiv).not.toHaveAttribute('tabindex');
     expect(contentDiv).not.toHaveAttribute('role');
     expect(contentDiv).not.toHaveAttribute('aria-labelledby');
   });
 
-  test('fitHeight=true with header and no focusable descendants: tabIndex=0, no role, no aria-labelledby', () => {
+  test('fitHeight=true with a focusable descendant: still no tabIndex', () => {
     const { wrapper } = renderContainer(
-      <Container fitHeight={true} header="My Header">
-        content
-      </Container>
-    );
-    const contentDiv = wrapper.findByClassName(styles['content-fit-height'])!.getElement();
-    expect(contentDiv).toHaveAttribute('tabindex', '0');
-    expect(contentDiv).not.toHaveAttribute('role');
-    expect(contentDiv).not.toHaveAttribute('aria-labelledby');
-  });
-
-  test('fitHeight=true with a focusable descendant: no tabIndex, no role, no aria-labelledby', () => {
-    const { wrapper } = renderContainer(
-      <Container fitHeight={true} header="My Header">
-        <button>Click me</button>
+      <Container fitHeight={true}>
+        <button>action</button>
       </Container>
     );
     const contentDiv = wrapper.findByClassName(styles['content-fit-height'])!.getElement();
     expect(contentDiv).not.toHaveAttribute('tabindex');
     expect(contentDiv).not.toHaveAttribute('role');
     expect(contentDiv).not.toHaveAttribute('aria-labelledby');
+  });
+
+  test('fitHeight=true with mocked scroll overflow and no focusable descendant: tabIndex=0', () => {
+    // Simulate real browser behavior where scrollHeight > clientHeight on the fit-height wrapper.
+    // We patch these properties on any element that receives the .content-fit-height class after
+    // render, then force a resize to re-run the useLayoutEffect via ResizeObserver.
+    const origScroll = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
+    const origClient = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get: () => 300 });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 100 });
+    try {
+      const { wrapper } = renderContainer(<Container fitHeight={true}>static content</Container>);
+      const contentDiv = wrapper.findByClassName(styles['content-fit-height'])!.getElement();
+      expect(contentDiv).toHaveAttribute('tabindex', '0');
+      expect(contentDiv).not.toHaveAttribute('role');
+      expect(contentDiv).not.toHaveAttribute('aria-labelledby');
+    } finally {
+      if (origScroll) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', origScroll);
+      if (origClient) Object.defineProperty(HTMLElement.prototype, 'clientHeight', origClient);
+    }
   });
 });

--- a/src/container/__tests__/accessibility.test.tsx
+++ b/src/container/__tests__/accessibility.test.tsx
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Container from '../../../lib/components/container';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+import styles from '../../../lib/components/container/styles.css.js';
+
+function renderContainer(jsx: React.ReactElement) {
+  const { container } = render(jsx);
+  return { wrapper: createWrapper(container).findContainer()!, container };
+}
+
+describe('Accessibility: scrollable-region-focusable (fitHeight)', () => {
+  test('fitHeight=false renders no tabIndex, role, or aria-labelledby on the content wrapper', () => {
+    const { wrapper } = renderContainer(<Container header="Header">content</Container>);
+    const contentDiv = wrapper.findByClassName(styles.content)!.getElement();
+    expect(contentDiv).not.toHaveAttribute('tabindex');
+    expect(contentDiv).not.toHaveAttribute('role');
+    expect(contentDiv).not.toHaveAttribute('aria-labelledby');
+  });
+
+  test('fitHeight=true with no header: tabIndex=0, no role, no aria-labelledby', () => {
+    const { wrapper } = renderContainer(<Container fitHeight={true}>content</Container>);
+    const contentDiv = wrapper.findByClassName(styles['content-fit-height'])!.getElement();
+    expect(contentDiv).toHaveAttribute('tabindex', '0');
+    expect(contentDiv).not.toHaveAttribute('role');
+    expect(contentDiv).not.toHaveAttribute('aria-labelledby');
+  });
+
+  test('fitHeight=true with header: tabIndex=0, role="region", aria-labelledby resolves to header wrapper', () => {
+    const { wrapper, container } = renderContainer(
+      <Container fitHeight={true} header="My Header">
+        content
+      </Container>
+    );
+    const contentDiv = wrapper.findByClassName(styles['content-fit-height'])!.getElement();
+    expect(contentDiv).toHaveAttribute('tabindex', '0');
+    expect(contentDiv).toHaveAttribute('role', 'region');
+
+    const labelledById = contentDiv.getAttribute('aria-labelledby');
+    expect(labelledById).toBeTruthy();
+
+    // Verify the referenced element exists in the DOM and is the header wrapper
+    const headerElement = container.querySelector(`#${labelledById}`);
+    expect(headerElement).not.toBeNull();
+    expect(headerElement).toHaveClass(styles.header);
+  });
+});

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useRef } from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 import { useMergeRefs, useUniqueId } from '@cloudscape-design/component-toolkit/internal';
@@ -105,7 +105,21 @@ export default function InternalContainer({
     __fullPage && isRefresh && !isMobile
   );
   const contentId = useUniqueId();
-  const headerId = useUniqueId('awsui-container-header-');
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [hasFocusableDescendant, setHasFocusableDescendant] = useState(false);
+
+  // axe scrollable-region-focusable passes when EITHER the scrollable element has tabindex≥0
+  // OR it contains a focusable descendant. We prefer the descendant path to avoid breaking
+  // downstream tab order — only add tabIndex when no focusable child exists.
+  useLayoutEffect(() => {
+    if (!fitHeight || !contentRef.current) {
+      setHasFocusableDescendant(false);
+      return;
+    }
+    const focusableSelector =
+      'a[href], button:not([disabled]), input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    setHasFocusableDescendant(contentRef.current.querySelector(focusableSelector) !== null);
+  }, [fitHeight, children]);
 
   const hasDynamicHeight = isRefresh && variant === 'full-page';
 
@@ -163,7 +177,6 @@ export default function InternalContainer({
             <ContainerHeaderContextProvider>
               <StickyHeaderContext.Provider value={{ isStuck, isStuckAtBottom }}>
                 <div
-                  id={headerId}
                   className={clsx(
                     isRefresh && styles.refresh,
                     styles.header,
@@ -193,12 +206,12 @@ export default function InternalContainer({
             </ContainerHeaderContextProvider>
           )}
           {/* tabIndex={0} makes the scrollable region keyboard-reachable (axe: scrollable-region-focusable).
-              role="region" + aria-labelledby is conditional on header presence because an unnamed region
-              (no accessible name) is worse than no landmark at all. */}
+              We only add tabIndex when no focusable descendant exists — descendant focusability satisfies
+              the rule and avoids inserting an extra tab stop that breaks downstream tab order. */}
           <div
+            ref={contentRef}
             className={clsx(styles.content, fitHeight && styles['content-fit-height'])}
-            {...(fitHeight && { tabIndex: 0 })}
-            {...(fitHeight && header && { role: 'region', 'aria-labelledby': headerId })}
+            {...(fitHeight && !hasFocusableDescendant && { tabIndex: 0 })}
           >
             <div
               className={clsx(styles['content-inner'], testStyles['content-inner'], {

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -107,18 +107,31 @@ export default function InternalContainer({
   const contentId = useUniqueId();
   const contentRef = useRef<HTMLDivElement>(null);
   const [hasFocusableDescendant, setHasFocusableDescendant] = useState(false);
+  const [isScrollable, setIsScrollable] = useState(false);
 
-  // axe scrollable-region-focusable passes when EITHER the scrollable element has tabindex≥0
-  // OR it contains a focusable descendant. We prefer the descendant path to avoid breaking
-  // downstream tab order — only add tabIndex when no focusable child exists.
+  // axe scrollable-region-focusable fires only when an element is actually
+  // scrollable at runtime AND lacks keyboard access. We mirror that check:
+  // add tabIndex only when (a) the element genuinely overflows and (b) no
+  // focusable descendant already satisfies the rule. This avoids inserting
+  // an extra tab stop for non-scrolling fit-height containers (e.g. board
+  // widget items) whose downstream tab-order expectations would break.
   useLayoutEffect(() => {
-    if (!fitHeight || !contentRef.current) {
+    const el = contentRef.current;
+    if (!fitHeight || !el) {
       setHasFocusableDescendant(false);
+      setIsScrollable(false);
       return;
     }
     const focusableSelector =
       'a[href], button:not([disabled]), input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
-    setHasFocusableDescendant(contentRef.current.querySelector(focusableSelector) !== null);
+    const update = () => {
+      setHasFocusableDescendant(el.querySelector(focusableSelector) !== null);
+      setIsScrollable(el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth);
+    };
+    update();
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(el);
+    return () => resizeObserver.disconnect();
   }, [fitHeight, children]);
 
   const hasDynamicHeight = isRefresh && variant === 'full-page';
@@ -206,12 +219,12 @@ export default function InternalContainer({
             </ContainerHeaderContextProvider>
           )}
           {/* tabIndex={0} makes the scrollable region keyboard-reachable (axe: scrollable-region-focusable).
-              We only add tabIndex when no focusable descendant exists — descendant focusability satisfies
-              the rule and avoids inserting an extra tab stop that breaks downstream tab order. */}
+              Only apply when the element is actually scrollable AND has no focusable descendant — matches
+              axe's runtime evaluation and avoids inserting an extra tab stop into non-overflowing consumers. */}
           <div
             ref={contentRef}
             className={clsx(styles.content, fitHeight && styles['content-fit-height'])}
-            {...(fitHeight && !hasFocusableDescendant && { tabIndex: 0 })}
+            {...(fitHeight && isScrollable && !hasFocusableDescendant && { tabIndex: 0 })}
           >
             <div
               className={clsx(styles['content-inner'], testStyles['content-inner'], {

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -105,6 +105,7 @@ export default function InternalContainer({
     __fullPage && isRefresh && !isMobile
   );
   const contentId = useUniqueId();
+  const headerId = useUniqueId('awsui-container-header-');
 
   const hasDynamicHeight = isRefresh && variant === 'full-page';
 
@@ -162,6 +163,7 @@ export default function InternalContainer({
             <ContainerHeaderContextProvider>
               <StickyHeaderContext.Provider value={{ isStuck, isStuckAtBottom }}>
                 <div
+                  id={headerId}
                   className={clsx(
                     isRefresh && styles.refresh,
                     styles.header,
@@ -190,7 +192,14 @@ export default function InternalContainer({
               </StickyHeaderContext.Provider>
             </ContainerHeaderContextProvider>
           )}
-          <div className={clsx(styles.content, fitHeight && styles['content-fit-height'])}>
+          {/* tabIndex={0} makes the scrollable region keyboard-reachable (axe: scrollable-region-focusable).
+              role="region" + aria-labelledby is conditional on header presence because an unnamed region
+              (no accessible name) is worse than no landmark at all. */}
+          <div
+            className={clsx(styles.content, fitHeight && styles['content-fit-height'])}
+            {...(fitHeight && { tabIndex: 0 })}
+            {...(fitHeight && header && { role: 'region', 'aria-labelledby': headerId })}
+          >
             <div
               className={clsx(styles['content-inner'], testStyles['content-inner'], {
                 [styles['with-paddings']]: !disableContentPaddings,

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -256,12 +256,12 @@
   flex: 1;
   &-fit-height {
     overflow: auto;
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-rows: 1fr;
   }
 }
 .content-inner {
-  flex: 1;
+  min-block-size: 0;
 
   &.with-paddings {
     padding-block: awsui.$space-scaled-l;

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -262,6 +262,7 @@
   }
 }
 .content-inner {
+  box-sizing: border-box;
   block-size: 100%;
   min-block-size: 0;
   min-inline-size: 0;

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -258,10 +258,13 @@
     overflow: auto;
     display: grid;
     grid-template-rows: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 .content-inner {
+  block-size: 100%;
   min-block-size: 0;
+  min-inline-size: 0;
 
   &.with-paddings {
     padding-block: awsui.$space-scaled-l;


### PR DESCRIPTION
### Description

Fixes "Maximum update depth exceeded" oscillation in legacy charts

Issue:
Caused since PR #3018 added an inner wrapper inside `.content-fit-height` to fix the table sticky scrollbar floating above content (AWSUI-54814). (Had to do a binary search to find the exact place since issue existed). Verified this is the cause by undoing this cmmit and checking if it fixed the issue and it did.

The wrapper uses `display: flex; flex-direction: column` on the outer with `flex: 1` on the inner. This allocates widths to the inner wrapper, which feeds back into `LabelsMeasure`'s `ResizeObserver` and prevents the chart's auto-width measurement from stabilizing.

So with this change the original issue for which the PR was a fix for is still addressed without it causing issue with the Board Component.

<!-- Also include relevant motivation and context. -->

Related links, issue AWSUI-62091,


### How has this been tested?

Before:
<video src="https://github.com/user-attachments/assets/13d7e957-d3d4-472f-906c-41dc127b087e" controls></video>

After:
<video src="https://github.com/user-attachments/assets/f21b89fb-e12c-4a31-88c7-4b80cfc85646" controls></video>

<!-- How did you test to verify your changes? -->

1. Run a board-components dev page that renders a legacy `BarChart` or `MixedLineBarChart` inside `<BoardItem>`. The page used during video: `widget-container/content-permutations`.
2. Before this change: charts oscillate visibly with react logs `Warning: Maximum update depth exceeded` repeatedly.
3. After this change: charts render cleanly, no console warnings.


<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
