### PR TITLE
chore: Styling v2 utils, part 1

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,7 +4,7 @@
     "stylelint-prettier/recommended"
   ],
   "rules": {
-    "custom-property-pattern": "^(?!.+)",
+    "custom-property-pattern": "^awsui-(internal-)?style-",
     "scss/comment-no-empty": null,
     "scss/operator-no-newline-after": null,
     "selector-pseudo-class-no-unknown": [

--- a/pages/styling/custom-panel.scss
+++ b/pages/styling/custom-panel.scss
@@ -1,0 +1,41 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '../../src/internal/styles/style-api' as style-api;
+
+// Illustrates a shared token group.
+$surface: (color-text, color-background, color-border, border-width, border-radius);
+
+// Creates panel props by combining shared and component-specific tokens.
+$props: style-api.combine($surface, (color-text-secondary));
+$tokens: style-api.resolve($props, carrier);
+
+@include style-api.register($props);
+
+.panel {
+  @include style-api.carriers($props);
+  box-sizing: border-box;
+  max-inline-size: 360px;
+  background: var(#{style-api.read($tokens, color-background)}, #fcf2f4);
+  border-block: var(#{style-api.read($tokens, border-width)}, 1px) solid
+    var(#{style-api.read($tokens, color-border)}, #ff8da1);
+  border-inline: var(#{style-api.read($tokens, border-width)}, 1px) solid
+    var(#{style-api.read($tokens, color-border)}, #ff8da1);
+  border-start-start-radius: var(#{style-api.read($tokens, border-radius)}, 8px);
+  border-start-end-radius: var(#{style-api.read($tokens, border-radius)}, 8px);
+  border-end-start-radius: var(#{style-api.read($tokens, border-radius)}, 8px);
+  border-end-end-radius: var(#{style-api.read($tokens, border-radius)}, 8px);
+  padding-block: 16px;
+  padding-inline: 16px;
+}
+// Descendant elements can read tokens because of the carrier re-anchoring inside panel.
+.title {
+  color: var(#{style-api.read($tokens, color-text)}, #16191f);
+  font-weight: 700;
+}
+.body {
+  margin-block-start: 8px;
+  color: var(#{style-api.read($tokens, color-text-secondary)}, #5f6b7a);
+}

--- a/pages/styling/custom-panel.tsx
+++ b/pages/styling/custom-panel.tsx
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+
+import styles from './custom-panel.scss';
+
+export interface CustomPanelProps {
+  title: React.ReactNode;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+// A simple custom component that uses --awsui-style-* tokens with a carrier layer, thus allowing nested
+// elements to inherit them.
+export function CustomPanel({ title, className, children }: CustomPanelProps) {
+  return (
+    <div className={clsx(styles.panel, className)}>
+      <div className={styles.title}>{title}</div>
+      <div className={styles.body}>{children}</div>
+    </div>
+  );
+}

--- a/pages/styling/custom-pill.scss
+++ b/pages/styling/custom-pill.scss
@@ -1,0 +1,25 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '../../src/internal/styles/style-api' as style-api;
+
+$props: (color-background, color-border, color-text, border-radius);
+$tokens: style-api.resolve($props, public);
+
+@include style-api.register($props);
+
+.pill {
+  box-sizing: border-box;
+  background: var(#{style-api.read($tokens, color-background)}, #c2185b);
+  color: var(#{style-api.read($tokens, color-text)}, #ffffff);
+  border-block: 1px solid var(#{style-api.read($tokens, color-border)}, #c2185b);
+  border-inline: 1px solid var(#{style-api.read($tokens, color-border)}, #c2185b);
+  border-start-start-radius: var(#{style-api.read($tokens, border-radius)}, 12px);
+  border-start-end-radius: var(#{style-api.read($tokens, border-radius)}, 12px);
+  border-end-start-radius: var(#{style-api.read($tokens, border-radius)}, 12px);
+  border-end-end-radius: var(#{style-api.read($tokens, border-radius)}, 12px);
+  padding-block: 4px;
+  padding-inline: 8px;
+}

--- a/pages/styling/custom-pill.tsx
+++ b/pages/styling/custom-pill.tsx
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+
+import styles from './custom-pill.scss';
+
+export interface CustomPillProps {
+  className?: string;
+  children?: React.ReactNode;
+}
+
+// A simple custom component that uses --awsui-style-* tokens directly (no inheritance and carrier tokens needed).
+export function CustomPill({ className, children }: CustomPillProps) {
+  return <div className={clsx(styles.pill, className)}>{children}</div>;
+}

--- a/pages/styling/style-api-tools.page.tsx
+++ b/pages/styling/style-api-tools.page.tsx
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { Box, SpaceBetween } from '~components';
+
+import { SimplePage } from '../app/templates';
+import { CustomPanel } from './custom-panel';
+import { CustomPill } from './custom-pill';
+
+import overrides from './style-overrides.scss';
+
+export default function StyleApiToolsPage() {
+  return (
+    <SimplePage
+      title="Style API v2: tools"
+      subtitle={
+        <Box variant="span">
+          Applies style-api tools to a set of custom components, which are then themed via{' '}
+          <Box variant="awsui-inline-code">--awsui-style-*</Box> tokens.
+        </Box>
+      }
+      screenshotArea={{}}
+    >
+      <div>
+        <h2>Examples</h2>
+
+        <h3>Without carrier tokens — no token inheritance needed</h3>
+        <SpaceBetween size="s" direction="horizontal">
+          <CustomPill>Default</CustomPill>
+          <CustomPill className={overrides.pill}>Themed</CustomPill>
+        </SpaceBetween>
+
+        <h3>With carrier tokens — style tokens read by descendant elements</h3>
+        <SpaceBetween size="s" direction="horizontal">
+          <CustomPanel title="Default">Default style (no overrides).</CustomPanel>
+          <CustomPanel className={overrides.panel} title="Themed">
+            <SpaceBetween size="s">
+              <span>Themed via --awsui-style-* on the root; the title and body colors resolve through carriers.</span>
+              <CustomPanel title="Default">Default style (no overrides).</CustomPanel>
+            </SpaceBetween>
+          </CustomPanel>
+        </SpaceBetween>
+      </div>
+    </SimplePage>
+  );
+}

--- a/pages/styling/style-overrides.scss
+++ b/pages/styling/style-overrides.scss
@@ -1,0 +1,24 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '~design-tokens' as tokens;
+
+// Consumer style overrides. These can use any values: raw, var(...), light-dark(...), or design tokens.
+
+.panel {
+  --awsui-style-color-background: #{tokens.$color-background-status-info};
+  --awsui-style-color-text: #{tokens.$color-text-status-info};
+  --awsui-style-color-text-secondary: #{tokens.$color-text-body-secondary};
+  --awsui-style-color-border: #{tokens.$color-border-status-info};
+  --awsui-style-border-width: 2px;
+  --awsui-style-border-radius: 4px;
+}
+
+.pill {
+  --awsui-style-color-background: #{tokens.$color-background-status-info};
+  --awsui-style-color-text: #{tokens.$color-text-status-info};
+  --awsui-style-color-border: #{tokens.$color-border-status-info};
+  --awsui-style-border-radius: 4px;
+}

--- a/src/internal/styles/style-api.scss
+++ b/src/internal/styles/style-api.scss
@@ -1,0 +1,94 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use 'sass:map';
+@use 'sass:list';
+@use 'sass:string';
+
+// Style API v2 authoring utils for shared, component-agnostic style tokens (e.g. --awsui-style-color-text,
+// not --awsui-style-button-color-text). The owning component is implied by where the consumer applies the
+// class, so one abstract token name is reused across components and shared token groups can be composed.
+//
+// Model: each public token `--awsui-style-<prop>` is registered `@property { syntax:'*'; inherits:false }`.
+// A component resolves its prop set into a <prop> -> custom-property map for one of two LAYERS, then reads via
+// `var(#{read($tokens, <prop>)}, <default>)` (uniform at every read site):
+//
+//  - PUBLIC layer: read the public token directly, on the element the consumer themes. It doesn't inherit, so
+//    it can't pick up an ancestor component's value. Use for single-element components (e.g. a button).
+//  - CARRIER layer: the public token is mirrored into an INHERITED internal carrier `--awsui-internal-style-<prop>`
+//    re-anchored on the component root (carriers() mixin), so descendants can read it. Each root re-anchors from
+//    its own (unset) public token, so values scope to the instance and reset at every nested boundary — no
+//    leakage. Registrations are byte-identical across components, so order-independent.
+//
+// Example:
+//
+//   @use '../internal/styles/style-api' as style-api;
+//   @use '../internal/styles/style-groups/surface' as surface;
+//
+//   $props: style-api.combine(surface.$props, (icon-color)); // 1. union shared group(s) + own tokens (deduped)
+//   $tokens: style-api.resolve($props, carrier);             // 2. map for the carrier layer -> pass to read()
+//   @include style-api.register($props);                     // 3. declare the public @property (top level, once)
+//
+//   .alert-root {
+//     @include style-api.carriers($props);                   // 4. re-anchor public -> internal on the boundary
+//     color: var(#{style-api.read($tokens, color-text)}, #{awsui.$color-text-body-default}); // 5. apply token
+//   }
+//
+// A consumer themes an instance by setting the public token on a class applied to the component:
+//   .my-alert { --awsui-style-color-text: light-dark(black, white); }
+
+// 1. Deduped union of token lists.
+@function combine($lists...) {
+  $result: ();
+  @each $list in $lists {
+    @each $prop in $list {
+      @if not list.index($result, $prop) {
+        $result: list.append($result, $prop);
+      }
+    }
+  }
+  @return $result;
+}
+
+// 2. Resolves `$props` into a <prop> -> custom-property map for `$layer` (`public` or `carrier`), consumed by
+// read() at read sites. `$layer` is required so the layer choice is always explicit at the call site.
+@function resolve($props, $layer) {
+  @if $layer != public and $layer != carrier {
+    @error 'Unknown layer "#{$layer}". Use `public` or `carrier`.';
+  }
+  $prefix: if($layer == public, '--awsui-style-', '--awsui-internal-style-');
+  $tokens: ();
+  @each $prop in $props {
+    $tokens: map.set($tokens, $prop, string.unquote('#{$prefix}#{$prop}'));
+  }
+  @return $tokens;
+}
+
+// 3. Registers the public tokens as non-inheriting @property. Top level only.
+@mixin register($props) {
+  @each $prop in $props {
+    @property --awsui-style-#{$prop} {
+      syntax: '*';
+      inherits: false;
+    }
+  }
+}
+
+// 4. Re-anchors each public token into its inherited internal carrier. Include on the component's root; pair
+// with a `resolve($props, carrier)` map so descendants read the re-anchored values.
+@mixin carriers($props) {
+  @each $prop in $props {
+    --awsui-internal-style-#{$prop}: var(--awsui-style-#{$prop});
+  }
+}
+
+// 5. The custom-property to read for `$prop`, looked up in the given map. Errors at compile time on an
+// undeclared prop (a typo, or a token the component never composed into its set).
+@function read($tokens, $prop) {
+  @if not map.has-key($tokens, $prop) {
+    @error 'Unknown style token "#{$prop}". Declared: #{map.keys($tokens)}.';
+  }
+  @return map.get($tokens, $prop);
+}


### PR DESCRIPTION
### Description

Introducing the first set of Style API v2 utils, see QUIP [RF7BAXdY9QZb] and [3LQzAqi0WIlT]. These utils were originally added in the POC implementation (https://github.com/cloudscape-design/components/pull/4577), but here I am adding them as a standalone change, covered with a dedicated test page (to be covered with screenshot tests). Compared to the POC, I introduced a few small ergonomics/naming changes.

Once this one is merged, I will follow it up by a few more similar PRs - introducing shared token groups (surface, focus outline, etc.), and a mechanism to extract style tokens documentation.

### How has this been tested?

* New test page, to be covered with a screenshot test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
