### PR TITLE
fix: Fixes actions wrapping in item card component

### DIFF
--- a/pages/item-card/common.tsx
+++ b/pages/item-card/common.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import clsx from 'clsx';
 
 import { Box, Button, Icon } from '~components';
+import Badge from '~components/badge';
 import ButtonGroup from '~components/button-group';
 import FormField from '~components/form-field';
 import Input from '~components/input';
@@ -78,6 +79,13 @@ export const actions = (
       { type: 'icon-button', id: 'delete', iconName: 'remove', text: 'Delete' },
     ]}
   />
+);
+
+export const wideActions = (
+  <SpaceBetween direction="horizontal" size="xs" alignItems="center">
+    <Badge color="grey">status</Badge>
+    <Button variant="normal">Action</Button>
+  </SpaceBetween>
 );
 
 export const icon = <Icon name="settings"></Icon>;

--- a/pages/item-card/permutations.page.tsx
+++ b/pages/item-card/permutations.page.tsx
@@ -18,6 +18,7 @@ import {
   shortDescription,
   shortFooter,
   shortHeader,
+  wideActions,
 } from './common';
 
 /* Content slot combinations: header, description, children, footer, actions, icon */
@@ -56,6 +57,13 @@ const permutations = createPermutations<ItemCardProps>([
     children: [longContent],
     actions: [actions, undefined],
     description: [longDescription],
+  },
+  // With wide actions and long header
+  {
+    header: [longHeader],
+    description: [shortDescription, undefined],
+    children: [longContent],
+    actions: [wideActions],
   },
   // Minimal: content only
   {

--- a/src/item-card/internal.tsx
+++ b/src/item-card/internal.tsx
@@ -77,7 +77,7 @@ export default function InternalItemCard({
               icon={icon && <div className={testStyles.icon}>{icon}</div>}
               actions={actions}
               disablePaddings={disableHeaderPaddings}
-              wrapActions={false}
+              wrapActions={true}
             />
           </div>
         )}


### PR DESCRIPTION
### Description

Allows item card actions to wrap. This prevents long actions from taking the entire header space - causing header text to wrap too much.

The wrap actions behaviour is a better default as it prevents card height from exploding in case both header text and actions are wide. At the same time, there might be a use case for wrap=false in case the actions are small (1-2 icon buttons), and the preference is to keep them on the same line. This can be addressed by introducing `wrapActions` flag, if requested.

Rel: AWSUI-62141

Before:

<img width="379" height="204" alt="Screenshot 2026-07-10 at 08 00 29" src="https://github.com/user-attachments/assets/389514c4-24e4-4bca-98d1-3e283236b771" />

<img width="379" height="229" alt="Screenshot 2026-07-10 at 08 00 42" src="https://github.com/user-attachments/assets/721d252f-d18e-4fe1-9a2e-bb7e2263b537" />

After:

<img width="379" height="229" alt="Screenshot 2026-07-10 at 08 01 08" src="https://github.com/user-attachments/assets/20b70d7e-46ea-474d-a4db-7c7348f43bb5" />

<img width="379" height="215" alt="Screenshot 2026-07-10 at 08 01 22" src="https://github.com/user-attachments/assets/547647c1-170b-447f-8e74-d35ebd61d329" />


### How has this been tested?

* New permutations - already covered with screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
