### PR TITLE
fix: Ignore IME composition enter in select and multiselect filtering

### DIFF
--- a/src/select/__tests__/use-select.test.ts
+++ b/src/select/__tests__/use-select.test.ts
@@ -10,7 +10,7 @@ import { KeyCode } from '../../internal/keycode';
 import { BaseKeyDetail } from '../../types/events';
 import { useSelect } from '../utils/use-select';
 
-const createTestEvent = (keyCode: KeyCode): CustomEvent<BaseKeyDetail> =>
+const createTestEvent = (keyCode: KeyCode, isComposing = false): CustomEvent<BaseKeyDetail> =>
   createCustomEvent({
     cancelable: true,
     detail: {
@@ -20,7 +20,7 @@ const createTestEvent = (keyCode: KeyCode): CustomEvent<BaseKeyDetail> =>
       shiftKey: false,
       altKey: false,
       metaKey: false,
-      isComposing: false,
+      isComposing,
     },
   });
 
@@ -375,6 +375,27 @@ describe('useSelect', () => {
       label: 'Child 1',
       value: 'child1',
     });
+  });
+
+  test('should not select the highlighted option on enter that ends an IME composition', () => {
+    const hook = renderHook(useSelect, {
+      initialProps: { ...initialProps, keepOpen: true },
+    });
+
+    const { getTriggerProps } = hook.result.current;
+    const triggerProps = getTriggerProps();
+    act(() => triggerProps.onKeyDown && triggerProps.onKeyDown(createTestEvent(KeyCode.down)));
+    const { getFilterProps } = hook.result.current;
+    updateSelectedOption.mockClear();
+
+    // Pressing enter to commit a composition candidate must not select the highlighted option.
+    act(() => getFilterProps().onKeyDown!(createTestEvent(KeyCode.enter, true)));
+    expect(updateSelectedOption).not.toHaveBeenCalled();
+    expect(hook.result.current.isOpen).toBe(true);
+
+    // A regular enter (not part of a composition) still selects the highlighted option.
+    act(() => getFilterProps().onKeyDown!(createTestEvent(KeyCode.enter, false)));
+    expect(updateSelectedOption).toHaveBeenCalledWith({ label: 'Child 1', value: 'child1' });
   });
 
   test('should open and navigate to the second disabled option', () => {

--- a/src/select/utils/use-select.ts
+++ b/src/select/utils/use-select.ts
@@ -16,9 +16,10 @@ import { useMenuKeyboard, useTriggerKeyboard } from '../../internal/components/o
 import { useOpenState } from '../../internal/components/options-list/utils/use-open-state';
 import { fireNonCancelableEvent } from '../../internal/events';
 import useForwardFocus from '../../internal/hooks/forward-focus';
+import { useIMEComposition } from '../../internal/hooks/use-ime-composition';
 import { usePrevious } from '../../internal/hooks/use-previous';
 import { DropdownStatusProps } from '../../types/dropdown-status';
-import { NonCancelableEventHandler } from '../../types/events';
+import { BaseKeyDetail, NonCancelableEventHandler } from '../../types/events';
 import { OptionDefinition, OptionGroup } from '../../types/option';
 import { FilterProps } from '../parts/filter';
 import { ItemProps } from '../parts/item';
@@ -75,6 +76,7 @@ export function useSelect({
   const filterRef = useRef<HTMLInputElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const { isComposing } = useIMEComposition(filterRef);
   const hasFilter = filteringType !== 'none' && !embedded;
   const activeRef = hasFilter ? filterRef : menuRef;
   const __selectedOptions = connectOptionsByValue(options, selectedOptions);
@@ -214,7 +216,16 @@ export function useSelect({
 
     return {
       ref: filterRef,
-      onKeyDown: activeKeyDownHandler,
+      onKeyDown: (event: CustomEvent<BaseKeyDetail>) => {
+        // Ignore keystrokes that are part of an IME composition, as well as the spurious
+        // Enter that some browsers fire right after the composition ends. Otherwise pressing
+        // Enter to commit a composition candidate would select the highlighted option and
+        // close the dropdown. Matches the autosuggest and prompt input handling.
+        if (event.detail.isComposing || isComposing()) {
+          return;
+        }
+        activeKeyDownHandler(event);
+      },
       onChange: event => {
         setFilteringValue(event.detail.value);
         resetHighlightWithKeyboard();


### PR DESCRIPTION
### Description

The filtering input of `Select` and `Multiselect` selects the highlighted option when Enter is pressed, but it does not account for IME composition. When a user composes text with an IME (for example Japanese, Chinese or Korean) and presses Enter to confirm a candidate, that Enter is also treated as an option selection: the highlighted option is selected and the dropdown closes, instead of the keypress just committing the composed text into the filter.

The other text inputs in this repository already guard against this. `autosuggest-input` reads `useIMEComposition` and ignores Enter while `isComposing()` is true, and `prompt-input` checks `event.nativeEvent.isComposing || props.isComposing?.()`. The select filter input was passing its keydown straight to `useMenuKeyboard` without any such guard.

This applies the same guard to the filter handler in `useSelect` (shared by `Select` and `Multiselect`). `event.detail.isComposing` covers the keydown fired during composition, and `useIMEComposition(filterRef)` covers the brief window after `compositionend` where some browsers fire a spurious Enter, matching `autosuggest-input` and `prompt-input`. Other key handling is unchanged.

Related links, issue #, if available: n/a

### How has this been tested?

Added a unit test in `src/select/__tests__/use-select.test.ts`: with an option highlighted, an Enter whose `isComposing` detail is `true` no longer calls `updateSelectedOption` and keeps the dropdown open, while a regular Enter still selects the option. The existing `use-select` unit tests continue to pass.
