### PR TITLE
feat: add compact variant to pagination

### DIFF
--- a/pages/pagination/permutations.page.tsx
+++ b/pages/pagination/permutations.page.tsx
@@ -19,6 +19,7 @@ const paginationLabels: PaginationProps.Labels = {
 
 const permutations = createPermutations<PaginationProps>([
   {
+    pagesVariant: ['compact'],
     currentPageIndex: [7],
     pagesCount: [15],
     disabled: [true],
@@ -26,6 +27,7 @@ const permutations = createPermutations<PaginationProps>([
     jumpToPage: [undefined, { loading: false }],
   },
   {
+    pagesVariant: ['compact', 'normal'],
     currentPageIndex: [1, 6, 15],
     pagesCount: [15],
     openEnd: [true, false],

--- a/pages/pagination/simple.page.tsx
+++ b/pages/pagination/simple.page.tsx
@@ -24,6 +24,8 @@ const i18nStrings: PaginationProps.I18nStrings = {
 export default function PaginationSimplePage() {
   const [basicPageIndex, setBasicPageIndex] = useState(1);
   const [jumpPageIndex, setJumpPageIndex] = useState(1);
+  const [compactPageIndex, setCompactPageIndex] = useState(1);
+  const [compactOpenEndPageIndex, setCompactOpenEndPageIndex] = useState(1);
 
   return (
     <I18nProvider messages={[messages]} locale="en">
@@ -45,6 +47,25 @@ export default function PaginationSimplePage() {
           i18nStrings={i18nStrings}
           jumpToPage={{}}
           onChange={event => setJumpPageIndex(event.detail.currentPageIndex)}
+        />
+
+        <h2>Compact pages</h2>
+        <Pagination
+          pagesVariant="compact"
+          currentPageIndex={compactPageIndex}
+          pagesCount={20}
+          ariaLabels={paginationLabels}
+          onChange={event => setCompactPageIndex(event.detail.currentPageIndex)}
+        />
+
+        <h2>Compact pages with open end</h2>
+        <Pagination
+          pagesVariant="compact"
+          currentPageIndex={compactOpenEndPageIndex}
+          pagesCount={20}
+          openEnd={true}
+          ariaLabels={paginationLabels}
+          onChange={event => setCompactOpenEndPageIndex(event.detail.currentPageIndex)}
         />
       </ScreenshotArea>
     </I18nProvider>

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -20497,8 +20497,7 @@ never disabled. When the user clicks on it but there are no more items to show, 
       "type": "boolean",
     },
     {
-      "description": "Sets the total number of pages. When \`openEnd\` is \`true\`, this is the number of pages currently available.
-Only positive integers are allowed.",
+      "description": "Sets the total number of pages. Only positive integers are allowed.",
       "name": "pagesCount",
       "optional": false,
       "type": "number",

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -20420,6 +20420,13 @@ from changing page before items are loaded.",
       "type": "boolean",
     },
     {
+      "description": "An object containing all the necessary localized strings required by the component:
+* \`jumpToPageInputLabel\` (string) - Accessible label for the jump-to-page number input.
+* \`jumpToPageError\` (string) - Error message displayed when the entered page number is invalid.
+* \`jumpToPageLoadingText\` (string) - Loading text displayed while the jump-to-page action is in progress.
+* \`pagesCompactText\` ((options: { currentPage: number; pagesCount: number; openEnd: boolean }) => string) -
+  Provides the visible text for compact pages, for example \`3 of 12\`, or \`3 of 12+\` when \`openEnd\` is \`true\`.
+  Receives the current page, page count, and whether pagination is open-ended.",
       "i18nTag": true,
       "inlineType": {
         "name": "PaginationProps.I18nStrings",
@@ -20438,6 +20445,22 @@ from changing page before items are loaded.",
             "name": "jumpToPageLoadingText",
             "optional": true,
             "type": "string",
+          },
+          {
+            "inlineType": {
+              "name": "(options: { currentPage: number; pagesCount: number; openEnd: boolean; }) => string",
+              "parameters": [
+                {
+                  "name": "options",
+                  "type": "{ currentPage: number; pagesCount: number; openEnd: boolean; }",
+                },
+              ],
+              "returnType": "string",
+              "type": "function",
+            },
+            "name": "pagesCompactText",
+            "optional": true,
+            "type": "((options: { currentPage: number; pagesCount: number; openEnd: boolean; }) => string)",
           },
         ],
         "type": "object",
@@ -20474,10 +20497,28 @@ never disabled. When the user clicks on it but there are no more items to show, 
       "type": "boolean",
     },
     {
-      "description": "Sets the total number of pages. Only positive integers are allowed.",
+      "description": "Sets the total number of pages. When \`openEnd\` is \`true\`, this is the number of pages currently available.
+Only positive integers are allowed.",
       "name": "pagesCount",
       "optional": false,
       "type": "number",
+    },
+    {
+      "defaultValue": "'normal'",
+      "description": "Specifies how pages are displayed:
+* \`normal\` - Displays page number buttons. For larger page ranges, the displayed range is truncated with ellipses.
+* \`compact\` - Displays the current page and page count between the previous and next buttons. When \`openEnd\` is \`true\`, a plus sign after the page count indicates that more pages are available.",
+      "inlineType": {
+        "name": "PaginationProps.PagesVariant",
+        "type": "union",
+        "values": [
+          "normal",
+          "compact",
+        ],
+      },
+      "name": "pagesVariant",
+      "optional": true,
+      "type": "string",
     },
   ],
   "regions": [],
@@ -38371,6 +38412,20 @@ To find a specific item use the \`findBreadcrumbLink(n)\` function as chaining \
           },
         },
         {
+          "description": "Returns the visible text for compact pages (for example, \`3 of 12\` or \`3 of 12+\`).",
+          "name": "findPagesCompactText",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
           "name": "findPreviousPageButton",
           "parameters": [],
           "returnType": {
@@ -50062,6 +50117,15 @@ To find a specific item use the \`findBreadcrumbLink(n)\` function as chaining \
                 "name": "PaginationButtonWrapper",
               },
             ],
+          },
+        },
+        {
+          "description": "Returns the visible text for compact pages (for example, \`3 of 12\` or \`3 of 12+\`).",
+          "name": "findPagesCompactText",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
           },
         },
         {

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -499,6 +499,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_jump-to-page-input_fvjdu",
     "awsui_jump-to-page_fvjdu",
     "awsui_page-number_fvjdu",
+    "awsui_pages-compact-text_lmd86",
     "awsui_root_fvjdu",
   ],
   "panel-layout": [

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -335,6 +335,11 @@ export interface I18nFormatArgTypes {
     'i18nStrings.jumpToPageInputLabel': never;
     'i18nStrings.jumpToPageError': never;
     'i18nStrings.jumpToPageLoadingText': never;
+    'i18nStrings.pagesCompactText': {
+      openEnd: string;
+      currentPage: string | number;
+      pagesCount: string | number;
+    };
   };
   'panel-resize-handle': {
     'i18nStrings.resizeHandleAriaLabel': never;

--- a/src/i18n/messages/all.ar.json
+++ b/src/i18n/messages/all.ar.json
@@ -257,7 +257,8 @@
     "ariaLabels.jumpToPageButtonLabel": "الانتقال إلى الصفحة",
     "i18nStrings.jumpToPageInputLabel": "صفحة",
     "i18nStrings.jumpToPageError": "الصفحة خارج نطاق الوصول. جارٍ عرض آخر صفحة متاحة.",
-    "i18nStrings.jumpToPageLoadingText": "جار التحميل"
+    "i18nStrings.jumpToPageLoadingText": "جار التحميل",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} من {pagesCount} +} false {{currentPage} من {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "مقبض تغيير حجم اللوحة",

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -257,7 +257,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Zur Seite springen",
     "i18nStrings.jumpToPageInputLabel": "Seite",
     "i18nStrings.jumpToPageError": "Seite ist außerhalb des Bereichs. Zeigt die letzte verfügbare Seite an.",
-    "i18nStrings.jumpToPageLoadingText": "Wird geladen"
+    "i18nStrings.jumpToPageLoadingText": "Wird geladen",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} von {pagesCount}+} false {{currentPage} von {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Größe des Panels ändern",

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -257,7 +257,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Jump to page",
     "i18nStrings.jumpToPageInputLabel": "Page",
     "i18nStrings.jumpToPageError": "Page out of range. Showing the last available page.",
-    "i18nStrings.jumpToPageLoadingText": "Loading"
+    "i18nStrings.jumpToPageLoadingText": "Loading",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} of {pagesCount}+} false {{currentPage} of {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Panel resize handle",

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -257,7 +257,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Jump to page",
     "i18nStrings.jumpToPageInputLabel": "Page",
     "i18nStrings.jumpToPageError": "Page out of range. Showing last available page.",
-    "i18nStrings.jumpToPageLoadingText": "Loading"
+    "i18nStrings.jumpToPageLoadingText": "Loading",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} of {pagesCount}+} false {{currentPage} of {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Panel resize handle",

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -257,7 +257,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Ir a la página",
     "i18nStrings.jumpToPageInputLabel": "Página",
     "i18nStrings.jumpToPageError": "Página fuera de rango. Se muestra la última página disponible.",
-    "i18nStrings.jumpToPageLoadingText": "Cargando"
+    "i18nStrings.jumpToPageLoadingText": "Cargando",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} de {pagesCount}+} false {{currentPage} de {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Controlador de cambio del tamaño del panel",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -257,7 +257,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Aller à la page",
     "i18nStrings.jumpToPageInputLabel": "Page",
     "i18nStrings.jumpToPageError": "Page hors de portée. Affichage de la dernière page disponible.",
-    "i18nStrings.jumpToPageLoadingText": "Chargement en cours"
+    "i18nStrings.jumpToPageLoadingText": "Chargement en cours",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} sur plus de {pagesCount}} false {{currentPage} sur {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Poignée de redimensionnement du panneau",

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -257,7 +257,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Langsung ke halaman",
     "i18nStrings.jumpToPageInputLabel": "Halaman",
     "i18nStrings.jumpToPageError": "Halaman di luar rentang. Menampilkan halaman terakhir yang tersedia.",
-    "i18nStrings.jumpToPageLoadingText": "Memuat"
+    "i18nStrings.jumpToPageLoadingText": "Memuat",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} dari {pagesCount}+} false {{currentPage} dari {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Handel pengubahan ukuran panel",

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -257,7 +257,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Vai alla pagina",
     "i18nStrings.jumpToPageInputLabel": "Pagina",
     "i18nStrings.jumpToPageError": "Pagina fuori intervallo. Mostra l'ultima pagina disponibile.",
-    "i18nStrings.jumpToPageLoadingText": "Caricamento in corso"
+    "i18nStrings.jumpToPageLoadingText": "Caricamento in corso",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} di {pagesCount}+} false {{currentPage} di {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Maniglia di ridimensionamento del pannello",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -257,7 +257,8 @@
     "ariaLabels.jumpToPageButtonLabel": "ページに移動",
     "i18nStrings.jumpToPageInputLabel": "ページ",
     "i18nStrings.jumpToPageError": "ページが範囲外です。最後に利用可能なページを表示しています。",
-    "i18nStrings.jumpToPageLoadingText": "ロード中"
+    "i18nStrings.jumpToPageLoadingText": "ロード中",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage}/{pagesCount}+} false {{currentPage}/{pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "パネルのサイズ変更ハンドル",

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -257,7 +257,8 @@
     "ariaLabels.jumpToPageButtonLabel": "페이지로 이동",
     "i18nStrings.jumpToPageInputLabel": "페이지",
     "i18nStrings.jumpToPageError": "페이지가 범위를 벗어났습니다. 마지막으로 사용 가능한 페이지를 표시합니다.",
-    "i18nStrings.jumpToPageLoadingText": "로드 중"
+    "i18nStrings.jumpToPageLoadingText": "로드 중",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage}/{pagesCount}+} false {{currentPage}/{pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "패널 크기 조정 핸들",

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -257,7 +257,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Ir para a página",
     "i18nStrings.jumpToPageInputLabel": "Página",
     "i18nStrings.jumpToPageError": "Página fora do alcance. Mostrando a última página disponível.",
-    "i18nStrings.jumpToPageLoadingText": "Carregando"
+    "i18nStrings.jumpToPageLoadingText": "Carregando",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {mais {currentPage} de {pagesCount}} false {{currentPage} de {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Alça de redimensionamento do painel",

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -256,8 +256,9 @@
     "ariaLabels.previousPageLabel": "Önceki sayfa",
     "ariaLabels.jumpToPageButtonLabel": "Sayfaya atla",
     "i18nStrings.jumpToPageInputLabel": "Sayfa",
-    "i18nStrings.jumpToPageError": "Aralık dışı sayfa. Mevcut son sayfa gösteriliyor.",
-    "i18nStrings.jumpToPageLoadingText": "Yükleniyor"
+    "i18nStrings.jumpToPageError": "Sayfa aralık dışında. Mevcut son sayfa gösteriliyor.",
+    "i18nStrings.jumpToPageLoadingText": "Yükleniyor",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage}/{pagesCount}+} false {{currentPage}/{pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Panel yeniden boyutlandırma tutamacı",

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -257,7 +257,8 @@
     "ariaLabels.jumpToPageButtonLabel": "跳转到页面",
     "i18nStrings.jumpToPageInputLabel": "页面",
     "i18nStrings.jumpToPageError": "页面超出范围。显示最后一个可用页面。",
-    "i18nStrings.jumpToPageLoadingText": "正在加载"
+    "i18nStrings.jumpToPageLoadingText": "正在加载",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} / {pagesCount}+} false {{currentPage}/{pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "面板大小调整手柄",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -257,7 +257,8 @@
     "ariaLabels.jumpToPageButtonLabel": "跳到頁面",
     "i18nStrings.jumpToPageInputLabel": "頁面",
     "i18nStrings.jumpToPageError": "頁面超出範圍。顯示最後一個可用頁面。",
-    "i18nStrings.jumpToPageLoadingText": "正在載入"
+    "i18nStrings.jumpToPageLoadingText": "正在載入",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage}/{pagesCount}+} false {{currentPage}/{pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "面板調整大小控點",

--- a/src/pagination/__tests__/pagination-compact.test.tsx
+++ b/src/pagination/__tests__/pagination-compact.test.tsx
@@ -16,16 +16,10 @@ const i18nMessages = {
   },
 };
 
-function renderPagination(jsx: React.ReactElement) {
-  const { container, rerender } = render(jsx);
-  const wrapper = createWrapper(container).findPagination()!;
-  return { wrapper, rerender };
-}
-
 function renderWithI18n(jsx: React.ReactElement) {
-  const { container, rerender } = render(<TestI18nProvider messages={i18nMessages}>{jsx}</TestI18nProvider>);
+  const { container } = render(<TestI18nProvider messages={i18nMessages}>{jsx}</TestI18nProvider>);
   const wrapper = createWrapper(container).findPagination()!;
-  return { wrapper, rerender };
+  return { wrapper };
 }
 
 describe('compact variant', () => {
@@ -41,26 +35,6 @@ describe('compact variant', () => {
       );
       expect(wrapper.findPagesCompactText()!.getElement().textContent).toBe('3 of 12+');
     });
-
-    test('calls the consumer override with the page state and uses its result (no i18n provider)', () => {
-      const pagesCompactText = jest.fn(
-        ({ currentPage, pagesCount, openEnd }: { currentPage: number; pagesCount: number; openEnd: boolean }) =>
-          `${currentPage} / ${pagesCount}${openEnd ? '+' : ''}`
-      );
-      const { wrapper } = renderPagination(
-        <Pagination
-          pagesVariant="compact"
-          currentPageIndex={3}
-          pagesCount={12}
-          openEnd={true}
-          i18nStrings={{ pagesCompactText }}
-        />
-      );
-
-      expect(pagesCompactText).toHaveBeenCalledWith({ currentPage: 3, pagesCount: 12, openEnd: true });
-      expect(wrapper.findPagesCompactText()!.getElement().textContent).toBe('3 / 12+');
-    });
-
     test('consumer override takes precedence over the i18n provider string', () => {
       const { wrapper } = renderWithI18n(
         <Pagination

--- a/src/pagination/__tests__/pagination-compact.test.tsx
+++ b/src/pagination/__tests__/pagination-compact.test.tsx
@@ -1,0 +1,74 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import I18nProvider from '../../../lib/components/i18n';
+import messages from '../../../lib/components/i18n/messages/all.en';
+import Pagination from '../../../lib/components/pagination';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+function renderPagination(jsx: React.ReactElement) {
+  const { container, rerender } = render(jsx);
+  const wrapper = createWrapper(container).findPagination()!;
+  return { wrapper, rerender };
+}
+
+function renderWithI18n(jsx: React.ReactElement) {
+  const { container, rerender } = render(
+    <I18nProvider messages={[messages]} locale="en">
+      {jsx}
+    </I18nProvider>
+  );
+  const wrapper = createWrapper(container).findPagination()!;
+  return { wrapper, rerender };
+}
+
+describe('compact variant', () => {
+  describe('visible counter text', () => {
+    test('uses i18n catalog "# of #" format when i18n provider is present', () => {
+      const { wrapper } = renderWithI18n(<Pagination pagesVariant="compact" currentPageIndex={3} pagesCount={12} />);
+      expect(wrapper.findPagesCompactText()!.getElement().textContent).toBe('3 of 12');
+    });
+
+    test('appends "+" to the localized text when openEnd is true', () => {
+      const { wrapper } = renderWithI18n(
+        <Pagination pagesVariant="compact" currentPageIndex={3} pagesCount={12} openEnd={true} />
+      );
+      expect(wrapper.findPagesCompactText()!.getElement().textContent).toBe('3 of 12+');
+    });
+
+    test('calls the consumer override with the page state and uses its result (no i18n provider)', () => {
+      const pagesCompactText = jest.fn(
+        ({ currentPage, pagesCount, openEnd }: { currentPage: number; pagesCount: number; openEnd: boolean }) =>
+          `${currentPage} / ${pagesCount}${openEnd ? '+' : ''}`
+      );
+      const { wrapper } = renderPagination(
+        <Pagination
+          pagesVariant="compact"
+          currentPageIndex={3}
+          pagesCount={12}
+          openEnd={true}
+          i18nStrings={{ pagesCompactText }}
+        />
+      );
+
+      expect(pagesCompactText).toHaveBeenCalledWith({ currentPage: 3, pagesCount: 12, openEnd: true });
+      expect(wrapper.findPagesCompactText()!.getElement().textContent).toBe('3 / 12+');
+    });
+
+    test('visible text updates when currentPageIndex changes', () => {
+      const { wrapper, rerender } = renderWithI18n(
+        <Pagination pagesVariant="compact" currentPageIndex={1} pagesCount={10} />
+      );
+      expect(wrapper.findPagesCompactText()!.getElement().textContent).toBe('1 of 10');
+
+      rerender(
+        <I18nProvider messages={[messages]} locale="en">
+          <Pagination pagesVariant="compact" currentPageIndex={7} pagesCount={10} />
+        </I18nProvider>
+      );
+      expect(wrapper.findPagesCompactText()!.getElement().textContent).toBe('7 of 10');
+    });
+  });
+});

--- a/src/pagination/__tests__/pagination-compact.test.tsx
+++ b/src/pagination/__tests__/pagination-compact.test.tsx
@@ -3,10 +3,18 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 
-import I18nProvider from '../../../lib/components/i18n';
-import messages from '../../../lib/components/i18n/messages/all.en';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 import Pagination from '../../../lib/components/pagination';
 import createWrapper from '../../../lib/components/test-utils/dom';
+
+// A controlled catalog so the tests exercise pagination's substitution and the
+// openEnd `select` branch, independent of the real shipped strings.
+const i18nMessages = {
+  pagination: {
+    'i18nStrings.pagesCompactText':
+      '{openEnd, select, true {{currentPage} of {pagesCount}+} false {{currentPage} of {pagesCount}} other {}}',
+  },
+};
 
 function renderPagination(jsx: React.ReactElement) {
   const { container, rerender } = render(jsx);
@@ -15,23 +23,19 @@ function renderPagination(jsx: React.ReactElement) {
 }
 
 function renderWithI18n(jsx: React.ReactElement) {
-  const { container, rerender } = render(
-    <I18nProvider messages={[messages]} locale="en">
-      {jsx}
-    </I18nProvider>
-  );
+  const { container, rerender } = render(<TestI18nProvider messages={i18nMessages}>{jsx}</TestI18nProvider>);
   const wrapper = createWrapper(container).findPagination()!;
   return { wrapper, rerender };
 }
 
 describe('compact variant', () => {
   describe('visible counter text', () => {
-    test('uses i18n catalog "# of #" format when i18n provider is present', () => {
+    test('substitutes the page state into the i18n string when a provider is present', () => {
       const { wrapper } = renderWithI18n(<Pagination pagesVariant="compact" currentPageIndex={3} pagesCount={12} />);
       expect(wrapper.findPagesCompactText()!.getElement().textContent).toBe('3 of 12');
     });
 
-    test('appends "+" to the localized text when openEnd is true', () => {
+    test('selects the openEnd branch of the i18n string when openEnd is true', () => {
       const { wrapper } = renderWithI18n(
         <Pagination pagesVariant="compact" currentPageIndex={3} pagesCount={12} openEnd={true} />
       );
@@ -57,18 +61,16 @@ describe('compact variant', () => {
       expect(wrapper.findPagesCompactText()!.getElement().textContent).toBe('3 / 12+');
     });
 
-    test('visible text updates when currentPageIndex changes', () => {
-      const { wrapper, rerender } = renderWithI18n(
-        <Pagination pagesVariant="compact" currentPageIndex={1} pagesCount={10} />
+    test('consumer override takes precedence over the i18n provider string', () => {
+      const { wrapper } = renderWithI18n(
+        <Pagination
+          pagesVariant="compact"
+          currentPageIndex={3}
+          pagesCount={12}
+          i18nStrings={{ pagesCompactText: ({ currentPage, pagesCount }) => `${currentPage} / ${pagesCount}` }}
+        />
       );
-      expect(wrapper.findPagesCompactText()!.getElement().textContent).toBe('1 of 10');
-
-      rerender(
-        <I18nProvider messages={[messages]} locale="en">
-          <Pagination pagesVariant="compact" currentPageIndex={7} pagesCount={10} />
-        </I18nProvider>
-      );
-      expect(wrapper.findPagesCompactText()!.getElement().textContent).toBe('7 of 10');
+      expect(wrapper.findPagesCompactText()!.getElement().textContent).toBe('3 / 12');
     });
   });
 });

--- a/src/pagination/index.tsx
+++ b/src/pagination/index.tsx
@@ -13,30 +13,33 @@ import InternalPagination from './internal';
 
 export { PaginationProps };
 
-const Pagination = React.forwardRef<PaginationProps.Ref, PaginationProps>((props, ref) => {
-  const baseComponentProps = useBaseComponent('Pagination', {
-    props: { openEnd: props.openEnd },
-    metadata: { hasJumpToPage: !!props.jumpToPage },
-  });
-  return (
-    <InternalPagination
-      {...props}
-      {...baseComponentProps}
-      ref={ref}
-      {...getAnalyticsMetadataAttribute({
-        component: {
-          name: 'awsui.Pagination',
-          label: { root: 'self' },
-          properties: {
-            openEnd: `${!!props.openEnd}`,
-            pagesCount: `${props.pagesCount || ''}`,
-            currentPageIndex: `${props.currentPageIndex}`,
-          },
-        } as GeneratedAnalyticsMetadataPaginationComponent,
-      })}
-    />
-  );
-});
+const Pagination = React.forwardRef<PaginationProps.Ref, PaginationProps>(
+  ({ pagesVariant = 'normal', ...props }, ref) => {
+    const baseComponentProps = useBaseComponent('Pagination', {
+      props: { openEnd: props.openEnd, pagesVariant },
+      metadata: { hasJumpToPage: !!props.jumpToPage },
+    });
+    return (
+      <InternalPagination
+        pagesVariant={pagesVariant}
+        {...props}
+        {...baseComponentProps}
+        ref={ref}
+        {...getAnalyticsMetadataAttribute({
+          component: {
+            name: 'awsui.Pagination',
+            label: { root: 'self' },
+            properties: {
+              openEnd: `${!!props.openEnd}`,
+              pagesCount: `${props.pagesCount || ''}`,
+              currentPageIndex: `${props.currentPageIndex}`,
+            },
+          } as GeneratedAnalyticsMetadataPaginationComponent,
+        })}
+      />
+    );
+  }
+);
 
 applyDisplayName(Pagination, 'Pagination');
 

--- a/src/pagination/interfaces.ts
+++ b/src/pagination/interfaces.ts
@@ -104,13 +104,9 @@ export namespace PaginationProps {
   }
 
   export interface I18nStrings {
-    /** @i18n */
     jumpToPageInputLabel?: string;
-    /** @i18n */
     jumpToPageError?: string;
-    /** @i18n */
     jumpToPageLoadingText?: string;
-    /** @i18n */
     pagesCompactText?: (options: { currentPage: number; pagesCount: number; openEnd: boolean }) => string;
   }
 

--- a/src/pagination/interfaces.ts
+++ b/src/pagination/interfaces.ts
@@ -23,6 +23,13 @@ export interface PaginationProps {
   openEnd?: boolean;
 
   /**
+   * Specifies how pages are displayed:
+   * * `normal` - Displays page number buttons. For larger page ranges, the displayed range is truncated with ellipses.
+   * * `compact` - Displays the current page and page count between the previous and next buttons. When `openEnd` is `true`, a plus sign after the page count indicates that more pages are available.
+   */
+  pagesVariant?: PaginationProps.PagesVariant;
+
+  /**
    * If set to `true`, the pagination links will be disabled. Use it, for example, if you want to prevent the user
    * from changing page before items are loaded.
    */
@@ -49,6 +56,13 @@ export interface PaginationProps {
    */
   ariaLabels?: PaginationProps.Labels;
   /**
+   * An object containing all the necessary localized strings required by the component:
+   * * `jumpToPageInputLabel` (string) - Accessible label for the jump-to-page number input.
+   * * `jumpToPageError` (string) - Error message displayed when the entered page number is invalid.
+   * * `jumpToPageLoadingText` (string) - Loading text displayed while the jump-to-page action is in progress.
+   * * `pagesCompactText` ((options: { currentPage: number; pagesCount: number; openEnd: boolean }) => string) -
+   *   Provides the visible text for compact pages, for example `3 of 12`, or `3 of 12+` when `openEnd` is `true`.
+   *   Receives the current page, page count, and whether pagination is open-ended.
    * @i18n
    */
   i18nStrings?: PaginationProps.I18nStrings;
@@ -79,6 +93,8 @@ export interface PaginationProps {
 }
 
 export namespace PaginationProps {
+  export type PagesVariant = 'normal' | 'compact';
+
   export interface Labels {
     nextPageLabel?: string;
     paginationLabel?: string;
@@ -94,6 +110,8 @@ export namespace PaginationProps {
     jumpToPageError?: string;
     /** @i18n */
     jumpToPageLoadingText?: string;
+    /** @i18n */
+    pagesCompactText?: (options: { currentPage: number; pagesCount: number; openEnd: boolean }) => string;
   }
 
   export interface ChangeDetail {

--- a/src/pagination/internal.tsx
+++ b/src/pagination/internal.tsx
@@ -160,7 +160,7 @@ const InternalPagination = React.forwardRef(
         format({
           currentPage: options.currentPage,
           pagesCount: options.pagesCount,
-          openEnd: options.openEnd ? "true" : "false",
+          openEnd: options.openEnd ? 'true' : 'false',
         })
     );
 

--- a/src/pagination/internal.tsx
+++ b/src/pagination/internal.tsx
@@ -26,6 +26,7 @@ import { PaginationProps } from './interfaces';
 import { getPaginationState, range } from './utils';
 
 import styles from './styles.css.js';
+import testUtilStyles from './test-classes/styles.css.js';
 
 interface PageButtonProps {
   className?: string;
@@ -114,6 +115,7 @@ const InternalPagination = React.forwardRef(
       i18nStrings,
       pagesCount,
       disabled,
+      pagesVariant = 'normal',
       onChange,
       onNextPageClick,
       onPreviousPageClick,
@@ -150,6 +152,17 @@ const InternalPagination = React.forwardRef(
     const pageNumberLabelFn =
       i18n('ariaLabels.pageLabel', ariaLabels?.pageLabel, format => pageNumber => format({ pageNumber })) ??
       ((pageNumber: number) => `${pageNumber}`);
+
+    const pagesCompactText = i18n(
+      'i18nStrings.pagesCompactText',
+      i18nStrings?.pagesCompactText,
+      format => options =>
+        format({
+          currentPage: options.currentPage,
+          pagesCount: options.pagesCount,
+          openEnd: `${options.openEnd}`,
+        })
+    );
 
     const jumpToPageLabel = i18n('i18nStrings.jumpToPageInputLabel', i18nStrings?.jumpToPageInputLabel) ?? '';
     const jumpToPageButtonLabel = i18n('ariaLabels.jumpToPageButtonLabel', ariaLabels?.jumpToPageButton) ?? '';
@@ -248,33 +261,47 @@ const InternalPagination = React.forwardRef(
         >
           <InternalIcon name="angle-left" variant={disabled ? 'disabled' : 'normal'} />
         </PageButton>
-        <PageNumber
-          pageIndex={1}
-          isCurrent={currentPageIndex === 1}
-          disabled={disabled}
-          ariaLabel={pageNumberLabelFn(1)}
-          onClick={handlePageClick}
-        />
-        {leftDots && <li className={styles.dots}>...</li>}
-        {range(leftIndex, rightIndex).map(pageIndex => (
-          <PageNumber
-            key={pageIndex}
-            isCurrent={currentPageIndex === pageIndex}
-            pageIndex={pageIndex}
-            disabled={disabled}
-            ariaLabel={pageNumberLabelFn(pageIndex)}
-            onClick={handlePageClick}
-          />
-        ))}
-        {rightDots && <li className={styles.dots}>...</li>}
-        {!openEnd && pagesCount > 1 && (
-          <PageNumber
-            isCurrent={currentPageIndex === pagesCount}
-            pageIndex={pagesCount}
-            disabled={disabled}
-            ariaLabel={pageNumberLabelFn(pagesCount)}
-            onClick={handlePageClick}
-          />
+        {pagesVariant === 'compact' ? (
+          <li aria-disabled={disabled ? true : undefined} className={styles['pages-compact']}>
+            <span className={testUtilStyles['pages-compact-text']}>
+              {pagesCompactText?.({
+                currentPage: currentPageIndex,
+                pagesCount,
+                openEnd: !!openEnd,
+              })}
+            </span>
+          </li>
+        ) : (
+          <>
+            <PageNumber
+              pageIndex={1}
+              isCurrent={currentPageIndex === 1}
+              disabled={disabled}
+              ariaLabel={pageNumberLabelFn(1)}
+              onClick={handlePageClick}
+            />
+            {leftDots && <li className={styles.dots}>...</li>}
+            {range(leftIndex, rightIndex).map(pageIndex => (
+              <PageNumber
+                key={pageIndex}
+                isCurrent={currentPageIndex === pageIndex}
+                pageIndex={pageIndex}
+                disabled={disabled}
+                ariaLabel={pageNumberLabelFn(pageIndex)}
+                onClick={handlePageClick}
+              />
+            ))}
+            {rightDots && <li className={styles.dots}>...</li>}
+            {!openEnd && pagesCount > 1 && (
+              <PageNumber
+                isCurrent={currentPageIndex === pagesCount}
+                pageIndex={pagesCount}
+                disabled={disabled}
+                ariaLabel={pageNumberLabelFn(pagesCount)}
+                onClick={handlePageClick}
+              />
+            )}
+          </>
         )}
         <PageButton
           className={styles.arrow}

--- a/src/pagination/internal.tsx
+++ b/src/pagination/internal.tsx
@@ -160,7 +160,7 @@ const InternalPagination = React.forwardRef(
         format({
           currentPage: options.currentPage,
           pagesCount: options.pagesCount,
-          openEnd: `${options.openEnd}`,
+          openEnd: options.openEnd ? "true" : "false",
         })
     );
 

--- a/src/pagination/styles.scss
+++ b/src/pagination/styles.scss
@@ -98,8 +98,14 @@
   color: awsui.$color-text-interactive-default;
 }
 
+.pages-compact {
+  color: awsui.$color-text-pagination-page-number-default;
+  white-space: nowrap;
+}
+
 .page-item,
-.dots {
+.dots,
+.pages-compact {
   margin-block: styles.$control-padding-vertical;
   margin-inline: awsui.$space-xxs;
   text-align: center;
@@ -114,6 +120,7 @@
   }
 }
 
-.root-disabled > .dots {
+.root-disabled > .dots,
+.root-disabled > .pages-compact {
   color: awsui.$color-text-interactive-disabled;
 }

--- a/src/pagination/test-classes/styles.scss
+++ b/src/pagination/test-classes/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.pages-compact-text {
+  /* used in test-utils or tests */
+}

--- a/src/test-utils/dom/pagination/index.ts
+++ b/src/test-utils/dom/pagination/index.ts
@@ -1,12 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentWrapper, usesDom } from '@cloudscape-design/test-utils-core/dom';
+import { ComponentWrapper, ElementWrapper, usesDom } from '@cloudscape-design/test-utils-core/dom';
 
 import ButtonWrapper from '../button';
 import InputWrapper from '../input';
 import PopoverWrapper from '../popover';
 
 import styles from '../../../pagination/styles.selectors.js';
+import testStyles from '../../../pagination/test-classes/styles.selectors.js';
 
 export class PaginationButtonWrapper extends ComponentWrapper<HTMLButtonElement> {
   @usesDom
@@ -45,6 +46,13 @@ export default class PaginationWrapper extends ComponentWrapper {
 
   findNextPageButton(): PaginationButtonWrapper {
     return this.findComponent(`li:not(:first-child) .${styles.arrow}`, PaginationButtonWrapper)!;
+  }
+
+  /**
+   * Returns the visible text for compact pages (for example, `3 of 12` or `3 of 12+`).
+   */
+  findPagesCompactText(): ElementWrapper | null {
+    return this.findByClassName(testStyles['pages-compact-text']);
   }
 
   /**


### PR DESCRIPTION
### Description
Adds a compact Pagination variant via `pagesVariant="compact"`, which shows a single `3 of 12` counter between the arrows instead of numbered page buttons, for space-constrained layouts. The text is localized through `i18nStrings.pagesCompactText` (receiving `{ currentPage, pagesCount, openEnd }`); `openEnd` appends a `+`. `pagesVariant` defaults to `'normal'`, so existing usage is unchanged.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: fUKQXLDPlRFb

### How has this been tested?
Unit tests, and visual on test pages, and added to visual regression test as well.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
