### PR TITLE
fix: Emit funnelStepComplete before content is removed in react 18

### DIFF
--- a/src/internal/analytics/__integ__/static-single-page-flow.test.ts
+++ b/src/internal/analytics/__integ__/static-single-page-flow.test.ts
@@ -237,7 +237,7 @@ describe.each(['refresh', 'refresh-toolbar'] as Theme[])('%s', theme => {
     })
   );
 
-  (process.env.REACT_VERSION !== '18' ? test : test.skip)(
+  test(
     'Form submission',
     setupTest(async page => {
       await page.click('[data-testid=submit]');

--- a/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
+++ b/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
@@ -412,6 +412,37 @@ describe('AnalyticsFunnelStep', () => {
     });
   });
 
+  test('resolves the step DOM selectors while emitting funnelStepComplete when the step unmounts', () => {
+    // Regression test for AWSUI-61222. The analytics client re-resolves
+    // `stepNameSelector`/`subStepAllSelector` against the live DOM at the moment
+    // `funnelStepComplete` is emitted. In React 18, a passive `useEffect` cleanup
+    // runs *after* the step content has been detached from the document, so those
+    // selectors would resolve to nothing. Emitting from a layout-effect cleanup
+    // keeps the content attached while the event is dispatched, matching React 16.
+    const stepNumber = 1;
+    const stepNameSelector = '.step-name-selector';
+
+    let stepNameResolvableAtEmit: boolean | undefined;
+    (FunnelMetrics.funnelStepComplete as jest.Mock).mockImplementation(({ stepNameSelector }) => {
+      stepNameResolvableAtEmit = document.querySelector(stepNameSelector) !== null;
+    });
+
+    const { rerender } = render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+        <AnalyticsFunnelStep stepNumber={stepNumber} stepNameSelector={stepNameSelector}>
+          <div className="step-name-selector">My funnel step</div>
+        </AnalyticsFunnelStep>
+      </AnalyticsFunnel>
+    );
+    act(() => void jest.runAllTimers());
+
+    rerender(<AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1} />);
+    act(() => void jest.runAllTimers());
+
+    expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledTimes(1);
+    expect(stepNameResolvableAtEmit).toBe(true);
+  });
+
   test('treats container-like tables as their own substep', () => {
     render(
       <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>

--- a/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
+++ b/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
@@ -412,37 +412,6 @@ describe('AnalyticsFunnelStep', () => {
     });
   });
 
-  test('resolves the step DOM selectors while emitting funnelStepComplete when the step unmounts', () => {
-    // Regression test for AWSUI-61222. The analytics client re-resolves
-    // `stepNameSelector`/`subStepAllSelector` against the live DOM at the moment
-    // `funnelStepComplete` is emitted. In React 18, a passive `useEffect` cleanup
-    // runs *after* the step content has been detached from the document, so those
-    // selectors would resolve to nothing. Emitting from a layout-effect cleanup
-    // keeps the content attached while the event is dispatched, matching React 16.
-    const stepNumber = 1;
-    const stepNameSelector = '.step-name-selector';
-
-    let stepNameResolvableAtEmit: boolean | undefined;
-    (FunnelMetrics.funnelStepComplete as jest.Mock).mockImplementation(({ stepNameSelector }) => {
-      stepNameResolvableAtEmit = document.querySelector(stepNameSelector) !== null;
-    });
-
-    const { rerender } = render(
-      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
-        <AnalyticsFunnelStep stepNumber={stepNumber} stepNameSelector={stepNameSelector}>
-          <div className="step-name-selector">My funnel step</div>
-        </AnalyticsFunnelStep>
-      </AnalyticsFunnel>
-    );
-    act(() => void jest.runAllTimers());
-
-    rerender(<AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1} />);
-    act(() => void jest.runAllTimers());
-
-    expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledTimes(1);
-    expect(stepNameResolvableAtEmit).toBe(true);
-  });
-
   test('treats container-like tables as their own substep', () => {
     render(
       <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { useUniqueId } from '@cloudscape-design/component-toolkit/internal';
 
@@ -121,7 +121,7 @@ const InnerAnalyticsFunnel = ({ mounted = true, children, stepConfiguration, ...
   const latestFocusCleanupFunction = useRef<undefined | (() => void)>(undefined);
   const formSubmitStartTime = useRef<number>(0);
   const activeValidationTimerId = useRef<ReturnType<typeof setTimeout>>();
-  // This useEffect hook is run once on component mount to initiate the funnel analytics.
+  // This effect is run once on component mount to initiate the funnel analytics.
   // It first calls the 'funnelStart' method from FunnelMetrics, providing all necessary details
   // about the funnel, and receives a unique interaction id.
   // This unique interaction id is then stored in the state for further use.
@@ -129,9 +129,14 @@ const InnerAnalyticsFunnel = ({ mounted = true, children, stepConfiguration, ...
   // On component unmount, it checks whether the funnel was successfully completed.
   // Based on this, it either calls 'funnelComplete' or 'funnelCancelled' method from FunnelMetrics.
   //
+  // We use a layout effect (rather than a passive effect) so that the cleanup runs during the
+  // synchronous commit phase, before React detaches the funnel's DOM subtree. This keeps the
+  // funnel state transition ordered before the funnel step cleanup (parent-before-child), which
+  // the step relies on to decide whether to emit `funnelStepComplete`. See AWSUI-61222.
+  //
   // The eslint-disable is required as we deliberately want this effect to run only once on mount and unmount,
   // hence we do not provide any dependencies.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!mounted) {
       return;
     }
@@ -454,11 +459,17 @@ const InnerAnalyticsFunnelStep = ({
     mounted,
   ]);
 
-  // This useEffect hook is used to track the start and completion of interaction with the step.
+  // This effect is used to track the start and completion of interaction with the step.
   // On mount, if there is a valid funnel interaction id, it calls the 'funnelStepStart' method from FunnelMetrics
   // to record the beginning of the interaction with the current step.
   // On unmount, it does a similar thing but this time calling 'funnelStepComplete' to record the completion of the interaction.
-  useEffect(() => {
+  //
+  // We use a layout effect (rather than a passive effect) so that the cleanup runs synchronously
+  // during the commit phase, while the step content is still attached to the document. The
+  // analytics client re-resolves `stepNameSelector`/`subStepAllSelector` against the live DOM when
+  // `funnelStepComplete` is emitted; in React 18 a passive-effect cleanup would run only after the
+  // content has been detached, so those selectors would resolve to nothing. See AWSUI-61222.
+  useLayoutEffect(() => {
     if (!funnelInteractionId) {
       // This step is not inside an active funnel.
       return;


### PR DESCRIPTION
### Description

On React 18, funnelStepComplete came through with `stepName: undefined`. We fire it from an effect cleanup, and the analytics client reads the step's selectors off the DOM at that point, but on React 18 useEffect cleanups run after the DOM is already gone, so nothing matches

Switched the funnel and step unmount effects to useLayoutEffect so cleanup runs while the content is still on the page. Both are moved together to keep the funnel cleanup running before the step cleanup, which the cancel check relies on.

Also re-enabled the "Form submission" funnel integ test on React 18, which was skipped because of this bug.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
