### PR TITLE
chore: Sync rendering in iframe wrapper

### DIFF
--- a/pages/utils/iframe-wrapper.tsx
+++ b/pages/utils/iframe-wrapper.tsx
@@ -6,14 +6,24 @@ import { mount, unmount } from '~mount';
 
 import styles from './iframe-wrapper.scss';
 
-function copyStyles(srcDoc: Document, targetDoc: Document) {
+function copyStyles(srcDoc: Document, targetDoc: Document): Promise<unknown> {
+  const pending: Promise<void>[] = [];
+
   for (const stylesheet of Array.from(srcDoc.querySelectorAll('link[rel=stylesheet]'))) {
     const newStylesheet = targetDoc.createElement('link');
     for (const attr of stylesheet.getAttributeNames()) {
       newStylesheet.setAttribute(attr, stylesheet.getAttribute(attr)!);
     }
+    pending.push(
+      new Promise<void>(resolve => {
+        newStylesheet.addEventListener('load', () => resolve());
+        newStylesheet.addEventListener('error', () => resolve());
+      })
+    );
     targetDoc.head.appendChild(newStylesheet);
   }
+
+  return Promise.all(pending);
 }
 
 function syncClasses(from: HTMLElement, to: HTMLElement) {
@@ -56,11 +66,22 @@ export function IframeWrapper({ id, AppComponent }: { id: string; AppComponent: 
 
       const innerAppRoot = iframeDocument.createElement('div');
       iframeDocument.body.appendChild(innerAppRoot);
-      copyStyles(document, iframeDocument);
       iframeDocument.dir = document.dir;
       const syncClassesCleanup = syncClasses(document.body, iframeDocument.body);
-      mount(<AppComponent />, innerAppRoot);
+
+      // Wait for the copied stylesheets to load before mounting the app. Mounting synchronously
+      // would run layout effects against an unstyled DOM, producing incorrect computed styles
+      // that never get recalculated afterwards.
+      let disposed = false;
+      copyStyles(document, iframeDocument).then(() => {
+        if (disposed) {
+          return;
+        }
+        mount(<AppComponent />, innerAppRoot);
+      });
+
       cleanupRef.current = () => {
+        disposed = true;
         syncClassesCleanup();
         unmount(innerAppRoot);
         container.removeChild(iframeEl);


### PR DESCRIPTION
### Description

In iframe wrapper utils we copy stylesheets to the iframe before mounting React content. However, the styles are applied asynchronously by the browser and they are not correct during the first render. This causes component layout effects to run against the un-styled page.

<img width="1155" height="904" alt="Screenshot 2026-07-06 at 10 08 56" src="https://github.com/user-attachments/assets/c894a405-209d-4b93-84a7-1e5492a5502e" />

This particular issue causes the link's layout effect to compute incorrectly. See before:

<img width="147" height="44" alt="Screenshot 2026-07-06 at 10 09 10" src="https://github.com/user-attachments/assets/fc068968-afb3-479f-b8ba-1712fda1e62b" />

, and after:

<img width="147" height="44" alt="Screenshot 2026-07-06 at 10 13 21" src="https://github.com/user-attachments/assets/c8495bf1-853e-4188-b7e3-623b3ca551e5" />



### How has this been tested?

* Existing screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
