### PR TITLE
feat: expose link underline design tokens

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
@@ -2843,6 +2843,20 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#ffffff",
           },
         },
+        "color-text-link-decoration-default": {
+          "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
+        "color-text-link-decoration-hover": {
+          "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
         "color-text-link-default": {
           "$description": "The default color for links. For example: text in an anchor tag, info links, breadcrumb links, and icon links.",
           "$value": {
@@ -6431,6 +6445,20 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#16191f",
             "light": "#ffffff",
+          },
+        },
+        "color-text-link-decoration-default": {
+          "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
+        "color-text-link-decoration-hover": {
+          "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
           },
         },
         "color-text-link-default": {
@@ -10023,6 +10051,20 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#ffffff",
           },
         },
+        "color-text-link-decoration-default": {
+          "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
+        "color-text-link-decoration-hover": {
+          "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
         "color-text-link-default": {
           "$description": "The default color for links. For example: text in an anchor tag, info links, breadcrumb links, and icon links.",
           "$value": {
@@ -13611,6 +13653,20 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
           "$value": {
             "dark": "#16191f",
             "light": "#ffffff",
+          },
+        },
+        "color-text-link-decoration-default": {
+          "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
+        "color-text-link-decoration-hover": {
+          "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
           },
         },
         "color-text-link-default": {
@@ -17203,6 +17259,20 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#ffffff",
           },
         },
+        "color-text-link-decoration-default": {
+          "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
+        "color-text-link-decoration-hover": {
+          "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
         "color-text-link-default": {
           "$description": "The default color for links. For example: text in an anchor tag, info links, breadcrumb links, and icon links.",
           "$value": {
@@ -20793,6 +20863,20 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
             "light": "#16191f",
           },
         },
+        "color-text-link-decoration-default": {
+          "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
+        "color-text-link-decoration-hover": {
+          "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
         "color-text-link-default": {
           "$description": "The default color for links. For example: text in an anchor tag, info links, breadcrumb links, and icon links.",
           "$value": {
@@ -24381,6 +24465,20 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
       "$value": {
         "dark": "#16191f",
         "light": "#ffffff",
+      },
+    },
+    "color-text-link-decoration-default": {
+      "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+      "$value": {
+        "dark": "currentColor",
+        "light": "currentColor",
+      },
+    },
+    "color-text-link-decoration-hover": {
+      "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+      "$value": {
+        "dark": "currentColor",
+        "light": "currentColor",
       },
     },
     "color-text-link-default": {
@@ -27978,6 +28076,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#ffffff",
           },
         },
+        "color-text-link-decoration-default": {
+          "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
+        "color-text-link-decoration-hover": {
+          "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
         "color-text-link-default": {
           "$description": "The default color for links. For example: text in an anchor tag, info links, breadcrumb links, and icon links.",
           "$value": {
@@ -31566,6 +31678,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#0f141a",
             "light": "#0f141a",
+          },
+        },
+        "color-text-link-decoration-default": {
+          "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
+        "color-text-link-decoration-hover": {
+          "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
           },
         },
         "color-text-link-default": {
@@ -35158,6 +35284,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#ffffff",
           },
         },
+        "color-text-link-decoration-default": {
+          "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
+        "color-text-link-decoration-hover": {
+          "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
         "color-text-link-default": {
           "$description": "The default color for links. For example: text in an anchor tag, info links, breadcrumb links, and icon links.",
           "$value": {
@@ -38746,6 +38886,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#0f141a",
             "light": "#ffffff",
+          },
+        },
+        "color-text-link-decoration-default": {
+          "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
+        "color-text-link-decoration-hover": {
+          "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
           },
         },
         "color-text-link-default": {
@@ -42338,6 +42492,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#ffffff",
           },
         },
+        "color-text-link-decoration-default": {
+          "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
+        "color-text-link-decoration-hover": {
+          "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
         "color-text-link-default": {
           "$description": "The default color for links. For example: text in an anchor tag, info links, breadcrumb links, and icon links.",
           "$value": {
@@ -45926,6 +46094,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
           "$value": {
             "dark": "#0f141a",
             "light": "#ffffff",
+          },
+        },
+        "color-text-link-decoration-default": {
+          "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
+        "color-text-link-decoration-hover": {
+          "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
           },
         },
         "color-text-link-default": {
@@ -49518,6 +49700,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#0f141a",
           },
         },
+        "color-text-link-decoration-default": {
+          "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
+        "color-text-link-decoration-hover": {
+          "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
         "color-text-link-default": {
           "$description": "The default color for links. For example: text in an anchor tag, info links, breadcrumb links, and icon links.",
           "$value": {
@@ -53108,6 +53304,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
             "light": "#0f141a",
           },
         },
+        "color-text-link-decoration-default": {
+          "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
+        "color-text-link-decoration-hover": {
+          "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+          "$value": {
+            "dark": "currentColor",
+            "light": "currentColor",
+          },
+        },
         "color-text-link-default": {
           "$description": "The default color for links. For example: text in an anchor tag, info links, breadcrumb links, and icon links.",
           "$value": {
@@ -56696,6 +56906,20 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
       "$value": {
         "dark": "#0f141a",
         "light": "#ffffff",
+      },
+    },
+    "color-text-link-decoration-default": {
+      "$description": "The default color of the text decoration (underline) of links. Defaults to the link text color.",
+      "$value": {
+        "dark": "currentColor",
+        "light": "currentColor",
+      },
+    },
+    "color-text-link-decoration-hover": {
+      "$description": "The hover color of the text decoration (underline) of links. Defaults to the link hover text color.",
+      "$value": {
+        "dark": "currentColor",
+        "light": "currentColor",
       },
     },
     "color-text-link-default": {

--- a/src/link/constants.scss
+++ b/src/link/constants.scss
@@ -66,7 +66,7 @@ $link-variants: (
     'font-weight': awsui.$font-weight-link-secondary,
     'decoration-line': none,
     'decoration-color': transparent,
-    'decoration-color-hover': currentColor,
+    'decoration-color-hover': awsui.$color-text-link-decoration-hover,
     'letter-spacing': normal,
   ),
   'primary': (

--- a/style-dictionary/visual-refresh/metadata/colors.ts
+++ b/style-dictionary/visual-refresh/metadata/colors.ts
@@ -1003,12 +1003,12 @@ const metadata: StyleDictionary.MetadataIndex = {
   },
   colorTextLinkDecorationDefault: {
     description: 'The default color of the text decoration (underline) of links. Defaults to the link text color.',
-    public: false,
+    public: true,
     themeable: true,
   },
   colorTextLinkDecorationHover: {
     description: 'The hover color of the text decoration (underline) of links. Defaults to the link hover text color.',
-    public: false,
+    public: true,
     themeable: true,
   },
   colorTextLinkSecondaryDefault: {


### PR DESCRIPTION
### Description
Adds two design tokens to color a link's underline independently from its text color:
- `colorTextLinkDecorationDefault` - underline color at rest
- `colorTextLinkDecorationHover` -  underline color on hover

Dependent on PR: https://github.com/cloudscape-design/theming-core/pull/189

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-62072

### Testing:
Added a primary and secondary `Link` to `pages/theming/integration.page.tsx` and overrode both tokens via `applyTheme` with colors distinct from the link text. Confirmed the theme colors the primary, external and secondary underline. And also It doesn't apply if color is inverted, which is expected.


### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing


- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
