### PR TITLE
chore: Apply font smoothing inheritance to link variants

### DIFF
--- a/src/internal/styles/links.scss
+++ b/src/internal/styles/links.scss
@@ -59,6 +59,8 @@
 /* Style used for links in slots/components that are text heavy, to help links stand out among
 surrounding text. (WCAG F73) https://www.w3.org/WAI/WCAG21/Techniques/failures/F73#description */
 @mixin link-inline($font-size: 'inherit') {
+  -webkit-font-smoothing: inherit;
+  -moz-osx-font-smoothing: inherit;
   @include link-font-size-style(map.get(constants.$link-font-sizes, $font-size));
   @include link-variant-style(map.get(constants.$link-variants, 'primary'));
 }

--- a/src/link/styles.scss
+++ b/src/link/styles.scss
@@ -28,7 +28,7 @@
       @if $variant == 'info' or $variant == 'top-navigation' {
         @include styles.font-smoothing;
       }
-      @if $variant == 'secondary' {
+      @if $variant == 'secondary' or $variant == 'primary' {
         -webkit-font-smoothing: inherit;
         -moz-osx-font-smoothing: inherit;
       }


### PR DESCRIPTION
### Description
The `font-smooth: inherit` style was previously applied only to the secondary link variant, resulting in inconsistent text rendering between the primary and secondary links. This PR extends the same `font-smooth: inherit` behavior to the primary link variant for a consistent appearance.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
