### PR TITLE
feat: add status log for steps

### DIFF
--- a/pages/steps/permutations-utils.tsx
+++ b/pages/steps/permutations-utils.tsx
@@ -298,6 +298,28 @@ export const allStatusesSteps: ReadonlyArray<StepsProps.Step> = [
     header: 'not started step',
     details: 'Test description',
   },
+  {
+    status: 'log',
+    statusIconAriaLabel: 'log entry',
+    header: 'log step',
+    details: 'Test description',
+  },
+];
+
+export const logSteps: ReadonlyArray<StepsProps.Step> = [
+  {
+    status: 'log',
+    header: 'Request received',
+  },
+  {
+    status: 'log',
+    header: 'Request parameters recorded',
+    details: 'The request parameters were added to the execution log.',
+  },
+  {
+    status: 'log',
+    header: 'Request forwarded',
+  },
 ];
 
 export const initialStepsInteractive: ReadonlyArray<StepsProps.Step> = [

--- a/pages/steps/permutations.page.tsx
+++ b/pages/steps/permutations.page.tsx
@@ -21,6 +21,7 @@ const stepsPermutations = createPermutations<StepsProps>([
       variants.blockedSteps,
       variants.failedSteps,
       variants.allStatusesSteps,
+      variants.logSteps,
       variants.initialStepsInteractive,
       variants.loadingStepsInteractive,
       variants.loadingSteps2Interactive,

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -27831,7 +27831,7 @@ The function is called for each step and should return an object with the follow
       "description": "An array of individual steps
 
 Each step definition has the following properties:
- * \`status\` (string) - Status of the step corresponding to a status indicator.
+ * \`status\` (string) - Status of the step corresponding to a status indicator. The \`log\` status renders a neutral dot marker.
  * \`statusIconAriaLabel\` - (string) - (Optional) Alternative text for the status icon.
  * \`header\` (ReactNode) - Summary corresponding to the step.
  * \`details\` (ReactNode) - (Optional) Additional information corresponding to the step.",

--- a/src/status-indicator/internal-interfaces.ts
+++ b/src/status-indicator/internal-interfaces.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { StatusIndicatorProps } from './interfaces';
+
+export type InternalStatusIndicatorType = StatusIndicatorProps.Type | 'log';

--- a/src/status-indicator/internal.tsx
+++ b/src/status-indicator/internal.tsx
@@ -9,19 +9,22 @@ import { IconProps } from '../icon/interfaces';
 import InternalIcon from '../icon/internal';
 import { getBaseProps } from '../internal/base-component';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
-import { SomeRequired } from '../internal/types';
 /**
  * @awsuiSystem core
  */
 import WithNativeAttributes from '../internal/utils/with-native-attributes';
 import InternalSpinner from '../spinner/internal';
 import { StatusIndicatorProps } from './interfaces';
+import { InternalStatusIndicatorType } from './internal-interfaces';
 
 import styles from './styles.css.js';
 
-export interface InternalStatusIndicatorProps
-  extends SomeRequired<StatusIndicatorProps, 'type'>,
-    InternalBaseComponentProps {
+export interface InternalStatusIndicatorProps extends Omit<StatusIndicatorProps, 'type'>, InternalBaseComponentProps {
+  /**
+   * Status type. The internal `log` value renders a plain dot for Steps.
+   */
+  type: InternalStatusIndicatorType;
+
   /**
    * Play an animation on the error icon when first rendered
    */
@@ -38,7 +41,7 @@ export interface InternalStatusIndicatorProps
   __display?: 'inline' | 'inline-block';
 }
 
-const typeToIcon: (size: IconProps.Size) => Record<StatusIndicatorProps.Type, JSX.Element> = size => ({
+const typeToIcon: (size: IconProps.Size) => Record<InternalStatusIndicatorType, JSX.Element> = size => ({
   error: <InternalIcon name="status-negative" size={size} />,
   warning: <InternalIcon name="status-warning" size={size} />,
   success: <InternalIcon name="status-positive" size={size} />,
@@ -48,6 +51,7 @@ const typeToIcon: (size: IconProps.Size) => Record<StatusIndicatorProps.Type, JS
   'in-progress': <InternalIcon name="status-in-progress" size={size} />,
   loading: <InternalSpinner />,
   'not-started': <InternalIcon name="status-not-started" size={size} />,
+  log: <InternalIcon name="dot" size={size} />,
 });
 
 interface InternalStatusIconProps extends Pick<InternalStatusIndicatorProps, 'type' | 'iconAriaLabel'> {

--- a/src/status-indicator/styles.scss
+++ b/src/status-indicator/styles.scss
@@ -20,6 +20,7 @@ $_status-colors: (
   'in-progress': awsui.$color-text-status-inactive,
   'loading': awsui.$color-text-status-inactive,
   'not-started': awsui.$color-text-status-inactive,
+  'log': awsui.$color-text-status-inactive,
 );
 
 $_color-overrides: (
@@ -40,6 +41,7 @@ $_status-backgrounds: (
   'in-progress': awsui.$color-background-status-indicator-neutral,
   'loading': awsui.$color-background-status-indicator-neutral,
   'not-started': awsui.$color-background-status-indicator-neutral,
+  'log': awsui.$color-background-status-indicator-neutral,
 );
 
 $_background-overrides: (

--- a/src/steps/interfaces.ts
+++ b/src/steps/interfaces.ts
@@ -8,7 +8,7 @@ export interface StepsProps extends BaseComponentProps {
    * An array of individual steps
    *
    * Each step definition has the following properties:
-   *  * `status` (string) - Status of the step corresponding to a status indicator.
+   *  * `status` (string) - Status of the step corresponding to a status indicator. The `log` status renders a neutral dot marker.
    *  * `statusIconAriaLabel` - (string) - (Optional) Alternative text for the status icon.
    *  * `header` (ReactNode) - Summary corresponding to the step.
    *  * `details` (ReactNode) - (Optional) Additional information corresponding to the step.
@@ -49,7 +49,7 @@ export interface StepsProps extends BaseComponentProps {
 }
 
 export namespace StepsProps {
-  export type Status = StatusIndicatorProps.Type;
+  export type Status = StatusIndicatorProps.Type | 'log';
 
   export interface Step {
     status: Status;

--- a/src/steps/internal.tsx
+++ b/src/steps/internal.tsx
@@ -24,6 +24,7 @@ const statusToColor: Record<StepsProps.Status, BoxProps.Color> = {
   'in-progress': 'text-status-inactive',
   loading: 'text-status-inactive',
   'not-started': 'text-status-inactive',
+  log: 'text-status-inactive',
 };
 
 const CustomStep = ({


### PR DESCRIPTION
### Description
Adds a log status to Steps. The log status renders a dot icon and displays its text using the inactive status color. A follow up PR to add the annotation will follow next: https://github.com/cloudscape-design/components/pull/4687

Example image: 
<img width="431" height="123" alt="image" src="https://github.com/user-attachments/assets/cbcbe2d9-f061-42a9-ae5c-634e2425db73" />

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: Chorus [AzznTbsZXUA1]

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
