### PR TITLE
fix: Prevent HelpPanel content from clipping at drawer bottom edge

### DIFF
--- a/src/help-panel/styles.scss
+++ b/src/help-panel/styles.scss
@@ -10,7 +10,12 @@
   @include styles.styles-reset;
   word-wrap: break-word;
   padding-block-start: awsui.$space-panel-header-vertical;
-  padding-block-end: 0;
+  // Reserve the bottom whitespace as padding on the panel root rather than as a
+  // margin on the last child. A descendant's block-end margin is not added to an
+  // ancestor scroll container's scrollable region, so when the panel is rendered
+  // inside a fixed-height, scrollable app-layout drawer the trailing margin gets
+  // clipped and the content sits flush against the bottom edge.
+  padding-block-end: awsui.$space-panel-content-bottom;
 
   /* stylelint-disable @cloudscape-design/no-implicit-descendant, selector-max-type */
   hr {
@@ -81,11 +86,6 @@
     margin-block-start: awsui.$space-xl;
     color: awsui.$color-text-heading-default;
   }
-  // sets padding at the bottom of the panel
-  & > :last-child {
-    margin-block-end: awsui.$space-panel-content-bottom;
-  }
-
   // add basic font-sizes
   p {
     color: inherit;


### PR DESCRIPTION
### Description

I noticed that when I scrolled to the bottom of a `HelpPanel`, there was no whitespace below the content.

The cause: `HelpPanel` reserved its bottom whitespace as `margin-block-end` on its last child. A descendant's block-end margin is not added to an ancestor scroll container's scrollable region, so when the panel renders inside a fixed-height, scrollable app-layout drawer, that trailing margin is clipped and content sits flush against the bottom edge.

This fix reserves the space as `padding-block-end` on the panel root instead. An element's own padding *is* included in the scroll extent, so the whitespace renders consistently regardless of the wrapping container.

### How has this been tested?

- Existing `HelpPanel` unit tests pass (6/6); app-layout unit suite passes (1563 tests, 38 suites, 10 snapshots).
- Manually verified in the dev server (`app-layout/default`).

#### Before

<img width="1305" height="1041" alt="Screenshot 2026-07-11 at 5 10 12 PM" src="https://github.com/user-attachments/assets/67004d2b-8233-4f6c-ba8a-00b41535e7fb" />

#### After

<img width="1305" height="1041" alt="Screenshot 2026-07-11 at 5 09 06 PM" src="https://github.com/user-attachments/assets/43bf31fd-8e12-4906-84c1-aad8b08ced05" />