### PR TITLE
chore: Log app layout error-boundary catches

### DIFF
--- a/src/app-layout/__tests__/widget-areas-error-boundaries.test.tsx
+++ b/src/app-layout/__tests__/widget-areas-error-boundaries.test.tsx
@@ -87,6 +87,7 @@ describe('AppLayout error boundaries: errors in different areas does not crash t
       (wrappedWithErrorBoundary: boolean) => {
         const onError = jest.fn();
         const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
         const AppLayoutWrapper = wrappedWithErrorBoundary ? ErrorBoundary : 'div';
         const appLayoutWrapperProps = wrappedWithErrorBoundary ? { onError } : {};
         const content = <div>content</div>;
@@ -104,6 +105,10 @@ describe('AppLayout error boundaries: errors in different areas does not crash t
               appLayoutPart,
               errorMessage: expect.any(String),
             });
+            expect(consoleLogSpy).toHaveBeenCalledWith(
+              `[AwsUiAppLayoutError] appLayoutPart=${appLayoutPart}`,
+              expect.anything()
+            );
           }
           const reportedParts = sendPanoramaMetricSpy.mock.calls
             .filter(call => call[0] === 'awsui-app-layout-error-boundary-fired')

--- a/src/error-boundary/internal.tsx
+++ b/src/error-boundary/internal.tsx
@@ -110,6 +110,7 @@ export function AppLayoutBuiltInErrorBoundary({
           errorMessage: error?.error?.message ?? '',
           appLayoutPart: appLayoutPart ?? '',
         });
+        console.log(`[AwsUiAppLayoutError] appLayoutPart=${appLayoutPart ?? ''}`, error?.error);
       }}
     >
       <ErrorBoundariesContext.Provider value={{ ...context, suppressed: nextSuppressed, renderFallback }}>


### PR DESCRIPTION
## Summary

App layout error boundaries now emit a fixed `[AwsUiAppLayoutError]` prefix to the console on each catch. This lets the integration/canary tests detect real App Layout breakage by matching the prefix, instead of maintaining an allowlist of every other service's console noise. The prefix is a string literal, so it survives minification.

## Testing

Unit tests assert the marker fires per app layout part on a real boundary catch. quick-build, unit suites, and lint all pass.
