### PR TITLE
chore: Expose app layout error-boundary catches for canary detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     {
       "path": "lib/components/internal/plugins/index.js",
       "brotli": false,
-      "limit": "15 kB"
+      "limit": "16 kB"
     },
     {
       "path": "lib/components/internal/widget-exports.js",

--- a/src/app-layout/__tests__/widget-areas-error-boundaries.test.tsx
+++ b/src/app-layout/__tests__/widget-areas-error-boundaries.test.tsx
@@ -66,7 +66,7 @@ beforeEach(() => {
   // masked the exact appLayoutPart values asserted below.
   awsuiPlugins.appLayout.clearRegisteredDrawersForTesting();
   awsuiWidgetInternal.clearInitialMessages();
-  sendPanoramaMetricSpy = jest.spyOn(metrics, 'sendOpsMetricObject').mockImplementation(() => {});
+  sendPanoramaMetricSpy = jest.spyOn(metrics, 'sendPanoramaMetric').mockImplementation(() => {});
 });
 
 describe('AppLayout error boundaries: errors in different areas does not crash the entire app layout', () => {
@@ -100,14 +100,18 @@ describe('AppLayout error boundaries: errors in different areas does not crash t
           }
           expect(consoleSpy).toHaveBeenCalled();
           for (const appLayoutPart of appLayoutParts) {
-            expect(sendPanoramaMetricSpy).toHaveBeenCalledWith('awsui-app-layout-error-boundary-fired', {
-              appLayoutPart,
-              errorMessage: expect.any(String),
+            expect(sendPanoramaMetricSpy).toHaveBeenCalledWith({
+              eventContext: 'awsui-app-layout-error-boundary-fired',
+              eventDetail: {
+                appLayoutPart,
+                errorMessage: expect.any(String),
+              },
+              eventValue: '1',
             });
           }
           const reportedParts = sendPanoramaMetricSpy.mock.calls
-            .filter(call => call[0] === 'awsui-app-layout-error-boundary-fired')
-            .map(call => call[1].appLayoutPart);
+            .filter(call => call[0]?.eventContext === 'awsui-app-layout-error-boundary-fired')
+            .map(call => call[0].eventDetail.appLayoutPart);
           expect(reportedParts).toEqual(appLayoutParts);
         };
 
@@ -324,8 +328,7 @@ describe('AppLayout error boundaries: errors in different areas does not crash t
             expect(errorBoundaryWrapper.getElement()).toBeInTheDocument();
             expect(errorBoundaryWrapper.findHeader()).toBeTruthy();
             expect(sendPanoramaMetricSpy).not.toHaveBeenCalledWith(
-              'awsui-app-layout-error-boundary-fired',
-              expect.anything()
+              expect.objectContaining({ eventContext: 'awsui-app-layout-error-boundary-fired' })
             );
             expect(consoleSpy).toHaveBeenCalled();
             expect(onError).toHaveBeenCalled();

--- a/src/app-layout/__tests__/widget-areas-error-boundaries.test.tsx
+++ b/src/app-layout/__tests__/widget-areas-error-boundaries.test.tsx
@@ -66,7 +66,7 @@ beforeEach(() => {
   // masked the exact appLayoutPart values asserted below.
   awsuiPlugins.appLayout.clearRegisteredDrawersForTesting();
   awsuiWidgetInternal.clearInitialMessages();
-  sendPanoramaMetricSpy = jest.spyOn(metrics, 'sendPanoramaMetric').mockImplementation(() => {});
+  sendPanoramaMetricSpy = jest.spyOn(metrics, 'sendOpsMetricObject').mockImplementation(() => {});
 });
 
 describe('AppLayout error boundaries: errors in different areas does not crash the entire app layout', () => {
@@ -100,18 +100,14 @@ describe('AppLayout error boundaries: errors in different areas does not crash t
           }
           expect(consoleSpy).toHaveBeenCalled();
           for (const appLayoutPart of appLayoutParts) {
-            expect(sendPanoramaMetricSpy).toHaveBeenCalledWith({
-              eventContext: 'awsui-app-layout-error-boundary-fired',
-              eventDetail: {
-                appLayoutPart,
-                errorMessage: expect.any(String),
-              },
-              eventValue: '1',
+            expect(sendPanoramaMetricSpy).toHaveBeenCalledWith('awsui-app-layout-error-boundary-fired', {
+              appLayoutPart,
+              errorMessage: expect.any(String),
             });
           }
           const reportedParts = sendPanoramaMetricSpy.mock.calls
-            .filter(call => call[0]?.eventContext === 'awsui-app-layout-error-boundary-fired')
-            .map(call => call[0].eventDetail.appLayoutPart);
+            .filter(call => call[0] === 'awsui-app-layout-error-boundary-fired')
+            .map(call => call[1].appLayoutPart);
           expect(reportedParts).toEqual(appLayoutParts);
         };
 
@@ -328,7 +324,8 @@ describe('AppLayout error boundaries: errors in different areas does not crash t
             expect(errorBoundaryWrapper.getElement()).toBeInTheDocument();
             expect(errorBoundaryWrapper.findHeader()).toBeTruthy();
             expect(sendPanoramaMetricSpy).not.toHaveBeenCalledWith(
-              expect.objectContaining({ eventContext: 'awsui-app-layout-error-boundary-fired' })
+              'awsui-app-layout-error-boundary-fired',
+              expect.anything()
             );
             expect(consoleSpy).toHaveBeenCalled();
             expect(onError).toHaveBeenCalled();

--- a/src/app-layout/__tests__/widget-areas-error-boundaries.test.tsx
+++ b/src/app-layout/__tests__/widget-areas-error-boundaries.test.tsx
@@ -343,3 +343,51 @@ describe('AppLayout error boundaries: errors in different areas does not crash t
     );
   });
 });
+
+describe('AppLayout error boundary detection hooks exposed on the app layout root', () => {
+  const ThrowError = ({ message }: { message: string }) => {
+    throw new Error(message);
+  };
+
+  const getAppLayoutRoot = (container: HTMLElement) => {
+    const root = container.querySelector<HTMLElement>('[data-awsui-app-layout-widget-loaded]');
+    if (!root) {
+      throw new Error('App layout root element not found');
+    }
+    return root;
+  };
+
+  describeEachAppLayout({ themes: ['refresh-toolbar'] }, () => {
+    let consoleSpy: jest.SpyInstance;
+    beforeEach(() => {
+      consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    test('a real boundary catch is recorded and readable via getAppLayoutErrors on the app layout root', () => {
+      const message = `nav failure ${Math.random()}`;
+      const { container } = renderComponent(
+        <AppLayout content={<div>content</div>} navigation={<ThrowError message={message} />} navigationOpen={true} />
+      );
+
+      const root = getAppLayoutRoot(container);
+      expect(typeof root.__awsui__?.getAppLayoutErrors).toBe('function');
+      expect(root.__awsui__!.getAppLayoutErrors!()).toContainEqual({ appLayoutPart: 'before-main-slot', message });
+    });
+
+    test('throwInAppLayoutPart drives a real boundary catch that lands in the registry', () => {
+      const { container } = renderComponent(<AppLayout content={<div>content</div>} />);
+
+      const root = getAppLayoutRoot(container);
+      root.__awsui__!.clearAppLayoutErrors!();
+      act(() => root.__awsui__!.throwInAppLayoutPart!('before-main-slot'));
+
+      expect(root.__awsui__!.getAppLayoutErrors!()).toContainEqual({
+        appLayoutPart: 'before-main-slot',
+        message: '[AwsUiAppLayout] forced test error',
+      });
+    });
+  });
+});

--- a/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
@@ -3,10 +3,11 @@
 import React from 'react';
 import clsx from 'clsx';
 
+import { useMergeRefs } from '@cloudscape-design/component-toolkit/internal';
 import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 import { GeneratedAnalyticsMetadataAppLayoutToolbarComponent } from '../../../app-layout-toolbar/analytics-metadata/interfaces';
-import { BuiltInErrorBoundary } from '../../../error-boundary/internal';
+import { attachAppLayoutErrorBoundaryTestHooks, BuiltInErrorBoundary } from '../../../error-boundary/internal';
 import VisualContext from '../../../internal/components/visual-context';
 import customCssProps from '../../../internal/generated/custom-css-properties';
 import { AppLayoutInternalProps, AppLayoutPendingState } from '../interfaces';
@@ -64,11 +65,16 @@ export const SkeletonLayout = ({
 
   const isWidgetLoaded = isWidgetReady(appLayoutState);
 
+  const rootRef = useMergeRefs(
+    appLayoutState.rootRef as React.Ref<HTMLDivElement>,
+    attachAppLayoutErrorBoundaryTestHooks
+  );
+
   return (
     <VisualContext contextName="app-layout-toolbar">
       <div
         {...getAnalyticsMetadataAttribute({ component: componentAnalyticsMetadata })}
-        ref={appLayoutState.rootRef as React.Ref<HTMLDivElement>}
+        ref={rootRef}
         data-awsui-app-layout-widget-loaded={isWidgetLoaded}
         {...wrapperElAttributes}
         className={

--- a/src/error-boundary/__tests__/error-boundary.test.tsx
+++ b/src/error-boundary/__tests__/error-boundary.test.tsx
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 import ErrorBoundary, { ErrorBoundaryProps } from '../../../lib/components/error-boundary';
 import { BuiltInErrorBoundaryProps } from '../../../lib/components/error-boundary/interfaces';
-import { BuiltInErrorBoundary } from '../../../lib/components/error-boundary/internal';
+import {
+  AppLayoutBuiltInErrorBoundary,
+  attachAppLayoutErrorBoundaryTestHooks,
+  BuiltInErrorBoundary,
+} from '../../../lib/components/error-boundary/internal';
 import TestI18nProvider from '../../../lib/components/i18n/testing';
+import { metrics } from '../../../lib/components/internal/metrics';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
 type RenderProps = Omit<
@@ -707,5 +712,78 @@ describe('component misuse', () => {
     const ErrorBoundaryCustom = ErrorBoundary as React.ComponentType<Omit<ErrorBoundaryProps, 'onError'>>;
     render(<ErrorBoundaryCustom i18nStrings={{ headerText: 'Ooops!' }}>{{}}</ErrorBoundaryCustom>);
     expect(findHeader()!.getElement().textContent).toBe('Ooops!');
+  });
+});
+
+describe('app layout error boundary detection', () => {
+  let hooksEl: HTMLElement;
+  let panoramaSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // The detection hooks are attached to the app layout root element; here we attach them to a
+    // standalone element to exercise the same registry that the app layout root would expose.
+    hooksEl = document.createElement('div');
+    attachAppLayoutErrorBoundaryTestHooks(hooksEl);
+    hooksEl.__awsui__!.clearAppLayoutErrors!();
+    panoramaSpy = jest.spyOn(metrics, 'sendPanoramaMetric').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    hooksEl.__awsui__!.clearAppLayoutErrors!();
+    panoramaSpy.mockRestore();
+  });
+
+  test('records a caught error and exposes it via getAppLayoutErrors', () => {
+    render(
+      <AppLayoutBuiltInErrorBoundary appLayoutPart="nav">
+        <div>{{}}</div>
+      </AppLayoutBuiltInErrorBoundary>
+    );
+    const errors = hooksEl.__awsui__!.getAppLayoutErrors!();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].appLayoutPart).toBe('nav');
+    expect(errors[0].message).toEqual(expect.any(String));
+  });
+
+  test('reports each catch to Panorama with the app layout part', () => {
+    render(
+      <AppLayoutBuiltInErrorBoundary appLayoutPart="tools">
+        <div>{{}}</div>
+      </AppLayoutBuiltInErrorBoundary>
+    );
+    expect(panoramaSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventContext: 'awsui-app-layout-error-boundary-fired',
+        eventDetail: expect.objectContaining({ appLayoutPart: 'tools' }),
+      })
+    );
+  });
+
+  test('throwInAppLayoutPart triggers a real, recorded boundary catch', () => {
+    render(
+      <AppLayoutBuiltInErrorBoundary appLayoutPart="drawer">
+        <div id="al-content">ok</div>
+      </AppLayoutBuiltInErrorBoundary>
+    );
+    expect(createWrapper().find('#al-content')).not.toBe(null);
+    expect(hooksEl.__awsui__!.getAppLayoutErrors!()).toHaveLength(0);
+
+    act(() => hooksEl.__awsui__!.throwInAppLayoutPart!('drawer'));
+
+    expect(createWrapper().find('#al-content')).toBe(null);
+    const errors = hooksEl.__awsui__!.getAppLayoutErrors!();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].appLayoutPart).toBe('drawer');
+  });
+
+  test('clearAppLayoutErrors empties the registry', () => {
+    render(
+      <AppLayoutBuiltInErrorBoundary appLayoutPart="nav">
+        <div>{{}}</div>
+      </AppLayoutBuiltInErrorBoundary>
+    );
+    expect(hooksEl.__awsui__!.getAppLayoutErrors!().length).toBeGreaterThan(0);
+    hooksEl.__awsui__!.clearAppLayoutErrors!();
+    expect(hooksEl.__awsui__!.getAppLayoutErrors!()).toHaveLength(0);
   });
 });

--- a/src/error-boundary/__tests__/error-boundary.test.tsx
+++ b/src/error-boundary/__tests__/error-boundary.test.tsx
@@ -783,4 +783,46 @@ describe('app layout error boundary detection', () => {
     hooksEl.__awsui__!.clearAppLayoutErrors!();
     expect(hooksEl.__awsui__!.getAppLayoutErrors!()).toHaveLength(0);
   });
+
+  test('does not record errors caught by non-app-layout boundaries', () => {
+    render(
+      <ErrorBoundary onError={() => {}}>
+        <BuiltInErrorBoundary>
+          <div>{{}}</div>
+        </BuiltInErrorBoundary>
+      </ErrorBoundary>
+    );
+    expect(hooksEl.__awsui__!.getAppLayoutErrors!()).toHaveLength(0);
+  });
+
+  test('throwInAppLayoutPart fires in every mounted boundary sharing the part', () => {
+    render(
+      <>
+        <AppLayoutBuiltInErrorBoundary appLayoutPart="nav">
+          <div id="nav-1">one</div>
+        </AppLayoutBuiltInErrorBoundary>
+        <AppLayoutBuiltInErrorBoundary appLayoutPart="nav">
+          <div id="nav-2">two</div>
+        </AppLayoutBuiltInErrorBoundary>
+      </>
+    );
+    act(() => hooksEl.__awsui__!.throwInAppLayoutPart!('nav'));
+
+    expect(createWrapper().find('#nav-1')).toBe(null);
+    expect(createWrapper().find('#nav-2')).toBe(null);
+    expect(hooksEl.__awsui__!.getAppLayoutErrors!()).toHaveLength(2);
+  });
+
+  test('attachAppLayoutErrorBoundaryTestHooks is a no-op for a null node', () => {
+    expect(() => attachAppLayoutErrorBoundaryTestHooks(null)).not.toThrow();
+  });
+
+  test('attachAppLayoutErrorBoundaryTestHooks preserves existing __awsui__ hooks', () => {
+    const node = document.createElement('div');
+    const forceError = () => {};
+    node.__awsui__ = { forceError };
+    attachAppLayoutErrorBoundaryTestHooks(node);
+    expect(node.__awsui__!.forceError).toBe(forceError);
+    expect(typeof node.__awsui__!.getAppLayoutErrors).toBe('function');
+  });
 });

--- a/src/error-boundary/__tests__/error-boundary.test.tsx
+++ b/src/error-boundary/__tests__/error-boundary.test.tsx
@@ -717,7 +717,6 @@ describe('component misuse', () => {
 
 describe('app layout error boundary detection', () => {
   let hooksEl: HTMLElement;
-  let panoramaSpy: jest.SpyInstance;
 
   beforeEach(() => {
     // The detection hooks are attached to the app layout root element; here we attach them to a
@@ -725,12 +724,10 @@ describe('app layout error boundary detection', () => {
     hooksEl = document.createElement('div');
     attachAppLayoutErrorBoundaryTestHooks(hooksEl);
     hooksEl.__awsui__!.clearAppLayoutErrors!();
-    panoramaSpy = jest.spyOn(metrics, 'sendPanoramaMetric').mockImplementation(() => {});
   });
 
   afterEach(() => {
     hooksEl.__awsui__!.clearAppLayoutErrors!();
-    panoramaSpy.mockRestore();
   });
 
   test('records a caught error and exposes it via getAppLayoutErrors', () => {
@@ -745,18 +742,18 @@ describe('app layout error boundary detection', () => {
     expect(errors[0].message).toEqual(expect.any(String));
   });
 
-  test('reports each catch to Panorama with the app layout part', () => {
+  test('reports each catch to the ops metric with the app layout part', () => {
+    const opsSpy = jest.spyOn(metrics, 'sendOpsMetricObject').mockImplementation(() => {});
     render(
       <AppLayoutBuiltInErrorBoundary appLayoutPart="tools">
         <div>{{}}</div>
       </AppLayoutBuiltInErrorBoundary>
     );
-    expect(panoramaSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        eventContext: 'awsui-app-layout-error-boundary-fired',
-        eventDetail: expect.objectContaining({ appLayoutPart: 'tools' }),
-      })
+    expect(opsSpy).toHaveBeenCalledWith(
+      'awsui-app-layout-error-boundary-fired',
+      expect.objectContaining({ appLayoutPart: 'tools' })
     );
+    opsSpy.mockRestore();
   });
 
   test('throwInAppLayoutPart triggers a real, recorded boundary catch', () => {

--- a/src/error-boundary/internal.tsx
+++ b/src/error-boundary/internal.tsx
@@ -178,13 +178,9 @@ export function AppLayoutBuiltInErrorBoundary({
       onError={error => {
         context?.onError?.(error);
         recordAppLayoutError({ appLayoutPart: appLayoutPart ?? '', message: error?.error?.message ?? '' });
-        metrics.sendPanoramaMetric({
-          eventContext: 'awsui-app-layout-error-boundary-fired',
-          eventDetail: {
-            errorMessage: error?.error?.message ?? '',
-            appLayoutPart: appLayoutPart ?? '',
-          },
-          eventValue: '1',
+        metrics.sendOpsMetricObject('awsui-app-layout-error-boundary-fired', {
+          errorMessage: error?.error?.message ?? '',
+          appLayoutPart: appLayoutPart ?? '',
         });
       }}
     >

--- a/src/error-boundary/internal.tsx
+++ b/src/error-boundary/internal.tsx
@@ -7,6 +7,8 @@ import { useMergeRefs } from '@cloudscape-design/component-toolkit/internal';
 
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { metrics } from '../internal/metrics';
+import { awsuiPluginsInternal } from '../internal/plugins/api';
+import { AppLayoutErrorEntry } from '../internal/plugins/controllers/error-boundary';
 import { SomeRequired } from '../internal/types';
 import { ErrorBoundaryFallback } from './fallback';
 import { AppLayoutBuiltInErrorBoundaryProps, BuiltInErrorBoundaryProps, ErrorBoundaryProps } from './interfaces';
@@ -26,34 +28,9 @@ declare global {
   }
 }
 
-export interface AppLayoutErrorEntry {
-  appLayoutPart: string;
-  message: string;
-}
-
-// Errors caught by app layout built-in error boundaries, recorded so integration/canary tests can assert
-// on real boundary catches instead of scraping the console. A single shared buffer across all app layouts
-// on the page, capped so it never grows unbounded.
-const MAX_RECORDED_APP_LAYOUT_ERRORS = 50;
-const appLayoutErrors: AppLayoutErrorEntry[] = [];
-
-function recordAppLayoutError(entry: AppLayoutErrorEntry) {
-  appLayoutErrors.push(entry);
-  if (appLayoutErrors.length > MAX_RECORDED_APP_LAYOUT_ERRORS) {
-    appLayoutErrors.shift();
-  }
-}
-
-function getAppLayoutErrors(): ReadonlyArray<AppLayoutErrorEntry> {
-  return appLayoutErrors.slice();
-}
-
-function clearAppLayoutErrors() {
-  appLayoutErrors.length = 0;
-}
-
 // Forces a real render throw in every mounted boundary for a given part. The resulting catch is not
-// recoverable (React latches the boundary), so the canary reloads between checks.
+// recoverable (React latches the boundary), so it has no reset counterpart — the canary reloads between
+// checks. Kept local (not on the shared plugin API) so a throw never reaches boundaries in other frames.
 const forcedThrowSetters = new Map<string, Set<(forced: boolean) => void>>();
 
 function throwInAppLayoutPart(appLayoutPart: string) {
@@ -75,8 +52,8 @@ export function attachAppLayoutErrorBoundaryTestHooks(node: HTMLElement | null) 
   if (!node.__awsui__) {
     node.__awsui__ = {};
   }
-  node.__awsui__.getAppLayoutErrors = getAppLayoutErrors;
-  node.__awsui__.clearAppLayoutErrors = clearAppLayoutErrors;
+  node.__awsui__.getAppLayoutErrors = awsuiPluginsInternal.errorBoundary.getErrors;
+  node.__awsui__.clearAppLayoutErrors = awsuiPluginsInternal.errorBoundary.clearErrors;
   node.__awsui__.throwInAppLayoutPart = throwInAppLayoutPart;
 }
 
@@ -159,7 +136,6 @@ export function AppLayoutBuiltInErrorBoundary({
   const thisSuppressed = context.suppressed === true || context.suppressed === RootSuppressed;
   const nextSuppressed = suppressNested || thisSuppressed;
 
-  // Test-only: allow the canary positive-control to force a real throw inside this boundary.
   const [forcedThrow, setForcedThrow] = useState(false);
   useEffect(() => {
     if (!appLayoutPart) {
@@ -187,7 +163,10 @@ export function AppLayoutBuiltInErrorBoundary({
       className={styles['app-layout-part-fallback']}
       onError={error => {
         context?.onError?.(error);
-        recordAppLayoutError({ appLayoutPart: appLayoutPart ?? '', message: error?.error?.message ?? '' });
+        awsuiPluginsInternal.errorBoundary.recordError({
+          appLayoutPart: appLayoutPart ?? '',
+          message: error?.error?.message ?? '',
+        });
         metrics.sendOpsMetricObject('awsui-app-layout-error-boundary-fired', {
           errorMessage: error?.error?.message ?? '',
           appLayoutPart: appLayoutPart ?? '',

--- a/src/error-boundary/internal.tsx
+++ b/src/error-boundary/internal.tsx
@@ -19,7 +19,6 @@ declare global {
     __awsui__?: {
       forceError?(): void;
       clearForcedError?(): void;
-      // App layout error-boundary detection hooks (see attachAppLayoutErrorBoundaryTestHooks).
       getAppLayoutErrors?(): ReadonlyArray<AppLayoutErrorEntry>;
       clearAppLayoutErrors?(): void;
       throwInAppLayoutPart?(appLayoutPart: string): void;
@@ -32,12 +31,17 @@ export interface AppLayoutErrorEntry {
   message: string;
 }
 
-// Errors caught by app layout built-in error boundaries, recorded so that integration/canary tests
-// can assert on real boundary catches instead of scraping the console. Not for production consumption.
+// Errors caught by app layout built-in error boundaries, recorded so integration/canary tests can assert
+// on real boundary catches instead of scraping the console. A single shared buffer across all app layouts
+// on the page, capped so it never grows unbounded.
+const MAX_RECORDED_APP_LAYOUT_ERRORS = 50;
 const appLayoutErrors: AppLayoutErrorEntry[] = [];
 
 function recordAppLayoutError(entry: AppLayoutErrorEntry) {
   appLayoutErrors.push(entry);
+  if (appLayoutErrors.length > MAX_RECORDED_APP_LAYOUT_ERRORS) {
+    appLayoutErrors.shift();
+  }
 }
 
 function getAppLayoutErrors(): ReadonlyArray<AppLayoutErrorEntry> {
@@ -48,13 +52,12 @@ function clearAppLayoutErrors() {
   appLayoutErrors.length = 0;
 }
 
-// Per-part trigger that forces a real render throw inside the matching app layout boundary. Used by the
-// production canary positive-control test to verify that a genuine caught error is still detectable. The
-// resulting catch is not recoverable (React latches the boundary), so the canary reloads between checks.
-const forcedThrowSetters = new Map<string, (forced: boolean) => void>();
+// Forces a real render throw in every mounted boundary for a given part. The resulting catch is not
+// recoverable (React latches the boundary), so the canary reloads between checks.
+const forcedThrowSetters = new Map<string, Set<(forced: boolean) => void>>();
 
 function throwInAppLayoutPart(appLayoutPart: string) {
-  forcedThrowSetters.get(appLayoutPart)?.(true);
+  forcedThrowSetters.get(appLayoutPart)?.forEach(setForced => setForced(true));
 }
 
 function ForcedTestError(): null {
@@ -62,9 +65,8 @@ function ForcedTestError(): null {
 }
 
 /**
- * Attaches the app layout error-boundary detection hooks to a DOM element (the app layout root).
- * These are test-only helpers: integration/canary tests read caught errors via `getAppLayoutErrors`
- * and can trigger a real, boundary-caught throw via `throwInAppLayoutPart`.
+ * Attaches test-only error-boundary detection hooks to the app layout root element. Used by
+ * integration/canary tests, not production.
  */
 export function attachAppLayoutErrorBoundaryTestHooks(node: HTMLElement | null) {
   if (!node) {
@@ -163,9 +165,17 @@ export function AppLayoutBuiltInErrorBoundary({
     if (!appLayoutPart) {
       return;
     }
-    forcedThrowSetters.set(appLayoutPart, setForcedThrow);
+    let setters = forcedThrowSetters.get(appLayoutPart);
+    if (!setters) {
+      setters = new Set();
+      forcedThrowSetters.set(appLayoutPart, setters);
+    }
+    setters.add(setForcedThrow);
     return () => {
-      forcedThrowSetters.delete(appLayoutPart);
+      setters.delete(setForcedThrow);
+      if (setters.size === 0) {
+        forcedThrowSetters.delete(appLayoutPart);
+      }
     };
   }, [appLayoutPart]);
 

--- a/src/error-boundary/internal.tsx
+++ b/src/error-boundary/internal.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { Component, createContext, useContext, useState } from 'react';
+import React, { Component, createContext, useContext, useEffect, useState } from 'react';
 
 import { useMergeRefs } from '@cloudscape-design/component-toolkit/internal';
 
@@ -16,8 +16,66 @@ import styles from './styles.css.js';
 // Helper methods attached to the component's root node for e2e testing.
 declare global {
   interface HTMLElement {
-    __awsui__?: { forceError?(): void; clearForcedError?(): void };
+    __awsui__?: {
+      forceError?(): void;
+      clearForcedError?(): void;
+      // App layout error-boundary detection hooks (see attachAppLayoutErrorBoundaryTestHooks).
+      getAppLayoutErrors?(): ReadonlyArray<AppLayoutErrorEntry>;
+      clearAppLayoutErrors?(): void;
+      throwInAppLayoutPart?(appLayoutPart: string): void;
+    };
   }
+}
+
+export interface AppLayoutErrorEntry {
+  appLayoutPart: string;
+  message: string;
+}
+
+// Errors caught by app layout built-in error boundaries, recorded so that integration/canary tests
+// can assert on real boundary catches instead of scraping the console. Not for production consumption.
+const appLayoutErrors: AppLayoutErrorEntry[] = [];
+
+function recordAppLayoutError(entry: AppLayoutErrorEntry) {
+  appLayoutErrors.push(entry);
+}
+
+function getAppLayoutErrors(): ReadonlyArray<AppLayoutErrorEntry> {
+  return appLayoutErrors.slice();
+}
+
+function clearAppLayoutErrors() {
+  appLayoutErrors.length = 0;
+}
+
+// Per-part trigger that forces a real render throw inside the matching app layout boundary. Used by the
+// production canary positive-control test to verify that a genuine caught error is still detectable. The
+// resulting catch is not recoverable (React latches the boundary), so the canary reloads between checks.
+const forcedThrowSetters = new Map<string, (forced: boolean) => void>();
+
+function throwInAppLayoutPart(appLayoutPart: string) {
+  forcedThrowSetters.get(appLayoutPart)?.(true);
+}
+
+function ForcedTestError(): null {
+  throw new Error('[AwsUiAppLayout] forced test error');
+}
+
+/**
+ * Attaches the app layout error-boundary detection hooks to a DOM element (the app layout root).
+ * These are test-only helpers: integration/canary tests read caught errors via `getAppLayoutErrors`
+ * and can trigger a real, boundary-caught throw via `throwInAppLayoutPart`.
+ */
+export function attachAppLayoutErrorBoundaryTestHooks(node: HTMLElement | null) {
+  if (!node) {
+    return;
+  }
+  if (!node.__awsui__) {
+    node.__awsui__ = {};
+  }
+  node.__awsui__.getAppLayoutErrors = getAppLayoutErrors;
+  node.__awsui__.clearAppLayoutErrors = clearAppLayoutErrors;
+  node.__awsui__.throwInAppLayoutPart = throwInAppLayoutPart;
 }
 
 const RootSuppressed = Symbol();
@@ -98,6 +156,19 @@ export function AppLayoutBuiltInErrorBoundary({
   const context = useContext(ErrorBoundariesContext);
   const thisSuppressed = context.suppressed === true || context.suppressed === RootSuppressed;
   const nextSuppressed = suppressNested || thisSuppressed;
+
+  // Test-only: allow the canary positive-control to force a real throw inside this boundary.
+  const [forcedThrow, setForcedThrow] = useState(false);
+  useEffect(() => {
+    if (!appLayoutPart) {
+      return;
+    }
+    forcedThrowSetters.set(appLayoutPart, setForcedThrow);
+    return () => {
+      forcedThrowSetters.delete(appLayoutPart);
+    };
+  }, [appLayoutPart]);
+
   return (
     <ErrorBoundaryImpl
       {...context}
@@ -106,13 +177,19 @@ export function AppLayoutBuiltInErrorBoundary({
       className={styles['app-layout-part-fallback']}
       onError={error => {
         context?.onError?.(error);
-        metrics.sendOpsMetricObject('awsui-app-layout-error-boundary-fired', {
-          errorMessage: error?.error?.message ?? '',
-          appLayoutPart: appLayoutPart ?? '',
+        recordAppLayoutError({ appLayoutPart: appLayoutPart ?? '', message: error?.error?.message ?? '' });
+        metrics.sendPanoramaMetric({
+          eventContext: 'awsui-app-layout-error-boundary-fired',
+          eventDetail: {
+            errorMessage: error?.error?.message ?? '',
+            appLayoutPart: appLayoutPart ?? '',
+          },
+          eventValue: '1',
         });
       }}
     >
       <ErrorBoundariesContext.Provider value={{ ...context, suppressed: nextSuppressed, renderFallback }}>
+        {forcedThrow && <ForcedTestError />}
         {children}
       </ErrorBoundariesContext.Provider>
     </ErrorBoundaryImpl>

--- a/src/internal/plugins/__tests__/api.test.ts
+++ b/src/internal/plugins/__tests__/api.test.ts
@@ -67,6 +67,15 @@ test('partial API can be extended', () => {
   expect(api.awsuiPluginsInternal.alert).toBeDefined();
 });
 
+test('errorBoundary controller is reused across loadApi calls, aggregating recorded errors', () => {
+  const api1 = loadApi();
+  api1.awsuiPluginsInternal.errorBoundary.recordError({ appLayoutPart: 'nav', message: 'boom' });
+
+  const api2 = loadApi();
+  expect(api2.awsuiPluginsInternal.errorBoundary.getErrors()).toContainEqual({ appLayoutPart: 'nav', message: 'boom' });
+  expect(api2.awsuiPluginsInternal.errorBoundary.recordError).toBe(api1.awsuiPluginsInternal.errorBoundary.recordError);
+});
+
 describe('usage metrics', () => {
   let sendPanoramaMetricSpy: jest.SpyInstance;
   beforeEach(() => {

--- a/src/internal/plugins/api.ts
+++ b/src/internal/plugins/api.ts
@@ -10,6 +10,7 @@ import {
 import { AppLayoutWidgetApiInternal, AppLayoutWidgetController } from './controllers/app-layout-widget';
 import { BreadcrumbsApiInternal, BreadcrumbsController } from './controllers/breadcrumbs';
 import { DrawersApiInternal, DrawersApiPublic, DrawersController } from './controllers/drawers';
+import { ErrorBoundaryApiInternal, ErrorBoundaryController } from './controllers/error-boundary';
 import { SharedReactContexts, SharedReactContextsApiInternal } from './controllers/shared-react-contexts';
 import { reportRuntimeApiLoadMetric } from './helpers/metrics';
 
@@ -31,6 +32,7 @@ interface AwsuiApi {
     flashbar: ActionsApiInternal;
     flashContent: AlertFlashContentApiInternal;
     breadcrumbs: BreadcrumbsApiInternal<BreadcrumbGroupProps>;
+    errorBoundary: ErrorBoundaryApiInternal;
     sharedReactContexts: SharedReactContextsApiInternal;
   };
 }
@@ -105,6 +107,9 @@ function installApi(api: DeepPartial<AwsuiApi>): AwsuiApi {
 
   const breadcrumbs = new BreadcrumbsController<BreadcrumbGroupProps>();
   api.awsuiPluginsInternal.breadcrumbs = breadcrumbs.installInternal(api.awsuiPluginsInternal.breadcrumbs);
+
+  const errorBoundary = new ErrorBoundaryController();
+  api.awsuiPluginsInternal.errorBoundary = errorBoundary.installInternal(api.awsuiPluginsInternal.errorBoundary);
 
   const sharedReactContexts = new SharedReactContexts();
   api.awsuiPluginsInternal.sharedReactContexts = sharedReactContexts.installInternal(

--- a/src/internal/plugins/controllers/__tests__/error-boundary.test.ts
+++ b/src/internal/plugins/controllers/__tests__/error-boundary.test.ts
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ErrorBoundaryController } from '../../../../../lib/components/internal/plugins/controllers/error-boundary';
+
+test('getErrors returns recorded errors as an independent copy', () => {
+  const controller = new ErrorBoundaryController();
+  controller.recordError({ appLayoutPart: 'nav', message: 'boom' });
+
+  const errors = controller.getErrors();
+  expect(errors).toEqual([{ appLayoutPart: 'nav', message: 'boom' }]);
+
+  (errors as Array<unknown>).push({ appLayoutPart: 'x', message: 'y' });
+  expect(controller.getErrors()).toHaveLength(1);
+});
+
+test('clearErrors empties the buffer', () => {
+  const controller = new ErrorBoundaryController();
+  controller.recordError({ appLayoutPart: 'nav', message: 'boom' });
+  controller.clearErrors();
+  expect(controller.getErrors()).toEqual([]);
+});
+
+test('the buffer is capped and evicts oldest entries first', () => {
+  const controller = new ErrorBoundaryController();
+  for (let i = 0; i < 60; i++) {
+    controller.recordError({ appLayoutPart: 'nav', message: `error-${i}` });
+  }
+
+  const errors = controller.getErrors();
+  expect(errors).toHaveLength(50);
+  expect(errors[0]).toEqual({ appLayoutPart: 'nav', message: 'error-10' });
+  expect(errors[49]).toEqual({ appLayoutPart: 'nav', message: 'error-59' });
+});
+
+test('installInternal backfills missing methods without overwriting existing ones', () => {
+  const controller = new ErrorBoundaryController();
+  const existingRecordError = jest.fn();
+
+  const api = controller.installInternal({ recordError: existingRecordError });
+
+  expect(api.recordError).toBe(existingRecordError);
+  expect(api.getErrors).toBe(controller.getErrors);
+  expect(api.clearErrors).toBe(controller.clearErrors);
+});

--- a/src/internal/plugins/controllers/error-boundary.ts
+++ b/src/internal/plugins/controllers/error-boundary.ts
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export interface AppLayoutErrorEntry {
+  appLayoutPart: string;
+  message: string;
+}
+
+export interface ErrorBoundaryApiInternal {
+  recordError: (entry: AppLayoutErrorEntry) => void;
+  getErrors: () => ReadonlyArray<AppLayoutErrorEntry>;
+  clearErrors: () => void;
+}
+
+const MAX_RECORDED_ERRORS = 50;
+
+// Aggregates app layout error-boundary catches so integration/canary tests can assert on real boundary
+// catches instead of scraping the console. Installed on the plugin API, so every same-origin frame
+// resolves to the one instance on the top window and errors from child iframes funnel to a single place.
+export class ErrorBoundaryController {
+  #errors: Array<AppLayoutErrorEntry> = [];
+
+  recordError = (entry: AppLayoutErrorEntry) => {
+    this.#errors.push(entry);
+    if (this.#errors.length > MAX_RECORDED_ERRORS) {
+      this.#errors.shift();
+    }
+  };
+
+  getErrors = (): ReadonlyArray<AppLayoutErrorEntry> => this.#errors.slice();
+
+  clearErrors = () => {
+    this.#errors.length = 0;
+  };
+
+  installInternal(internalApi: Partial<ErrorBoundaryApiInternal> = {}): ErrorBoundaryApiInternal {
+    internalApi.recordError ??= this.recordError;
+    internalApi.getErrors ??= this.getErrors;
+    internalApi.clearErrors ??= this.clearErrors;
+
+    return internalApi as ErrorBoundaryApiInternal;
+  }
+}


### PR DESCRIPTION
## Summary

Lets our integration/canary tests detect errors that an App Layout error boundary caught.

## What changed

- **Record + expose caught errors.** `AppLayoutBuiltInErrorBoundary` records each caught error (`{ appLayoutPart, message }`) into a bounded module registry. A new `getAppLayoutErrors()` / `clearAppLayoutErrors()` accessor is exposed on the App Layout root element's `__awsui__` (via `attachAppLayoutErrorBoundaryTestHooks`, wired through the skeleton root ref). No console logging — teams that wrap App Layout in their own `<ErrorBoundary>` keep errors handled quietly, and the signal is a passive DOM query invisible to users.
- **Production positive-control hook.** Adds a test-only `throwInAppLayoutPart(part)` that forces a *genuine* boundary catch, so a canary can verify — against the real minified prod bundle — that detection still works and hasn't been broken by a build change. It fans out to every mounted boundary for the part, so multiple App Layouts on one page do not clobber each other.

## Testing

- Unit tests in `error-boundary.test.tsx`: records + exposes errors, `throwInAppLayoutPart` triggers a real recorded catch, `clearAppLayoutErrors`, `attach` no-ops on null and merges (does not clobber) an existing `__awsui__`, a non-app-layout boundary catch is not recorded, and multi-instance fan-out.
- Integration tests in `widget-areas-error-boundaries.test.tsx` that go through the real skeleton-wired App Layout root element: a genuine boundary catch is readable via `getAppLayoutErrors()`, and `throwInAppLayoutPart` drives a real catch into the registry.
- eslint + prettier clean; quick-build clean.
