### PR TITLE
fix: resolve external <label for> for CollectionPreferences toggle analytics label

### DIFF
--- a/src/collection-preferences/__tests__/analytics-metadata.test.tsx
+++ b/src/collection-preferences/__tests__/analytics-metadata.test.tsx
@@ -326,6 +326,28 @@ describe('CollectionPreferences renders correct analytics metadata', () => {
       expect(getGeneratedAnalyticsMetadata(area)).toEqual(getMetadata({}, 'visibleContent'));
     });
 
+    test('resolves the column label for a visibleContent option toggle', () => {
+      const wrapper = renderCollectionPreferences({
+        visibleContentPreference,
+      });
+
+      wrapper.findTriggerButton().click();
+
+      const area = wrapper
+        .findModal()!
+        .findVisibleContentPreference()!
+        .findToggleByIndex(1, 2)!
+        .findNativeInput()
+        .getElement();
+      expect(getGeneratedAnalyticsMetadata(area)).toEqual({
+        action: 'select',
+        detail: {
+          label: 'Domain name',
+        },
+        ...getMetadata({}, 'visibleContent'),
+      });
+    });
+
     test('with contentDisplay preference', () => {
       const wrapper = renderCollectionPreferences({
         contentDisplayPreference,

--- a/src/internal/components/abstract-switch/index.tsx
+++ b/src/internal/components/abstract-switch/index.tsx
@@ -7,6 +7,7 @@ import { useUniqueId } from '@cloudscape-design/component-toolkit/internal';
 import {
   getAnalyticsLabelAttribute,
   getAnalyticsMetadataAttribute,
+  LabelIdentifier,
 } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 import customCssProps from '../../../internal/generated/custom-css-properties';
@@ -97,6 +98,13 @@ export default function AbstractSwitch({
     ariaDescriptions.push(descriptionId);
   }
 
+  // Resolve the interaction label from the associated `<label for>` when there is no inline label, for example when used in collection preferences.
+  const interactionLabel: string | LabelIdentifier = label
+    ? `.${analyticsSelectors.label}`
+    : !ariaLabel && !ariaLabelledby && controlId
+      ? { root: 'body', selector: `label[for="${controlId}"]` }
+      : `.${analyticsSelectors['native-input']}`;
+
   return (
     <span
       {...rest}
@@ -114,7 +122,7 @@ export default function AbstractSwitch({
             : {
                 action: 'select',
                 detail: {
-                  label: label ? `.${analyticsSelectors.label}` : `.${analyticsSelectors['native-input']}`,
+                  label: interactionLabel,
                 },
               }
         )}


### PR DESCRIPTION
### Description

`CollectionPreferences` visible-content / content-display option toggles emitted an empty `autoCaptureLabel` because their label is an external `<label for>` and `AbstractSwitch` pointed `detail.label` at the label-less native input. Point it directly at the associated `<label for>` element so its text is captured. Inline-label and aria-labelled switches are unchanged.

(component-toolkit#228 added `input.id → label[for]` resolution to `getLabelFromElement`, but production auto-capture doesn't use that path, so resolving the label element directly is needed.)

Related links, issue #, if available: component-toolkit#228

### How has this been tested?

`src/collection-preferences/__tests__/analytics-metadata.test.tsx` asserts a visible-content option toggle emits `detail.label: 'Domain name'`. All collection-preferences analytics and toggle/checkbox/radio/abstract-switch unit tests pass.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
