### PR TITLE
fix: vertically center chart tooltip and legend markers

### DIFF
--- a/src/internal/components/chart-legend/styles.scss
+++ b/src/internal/components/chart-legend/styles.scss
@@ -33,7 +33,7 @@
 
 .marker {
   display: inline-flex;
-  align-items: flex-start;
+  align-items: center;
   padding-block: 0;
   padding-inline: 0;
   border-block: 0;

--- a/src/internal/components/chart-series-details/styles.scss
+++ b/src/internal/components/chart-series-details/styles.scss
@@ -65,7 +65,7 @@ $font-weight-bold: awsui.$font-weight-heading-s;
 
   > .list-item {
     > .key-value-pair > .key {
-      align-items: flex-start;
+      align-items: center;
     }
 
     &.dimmed {

--- a/src/internal/components/chart-series-marker/styles.scss
+++ b/src/internal/components/chart-series-marker/styles.scss
@@ -12,7 +12,6 @@ $marker-margin-right: awsui.$space-xxs;
 .marker {
   @include styles.styles-reset;
   margin-inline-end: $marker-margin-right;
-  margin-block-start: awsui.$space-xxs;
   border-start-start-radius: 2px;
   border-start-end-radius: 2px;
   border-end-start-radius: 2px;
@@ -22,8 +21,6 @@ $marker-margin-right: awsui.$space-xxs;
   cursor: inherit;
 
   &--line {
-    // same margin as in filled marker + half the difference in their size
-    margin-block-start: 0.9 * styles.$base-size;
     block-size: 0.4 * styles.$base-size;
   }
 
@@ -57,8 +54,6 @@ $marker-margin-right: awsui.$space-xxs;
   &--dashed {
     block-size: 0.4 * styles.$base-size;
     inline-size: 0.6 * styles.$base-size;
-    // same margins as in filled marker + half the difference in their size
-    margin-block-start: 0.9 * styles.$base-size;
     margin-inline-end: 1.2 * styles.$base-size;
 
     &::after {


### PR DESCRIPTION
### Description

Chart series markers weren't vertically centered against their label in tooltips (and legends) - the marker sat low/high depending on type, because each marker carried a hardcoded `margin-block-start` to fake alignment under a `top-aligned` (`flex-start`) row.

Fix - center the row and drop the magic margins so alignment is geometric:
- chart-series-details: the key row uses `align-items: center` instead of `flex-start`.
- chart-legend: legend item row `align-items: center`.
- chart-series-marker: removed `margin-block-start `from `.marker`, `.marker--line`, and `.marker--dashed`.


Affects chart tooltips and legends (shared marker), so expect visual-snapshot diffs across those. Note: multi-line tooltip keys now center the marker against the whole block rather than the first line.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
