### PR TITLE
feat: Add usage metrics for Alert and Flashbar persistence props

### DIFF
--- a/src/alert/index.tsx
+++ b/src/alert/index.tsx
@@ -28,6 +28,10 @@ const Alert = React.forwardRef(
       'Alert',
       {
         props: { type, visible, dismissible: props.dismissible },
+        metadata: {
+          hasPersistenceConfig: !!props.persistenceConfig?.uniqueKey,
+          crossServicePersistence: !!props.persistenceConfig?.crossServicePersistence,
+        },
       },
       analyticsMetadata
     );

--- a/src/flashbar/index.tsx
+++ b/src/flashbar/index.tsx
@@ -13,6 +13,11 @@ export { FlashbarProps };
 export default function Flashbar(props: FlashbarProps) {
   const { __internalRootRef } = useBaseComponent('Flashbar', {
     props: { stackItems: props.stackItems },
+    metadata: {
+      itemsWithPersistence: props.items?.filter(item => !!item.persistenceConfig?.uniqueKey).length ?? null,
+      itemsWithCrossServicePersistence:
+        props.items?.filter(item => !!item.persistenceConfig?.crossServicePersistence).length ?? null,
+    },
   });
   return <InternalFlashbar __internalRootRef={__internalRootRef} {...props} />;
 }


### PR DESCRIPTION
### Description

Adds usage metrics for the dismiss-persistence properties on Alert and Flashbar so we can track real adoption of the `persistenceConfig` feature in consoles.

- **Alert** (`persistenceConfig` is a single top-level prop): adds a `metadata` block with `hasPersistenceConfig` (active only when `uniqueKey` is set) and `crossServicePersistence`.
- **Flashbar** (`persistenceConfig` lives per-item on `items`): adds counts `itemsWithPersistence` and `itemsWithCrossServicePersistence`.

Metrics are reported via the existing `useBaseComponent` `metadata` channel (same pattern as e.g. `attribute-editor`). No public API changes.

Related links, issue #, if available: n/a

### How has this been tested?

- `npm run quick-build` passes.
- `jest -c jest.unit.config.js src/alert src/flashbar` — 318/318 unit tests pass.
- Type-checked with `tsc --noEmit`; no errors in the changed files.

This is a metrics-only change (internal `metadata` channel), backward-compatible, no rendered output or public API change.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
