### PR TITLE
fix: Suppress tab-header resize oscillation that causes infinite update loop

### DIFF
--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -111,7 +111,15 @@ export function TabHeaderBar({
   const containerObjectRef = useRef<HTMLDivElement>(null);
   const documentRef = useRef<null | Document>(typeof document !== 'undefined' ? document : null);
   const documentRefCallback = (node: null | Element) => (documentRef.current = node?.ownerDocument ?? document);
-  const [widthChange, containerMeasureRef] = useContainerQuery<number>(rect => rect.contentBoxWidth);
+  const [widthChange, containerMeasureRef] = useContainerQuery<number>((rect, prev) => {
+    if (prev === null) {
+      return rect.contentBoxWidth;
+    }
+    // Suppress oscillation: pagination buttons appearing/disappearing cause a ~73px
+    // layout shift that would flip the overflow state again, creating an infinite loop.
+    // Only propagate the measurement when the change is large enough to be a genuine resize.
+    return Math.abs(prev - rect.contentBoxWidth) >= 2 ? rect.contentBoxWidth : prev;
+  });
   const containerRef = useMergeRefs(containerObjectRef, containerMeasureRef, documentRefCallback);
   const tabRefs = useRef<Map<string, HTMLElement>>(new Map());
   const [horizontalOverflow, setHorizontalOverflow] = useState(false);


### PR DESCRIPTION
When the tabs container is near the overflow threshold, showing/hiding pagination buttons causes a layout shift (~73px) that immediately flips the overflow state back, creating an infinite ResizeObserver loop that eventually triggers React's 'Maximum update depth exceeded' error.

Fix: apply a 2px threshold to the useContainerQuery callback so that sub-pixel or pagination-button-sized width changes are not propagated as new measurements, breaking the oscillation cycle.

Mirrors the pattern used in useContainerWidth (PR #4615).

Fixes AWSUI-62011

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
