### PR TITLE
chore: Add visual regression tests for more components (A-B)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,12 +101,14 @@ jobs:
         working-directory: /tmp/baseline
         env:
           NODE_ENV: production
+          REACT_VERSION: 18
 
       - name: Bundle baseline pages
         run: node_modules/.bin/webpack --config pages/webpack.config.integ.cjs --output-path "${GITHUB_WORKSPACE}/pages/lib/static-visual-baseline"
         working-directory: /tmp/baseline
         env:
           NODE_ENV: production
+          REACT_VERSION: 18
 
       - name: Upload baseline artifact
         uses: actions/upload-artifact@v4

--- a/test/definitions/index.ts
+++ b/test/definitions/index.ts
@@ -18,6 +18,15 @@ import appLayoutResponsive from './visual/app-layout-responsive';
 import appLayoutStickyTableHeaderSplitPanel from './visual/app-layout-sticky-table-header-split-panel';
 import appLayoutToolbar from './visual/app-layout-toolbar';
 import appLayoutZIndex from './visual/app-layout-z-index';
+import areaChart from './visual/area-chart';
+import attributeEditor from './visual/attribute-editor';
+import autosuggest from './visual/autosuggest';
+import badgeSuite from './visual/badge';
+import barChart from './visual/bar-chart';
+import boxSuite from './visual/box';
+import breadcrumbGroup from './visual/breadcrumb-group';
+import buttonSuite from './visual/button';
+import buttonGroup from './visual/button-group';
 
 // Per-component exports (grouped by component)
 export const actionCard: TestSuite[] = [actionCardSuite];
@@ -34,5 +43,27 @@ export const appLayout: TestSuite[] = [
   appLayoutToolbar,
   appLayoutZIndex,
 ];
+export const areaChartSuites: TestSuite[] = [areaChart];
+export const attributeEditorSuites: TestSuite[] = [attributeEditor];
+export const autosuggestSuites: TestSuite[] = [autosuggest];
+export const badge: TestSuite[] = [badgeSuite];
+export const barChartSuites: TestSuite[] = [barChart];
+export const box: TestSuite[] = [boxSuite];
+export const breadcrumbGroupSuites: TestSuite[] = [breadcrumbGroup];
+export const button: TestSuite[] = [buttonSuite];
+export const buttonGroupSuites: TestSuite[] = [buttonGroup];
 
-export const allSuites: TestSuite[] = [...actionCard, ...alert, ...appLayout];
+export const allSuites: TestSuite[] = [
+  ...actionCard,
+  ...alert,
+  ...appLayout,
+  ...areaChartSuites,
+  ...attributeEditorSuites,
+  ...autosuggestSuites,
+  ...badge,
+  ...barChartSuites,
+  ...box,
+  ...breadcrumbGroupSuites,
+  ...button,
+  ...buttonGroupSuites,
+];

--- a/test/definitions/index.ts
+++ b/test/definitions/index.ts
@@ -26,6 +26,7 @@ import barChart from './visual/bar-chart';
 import boxSuite from './visual/box';
 import breadcrumbGroup from './visual/breadcrumb-group';
 import buttonSuite from './visual/button';
+import buttonDropdown from './visual/button-dropdown';
 import buttonGroup from './visual/button-group';
 
 // Per-component exports (grouped by component)
@@ -51,6 +52,7 @@ export const barChartSuites: TestSuite[] = [barChart];
 export const box: TestSuite[] = [boxSuite];
 export const breadcrumbGroupSuites: TestSuite[] = [breadcrumbGroup];
 export const button: TestSuite[] = [buttonSuite];
+export const buttonDropdownSuites: TestSuite[] = [buttonDropdown];
 export const buttonGroupSuites: TestSuite[] = [buttonGroup];
 
 export const allSuites: TestSuite[] = [
@@ -65,5 +67,6 @@ export const allSuites: TestSuite[] = [
   ...box,
   ...breadcrumbGroupSuites,
   ...button,
+  ...buttonDropdownSuites,
   ...buttonGroupSuites,
 ];

--- a/test/definitions/index.ts
+++ b/test/definitions/index.ts
@@ -18,16 +18,16 @@ import appLayoutResponsive from './visual/app-layout-responsive';
 import appLayoutStickyTableHeaderSplitPanel from './visual/app-layout-sticky-table-header-split-panel';
 import appLayoutToolbar from './visual/app-layout-toolbar';
 import appLayoutZIndex from './visual/app-layout-z-index';
-import areaChart from './visual/area-chart';
-import attributeEditor from './visual/attribute-editor';
-import autosuggest from './visual/autosuggest';
+import areaChartSuite from './visual/area-chart';
+import attributeEditorSuite from './visual/attribute-editor';
+import autosuggestSuite from './visual/autosuggest';
 import badgeSuite from './visual/badge';
-import barChart from './visual/bar-chart';
+import barChartSuite from './visual/bar-chart';
 import boxSuite from './visual/box';
-import breadcrumbGroup from './visual/breadcrumb-group';
+import breadcrumbGroupSuite from './visual/breadcrumb-group';
 import buttonSuite from './visual/button';
-import buttonDropdown from './visual/button-dropdown';
-import buttonGroup from './visual/button-group';
+import buttonDropdownSuite from './visual/button-dropdown';
+import buttonGroupSuite from './visual/button-group';
 
 // Per-component exports (grouped by component)
 export const actionCard: TestSuite[] = [actionCardSuite];
@@ -44,29 +44,29 @@ export const appLayout: TestSuite[] = [
   appLayoutToolbar,
   appLayoutZIndex,
 ];
-export const areaChartSuites: TestSuite[] = [areaChart];
-export const attributeEditorSuites: TestSuite[] = [attributeEditor];
-export const autosuggestSuites: TestSuite[] = [autosuggest];
+export const areaChart: TestSuite[] = [areaChartSuite];
+export const attributeEditor: TestSuite[] = [attributeEditorSuite];
+export const autosuggest: TestSuite[] = [autosuggestSuite];
 export const badge: TestSuite[] = [badgeSuite];
-export const barChartSuites: TestSuite[] = [barChart];
+export const barChart: TestSuite[] = [barChartSuite];
 export const box: TestSuite[] = [boxSuite];
-export const breadcrumbGroupSuites: TestSuite[] = [breadcrumbGroup];
+export const breadcrumbGroup: TestSuite[] = [breadcrumbGroupSuite];
 export const button: TestSuite[] = [buttonSuite];
-export const buttonDropdownSuites: TestSuite[] = [buttonDropdown];
-export const buttonGroupSuites: TestSuite[] = [buttonGroup];
+export const buttonDropdown: TestSuite[] = [buttonDropdownSuite];
+export const buttonGroup: TestSuite[] = [buttonGroupSuite];
 
 export const allSuites: TestSuite[] = [
   ...actionCard,
   ...alert,
   ...appLayout,
-  ...areaChartSuites,
-  ...attributeEditorSuites,
-  ...autosuggestSuites,
+  ...areaChart,
+  ...attributeEditor,
+  ...autosuggest,
   ...badge,
-  ...barChartSuites,
+  ...barChart,
   ...box,
-  ...breadcrumbGroupSuites,
+  ...breadcrumbGroup,
   ...button,
-  ...buttonDropdownSuites,
-  ...buttonGroupSuites,
+  ...buttonDropdown,
+  ...buttonGroup,
 ];

--- a/test/definitions/page-object.ts
+++ b/test/definitions/page-object.ts
@@ -2,10 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { RawScreenshotPageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 
-/**
- * Extended page object for visual regression tests.
- * Adds helper methods that were available in the IntegrationTests page object.
- */
 export default class VisualTestPageObject extends RawScreenshotPageObject {
   /**
    * Dispatches a focus event on all input elements in the page.

--- a/test/definitions/page-object.ts
+++ b/test/definitions/page-object.ts
@@ -2,25 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 import { RawScreenshotPageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 
-import createWrapper from '../../lib/components/test-utils/selectors';
-
-const nativeInputSelector = createWrapper().findAutosuggest().findNativeInput().toSelector();
-
 /**
  * Extended page object for visual regression tests.
+ * Adds helper methods that were available in the IntegrationTests page object.
  */
 export default class VisualTestPageObject extends RawScreenshotPageObject {
   /**
-   * Dispatches a focusin event on all autosuggest native inputs to open their dropdowns.
+   * Dispatches a focusin event on all input elements to open their dropdowns.
    * Uses focusin (which bubbles) because React's event delegation listens for it.
+   * Targets native `input` elements to avoid dependency on test-utils selectors
+   * which may differ between the PR and baseline builds.
    */
   async focusInputs(): Promise<void> {
-    await this.waitForVisible(nativeInputSelector);
-    await this.browser.execute(function (selector: string) {
-      document.querySelectorAll(selector).forEach(function (input) {
+    await this.waitForVisible('input');
+    await this.browser.execute(function () {
+      document.querySelectorAll('input').forEach(function (input) {
         input.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: null }));
       });
-    }, nativeInputSelector);
+    });
     await this.waitForJsTimers(500);
   }
 }

--- a/test/definitions/page-object.ts
+++ b/test/definitions/page-object.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ScreenshotBasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+
+/**
+ * Extended page object for visual regression tests.
+ * Adds helper methods that were available in the IntegrationTests page object.
+ */
+export default class VisualTestPageObject extends ScreenshotBasePageObject {
+  /**
+   * Dispatches a focus event on all input elements in the page.
+   * Useful for triggering dropdown opens in permutation pages.
+   */
+  async focusInputs(): Promise<void> {
+    await this.browser.execute(function () {
+      Array.prototype.forEach.call(document.querySelectorAll('input'), function (inputElement: HTMLInputElement) {
+        const ev = new FocusEvent('focus');
+        inputElement.dispatchEvent(ev);
+      });
+    });
+    // Wait until dropdown auto-reposition timeout ends
+    await this.waitForJsTimers(500);
+  }
+}

--- a/test/definitions/page-object.ts
+++ b/test/definitions/page-object.ts
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ScreenshotBasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import { RawScreenshotPageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 
 /**
  * Extended page object for visual regression tests.
  * Adds helper methods that were available in the IntegrationTests page object.
  */
-export default class VisualTestPageObject extends ScreenshotBasePageObject {
+export default class VisualTestPageObject extends RawScreenshotPageObject {
   /**
    * Dispatches a focus event on all input elements in the page.
    * Useful for triggering dropdown opens in permutation pages.

--- a/test/definitions/page-object.ts
+++ b/test/definitions/page-object.ts
@@ -4,17 +4,15 @@ import { RawScreenshotPageObject } from '@cloudscape-design/browser-test-tools/p
 
 export default class VisualTestPageObject extends RawScreenshotPageObject {
   /**
-   * Dispatches a focus event on all input elements in the page.
-   * Useful for triggering dropdown opens in permutation pages.
+   * Dispatches a focusin event on all input elements in the page to open their dropdowns.
+   * Uses focusin (which bubbles) because React's event delegation listens for it.
    */
   async focusInputs(): Promise<void> {
     await this.browser.execute(function () {
-      Array.prototype.forEach.call(document.querySelectorAll('input'), function (inputElement: HTMLInputElement) {
-        const ev = new FocusEvent('focus');
-        inputElement.dispatchEvent(ev);
+      document.querySelectorAll('input').forEach(function (input) {
+        input.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: null }));
       });
     });
-    // Wait until dropdown auto-reposition timeout ends
     await this.waitForJsTimers(500);
   }
 }

--- a/test/definitions/page-object.ts
+++ b/test/definitions/page-object.ts
@@ -2,17 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 import { RawScreenshotPageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 
+import createWrapper from '../../lib/components/test-utils/selectors';
+
+const nativeInputSelector = createWrapper().findAutosuggest().findNativeInput().toSelector();
+
+/**
+ * Extended page object for visual regression tests.
+ */
 export default class VisualTestPageObject extends RawScreenshotPageObject {
   /**
-   * Dispatches a focusin event on all input elements in the page to open their dropdowns.
+   * Dispatches a focusin event on all autosuggest native inputs to open their dropdowns.
    * Uses focusin (which bubbles) because React's event delegation listens for it.
    */
   async focusInputs(): Promise<void> {
-    await this.browser.execute(function () {
-      document.querySelectorAll('input').forEach(function (input) {
+    await this.waitForVisible(nativeInputSelector);
+    await this.browser.execute(function (selector: string) {
+      document.querySelectorAll(selector).forEach(function (input) {
         input.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: null }));
       });
-    });
+    }, nativeInputSelector);
     await this.waitForJsTimers(500);
   }
 }

--- a/test/definitions/types.ts
+++ b/test/definitions/types.ts
@@ -1,10 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Browser } from 'webdriverio';
-
-import type { ScreenshotBasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import type { Browser } from 'webdriverio';
 
 import type createWrapper from '../../lib/components/test-utils/selectors';
+import type VisualTestPageObject from './page-object';
 
 export type Wrapper = ReturnType<typeof createWrapper>;
 
@@ -17,6 +16,10 @@ export interface ScreenshotTestConfiguration {
 // 'permutations'  — captures the entire page and crops permutations out of it.
 export type ScreenshotType = 'screenshotArea' | 'permutations' | 'viewport';
 
+export interface SetupConfiguration {
+  direction?: 'ltr' | 'rtl';
+}
+
 export interface TestDefinition {
   description: string;
   path: string;
@@ -24,7 +27,12 @@ export interface TestDefinition {
   queryParams?: Record<string, string>;
   configuration?: ScreenshotTestConfiguration;
   pixelDiffTolerance?: number;
-  setup?: ({ page, wrapper, browser }: { page: ScreenshotBasePageObject; wrapper: Wrapper; browser?: Browser }) => void;
+  setup?: (context: {
+    page: VisualTestPageObject;
+    wrapper: Wrapper;
+    browser?: Browser;
+    configuration?: SetupConfiguration;
+  }) => void;
 }
 
 export interface TestSuite {

--- a/test/definitions/types.ts
+++ b/test/definitions/types.ts
@@ -23,6 +23,7 @@ export interface TestDefinition {
   screenshotType: ScreenshotType;
   queryParams?: Record<string, string>;
   configuration?: ScreenshotTestConfiguration;
+  pixelDiffTolerance?: number;
   setup?: ({ page, wrapper, browser }: { page: ScreenshotBasePageObject; wrapper: Wrapper; browser?: Browser }) => void;
 }
 

--- a/test/definitions/utils.ts
+++ b/test/definitions/utils.ts
@@ -122,7 +122,7 @@ function registerTest(testDef: TestDefinition, getBrowser: () => WebdriverIO.Bro
           }
         });
       }
-      expect(failures).toBe(0);
+      expect(failures).toBe(testDef.pixelDiffTolerance);
       return;
     }
 

--- a/test/definitions/utils.ts
+++ b/test/definitions/utils.ts
@@ -13,8 +13,6 @@ import {
 import { TestDefinition, TestSuite } from './types';
 const defaultWindowSize = { width: 1200, height: 800 };
 
-const tolerance = 0;
-
 // NEW_HOST serves the PR's pages, OLD_HOST serves the baseline (main) pages.
 const newHost = process.env.NEW_HOST || 'http://localhost:8080';
 const oldHost = process.env.OLD_HOST || 'http://localhost:8080';
@@ -99,6 +97,8 @@ function registerTest(testDef: TestDefinition, getBrowser: () => WebdriverIO.Bro
     const newUrl = buildUrl(newHost, testDef.path, testDef.queryParams);
     const oldUrl = buildUrl(oldHost, testDef.path, testDef.queryParams);
 
+    const tolerance = testDef.pixelDiffTolerance ?? 0;
+
     if (testDef.screenshotType === 'permutations') {
       await preparePage(browser, page, newUrl, testDef, testDef.configuration);
       const newPermutations = await page.capturePermutations();
@@ -122,7 +122,7 @@ function registerTest(testDef: TestDefinition, getBrowser: () => WebdriverIO.Bro
           }
         });
       }
-      expect(failures).toBe(testDef.pixelDiffTolerance);
+      expect(failures).toBe(0);
       return;
     }
 

--- a/test/definitions/utils.ts
+++ b/test/definitions/utils.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { attachment, step } from 'allure-js-commons';
 
-import { RawScreenshotPageObject } from '@cloudscape-design/browser-test-tools/page-objects';
-
 import createWrapper from '../../lib/components/test-utils/selectors';
+import VisualTestPageObject from './page-object';
 import {
   captureSingleScreenshot,
   compareScreenshots,
@@ -45,7 +44,7 @@ async function attachDiffImages(result: CropAndCompareResult, testName: string):
 
 async function preparePage(
   browser: WebdriverIO.Browser,
-  page: RawScreenshotPageObject,
+  page: VisualTestPageObject,
   url: string,
   testDef: TestDefinition,
   windowSize?: { width?: number; height?: number }
@@ -95,7 +94,7 @@ function registerSuites(suites: Array<TestDefinition | TestSuite>, getBrowser: (
 function registerTest(testDef: TestDefinition, getBrowser: () => WebdriverIO.Browser) {
   test(testDef.description, async () => {
     const browser = getBrowser();
-    const page = new RawScreenshotPageObject(browser);
+    const page = new VisualTestPageObject(browser);
 
     const newUrl = buildUrl(newHost, testDef.path, testDef.queryParams);
     const oldUrl = buildUrl(oldHost, testDef.path, testDef.queryParams);

--- a/test/definitions/visual/area-chart.ts
+++ b/test/definitions/visual/area-chart.ts
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { TestSuite } from '../types';
+
+const TEST_CHART_FILTER_TRIGGER = '#linear-latency-chart button';
+const TEST_CHART_TOOLTIP_HEADER = '#linear-latency-chart h2';
+
+const suite: TestSuite = {
+  description: 'Area chart',
+  componentName: 'area-chart',
+  tests: [
+    {
+      description: 'permutations',
+      path: 'area-chart/permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'fit-height',
+      path: 'area-chart/fit-height',
+      screenshotType: 'screenshotArea',
+    },
+    {
+      description: 'fit-height no filter, no legend',
+      path: 'area-chart/fit-height',
+      screenshotType: 'screenshotArea',
+      queryParams: { hideFilter: 'true', hideLegend: 'true' },
+    },
+    {
+      description: 'fit-height, no legend',
+      path: 'area-chart/fit-height',
+      screenshotType: 'screenshotArea',
+      queryParams: { hideLegend: 'true' },
+    },
+    {
+      description: 'chart plot has a focus outline',
+      path: 'area-chart/test',
+      screenshotType: 'viewport',
+      configuration: { width: 800, height: 800 },
+      setup: async ({ page }) => {
+        await page.click(TEST_CHART_FILTER_TRIGGER);
+        await page.keys(['Escape']);
+        await (page as any).focusNextElement();
+      },
+    },
+    {
+      description: 'can navigate along X axis highlighting all series with keyboard',
+      path: 'area-chart/test',
+      screenshotType: 'viewport',
+      configuration: { width: 800, height: 800 },
+      setup: async ({ page }) => {
+        await page.click(TEST_CHART_FILTER_TRIGGER);
+        await page.keys(['Escape']);
+        await (page as any).focusNextElement();
+        await page.keys(['ArrowRight', 'ArrowRight']);
+        await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
+      },
+    },
+    {
+      description: 'can navigate a specific series with keyboard',
+      path: 'area-chart/test',
+      screenshotType: 'viewport',
+      configuration: { width: 800, height: 800 },
+      setup: async ({ page }) => {
+        await page.click(TEST_CHART_FILTER_TRIGGER);
+        await page.keys(['Escape']);
+        await (page as any).focusNextElement();
+        await page.keys(['ArrowRight']);
+        await page.keys(['ArrowDown']);
+        await page.keys(['ArrowRight']);
+        await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
+      },
+    },
+    {
+      description: 'selects correct series when navigated back from legend',
+      path: 'area-chart/test',
+      screenshotType: 'viewport',
+      configuration: { width: 800, height: 800 },
+      setup: async ({ page }) => {
+        await page.click(TEST_CHART_FILTER_TRIGGER);
+        await page.keys(['Escape']);
+        await page.keys(['Tab']);
+        await page.keys(['Tab']);
+        await page.keys(['ArrowRight']);
+        await page.keys(['Shift', 'Tab']);
+        await page.keys(['ArrowRight']);
+        await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
+      },
+    },
+    {
+      description: 'can pin popover for all data points at a given X coordinate with keyboard',
+      path: 'area-chart/test',
+      screenshotType: 'viewport',
+      configuration: { width: 800, height: 800 },
+      setup: async ({ page }) => {
+        await page.click(TEST_CHART_FILTER_TRIGGER);
+        await page.keys(['Escape']);
+        await (page as any).focusNextElement();
+        await page.keys(['ArrowRight']);
+        await page.keys(['ArrowRight']);
+        await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
+        await page.keys(['Enter']);
+        await page.waitForVisible('[aria-label="Dismiss"]');
+      },
+    },
+    {
+      description: 'can pin popover for a point in a specific series with keyboard',
+      path: 'area-chart/test',
+      screenshotType: 'viewport',
+      configuration: { width: 800, height: 800 },
+      setup: async ({ page }) => {
+        await page.click(TEST_CHART_FILTER_TRIGGER);
+        await page.keys(['Escape']);
+        await (page as any).focusNextElement();
+        await page.keys(['ArrowRight']);
+        await page.keys(['ArrowDown']);
+        await page.keys(['ArrowRight']);
+        await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
+        await page.keys(['Enter']);
+        await page.waitForVisible('[aria-label="Dismiss"]');
+      },
+    },
+    {
+      description: 'shows popover on hover',
+      path: 'area-chart/test',
+      screenshotType: 'viewport',
+      configuration: { width: 800, height: 800 },
+      setup: async ({ page }) => {
+        await page.hoverElement('[aria-label="Linear latency chart"]', 200, 50);
+        await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
+      },
+    },
+  ],
+};
+
+export default suite;

--- a/test/definitions/visual/area-chart.ts
+++ b/test/definitions/visual/area-chart.ts
@@ -39,7 +39,7 @@ const suite: TestSuite = {
       setup: async ({ page }) => {
         await page.click(TEST_CHART_FILTER_TRIGGER);
         await page.keys(['Escape']);
-        await (page as any).focusNextElement();
+        await page.focusNextElement();
       },
     },
     {
@@ -50,7 +50,7 @@ const suite: TestSuite = {
       setup: async ({ page }) => {
         await page.click(TEST_CHART_FILTER_TRIGGER);
         await page.keys(['Escape']);
-        await (page as any).focusNextElement();
+        await page.focusNextElement();
         await page.keys(['ArrowRight', 'ArrowRight']);
         await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
       },
@@ -63,7 +63,7 @@ const suite: TestSuite = {
       setup: async ({ page }) => {
         await page.click(TEST_CHART_FILTER_TRIGGER);
         await page.keys(['Escape']);
-        await (page as any).focusNextElement();
+        await page.focusNextElement();
         await page.keys(['ArrowRight']);
         await page.keys(['ArrowDown']);
         await page.keys(['ArrowRight']);
@@ -94,7 +94,7 @@ const suite: TestSuite = {
       setup: async ({ page }) => {
         await page.click(TEST_CHART_FILTER_TRIGGER);
         await page.keys(['Escape']);
-        await (page as any).focusNextElement();
+        await page.focusNextElement();
         await page.keys(['ArrowRight']);
         await page.keys(['ArrowRight']);
         await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
@@ -110,7 +110,7 @@ const suite: TestSuite = {
       setup: async ({ page }) => {
         await page.click(TEST_CHART_FILTER_TRIGGER);
         await page.keys(['Escape']);
-        await (page as any).focusNextElement();
+        await page.focusNextElement();
         await page.keys(['ArrowRight']);
         await page.keys(['ArrowDown']);
         await page.keys(['ArrowRight']);

--- a/test/definitions/visual/area-chart.ts
+++ b/test/definitions/visual/area-chart.ts
@@ -97,6 +97,7 @@ const suite: TestSuite = {
       path: 'area-chart/test',
       screenshotType: 'viewport',
       configuration: { width: 800, height: 800 },
+      pixelDiffTolerance: 10,
       setup: async ({ page, configuration }) => {
         const forward = configuration?.direction === 'rtl' ? 'ArrowLeft' : 'ArrowRight';
         // Focus and close the filtering select

--- a/test/definitions/visual/area-chart.ts
+++ b/test/definitions/visual/area-chart.ts
@@ -64,6 +64,7 @@ const suite: TestSuite = {
       path: 'area-chart/test',
       screenshotType: 'viewport',
       configuration: { width: 800, height: 800 },
+      pixelDiffTolerance: 10,
       setup: async ({ page, configuration }) => {
         const forward = configuration?.direction === 'rtl' ? 'ArrowLeft' : 'ArrowRight';
         // Focus and close the filtering select

--- a/test/definitions/visual/area-chart.ts
+++ b/test/definitions/visual/area-chart.ts
@@ -47,6 +47,7 @@ const suite: TestSuite = {
       path: 'area-chart/test',
       screenshotType: 'viewport',
       configuration: { width: 800, height: 800 },
+      pixelDiffTolerance: 10,
       setup: async ({ page }) => {
         await page.click(TEST_CHART_FILTER_TRIGGER);
         await page.keys(['Escape']);
@@ -60,6 +61,7 @@ const suite: TestSuite = {
       path: 'area-chart/test',
       screenshotType: 'viewport',
       configuration: { width: 800, height: 800 },
+      pixelDiffTolerance: 10,
       setup: async ({ page }) => {
         await page.click(TEST_CHART_FILTER_TRIGGER);
         await page.keys(['Escape']);
@@ -107,6 +109,7 @@ const suite: TestSuite = {
       path: 'area-chart/test',
       screenshotType: 'viewport',
       configuration: { width: 800, height: 800 },
+      pixelDiffTolerance: 10,
       setup: async ({ page }) => {
         await page.click(TEST_CHART_FILTER_TRIGGER);
         await page.keys(['Escape']);

--- a/test/definitions/visual/area-chart.ts
+++ b/test/definitions/visual/area-chart.ts
@@ -37,6 +37,7 @@ const suite: TestSuite = {
       screenshotType: 'viewport',
       configuration: { width: 800, height: 800 },
       setup: async ({ page }) => {
+        // Focus and close the filtering select
         await page.click(TEST_CHART_FILTER_TRIGGER);
         await page.keys(['Escape']);
         await page.focusNextElement();
@@ -47,12 +48,13 @@ const suite: TestSuite = {
       path: 'area-chart/test',
       screenshotType: 'viewport',
       configuration: { width: 800, height: 800 },
-      pixelDiffTolerance: 10,
-      setup: async ({ page }) => {
+      setup: async ({ page, configuration }) => {
+        const forward = configuration?.direction === 'rtl' ? 'ArrowLeft' : 'ArrowRight';
+        // Focus and close the filtering select
         await page.click(TEST_CHART_FILTER_TRIGGER);
         await page.keys(['Escape']);
         await page.focusNextElement();
-        await page.keys(['ArrowRight', 'ArrowRight']);
+        await page.keys([forward, forward]);
         await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
       },
     },
@@ -61,14 +63,15 @@ const suite: TestSuite = {
       path: 'area-chart/test',
       screenshotType: 'viewport',
       configuration: { width: 800, height: 800 },
-      pixelDiffTolerance: 10,
-      setup: async ({ page }) => {
+      setup: async ({ page, configuration }) => {
+        const forward = configuration?.direction === 'rtl' ? 'ArrowLeft' : 'ArrowRight';
+        // Focus and close the filtering select
         await page.click(TEST_CHART_FILTER_TRIGGER);
         await page.keys(['Escape']);
         await page.focusNextElement();
-        await page.keys(['ArrowRight']);
+        await page.keys([forward]);
         await page.keys(['ArrowDown']);
-        await page.keys(['ArrowRight']);
+        await page.keys([forward]);
         await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
       },
     },
@@ -78,6 +81,7 @@ const suite: TestSuite = {
       screenshotType: 'viewport',
       configuration: { width: 800, height: 800 },
       setup: async ({ page }) => {
+        // Focus and close the filtering select
         await page.click(TEST_CHART_FILTER_TRIGGER);
         await page.keys(['Escape']);
         await page.keys(['Tab']);
@@ -93,12 +97,14 @@ const suite: TestSuite = {
       path: 'area-chart/test',
       screenshotType: 'viewport',
       configuration: { width: 800, height: 800 },
-      setup: async ({ page }) => {
+      setup: async ({ page, configuration }) => {
+        const forward = configuration?.direction === 'rtl' ? 'ArrowLeft' : 'ArrowRight';
+        // Focus and close the filtering select
         await page.click(TEST_CHART_FILTER_TRIGGER);
         await page.keys(['Escape']);
         await page.focusNextElement();
-        await page.keys(['ArrowRight']);
-        await page.keys(['ArrowRight']);
+        await page.keys([forward]);
+        await page.keys([forward]);
         await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
         await page.keys(['Enter']);
         await page.waitForVisible('[aria-label="Dismiss"]');
@@ -109,14 +115,15 @@ const suite: TestSuite = {
       path: 'area-chart/test',
       screenshotType: 'viewport',
       configuration: { width: 800, height: 800 },
-      pixelDiffTolerance: 10,
-      setup: async ({ page }) => {
+      setup: async ({ page, configuration }) => {
+        const forward = configuration?.direction === 'rtl' ? 'ArrowLeft' : 'ArrowRight';
+        // Focus and close the filtering select
         await page.click(TEST_CHART_FILTER_TRIGGER);
         await page.keys(['Escape']);
         await page.focusNextElement();
-        await page.keys(['ArrowRight']);
+        await page.keys([forward]);
         await page.keys(['ArrowDown']);
-        await page.keys(['ArrowRight']);
+        await page.keys([forward]);
         await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
         await page.keys(['Enter']);
         await page.waitForVisible('[aria-label="Dismiss"]');

--- a/test/definitions/visual/area-chart.ts
+++ b/test/definitions/visual/area-chart.ts
@@ -48,6 +48,7 @@ const suite: TestSuite = {
       path: 'area-chart/test',
       screenshotType: 'viewport',
       configuration: { width: 800, height: 800 },
+      pixelDiffTolerance: 10,
       setup: async ({ page, configuration }) => {
         const forward = configuration?.direction === 'rtl' ? 'ArrowLeft' : 'ArrowRight';
         // Focus and close the filtering select
@@ -116,6 +117,7 @@ const suite: TestSuite = {
       path: 'area-chart/test',
       screenshotType: 'viewport',
       configuration: { width: 800, height: 800 },
+      pixelDiffTolerance: 10,
       setup: async ({ page, configuration }) => {
         const forward = configuration?.direction === 'rtl' ? 'ArrowLeft' : 'ArrowRight';
         // Focus and close the filtering select

--- a/test/definitions/visual/attribute-editor.ts
+++ b/test/definitions/visual/attribute-editor.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { TestSuite } from '../types';
+
+const suite: TestSuite = {
+  description: 'Attribute Editor',
+  componentName: 'attribute-editor',
+  tests: [360, 768, 992].flatMap(width => [
+    {
+      description: `permutations at ${width}px`,
+      path: 'attribute-editor/permutations',
+      screenshotType: 'permutations' as const,
+      configuration: { width },
+    },
+    {
+      description: `customizable-footer at ${width}px`,
+      path: 'attribute-editor/customizable-footer',
+      screenshotType: 'screenshotArea' as const,
+      configuration: { width },
+    },
+    {
+      description: `with long select at ${width}px`,
+      path: 'attribute-editor/select-with-long-value',
+      screenshotType: 'screenshotArea' as const,
+      configuration: { width },
+    },
+  ]),
+};
+
+export default suite;

--- a/test/definitions/visual/autosuggest.ts
+++ b/test/definitions/visual/autosuggest.ts
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { TestDefinition, TestSuite } from '../types';
+
+const suite: TestSuite = {
+  description: 'Autosuggest',
+  componentName: 'autosuggest',
+  tests: [
+    {
+      description: 'permutations',
+      path: 'autosuggest/permutations',
+      screenshotType: 'permutations',
+      setup: async ({ page }) => {
+        await page.click('input');
+      },
+    },
+    {
+      description: 'permutations for async properties',
+      path: 'autosuggest/permutations-async',
+      screenshotType: 'permutations',
+      setup: async ({ page }) => {
+        await page.click('input');
+      },
+    },
+    {
+      description: 'Displays options with groups correctly',
+      path: 'autosuggest/scenarios',
+      screenshotType: 'screenshotArea',
+      setup: async ({ page }) => {
+        await page.click('input');
+      },
+    },
+    {
+      description: 'Correctly displays dropdown regions',
+      path: 'autosuggest/regions-scenarios',
+      screenshotType: 'screenshotArea',
+      setup: async ({ page }) => {
+        await page.click('input');
+      },
+    },
+    {
+      description: 'Long virtual list - navigate to last item',
+      path: 'autosuggest/virtual-scroll',
+      screenshotType: 'screenshotArea',
+      setup: async ({ page, wrapper }) => {
+        await page.click(wrapper.findAutosuggest().findNativeInput().toSelector());
+        await page.keys(['ArrowUp']);
+      },
+    },
+    ...[true, false].map(
+      virtualScroll =>
+        ({
+          description: `with custom renderOption (virtualScroll=${virtualScroll})`,
+          path: 'autosuggest/custom-render-option',
+          screenshotType: 'screenshotArea',
+          queryParams: { virtualScroll: String(virtualScroll) },
+          setup: async ({ page, wrapper }) => {
+            await page.click(wrapper.findAutosuggest().findNativeInput().toSelector());
+            await page.keys(['ArrowDown']);
+          },
+        }) as TestDefinition
+    ),
+  ],
+};
+
+export default suite;

--- a/test/definitions/visual/autosuggest.ts
+++ b/test/definitions/visual/autosuggest.ts
@@ -11,7 +11,7 @@ const suite: TestSuite = {
       path: 'autosuggest/permutations',
       screenshotType: 'permutations',
       setup: async ({ page }) => {
-        await page.click('input');
+        await page.focusInputs();
       },
     },
     {
@@ -19,7 +19,7 @@ const suite: TestSuite = {
       path: 'autosuggest/permutations-async',
       screenshotType: 'permutations',
       setup: async ({ page }) => {
-        await page.click('input');
+        await page.focusInputs();
       },
     },
     {
@@ -27,7 +27,7 @@ const suite: TestSuite = {
       path: 'autosuggest/scenarios',
       screenshotType: 'screenshotArea',
       setup: async ({ page }) => {
-        await page.click('input');
+        await page.focusInputs();
       },
     },
     {
@@ -35,7 +35,7 @@ const suite: TestSuite = {
       path: 'autosuggest/regions-scenarios',
       screenshotType: 'screenshotArea',
       setup: async ({ page }) => {
-        await page.click('input');
+        await page.focusInputs();
       },
     },
     {

--- a/test/definitions/visual/badge.ts
+++ b/test/definitions/visual/badge.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { TestSuite } from '../types';
+
+const suite: TestSuite = {
+  description: 'Badge',
+  componentName: 'badge',
+  tests: [
+    {
+      description: 'permutation page',
+      path: 'badge/permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'style custom page',
+      path: 'badge/style-custom-types',
+      screenshotType: 'screenshotArea',
+    },
+  ],
+};
+
+export default suite;

--- a/test/definitions/visual/bar-chart.ts
+++ b/test/definitions/visual/bar-chart.ts
@@ -46,8 +46,8 @@ const suite: TestSuite = {
       pixelDiffTolerance: 12,
       setup: async ({ page }) => {
         await page.click('#focus-target');
-        await (page as any).focusNextElement();
-        await (page as any).focusNextElement();
+        await page.focusNextElement();
+        await page.focusNextElement();
         await page.keys(['ArrowRight', 'ArrowRight']);
         await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
       },
@@ -60,8 +60,8 @@ const suite: TestSuite = {
       pixelDiffTolerance: 10,
       setup: async ({ page }) => {
         await page.click('#focus-target');
-        await (page as any).focusNextElement();
-        await (page as any).focusNextElement();
+        await page.focusNextElement();
+        await page.focusNextElement();
         await page.keys(['ArrowRight', 'ArrowRight']);
         await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
         await page.keys(['Enter']);
@@ -84,10 +84,10 @@ const suite: TestSuite = {
       screenshotType: 'viewport',
       configuration: { width: 800, height: 800 },
       setup: async ({ page }) => {
-        await (page as any).scrollToBottom('html');
+        await page.scrollToBottom('html');
         await page.click('#focus-target-3');
-        await (page as any).focusNextElement();
-        await (page as any).focusNextElement();
+        await page.focusNextElement();
+        await page.focusNextElement();
         await page.keys(['ArrowRight', 'Enter']);
         await page.waitForVisible('[aria-label="Dismiss"]');
       },

--- a/test/definitions/visual/bar-chart.ts
+++ b/test/definitions/visual/bar-chart.ts
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { TestSuite } from '../types';
+
+const TEST_CHART_TOOLTIP_HEADER = '#chart';
+
+const suite: TestSuite = {
+  description: 'Bar chart',
+  componentName: 'bar-chart',
+  tests: [
+    {
+      description: 'Horizontal bars permutations',
+      path: 'bar-chart/horizontal-bars-permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'Horizontal stacked bars permutations',
+      path: 'bar-chart/horizontal-stacked-bars-permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'Other permutations',
+      path: 'bar-chart/other-permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'Threshold permutations',
+      path: 'bar-chart/threshold-permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'Vertical bars permutations',
+      path: 'bar-chart/vertical-bars-permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'Vertical stacked bars permutations',
+      path: 'bar-chart/vertical-stacked-bars-permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'can navigate series with keyboard',
+      path: 'bar-chart/test',
+      screenshotType: 'viewport',
+      configuration: { width: 800, height: 800 },
+      pixelDiffTolerance: 12,
+      setup: async ({ page }) => {
+        await page.click('#focus-target');
+        await (page as any).focusNextElement();
+        await (page as any).focusNextElement();
+        await page.keys(['ArrowRight', 'ArrowRight']);
+        await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
+      },
+    },
+    {
+      description: 'can pin popover with keyboard',
+      path: 'bar-chart/test',
+      screenshotType: 'viewport',
+      configuration: { width: 800, height: 800 },
+      pixelDiffTolerance: 10,
+      setup: async ({ page }) => {
+        await page.click('#focus-target');
+        await (page as any).focusNextElement();
+        await (page as any).focusNextElement();
+        await page.keys(['ArrowRight', 'ArrowRight']);
+        await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
+        await page.keys(['Enter']);
+        await page.waitForVisible('[aria-label="Dismiss"]');
+      },
+    },
+    {
+      description: 'shows popover on hover',
+      path: 'bar-chart/test',
+      screenshotType: 'viewport',
+      configuration: { width: 800, height: 800 },
+      setup: async ({ page }) => {
+        await page.hoverElement('#chart svg[aria-label="Bar chart"]');
+        await page.waitForVisible(TEST_CHART_TOOLTIP_HEADER);
+      },
+    },
+    {
+      description: 'wrapping long series title 123',
+      path: 'bar-chart/test',
+      screenshotType: 'viewport',
+      configuration: { width: 800, height: 800 },
+      setup: async ({ page }) => {
+        await (page as any).scrollToBottom('html');
+        await page.click('#focus-target-3');
+        await (page as any).focusNextElement();
+        await (page as any).focusNextElement();
+        await page.keys(['ArrowRight', 'Enter']);
+        await page.waitForVisible('[aria-label="Dismiss"]');
+      },
+    },
+  ],
+};
+
+export default suite;

--- a/test/definitions/visual/box.ts
+++ b/test/definitions/visual/box.ts
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { TestSuite } from '../types';
+
+const suite: TestSuite = {
+  description: 'Box',
+  componentName: 'box',
+  tests: [
+    {
+      description: 'variants permutations',
+      path: 'box/variants',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'margins permutations',
+      path: 'box/margins',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'paddings permutations',
+      path: 'box/paddings',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'float and textAlign',
+      path: 'box/float-align',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'with overrides to layout defaults',
+      path: 'box/elements-with-extra-defaults',
+      screenshotType: 'screenshotArea',
+    },
+    {
+      description: 'with icons in content',
+      path: 'box/iconography',
+      screenshotType: 'screenshotArea',
+    },
+  ],
+};
+
+export default suite;

--- a/test/definitions/visual/breadcrumb-group.ts
+++ b/test/definitions/visual/breadcrumb-group.ts
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { TestSuite } from '../types';
+
+const suite: TestSuite = {
+  description: 'BreadcrumbGroup',
+  componentName: 'breadcrumb-group',
+  tests: [
+    {
+      description: 'layout at 300px',
+      path: 'breadcrumb-group/scenarios',
+      screenshotType: 'screenshotArea',
+      configuration: { width: 300 },
+    },
+    {
+      description: 'layout at 680px',
+      path: 'breadcrumb-group/scenarios',
+      screenshotType: 'screenshotArea',
+      configuration: { width: 680 },
+    },
+    {
+      description: 'layout at 1200px',
+      path: 'breadcrumb-group/scenarios',
+      screenshotType: 'screenshotArea',
+      configuration: { width: 1200 },
+    },
+    {
+      description: 'dropdown',
+      path: 'breadcrumb-group/scenarios',
+      screenshotType: 'viewport',
+      configuration: { width: 300, height: 1000 },
+      setup: async ({ page, wrapper }) => {
+        await page.click(wrapper.findBreadcrumbGroup('[data-testid="breadcrumbs-6"]').findDropdown().toSelector());
+      },
+    },
+    {
+      description: 'responsive behavior',
+      path: 'breadcrumb-group/responsive',
+      screenshotType: 'screenshotArea',
+      configuration: { width: 1200 },
+    },
+  ],
+};
+
+export default suite;

--- a/test/definitions/visual/button-dropdown.ts
+++ b/test/definitions/visual/button-dropdown.ts
@@ -168,6 +168,7 @@ const suite: TestSuite = {
         screenshotType: 'screenshotArea' as const,
         configuration: { width },
         queryParams: { expandableGroups: String(expandableGroups) },
+        pixelDiffTolerance: 10,
         setup: async ({ page, wrapper }) => {
           await page.click(wrapper.findButtonDropdown().toSelector());
           if (expandableGroups) {

--- a/test/definitions/visual/button-dropdown.ts
+++ b/test/definitions/visual/button-dropdown.ts
@@ -1,0 +1,198 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { TestDefinition, TestSuite } from '../types';
+
+const suite: TestSuite = {
+  description: 'ButtonDropdown',
+  componentName: 'button-dropdown',
+  tests: [
+    // ── Positioning ───────────────────────────────────────────────────────
+    ...[500, 800].flatMap<TestDefinition>(width =>
+      ['.bd-top-left', '.bd-top-right', '.bd-bottom-left', '.bd-bottom-right'].map(selector => ({
+        description: `opening ${selector.replace('.bd-', '')} at ${width}`,
+        path: 'button-dropdown/scenarios-positioning',
+        screenshotType: 'viewport' as const,
+        configuration: { width },
+        setup: async ({ page }) => {
+          await page.click(selector);
+        },
+      }))
+    ),
+    {
+      description: 'opening top left, width maximum truncated',
+      path: 'button-dropdown/scenarios-positioning',
+      screenshotType: 'viewport',
+      configuration: { width: 230, height: 400 },
+      setup: async ({ page }) => {
+        await page.click('.bd-top-left');
+      },
+    },
+    {
+      description: 'opening bottom left, width maximum truncated',
+      path: 'button-dropdown/scenarios-positioning',
+      screenshotType: 'viewport',
+      configuration: { width: 230, height: 400 },
+      setup: async ({ page }) => {
+        await page.click('.bd-bottom-left');
+      },
+    },
+    // ── Expandable groups ─────────────────────────────────────────────────
+    ...[500, 1200].flatMap<TestDefinition>(width =>
+      ['.bd-top-left', '.bd-top-right', '.bd-bottom-left', '.bd-bottom-right'].map(selector => ({
+        description: `with expandable groups opening ${selector.replace('.bd-', '')} at ${width}`,
+        path: 'button-dropdown/scenarios-expandable',
+        screenshotType: 'viewport' as const,
+        configuration: { width },
+        setup: async ({ page }) => {
+          await page.click(selector);
+          await page.click('[data-testid="category1"]');
+        },
+      }))
+    ),
+    // ── Scrollable / overflow containers ──────────────────────────────────
+    {
+      description: 'in scrollable container',
+      path: 'button-dropdown/scenarios-container',
+      screenshotType: 'viewport',
+      configuration: { width: 600 },
+      setup: async ({ page }) => {
+        await page.waitForVisible('#scrollable-container');
+        const containerBBox = await page.getBoundingBox('#scrollable-container');
+        const buttonBBox = await page.getBoundingBox('#ButtonDropdown button');
+        await page.elementScrollTo('#scrollable-container', {
+          top: (containerBBox.height + buttonBBox.width) / 2,
+          left: (containerBBox.width + buttonBBox.width) / 2,
+        });
+        await page.click('#ButtonDropdown');
+      },
+    },
+    {
+      description: 'with expandToViewport overflowing a scroll container',
+      path: 'button-dropdown/scenarios-overflow-container',
+      screenshotType: 'viewport',
+      configuration: { width: 1000 },
+      setup: async ({ page }) => {
+        await page.waitForVisible('#scroll-container');
+        const containerBBox = await page.getBoundingBox('#scroll-container');
+        const buttonBBox = await page.getBoundingBox('#button-dropdown-scroll button');
+        await page.elementScrollTo('#scroll-container', {
+          top: (containerBBox.height + buttonBBox.width) / 2,
+          left: (containerBBox.width + buttonBBox.width) / 2,
+        });
+        await page.click('#button-dropdown-scroll');
+        await page.click('[data-testid="category1"]');
+      },
+    },
+    {
+      description: 'with expandToViewport overflowing a hidden container',
+      path: 'button-dropdown/scenarios-overflow-container',
+      screenshotType: 'viewport',
+      configuration: { width: 1000 },
+      setup: async ({ page }) => {
+        await page.waitForVisible('#hidden-container');
+        await page.click('#button-dropdown-hidden');
+        await page.click('[data-testid="category1"]');
+      },
+    },
+    {
+      description: 'with expandToViewport overflowing an auto container',
+      path: 'button-dropdown/scenarios-overflow-container',
+      screenshotType: 'viewport',
+      configuration: { width: 1000 },
+      setup: async ({ page }) => {
+        await page.waitForVisible('#auto-container');
+        const containerBBox = await page.getBoundingBox('#auto-container');
+        const buttonBBox = await page.getBoundingBox('#button-dropdown-auto button');
+        await page.elementScrollTo('#auto-container', {
+          top: (containerBBox.height + buttonBBox.width) / 2,
+          left: (containerBBox.width + buttonBBox.width) / 2,
+        });
+        await page.click('#button-dropdown-auto');
+        await page.click('[data-testid="category1"]');
+      },
+    },
+    // ── Permutations ──────────────────────────────────────────────────────
+    {
+      description: 'permutations',
+      path: 'button-dropdown/permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'item element permutations',
+      path: 'button-dropdown/item-element.permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'main action permutations',
+      path: 'button-dropdown/permutations-main-action',
+      screenshotType: 'permutations',
+    },
+    // ── Dimmed category group ─────────────────────────────────────────────
+    ...[500, 800].map<TestDefinition>(width => ({
+      description: `dimmed category group at width ${width}`,
+      path: 'button-dropdown/simple',
+      screenshotType: 'screenshotArea' as const,
+      configuration: { width },
+      setup: async ({ page }) => {
+        await page.click('#ButtonDropdown8');
+        await page.keys(['ArrowDown', 'ArrowDown', 'Enter']);
+      },
+    })),
+    // ── Disabled reason ───────────────────────────────────────────────────
+    ...[500, 800].flatMap<TestDefinition>(width => [
+      {
+        description: `with disabled reason at width ${width}`,
+        path: 'button-dropdown/disabled-reason',
+        screenshotType: 'screenshotArea' as const,
+        configuration: { width },
+        setup: async ({ page }) => {
+          await page.click('[data-testid="buttonDropdown"]');
+          await page.keys(['ArrowDown', 'ArrowDown', 'ArrowDown']);
+        },
+      },
+      {
+        description: `with disabled reason for selectable item at width ${width}`,
+        path: 'button-dropdown/disabled-reason',
+        screenshotType: 'screenshotArea' as const,
+        configuration: { width },
+        setup: async ({ page }) => {
+          await page.click('[data-testid="buttonDropdownSelectableItems"]');
+        },
+      },
+    ]),
+    // ── Icons in groups ───────────────────────────────────────────────────
+    ...[500, 800].flatMap<TestDefinition>(width =>
+      [true, false].map(expandableGroups => ({
+        description: `${expandableGroups ? 'expandable' : 'non-expandable'} groups show icons at width ${width}`,
+        path: 'button-dropdown/icon-expandable',
+        screenshotType: 'screenshotArea' as const,
+        configuration: { width },
+        queryParams: { expandableGroups: String(expandableGroups) },
+        setup: async ({ page, wrapper }) => {
+          await page.click(wrapper.findButtonDropdown().toSelector());
+          if (expandableGroups) {
+            await page.click('[data-testid="category1"]');
+          }
+        },
+      }))
+    ),
+    // ── Custom renderItem ─────────────────────────────────────────────────
+    ...[500, 1000].flatMap<TestDefinition>(width =>
+      [true, false].map(expandableGroups => ({
+        description: `${expandableGroups ? 'expandable' : 'non-expandable'} groups with custom renderItem width ${width}`,
+        path: 'button-dropdown/custom-render-item',
+        screenshotType: 'screenshotArea' as const,
+        configuration: { width },
+        queryParams: { expandableGroups: String(expandableGroups) },
+        setup: async ({ page, wrapper }) => {
+          await page.click(wrapper.findButtonDropdown().toSelector());
+          if (expandableGroups) {
+            await page.click('[data-testid="group"]');
+          }
+        },
+      }))
+    ),
+  ],
+};
+
+export default suite;

--- a/test/definitions/visual/button-dropdown.ts
+++ b/test/definitions/visual/button-dropdown.ts
@@ -184,6 +184,7 @@ const suite: TestSuite = {
         screenshotType: 'screenshotArea' as const,
         configuration: { width },
         queryParams: { expandableGroups: String(expandableGroups) },
+        pixelDiffTolerance: 10,
         setup: async ({ page, wrapper }) => {
           await page.click(wrapper.findButtonDropdown().toSelector());
           if (expandableGroups) {

--- a/test/definitions/visual/button-group.ts
+++ b/test/definitions/visual/button-group.ts
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { TestSuite } from '../types';
+
+const suite: TestSuite = {
+  description: 'ButtonGroup',
+  componentName: 'button-group',
+  tests: [
+    {
+      description: 'item permutations',
+      path: 'button-group/item-permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'permutations',
+      path: 'button-group/permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'shows tooltip when hovering item',
+      path: 'button-group/test',
+      screenshotType: 'screenshotArea',
+      setup: async ({ page }) => {
+        await page.hoverElement('[data-testid="like"]');
+      },
+    },
+    {
+      description: 'shows tooltip when hovering menu',
+      path: 'button-group/test',
+      screenshotType: 'screenshotArea',
+      setup: async ({ page }) => {
+        await page.hoverElement('[data-testid="more-actions"]');
+      },
+    },
+    {
+      description: 'shows feedback when clicking copy',
+      path: 'button-group/test',
+      screenshotType: 'screenshotArea',
+      setup: async ({ page }) => {
+        await page.hoverElement('[data-testid="copy"]');
+      },
+    },
+    {
+      description: 'style custom page',
+      path: 'button-group/style-custom-types',
+      screenshotType: 'screenshotArea',
+    },
+  ],
+};
+
+export default suite;

--- a/test/definitions/visual/button.ts
+++ b/test/definitions/visual/button.ts
@@ -47,7 +47,7 @@ const suite: TestSuite = {
       screenshotType: 'screenshotArea',
       setup: async ({ page }) => {
         await page.click('#focusButton');
-        await (page as any).focusNextElement();
+        await page.focusNextElement();
       },
     },
     {

--- a/test/definitions/visual/button.ts
+++ b/test/definitions/visual/button.ts
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { TestSuite } from '../types';
+
+const suite: TestSuite = {
+  description: 'Button',
+  componentName: 'button',
+  tests: [
+    {
+      description: 'permutations',
+      path: 'button/permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'style-permutations',
+      path: 'button/style-permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'style-custom-types',
+      path: 'button/style-custom-types',
+      screenshotType: 'screenshotArea',
+    },
+    {
+      description: 'external',
+      path: 'button/external.permutations',
+      screenshotType: 'permutations',
+    },
+    {
+      description: 'alignment',
+      path: 'button/alignment',
+      screenshotType: 'screenshotArea',
+    },
+    {
+      description: 'wrapping text',
+      path: 'button/text-wrap',
+      screenshotType: 'screenshotArea',
+    },
+    {
+      description: 'wrapping text with icon',
+      path: 'button/with-icon-wrap',
+      screenshotType: 'screenshotArea',
+    },
+    {
+      description: 'Button is focused',
+      path: 'button/tab-navigation',
+      screenshotType: 'screenshotArea',
+      setup: async ({ page }) => {
+        await page.click('#focusButton');
+        await (page as any).focusNextElement();
+      },
+    },
+    {
+      description: 'shows disabled reason tooltip on hover within modal',
+      path: 'button/disabled-reason-modal',
+      screenshotType: 'screenshotArea',
+      setup: async ({ page }) => {
+        await page.hoverElement('[data-testid="button"]');
+      },
+    },
+    {
+      description: 'shows disabled reason tooltip on hover over a button with an href',
+      path: 'button/disabled-reason',
+      screenshotType: 'screenshotArea',
+      setup: async ({ page }) => {
+        await page.hoverElement('[data-testid="normal-button-with-href"]');
+      },
+    },
+  ],
+};
+
+export default suite;

--- a/test/visual/area-chart.test.ts
+++ b/test/visual/area-chart.test.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { runTestSuites } from '../definitions/utils';
+import suite from '../definitions/visual/area-chart';
+
+runTestSuites([suite]);

--- a/test/visual/attribute-editor.test.ts
+++ b/test/visual/attribute-editor.test.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { runTestSuites } from '../definitions/utils';
+import suite from '../definitions/visual/attribute-editor';
+
+runTestSuites([suite]);

--- a/test/visual/autosuggest.test.ts
+++ b/test/visual/autosuggest.test.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { runTestSuites } from '../definitions/utils';
+import suite from '../definitions/visual/autosuggest';
+
+runTestSuites([suite]);

--- a/test/visual/badge.test.ts
+++ b/test/visual/badge.test.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { runTestSuites } from '../definitions/utils';
+import suite from '../definitions/visual/badge';
+
+runTestSuites([suite]);

--- a/test/visual/bar-chart.test.ts
+++ b/test/visual/bar-chart.test.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { runTestSuites } from '../definitions/utils';
+import suite from '../definitions/visual/bar-chart';
+
+runTestSuites([suite]);

--- a/test/visual/box.test.ts
+++ b/test/visual/box.test.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { runTestSuites } from '../definitions/utils';
+import suite from '../definitions/visual/box';
+
+runTestSuites([suite]);

--- a/test/visual/breadcrumb-group.test.ts
+++ b/test/visual/breadcrumb-group.test.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { runTestSuites } from '../definitions/utils';
+import suite from '../definitions/visual/breadcrumb-group';
+
+runTestSuites([suite]);

--- a/test/visual/button-dropdown.test.ts
+++ b/test/visual/button-dropdown.test.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { runTestSuites } from '../definitions/utils';
+import suite from '../definitions/visual/button-dropdown';
+
+runTestSuites([suite]);

--- a/test/visual/button-group.test.ts
+++ b/test/visual/button-group.test.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { runTestSuites } from '../definitions/utils';
+import suite from '../definitions/visual/button-group';
+
+runTestSuites([suite]);

--- a/test/visual/button.test.ts
+++ b/test/visual/button.test.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { runTestSuites } from '../definitions/utils';
+import suite from '../definitions/visual/button';
+
+runTestSuites([suite]);


### PR DESCRIPTION
### Description

Adds visual regression tests for the rest of components starting with A or B (action card and alert are already merged and app layout has its own PR: https://github.com/cloudscape-design/components/pull/4714).

### How has this been tested?

- As part of the PR checks (see Allure report in the deployments section below)
- In my pipeline (`dev-v3-jotresse`)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
