### PR TITLE
feat: Add usage metrics for table skeleton loading prop

### DIFF
--- a/src/table/index.tsx
+++ b/src/table/index.tsx
@@ -54,6 +54,8 @@ const Table = React.forwardRef(
         metadata: {
           expandableRows: !!props.expandableRows,
           progressiveLoading: !!props.getLoadingStatus,
+          hasSkeleton: !!props.skeleton,
+          skeletonTotalRows: props.skeleton?.totalRows ?? null,
           groupSelection: !!props.expandableRows?.groupSelection,
           columnGroups: !!props.groupDefinitions?.length,
           columnGroupsDepth: getColumnGroupsDepth(props.columnDisplay),


### PR DESCRIPTION
Adds two analytics `metadata` fields to the Table component so we can report on adoption of the skeleton loading feature:

- `hasSkeleton` — whether the `skeleton` prop is configured (adoption signal; parallels the existing `progressiveLoading` metadata).
- `skeletonTotalRows` — the configured `totalRows` value, or `null` (config-value distribution).

These measure configuration/intent, consistent with existing metadata like `hasPersistenceConfig`.
