### PR TITLE
fix: disable jump-to-page control when pagination is disabled

### DIFF
--- a/pages/pagination/permutations.page.tsx
+++ b/pages/pagination/permutations.page.tsx
@@ -23,6 +23,7 @@ const permutations = createPermutations<PaginationProps>([
     pagesCount: [15],
     disabled: [true],
     ariaLabels: [paginationLabels],
+    jumpToPage: [undefined, { loading: false }],
   },
   {
     currentPageIndex: [1, 6, 15],

--- a/src/pagination/__tests__/pagination.test.tsx
+++ b/src/pagination/__tests__/pagination.test.tsx
@@ -310,6 +310,15 @@ describe('jump to page', () => {
     expect(wrapper.findJumpToPageButton()).toBeTruthy();
   });
 
+  test('should disable jump to page input and button when pagination is disabled', () => {
+    const { wrapper } = renderPagination(
+      <Pagination currentPageIndex={1} pagesCount={10} disabled={true} jumpToPage={{}} />
+    );
+
+    expect(wrapper.findJumpToPageInput()!.findNativeInput().getElement()).toBeDisabled();
+    expect(wrapper.findJumpToPageButton()!.getElement()).toBeDisabled();
+  });
+
   test('should not render jump to page when jumpToPage is not provided', () => {
     const { wrapper } = renderPagination(<Pagination currentPageIndex={1} pagesCount={10} />);
 

--- a/src/pagination/internal.tsx
+++ b/src/pagination/internal.tsx
@@ -221,13 +221,14 @@ const InternalPagination = React.forwardRef(
         loadingText={jumpToPageLoadingText}
         ariaLabel={jumpToPage?.loading ? jumpToPageLoadingText : jumpToPageButtonLabel}
         onClick={() => handleJumpToPageClick(Number(jumpToPageValue))}
-        disabled={!jumpToPageValue || Number(jumpToPageValue) === currentPageIndex}
+        disabled={disabled || !jumpToPageValue || Number(jumpToPageValue) === currentPageIndex}
       />
     );
 
     return (
       <ul
         aria-label={paginationLabel}
+        aria-disabled={disabled}
         {...baseProps}
         className={clsx(baseProps.className, styles.root, disabled && styles['root-disabled'])}
         ref={__internalRootRef}
@@ -300,6 +301,7 @@ const InternalPagination = React.forwardRef(
                   ref={jumpToPageInputRef}
                   type="number"
                   value={jumpToPageValue}
+                  disabled={disabled}
                   __inlineLabelText={jumpToPageLabel || undefined}
                   __fullWidth={true}
                   ariaLabel={jumpToPageLabel || undefined}

--- a/src/pagination/internal.tsx
+++ b/src/pagination/internal.tsx
@@ -228,7 +228,6 @@ const InternalPagination = React.forwardRef(
     return (
       <ul
         aria-label={paginationLabel}
-        aria-disabled={disabled}
         {...baseProps}
         className={clsx(baseProps.className, styles.root, disabled && styles['root-disabled'])}
         ref={__internalRootRef}


### PR DESCRIPTION
### Description
When `disabled` was set, the arrows and page buttons were disabled but the jump-to-page input and go-button stayed interactive, so users could still navigate. Disable both, and mark the root `aria-disabled` so the whole control is conveyed as disabled. Adds a unit test.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-62134

### How has this been tested?
Using unit test and dev pages locally

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
