### PR TITLE
fix: Use ButtonWrapper for pagination buttons

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -37640,12 +37640,7 @@ Returns the current value of the input.",
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
+            "name": "PaginationButtonWrapper",
           },
         },
         {
@@ -37680,12 +37675,7 @@ Returns the current value of the input.",
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
+            "name": "PaginationButtonWrapper",
           },
         },
         {
@@ -37703,12 +37693,7 @@ Returns the current value of the input.",
           ],
           "returnType": {
             "isNullable": true,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
+            "name": "PaginationButtonWrapper",
           },
         },
         {
@@ -37719,7 +37704,7 @@ Returns the current value of the input.",
             "name": "Array",
             "typeArguments": [
               {
-                "name": "ElementWrapper<HTMLElement>",
+                "name": "PaginationButtonWrapper",
               },
             ],
           },
@@ -37729,12 +37714,7 @@ Returns the current value of the input.",
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "ElementWrapper",
-            "typeArguments": [
-              {
-                "name": "HTMLElement",
-              },
-            ],
+            "name": "PaginationButtonWrapper",
           },
         },
         {
@@ -37747,6 +37727,19 @@ Returns the current value of the input.",
         },
       ],
       "name": "PaginationWrapper",
+    },
+    {
+      "methods": [
+        {
+          "name": "isDisabled",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "boolean",
+          },
+        },
+      ],
+      "name": "PaginationButtonWrapper",
     },
     {
       "methods": [
@@ -48804,7 +48797,7 @@ To find a specific item use the \`findBreadcrumbLink(n)\` function as chaining \
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "ElementWrapper",
+            "name": "PaginationButtonWrapper",
           },
         },
         {
@@ -48839,7 +48832,7 @@ To find a specific item use the \`findBreadcrumbLink(n)\` function as chaining \
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "ElementWrapper",
+            "name": "PaginationButtonWrapper",
           },
         },
         {
@@ -48857,7 +48850,7 @@ To find a specific item use the \`findBreadcrumbLink(n)\` function as chaining \
           ],
           "returnType": {
             "isNullable": false,
-            "name": "ElementWrapper",
+            "name": "PaginationButtonWrapper",
           },
         },
         {
@@ -48868,7 +48861,7 @@ To find a specific item use the \`findBreadcrumbLink(n)\` function as chaining \
             "name": "MultiElementWrapper",
             "typeArguments": [
               {
-                "name": "ElementWrapper",
+                "name": "PaginationButtonWrapper",
               },
             ],
           },
@@ -48878,11 +48871,15 @@ To find a specific item use the \`findBreadcrumbLink(n)\` function as chaining \
           "parameters": [],
           "returnType": {
             "isNullable": false,
-            "name": "ElementWrapper",
+            "name": "PaginationButtonWrapper",
           },
         },
       ],
       "name": "PaginationWrapper",
+    },
+    {
+      "methods": [],
+      "name": "PaginationButtonWrapper",
     },
     {
       "methods": [

--- a/src/pagination/__tests__/pagination.test.tsx
+++ b/src/pagination/__tests__/pagination.test.tsx
@@ -47,8 +47,8 @@ test('should re-render component correctly after current page state change', () 
 
 test('should have both arrows disabled when there is only one page', () => {
   const { wrapper } = renderPagination(<Pagination currentPageIndex={1} pagesCount={1} />);
-  expect(wrapper.findPreviousPageButton().getElement()).toHaveAttribute('aria-disabled', 'true');
-  expect(wrapper.findNextPageButton().getElement()).toHaveAttribute('aria-disabled', 'true');
+  expect(wrapper.findPreviousPageButton().isDisabled()).toBe(true);
+  expect(wrapper.findNextPageButton().isDisabled()).toBe(true);
   expect(wrapper.findPageNumberByIndex(1)!.getElement()).toHaveTextContent('1');
   expect(getItemsContent(wrapper)).toEqual(['1']);
 });
@@ -63,10 +63,34 @@ test('should have both arrows disabled when there are no pages', () => {
 
 test('should show all buttons when middle page selected', () => {
   const { wrapper } = renderPagination(<Pagination currentPageIndex={5} pagesCount={9} />);
-  expect(wrapper.findPreviousPageButton().getElement()).not.toHaveAttribute('aria-disabled');
-  expect(wrapper.findNextPageButton().getElement()).not.toHaveAttribute('aria-disabled');
+  expect(wrapper.findPreviousPageButton().isDisabled()).toBe(false);
+  expect(wrapper.findNextPageButton().isDisabled()).toBe(false);
   expect(wrapper.findCurrentPage().getElement()).toHaveTextContent('5');
   expect(getItemsContent(wrapper)).toEqual(['1', '2', '3', '4', '5', '6', '7', '8', '9']);
+});
+
+test('keeps focus on the previous page button when it becomes disabled after navigating to the first page', () => {
+  const { wrapper, rerender } = renderPagination(<Pagination currentPageIndex={2} pagesCount={10} />);
+
+  wrapper.findPreviousPageButton().focus();
+  expect(wrapper.findPreviousPageButton().getElement()).toHaveFocus();
+
+  rerender(<Pagination currentPageIndex={1} pagesCount={10} />);
+
+  expect(wrapper.findPreviousPageButton().isDisabled()).toBe(true);
+  expect(wrapper.findPreviousPageButton().getElement()).toHaveFocus();
+});
+
+test('keeps focus on the next page button when it becomes disabled after navigating to the last page', () => {
+  const { wrapper, rerender } = renderPagination(<Pagination currentPageIndex={9} pagesCount={10} />);
+
+  wrapper.findNextPageButton().focus();
+  expect(wrapper.findNextPageButton().getElement()).toHaveFocus();
+
+  rerender(<Pagination currentPageIndex={10} pagesCount={10} />);
+
+  expect(wrapper.findNextPageButton().isDisabled()).toBe(true);
+  expect(wrapper.findNextPageButton().getElement()).toHaveFocus();
 });
 
 test('should not fire nextPageClick event when clicking next page with the last page being active', () => {

--- a/src/s3-resource-selector/s3-modal/__tests__/utils.ts
+++ b/src/s3-resource-selector/s3-modal/__tests__/utils.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 
-import { ElementWrapper, TableWrapper } from '../../../../lib/components/test-utils/dom';
+import { TableWrapper } from '../../../../lib/components/test-utils/dom';
 import { buckets, i18nStrings, objects, versions, waitForFetch } from '../../__tests__/fixtures';
 
 import screenreaderOnlyStyles from '../../../../lib/components/internal/components/screenreader-only/styles.selectors.js';

--- a/src/s3-resource-selector/s3-modal/__tests__/utils.ts
+++ b/src/s3-resource-selector/s3-modal/__tests__/utils.ts
@@ -1,5 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { ComponentWrapper } from '@cloudscape-design/test-utils-core/dom';
+
 import { ElementWrapper, TableWrapper } from '../../../../lib/components/test-utils/dom';
 import { buckets, i18nStrings, objects, versions, waitForFetch } from '../../__tests__/fixtures';
 
@@ -39,7 +41,7 @@ export async function navigateToTableItem(wrapper: ElementWrapper<Element>, rowI
   await waitForFetch();
 }
 
-export function getElementsText(wrappers: ReadonlyArray<ElementWrapper>) {
+export function getElementsText(wrappers: ReadonlyArray<ElementWrapper | ComponentWrapper>) {
   return wrappers.map(wrapper => wrapper.getElement().textContent!.trim());
 }
 

--- a/src/test-utils/dom/pagination/index.ts
+++ b/src/test-utils/dom/pagination/index.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentWrapper, ElementWrapper, usesDom } from '@cloudscape-design/test-utils-core/dom';
+import { ComponentWrapper, usesDom } from '@cloudscape-design/test-utils-core/dom';
 
 import ButtonWrapper from '../button';
 import InputWrapper from '../input';
@@ -11,12 +11,14 @@ import styles from '../../../pagination/styles.selectors.js';
 export default class PaginationWrapper extends ComponentWrapper {
   static rootSelector = styles.root;
 
-  findCurrentPage(): ElementWrapper {
-    return this.findByClassName(styles['button-current'])!;
+  findCurrentPage(): ButtonWrapper {
+    return this.findComponent(`.${styles['button-current']}`, ButtonWrapper)!;
   }
 
-  findPageNumbers(): Array<ElementWrapper> {
-    return this.findAllByClassName(styles['page-number']);
+  findPageNumbers(): Array<ButtonWrapper> {
+    return this.findAllByClassName<HTMLButtonElement>(styles['page-number']).map(
+      wrapper => new ButtonWrapper(wrapper.getElement())
+    );
   }
 
   /**
@@ -24,18 +26,18 @@ export default class PaginationWrapper extends ComponentWrapper {
    *
    * @param index 1-based index of the page number to return.
    */
-  findPageNumberByIndex(index: number): ElementWrapper | null {
+  findPageNumberByIndex(index: number): ButtonWrapper | null {
     // we need to skip the "previous page" button
     const pageIndex = index + 1;
-    return this.find(`li:nth-child(${pageIndex}) .${styles.button}`);
+    return this.findComponent(`li:nth-child(${pageIndex}) .${styles.button}`, ButtonWrapper);
   }
 
-  findPreviousPageButton(): ElementWrapper {
-    return this.find(`li:first-child .${styles.button}`)!;
+  findPreviousPageButton(): ButtonWrapper {
+    return this.findComponent(`li:first-child .${styles.button}`, ButtonWrapper)!;
   }
 
-  findNextPageButton(): ElementWrapper {
-    return this.find(`li:last-child .${styles.button}`)!;
+  findNextPageButton(): ButtonWrapper {
+    return this.findComponent(`li:last-child .${styles.button}`, ButtonWrapper)!;
   }
 
   /**

--- a/src/test-utils/dom/pagination/index.ts
+++ b/src/test-utils/dom/pagination/index.ts
@@ -8,16 +8,23 @@ import PopoverWrapper from '../popover';
 
 import styles from '../../../pagination/styles.selectors.js';
 
+export class PaginationButtonWrapper extends ComponentWrapper<HTMLButtonElement> {
+  @usesDom
+  isDisabled(): boolean {
+    return this.element.disabled || this.element.getAttribute('aria-disabled') === 'true';
+  }
+}
+
 export default class PaginationWrapper extends ComponentWrapper {
   static rootSelector = styles.root;
 
-  findCurrentPage(): ButtonWrapper {
-    return this.findComponent(`.${styles['button-current']}`, ButtonWrapper)!;
+  findCurrentPage(): PaginationButtonWrapper {
+    return this.findComponent(`.${styles['button-current']}`, PaginationButtonWrapper)!;
   }
 
-  findPageNumbers(): Array<ButtonWrapper> {
+  findPageNumbers(): Array<PaginationButtonWrapper> {
     return this.findAllByClassName<HTMLButtonElement>(styles['page-number']).map(
-      wrapper => new ButtonWrapper(wrapper.getElement())
+      wrapper => new PaginationButtonWrapper(wrapper.getElement())
     );
   }
 
@@ -26,18 +33,18 @@ export default class PaginationWrapper extends ComponentWrapper {
    *
    * @param index 1-based index of the page number to return.
    */
-  findPageNumberByIndex(index: number): ButtonWrapper | null {
+  findPageNumberByIndex(index: number): PaginationButtonWrapper | null {
     // we need to skip the "previous page" button
     const pageIndex = index + 1;
-    return this.findComponent(`li:nth-child(${pageIndex}) .${styles.button}`, ButtonWrapper);
+    return this.findComponent(`li:nth-child(${pageIndex}) .${styles.button}`, PaginationButtonWrapper);
   }
 
-  findPreviousPageButton(): ButtonWrapper {
-    return this.findComponent(`li:first-child .${styles.button}`, ButtonWrapper)!;
+  findPreviousPageButton(): PaginationButtonWrapper {
+    return this.findComponent(`li:first-child .${styles.button}`, PaginationButtonWrapper)!;
   }
 
-  findNextPageButton(): ButtonWrapper {
-    return this.findComponent(`li:last-child .${styles.button}`, ButtonWrapper)!;
+  findNextPageButton(): PaginationButtonWrapper {
+    return this.findComponent(`li:last-child .${styles.button}`, PaginationButtonWrapper)!;
   }
 
   /**


### PR DESCRIPTION
## Description

Pagination's page-button finders returned `ElementWrapper`, so consumers couldn't call `isDisabled()` — the buttons use `aria-disabled` rather than the native `disabled` attribute (see #4576). This adds a pagination-scoped `PaginationButtonWrapper` (exposing `isDisabled()`) and returns it from `findPreviousPageButton`, `findNextPageButton`, `findPageNumberByIndex`, `findCurrentPage`, and `findPageNumbers`. Pagination renders bare `<button>`s rather than the `Button` component, so a dedicated wrapper is used instead of reusing `ButtonWrapper` (`findJumpToPageButton` still returns `ButtonWrapper`, as it wraps an actual `Button`). Non-breaking, since `PaginationButtonWrapper extends ElementWrapper`.

## How has this been tested?

Updated the pagination tests to assert disabled state via `isDisabled()`, and added prev/next focus-retention tests (#4576 switched to `aria-disabled` to keep focus but shipped without a test for it).
