### PR TITLE
feat: VirtualTable (composable / F1-A2) P5 default styling matches Cloudscape Table

### DIFF
--- a/build-tools/tasks/docs.js
+++ b/build-tools/tasks/docs.js
@@ -8,7 +8,12 @@ module.exports = function docs() {
   writeComponentsDocumentation({
     outDir: path.join(workspace.apiDocsPath, 'components'),
     tsconfigPath: require.resolve('../../tsconfig.json'),
-    publicFilesGlob: 'src/*/index.tsx',
+    // VirtualTable (design-study cell F1-A2) is a compound-component namespace exported as an
+    // object literal ({ Root, Header, Body, Row, Cell, ExpandedContent }). The API documenter
+    // only supports a single-function default export per index.tsx, so it is excluded here
+    // pending documenter support for compound components (tracked as a PR follow-up). Its API
+    // is described in src/virtual-table/USAGE.md instead.
+    publicFilesGlob: 'src/!(virtual-table)/index.tsx',
     extraExports: {
       FileDropzone: ['useFilesDragging'],
       IconProvider: ['defineIcons', 'IconRegistry', 'IconMap'],

--- a/build-tools/utils/pluralize.js
+++ b/build-tools/utils/pluralize.js
@@ -95,6 +95,7 @@ const pluralizationMap = {
   TreeView: 'TreeViews',
   TruncatedText: 'TruncatedTexts',
   TutorialPanel: 'TutorialPanels',
+  VirtualTable: 'VirtualTables',
   Wizard: 'Wizards',
 };
 

--- a/pages/virtual-table/cloudwatch-patterns.page.tsx
+++ b/pages/virtual-table/cloudwatch-patterns.page.tsx
@@ -396,11 +396,12 @@ export default function CloudWatchPatternsCompoundPage() {
         <Button onClick={toggleDiffMode}>{diffMode ? 'Exit compare mode' : 'Compare across time'}</Button>
       </div>
       <ScreenshotArea>
-        <div style={{ blockSize: 480 }}>
+        <div>
           <VirtualTable.Root
             items={items}
             trackBy={item => item.id}
             estimatedRowHeight={23}
+            height={480}
             overscan={20}
             resizableColumns={true}
             sortingColumn={sortingColumnId ? { columnId: sortingColumnId } : undefined}

--- a/pages/virtual-table/cloudwatch-patterns.page.tsx
+++ b/pages/virtual-table/cloudwatch-patterns.page.tsx
@@ -1,0 +1,458 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useCallback, useMemo, useState } from 'react';
+
+import Button from '~components/button';
+import VirtualTable, { VirtualTableProps } from '~components/virtual-table';
+import { colorBackgroundControlDisabled, colorChartsPaletteCategorical1, colorTextBodySecondary } from '~design-tokens';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+// CloudWatch Logs Insights "Show patterns" view on the F1-A2 COMPOUND API.
+// Same CloudWatch surface as the F1-A1 config-driven patterns demo, expressed through
+// the compound tree (Root / Header / HeaderCell / Body row-template / Cell /
+// ExpandedContent). See research/cloudwatch-requirements.md:
+//  - CW-6  R-EXPAND shape B: <VirtualTable.ExpandedContent estimatedHeight={150}> renders
+//          a pattern detail (histogram + token enumeration + pattern actions) — arbitrary,
+//          non-tabular, NOT the column set — measured at the patterns density (~150 px).
+//  - CW-9  per-column sort (a patterns-view capability; the standard view has none),
+//          declared via `sortingField` on the sortable HeaderCells, and column resize.
+//  - CW-11 compare/diff mode as a HeaderCell/column-set swap: a different set of
+//          HeaderCells + Cells (difference count, difference description) with its own
+//          sort. No diff-specific component API — the same compound tree, fewer/other cells.
+//  - Shared cross-row histogram scale computed ONCE consumer-side over the full dataset
+//          (computeGlobalHistogramPeak) and closed over by the frequency cell, so the
+//          y-scale is stable across scroll. The F1 framing keeps this consumer-side:
+//          RowApi exposes only rowIndex/totalItemCount/isExpanded, never the windowed
+//          slice (design decision B3, the divergence from F2-A1 which owns the patterns
+//          view and surfaces the peak via CellContext.histogramPeak).
+// Density is preserved: 23 px collapsed rows, ~150 px expanded estimate, overscan 20.
+
+type Severity = 'high' | 'medium' | 'low' | 'info';
+type FindingType = 'new' | 'change-in-count' | 'missing';
+
+interface LogPattern {
+  id: string;
+  severity: Severity;
+  pattern: string;
+  matchingLogs: number;
+  sharePercent: number;
+  // Per-bucket frequency over the query window; normalised to a shared peak.
+  histogram: ReadonlyArray<number>;
+  previousHistogram: ReadonlyArray<number>;
+  lastSeen: number;
+  tokens: ReadonlyArray<string>;
+  // Compare/diff-mode fields (CW-11).
+  diffCount: number;
+  findingType: FindingType;
+}
+
+const SEVERITIES: ReadonlyArray<Severity> = ['high', 'medium', 'low', 'info'];
+const FINDING_TYPES: ReadonlyArray<FindingType> = ['new', 'change-in-count', 'missing'];
+const PATTERN_TEMPLATES = [
+  'Handler failed: DynamoDB throttled after <*> retries (requestId=<*>)',
+  'Processed event <*> for requestId=<*> in <*>ms',
+  'START RequestId: <*> Version: <*>',
+  'REPORT RequestId: <*> Duration: <*> ms Billed Duration: <*> ms',
+  'Timed out after <*>ms waiting for downstream <*>',
+  'Cold start: initialising runtime for <*>',
+];
+
+const BUCKET_COUNT = 24;
+
+function makePattern(index: number): LogPattern {
+  const severity = SEVERITIES[index % SEVERITIES.length];
+  const template = PATTERN_TEMPLATES[index % PATTERN_TEMPLATES.length];
+  const histogram = Array.from({ length: BUCKET_COUNT }, (_, bucket) =>
+    Math.round(20 + 80 * Math.abs(Math.sin(index * 0.7 + bucket * 0.4)) * (1 + (index % 5)))
+  );
+  const previousHistogram = histogram.map(value => Math.max(0, Math.round(value * (0.6 + (index % 3) * 0.2))));
+  const matchingLogs = histogram.reduce((sum, value) => sum + value, 0);
+  const previousTotal = previousHistogram.reduce((sum, value) => sum + value, 0);
+  return {
+    id: `pattern-${index}`,
+    severity,
+    pattern: `${template} #${index}`,
+    matchingLogs,
+    sharePercent: Number(((matchingLogs % 1000) / 10).toFixed(1)),
+    histogram,
+    previousHistogram,
+    lastSeen: 1_700_000_000_000 - index * 60_000,
+    tokens: [`requestId`, `durationMs`, `retryCount#${index % 7}`, `region-${index % 4}`],
+    diffCount: matchingLogs - previousTotal,
+    findingType: FINDING_TYPES[index % FINDING_TYPES.length],
+  };
+}
+
+const PATTERN_COUNT = 800;
+
+// Shared cross-row histogram scale. Computed over the FULL dataset so every row's
+// sparkline is normalised to the same y-axis and the scale does not jump as the
+// window changes on scroll (the console's computeGlobalHistogramPeak).
+function computeGlobalHistogramPeak(patterns: ReadonlyArray<LogPattern>): number {
+  let peak = 1;
+  for (const pattern of patterns) {
+    for (const value of pattern.histogram) {
+      if (value > peak) {
+        peak = value;
+      }
+    }
+    for (const value of pattern.previousHistogram) {
+      if (value > peak) {
+        peak = value;
+      }
+    }
+  }
+  return peak;
+}
+
+// Visually-hidden text so screen-reader users get the histogram's meaning while the
+// bars stay decorative. Standard clip pattern (a dev page has no util import).
+const visuallyHidden: React.CSSProperties = {
+  position: 'absolute',
+  inlineSize: 1,
+  blockSize: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
+
+// Concise non-visual summary of a frequency histogram: total matches, interval
+// count, and peak bucket. Carries the sparkline's meaning to assistive tech.
+function describeHistogram(values: ReadonlyArray<number>): string {
+  const total = values.reduce((sum, value) => sum + value, 0);
+  const peak = values.reduce((max, value) => (value > max ? value : max), 0);
+  return `${total.toLocaleString()} matches across ${values.length} intervals, peak ${peak.toLocaleString()} in one interval.`;
+}
+
+// Short trend statement comparing the current window to the previous one (diff mode).
+function describeTrend(pattern: LogPattern): string {
+  const current = pattern.histogram.reduce((sum, value) => sum + value, 0);
+  const previous = pattern.previousHistogram.reduce((sum, value) => sum + value, 0);
+  const delta = current - previous;
+  if (delta === 0) {
+    return `Frequency unchanged vs previous period (${current.toLocaleString()} matches).`;
+  }
+  const direction = delta > 0 ? 'up' : 'down';
+  const magnitude =
+    previous === 0
+      ? `${Math.abs(delta).toLocaleString()} matches`
+      : `${Math.abs(Math.round((delta / previous) * 100))}%`;
+  return `Frequency ${direction} ${magnitude} vs previous period (${current.toLocaleString()} vs ${previous.toLocaleString()} matches).`;
+}
+
+// Fixed UTC HH:MM:SS so the demo/screenshot is reproducible across locales/timezones.
+function formatTimeUtc(ms: number): string {
+  return `${new Date(ms).toISOString().slice(11, 19)} UTC`;
+}
+
+// Human-readable labels for the diff-mode finding types.
+const FINDING_LABELS: Record<FindingType, string> = {
+  new: 'New',
+  'change-in-count': 'Change in count',
+  missing: 'Missing',
+};
+
+// A minimal sparkline normalised to a shared peak. The bars are decorative
+// (aria-hidden); when `summary` is supplied it is exposed to screen readers as
+// visually-hidden text, so the frequency column cell and the expanded detail are
+// not silent (the header/cell content stays consistent for SR — CW-16, WCAG 1.1.1).
+function Sparkline({
+  values,
+  peak,
+  muted = false,
+  summary,
+}: {
+  values: ReadonlyArray<number>;
+  peak: number;
+  muted?: boolean;
+  summary?: string;
+}) {
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center' }}>
+      <span aria-hidden={true} style={{ display: 'inline-flex', alignItems: 'flex-end', gap: 1, blockSize: 18 }}>
+        {values.map((value, bucket) => (
+          <span
+            key={bucket}
+            style={{
+              display: 'inline-block',
+              inlineSize: 2,
+              blockSize: `${Math.max(1, Math.round((value / peak) * 18))}px`,
+              background: muted ? colorBackgroundControlDisabled : colorChartsPaletteCategorical1,
+            }}
+          />
+        ))}
+      </span>
+      {summary && <span style={visuallyHidden}>{summary}</span>}
+    </span>
+  );
+}
+
+// R-EXPAND shape B: arbitrary, non-tabular pattern detail — histogram (current, plus
+// previous in diff mode), token enumeration, and pattern actions. Deliberately not
+// the column layout; measured at ~150 px.
+function PatternDetail({ pattern, peak, diffMode }: { pattern: LogPattern; peak: number; diffMode: boolean }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: '4px 0' }}>
+      <div style={{ display: 'flex', gap: 24, alignItems: 'flex-end' }}>
+        <div>
+          <div style={{ fontSize: 12, color: colorTextBodySecondary }}>Current</div>
+          <Sparkline
+            values={pattern.histogram}
+            peak={peak}
+            summary={`Current period: ${describeHistogram(pattern.histogram)}`}
+          />
+        </div>
+        {diffMode && (
+          <div>
+            <div style={{ fontSize: 12, color: colorTextBodySecondary }}>Previous</div>
+            <Sparkline
+              values={pattern.previousHistogram}
+              peak={peak}
+              muted={true}
+              summary={`Previous period: ${describeHistogram(pattern.previousHistogram)}`}
+            />
+          </div>
+        )}
+      </div>
+      {diffMode && <div style={{ fontSize: 12 }}>{describeTrend(pattern)}</div>}
+      <div>
+        <span style={{ fontSize: 12, color: colorTextBodySecondary }}>Tokens: </span>
+        {pattern.tokens.map(token => (
+          <code key={token} style={{ marginInlineEnd: 8 }}>
+            {token}
+          </code>
+        ))}
+      </div>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <Button>View matching logs</Button>
+        <Button>Tail pattern</Button>
+        <Button>Compare across time</Button>
+      </div>
+    </div>
+  );
+}
+
+// A column descriptor drives BOTH the HeaderCell (in Header) and the matched-by-columnId
+// Cell (in the row template) so the two stay in sync — the compound API reconciles body
+// Cells to the HeaderCell authority by columnId. `sortingField` marks a sortable column
+// (per-column sort is a patterns-view capability, CW-9).
+interface PatternColumn {
+  columnId: string;
+  header: React.ReactNode;
+  renderCell: (item: LogPattern) => React.ReactNode;
+  sortingField?: keyof LogPattern;
+  width?: number;
+  stretch?: boolean;
+}
+
+export default function CloudWatchPatternsCompoundPage() {
+  const [diffMode, setDiffMode] = useState(false);
+  const [expandedItems, setExpandedItems] = useState<ReadonlyArray<string>>([]);
+  // The compound API reflects sort state by columnId (SortingDetail carries a columnId,
+  // not a column definition) and emits intent; the consumer applies the sort.
+  const [sortingColumnId, setSortingColumnId] = useState<string | undefined>();
+  const [sortingDescending, setSortingDescending] = useState(false);
+
+  const basePatterns = useMemo<ReadonlyArray<LogPattern>>(
+    () => Array.from({ length: PATTERN_COUNT }, (_, index) => makePattern(index)),
+    []
+  );
+
+  // Shared histogram peak over the full dataset — stable across scroll, computed once,
+  // closed over by the frequency cell (F1 keeps this consumer-side; RowApi never exposes
+  // the windowed slice).
+  const histogramPeak = useMemo(() => computeGlobalHistogramPeak(basePatterns), [basePatterns]);
+
+  // Normal-mode columns. The frequency cell closes over the shared peak.
+  const normalColumns = useMemo<ReadonlyArray<PatternColumn>>(
+    () => [
+      {
+        columnId: 'severity',
+        header: 'Severity',
+        renderCell: item => <span style={{ textTransform: 'capitalize' }}>{item.severity}</span>,
+        width: 110,
+      },
+      {
+        columnId: 'matchingLogs',
+        header: 'Matching logs',
+        renderCell: item => item.matchingLogs.toLocaleString(),
+        sortingField: 'matchingLogs',
+        width: 130,
+      },
+      {
+        columnId: 'sharePercent',
+        header: 'Share',
+        renderCell: item => `${item.sharePercent}%`,
+        sortingField: 'sharePercent',
+        width: 90,
+      },
+      {
+        columnId: 'frequency',
+        // The sparkline carries a visually-hidden summary so the cell is not silent and
+        // stays consistent with its "Frequency" header for screen readers.
+        header: 'Frequency',
+        renderCell: item => (
+          <Sparkline values={item.histogram} peak={histogramPeak} summary={describeHistogram(item.histogram)} />
+        ),
+        width: 140,
+      },
+      {
+        columnId: 'lastSeen',
+        header: 'Last seen',
+        renderCell: item => formatTimeUtc(item.lastSeen),
+        sortingField: 'lastSeen',
+        width: 110,
+      },
+      {
+        columnId: 'pattern',
+        header: 'Pattern',
+        renderCell: item => <span style={{ fontFamily: 'monospace' }}>{item.pattern}</span>,
+        stretch: true,
+      },
+    ],
+    [histogramPeak]
+  );
+
+  // CW-11 compare/diff mode: a different HeaderCell/Cell set with its own sort. Selecting
+  // it swaps which compound cells render — no diff-specific component API.
+  const diffColumns = useMemo<ReadonlyArray<PatternColumn>>(
+    () => [
+      {
+        columnId: 'severity',
+        header: 'Severity',
+        renderCell: item => <span style={{ textTransform: 'capitalize' }}>{item.severity}</span>,
+        width: 110,
+      },
+      {
+        columnId: 'diffCount',
+        header: '(Previous → Current) difference count',
+        renderCell: item =>
+          item.diffCount >= 0 ? `+${item.diffCount.toLocaleString()}` : item.diffCount.toLocaleString(),
+        sortingField: 'diffCount',
+        width: 260,
+      },
+      {
+        columnId: 'findingType',
+        header: 'Difference description',
+        renderCell: item => FINDING_LABELS[item.findingType],
+        sortingField: 'findingType',
+        width: 180,
+      },
+      {
+        columnId: 'pattern',
+        header: 'Pattern',
+        renderCell: item => <span style={{ fontFamily: 'monospace' }}>{item.pattern}</span>,
+        stretch: true,
+      },
+    ],
+    []
+  );
+
+  const columns = diffMode ? diffColumns : normalColumns;
+
+  // VirtualTable reflects sort state and emits intent; it does not sort data. The consumer
+  // applies the sort here (CW-9). The active column's `sortingField` is the data key.
+  const items = useMemo<ReadonlyArray<LogPattern>>(() => {
+    const activeColumn = columns.find(column => column.columnId === sortingColumnId);
+    const field = activeColumn?.sortingField;
+    if (!field) {
+      return basePatterns;
+    }
+    const sorted = [...basePatterns].sort((a, b) => {
+      const left = a[field];
+      const right = b[field];
+      if (typeof left === 'number' && typeof right === 'number') {
+        return left - right;
+      }
+      return String(left).localeCompare(String(right));
+    });
+    return sortingDescending ? sorted.reverse() : sorted;
+  }, [basePatterns, columns, sortingColumnId, sortingDescending]);
+
+  const handleSortingChange = useCallback((detail: VirtualTableProps.SortingDetail) => {
+    setSortingColumnId(detail.columnId);
+    setSortingDescending(detail.sortingDescending);
+  }, []);
+
+  const toggleDiffMode = useCallback(() => {
+    // The two modes have disjoint sort fields; clear sort so a stale column from the
+    // other set is not applied to the swapped-in columns.
+    setSortingColumnId(undefined);
+    setSortingDescending(false);
+    setDiffMode(value => !value);
+  }, []);
+
+  return (
+    <>
+      <h1>VirtualTable — CloudWatch Logs Insights (Show patterns view, compound)</h1>
+      <p>
+        {items.length.toLocaleString()} patterns · {diffMode ? 'compare / diff mode' : 'normal mode'}
+      </p>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+        <Button onClick={toggleDiffMode}>{diffMode ? 'Exit compare mode' : 'Compare across time'}</Button>
+      </div>
+      <ScreenshotArea>
+        <div style={{ blockSize: 480 }}>
+          <VirtualTable.Root
+            items={items}
+            trackBy={item => item.id}
+            estimatedRowHeight={23}
+            overscan={20}
+            resizableColumns={true}
+            sortingColumn={sortingColumnId ? { columnId: sortingColumnId } : undefined}
+            sortingDescending={sortingDescending}
+            onSortingChange={({ detail }) => handleSortingChange(detail)}
+            expandedItems={expandedItems}
+            onExpandChange={({ detail }) => setExpandedItems(detail.expandedItems)}
+            ariaLabels={{
+              tableLabel: 'CloudWatch log patterns',
+              expandButtonLabel: (item, expanded) => `${expanded ? 'Collapse' : 'Expand'} pattern: ${item.pattern}`,
+              expandedRegionLabel: item => `Pattern detail for ${item.pattern}`,
+              activateSortLabel: columnId => {
+                const column = columns.find(candidate => candidate.columnId === columnId);
+                const label = typeof column?.header === 'string' ? column.header : columnId;
+                return `Sort by ${label}`;
+              },
+            }}
+          >
+            {/* CW-9: sortable columns declare a `sortingField`; the sticky header keeps
+                the column labels visible while scrolling the windowed body. */}
+            <VirtualTable.Header sticky={true}>
+              {columns.map(column => (
+                <VirtualTable.HeaderCell
+                  key={column.columnId}
+                  columnId={column.columnId}
+                  sortingField={column.sortingField as string | undefined}
+                  width={column.width}
+                  stretch={column.stretch}
+                >
+                  {column.header}
+                </VirtualTable.HeaderCell>
+              ))}
+            </VirtualTable.Header>
+            <VirtualTable.Body>
+              {(item: LogPattern, api) => (
+                <VirtualTable.Row item={item} api={api}>
+                  {columns.map(column => (
+                    <VirtualTable.Cell key={column.columnId} columnId={column.columnId}>
+                      {column.renderCell(item)}
+                    </VirtualTable.Cell>
+                  ))}
+                  {/* R-EXPAND shape B: declared unconditionally (Root mounts it only for
+                      expanded rows), arbitrary non-tabular detail, measured (~150 px). */}
+                  <VirtualTable.ExpandedContent estimatedHeight={150}>
+                    <PatternDetail pattern={item} peak={histogramPeak} diffMode={diffMode} />
+                  </VirtualTable.ExpandedContent>
+                </VirtualTable.Row>
+              )}
+            </VirtualTable.Body>
+          </VirtualTable.Root>
+        </div>
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/pages/virtual-table/cloudwatch-raw.page.tsx
+++ b/pages/virtual-table/cloudwatch-raw.page.tsx
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import VirtualTable from '~components/virtual-table';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+// CloudWatch file / raw view — the third required surface (CW-15) on the F1-A2
+// COMPOUND API. This is the same compound tree reduced to its simplest shape:
+//  - a single column (one HeaderCell + one Cell) rendering the raw log line,
+//  - no <VirtualTable.ExpandedContent> child (expansion off, so no disclosure column),
+//  - estimatedRowHeight = 20 (RAW_LINE_HEIGHT), overscan = 40 (FILE_VIEW_OVERSCAN),
+//  - getRowHeight returns 'auto' only for wrapping candidates (long lines span more
+//    than one 20 px line box); short lines keep the fixed 20 px baseline so the
+//    observer is not attached to every windowed line (F1-A1 cw-standard NB5 carried
+//    forward; enabled by the F1-A2 core getRowHeight data-row measurement path).
+// Demonstrates that all three CloudWatch surfaces are reachable from one compound
+// API without a specialized "raw" mode.
+
+interface RawLine {
+  id: string;
+  text: string;
+}
+
+const RAW_LINE_HEIGHT = 20;
+const FILE_VIEW_OVERSCAN = 40;
+const LINE_COUNT = 5000;
+
+function makeLine(index: number): RawLine {
+  // Every ~7th line is long enough to wrap, exercising measured variable heights.
+  const long = index % 7 === 0;
+  const base = `2024-06-01T12:00:${String(index % 60).padStart(2, '0')}.123Z [INFO] request ${index} completed`;
+  return {
+    id: `line-${index}`,
+    text: long
+      ? `${base} — payload=${'x'.repeat(220)} (truncation off, wraps across multiple ${RAW_LINE_HEIGHT}px line boxes)`
+      : base,
+  };
+}
+
+export default function CloudWatchRawCompoundPage() {
+  const [items] = useState<RawLine[]>(() => Array.from({ length: LINE_COUNT }, (_, index) => makeLine(index)));
+
+  return (
+    <>
+      <h1>VirtualTable — CloudWatch file / raw view (compound)</h1>
+      <p>{items.length.toLocaleString()} raw log lines · wrapping, expansion off</p>
+      <ScreenshotArea>
+        <div style={{ blockSize: 480 }}>
+          <VirtualTable.Root
+            items={items}
+            trackBy={item => item.id}
+            estimatedRowHeight={RAW_LINE_HEIGHT}
+            getRowHeight={item => (item.text.length > 120 ? 'auto' : RAW_LINE_HEIGHT)}
+            overscan={FILE_VIEW_OVERSCAN}
+            ariaLabels={{ tableLabel: 'Raw log events' }}
+          >
+            <VirtualTable.Header sticky={true}>
+              <VirtualTable.HeaderCell columnId="line" stretch={true}>
+                Log events
+              </VirtualTable.HeaderCell>
+            </VirtualTable.Header>
+            <VirtualTable.Body>
+              {(item: RawLine, api) => (
+                <VirtualTable.Row item={item} api={api}>
+                  <VirtualTable.Cell columnId="line">
+                    <span
+                      style={{ fontFamily: 'monospace', fontSize: 12, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+                    >
+                      {item.text}
+                    </span>
+                  </VirtualTable.Cell>
+                </VirtualTable.Row>
+              )}
+            </VirtualTable.Body>
+          </VirtualTable.Root>
+        </div>
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/pages/virtual-table/cloudwatch-raw.page.tsx
+++ b/pages/virtual-table/cloudwatch-raw.page.tsx
@@ -47,11 +47,12 @@ export default function CloudWatchRawCompoundPage() {
       <h1>VirtualTable — CloudWatch file / raw view (compound)</h1>
       <p>{items.length.toLocaleString()} raw log lines · wrapping, expansion off</p>
       <ScreenshotArea>
-        <div style={{ blockSize: 480 }}>
+        <div>
           <VirtualTable.Root
             items={items}
             trackBy={item => item.id}
             estimatedRowHeight={RAW_LINE_HEIGHT}
+            height={480}
             getRowHeight={item => (item.text.length > 120 ? 'auto' : RAW_LINE_HEIGHT)}
             overscan={FILE_VIEW_OVERSCAN}
             ariaLabels={{ tableLabel: 'Raw log events' }}

--- a/pages/virtual-table/cloudwatch-standard.page.tsx
+++ b/pages/virtual-table/cloudwatch-standard.page.tsx
@@ -1,0 +1,228 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+import Button from '~components/button';
+import VirtualTable, { VirtualTableProps } from '~components/virtual-table';
+import { colorTextBodySecondary } from '~design-tokens';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+// CloudWatch Logs Insights STANDARD view on the F1-A2 COMPOUND API.
+// Same CloudWatch surface as the F1-A1 config-driven demo, expressed through the
+// compound tree (Root / Header / HeaderCell / Body row-template / Cell /
+// ExpandedContent). See research/cloudwatch-requirements.md:
+//  - CW-8  dynamic columns from arbitrary fields (rendered as HeaderCells + Cells)
+//          + the leading disclosure column materialised by Root; fixed layout with
+//          @message as the single stretch-last column.
+//  - CW-12 accurate visible-range reporting under variable heights.
+//  - CW-13 scroll-to-and-reveal a specific row (expand + scroll) via the ref.
+//  - CW-7  consumer-composed live tail (pin to newest, release on manual scroll)
+//          built on the imperative ref — the component owns no follow policy.
+//  - R-EXPAND shape A: <VirtualTable.ExpandedContent> renders the full log record as
+//          arbitrary, non-tabular key/value detail (NOT the column set), measured (~300 px).
+// Density is preserved: 23 px collapsed rows, ~300 px expanded estimate, overscan 20.
+
+const LOG_LEVELS = ['INFO', 'WARN', 'ERROR', 'DEBUG'] as const;
+type LogLevel = (typeof LOG_LEVELS)[number];
+
+interface LogRecord {
+  id: string;
+  timestamp: number;
+  level: LogLevel;
+  message: string;
+  // Arbitrary discovered fields — the standard view surfaces a subset as columns
+  // and the full record in the expanded detail.
+  fields: Record<string, string>;
+}
+
+const REQUEST_IDS = ['a1b2c3d4', 'e5f6a7b8', 'c9d0e1f2', '3a4b5c6d'];
+
+function makeRecord(index: number): LogRecord {
+  const level = LOG_LEVELS[index % LOG_LEVELS.length];
+  const requestId = REQUEST_IDS[index % REQUEST_IDS.length];
+  return {
+    id: `log-${index}`,
+    timestamp: 1_700_000_000_000 + index * 137,
+    level,
+    message:
+      level === 'ERROR'
+        ? `Handler failed: DynamoDB throttled after 3 retries (requestId=${requestId})`
+        : `Processed event ${index} for requestId=${requestId} in ${8 + (index % 40)}ms`,
+    fields: {
+      '@timestamp': new Date(1_700_000_000_000 + index * 137).toISOString(),
+      '@logStream': `2024/06/01/[$LATEST]${requestId}`,
+      '@requestId': requestId,
+      level,
+      durationMs: String(8 + (index % 40)),
+      billedMs: String(10 + (index % 40)),
+      memoryUsedMB: String(64 + (index % 128)),
+    },
+  };
+}
+
+const INITIAL_COUNT = 2000;
+
+// CW-8: the standard view surfaces a consumer-chosen subset of discovered fields
+// as columns; the set is dynamic (mapped to HeaderCells + Cells below), not a fixed
+// three. @message is the single stretch-last column.
+const DISPLAYED_FIELDS = ['@timestamp', 'level', '@requestId', 'durationMs'];
+
+// Arbitrary, non-tabular expanded content (R-EXPAND shape A): a key/value detail
+// list plus the raw JSON record. Deliberately not the column layout.
+function LogRecordDetail({ record }: { record: LogRecord }) {
+  const entries = Object.entries(record.fields);
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: '4px 0' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'max-content 1fr', columnGap: 16, rowGap: 2 }}>
+        {entries.map(([key, value]) => (
+          <React.Fragment key={key}>
+            <span style={{ fontFamily: 'monospace', color: colorTextBodySecondary }}>{key}</span>
+            <span style={{ fontFamily: 'monospace' }}>{value}</span>
+          </React.Fragment>
+        ))}
+      </div>
+      <details>
+        <summary style={{ cursor: 'pointer' }}>Raw record (JSON)</summary>
+        <pre style={{ margin: '4px 0 0', fontSize: 12, whiteSpace: 'pre-wrap' }}>
+          {JSON.stringify({ id: record.id, message: record.message, ...record.fields }, null, 2)}
+        </pre>
+      </details>
+    </div>
+  );
+}
+
+export default function CloudWatchStandardCompoundPage() {
+  const [items, setItems] = useState<LogRecord[]>(() =>
+    Array.from({ length: INITIAL_COUNT }, (_, index) => makeRecord(index))
+  );
+  const [expandedItems, setExpandedItems] = useState<ReadonlyArray<string>>([]);
+  const [following, setFollowing] = useState(true);
+  const [visibleRange, setVisibleRange] = useState({ firstIndex: 0, lastIndex: 0 });
+
+  const ref = useRef<VirtualTableProps.Ref>(null);
+  const nextIndexRef = useRef(INITIAL_COUNT);
+  // Pinned state is captured BEFORE each append so the follow decision does not
+  // depend on the core's "at bottom edge" tolerance after the runway grows
+  // (F1-A1 cw-standard B1 learning carried forward).
+  const wasPinnedRef = useRef(true);
+
+  // Live tail (CW-7): the component exposes only mechanism (scrollToEnd /
+  // isPinnedToEnd); the follow *policy* lives here.
+  useEffect(() => {
+    if (!following) {
+      return;
+    }
+    // On (re)start, establish the pinned state so following=true actually tails from
+    // the current position: at mount the viewport sits at the top over the initial
+    // dataset, so isPinnedToEnd() is false and nothing would tail until the user
+    // scrolled down once. Seeding pinned + snapping to the newest row makes live tail
+    // engage immediately on load and on resume (B1 fix; folds NB2 snap-on-resume).
+    wasPinnedRef.current = true;
+    ref.current?.scrollToEnd();
+    const timer = setInterval(() => {
+      // Capture pinned state BEFORE the append grows the runway (tolerance-independent),
+      // and generate the batch + ids OUTSIDE the state updater so the updater stays pure
+      // under React 18 StrictMode double-invoke (F1-A1 cw-standard B1/B2 learnings).
+      wasPinnedRef.current = ref.current?.isPinnedToEnd() !== false;
+      const base = nextIndexRef.current;
+      nextIndexRef.current = base + 3;
+      const added = [makeRecord(base), makeRecord(base + 1), makeRecord(base + 2)];
+      setItems(prev => [...prev, ...added]);
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [following]);
+
+  // Re-pin to the newest row after the appended rows have laid out, but only if the
+  // viewport was pinned at capture time. A manual scroll away makes the next tick
+  // capture wasPinnedRef=false, naturally releasing follow.
+  useLayoutEffect(() => {
+    if (following && wasPinnedRef.current) {
+      ref.current?.scrollToEnd();
+    }
+  }, [items, following]);
+
+  const handleExpandChange = useCallback(
+    (detail: VirtualTableProps.ExpandChangeDetail<LogRecord>) => setExpandedItems(detail.expandedItems),
+    []
+  );
+
+  // CW-13: reveal (expand + scroll) an arbitrary row by id.
+  const revealFirstError = useCallback(() => {
+    const target = items.find(item => item.level === 'ERROR');
+    if (target) {
+      ref.current?.scrollToItem(target.id, { reveal: true });
+    }
+  }, [items]);
+
+  return (
+    <>
+      <h1>VirtualTable — CloudWatch Logs Insights (standard view, compound)</h1>
+      <p>
+        {items.length.toLocaleString()} log records · showing rows {visibleRange.firstIndex}–{visibleRange.lastIndex} ·
+        live tail {following ? 'on' : 'paused'}
+      </p>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+        <Button onClick={() => setFollowing(value => !value)}>
+          {following ? 'Pause live tail' : 'Resume live tail'}
+        </Button>
+        <Button onClick={revealFirstError}>Reveal first error</Button>
+      </div>
+      <ScreenshotArea>
+        <div style={{ blockSize: 480 }}>
+          <VirtualTable.Root
+            items={items}
+            trackBy={item => item.id}
+            estimatedRowHeight={23}
+            overscan={20}
+            resizableColumns={true}
+            expandedItems={expandedItems}
+            onExpandChange={({ detail }) => handleExpandChange(detail)}
+            onVisibleRangeChange={({ detail }) => setVisibleRange(detail)}
+            imperativeRef={ref}
+            ariaLabels={{
+              tableLabel: 'CloudWatch log records',
+              expandButtonLabel: (item, expanded) =>
+                `${expanded ? 'Collapse' : 'Expand'} record ${item.fields['@requestId']}`,
+              expandedRegionLabel: item => `Log record detail for ${item.fields['@requestId']}`,
+              appendAnnouncement: ({ addedCount, totalCount }) => `${addedCount} new log records, ${totalCount} total`,
+            }}
+          >
+            {/* CW-8: dynamic columns declared as HeaderCells; @message is the single
+                stretch-last column. No sortingField — per-column sort is a patterns-view
+                capability (CW-9); the standard view has no per-column sort. */}
+            <VirtualTable.Header sticky={true}>
+              {DISPLAYED_FIELDS.map(field => (
+                <VirtualTable.HeaderCell key={field} columnId={field} width={field === '@timestamp' ? 210 : 120}>
+                  {field}
+                </VirtualTable.HeaderCell>
+              ))}
+              <VirtualTable.HeaderCell columnId="@message" stretch={true}>
+                @message
+              </VirtualTable.HeaderCell>
+            </VirtualTable.Header>
+            <VirtualTable.Body>
+              {(item: LogRecord, api) => (
+                <VirtualTable.Row item={item} api={api}>
+                  {DISPLAYED_FIELDS.map(field => (
+                    <VirtualTable.Cell key={field} columnId={field}>
+                      <span style={{ fontFamily: 'monospace' }}>{item.fields[field]}</span>
+                    </VirtualTable.Cell>
+                  ))}
+                  <VirtualTable.Cell columnId="@message">
+                    <span style={{ fontFamily: 'monospace' }}>{item.message}</span>
+                  </VirtualTable.Cell>
+                  {/* R-EXPAND shape A: declared unconditionally (Root mounts it only for
+                      expanded rows), arbitrary non-tabular detail, measured (~300 px). */}
+                  <VirtualTable.ExpandedContent estimatedHeight={300}>
+                    <LogRecordDetail record={item} />
+                  </VirtualTable.ExpandedContent>
+                </VirtualTable.Row>
+              )}
+            </VirtualTable.Body>
+          </VirtualTable.Root>
+        </div>
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/pages/virtual-table/cloudwatch-standard.page.tsx
+++ b/pages/virtual-table/cloudwatch-standard.page.tsx
@@ -169,11 +169,12 @@ export default function CloudWatchStandardCompoundPage() {
         <Button onClick={revealFirstError}>Reveal first error</Button>
       </div>
       <ScreenshotArea>
-        <div style={{ blockSize: 480 }}>
+        <div>
           <VirtualTable.Root
             items={items}
             trackBy={item => item.id}
             estimatedRowHeight={23}
+            height={480}
             overscan={20}
             resizableColumns={true}
             expandedItems={expandedItems}

--- a/pages/virtual-table/simple.page.tsx
+++ b/pages/virtual-table/simple.page.tsx
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import VirtualTable from '~components/virtual-table';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+interface Item {
+  id: string;
+  name: string;
+  status: string;
+  detail: string;
+}
+
+const items: Item[] = Array.from({ length: 25 }, (_, index) => ({
+  id: `row-${index}`,
+  name: `Resource ${index}`,
+  status: index % 2 === 0 ? 'Available' : 'Pending',
+  detail: `Extended detail for resource ${index}: arbitrary non-tabular expanded content.`,
+}));
+
+export default function VirtualTableCompoundSimplePage() {
+  return (
+    <>
+      <h1>VirtualTable — compound scaffold</h1>
+      <p>
+        Generic compound-components VirtualTable (cell F1-A2). This dev page exercises the scaffolded compound shell —
+        Root/Header/HeaderCell/Body/Row/Cell/ExpandedContent — including a materialised disclosure column and a
+        first-class ExpandedContent child for arbitrary non-tabular row detail. Windowing, measurement, and the full
+        expansion/live-tail engine land in the core implementation unit.
+      </p>
+      <ScreenshotArea>
+        <VirtualTable.Root
+          items={items}
+          trackBy={item => item.id}
+          estimatedRowHeight={23}
+          defaultExpandedItems={['row-0']}
+          ariaLabels={{
+            tableLabel: 'Resources',
+            expandButtonLabel: (item, expanded) => `${expanded ? 'Collapse' : 'Expand'} ${item.name}`,
+            expandedRegionLabel: item => `${item.name} details`,
+          }}
+        >
+          <VirtualTable.Header sticky={true}>
+            <VirtualTable.HeaderCell columnId="name">Name</VirtualTable.HeaderCell>
+            <VirtualTable.HeaderCell columnId="status" stretch={true}>
+              Status
+            </VirtualTable.HeaderCell>
+          </VirtualTable.Header>
+          <VirtualTable.Body>
+            {(item: Item, api) => (
+              <VirtualTable.Row item={item} api={api}>
+                <VirtualTable.Cell columnId="name">{item.name}</VirtualTable.Cell>
+                <VirtualTable.Cell columnId="status">{item.status}</VirtualTable.Cell>
+                <VirtualTable.ExpandedContent estimatedHeight={80}>
+                  <div>
+                    <strong>Details</strong>
+                    <p>{item.detail}</p>
+                  </div>
+                </VirtualTable.ExpandedContent>
+              </VirtualTable.Row>
+            )}
+          </VirtualTable.Body>
+        </VirtualTable.Root>
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/pages/virtual-table/simple.page.tsx
+++ b/pages/virtual-table/simple.page.tsx
@@ -10,13 +10,17 @@ interface Item {
   id: string;
   name: string;
   status: string;
+  region: string;
   detail: string;
 }
+
+const REGIONS = ['us-east-1', 'eu-west-1', 'ap-southeast-2', 'us-west-2'];
 
 const items: Item[] = Array.from({ length: 25 }, (_, index) => ({
   id: `row-${index}`,
   name: `Resource ${index}`,
   status: index % 2 === 0 ? 'Available' : 'Pending',
+  region: REGIONS[index % REGIONS.length],
   detail: `Extended detail for resource ${index}: arbitrary non-tabular expanded content.`,
 }));
 
@@ -35,6 +39,7 @@ export default function VirtualTableCompoundSimplePage() {
           items={items}
           trackBy={item => item.id}
           estimatedRowHeight={23}
+          resizableColumns={true}
           defaultExpandedItems={['row-0']}
           ariaLabels={{
             tableLabel: 'Resources',
@@ -43,9 +48,12 @@ export default function VirtualTableCompoundSimplePage() {
           }}
         >
           <VirtualTable.Header sticky={true}>
-            <VirtualTable.HeaderCell columnId="name">Name</VirtualTable.HeaderCell>
-            <VirtualTable.HeaderCell columnId="status" stretch={true}>
-              Status
+            <VirtualTable.HeaderCell columnId="name" width={200}>
+              Name
+            </VirtualTable.HeaderCell>
+            <VirtualTable.HeaderCell columnId="status">Status</VirtualTable.HeaderCell>
+            <VirtualTable.HeaderCell columnId="region" stretch={true}>
+              Region
             </VirtualTable.HeaderCell>
           </VirtualTable.Header>
           <VirtualTable.Body>
@@ -53,6 +61,7 @@ export default function VirtualTableCompoundSimplePage() {
               <VirtualTable.Row item={item} api={api}>
                 <VirtualTable.Cell columnId="name">{item.name}</VirtualTable.Cell>
                 <VirtualTable.Cell columnId="status">{item.status}</VirtualTable.Cell>
+                <VirtualTable.Cell columnId="region">{item.region}</VirtualTable.Cell>
                 <VirtualTable.ExpandedContent estimatedHeight={80}>
                   <div>
                     <strong>Details</strong>

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -33703,6 +33703,8 @@ specified in the \`i18nStrings\` property.",
 }
 `;
 
+exports[`Components definition for virtual-table matches the snapshot: virtual-table 1`] = `undefined`;
+
 exports[`Components definition for wizard matches the snapshot: wizard 1`] = `
 {
   "dashCaseName": "wizard",
@@ -46284,6 +46286,135 @@ Supported options:
     {
       "methods": [
         {
+          "name": "findColumnHeaders",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "The labeled expanded region for a data row, or null if not expanded/windowed.",
+          "name": "findExpandedRegion",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "dataIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "The disclosure toggle button for a data row, or null if the row is outside the window.",
+          "name": "findExpandToggle",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "dataIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "The header row element (returned regardless of the \`sticky\` prop).",
+          "name": "findHeaderRow",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "The polite append aria-live node.",
+          "name": "findLiveRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns null for rows outside the current window (by design). Locates by the row's
+\`aria-rowindex\`, which is the full-dataset index offset by the header row: the header
+is \`aria-rowindex=1\`, so data row \`dataIndex\` is \`aria-rowindex=dataIndex+2\`. Indexing
+this way (not by position in the windowed array) is correct under virtualization.",
+          "name": "findRowByIndex",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "dataIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Rendered (windowed) rows only.",
+          "name": "findRows",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+      ],
+      "name": "VirtualTableWrapper",
+    },
+    {
+      "methods": [
+        {
           "inheritedFrom": {
             "name": "FormWrapper.findActions",
           },
@@ -55137,6 +55268,110 @@ Supported options:
         },
       ],
       "name": "TutorialTaskWrapper",
+    },
+    {
+      "methods": [
+        {
+          "name": "findColumnHeaders",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "The labeled expanded region for a data row, or null if not expanded/windowed.",
+          "name": "findExpandedRegion",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "dataIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "The disclosure toggle button for a data row, or null if the row is outside the window.",
+          "name": "findExpandToggle",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "dataIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "The header row element (returned regardless of the \`sticky\` prop).",
+          "name": "findHeaderRow",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "The polite append aria-live node.",
+          "name": "findLiveRegion",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns null for rows outside the current window (by design). Locates by the row's
+\`aria-rowindex\`, which is the full-dataset index offset by the header row: the header
+is \`aria-rowindex=1\`, so data row \`dataIndex\` is \`aria-rowindex=dataIndex+2\`. Indexing
+this way (not by position in the windowed array) is correct under virtualization.",
+          "name": "findRowByIndex",
+          "parameters": [
+            {
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "dataIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Rendered (windowed) rows only.",
+          "name": "findRows",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+      ],
+      "name": "VirtualTableWrapper",
     },
     {
       "methods": [

--- a/src/internal/components/expand-toggle-button/index.tsx
+++ b/src/internal/components/expand-toggle-button/index.tsx
@@ -18,6 +18,8 @@ export function ExpandToggleButton({
   customIcon,
   className,
   disableFocusHighlight,
+  id,
+  ariaControls,
 }: {
   isExpanded?: boolean;
   onExpandableItemToggle?: () => void;
@@ -26,6 +28,8 @@ export function ExpandToggleButton({
   customIcon?: React.ReactNode;
   className?: string;
   disableFocusHighlight?: boolean;
+  id?: string;
+  ariaControls?: string;
 }) {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const { tabIndex } = useSingleTabStopNavigation(buttonRef);
@@ -34,9 +38,11 @@ export function ExpandToggleButton({
     <button
       type="button"
       ref={buttonRef}
+      id={id}
       tabIndex={tabIndex}
       aria-label={isExpanded ? collapseButtonLabel : expandButtonLabel}
       aria-expanded={isExpanded}
+      aria-controls={ariaControls}
       className={clsx(styles['expand-toggle'], disableFocusHighlight && styles['disable-focus-highlight'], className)}
       onClick={onExpandableItemToggle}
     >

--- a/src/test-utils/dom/virtual-table/index.ts
+++ b/src/test-utils/dom/virtual-table/index.ts
@@ -24,7 +24,7 @@ export default class VirtualTableWrapper extends ComponentWrapper {
 
   /** The disclosure toggle button for a data row, or null if the row is outside the window. */
   findExpandToggle(dataIndex: number): ElementWrapper | null {
-    return this.findRowByIndex(dataIndex)?.findByClassName(styles['disclosure-button']) ?? null;
+    return this.findRowByIndex(dataIndex)?.find(`.${styles['disclosure-cell']} button`) ?? null;
   }
 
   /** The labeled expanded region for a data row, or null if not expanded/windowed. */

--- a/src/test-utils/dom/virtual-table/index.ts
+++ b/src/test-utils/dom/virtual-table/index.ts
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+
+import styles from '../../../virtual-table/styles.selectors.js';
+
+export default class VirtualTableWrapper extends ComponentWrapper {
+  static rootSelector: string = styles.root;
+
+  /** Rendered (windowed) rows only. */
+  findRows(): Array<ElementWrapper> {
+    return this.findAllByClassName(styles.row);
+  }
+
+  /**
+   * Returns null for rows outside the current window (by design). Locates by the row's
+   * `aria-rowindex`, which is the full-dataset index offset by the header row: the header
+   * is `aria-rowindex=1`, so data row `dataIndex` is `aria-rowindex=dataIndex+2`. Indexing
+   * this way (not by position in the windowed array) is correct under virtualization.
+   */
+  findRowByIndex(dataIndex: number): ElementWrapper | null {
+    return this.find(`.${styles.row}[aria-rowindex="${dataIndex + 2}"]`);
+  }
+
+  /** The disclosure toggle button for a data row, or null if the row is outside the window. */
+  findExpandToggle(dataIndex: number): ElementWrapper | null {
+    return this.findRowByIndex(dataIndex)?.findByClassName(styles['disclosure-button']) ?? null;
+  }
+
+  /** The labeled expanded region for a data row, or null if not expanded/windowed. */
+  findExpandedRegion(dataIndex: number): ElementWrapper | null {
+    // The expanded row shares its data row's aria-rowindex (dataIndex + 2) and carries the
+    // `expanded-row` class, so it is addressable by selector alone — no runtime attribute
+    // read, which keeps this method valid in the selectors test-utils variant too.
+    return this.find(`.${styles['expanded-row']}[aria-rowindex="${dataIndex + 2}"] .${styles['expanded-region']}`);
+  }
+
+  findColumnHeaders(): Array<ElementWrapper> {
+    return this.findAllByClassName(styles['header-cell']);
+  }
+
+  /** The header row element (returned regardless of the `sticky` prop). */
+  findHeaderRow(): ElementWrapper | null {
+    return this.findByClassName(styles['header-row']);
+  }
+
+  /** The polite append aria-live node. */
+  findLiveRegion(): ElementWrapper | null {
+    return this.findByClassName(styles['live-region']);
+  }
+}

--- a/src/virtual-table/USAGE.md
+++ b/src/virtual-table/USAGE.md
@@ -1,0 +1,271 @@
+<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# VirtualTable usage
+
+VirtualTable is a virtualization-first table for large and streaming datasets. It
+renders only the rows in view, so it stays responsive with tens of thousands of
+rows and with data that appends over time, such as a live log stream. It's a new,
+additive component that coexists with Table — reach for it when the dataset is
+large, streaming, or needs rows that expand into content laid out differently from
+the columns.
+
+VirtualTable is a compound component. You assemble it from a small set of parts —
+`VirtualTable.Root` wraps a `VirtualTable.Header` of `VirtualTable.HeaderCell`s and
+a `VirtualTable.Body`. The body takes a row template, a function that returns a
+`VirtualTable.Row` of `VirtualTable.Cell`s and an optional
+`VirtualTable.ExpandedContent`. Root invokes that template only for the rows in
+view and handles windowing, measurement, keyboard interaction, and announcements
+for you.
+
+## When to use
+
+- Use VirtualTable when the dataset is large enough that rendering every row hurts
+  responsiveness, or when rows arrive continuously and the view needs to keep up.
+- Use VirtualTable when rows expand into detail content that doesn't match the
+  column layout — for example a key-value record, a raw or formatted log line, or a
+  small chart with actions. The expanded content is a first-class part you compose
+  into the row, so it's a natural home for arbitrary detail.
+- Use the compound shape when you want to own how each row and its expanded content
+  are assembled — the parts read like markup and keep complex expanded content next
+  to the row it belongs to.
+- Use Table for small, static datasets, or when you need built-in selection,
+  inline editing, or the standard expandable-rows model that reuses the same
+  columns. VirtualTable deliberately keeps a smaller surface and doesn't offer
+  those.
+
+## General guidelines
+
+### Do
+
+Structure and columns
+
+- Declare each column once as a header cell, and match its body cell by the same
+  column id. The header set is the single source of truth for column order and
+  count, so the two always line up.
+- Keep the row template a plain function of the row and its row info. Compose the
+  cells and the expanded content from those inputs, and don't reach for state or
+  effects inside it.
+- Set the estimated row height to match your content density so the scrollbar is
+  accurate before rows are measured.
+- Give one column the room to stretch so the table fills its container, and keep
+  the other columns sized to their content.
+- Turn on column resizing when users need to see long values, and persist the
+  widths users choose so their layout survives a reload.
+- Keep the number of columns focused. Move secondary detail into the expanded row
+  rather than adding columns users must scroll to reach.
+
+Row expansion
+
+- Add the expanded content part to the row template whenever a row can expand, and
+  keep it there unconditionally — Root decides when to mount it. Leaving it out or
+  hiding it behind the row's open state disables expansion.
+- Use the expanded row for content that reads differently from the columns:
+  key-value detail, a raw record, a small visualization, or nested panels.
+- Give every expanded region a clear, row-specific accessible name so people
+  navigating by region know which row they're reading.
+- Let the expanded content size itself. Variable expanded heights are measured and
+  windowed for you, so detail panels of different sizes all scroll smoothly.
+
+Large and streaming data
+
+- Append new rows to the end of the dataset for the live-tail case, and compose
+  stick-to-bottom following on top of the scroll-anchoring controls so the view
+  releases the moment a user scrolls up to read.
+- Keep rows at a fixed height when you can — fixed rows skip measurement and stay
+  fast at very large sizes. Opt individual rows into measurement only when their
+  height truly varies, such as wrapping lines.
+- Compute any cross-row scale, such as a shared chart maximum, once over the full
+  dataset so it stays stable as the user scrolls. The row info gives you the
+  dataset position and size, not the rows currently in view, so derive shared
+  values from your own full dataset.
+
+Header and states
+
+- Use a sticky header for long tables so column meaning stays visible while
+  scrolling.
+- Provide an empty state with a short explanation and, where it helps, a recovery
+  action.
+- Show the loading state while the first page of data is on its way, and write
+  loading text that says what's loading.
+
+Accessibility
+
+- Always supply the accessible names VirtualTable asks for — the table name, the
+  expand and collapse control label, and the expanded region name. These names are
+  part of the component's accessibility contract; without them the table, its
+  controls, and its regions have no accessible name.
+- Keep interactive content inside an expanded row reachable by keyboard. VirtualTable
+  moves focus into the region and returns it to the row's control when the user
+  leaves, and it keeps arrow-key row navigation from interfering with controls
+  inside the region.
+
+### Don't
+
+- Don't render the full dataset yourself or hand-write a row per item — the body
+  template is called only for the rows in view, and materializing every row defeats
+  the purpose.
+- Don't put state, effects, or other hooks inside the row template. It runs inside
+  the windowed render loop for each visible row; keep hooks in the components the
+  template renders.
+- Don't reuse the column layout for the expanded row when the detail is genuinely
+  different. If the expanded content is just more columns, a standard table
+  suits better.
+- Don't compute a shared scale, running total, or ranking from the visible rows —
+  it will jump as the user scrolls. Compute it over the full dataset.
+- Don't assume VirtualTable sorts your data. It reflects sort intent but doesn't
+  reorder rows itself, so wire sorting only where it fits your dataset — a
+  fast-appending stream is usually left unsorted.
+- Don't leave the table, its expand controls, or its expanded regions without
+  accessible names.
+
+## Features
+
+### Composition
+
+VirtualTable is assembled from parts rather than configured through one large prop
+set. Root owns the grid state and the scroll container; the header cells declare
+the columns; the body template describes a single row and its expanded content.
+Because the parts nest like the markup they produce, complex rows — especially ones
+with rich expanded content — stay readable and live next to the row they belong to.
+
+### Virtualization
+
+VirtualTable renders only the rows near the viewport and recycles their DOM as the
+user scrolls, so it handles very large datasets without the cost of a full render.
+The body template is invoked only for the rows in view. Rows can be a fixed height
+for the fastest path, or opt into measurement when their height varies. Measured
+heights are cached and the scroll position is corrected as rows above the viewport
+settle, so content doesn't drift under the user.
+
+### Custom row expansion
+
+A row can expand into arbitrary content that isn't bound to the column layout —
+key-value detail, a raw or formatted record, a chart, or nested panels. You add it
+as the expanded content part of the row template. The expanded region is a
+first-class part of the table's structure with its own accessible name and its own
+measured height, so panels of different sizes all window correctly. Expansion can
+be controlled or left to the component.
+
+### Live tail and streaming
+
+Appending rows to the dataset is the streaming path. VirtualTable reports the
+visible range as it changes and exposes controls to pin the view to the newest row
+and to check whether it's currently pinned, so you can build stick-to-bottom
+following that releases when the user scrolls up. New-row announcements are batched
+and summarized so a fast stream doesn't flood assistive technology.
+
+### Columns, sorting, and resizing
+
+Columns are declared once by the header cells and can be resized, with widths
+reported so you can persist them. VirtualTable reflects sort state and reports the
+user's sort intent, but it doesn't reorder the data itself — you sort the dataset
+and pass it back. Compare-style views are a swap to a different set of columns
+rather than a separate mode.
+
+## Writing guidelines
+
+Write table content so it scans quickly. Keep it short, consistent, and specific
+to the row.
+
+### Table name
+
+- Give the table a short, descriptive name that says what the rows are, such as
+  *Log events* or *Query patterns*.
+- Use sentence case and no ending punctuation.
+
+### Column headers
+
+- Use nouns or short noun phrases, such as *Timestamp*, *Level*, or *Message*.
+- Keep headers to one or two words where you can, and use sentence case.
+
+### Cells
+
+- Keep cell text terse and scannable. Avoid full sentences in a cell.
+- Right-align numeric values and keep units consistent down a column.
+
+### Expand and collapse controls
+
+- Write the control label so it names the action and the row it acts on, and
+  reflects whether the row is open or closed, such as *Show details for this event*.
+
+### Expanded region name
+
+- Name the region for the row it belongs to, such as *Details for 10:04:22 event*,
+  so people who navigate by region know which row they're reading.
+
+### Empty state
+
+- Say why there's nothing to show and what to do next, such as *No log events in
+  the selected time range. Widen the range to see more.*
+
+### Loading text
+
+- Say what's loading, such as *Loading log events*. Keep it to a short phrase.
+
+## API reference
+
+The full typed API lives in `interfaces.ts` (`VirtualTableProps<T>` and the
+`VirtualTableProps` namespace) and is described in the design document
+`deliverables/design/design-F1-A2.md`. VirtualTable is exported as a namespace of
+compound parts: `VirtualTable.Root`, `Header`, `HeaderCell`, `Body`, `Row`, `Cell`,
+and `ExpandedContent`. In summary:
+
+- Data and identity: `Root` takes `items` and a required `trackBy` — a stable key
+  is mandatory because row DOM is recycled.
+- Columns: each `HeaderCell` declares a `columnId` and optional `stretch`,
+  `sortingField`, `width`, and `minWidth`; body `Cell`s bind to a header by
+  `columnId`. The header set is the single column authority.
+- Body template: `Body` takes a function `(item, api) => <Row item api>` that Root
+  invokes only for windowed rows. The `api` carries `rowIndex`, `totalItemCount`,
+  and `isExpanded` — the dataset position and size, not the window slice.
+- Row expansion: add `ExpandedContent` (with an `estimatedHeight`, or a rare
+  `fixedHeight`) as a child of the row template to enable the leading disclosure
+  column and render arbitrary non-tabular detail; expansion state is on `Root` via
+  `expandedItems` / `defaultExpandedItems` / `onExpandChange`.
+- Virtualization: `estimatedRowHeight`, `getRowHeight` (fixed px or `"auto"` to
+  measure a data row so wrapping lines window correctly), `overscan`, and
+  `onVisibleRangeChange`.
+- Columns, sorting, sizing: `resizableColumns`, `columnWidths` /
+  `onColumnWidthsChange`, `columnLayout`, and `sortingColumn` / `sortingDescending`
+  / `onSortingChange` (VirtualTable reflects sort state and emits intent; it
+  doesn't sort the data).
+- Header and states: `Header`'s `sticky`, plus `Root`'s `header`, `empty`,
+  `loading` / `loadingText`.
+- Accessibility: `ariaLabels` (`tableLabel`, `expandButtonLabel`,
+  `expandedRegionLabel`, `appendAnnouncement`, `activateSortLabel`) and `role`.
+- Imperative surface: `imperativeRef` exposing `scrollToEnd`, `scrollToItem`, and
+  `isPinnedToEnd` for scroll anchoring and live tail.
+
+Some behaviors worth calling out for implementers:
+
+- Row template contract: the body template must be a pure, hook-free function of
+  `(item, api)`, must forward both to its `<VirtualTable.Row>`, and must declare
+  `<VirtualTable.ExpandedContent>` unconditionally when a row can expand — Root
+  decides when to mount it. Gating the expanded content on the row's open state
+  disables the disclosure column and expansion.
+- Typing the template: because `Body` is its own component, the row `item` type
+  doesn't flow automatically from `Root`'s `items` through the namespace. Annotate
+  the template parameter (`(item: LogRecord, api) => …`) so the row reads with full
+  types.
+- Keyboard model: the grid is a single tab stop and arrow keys move an active row
+  (row-granular), not a cell cursor. Left and right arrows don't move a cell
+  selection. This is a deliberate choice for a virtualized log grid; if you need
+  2D cell navigation, Table is the better fit.
+- Accessible names: `ariaLabels.tableLabel`, `expandButtonLabel`, and
+  `expandedRegionLabel` are required for a complete accessible experience. Omitting
+  them leaves the table, its disclosure controls, or its expanded regions without
+  an accessible name.
+
+## Examples
+
+Runnable dev pages in `pages/virtual-table/`:
+
+- `simple.page.tsx` — the minimal starting point: a basic compound table.
+- `cloudwatch-standard.page.tsx` — the CloudWatch Logs Insights standard view:
+  dynamic columns, a stretch-last message column, expanded log-record detail as a
+  compound child, and consumer-composed live tail.
+- `cloudwatch-raw.page.tsx` — the raw / file view: a single wrapping line column
+  with no expanded content, at raw-line density.
+- `cloudwatch-patterns.page.tsx` — the "Show patterns" view: per-column sort, a
+  compare/diff column swap, a shared histogram scale, and expanded pattern detail.

--- a/src/virtual-table/__tests__/use-expansion.test.tsx
+++ b/src/virtual-table/__tests__/use-expansion.test.tsx
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { act, renderHook } from '../../__tests__/render-hook';
+import { useExpansion } from '../use-expansion';
+
+// Root owns the R-EXPAND expansion state for the compound VirtualTable. These tests pin the
+// controlled/uncontrolled contract and the stable signature the windowing layout depends on.
+
+interface Item {
+  id: string;
+}
+
+const trackBy = (item: Item) => item.id;
+const a: Item = { id: 'a' };
+
+describe('VirtualTable (F1-A2 compound) useExpansion', () => {
+  test('is empty by default (uncontrolled)', () => {
+    const { result } = renderHook(() => useExpansion<Item>({ trackBy }));
+    expect(result.current.expandedIds.size).toBe(0);
+    expect(result.current.expandedSignature).toBe('');
+    expect(result.current.isExpanded('a')).toBe(false);
+  });
+
+  test('honours defaultExpandedItems', () => {
+    const { result } = renderHook(() => useExpansion<Item>({ trackBy, defaultExpandedItems: ['a'] }));
+    expect(result.current.isExpanded('a')).toBe(true);
+    expect(result.current.expandedSignature).toBe('a');
+  });
+
+  test('toggle adds then removes an id and fires onExpandChange with the resulting set', () => {
+    const onExpandChange = jest.fn();
+    const { result } = renderHook(() => useExpansion<Item>({ trackBy, onExpandChange }));
+
+    act(() => result.current.toggle(a));
+    expect(result.current.isExpanded('a')).toBe(true);
+    expect(onExpandChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ detail: expect.objectContaining({ item: a, expanded: true, expandedItems: ['a'] }) })
+    );
+
+    act(() => result.current.toggle(a));
+    expect(result.current.isExpanded('a')).toBe(false);
+    expect(onExpandChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ detail: expect.objectContaining({ expanded: false, expandedItems: [] }) })
+    );
+  });
+
+  test('expand is idempotent', () => {
+    const { result } = renderHook(() => useExpansion<Item>({ trackBy }));
+    act(() => result.current.expand(a));
+    act(() => result.current.expand(a));
+    expect(result.current.expandedIds.size).toBe(1);
+  });
+
+  test('controlled mode is driven by expandedItems, not internal state', () => {
+    const onExpandChange = jest.fn();
+    const { result } = renderHook(() => useExpansion<Item>({ trackBy, expandedItems: ['a'], onExpandChange }));
+    expect(result.current.isExpanded('a')).toBe(true);
+
+    // Toggling in controlled mode emits collapse intent but must not mutate local state: the
+    // controlled prop is unchanged, so the row stays expanded until the consumer updates it.
+    act(() => result.current.toggle(a));
+    expect(onExpandChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ detail: expect.objectContaining({ expanded: false, expandedItems: [] }) })
+    );
+    expect(result.current.isExpanded('a')).toBe(true);
+  });
+
+  test('signature is order-independent and stable across identical sets', () => {
+    const first = renderHook(() => useExpansion<Item>({ trackBy, defaultExpandedItems: ['b', 'a'] }));
+    const second = renderHook(() => useExpansion<Item>({ trackBy, defaultExpandedItems: ['a', 'b'] }));
+    expect(first.result.current.expandedSignature).toBe(second.result.current.expandedSignature);
+  });
+});

--- a/src/virtual-table/__tests__/use-virtual-model.test.tsx
+++ b/src/virtual-table/__tests__/use-virtual-model.test.tsx
@@ -1,0 +1,189 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { act, renderHook } from '../../__tests__/render-hook';
+import { useVirtualModel } from '../use-virtual-model';
+
+// The compound F1-A2 core drives the same windowing + opt-in measurement engine the
+// config-driven cell uses: Root owns one inner scroll container, data rows are fixed at the
+// density estimate (no measurement cost) unless getRowHeight opts them into 'auto', and only
+// expanded regions / opted-in rows are measured, with anchor-based offset correction so
+// measured growth above the fold does not shift the viewport. jsdom has no layout, so the
+// DOM-driven paths are exercised with a controllable ResizeObserver and a fake scroll
+// container whose scrollTop/clientHeight/scrollHeight are stubbed (viewport falls back to
+// 600px when clientHeight is 0).
+
+interface Row {
+  id: string;
+}
+const trackBy = (row: Row) => row.id;
+const makeItems = (n: number): Row[] => Array.from({ length: n }, (_, i) => ({ id: String(i) }));
+
+interface FakeContainer {
+  clientHeight?: number;
+  scrollHeight?: number;
+  scrollTop?: number;
+}
+function makeContainer({ clientHeight = 0, scrollHeight = 0, scrollTop = 0 }: FakeContainer = {}): HTMLElement {
+  const el = document.createElement('div');
+  let top = scrollTop;
+  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => clientHeight });
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => scrollHeight });
+  Object.defineProperty(el, 'scrollTop', { configurable: true, get: () => top, set: value => (top = value) });
+  return el;
+}
+
+// Records every ResizeObserver so a test can fire a measurement callback deterministically.
+interface MockObserver {
+  cb: ResizeObserverCallback;
+  node?: Element;
+  disconnected: boolean;
+}
+let observers: MockObserver[] = [];
+const OriginalResizeObserver = window.ResizeObserver;
+
+beforeEach(() => {
+  observers = [];
+  class MockResizeObserver {
+    private record: MockObserver;
+    constructor(cb: ResizeObserverCallback) {
+      this.record = { cb, disconnected: false };
+      observers.push(this.record);
+    }
+    observe(node: Element) {
+      this.record.node = node;
+    }
+    unobserve() {}
+    disconnect() {
+      this.record.disconnected = true;
+    }
+  }
+  window.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+});
+
+afterEach(() => {
+  window.ResizeObserver = OriginalResizeObserver;
+});
+
+function stubHeight(height: number): HTMLElement {
+  const node = document.createElement('div');
+  node.getBoundingClientRect = () =>
+    ({ height, width: 0, top: 0, left: 0, right: 0, bottom: 0, x: 0, y: 0, toJSON() {} }) as DOMRect;
+  return node;
+}
+
+interface ModelOptions {
+  items: Row[];
+  container?: HTMLElement;
+  expandedIds?: Set<string>;
+  expandedSignature?: string;
+  estimatedRowHeight?: number;
+  getRowHeight?: (item: Row) => number | 'auto';
+  getExpandedRowHeight?: (item: Row) => number | 'auto';
+  overscan?: number;
+}
+
+function renderModel(options: ModelOptions) {
+  const ref = { current: options.container ?? makeContainer() } as React.RefObject<HTMLElement>;
+  const { result, rerender } = renderHook(() =>
+    useVirtualModel<Row>({
+      items: options.items,
+      trackBy,
+      expandedIds: options.expandedIds ?? new Set<string>(),
+      expandedSignature: options.expandedSignature ?? '',
+      estimatedRowHeight: options.estimatedRowHeight ?? 20,
+      getRowHeight: options.getRowHeight,
+      getExpandedRowHeight: options.getExpandedRowHeight,
+      overscan: options.overscan ?? 5,
+      scrollContainerRef: ref,
+    })
+  );
+  return { result, rerender, container: ref.current! };
+}
+
+describe('VirtualTable (F1-A2 compound) useVirtualModel', () => {
+  test('windows a large dataset to far fewer rows than it holds', () => {
+    const items = makeItems(1000);
+    const { result } = renderModel({ items, estimatedRowHeight: 20, overscan: 5 });
+    expect(result.current.slots.length).toBeGreaterThan(0);
+    expect(result.current.slots.length).toBeLessThan(items.length);
+    expect(result.current.firstIndex).toBe(0);
+    // Window is bounded: 600px viewport / 20px rows = 30 visible + 5 overscan = last data index 35.
+    expect(result.current.lastIndex).toBe(35);
+    expect(result.current.slots.every(slot => slot.type === 'data')).toBe(true);
+    // Fixed rows: total runway is a simple product, independent of the window.
+    expect(result.current.totalSize).toBe(1000 * 20);
+  });
+
+  test('recomputes the visible range when the container scrolls', () => {
+    const container = makeContainer();
+    const { result } = renderModel({ items: makeItems(1000), estimatedRowHeight: 20, overscan: 5, container });
+    expect(result.current.firstIndex).toBe(0);
+
+    // Scroll to offset 4000 (row 200). The scroll listener re-reads scrollTop and the window
+    // recomputes: firstVisible 200 - 5 overscan = 195; lastVisible 230 + 5 = 235.
+    act(() => {
+      container.scrollTop = 4000;
+      container.dispatchEvent(new Event('scroll'));
+    });
+    expect(result.current.firstIndex).toBe(195);
+    expect(result.current.lastIndex).toBe(235);
+  });
+
+  test('inserts an expanded slot immediately after its data row and grows the runway by its height', () => {
+    const items = makeItems(50);
+    const { result } = renderModel({
+      items,
+      expandedIds: new Set(['0']),
+      expandedSignature: '0',
+      getExpandedRowHeight: () => 120,
+    });
+    const expandedSlot = result.current.slots.find(slot => slot.type === 'expanded');
+    expect(expandedSlot).toBeDefined();
+    expect(expandedSlot!.index).toBe(0);
+    expect(result.current.totalSize).toBe(50 * 20 + 120);
+  });
+
+  test('does not observe fixed-height rows but does observe auto rows, and applies the measured height', () => {
+    const items = makeItems(10);
+    const { result } = renderModel({ items, estimatedRowHeight: 20, getRowHeight: () => 'auto' });
+    expect(result.current.totalSize).toBe(10 * 20);
+
+    const before = observers.length;
+    // observers[0] is the engine's own viewport ResizeObserver (attached on mount); `before`
+    // is captured after mount so any new observer here is the measurement one. A fixed row
+    // (auto=false) is never observed — it never pays measurement cost.
+    act(() => result.current.measureRef('d:0', false)(stubHeight(55)));
+    expect(observers.length).toBe(before);
+
+    // An auto data row is observed (the F1-A2 getRowHeight='auto' path that lets the raw view
+    // wrap long lines); firing the observer applies the real height and reflows the runway.
+    act(() => result.current.measureRef('d:0', true)(stubHeight(55)));
+    expect(observers.length).toBe(before + 1);
+    act(() => observers[observers.length - 1].cb([], observers[observers.length - 1] as unknown as ResizeObserver));
+    expect(result.current.totalSize).toBe(55 + 9 * 20);
+  });
+
+  test('scrollToIndex positions the container at the row start', () => {
+    const container = makeContainer();
+    const { result } = renderModel({ items: makeItems(100), estimatedRowHeight: 20, container });
+    act(() => result.current.scrollToIndex(10));
+    expect(container.scrollTop).toBe(10 * 20);
+  });
+
+  test('scrollToEnd pins the container to the bottom of the runway', () => {
+    const container = makeContainer({ scrollHeight: 1234 });
+    const { result } = renderModel({ items: makeItems(100), container });
+    act(() => result.current.scrollToEnd());
+    expect(container.scrollTop).toBe(1234);
+  });
+
+  test('isPinnedToEnd reflects whether the viewport is at the bottom edge', () => {
+    const pinned = makeContainer({ clientHeight: 100, scrollHeight: 100, scrollTop: 0 });
+    expect(renderModel({ items: makeItems(100), container: pinned }).result.current.isPinnedToEnd()).toBe(true);
+
+    const scrolledUp = makeContainer({ clientHeight: 100, scrollHeight: 1000, scrollTop: 0 });
+    expect(renderModel({ items: makeItems(100), container: scrolledUp }).result.current.isPinnedToEnd()).toBe(false);
+  });
+});

--- a/src/virtual-table/__tests__/virtual-table-a11y.test.tsx
+++ b/src/virtual-table/__tests__/virtual-table-a11y.test.tsx
@@ -1,0 +1,447 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+
+import '../../__a11y__/to-validate-a11y';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import VirtualTable, { VirtualTableProps } from '../../../lib/components/virtual-table';
+
+// A11y tests for the COMPOUND VirtualTable (impl-F1-A2-tests-a11y). Placement mirrors the
+// F1-A1 tests-a11y decision: the `__a11y__` directory is the node/puppeteer integ runner
+// (`.ts`-only, tsconfig.integ), so axe + RTL keyboard/SR `.tsx` tests belong under
+// `__tests__/` where the unit runner collects them — its testRegex
+// `(/__tests__/.*(\.|/)test)\.[jt]sx?$` matches `virtual-table-a11y.test.tsx` and ts-jest
+// transforms the `.tsx` via `tsconfig.unit.json`, so `-pr` runs it as part of `npm test`.
+//
+// The central a11y claim for the compound API is that the Root/Header/HeaderCell/Body/Row/
+// Cell/ExpandedContent composition produces the SAME accessibility tree as a single monolithic
+// grid: one role="grid" that owns only rowgroups -> rows -> columnheader/gridcell, with the
+// materialised disclosure column, full-dataset aria-rowcount/rowindex + aria-colcount/colindex
+// coherence, a labeled expanded region, and non-row chrome (loading/empty/live-region) OUTSIDE
+// the grid. Coverage: axe/HTML validity, the compound-produces-one-grid contract, row-granular
+// keyboard nav via aria-activedescendant (incl. ArrowLeft/Right inert), sort-trigger a11y
+// (keyboard-operable + accessible name + aria-sort), disclosure activation, Tab-in / Escape-out
+// of the expanded region, live-append debounce, and focus-under-recycling.
+
+interface Item {
+  id: string;
+  name: string;
+  status: string;
+}
+
+const makeItems = (n: number): Item[] =>
+  Array.from({ length: n }, (_, i) => ({ id: `row-${i}`, name: `Resource ${i}`, status: i % 2 === 0 ? 'Up' : 'Down' }));
+
+// Stable identity so useLiveAnnouncement's effect does not re-run (and reset coalescing) on
+// unrelated rerenders — the compound Root threads this straight into the live-region hook.
+const appendAnnouncement = ({ addedCount, totalCount }: { addedCount: number; totalCount: number }) =>
+  `${addedCount} new log events, ${totalCount} total`;
+
+const ariaLabels: VirtualTableProps.AriaLabels<Item> = {
+  tableLabel: 'Log events',
+  expandButtonLabel: (item, expanded) => `${expanded ? 'Collapse' : 'Expand'} details for ${item.name}`,
+  expandedRegionLabel: item => `Details for ${item.name}`,
+  activateSortLabel: columnId => `Sort by ${columnId}`,
+  appendAnnouncement,
+};
+
+interface TreeOptions {
+  expandable?: boolean;
+  sortable?: boolean;
+  singleColumn?: boolean;
+  estimatedRowHeight?: number;
+  overscan?: number;
+  getRowHeight?: (item: Item) => number | 'auto';
+  expandedItems?: ReadonlyArray<string>;
+  onExpandChange?: VirtualTableProps<Item>['onExpandChange'];
+  sortingColumn?: { columnId: string };
+  sortingDescending?: boolean;
+  onSortingChange?: VirtualTableProps<Item>['onSortingChange'];
+  imperativeRef?: React.Ref<VirtualTableProps.Ref>;
+  loading?: boolean;
+  loadingText?: string;
+  empty?: React.ReactNode;
+}
+
+// A single tree builder used for both initial render and rerender so ariaLabels (and thus the
+// live-region hook identity) stays stable across renders.
+function buildTree(items: Item[], options: TreeOptions = {}) {
+  const detail = (item: Item) => (
+    <div>
+      <h3>Log record {item.id}</h3>
+      <dl>
+        <dt>Level</dt>
+        <dd>INFO</dd>
+        <dt>Message</dt>
+        <dd>{item.name}</dd>
+      </dl>
+      <button type="button">View matching logs</button>
+    </div>
+  );
+
+  return (
+    <VirtualTable.Root
+      items={items}
+      trackBy={item => item.id}
+      estimatedRowHeight={options.estimatedRowHeight ?? 23}
+      overscan={options.overscan}
+      getRowHeight={options.getRowHeight}
+      expandedItems={options.expandedItems}
+      onExpandChange={options.onExpandChange}
+      sortingColumn={options.sortingColumn}
+      sortingDescending={options.sortingDescending}
+      onSortingChange={options.onSortingChange}
+      imperativeRef={options.imperativeRef}
+      loading={options.loading}
+      loadingText={options.loadingText}
+      empty={options.empty}
+      ariaLabels={ariaLabels}
+    >
+      <VirtualTable.Header>
+        <VirtualTable.HeaderCell columnId="name" sortingField={options.sortable ? 'name' : undefined}>
+          Name
+        </VirtualTable.HeaderCell>
+        {!options.singleColumn && (
+          <VirtualTable.HeaderCell columnId="status" stretch={true}>
+            Status
+          </VirtualTable.HeaderCell>
+        )}
+      </VirtualTable.Header>
+      <VirtualTable.Body>
+        {(item: Item, api) => (
+          <VirtualTable.Row item={item} api={api}>
+            <VirtualTable.Cell columnId="name">{item.name}</VirtualTable.Cell>
+            {!options.singleColumn && <VirtualTable.Cell columnId="status">{item.status}</VirtualTable.Cell>}
+            {/* ExpandedContent is declared UNCONDITIONALLY (not gated on api.isExpanded) per the
+                BodyProps contract; Root mounts the region only for expanded rows. */}
+            {options.expandable && (
+              <VirtualTable.ExpandedContent estimatedHeight={300}>{detail(item)}</VirtualTable.ExpandedContent>
+            )}
+          </VirtualTable.Row>
+        )}
+      </VirtualTable.Body>
+    </VirtualTable.Root>
+  );
+}
+
+function renderTable(items: Item[], options: TreeOptions = {}) {
+  const { container, rerender } = render(buildTree(items, options));
+  const wrapper = createWrapper(container).findVirtualTable()!;
+  const update = (nextItems: Item[], nextOptions: TreeOptions = options) => rerender(buildTree(nextItems, nextOptions));
+  return { container, wrapper, update };
+}
+
+function getGrid(container: HTMLElement): HTMLElement {
+  return container.querySelector('[role="grid"]') as HTMLElement;
+}
+
+// Data columns (name + status); the disclosure column, when present, is counted on top.
+const DATA_COLUMNS = 2;
+
+describe('VirtualTable F1-A2 a11y', () => {
+  describe('axe / HTML validity', () => {
+    test('validates a plain compound grid without expansion', async () => {
+      const { container } = renderTable(makeItems(20));
+      await expect(container).toValidateA11y();
+    });
+
+    test('validates a grid with a collapsed disclosure column', async () => {
+      const { container } = renderTable(makeItems(20), { expandable: true });
+      await expect(container).toValidateA11y();
+    });
+
+    test('validates a grid with an expanded, labeled region containing arbitrary content', async () => {
+      const { container } = renderTable(makeItems(20), { expandable: true, expandedItems: ['row-0', 'row-3'] });
+      await expect(container).toValidateA11y();
+    });
+
+    test('validates sortable headers (native sort triggers + aria-sort)', async () => {
+      const { container } = renderTable(makeItems(20), { sortable: true, sortingColumn: { columnId: 'name' } });
+      await expect(container).toValidateA11y();
+    });
+
+    test('validates the reduced single-column (file/raw) shape', async () => {
+      const { container } = renderTable(makeItems(50), {
+        singleColumn: true,
+        estimatedRowHeight: 20,
+        overscan: 40,
+        getRowHeight: item => (item.name.length > 120 ? 'auto' : 20),
+      });
+      await expect(container).toValidateA11y();
+    });
+
+    test('validates the empty and loading states', async () => {
+      const empty = renderTable([], { empty: <span>No log events</span> });
+      await expect(empty.container).toValidateA11y();
+
+      const loading = renderTable([], { loading: true, loadingText: 'Loading log events' });
+      await expect(loading.container).toValidateA11y();
+    });
+  });
+
+  describe('compound structure produces a single grid accessibility tree', () => {
+    test('the seven compound sub-components collapse to one grid -> rowgroup -> row tree', () => {
+      const { container } = renderTable(makeItems(20), { expandable: true, expandedItems: ['row-0'] });
+      // Exactly one grid, regardless of how many compound elements were authored.
+      expect(container.querySelectorAll('[role="grid"]')).toHaveLength(1);
+      const grid = getGrid(container);
+
+      // The grid owns ONLY rowgroups (grid -> rowgroup -> row -> columnheader/gridcell); a
+      // compound Header/Body still yields a header rowgroup + a body rowgroup, same as a
+      // monolithic grid.
+      const directChildren = Array.from(grid.children);
+      expect(directChildren.length).toBeGreaterThan(0);
+      directChildren.forEach(child => expect(child.getAttribute('role')).toBe('rowgroup'));
+
+      // Every row lives under a rowgroup, and every columnheader/gridcell under a row.
+      grid.querySelectorAll('[role="row"]').forEach(row => {
+        expect(row.closest('[role="rowgroup"]')).not.toBeNull();
+      });
+      grid.querySelectorAll('[role="columnheader"], [role="gridcell"]').forEach(cell => {
+        expect(cell.closest('[role="row"]')).not.toBeNull();
+      });
+    });
+
+    test('non-row chrome (loading / live-region) is a sibling of the grid, never a grid child', () => {
+      const { wrapper } = renderTable([], { loading: true, loadingText: 'Loading' });
+      const status = wrapper.find('[role="status"]')!.getElement();
+      // A status node inside role=grid would be an invalid grid child; it must sit outside.
+      expect(status.closest('[role="grid"]')).toBeNull();
+
+      const live = renderTable(makeItems(5)).wrapper.findLiveRegion()!.getElement();
+      expect(live.closest('[role="grid"]')).toBeNull();
+    });
+  });
+
+  describe('keyboard navigation (aria-activedescendant grid model)', () => {
+    test('the grid is a single always-present tab stop and seeds an active descendant', () => {
+      const { container, wrapper } = renderTable(makeItems(20));
+      const grid = getGrid(container);
+      expect(grid.getAttribute('tabindex')).toBe('0');
+      const firstRow = wrapper.findRowByIndex(0)!.getElement();
+      expect(grid.getAttribute('aria-activedescendant')).toBe(firstRow.id);
+      expect(document.getElementById(firstRow.id)).not.toBeNull();
+    });
+
+    test('Arrow/Home/End move the active row when the grid holds focus', () => {
+      const { container, wrapper } = renderTable(makeItems(20));
+      const grid = getGrid(container);
+
+      fireEvent.keyDown(grid, { key: 'ArrowDown' });
+      expect(grid.getAttribute('aria-activedescendant')).toBe(wrapper.findRowByIndex(1)!.getElement().id);
+
+      fireEvent.keyDown(grid, { key: 'End' });
+      expect(grid.getAttribute('aria-activedescendant')).toBe(wrapper.findRowByIndex(19)!.getElement().id);
+
+      fireEvent.keyDown(grid, { key: 'Home' });
+      expect(grid.getAttribute('aria-activedescendant')).toBe(wrapper.findRowByIndex(0)!.getElement().id);
+    });
+
+    test('does not hijack arrow keys originating inside the expanded region', () => {
+      const { container, wrapper } = renderTable(makeItems(20), { expandable: true, expandedItems: ['row-0'] });
+      const grid = getGrid(container);
+      const before = grid.getAttribute('aria-activedescendant');
+
+      const innerButton = wrapper.findExpandedRegion(0)!.getElement().querySelector('button')!;
+      fireEvent.keyDown(innerButton, { key: 'ArrowDown' });
+
+      // onGridKeyDown bails unless the grid container itself is the event target, so arbitrary
+      // expanded content (goal 6) keeps its own arrow-key behaviour.
+      expect(grid.getAttribute('aria-activedescendant')).toBe(before);
+    });
+
+    test('ArrowLeft / ArrowRight are inert (deliberate row-granular grid, not 2D cell nav)', () => {
+      // Like F1-A1, the compound grid is deliberately row-granular: aria-activedescendant
+      // references a role="row" (never a gridcell) and onGridKeyDown handles only
+      // Up/Down/Home/End. A legitimate APG row-as-widget variant of role="grid"; the horizontal
+      // cell-navigation keys are intentionally inert. Carried to impl-F1-A2-docs as an explicit
+      // a11y contract note.
+      const { container, wrapper } = renderTable(makeItems(20));
+      const grid = getGrid(container);
+
+      fireEvent.keyDown(grid, { key: 'ArrowDown' });
+      const active = grid.getAttribute('aria-activedescendant');
+      expect(active).toBe(wrapper.findRowByIndex(1)!.getElement().id);
+
+      fireEvent.keyDown(grid, { key: 'ArrowRight' });
+      expect(grid.getAttribute('aria-activedescendant')).toBe(active);
+
+      fireEvent.keyDown(grid, { key: 'ArrowLeft' });
+      expect(grid.getAttribute('aria-activedescendant')).toBe(active);
+    });
+  });
+
+  describe('sort trigger accessibility', () => {
+    test('sortable headers expose a keyboard-operable trigger with an accessible name; non-sortable do not', () => {
+      const { wrapper } = renderTable(makeItems(10), { sortable: true });
+      const [nameHeader, statusHeader] = wrapper.findColumnHeaders();
+
+      const sortButton = nameHeader.find('button')!.getElement();
+      // A native <button> is implicitly keyboard-operable; its accessible name is the localized
+      // activateSortLabel (not the raw columnId announced bare).
+      expect(sortButton.tagName).toBe('BUTTON');
+      expect(sortButton.getAttribute('aria-label')).toBe('Sort by name');
+
+      // Non-sortable column: no trigger and no aria-sort attribute at all.
+      expect(statusHeader.find('button')).toBeNull();
+      expect(statusHeader.getElement().getAttribute('aria-sort')).toBeNull();
+    });
+
+    test('aria-sort reflects the active column and is "none" on a sortable-but-inactive column', () => {
+      const { wrapper } = renderTable(makeItems(10), {
+        sortable: true,
+        sortingColumn: { columnId: 'name' },
+        sortingDescending: true,
+      });
+      expect(wrapper.findColumnHeaders()[0].getElement().getAttribute('aria-sort')).toBe('descending');
+
+      const inactive = renderTable(makeItems(10), { sortable: true }).wrapper.findColumnHeaders()[0];
+      expect(inactive.getElement().getAttribute('aria-sort')).toBe('none');
+    });
+  });
+
+  describe('disclosure + expanded region wiring', () => {
+    test('the disclosure control is a labeled button reflecting aria-expanded / aria-controls', () => {
+      const { wrapper } = renderTable(makeItems(10), { expandable: true });
+      const toggle = wrapper.findExpandToggle(0)!.getElement();
+
+      expect(toggle.tagName).toBe('BUTTON');
+      expect(toggle.getAttribute('aria-label')).toBe('Expand details for Resource 0');
+      expect(toggle.getAttribute('aria-expanded')).toBe('false');
+      expect(toggle.getAttribute('aria-controls')).toBeNull();
+
+      fireEvent.click(toggle);
+
+      expect(toggle.getAttribute('aria-expanded')).toBe('true');
+      const region = wrapper.findExpandedRegion(0)!.getElement();
+      expect(toggle.getAttribute('aria-controls')).toBe(region.id);
+      expect(region.getAttribute('role')).toBe('region');
+    });
+
+    test('the expanded region carries the consumer-supplied accessible name', () => {
+      const { wrapper } = renderTable(makeItems(10), { expandable: true, expandedItems: ['row-2'] });
+      const region = wrapper.findExpandedRegion(2)!.getElement();
+      expect(region.getAttribute('aria-label')).toBe('Details for Resource 2');
+    });
+
+    test('Escape inside the expanded region returns focus to its disclosure trigger', () => {
+      const { wrapper } = renderTable(makeItems(10), { expandable: true, expandedItems: ['row-0'] });
+      const toggle = wrapper.findExpandToggle(0)!.getElement();
+      const innerButton = wrapper.findExpandedRegion(0)!.getElement().querySelector('button')!;
+
+      innerButton.focus();
+      expect(document.activeElement).toBe(innerButton);
+
+      fireEvent.keyDown(innerButton, { key: 'Escape' });
+      expect(document.activeElement).toBe(toggle);
+    });
+
+    test('the expanded region content is reachable (Tab-in half: not aria-hidden / inert / disabled)', () => {
+      const { wrapper } = renderTable(makeItems(10), { expandable: true, expandedItems: ['row-0'] });
+      const region = wrapper.findExpandedRegion(0)!.getElement();
+      const innerButton = region.querySelector('button') as HTMLButtonElement;
+
+      // jsdom cannot perform real Tab traversal; the Tab-in half of the contract is that the
+      // region's interactive content is genuinely focusable — not disabled and not inside an
+      // aria-hidden or inert ancestor that would remove it from the tab order.
+      expect(innerButton.closest('[aria-hidden="true"]')).toBeNull();
+      expect(innerButton.closest('[inert]')).toBeNull();
+      expect(innerButton.hasAttribute('disabled')).toBe(false);
+      innerButton.focus();
+      expect(document.activeElement).toBe(innerButton);
+    });
+  });
+
+  describe('live-append announcement', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    test('coalesces a burst of appends into one debounced polite message', () => {
+      const { wrapper, update } = renderTable(makeItems(10));
+      const live = wrapper.findLiveRegion()!.getElement();
+      expect(live.getAttribute('aria-live')).toBe('polite');
+      expect(live.textContent).toBe('');
+
+      // Two appends within the debounce window collapse into a single announcement.
+      update(makeItems(13));
+      update(makeItems(15));
+      expect(live.textContent).toBe('');
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(live.textContent).toContain('5 new log events');
+      expect(live.textContent).toContain('15 total');
+    });
+
+    test('does not announce when the dataset shrinks or is replaced', () => {
+      const { wrapper, update } = renderTable(makeItems(10));
+      const live = wrapper.findLiveRegion()!.getElement();
+
+      update(makeItems(4));
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(live.textContent).toBe('');
+    });
+  });
+
+  describe('focus under row recycling', () => {
+    test('keeps focus on a control when rows are appended (trackBy-keyed identity)', () => {
+      const { wrapper, update } = renderTable(makeItems(20), { expandable: true });
+      const toggle = wrapper.findExpandToggle(0)!.getElement();
+
+      toggle.focus();
+      expect(document.activeElement).toBe(toggle);
+
+      // Appending rows must not remount the still-windowed row 0, so its focused disclosure
+      // control retains focus (recycling is keyed by trackBy identity).
+      update(makeItems(30), { expandable: true });
+      expect(document.activeElement).toBe(wrapper.findExpandToggle(0)!.getElement());
+    });
+  });
+
+  describe('full-dataset ARIA coherence under windowing', () => {
+    test('aria-rowcount counts the header once and aria-colcount counts the disclosure column', () => {
+      const { container } = renderTable(makeItems(500), { expandable: true });
+      const grid = getGrid(container);
+      expect(grid.getAttribute('aria-rowcount')).toBe('501');
+      expect(grid.getAttribute('aria-colcount')).toBe(String(DATA_COLUMNS + 1));
+    });
+
+    test('the header row is aria-rowindex 1 with the disclosure columnheader at aria-colindex 1', () => {
+      const { wrapper } = renderTable(makeItems(500), { expandable: true });
+      const header = wrapper.findHeaderRow()!.getElement();
+      expect(header.getAttribute('aria-rowindex')).toBe('1');
+
+      const headers = header.querySelectorAll('[role="columnheader"]');
+      expect(headers[0].getAttribute('aria-colindex')).toBe('1'); // materialised disclosure column
+      expect(headers[1].getAttribute('aria-colindex')).toBe('2'); // first data column
+    });
+
+    test('data rows carry a full-dataset aria-rowindex and disclosure=1 / data-from-2 colindex', () => {
+      const { wrapper } = renderTable(makeItems(500), { expandable: true });
+      const row0 = wrapper.findRowByIndex(0)!.getElement();
+      expect(row0.getAttribute('aria-rowindex')).toBe('2'); // header is 1, so data index 0 -> 2
+
+      const cells = row0.querySelectorAll('[role="gridcell"]');
+      expect(cells[0].getAttribute('aria-colindex')).toBe('1'); // disclosure cell
+      expect(cells[1].getAttribute('aria-colindex')).toBe('2'); // first data cell
+    });
+
+    test('the expanded row shares its data row index and spans all columns without changing aria-rowcount', () => {
+      const { container, wrapper } = renderTable(makeItems(500), { expandable: true, expandedItems: ['row-0'] });
+      // Expanding a row does not add to the row count (design B1).
+      expect(getGrid(container).getAttribute('aria-rowcount')).toBe('501');
+
+      const region = wrapper.findExpandedRegion(0)!.getElement();
+      const expandedRow = region.closest('[role="row"]')!;
+      expect(expandedRow.getAttribute('aria-rowindex')).toBe('2'); // shares its data row's index
+
+      const expandedCell = expandedRow.querySelector('[role="gridcell"]')!;
+      expect(expandedCell.getAttribute('aria-colindex')).toBe('1');
+      expect(expandedCell.getAttribute('aria-colspan')).toBe(String(DATA_COLUMNS + 1));
+    });
+  });
+});

--- a/src/virtual-table/__tests__/virtual-table-a11y.test.tsx
+++ b/src/virtual-table/__tests__/virtual-table-a11y.test.tsx
@@ -219,14 +219,41 @@ describe('VirtualTable F1-A2 a11y', () => {
       const { container, wrapper } = renderTable(makeItems(20));
       const grid = getGrid(container);
       expect(grid.getAttribute('tabindex')).toBe('0');
+      // The active descendant is a keyboard-navigation concept, seeded only once the grid
+      // actually holds focus; it then defaults to the first (rendered) row.
+      fireEvent.focus(grid);
       const firstRow = wrapper.findRowByIndex(0)!.getElement();
       expect(grid.getAttribute('aria-activedescendant')).toBe(firstRow.id);
       expect(document.getElementById(firstRow.id)).not.toBeNull();
     });
 
+    test('advertises no active descendant until the grid holds focus', () => {
+      const { container, wrapper } = renderTable(makeItems(20));
+      const grid = getGrid(container);
+      // No active row is advertised on initial render (before any interaction).
+      expect(grid.getAttribute('aria-activedescendant')).toBeNull();
+
+      fireEvent.focus(grid);
+      expect(grid.getAttribute('aria-activedescendant')).toBe(wrapper.findRowByIndex(0)!.getElement().id);
+
+      // Blurring the container retracts the active descendant again.
+      fireEvent.blur(grid);
+      expect(grid.getAttribute('aria-activedescendant')).toBeNull();
+    });
+
+    test('focusing a descendant control does not advertise an active descendant on the grid', () => {
+      const { container, wrapper } = renderTable(makeItems(20), { expandable: true });
+      const grid = getGrid(container);
+      // focusin bubbles from the disclosure button to the container; the guard must ignore
+      // descendant focus so items[0] is not falsely activated (WCAG).
+      wrapper.findExpandToggle(0)!.getElement().focus();
+      expect(grid.getAttribute('aria-activedescendant')).toBeNull();
+    });
+
     test('Arrow/Home/End move the active row when the grid holds focus', () => {
       const { container, wrapper } = renderTable(makeItems(20));
       const grid = getGrid(container);
+      fireEvent.focus(grid);
 
       fireEvent.keyDown(grid, { key: 'ArrowDown' });
       expect(grid.getAttribute('aria-activedescendant')).toBe(wrapper.findRowByIndex(1)!.getElement().id);
@@ -241,6 +268,7 @@ describe('VirtualTable F1-A2 a11y', () => {
     test('does not hijack arrow keys originating inside the expanded region', () => {
       const { container, wrapper } = renderTable(makeItems(20), { expandable: true, expandedItems: ['row-0'] });
       const grid = getGrid(container);
+      fireEvent.focus(grid);
       const before = grid.getAttribute('aria-activedescendant');
 
       const innerButton = wrapper.findExpandedRegion(0)!.getElement().querySelector('button')!;
@@ -259,6 +287,7 @@ describe('VirtualTable F1-A2 a11y', () => {
       // a11y contract note.
       const { container, wrapper } = renderTable(makeItems(20));
       const grid = getGrid(container);
+      fireEvent.focus(grid);
 
       fireEvent.keyDown(grid, { key: 'ArrowDown' });
       const active = grid.getAttribute('aria-activedescendant');

--- a/src/virtual-table/__tests__/virtual-table.test.tsx
+++ b/src/virtual-table/__tests__/virtual-table.test.tsx
@@ -1,0 +1,332 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+
+import createWrapper from '../../../lib/components/test-utils/dom';
+import VirtualTable from '../../../lib/components/virtual-table';
+
+// Behavioural coverage for the compound VirtualTable core (impl-F1-A2-core), exercised through
+// the public compound namespace + the generated wrapper. Axe / keyboard / SR coverage lives in
+// impl-F1-A2-tests-a11y; this suite pins windowing, the windowed row-template invocation,
+// header<->body reconciliation, the materialised disclosure column, controlled/uncontrolled
+// expansion, sort activation, and the imperative ref.
+
+// warnOnce is mocked so the reconciliation + fail-loud dev warnings can be asserted (repo
+// dev-warnings convention). Built-lib component code resolves the same module specifier, so
+// the mock intercepts the compiled Row reconciliation path too.
+jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
+  ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
+  warnOnce: jest.fn(),
+}));
+
+afterEach(() => {
+  (warnOnce as jest.Mock).mockReset();
+});
+
+interface Item {
+  id: string;
+  name: string;
+  status: string;
+}
+
+const makeItems = (n: number): Item[] =>
+  Array.from({ length: n }, (_, index) => ({
+    id: `row-${index}`,
+    name: `Resource ${index}`,
+    status: index % 2 === 0 ? 'Available' : 'Pending',
+  }));
+
+interface RenderOptions {
+  items?: Item[];
+  count?: number;
+  expandable?: boolean;
+  controlledExpanded?: string[];
+  onExpandChange?: jest.Mock;
+  sortable?: boolean;
+  sortingColumn?: { columnId: string };
+  sortingDescending?: boolean;
+  onSortingChange?: jest.Mock;
+  imperativeRef?: React.Ref<any>;
+  omitStatusCell?: boolean;
+  ghostCell?: boolean;
+  templateSpy?: jest.Mock;
+  loading?: boolean;
+  empty?: React.ReactNode;
+}
+
+function renderTable(options: RenderOptions = {}) {
+  const items = options.items ?? makeItems(options.count ?? 5);
+  const utils = render(
+    <VirtualTable.Root
+      items={items}
+      trackBy={item => item.id}
+      estimatedRowHeight={23}
+      loading={options.loading}
+      empty={options.empty}
+      expandedItems={options.controlledExpanded}
+      onExpandChange={options.onExpandChange}
+      sortingColumn={options.sortingColumn}
+      sortingDescending={options.sortingDescending}
+      onSortingChange={options.onSortingChange}
+      imperativeRef={options.imperativeRef}
+      ariaLabels={{
+        tableLabel: 'Resources',
+        expandButtonLabel: (item, expanded) => `${expanded ? 'Collapse' : 'Expand'} ${item.name}`,
+        expandedRegionLabel: item => `Details for ${item.name}`,
+        activateSortLabel: columnId => `Sort by ${columnId}`,
+      }}
+    >
+      <VirtualTable.Header>
+        <VirtualTable.HeaderCell columnId="name" sortingField={options.sortable ? 'name' : undefined}>
+          Name
+        </VirtualTable.HeaderCell>
+        <VirtualTable.HeaderCell columnId="status" stretch={true}>
+          Status
+        </VirtualTable.HeaderCell>
+      </VirtualTable.Header>
+      <VirtualTable.Body>
+        {(item: Item, api) => {
+          options.templateSpy?.();
+          return (
+            <VirtualTable.Row item={item} api={api}>
+              <VirtualTable.Cell columnId="name">{item.name}</VirtualTable.Cell>
+              {!options.omitStatusCell && <VirtualTable.Cell columnId="status">{item.status}</VirtualTable.Cell>}
+              {options.ghostCell && <VirtualTable.Cell columnId="ghost">ghost</VirtualTable.Cell>}
+              {/* ExpandedContent is declared unconditionally (not gated on api.isExpanded) per
+                  the BodyProps contract; Root mounts the region only for expanded rows. */}
+              {options.expandable && (
+                <VirtualTable.ExpandedContent estimatedHeight={300}>
+                  <div>detail-{item.id}</div>
+                </VirtualTable.ExpandedContent>
+              )}
+            </VirtualTable.Row>
+          );
+        }}
+      </VirtualTable.Body>
+    </VirtualTable.Root>
+  );
+  const wrapper = createWrapper(utils.container).findVirtualTable()!;
+  return { wrapper, ...utils };
+}
+
+function grid(wrapper: ReturnType<typeof renderTable>['wrapper']) {
+  return wrapper.find('[role="grid"]')!.getElement();
+}
+
+describe('VirtualTable (F1-A2 compound)', () => {
+  test('renders and is discoverable through the wrapper with the declared column headers', () => {
+    const { wrapper } = renderTable();
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.findColumnHeaders()).toHaveLength(2);
+  });
+
+  test('windows a large dataset and returns null for rows outside the window', () => {
+    const { wrapper } = renderTable({ count: 500 });
+    expect(wrapper.findRows().length).toBeGreaterThan(0);
+    expect(wrapper.findRows().length).toBeLessThan(500);
+    expect(wrapper.findRowByIndex(0)).not.toBeNull();
+    expect(wrapper.findRowByIndex(499)).toBeNull();
+  });
+
+  test('invokes the Body row template only for windowed rows, not the whole dataset', () => {
+    const templateSpy = jest.fn();
+    renderTable({ count: 500, templateSpy });
+    // The template runs for the windowed slice (+ one probe), never once per dataset row —
+    // this is how the compound API virtualizes without the consumer materializing every Row.
+    expect(templateSpy.mock.calls.length).toBeGreaterThan(0);
+    expect(templateSpy.mock.calls.length).toBeLessThan(200);
+  });
+
+  test('exposes full-dataset aria-rowcount and aria-colcount (no disclosure column)', () => {
+    const { wrapper } = renderTable({ count: 40 });
+    // Header row is counted once: aria-rowcount = items.length + 1.
+    expect(grid(wrapper).getAttribute('aria-rowcount')).toBe('41');
+    // No expandable rows -> no disclosure column -> two data columns.
+    expect(grid(wrapper).getAttribute('aria-colcount')).toBe('2');
+    expect(wrapper.findColumnHeaders()[0].getElement().getAttribute('aria-colindex')).toBe('1');
+    expect(wrapper.findExpandToggle(0)).toBeNull();
+  });
+
+  test('materialises a counted leading disclosure column when the template can expand', () => {
+    const { wrapper } = renderTable({ count: 40, expandable: true });
+    // Disclosure column is counted at aria-colindex 1, so data columns start at 2 in the header.
+    expect(grid(wrapper).getAttribute('aria-colcount')).toBe('3');
+    expect(wrapper.find('[role="columnheader"][aria-colindex="1"]')).not.toBeNull();
+    expect(wrapper.findColumnHeaders()[0].getElement().getAttribute('aria-colindex')).toBe('2');
+    expect(wrapper.findColumnHeaders()[1].getElement().getAttribute('aria-colindex')).toBe('3');
+    expect(wrapper.findExpandToggle(0)).not.toBeNull();
+  });
+
+  test('reconciles a missing body Cell into an empty gridcell so the row stays a coherent rectangle', () => {
+    const { wrapper } = renderTable({ count: 5, omitStatusCell: true });
+    const cells = wrapper.findRowByIndex(0)!.findAll('[role="gridcell"]');
+    // Both columns are still present as gridcells (name filled, status empty), never diverging
+    // from the header column count.
+    expect(cells).toHaveLength(2);
+    expect(cells[0].getElement().textContent).toBe('Resource 0');
+    expect(cells[1].getElement().textContent).toBe('');
+    // A missing (not unknown) column is a valid gap, not a misconfiguration: no dev warning.
+    expect(warnOnce).not.toHaveBeenCalledWith('VirtualTable', expect.stringContaining('no matching HeaderCell'));
+  });
+
+  test('dev-warns and drops a body Cell whose columnId has no matching HeaderCell', () => {
+    const { wrapper } = renderTable({ count: 5, ghostCell: true });
+    // The unknown-columnId Cell is not rendered: the row still has exactly the header's columns.
+    expect(wrapper.findRowByIndex(0)!.findAll('[role="gridcell"]')).toHaveLength(2);
+    expect(warnOnce).toHaveBeenCalledWith('VirtualTable', expect.stringContaining('ghost'));
+  });
+
+  test('dev-warns (fail-loud) when a row is expanded but the template rendered no ExpandedContent', () => {
+    // expandable=false -> no ExpandedContent declared -> the probe finds no disclosure column,
+    // but a controlled-expanded row still asks Root to open: fail loudly, do not silently
+    // render nothing (B1 fail-loud guard).
+    renderTable({ count: 5, expandable: false, controlledExpanded: ['row-0'] });
+    expect(warnOnce).toHaveBeenCalledWith(
+      'VirtualTable',
+      expect.stringContaining('Declare ExpandedContent unconditionally')
+    );
+  });
+
+  test('mounts an expanded region only for expanded rows (lazy), with a label', () => {
+    const { wrapper, container } = renderTable({ count: 40, expandable: true, controlledExpanded: ['row-2'] });
+    const region = wrapper.findExpandedRegion(2);
+    expect(region).not.toBeNull();
+    expect(region!.getElement().getAttribute('aria-label')).toBe('Details for Resource 2');
+    // Collapsed rows do not build their detail subtree.
+    expect(wrapper.findExpandedRegion(0)).toBeNull();
+    expect(container.textContent).toContain('detail-row-2');
+    expect(container.textContent).not.toContain('detail-row-0');
+  });
+
+  test('uncontrolled disclosure toggle expands the row and fires onExpandChange', () => {
+    const onExpandChange = jest.fn();
+    const { wrapper } = renderTable({ count: 10, expandable: true, onExpandChange });
+    expect(wrapper.findExpandedRegion(0)).toBeNull();
+
+    fireEvent.click(wrapper.findExpandToggle(0)!.getElement());
+
+    expect(wrapper.findExpandedRegion(0)).not.toBeNull();
+    expect(onExpandChange).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: expect.objectContaining({ expanded: true }) })
+    );
+  });
+
+  test('exposes the imperative ref surface', () => {
+    const ref = React.createRef<any>();
+    renderTable({ count: 50, imperativeRef: ref });
+    expect(typeof ref.current.scrollToEnd).toBe('function');
+    expect(typeof ref.current.scrollToItem).toBe('function');
+    expect(typeof ref.current.isPinnedToEnd()).toBe('boolean');
+  });
+
+  describe('sort activation', () => {
+    test('renders a keyboard-operable sort trigger only for sortable columns', () => {
+      const { wrapper } = renderTable({ sortable: true });
+      const [nameHeader, statusHeader] = wrapper.findColumnHeaders();
+      // Sortable column: a native button trigger + aria-sort. Non-sortable: neither.
+      expect(nameHeader.find('button')).not.toBeNull();
+      expect(statusHeader.find('button')).toBeNull();
+      expect(statusHeader.getElement().getAttribute('aria-sort')).toBeNull();
+    });
+
+    test('reflects the active sort column via aria-sort and emits toggled intent on activation', () => {
+      const onSortingChange = jest.fn();
+      const { wrapper } = renderTable({
+        sortable: true,
+        sortingColumn: { columnId: 'name' },
+        sortingDescending: false,
+        onSortingChange,
+      });
+      const nameHeader = wrapper.findColumnHeaders()[0];
+      expect(nameHeader.getElement().getAttribute('aria-sort')).toBe('ascending');
+
+      // Active + ascending -> activating toggles to descending (reflect-not-sort: the event
+      // carries intent, the consumer reorders the data).
+      fireEvent.click(nameHeader.find('button')!.getElement());
+      expect(onSortingChange).toHaveBeenCalledWith(
+        expect.objectContaining({ detail: { columnId: 'name', sortingDescending: true } })
+      );
+    });
+
+    test('a sortable but inactive column reports aria-sort none and starts ascending on activation', () => {
+      const onSortingChange = jest.fn();
+      const { wrapper } = renderTable({ sortable: true, onSortingChange });
+      const nameHeader = wrapper.findColumnHeaders()[0];
+      expect(nameHeader.getElement().getAttribute('aria-sort')).toBe('none');
+
+      fireEvent.click(nameHeader.find('button')!.getElement());
+      expect(onSortingChange).toHaveBeenCalledWith(
+        expect.objectContaining({ detail: { columnId: 'name', sortingDescending: false } })
+      );
+    });
+  });
+
+  test('expansion is keyed by trackBy and survives a consumer re-sort (reorder) without losing windowing', () => {
+    const items = makeItems(60);
+    // Expand row-30: it is at dataset index 30 before the reverse and index 29 after it, so it
+    // stays inside the top window (~indices 0-36) in BOTH orderings. This lets us assert that
+    // expansion is keyed by the trackBy id (its detail persists even though its dataset index
+    // changed), without over-asserting an off-window row's DOM that windowing legitimately unmounts.
+    const { wrapper, rerender, container } = renderTable({ items, expandable: true, controlledExpanded: ['row-30'] });
+    expect(container.textContent).toContain('detail-row-30');
+    const windowedBefore = wrapper.findRows().length;
+    expect(windowedBefore).toBeLessThan(60);
+
+    // Consumer re-sorts (reverses) the data; expansion state is keyed by trackBy id, so the
+    // expanded row stays expanded despite its dataset index changing, and windowing still holds.
+    rerender(
+      <VirtualTable.Root
+        items={[...items].reverse()}
+        trackBy={item => item.id}
+        estimatedRowHeight={23}
+        expandedItems={['row-30']}
+        ariaLabels={{
+          tableLabel: 'Resources',
+          expandButtonLabel: (item, expanded) => `${expanded ? 'Collapse' : 'Expand'} ${item.name}`,
+          expandedRegionLabel: item => `Details for ${item.name}`,
+        }}
+      >
+        <VirtualTable.Header>
+          <VirtualTable.HeaderCell columnId="name">Name</VirtualTable.HeaderCell>
+          <VirtualTable.HeaderCell columnId="status" stretch={true}>
+            Status
+          </VirtualTable.HeaderCell>
+        </VirtualTable.Header>
+        <VirtualTable.Body>
+          {(item: Item, api) => (
+            <VirtualTable.Row item={item} api={api}>
+              <VirtualTable.Cell columnId="name">{item.name}</VirtualTable.Cell>
+              <VirtualTable.Cell columnId="status">{item.status}</VirtualTable.Cell>
+              <VirtualTable.ExpandedContent estimatedHeight={300}>
+                <div>detail-{item.id}</div>
+              </VirtualTable.ExpandedContent>
+            </VirtualTable.Row>
+          )}
+        </VirtualTable.Body>
+      </VirtualTable.Root>
+    );
+    expect(container.textContent).toContain('detail-row-30');
+    expect(wrapper.findRows().length).toBeLessThan(60);
+  });
+
+  test('renders a polite live-append region as a sibling of the grid', () => {
+    const { wrapper } = renderTable();
+    const live = wrapper.findLiveRegion();
+    expect(live).not.toBeNull();
+    expect(live!.getElement().getAttribute('aria-live')).toBe('polite');
+  });
+
+  test('renders the empty state when there are no items', () => {
+    const { wrapper } = renderTable({ items: [], empty: 'No resources' });
+    expect(wrapper.findRows()).toHaveLength(0);
+    expect(wrapper.getElement().textContent).toContain('No resources');
+  });
+
+  test('renders a status role while loading', () => {
+    const { wrapper } = renderTable({ loading: true });
+    expect(wrapper.find('[role="status"]')).not.toBeNull();
+  });
+});

--- a/src/virtual-table/context.ts
+++ b/src/virtual-table/context.ts
@@ -13,7 +13,10 @@ import React, { createContext, useContext } from 'react';
 /** Absolute-position + measurement descriptor for a windowed row's data and expanded slots. */
 export interface RowPosition {
   dataStart: number;
+  /** Fixed pitch of the data row from the model; used to clamp fixed rows to the windowed pitch. */
+  dataSize: number;
   expandedStart?: number;
+  expandedSize?: number;
 }
 
 export interface DerivedColumn {

--- a/src/virtual-table/context.ts
+++ b/src/virtual-table/context.ts
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { createContext, useContext } from 'react';
+
+// Shared state Root provides to the compound sub-components. Root — not the sub-components
+// — owns the grid-level and cross-cell ARIA (role, aria-rowcount / aria-colcount, and every
+// element's aria-colindex derived from the HeaderCell column authority), the windowing
+// positions, and the measurement callback. HeaderCell / Cell / Row render the role-bearing
+// DOM but read their index, style, absolute position, and measure ref from here so they
+// never choose their own indices or offsets (design NB1a). Header<->body reconciliation is
+// driven from the ordered `columns` list so body Cells are placed in header order.
+
+/** Absolute-position + measurement descriptor for a windowed row's data and expanded slots. */
+export interface RowPosition {
+  dataStart: number;
+  expandedStart?: number;
+}
+
+export interface DerivedColumn {
+  columnId: string;
+  stretch?: boolean;
+  width?: number;
+  minWidth?: number;
+  /** Present when the column is sortable; Root reflects sort state and emits intent (it never sorts data). */
+  sortingField?: string;
+}
+
+export interface VirtualTableContextValue<T = unknown> {
+  baseId: string;
+  /** True when the row template renders an ExpandedContent child (enables the disclosure column). */
+  hasDisclosureColumn: boolean;
+  /** Total column count including the materialised disclosure column. */
+  columnCount: number;
+  /** Ordered data columns from the HeaderCell authority; body Cells are placed in this order. */
+  columns: ReadonlyArray<DerivedColumn>;
+  /** 1-based aria-colindex for a data column id (disclosure column, when present, is 1). */
+  columnIndexOf: (columnId: string) => number;
+  /** Fixed-layout flex style for a column by id (width / stretch / share). */
+  columnStyleOf: (columnId: string) => React.CSSProperties;
+  /**
+   * aria-sort for a column: `'ascending'`/`'descending'` when it is the active sort column,
+   * `'none'` when sortable but inactive, and `undefined` when the column declares no
+   * `sortingField` (not sortable -> no aria-sort attribute and no sort trigger).
+   */
+  ariaSortOf: (columnId: string) => 'ascending' | 'descending' | 'none' | undefined;
+  /** Activate/toggle sort on a column; Root reflects state and fires onSortingChange (it never sorts data). */
+  onSort: (columnId: string) => void;
+  /** Accessible name for a column's sort trigger. */
+  activateSortLabel?: (columnId: string) => string;
+  /** Windowed absolute position for a row id (undefined when the row is outside the window). */
+  positionOf: (id: string) => RowPosition | undefined;
+  /** Measurement callback ref factory; `auto=false` slots are never observed. */
+  measureRef: (key: string, auto: boolean) => (node: HTMLElement | null) => void;
+  /** Per-row DATA height strategy (mirrors the engine): 'auto' -> the data row is measured. */
+  getRowHeight?: (item: T) => number | 'auto';
+  /** DOM id of the row that currently holds the roving active-descendant, or null. */
+  activeDescendantId: string | null;
+  ariaLabels?: {
+    expandButtonLabel?: (item: T, expanded: boolean) => string;
+    expandedRegionLabel?: (item: T) => string;
+  };
+  trackBy: (item: T) => string;
+  isExpanded: (id: string) => boolean;
+  toggle: (item: T) => void;
+  rowDomId: (id: string) => string;
+  toggleId: (id: string) => string;
+  regionId: (id: string) => string;
+}
+
+const VirtualTableContext = createContext<VirtualTableContextValue | null>(null);
+
+export const VirtualTableContextProvider = VirtualTableContext.Provider;
+
+export function useVirtualTableContext<T = unknown>(component: string): VirtualTableContextValue<T> {
+  const context = useContext(VirtualTableContext);
+  if (!context) {
+    throw new Error(`VirtualTable.${component} must be used within VirtualTable.Root.`);
+  }
+  return context as VirtualTableContextValue<T>;
+}

--- a/src/virtual-table/context.ts
+++ b/src/virtual-table/context.ts
@@ -38,8 +38,16 @@ export interface VirtualTableContextValue<T = unknown> {
   columns: ReadonlyArray<DerivedColumn>;
   /** 1-based aria-colindex for a data column id (disclosure column, when present, is 1). */
   columnIndexOf: (columnId: string) => number;
-  /** Fixed-layout flex style for a column by id (width / stretch / share). */
-  columnStyleOf: (columnId: string) => React.CSSProperties;
+  /** The SINGLE shared `grid-template-columns` string, computed once from the HeaderCell set
+   *  (+ the disclosure column). Applied identically to `.header-row` and EVERY body `.row`
+   *  so columns align across rows deterministically (content-independent). */
+  gridTemplateColumns: string;
+  /** True when `resizableColumns` is set: HeaderCell renders a drag handle on its trailing edge. */
+  resizableColumns: boolean;
+  /** Ref callback so Root can measure a header cell's rendered width (freeze-on-first-resize). */
+  registerHeaderCell: (columnId: string, node: HTMLElement | null) => void;
+  /** Begin a pointer-driven column resize for `columnId` from a HeaderCell's drag handle. */
+  startColumnResize: (columnId: string, event: React.PointerEvent<HTMLElement>) => void;
   /**
    * aria-sort for a column: `'ascending'`/`'descending'` when it is the active sort column,
    * `'none'` when sortable but inactive, and `undefined` when the column declares no

--- a/src/virtual-table/index.tsx
+++ b/src/virtual-table/index.tsx
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+'use client';
+import React from 'react';
+
+import useBaseComponent from '../internal/hooks/use-base-component';
+import { applyDisplayName } from '../internal/utils/apply-display-name';
+import { VirtualTableProps } from './interfaces';
+import { Body, Cell, ExpandedContent, Header, HeaderCell, InternalRoot, Row } from './internal';
+
+export { VirtualTableProps };
+
+// Compound-component set (cell F1-A2). `VirtualTable.Root` is the base component and the
+// owner of all grid state; the sub-components are the exact references Root compares its
+// children against, so consumer `<VirtualTable.Row>` etc. are recognised by identity.
+function VirtualTableRoot<T>({
+  estimatedRowHeight = 40,
+  overscan = 10,
+  columnLayout = 'fixed',
+  role = 'grid',
+  loading = false,
+  resizableColumns = false,
+  ...props
+}: VirtualTableProps<T>) {
+  const baseComponentProps = useBaseComponent('VirtualTable', {
+    props: { estimatedRowHeight, overscan, columnLayout, role, resizableColumns },
+  });
+  return (
+    <InternalRoot
+      estimatedRowHeight={estimatedRowHeight}
+      overscan={overscan}
+      columnLayout={columnLayout}
+      role={role}
+      loading={loading}
+      resizableColumns={resizableColumns}
+      {...props}
+      {...baseComponentProps}
+    />
+  );
+}
+
+applyDisplayName(VirtualTableRoot, 'VirtualTable.Root');
+applyDisplayName(Header, 'VirtualTable.Header');
+applyDisplayName(HeaderCell, 'VirtualTable.HeaderCell');
+applyDisplayName(Body, 'VirtualTable.Body');
+applyDisplayName(Row, 'VirtualTable.Row');
+applyDisplayName(Cell, 'VirtualTable.Cell');
+applyDisplayName(ExpandedContent, 'VirtualTable.ExpandedContent');
+
+const VirtualTable = {
+  Root: VirtualTableRoot,
+  Header,
+  HeaderCell,
+  Body,
+  Row,
+  Cell,
+  ExpandedContent,
+};
+
+export default VirtualTable;

--- a/src/virtual-table/interfaces.ts
+++ b/src/virtual-table/interfaces.ts
@@ -1,0 +1,267 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { BaseComponentProps } from '../types/base-component';
+import { NonCancelableEventHandler } from '../types/events';
+
+// VirtualTable (cell F1-A2): generic, virtualization-first table expressed as a
+// compound-component set (Root / Header / HeaderCell / Body / Row / Cell /
+// ExpandedContent), additive to and coexisting with `Table`. This file is the public
+// API surface; the windowing engine, measurement, header<->body reconciliation, and
+// R-EXPAND a11y wiring land in impl-F1-A2-core. See deliverables/design/design-F1-A2.md.
+//
+// Composition model: `VirtualTable.Root` owns all grid state (windowing, measurement
+// cache, expansion, sort reflection, focus, the append live-region) and the single
+// scroll container. The consumer never instantiates rows imperatively — `VirtualTable.Body`
+// receives a ROW-TEMPLATE FUNCTION `(item, api) => <VirtualTable.Row>` that Root invokes
+// only for windowed rows. `VirtualTable.ExpandedContent` is the first-class compound home
+// for arbitrary non-tabular expanded content (R-EXPAND, MASTER goal 6).
+
+export interface VirtualTableProps<T> extends BaseComponentProps {
+  /**
+   * The full dataset. Root windows this to the visible range; the array itself is
+   * never fully rendered to the DOM. Appending to it is the streaming/live path
+   * (see `imperativeRef` and `onVisibleRangeChange`).
+   */
+  items: ReadonlyArray<T>;
+
+  /**
+   * Stable identity per row. Required (unlike Table, where it is optional): row
+   * virtualization recycles DOM nodes, so a stable key is mandatory for correct focus
+   * retention, expansion state, and measurement caching across recycling.
+   */
+  trackBy: (item: T) => string;
+
+  // --- Virtualization ------------------------------------------------------
+
+  /**
+   * Estimated collapsed row height in px, used to size the scroll runway before a row
+   * is measured. Set to the design's row density (CloudWatch: 23). @defaultValue 40
+   */
+  estimatedRowHeight?: number;
+
+  /**
+   * Optional per-row height strategy for DATA rows. Return a fixed px height, or
+   * `'auto'` to measure the row so variable / wrapping rows window at their real
+   * height — this is what lets the CloudWatch file/raw view wrap long log lines at
+   * RAW_LINE_HEIGHT=20 (CW-15) and satisfies the variable/wrapping-row-heights goal.
+   * Omit for uniform fixed rows at `estimatedRowHeight`: the fast path where no data
+   * row is observed, so a 100k fixed-row dataset pays no measurement cost. (Expanded
+   * regions are always measured independently; this governs the data row only.)
+   */
+  getRowHeight?: (item: T) => number | 'auto';
+
+  /**
+   * Number of rows rendered beyond the visible range on each side, to avoid blank
+   * flashes on fast scroll. CloudWatch overrides higher (20 table / 40 file-raw).
+   * @defaultValue 10
+   */
+  overscan?: number;
+
+  /**
+   * Fires when the windowed visible range changes. `firstIndex`/`lastIndex` index
+   * into `items`.
+   */
+  onVisibleRangeChange?: NonCancelableEventHandler<VirtualTableProps.VisibleRangeDetail>;
+
+  // --- Row expansion (R-EXPAND) --------------------------------------------
+  // Expanded content is authored as a `VirtualTable.ExpandedContent` child of the row
+  // template, not a prop. Expansion STATE lives on Root (controlled/uncontrolled).
+
+  /** Controlled set of expanded row ids (as returned by `trackBy`). */
+  expandedItems?: ReadonlyArray<string>;
+
+  /** Uncontrolled initial expansion. @defaultValue [] */
+  defaultExpandedItems?: ReadonlyArray<string>;
+
+  /** Fires on a disclosure toggle with the row and the resulting expanded set. */
+  onExpandChange?: NonCancelableEventHandler<VirtualTableProps.ExpandChangeDetail<T>>;
+
+  // --- Sorting / sizing ----------------------------------------------------
+  // Column identity/order/width are declared by the `HeaderCell` set (the single column
+  // authority). These props carry cross-cutting sort/resize state Root reflects.
+
+  sortingColumn?: { columnId: string };
+  sortingDescending?: boolean;
+  /** VirtualTable does not sort data; it reflects sort state and emits intent. */
+  onSortingChange?: NonCancelableEventHandler<VirtualTableProps.SortingDetail>;
+
+  /** Enables column resize handles. Emits via `onColumnWidthsChange`. @defaultValue false */
+  resizableColumns?: boolean;
+  /** Controlled per-column widths (px), keyed by `columnId`. Uncontrolled if omitted. */
+  columnWidths?: Record<string, number>;
+  onColumnWidthsChange?: NonCancelableEventHandler<VirtualTableProps.ColumnWidthsDetail>;
+
+  /**
+   * Column layout. `"fixed"` (default) applies fixed table layout with per-cell
+   * truncation and a single stretch column. `"auto"` sizes to content. @defaultValue "fixed"
+   */
+  columnLayout?: VirtualTableProps.ColumnLayout;
+
+  // --- Header / chrome -----------------------------------------------------
+
+  /** Header slot above the grid (title, counter, actions), like Table's `header`. */
+  header?: React.ReactNode;
+
+  /** Rendered when `items` is empty. */
+  empty?: React.ReactNode;
+
+  /** Loading state for the whole grid. */
+  loading?: boolean;
+  loadingText?: string;
+
+  // --- Accessibility -------------------------------------------------------
+
+  /** Localized accessibility strings and label functions. @i18n */
+  ariaLabels?: VirtualTableProps.AriaLabels<T>;
+
+  /**
+   * Semantic role of the grid. `"grid"` (default) for interactive grids with keyboard
+   * cell/row navigation; `"table"` for static, non-interactive data. @defaultValue "grid"
+   */
+  role?: VirtualTableProps.Role;
+
+  // --- Imperative surface --------------------------------------------------
+
+  /** Imperative handle for scroll anchoring, live tail, and reveal. */
+  imperativeRef?: React.Ref<VirtualTableProps.Ref>;
+
+  /** Header + Body compound children. */
+  children: React.ReactNode;
+}
+
+export namespace VirtualTableProps {
+  export type Role = 'grid' | 'table';
+  export type ColumnLayout = 'fixed' | 'auto';
+
+  /** Props for `VirtualTable.Header`. */
+  export interface HeaderProps {
+    /** Renders a sticky header with horizontal scroll synced to the body. @defaultValue false */
+    sticky?: boolean;
+    children: React.ReactNode; // HeaderCell children
+  }
+
+  /**
+   * Props for `VirtualTable.HeaderCell`. The `HeaderCell` set is the single authority
+   * for column identity, order, count, and `aria-colindex`; body `Cell`s are matched
+   * and ordered to it by `columnId`.
+   */
+  export interface HeaderCellProps {
+    columnId: string;
+    /**
+     * Marks the single column that stretches to fill remaining width. If more than one
+     * is set, the last-declared wins (single stretch target).
+     */
+    stretch?: boolean;
+    sortingField?: string;
+    width?: number;
+    minWidth?: number;
+    children: React.ReactNode; // header content
+  }
+
+  /**
+   * Props for `VirtualTable.Body`. Receives a ROW-TEMPLATE FUNCTION, not row elements —
+   * Root invokes it only for windowed items, which is how a compound API windows large
+   * data without the consumer materializing every row.
+   *
+   * The template MUST forward the given `item` and `api` to its `<VirtualTable.Row item
+   * api>` (Root reads row identity and expansion through them). It MUST declare
+   * `<VirtualTable.ExpandedContent>` UNCONDITIONALLY when a row can expand — do NOT gate
+   * it on `api.isExpanded`. Root decides whether the region is mounted; a gated template
+   * hides the disclosure column entirely and disables expansion. The template must be a
+   * pure, hook-free function of `(item, api)` (it runs inside Root's windowed render loop).
+   */
+  export interface BodyProps<T> {
+    children: (item: T, api: RowApi) => React.ReactElement; // a VirtualTable.Row
+  }
+
+  /**
+   * Passed to the row template so it is a pure function of `(item, api)` with no closure
+   * over window internals. The windowed slice is deliberately not exposed: cross-row
+   * scale (e.g. a shared histogram peak) must be computed consumer-side over the full
+   * dataset so it does not jump on scroll.
+   */
+  export interface RowApi {
+    /** True 1-based dataset index (NOT the window offset). */
+    rowIndex: number;
+    /** Total dataset length. */
+    totalItemCount: number;
+    isExpanded: boolean;
+  }
+
+  /** Props for `VirtualTable.Row`. */
+  export interface RowProps<T> {
+    item: T;
+    api: RowApi;
+    children: React.ReactNode; // Cells + optional ExpandedContent
+  }
+
+  /** Props for `VirtualTable.Cell`. `columnId` aligns it to its `HeaderCell`. */
+  export interface CellProps {
+    columnId: string;
+    children: React.ReactNode;
+  }
+
+  /**
+   * Props for `VirtualTable.ExpandedContent` — the first-class compound home for
+   * ARBITRARY non-tabular expanded content. Presence of this child in the row template
+   * enables the leading disclosure column. Its children are unconstrained by the column set.
+   *
+   * Declare it UNCONDITIONALLY in the row template (not gated on `api.isExpanded`): Root
+   * mounts the region only for expanded rows, and uses its presence to decide the
+   * disclosure column and pre-measurement runway. A conditionally-rendered ExpandedContent
+   * disables expansion silently and triggers a dev warning when a row is opened.
+   */
+  export interface ExpandedContentProps {
+    /**
+     * px estimate used before measurement; the region is measured so variable expanded
+     * heights window correctly. CloudWatch: ~300 (standard), ~150 (patterns).
+     */
+    estimatedHeight?: number;
+    /** Force a fixed height instead of measuring (rare; measurement is the default). */
+    fixedHeight?: number;
+    children: React.ReactNode; // arbitrary non-tabular content
+  }
+
+  export interface VisibleRangeDetail {
+    firstIndex: number;
+    lastIndex: number;
+  }
+  export interface ExpandChangeDetail<T> {
+    item: T;
+    expanded: boolean;
+    expandedItems: string[];
+  }
+  export interface SortingDetail {
+    columnId: string;
+    sortingDescending: boolean;
+  }
+  export interface ColumnWidthsDetail {
+    widths: Record<string, number>;
+  }
+
+  export interface AriaLabels<T> {
+    tableLabel?: string;
+    /** Label for a row's disclosure trigger, given expansion state. */
+    expandButtonLabel?: (item: T, expanded: boolean) => string;
+    /** Accessible name for an expanded region, tying it to its row. */
+    expandedRegionLabel?: (item: T) => string;
+    /**
+     * Message announced (politely) when rows are appended during live streaming.
+     * Root coalesces bursts (debounced) into one summarized message per batch.
+     * Returning undefined suppresses the announcement.
+     */
+    appendAnnouncement?: (detail: { addedCount: number; totalCount: number }) => string | undefined;
+    activateSortLabel?: (columnId: string) => string;
+  }
+
+  export interface Ref {
+    /** Pin the viewport to the last row (compose stick-to-bottom live tail on top). */
+    scrollToEnd(): void;
+    /** Scroll a row into view; optionally expand it (`reveal`). Any highlight is consumer-composed. */
+    scrollToItem(id: string, options?: { reveal?: boolean }): void;
+    /** True when the viewport is pinned to the last row (at the bottom edge). */
+    isPinnedToEnd(): boolean;
+  }
+}

--- a/src/virtual-table/interfaces.ts
+++ b/src/virtual-table/interfaces.ts
@@ -60,6 +60,23 @@ export interface VirtualTableProps<T> extends BaseComponentProps {
   overscan?: number;
 
   /**
+   * Fixed height (px) of the scrollable viewport. Windowing REQUIRES a bounded viewport:
+   * the visible range is computed from the scroll container's own height, so without a
+   * bound the container grows to the full content height and every row mounts. Set this
+   * (or `maxHeight`, or bound Root's parent — Root is a height-owning flex column) to
+   * enable windowing.
+   */
+  height?: number;
+
+  /**
+   * Maximum height (px) of the scrollable viewport. The viewport grows with content up to
+   * this bound, then scrolls. Use instead of `height` when the table should be shorter than
+   * the bound for small datasets. Windowing needs `height`, `maxHeight`, or a height-bounded
+   * parent (see `height`).
+   */
+  maxHeight?: number;
+
+  /**
    * Fires when the windowed visible range changes. `firstIndex`/`lastIndex` index
    * into `items`.
    */

--- a/src/virtual-table/internal.tsx
+++ b/src/virtual-table/internal.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 
 import { useUniqueId, warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
+import InternalIcon from '../icon/internal';
 import { getBaseProps } from '../internal/base-component';
 import { fireNonCancelableEvent } from '../internal/events';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
@@ -171,11 +172,25 @@ function Row<T>({ item, api, children }: VirtualTableProps.RowProps<T>) {
   const dataAuto = ctx.getRowHeight ? ctx.getRowHeight(item) === 'auto' : false;
 
   const dataStyle: React.CSSProperties | undefined = position
-    ? { position: 'absolute', insetBlockStart: position.dataStart, insetInlineStart: 0, insetInlineEnd: 0 }
+    ? {
+        position: 'absolute',
+        insetBlockStart: position.dataStart,
+        insetInlineStart: 0,
+        insetInlineEnd: 0,
+        // Fixed rows are clamped to the windowed pitch (with .cell overflow:hidden) so the
+        // row box equals the model pitch and rows never overlap; measured rows stay auto.
+        blockSize: dataAuto ? undefined : position.dataSize,
+      }
     : undefined;
   const expandedStyle: React.CSSProperties | undefined =
     position && position.expandedStart !== undefined
-      ? { position: 'absolute', insetBlockStart: position.expandedStart, insetInlineStart: 0, insetInlineEnd: 0 }
+      ? {
+          position: 'absolute',
+          insetBlockStart: position.expandedStart,
+          insetInlineStart: 0,
+          insetInlineEnd: 0,
+          blockSize: expandedAuto ? undefined : position.expandedSize,
+        }
       : undefined;
 
   return (
@@ -199,7 +214,9 @@ function Row<T>({ item, api, children }: VirtualTableProps.RowProps<T>) {
                 aria-controls={expanded ? regionId : undefined}
                 aria-label={ctx.ariaLabels?.expandButtonLabel?.(item, expanded)}
                 onClick={() => ctx.toggle(item)}
-              />
+              >
+                <InternalIcon name={expanded ? 'angle-down' : 'angle-right'} />
+              </button>
             ) : null}
           </span>
         )}
@@ -292,6 +309,8 @@ function InternalRoot<T>({
   estimatedRowHeight = 40,
   getRowHeight,
   overscan = 10,
+  height,
+  maxHeight,
   onVisibleRangeChange,
   header,
   empty,
@@ -397,11 +416,13 @@ function InternalRoot<T>({
     const map = new Map<string, RowPosition>();
     for (const slot of model.slots) {
       const id = trackBy(items[slot.index]);
-      const entry = map.get(id) ?? { dataStart: 0 };
+      const entry = map.get(id) ?? { dataStart: 0, dataSize: 0 };
       if (slot.type === 'data') {
         entry.dataStart = slot.start;
+        entry.dataSize = slot.size;
       } else {
         entry.expandedStart = slot.start;
+        entry.expandedSize = slot.size;
       }
       map.set(id, entry);
     }
@@ -412,6 +433,11 @@ function InternalRoot<T>({
   // active row while it is windowed, so the grid is Tab-reachable at any scroll offset (design
   // B3). Arrow/Home/End move the active row and scroll it into view.
   const [activeId, setActiveId] = useState<string | null>(null);
+  // The active row is a keyboard-navigation concept: only meaningful — and only rendered —
+  // while the grid container actually holds focus. Gating on real focus stops the default
+  // active row (items[0]) from advertising aria-activedescendant / painting an active outline
+  // on initial load, before any interaction.
+  const [hasFocus, setHasFocus] = useState(false);
   const effectiveActiveId = activeId ?? (items.length > 0 ? trackBy(items[0]) : null);
   const windowedIds = useMemo(() => {
     const set = new Set<string>();
@@ -422,7 +448,8 @@ function InternalRoot<T>({
     }
     return set;
   }, [model.slots, items, trackBy]);
-  const activeDescendantId = effectiveActiveId && windowedIds.has(effectiveActiveId) ? effectiveActiveId : null;
+  const activeDescendantId =
+    hasFocus && effectiveActiveId && windowedIds.has(effectiveActiveId) ? effectiveActiveId : null;
 
   const moveActive = useCallback(
     (nextIndex: number) => {
@@ -568,6 +595,11 @@ function InternalRoot<T>({
           ref={scrollContainerRef}
           className={clsx(styles['scroll-container'], headerSticky && styles['sticky-header'])}
           role={role}
+          // A bounded viewport is what makes the model window: the visible range is derived
+          // from this container's clientHeight, so an explicit height/maxHeight (or a
+          // height-bounded parent via the flex-column root) clips it to the visible rows
+          // instead of mounting the whole dataset.
+          style={{ blockSize: height, maxBlockSize: maxHeight }}
           aria-label={ariaLabels?.tableLabel}
           aria-rowcount={items.length + 1}
           aria-colcount={columnCount}
@@ -575,6 +607,18 @@ function InternalRoot<T>({
           aria-activedescendant={
             role === 'grid' && activeDescendantId ? `${baseId}-row-${activeDescendantId}` : undefined
           }
+          // focusin/focusout bubble; only the grid container itself holding focus advertises an
+          // active row, so focusing a descendant control (disclosure / expanded content) does not.
+          onFocus={event => {
+            if (event.target === event.currentTarget) {
+              setHasFocus(true);
+            }
+          }}
+          onBlur={event => {
+            if (event.target === event.currentTarget) {
+              setHasFocus(false);
+            }
+          }}
           onKeyDown={role === 'grid' ? onGridKeyDown : undefined}
         >
           <div className={styles['header-rowgroup']} role="rowgroup">

--- a/src/virtual-table/internal.tsx
+++ b/src/virtual-table/internal.tsx
@@ -5,8 +5,8 @@ import clsx from 'clsx';
 
 import { useUniqueId, warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
-import InternalIcon from '../icon/internal';
 import { getBaseProps } from '../internal/base-component';
+import { ExpandToggleButton } from '../internal/components/expand-toggle-button';
 import { fireNonCancelableEvent } from '../internal/events';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import {
@@ -39,8 +39,14 @@ function Header({ children }: VirtualTableProps.HeaderProps) {
   const ctx = useVirtualTableContext('Header');
   return (
     // Header row is aria-rowindex 1 so it is counted exactly once and SR "row X of Y" is
-    // coherent under windowing (design B1).
-    <div className={styles['header-row']} role="row" aria-rowindex={1}>
+    // coherent under windowing (design B1). It carries the SAME shared grid-template-columns
+    // as every body row so the columns align across rows content-independently.
+    <div
+      className={styles['header-row']}
+      role="row"
+      aria-rowindex={1}
+      style={{ gridTemplateColumns: ctx.gridTemplateColumns }}
+    >
       {ctx.hasDisclosureColumn && (
         // Materialised leading disclosure column: an accessible, empty columnheader (a spacer
         // aligned to the row's disclosure-toggle column) counted at aria-colindex 1 so data
@@ -62,7 +68,7 @@ function HeaderCell({ columnId, children }: VirtualTableProps.HeaderCellProps) {
       role="columnheader"
       aria-colindex={ctx.columnIndexOf(columnId)}
       aria-sort={ariaSort}
-      style={ctx.columnStyleOf(columnId)}
+      ref={node => ctx.registerHeaderCell(columnId, node)}
     >
       {ariaSort !== undefined ? (
         // Sortable columns (those declaring a sortingField) expose a native, implicitly
@@ -81,6 +87,13 @@ function HeaderCell({ columnId, children }: VirtualTableProps.HeaderCellProps) {
       ) : (
         children
       )}
+      {ctx.resizableColumns && (
+        <span
+          aria-hidden="true"
+          className={styles['resize-handle']}
+          onPointerDown={event => ctx.startColumnResize(columnId, event)}
+        />
+      )}
     </span>
   );
 }
@@ -92,12 +105,7 @@ const Body = (() => null) as <T>(props: VirtualTableProps.BodyProps<T>) => React
 function Cell({ columnId, children }: VirtualTableProps.CellProps) {
   const ctx = useVirtualTableContext('Cell');
   return (
-    <span
-      className={styles.cell}
-      role="gridcell"
-      aria-colindex={ctx.columnIndexOf(columnId)}
-      style={ctx.columnStyleOf(columnId)}
-    >
+    <span className={styles.cell} role="gridcell" aria-colindex={ctx.columnIndexOf(columnId)}>
       {children}
     </span>
   );
@@ -146,7 +154,6 @@ function Row<T>({ item, api, children }: VirtualTableProps.RowProps<T>) {
         className={styles.cell}
         role="gridcell"
         aria-colindex={ctx.columnIndexOf(column.columnId)}
-        style={ctx.columnStyleOf(column.columnId)}
       />
     );
   });
@@ -200,23 +207,24 @@ function Row<T>({ item, api, children }: VirtualTableProps.RowProps<T>) {
         className={clsx(styles.row, isActive && styles['row-active'])}
         role="row"
         aria-rowindex={dataAriaRowIndex}
-        style={dataStyle}
+        style={{ ...dataStyle, gridTemplateColumns: ctx.gridTemplateColumns }}
         ref={ctx.measureRef('d:' + id, dataAuto)}
       >
         {ctx.hasDisclosureColumn && (
           <span className={styles['disclosure-cell']} role="gridcell" aria-colindex={1}>
             {expandedContent ? (
-              <button
+              // Match the standard Table expandable-row toggle exactly: the shared
+              // ExpandToggleButton renders the rotating angle-down/caret icon and owns the
+              // button role + aria-expanded + aria-label. The label function already resolves
+              // the state-correct string, so it feeds both label slots.
+              <ExpandToggleButton
+                isExpanded={expanded}
+                onExpandableItemToggle={() => ctx.toggle(item)}
+                expandButtonLabel={ctx.ariaLabels?.expandButtonLabel?.(item, expanded)}
+                collapseButtonLabel={ctx.ariaLabels?.expandButtonLabel?.(item, expanded)}
                 id={toggleId}
-                type="button"
-                className={styles['disclosure-button']}
-                aria-expanded={expanded}
-                aria-controls={expanded ? regionId : undefined}
-                aria-label={ctx.ariaLabels?.expandButtonLabel?.(item, expanded)}
-                onClick={() => ctx.toggle(item)}
-              >
-                <InternalIcon name={expanded ? 'angle-down' : 'angle-right'} />
-              </button>
+                ariaControls={expanded ? regionId : undefined}
+              />
             ) : null}
           </span>
         )}
@@ -232,7 +240,7 @@ function Row<T>({ item, api, children }: VirtualTableProps.RowProps<T>) {
           className={styles['expanded-row']}
           role="row"
           aria-rowindex={dataAriaRowIndex}
-          style={expandedStyle}
+          style={{ ...expandedStyle, gridTemplateColumns: ctx.gridTemplateColumns }}
           ref={ctx.measureRef('e:' + id, expandedAuto)}
         >
           {/* A div (not a span) holds the arbitrary, possibly block-level expanded content —
@@ -281,23 +289,6 @@ function deriveColumns(headerElement: React.ReactElement<VirtualTableProps.Heade
   return columns;
 }
 
-// Fixed-layout column sizing: an explicit width pins the column; the stretch column fills
-// remaining space; otherwise columns share space.
-function cellStyle(
-  column: DerivedColumn | undefined,
-  columnWidths: Record<string, number> | undefined,
-  stretch: boolean
-): React.CSSProperties {
-  const width = (column && columnWidths?.[column.columnId]) ?? column?.width;
-  if (stretch) {
-    return { flex: '1 1 auto', minInlineSize: column?.minWidth };
-  }
-  if (width !== undefined) {
-    return { flex: `0 0 ${width}px`, minInlineSize: column?.minWidth };
-  }
-  return { flex: '1 1 0', minInlineSize: column?.minWidth ?? 0 };
-}
-
 // --- Root -----------------------------------------------------------------------------
 
 interface InternalRootProps<T> extends VirtualTableProps<T>, InternalBaseComponentProps {}
@@ -322,7 +313,9 @@ function InternalRoot<T>({
   sortingColumn,
   sortingDescending,
   onSortingChange,
+  resizableColumns = false,
   columnWidths,
+  onColumnWidthsChange,
   ariaLabels,
   imperativeRef,
   children,
@@ -404,11 +397,109 @@ function InternalRoot<T>({
   const hasDisclosureColumn = probe.hasDisclosureColumn;
   const dataColumnStart = hasDisclosureColumn ? 2 : 1;
   const columnCount = columns.length + (hasDisclosureColumn ? 1 : 0);
-  const stretchColumnId = [...columns].reverse().find(column => column.stretch)?.columnId;
   const columnIndex = useMemo(
     () => new Map(columns.map((column, index) => [column.columnId, dataColumnStart + index])),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [columns.map(column => column.columnId).join('\u0000'), dataColumnStart]
+  );
+
+  // --- Shared column-track layout + resize -----------------------------------------------
+  // ONE grid-template-columns string is computed from the HeaderCell set (+ the disclosure
+  // column) and applied identically to the header row and every body row, so columns align
+  // across rows content-independently. Track rules: the disclosure column is a leading `auto`
+  // track that resolves to the disclosure cell's fixed inline-size ($space-xl); a column with
+  // a resized/explicit width is `<w>px`; a width-less column (incl. the stretch column) is
+  // `minmax(<minWidth||0>px, 1fr)` so flexible columns share the remaining width equally.
+  // Resize maps take precedence over declared width.
+  const isWidthControlled = columnWidths !== undefined;
+  const [uncontrolledWidths, setUncontrolledWidths] = useState<Record<string, number>>({});
+  const widths = isWidthControlled ? columnWidths! : uncontrolledWidths;
+
+  const gridTemplateColumns = (() => {
+    const tracks: string[] = [];
+    if (hasDisclosureColumn) {
+      tracks.push('auto');
+    }
+    for (const column of columns) {
+      const resized = widths[column.columnId];
+      if (resized !== undefined) {
+        tracks.push(`${Math.max(resized, column.minWidth ?? 0)}px`);
+      } else if (column.width !== undefined) {
+        tracks.push(`${column.width}px`);
+      } else {
+        tracks.push(`minmax(${column.minWidth ?? 0}px, 1fr)`);
+      }
+    }
+    return tracks.join(' ');
+  })();
+
+  // Refs so the pointer-drag handlers always read the latest widths / minWidths / cell nodes
+  // without re-subscribing listeners on every render.
+  const headerCellRefs = useRef(new Map<string, HTMLElement>());
+  const widthsRef = useRef(widths);
+  widthsRef.current = widths;
+  const minWidthByColumn = useRef(new Map<string, number | undefined>());
+  minWidthByColumn.current = new Map(columns.map(column => [column.columnId, column.minWidth]));
+
+  const registerHeaderCell = useCallback((columnId: string, node: HTMLElement | null) => {
+    if (node) {
+      headerCellRefs.current.set(columnId, node);
+    } else {
+      headerCellRefs.current.delete(columnId);
+    }
+  }, []);
+
+  const applyWidths = useCallback(
+    (next: Record<string, number>) => {
+      if (!isWidthControlled) {
+        setUncontrolledWidths(next);
+      }
+      if (onColumnWidthsChange) {
+        fireNonCancelableEvent(onColumnWidthsChange, { widths: next });
+      }
+    },
+    [isWidthControlled, onColumnWidthsChange]
+  );
+
+  const resizeState = useRef<{ columnId: string; startX: number; startWidth: number } | null>(null);
+  const startColumnResize = useCallback(
+    (columnId: string, event: React.PointerEvent<HTMLElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      // Freeze-on-first-resize: snapshot the CURRENT rendered px width of every column so
+      // flexible (1fr) tracks become fixed px, making the drag predictable and alignment-safe.
+      const frozen: Record<string, number> = { ...widthsRef.current };
+      let needSnapshot = false;
+      headerCellRefs.current.forEach((node, id) => {
+        if (frozen[id] === undefined) {
+          frozen[id] = Math.round(node.getBoundingClientRect().width);
+          needSnapshot = true;
+        }
+      });
+      const startWidth =
+        frozen[columnId] ?? Math.round(headerCellRefs.current.get(columnId)?.getBoundingClientRect().width ?? 0);
+      resizeState.current = { columnId, startX: event.clientX, startWidth };
+      if (needSnapshot) {
+        applyWidths(frozen);
+      }
+      const onMove = (moveEvent: PointerEvent) => {
+        const state = resizeState.current;
+        if (!state) {
+          return;
+        }
+        const min = minWidthByColumn.current.get(state.columnId) ?? 0;
+        const next = Math.max(min, Math.round(state.startWidth + (moveEvent.clientX - state.startX)));
+        applyWidths({ ...widthsRef.current, [state.columnId]: next });
+      };
+      const onUp = () => {
+        resizeState.current = null;
+        document.removeEventListener('pointermove', onMove);
+        document.removeEventListener('pointerup', onUp);
+      };
+      document.addEventListener('pointermove', onMove);
+      document.addEventListener('pointerup', onUp);
+    },
+    [applyWidths]
   );
 
   // Absolute positions for the windowed slots, keyed by row id.
@@ -547,10 +638,10 @@ function InternalRoot<T>({
     columnCount,
     columns,
     columnIndexOf: (columnId: string) => columnIndex.get(columnId) ?? dataColumnStart,
-    columnStyleOf: (columnId: string) => {
-      const column = columns.find(candidate => candidate.columnId === columnId);
-      return cellStyle(column, columnWidths, columnId === stretchColumnId);
-    },
+    gridTemplateColumns,
+    resizableColumns,
+    registerHeaderCell,
+    startColumnResize,
     ariaSortOf: (columnId: string) => {
       const column = columns.find(candidate => candidate.columnId === columnId);
       if (!column?.sortingField) {

--- a/src/virtual-table/internal.tsx
+++ b/src/virtual-table/internal.tsx
@@ -1,0 +1,607 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import clsx from 'clsx';
+
+import { useUniqueId, warnOnce } from '@cloudscape-design/component-toolkit/internal';
+
+import { getBaseProps } from '../internal/base-component';
+import { fireNonCancelableEvent } from '../internal/events';
+import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import {
+  DerivedColumn,
+  RowPosition,
+  useVirtualTableContext,
+  VirtualTableContextProvider,
+  VirtualTableContextValue,
+} from './context';
+import { VirtualTableProps } from './interfaces';
+import { useExpansion } from './use-expansion';
+import { useLiveAnnouncement } from './use-live-announcement';
+import { useVirtualModel } from './use-virtual-model';
+
+import styles from './styles.css.js';
+
+// impl-F1-A2-core: the compound windowing core. Root owns the single scroll container, the
+// windowing engine, expansion state, focus, the live-append region, and the imperative
+// handle; it invokes the Body row-template ONLY for windowed items (the compound answer to
+// "how do you virtualize 100k rows without the consumer materializing every <Row>"). The
+// HeaderCell set is the single column authority; body Cells are matched and ordered to it by
+// columnId (missing column -> empty gridcell, unknown columnId -> dev warning + not rendered).
+// Root centrally owns the grid roles and every element's aria-rowindex/aria-colindex/position
+// via context; the sub-components render the role-bearing DOM and read index/style/position
+// from context, so composition never chooses its own indices or offsets.
+
+// --- Sub-components (declarative; render the role-bearing DOM from context) ------------
+
+function Header({ children }: VirtualTableProps.HeaderProps) {
+  const ctx = useVirtualTableContext('Header');
+  return (
+    // Header row is aria-rowindex 1 so it is counted exactly once and SR "row X of Y" is
+    // coherent under windowing (design B1).
+    <div className={styles['header-row']} role="row" aria-rowindex={1}>
+      {ctx.hasDisclosureColumn && (
+        // Materialised leading disclosure column: an accessible, empty columnheader (a spacer
+        // aligned to the row's disclosure-toggle column) counted at aria-colindex 1 so data
+        // columns start at 2 in BOTH the header and every body row and never diverge (design
+        // B1). The empty header is intentional (repo axe disables empty-table-header).
+        <span className={styles['disclosure-header']} role="columnheader" aria-colindex={1} />
+      )}
+      {children}
+    </div>
+  );
+}
+
+function HeaderCell({ columnId, children }: VirtualTableProps.HeaderCellProps) {
+  const ctx = useVirtualTableContext('HeaderCell');
+  const ariaSort = ctx.ariaSortOf(columnId);
+  return (
+    <span
+      className={styles['header-cell']}
+      role="columnheader"
+      aria-colindex={ctx.columnIndexOf(columnId)}
+      aria-sort={ariaSort}
+      style={ctx.columnStyleOf(columnId)}
+    >
+      {ariaSort !== undefined ? (
+        // Sortable columns (those declaring a sortingField) expose a native, implicitly
+        // keyboard-operable button as the sort trigger; its accessible name comes from
+        // activateSortLabel, falling back to the header content. Root reflects the resulting
+        // state via aria-sort on this columnheader and fires onSortingChange — VirtualTable
+        // never sorts the data itself.
+        <button
+          type="button"
+          className={styles['sort-button']}
+          aria-label={ctx.activateSortLabel?.(columnId)}
+          onClick={() => ctx.onSort(columnId)}
+        >
+          {children}
+        </button>
+      ) : (
+        children
+      )}
+    </span>
+  );
+}
+
+// Body is a carrier for the row-template function child. Root reads its child and invokes it
+// per windowed item; Body itself never renders (Root intercepts).
+const Body = (() => null) as <T>(props: VirtualTableProps.BodyProps<T>) => React.ReactElement | null;
+
+function Cell({ columnId, children }: VirtualTableProps.CellProps) {
+  const ctx = useVirtualTableContext('Cell');
+  return (
+    <span
+      className={styles.cell}
+      role="gridcell"
+      aria-colindex={ctx.columnIndexOf(columnId)}
+      style={ctx.columnStyleOf(columnId)}
+    >
+      {children}
+    </span>
+  );
+}
+
+// ExpandedContent is a descriptor Row reads and hoists into a sibling expanded row; it does
+// not render on its own.
+const ExpandedContent = (() => null) as (props: VirtualTableProps.ExpandedContentProps) => React.ReactElement | null;
+
+function Row<T>({ item, api, children }: VirtualTableProps.RowProps<T>) {
+  const ctx = useVirtualTableContext<T>('Row');
+  const id = ctx.trackBy(item);
+  const expanded = ctx.isExpanded(id);
+  const position = ctx.positionOf(id);
+
+  // Partition the row template's children: keep Cells by columnId; an ExpandedContent child
+  // is hoisted into a sibling expanded row ("declared in the row, positioned as a sibling
+  // row"). Unknown columnIds are dev-warned and dropped (header<->body reconciliation).
+  const cellByColumnId = new Map<string, React.ReactNode>();
+  const childList = React.Children.toArray(children).filter(React.isValidElement);
+  const expandedContent =
+    (childList.find(child => child.type === ExpandedContent) as
+      | React.ReactElement<VirtualTableProps.ExpandedContentProps>
+      | undefined) ?? null;
+  childList.forEach(child => {
+    if (child.type === Cell) {
+      const columnId = (child.props as VirtualTableProps.CellProps).columnId;
+      if (ctx.columns.some(column => column.columnId === columnId)) {
+        cellByColumnId.set(columnId, child);
+      } else {
+        warnOnce('VirtualTable', `Cell with columnId "${columnId}" has no matching HeaderCell and was not rendered.`);
+      }
+    }
+  });
+
+  // Place cells in the header column order; a column with no Cell renders an empty gridcell so
+  // the row stays a coherent rectangle and aria-colindex never diverges from the header.
+  const orderedCells = ctx.columns.map(column => {
+    const cell = cellByColumnId.get(column.columnId);
+    if (cell) {
+      return <React.Fragment key={column.columnId}>{cell}</React.Fragment>;
+    }
+    return (
+      <span
+        key={column.columnId}
+        className={styles.cell}
+        role="gridcell"
+        aria-colindex={ctx.columnIndexOf(column.columnId)}
+        style={ctx.columnStyleOf(column.columnId)}
+      />
+    );
+  });
+
+  const regionId = ctx.regionId(id);
+  const toggleId = ctx.toggleId(id);
+  // Data rows are the header row (aria-rowindex 1) + the 1-based dataset index -> api.rowIndex + 1.
+  const dataAriaRowIndex = api.rowIndex + 1;
+  const isActive = ctx.activeDescendantId === id;
+  // Only the arbitrary expanded region is measured; a fixedHeight opts out.
+  const expandedAuto = expandedContent ? expandedContent.props.fixedHeight === undefined : true;
+  // A row in the expanded set that rendered no ExpandedContent means the template gated
+  // ExpandedContent on api.isExpanded (see BodyProps): fail loudly instead of silently
+  // showing nothing (B1).
+  if (expanded && !expandedContent) {
+    warnOnce(
+      'VirtualTable',
+      'A row is expanded but its row template rendered no <VirtualTable.ExpandedContent>. ' +
+        'Declare ExpandedContent unconditionally (do not gate it on api.isExpanded); Root mounts it only for expanded rows.'
+    );
+  }
+  // Data rows are fixed unless the consumer opts this row into measurement via getRowHeight.
+  const dataAuto = ctx.getRowHeight ? ctx.getRowHeight(item) === 'auto' : false;
+
+  const dataStyle: React.CSSProperties | undefined = position
+    ? { position: 'absolute', insetBlockStart: position.dataStart, insetInlineStart: 0, insetInlineEnd: 0 }
+    : undefined;
+  const expandedStyle: React.CSSProperties | undefined =
+    position && position.expandedStart !== undefined
+      ? { position: 'absolute', insetBlockStart: position.expandedStart, insetInlineStart: 0, insetInlineEnd: 0 }
+      : undefined;
+
+  return (
+    <>
+      <div
+        id={ctx.rowDomId(id)}
+        className={clsx(styles.row, isActive && styles['row-active'])}
+        role="row"
+        aria-rowindex={dataAriaRowIndex}
+        style={dataStyle}
+        ref={ctx.measureRef('d:' + id, dataAuto)}
+      >
+        {ctx.hasDisclosureColumn && (
+          <span className={styles['disclosure-cell']} role="gridcell" aria-colindex={1}>
+            {expandedContent ? (
+              <button
+                id={toggleId}
+                type="button"
+                className={styles['disclosure-button']}
+                aria-expanded={expanded}
+                aria-controls={expanded ? regionId : undefined}
+                aria-label={ctx.ariaLabels?.expandButtonLabel?.(item, expanded)}
+                onClick={() => ctx.toggle(item)}
+              />
+            ) : null}
+          </span>
+        )}
+        {orderedCells}
+      </div>
+
+      {expanded && expandedContent && (
+        // The expanded region belongs to its data row: it shares that row's aria-rowindex and
+        // is NOT added to aria-rowcount (design B1). A real row -> full-width gridcell ->
+        // labeled region keeps a valid grid child model (design B2). The row is measured so
+        // its variable height windows correctly.
+        <div
+          className={styles['expanded-row']}
+          role="row"
+          aria-rowindex={dataAriaRowIndex}
+          style={expandedStyle}
+          ref={ctx.measureRef('e:' + id, expandedAuto)}
+        >
+          {/* A div (not a span) holds the arbitrary, possibly block-level expanded content —
+              carry-forward from the F1-A1 -pr HTML-validity fix. */}
+          <div className={styles['expanded-cell']} role="gridcell" aria-colindex={1} aria-colspan={ctx.columnCount}>
+            <div
+              id={regionId}
+              className={styles['expanded-region']}
+              role="region"
+              aria-label={ctx.ariaLabels?.expandedRegionLabel?.(item)}
+              onKeyDown={event => {
+                if (event.key === 'Escape') {
+                  event.stopPropagation();
+                  document.getElementById(toggleId)?.focus();
+                }
+              }}
+            >
+              {expandedContent.props.children}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+// --- Column authority derivation ------------------------------------------------------
+
+function deriveColumns(headerElement: React.ReactElement<VirtualTableProps.HeaderProps> | null): DerivedColumn[] {
+  if (!headerElement) {
+    return [];
+  }
+  const columns: DerivedColumn[] = [];
+  React.Children.forEach(headerElement.props.children, child => {
+    if (React.isValidElement(child) && child.type === HeaderCell) {
+      const props = child.props as VirtualTableProps.HeaderCellProps;
+      columns.push({
+        columnId: props.columnId,
+        stretch: props.stretch,
+        width: props.width,
+        minWidth: props.minWidth,
+        sortingField: props.sortingField,
+      });
+    }
+  });
+  return columns;
+}
+
+// Fixed-layout column sizing: an explicit width pins the column; the stretch column fills
+// remaining space; otherwise columns share space.
+function cellStyle(
+  column: DerivedColumn | undefined,
+  columnWidths: Record<string, number> | undefined,
+  stretch: boolean
+): React.CSSProperties {
+  const width = (column && columnWidths?.[column.columnId]) ?? column?.width;
+  if (stretch) {
+    return { flex: '1 1 auto', minInlineSize: column?.minWidth };
+  }
+  if (width !== undefined) {
+    return { flex: `0 0 ${width}px`, minInlineSize: column?.minWidth };
+  }
+  return { flex: '1 1 0', minInlineSize: column?.minWidth ?? 0 };
+}
+
+// --- Root -----------------------------------------------------------------------------
+
+interface InternalRootProps<T> extends VirtualTableProps<T>, InternalBaseComponentProps {}
+
+function InternalRoot<T>({
+  items,
+  trackBy,
+  role = 'grid',
+  estimatedRowHeight = 40,
+  getRowHeight,
+  overscan = 10,
+  onVisibleRangeChange,
+  header,
+  empty,
+  loading = false,
+  loadingText,
+  expandedItems,
+  defaultExpandedItems,
+  onExpandChange,
+  sortingColumn,
+  sortingDescending,
+  onSortingChange,
+  columnWidths,
+  ariaLabels,
+  imperativeRef,
+  children,
+  __internalRootRef,
+  ...props
+}: InternalRootProps<T>) {
+  const baseProps = getBaseProps(props);
+  const baseId = useUniqueId('virtual-table');
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // Partition the compound children into Header + Body.
+  const rootChildren = React.Children.toArray(children).filter(React.isValidElement);
+  const headerElement =
+    (rootChildren.find(child => child.type === Header) as
+      | React.ReactElement<VirtualTableProps.HeaderProps>
+      | undefined) ?? null;
+  const bodyElement =
+    (rootChildren.find(child => child.type === Body) as
+      | React.ReactElement<VirtualTableProps.BodyProps<T>>
+      | undefined) ?? null;
+
+  const expansion = useExpansion<T>({ trackBy, expandedItems, defaultExpandedItems, onExpandChange });
+
+  // Probe the row template ONCE with the first item to read template-level facts that must be
+  // stable across windowing: whether the template renders an ExpandedContent child (enables
+  // the disclosure column) and the expanded region's height strategy (fixed vs measured, and
+  // the pre-measurement runway estimate — CloudWatch ~300 / ~150). Deriving these from a
+  // stable probe rather than the windowed row set stops the disclosure column from flickering
+  // as rows scroll in and out.
+  const probe = useMemo(() => {
+    if (!bodyElement || items.length === 0) {
+      return {
+        hasDisclosureColumn: false,
+        fixedHeight: undefined as number | undefined,
+        estimatedHeight: undefined as number | undefined,
+      };
+    }
+    const element = bodyElement.props.children(items[0], {
+      rowIndex: 1,
+      totalItemCount: items.length,
+      isExpanded: false,
+    });
+    let hasDisclosureColumn = false;
+    let fixedHeight: number | undefined;
+    let estimatedHeight: number | undefined;
+    React.Children.forEach(element.props.children, child => {
+      if (React.isValidElement(child) && child.type === ExpandedContent) {
+        hasDisclosureColumn = true;
+        const expandedProps = child.props as VirtualTableProps.ExpandedContentProps;
+        fixedHeight = expandedProps.fixedHeight;
+        estimatedHeight = expandedProps.estimatedHeight;
+      }
+    });
+    return { hasDisclosureColumn, fixedHeight, estimatedHeight };
+  }, [bodyElement, items]);
+
+  const model = useVirtualModel<T>({
+    items,
+    trackBy,
+    expandedIds: expansion.expandedIds,
+    expandedSignature: expansion.expandedSignature,
+    estimatedRowHeight,
+    getRowHeight,
+    getExpandedRowHeight: () => probe.fixedHeight ?? 'auto',
+    defaultExpandedEstimate: probe.estimatedHeight,
+    overscan,
+    scrollContainerRef,
+  });
+
+  // Fire the visible-range change when the windowed data range moves.
+  useEffect(() => {
+    if (model.firstIndex >= 0) {
+      fireNonCancelableEvent(onVisibleRangeChange, { firstIndex: model.firstIndex, lastIndex: model.lastIndex });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [model.firstIndex, model.lastIndex]);
+
+  const columns = deriveColumns(headerElement);
+  const hasDisclosureColumn = probe.hasDisclosureColumn;
+  const dataColumnStart = hasDisclosureColumn ? 2 : 1;
+  const columnCount = columns.length + (hasDisclosureColumn ? 1 : 0);
+  const stretchColumnId = [...columns].reverse().find(column => column.stretch)?.columnId;
+  const columnIndex = useMemo(
+    () => new Map(columns.map((column, index) => [column.columnId, dataColumnStart + index])),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [columns.map(column => column.columnId).join('\u0000'), dataColumnStart]
+  );
+
+  // Absolute positions for the windowed slots, keyed by row id.
+  const positions = useMemo(() => {
+    const map = new Map<string, RowPosition>();
+    for (const slot of model.slots) {
+      const id = trackBy(items[slot.index]);
+      const entry = map.get(id) ?? { dataStart: 0 };
+      if (slot.type === 'data') {
+        entry.dataStart = slot.start;
+      } else {
+        entry.expandedStart = slot.start;
+      }
+      map.set(id, entry);
+    }
+    return map;
+  }, [model.slots, items, trackBy]);
+
+  // Roving active descendant: the scroll container is the single tab stop and references the
+  // active row while it is windowed, so the grid is Tab-reachable at any scroll offset (design
+  // B3). Arrow/Home/End move the active row and scroll it into view.
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const effectiveActiveId = activeId ?? (items.length > 0 ? trackBy(items[0]) : null);
+  const windowedIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const slot of model.slots) {
+      if (slot.type === 'data') {
+        set.add(trackBy(items[slot.index]));
+      }
+    }
+    return set;
+  }, [model.slots, items, trackBy]);
+  const activeDescendantId = effectiveActiveId && windowedIds.has(effectiveActiveId) ? effectiveActiveId : null;
+
+  const moveActive = useCallback(
+    (nextIndex: number) => {
+      const clamped = Math.max(0, Math.min(items.length - 1, nextIndex));
+      if (clamped < 0 || items.length === 0) {
+        return;
+      }
+      setActiveId(trackBy(items[clamped]));
+      model.scrollToIndex(clamped);
+    },
+    [items, trackBy, model]
+  );
+
+  const onGridKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      // Only act when the grid container itself is focused; never steal Arrow/Home/End from
+      // interactive cell content or the arbitrary expanded region (design B2, MASTER goal 6).
+      if (event.target !== event.currentTarget) {
+        return;
+      }
+      const current = effectiveActiveId ? items.findIndex(item => trackBy(item) === effectiveActiveId) : -1;
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+          moveActive(current + 1);
+          break;
+        case 'ArrowUp':
+          event.preventDefault();
+          moveActive(current - 1);
+          break;
+        case 'Home':
+          event.preventDefault();
+          moveActive(0);
+          break;
+        case 'End':
+          event.preventDefault();
+          moveActive(items.length - 1);
+          break;
+      }
+    },
+    [effectiveActiveId, items, trackBy, moveActive]
+  );
+
+  // Reflect-not-sort: a HeaderCell sort trigger computes the next sort intent (toggle
+  // direction on the active column, otherwise start ascending) and emits it; the consumer
+  // applies the sort to `items`. VirtualTable never reorders the data itself.
+  const handleSort = useCallback(
+    (columnId: string) => {
+      const nextDescending = sortingColumn?.columnId === columnId ? !sortingDescending : false;
+      fireNonCancelableEvent(onSortingChange, { columnId, sortingDescending: nextDescending });
+    },
+    [sortingColumn, sortingDescending, onSortingChange]
+  );
+
+  useImperativeHandle(
+    imperativeRef,
+    () => ({
+      scrollToEnd: () => model.scrollToEnd(),
+      scrollToItem: (id: string, options?: { reveal?: boolean }) => {
+        const index = items.findIndex(item => trackBy(item) === id);
+        if (index < 0) {
+          return;
+        }
+        if (options?.reveal) {
+          expansion.expand(items[index]);
+        }
+        model.scrollToIndex(index);
+      },
+      isPinnedToEnd: () => model.isPinnedToEnd(),
+    }),
+    [model, items, trackBy, expansion]
+  );
+
+  const liveMessage = useLiveAnnouncement(items.length, ariaLabels?.appendAnnouncement);
+
+  // Invoke the row template ONLY for windowed data slots.
+  const rowElements =
+    bodyElement && !loading && items.length > 0
+      ? model.slots
+          .filter(slot => slot.type === 'data')
+          .map(slot => {
+            const item = items[slot.index];
+            const element = bodyElement!.props.children(item, {
+              rowIndex: slot.index + 1,
+              totalItemCount: items.length,
+              isExpanded: expansion.isExpanded(trackBy(item)),
+            });
+            return React.cloneElement(element, { key: trackBy(item) });
+          })
+      : [];
+
+  const contextValue: VirtualTableContextValue<T> = {
+    baseId,
+    hasDisclosureColumn,
+    columnCount,
+    columns,
+    columnIndexOf: (columnId: string) => columnIndex.get(columnId) ?? dataColumnStart,
+    columnStyleOf: (columnId: string) => {
+      const column = columns.find(candidate => candidate.columnId === columnId);
+      return cellStyle(column, columnWidths, columnId === stretchColumnId);
+    },
+    ariaSortOf: (columnId: string) => {
+      const column = columns.find(candidate => candidate.columnId === columnId);
+      if (!column?.sortingField) {
+        return undefined;
+      }
+      return sortingColumn?.columnId === columnId ? (sortingDescending ? 'descending' : 'ascending') : 'none';
+    },
+    onSort: handleSort,
+    activateSortLabel: ariaLabels?.activateSortLabel,
+    positionOf: (id: string) => positions.get(id),
+    measureRef: model.measureRef,
+    getRowHeight,
+    activeDescendantId,
+    ariaLabels: {
+      expandButtonLabel: ariaLabels?.expandButtonLabel,
+      expandedRegionLabel: ariaLabels?.expandedRegionLabel,
+    },
+    trackBy,
+    isExpanded: expansion.isExpanded,
+    toggle: expansion.toggle,
+    rowDomId: (id: string) => `${baseId}-row-${id}`,
+    toggleId: (id: string) => `${baseId}-toggle-${id}`,
+    regionId: (id: string) => `${baseId}-region-${id}`,
+  };
+
+  const showEmpty = !loading && items.length === 0;
+  const headerSticky = headerElement?.props.sticky ?? false;
+
+  return (
+    <VirtualTableContextProvider value={contextValue as VirtualTableContextValue}>
+      <div {...baseProps} ref={__internalRootRef} className={clsx(baseProps.className, styles.root)}>
+        {header && <div className={styles.header}>{header}</div>}
+
+        {/*
+          The grid owns only rowgroups; header and body rows sit in their own rowgroup
+          (grid -> rowgroup -> row -> columnheader/gridcell). Non-row chrome — loading
+          (role=status), empty state, and the live-append region — are siblings of the grid
+          under .root, never grid-owned children. The scroll container is the single owned
+          windowing viewport and the single tab stop (aria-activedescendant roving, design B3).
+        */}
+        <div
+          ref={scrollContainerRef}
+          className={clsx(styles['scroll-container'], headerSticky && styles['sticky-header'])}
+          role={role}
+          aria-label={ariaLabels?.tableLabel}
+          aria-rowcount={items.length + 1}
+          aria-colcount={columnCount}
+          tabIndex={role === 'grid' ? 0 : undefined}
+          aria-activedescendant={
+            role === 'grid' && activeDescendantId ? `${baseId}-row-${activeDescendantId}` : undefined
+          }
+          onKeyDown={role === 'grid' ? onGridKeyDown : undefined}
+        >
+          <div className={styles['header-rowgroup']} role="rowgroup">
+            {headerElement}
+          </div>
+
+          {!loading && !showEmpty && (
+            <div className={styles.body} role="rowgroup" style={{ blockSize: model.totalSize }}>
+              {rowElements}
+            </div>
+          )}
+        </div>
+
+        {loading && (
+          <div className={styles.loading} role="status">
+            {loadingText}
+          </div>
+        )}
+
+        {showEmpty && <div className={styles.empty}>{empty}</div>}
+
+        <div className={styles['live-region']} aria-live="polite" aria-atomic="true">
+          {liveMessage}
+        </div>
+      </div>
+    </VirtualTableContextProvider>
+  );
+}
+
+export { InternalRoot, Header, HeaderCell, Body, Row, Cell, ExpandedContent };

--- a/src/virtual-table/styles.scss
+++ b/src/virtual-table/styles.scss
@@ -1,0 +1,150 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '../internal/styles' as styles;
+@use '../internal/styles/tokens' as awsui;
+
+.root {
+  @include styles.styles-reset;
+  position: relative;
+  display: block;
+  inline-size: 100%;
+}
+
+.header {
+  margin-block-end: awsui.$space-scaled-s;
+}
+
+.scroll-container {
+  position: relative;
+  overflow: auto;
+  inline-size: 100%;
+  &:focus-visible {
+    outline: 2px solid awsui.$color-border-item-focused;
+    outline-offset: -2px;
+  }
+}
+
+.header-rowgroup {
+  display: block;
+}
+
+.header-row {
+  display: flex;
+}
+
+// Sticky header is opt-in; the header stays inside the single scroll container so it
+// scrolls horizontally with the body (CW-14). scaffold: gated wiring lands in core.
+.sticky-header {
+  & > .header-rowgroup {
+    position: sticky;
+    inset-block-start: 0;
+    z-index: 1;
+    background: awsui.$color-background-container-content;
+  }
+}
+
+.header-cell {
+  min-inline-size: 0;
+  font-weight: awsui.$font-weight-bold;
+  padding-block: awsui.$space-scaled-xxs;
+  padding-inline: awsui.$space-scaled-xs;
+  box-sizing: border-box;
+}
+
+.disclosure-header,
+.disclosure-cell {
+  flex: 0 0 auto;
+  inline-size: awsui.$space-xl;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+// impl-F1-A2-core: the body is the windowing runway — Root sets its block-size to the full
+// virtualized height and positions each windowed row absolutely at its measured offset.
+.body {
+  display: block;
+  position: relative;
+  inline-size: 100%;
+}
+
+.row,
+.expanded-row {
+  display: flex;
+  inline-size: 100%;
+  box-sizing: border-box;
+}
+
+.row {
+  align-items: center;
+  &:focus-visible {
+    outline: 2px solid awsui.$color-border-item-focused;
+    outline-offset: -2px;
+  }
+}
+
+// The row referenced by aria-activedescendant while the grid container holds focus.
+.row-active {
+  outline: 2px solid awsui.$color-border-item-focused;
+  outline-offset: -2px;
+}
+
+.cell {
+  min-inline-size: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-block: awsui.$space-scaled-xxs;
+  padding-inline: awsui.$space-scaled-xs;
+  box-sizing: border-box;
+}
+
+.disclosure-button {
+  @include styles.styles-reset;
+  cursor: pointer;
+  inline-size: 100%;
+  block-size: 100%;
+}
+
+// Sort trigger for a sortable HeaderCell: a native button (implicitly keyboard-operable)
+// that fills the header cell and inherits the bold header typography.
+.sort-button {
+  @include styles.styles-reset;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  inline-size: 100%;
+  text-align: start;
+  font-weight: awsui.$font-weight-bold;
+  &:focus-visible {
+    outline: 2px solid awsui.$color-border-item-focused;
+    outline-offset: -2px;
+  }
+}
+
+.expanded-cell {
+  flex: 1 1 auto;
+  min-inline-size: 0;
+  box-sizing: border-box;
+}
+
+.expanded-region {
+  display: block;
+  inline-size: 100%;
+  box-sizing: border-box;
+  padding-block: awsui.$space-scaled-s;
+  padding-inline: awsui.$space-scaled-m;
+}
+
+.loading,
+.empty {
+  padding-block: awsui.$space-scaled-l;
+  text-align: center;
+}
+
+.live-region {
+  @include styles.awsui-util-hide;
+}

--- a/src/virtual-table/styles.scss
+++ b/src/virtual-table/styles.scss
@@ -6,11 +6,21 @@
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
 
+// VirtualTable (F1-A2, compound) is styled to visually match the existing
+// Cloudscape `Table` BY DEFAULT. Every colour / border / spacing value below is a
+// Cloudscape design token REUSED from the Table component styles
+// (src/table/header-cell/styles.scss and src/table/body-cell/styles.scss) rather
+// than a bespoke value, so the look tracks Table + visual refresh automatically.
+// The virtualization viewport (.scroll-container) scrolls with the NATIVE browser
+// scrollbar — there is no custom / synthetic / overlay scrollbar in this component.
+
 .root {
   @include styles.styles-reset;
   position: relative;
   display: block;
   inline-size: 100%;
+  // Sit on the container content surface, like a Table inside a Container.
+  background: awsui.$color-background-container-content;
 }
 
 .header {
@@ -19,6 +29,7 @@
 
 .scroll-container {
   position: relative;
+  // Native scrollbar only — no ::-webkit-scrollbar / overlay scrollbar styling.
   overflow: auto;
   inline-size: 100%;
   &:focus-visible {
@@ -31,26 +42,35 @@
   display: block;
 }
 
+// Header treatment matches Table's thead: table-header surface + a default divider
+// under the header row (Table: border-block-end divider-list-width solid
+// color-border-divider-default).
 .header-row {
   display: flex;
+  background: awsui.$color-background-table-header;
+  border-block-end: awsui.$border-divider-list-width solid awsui.$color-border-divider-default;
 }
 
 // Sticky header is opt-in; the header stays inside the single scroll container so it
-// scrolls horizontally with the body (CW-14). scaffold: gated wiring lands in core.
+// scrolls horizontally with the body (CW-14) while pinning vertically. Its surface
+// matches the non-sticky header (Table sticky-header look).
 .sticky-header {
   & > .header-rowgroup {
     position: sticky;
     inset-block-start: 0;
     z-index: 1;
-    background: awsui.$color-background-container-content;
+    background: awsui.$color-background-table-header;
   }
 }
 
 .header-cell {
   min-inline-size: 0;
-  font-weight: awsui.$font-weight-bold;
+  color: awsui.$color-text-column-header;
+  font-weight: awsui.$font-weight-heading-s;
+  line-height: awsui.$line-height-heading-xs;
+  // Table cell rhythm: dense vertical padding, space-scaled-l inline padding.
   padding-block: awsui.$space-scaled-xxs;
-  padding-inline: awsui.$space-scaled-xs;
+  padding-inline: awsui.$space-scaled-l;
   box-sizing: border-box;
 }
 
@@ -80,6 +100,20 @@
 
 .row {
   align-items: center;
+  // Table's per-row divider: the border sits on the row (not the cell) so it always
+  // lands at the row boundary regardless of cell padding / fixed row height under
+  // virtualization.
+  border-block-end: awsui.$border-divider-list-width solid awsui.$color-border-divider-secondary;
+
+  // Selected-row surface, matching Table's selected row (color-background-item-selected
+  // + selected border). VirtualTable (F1-A2, compound) has no selection prop today;
+  // this is a style hook so a selected row reads identically to Table if a consumer
+  // marks one. Inert until a row carries the row-selected class.
+  &.row-selected {
+    background: awsui.$color-background-item-selected;
+    border-block: awsui.$border-width-item-selected solid awsui.$color-border-item-selected;
+  }
+
   &:focus-visible {
     outline: 2px solid awsui.$color-border-item-focused;
     outline-offset: -2px;
@@ -94,12 +128,24 @@
 
 .cell {
   min-inline-size: 0;
+  // Default: single line, truncate with an ellipsis. This matches Table's default
+  // (wrapLines = false). Wrapping is available via the cell-wrap hook on measured
+  // rows (getRowHeight: 'auto'), mirroring Table's opt-in wrapLines.
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   padding-block: awsui.$space-scaled-xxs;
-  padding-inline: awsui.$space-scaled-xs;
+  padding-inline: awsui.$space-scaled-l;
   box-sizing: border-box;
+}
+
+// Wrapping affordance (Table wrapLines parity). Apply on cells in rows that opt into
+// measured heights (getRowHeight: 'auto') so wrapped content is measured and
+// windowed correctly.
+.cell-wrap {
+  white-space: normal;
+  overflow-wrap: break-word;
+  text-overflow: clip;
 }
 
 .disclosure-button {
@@ -110,7 +156,7 @@
 }
 
 // Sort trigger for a sortable HeaderCell: a native button (implicitly keyboard-operable)
-// that fills the header cell and inherits the bold header typography.
+// that fills the header cell and inherits the Table column-header typography.
 .sort-button {
   @include styles.styles-reset;
   cursor: pointer;
@@ -118,7 +164,8 @@
   align-items: center;
   inline-size: 100%;
   text-align: start;
-  font-weight: awsui.$font-weight-bold;
+  color: awsui.$color-text-column-header;
+  font-weight: awsui.$font-weight-heading-s;
   &:focus-visible {
     outline: 2px solid awsui.$color-border-item-focused;
     outline-offset: -2px;
@@ -131,12 +178,17 @@
   box-sizing: border-box;
 }
 
+// The expanded region sits on the container content surface with a divider below, so
+// an expanded row reads as a detail panel attached to its data row (Table
+// expandable-rows look), while holding arbitrary non-tabular content (R-EXPAND).
 .expanded-region {
   display: block;
   inline-size: 100%;
   box-sizing: border-box;
+  background: awsui.$color-background-container-content;
+  border-block-end: awsui.$border-divider-list-width solid awsui.$color-border-divider-secondary;
   padding-block: awsui.$space-scaled-s;
-  padding-inline: awsui.$space-scaled-m;
+  padding-inline: awsui.$space-scaled-l;
 }
 
 .loading,

--- a/src/virtual-table/styles.scss
+++ b/src/virtual-table/styles.scss
@@ -54,9 +54,12 @@
 
 // Header treatment matches Table's thead: table-header surface + a default divider
 // under the header row (Table: border-block-end divider-list-width solid
-// color-border-divider-default).
+// color-border-divider-default). A grid (not flex) so the shared column template governs
+// every column's width identically to the body rows (columns align across rows
+// content-independently).
 .header-row {
-  display: flex;
+  display: grid;
+  inline-size: 100%;
   background: awsui.$color-background-table-header;
   border-block-end: awsui.$border-divider-list-width solid awsui.$color-border-divider-default;
 }
@@ -77,7 +80,13 @@
 }
 
 .header-cell {
+  position: relative;
   min-inline-size: 0;
+  // Opaque header surface per cell: when the header is sticky over the windowed (absolutely
+  // positioned) body rows, a transparent cell lets a body row composite behind the column
+  // label, dropping its contrast below WCAG AA in dark mode. Painting the table-header surface
+  // on the cell itself keeps the label on the dark header background (matches Table's cells).
+  background: awsui.$color-background-table-header;
   color: awsui.$color-text-column-header;
   font-weight: awsui.$font-weight-heading-s;
   line-height: awsui.$line-height-heading-xs;
@@ -87,10 +96,43 @@
   box-sizing: border-box;
 }
 
+// Column resize affordance: a pointer-only handle pinned to the header cell's inline-end
+// edge (aria-hidden — it adds no semantics; the columnheader keeps its role). Dragging it
+// drives the shared column template's width map. It renders a VISIBLE vertical divider on
+// the trailing edge to match Table's header resizer: a thin rule in the default divider
+// colour that switches to the interactive-divider colour on hover/active.
+.resize-handle {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: 0;
+  // Comfortable grab area hanging just inside the trailing edge; the visible rule is drawn on
+  // the edge itself via ::after so the hit target is wider than the 1px divider.
+  inline-size: awsui.$space-m;
+  cursor: col-resize;
+  user-select: none;
+  z-index: 1;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset-inline-end: 0;
+    // Small block gap top/bottom, like Table's column divider.
+    inset-block: awsui.$space-xxs;
+    inline-size: 0;
+    border-inline-start: awsui.$border-divider-list-width solid awsui.$color-border-divider-default;
+    box-sizing: border-box;
+  }
+
+  &:hover::after,
+  &:active::after {
+    border-inline-start-color: awsui.$color-border-divider-interactive-default;
+  }
+}
+
 .disclosure-header,
 .disclosure-cell {
-  flex: 0 0 auto;
   inline-size: awsui.$space-xl;
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -104,9 +146,13 @@
   inline-size: 100%;
 }
 
+// Header and body rows are CSS grids driven by the SAME `grid-template-columns` (applied
+// inline from context), so every column aligns across rows deterministically. Rows stay
+// absolutely positioned vertically in the runway (windowing unchanged) — grid governs only
+// the horizontal column axis.
 .row,
 .expanded-row {
-  display: flex;
+  display: grid;
   inline-size: 100%;
   box-sizing: border-box;
 }
@@ -167,13 +213,6 @@
   text-overflow: clip;
 }
 
-.disclosure-button {
-  @include styles.styles-reset;
-  cursor: pointer;
-  inline-size: 100%;
-  block-size: 100%;
-}
-
 // Sort trigger for a sortable HeaderCell: a native button (implicitly keyboard-operable)
 // that fills the header cell and inherits the Table column-header typography.
 .sort-button {
@@ -192,7 +231,8 @@
 }
 
 .expanded-cell {
-  flex: 1 1 auto;
+  // Span every column track (incl. the disclosure column) so the expanded region is full width.
+  grid-column: 1 / -1;
   min-inline-size: 0;
   box-sizing: border-box;
 }

--- a/src/virtual-table/styles.scss
+++ b/src/virtual-table/styles.scss
@@ -17,7 +17,12 @@
 .root {
   @include styles.styles-reset;
   position: relative;
-  display: block;
+  // Height-owning flex column: when the component (or a parent) is given a bounded
+  // block-size, the scroll container flexes to fill it and windows. Combined with the
+  // height / maxHeight props (which bound .scroll-container directly), this guarantees a
+  // bounded viewport so the model windows instead of mounting every row.
+  display: flex;
+  flex-direction: column;
   inline-size: 100%;
   // Sit on the container content surface, like a Table inside a Container.
   background: awsui.$color-background-container-content;
@@ -29,6 +34,11 @@
 
 .scroll-container {
   position: relative;
+  // Fill the height-owning root when it is bounded (min-block-size:0 lets a flex item shrink
+  // below its content so it can scroll); an explicit height / maxHeight prop overrides this
+  // with a fixed viewport. Either way the viewport is bounded.
+  flex: 1 1 auto;
+  min-block-size: 0;
   // Native scrollbar only — no ::-webkit-scrollbar / overlay scrollbar styling.
   overflow: auto;
   inline-size: 100%;
@@ -58,7 +68,10 @@
   & > .header-rowgroup {
     position: sticky;
     inset-block-start: 0;
-    z-index: 1;
+    // Match Table's sticky-header stacking convention (Table pins its sticky header at 800,
+    // above sticky columns at 798); a bare `1` risks under-layering other console stacking
+    // contexts.
+    z-index: 800;
     background: awsui.$color-background-table-header;
   }
 }
@@ -120,7 +133,11 @@
   }
 }
 
-// The row referenced by aria-activedescendant while the grid container holds focus.
+// The row referenced by aria-activedescendant while the grid container holds focus. Applied
+// via the .row-active class ONLY while the grid holds focus (see internal.tsx), so it never
+// paints on initial load. The shared styles.focus-highlight mixin is intentionally NOT used
+// here: it forces `position: relative`, which would break the row's `position: absolute`
+// windowing placement; the outline is inset to sit inside the row like Table's focused ring.
 .row-active {
   outline: 2px solid awsui.$color-border-item-focused;
   outline-offset: -2px;
@@ -134,7 +151,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  padding-block: awsui.$space-scaled-xxs;
+  // Match Table body-cell vertical density ($space-scaled-xs). Fixed-height rows are clamped
+  // by their explicit blockSize regardless; this aligns wrapping / auto rows with a real Table.
+  padding-block: awsui.$space-scaled-xs;
   padding-inline: awsui.$space-scaled-l;
   box-sizing: border-box;
 }
@@ -195,6 +214,12 @@
 .empty {
   padding-block: awsui.$space-scaled-l;
   text-align: center;
+}
+
+// Empty / no-match text is muted, matching Table's empty slot.
+.empty {
+  color: awsui.$color-text-empty;
+  padding-inline: awsui.$space-l;
 }
 
 .live-region {

--- a/src/virtual-table/use-expansion.ts
+++ b/src/virtual-table/use-expansion.ts
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { useCallback, useMemo, useState } from 'react';
+
+import { fireNonCancelableEvent, NonCancelableEventHandler } from '../internal/events';
+import { VirtualTableProps } from './interfaces';
+
+// Controlled/uncontrolled expansion state for the R-EXPAND disclosure column. Root owns
+// this state (design: Root, not the sub-components, owns grid state). Exposes a stable
+// signature so the windowing layout only recomputes when the set of expanded ids actually
+// changes, not on every parent render.
+interface UseExpansionParams<T> {
+  trackBy: (item: T) => string;
+  expandedItems?: ReadonlyArray<string>;
+  defaultExpandedItems?: ReadonlyArray<string>;
+  onExpandChange?: NonCancelableEventHandler<VirtualTableProps.ExpandChangeDetail<T>>;
+}
+
+interface Expansion<T> {
+  expandedIds: ReadonlySet<string>;
+  expandedSignature: string;
+  isExpanded: (id: string) => boolean;
+  toggle: (item: T) => void;
+  expand: (item: T) => void;
+}
+
+export function useExpansion<T>({
+  trackBy,
+  expandedItems,
+  defaultExpandedItems,
+  onExpandChange,
+}: UseExpansionParams<T>): Expansion<T> {
+  const controlled = expandedItems !== undefined;
+  const [uncontrolled, setUncontrolled] = useState<ReadonlyArray<string>>(defaultExpandedItems ?? []);
+  const current = controlled ? expandedItems! : uncontrolled;
+
+  const expandedIds = useMemo(() => new Set(current), [current]);
+  const expandedSignature = useMemo(() => [...current].sort().join('\u0000'), [current]);
+
+  const isExpanded = useCallback((id: string) => expandedIds.has(id), [expandedIds]);
+
+  const setExpanded = useCallback(
+    (item: T, expanded: boolean) => {
+      const id = trackBy(item);
+      const next = new Set(current);
+      if (expanded) {
+        next.add(id);
+      } else {
+        next.delete(id);
+      }
+      const nextArray = [...next];
+      if (!controlled) {
+        setUncontrolled(nextArray);
+      }
+      fireNonCancelableEvent(onExpandChange, { item, expanded, expandedItems: nextArray });
+    },
+    [current, controlled, trackBy, onExpandChange]
+  );
+
+  const toggle = useCallback(
+    (item: T) => setExpanded(item, !expandedIds.has(trackBy(item))),
+    [setExpanded, expandedIds, trackBy]
+  );
+
+  const expand = useCallback((item: T) => setExpanded(item, true), [setExpanded]);
+
+  return { expandedIds, expandedSignature, isExpanded, toggle, expand };
+}

--- a/src/virtual-table/use-live-announcement.ts
+++ b/src/virtual-table/use-live-announcement.ts
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { useEffect, useRef, useState } from 'react';
+
+const APPEND_DEBOUNCE_MS = 500;
+
+// Coalesces streaming appends into a single polite announcement per burst. The consumer
+// decides WHAT to announce (via ariaLabels.appendAnnouncement); the component owns the
+// debounce and the aria-live region so a high-rate live tail announces "N new log events"
+// once per ~500ms batch, not once per row.
+export function useLiveAnnouncement(
+  totalCount: number,
+  appendAnnouncement?: (detail: { addedCount: number; totalCount: number }) => string | undefined
+): string {
+  const [message, setMessage] = useState('');
+  const previousCount = useRef(totalCount);
+  const pendingAdded = useRef(0);
+  const timer = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    const delta = totalCount - previousCount.current;
+    previousCount.current = totalCount;
+
+    // Only appends are announced; a shrink/replace resets the running tally.
+    if (delta <= 0) {
+      pendingAdded.current = 0;
+      return;
+    }
+    if (!appendAnnouncement) {
+      return;
+    }
+    pendingAdded.current += delta;
+
+    if (timer.current) {
+      clearTimeout(timer.current);
+    }
+    timer.current = setTimeout(() => {
+      const added = pendingAdded.current;
+      pendingAdded.current = 0;
+      const next = appendAnnouncement({ addedCount: added, totalCount });
+      if (next !== undefined) {
+        // Toggle a trailing zero-width space when the text repeats so the SR re-announces.
+        setMessage(prev => (prev === next ? next + '\u200b' : next));
+      }
+    }, APPEND_DEBOUNCE_MS);
+  }, [totalCount, appendAnnouncement]);
+
+  useEffect(() => {
+    return () => {
+      if (timer.current) {
+        clearTimeout(timer.current);
+      }
+    };
+  }, []);
+
+  return message;
+}

--- a/src/virtual-table/use-virtual-model.ts
+++ b/src/virtual-table/use-virtual-model.ts
@@ -1,0 +1,307 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+// Windowing + opt-in measurement engine for the compound VirtualTable (impl-F1-A2-core).
+// This is the SAME behaviour/a11y engine the config-driven cell uses — Root owns a single
+// inner scroll container (design B4), the body windows within it, data rows are fixed at
+// `estimatedRowHeight` (23 at CloudWatch density), and only the expanded regions are
+// measured (design B5) so a 100k fixed-row dataset never pays ResizeObserver cost. Measured
+// growth of a region above the fold is corrected by re-anchoring on the first visible row's
+// identity, so scroll position stays put as variable EXPANDED heights are discovered (no
+// CW-3 drift). The compound Root reads slot positions + `measureRef` from here and hands them
+// to each windowed Row through context so the Row positions and measures its own DOM.
+
+const DEFAULT_EXPANDED_ESTIMATE = 200;
+const DEFAULT_VIEWPORT = 600;
+
+// A row slot is either a data row or the expanded region row that follows it. The expanded
+// slot is a real grid row in the DOM (design B2) but does not consume a data-row
+// aria-rowindex (design B1) — the index sequence tracks data rows only.
+export interface RowSlot {
+  type: 'data' | 'expanded';
+  index: number;
+  key: string;
+  auto: boolean;
+}
+
+export interface PositionedSlot extends RowSlot {
+  start: number;
+  size: number;
+}
+
+interface UseVirtualModelParams<T> {
+  items: ReadonlyArray<T>;
+  trackBy: (item: T) => string;
+  expandedIds: ReadonlySet<string>;
+  expandedSignature: string;
+  estimatedRowHeight: number;
+  /** Height strategy for a DATA row: a fixed px value or 'auto' (measured). Omit -> fixed at estimatedRowHeight. */
+  getRowHeight?: (item: T) => number | 'auto';
+  /** Height strategy for the expanded region of an item: a fixed px value or 'auto' (measured). */
+  getExpandedRowHeight?: (item: T) => number | 'auto';
+  /** Pre-measurement runway estimate for an 'auto' expanded region (CloudWatch ~300 / ~150). */
+  defaultExpandedEstimate?: number;
+  overscan: number;
+  scrollContainerRef: React.RefObject<HTMLElement>;
+}
+
+export interface VirtualModel {
+  slots: PositionedSlot[];
+  totalSize: number;
+  firstIndex: number;
+  lastIndex: number;
+  measureRef: (key: string, auto: boolean) => (node: HTMLElement | null) => void;
+  scrollToEnd: () => void;
+  scrollToIndex: (index: number) => void;
+  isPinnedToEnd: () => boolean;
+}
+
+// Largest i such that offsets[i] <= target (offsets is strictly non-decreasing).
+function findFloorIndex(offsets: number[], target: number): number {
+  let lo = 0;
+  let hi = offsets.length - 1;
+  let result = 0;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (offsets[mid] <= target) {
+      result = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return result;
+}
+
+export function useVirtualModel<T>({
+  items,
+  trackBy,
+  expandedIds,
+  expandedSignature,
+  estimatedRowHeight,
+  getRowHeight,
+  getExpandedRowHeight,
+  defaultExpandedEstimate = DEFAULT_EXPANDED_ESTIMATE,
+  overscan,
+  scrollContainerRef,
+}: UseVirtualModelParams<T>): VirtualModel {
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewport, setViewport] = useState(DEFAULT_VIEWPORT);
+  const [measureVersion, setMeasureVersion] = useState(0);
+
+  const measured = useRef(new Map<string, number>());
+  const observers = useRef(new Map<string, { node: HTMLElement; ro: ResizeObserver }>());
+  const anchor = useRef<{ id: string; top: number } | null>(null);
+
+  const latest = useRef({ getRowHeight, getExpandedRowHeight, estimatedRowHeight, defaultExpandedEstimate });
+  latest.current = { getRowHeight, getExpandedRowHeight, estimatedRowHeight, defaultExpandedEstimate };
+
+  const layout = useMemo(() => {
+    const {
+      getRowHeight: grh,
+      getExpandedRowHeight: gerh,
+      estimatedRowHeight: est,
+      defaultExpandedEstimate: expEst,
+    } = latest.current;
+    const slots: RowSlot[] = [];
+    const offsets: number[] = [];
+    const startById = new Map<string, number>();
+    let cursor = 0;
+
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      const id = trackBy(item);
+
+      // Data rows are fixed at the density estimate by default (no measurement cost). When
+      // getRowHeight opts a row into 'auto', it is measured so variable / wrapping rows (e.g.
+      // the CloudWatch file/raw view) window at their real height; a numeric return pins it.
+      const rawData = grh ? grh(item) : est;
+      const dataAuto = rawData === 'auto';
+      const dataSize = dataAuto ? (measured.current.get('d:' + id) ?? est) : (rawData as number);
+      slots.push({ type: 'data', index: i, key: 'd:' + id, auto: dataAuto });
+      offsets.push(cursor);
+      startById.set(id, cursor);
+      cursor += dataSize;
+
+      if (expandedIds.has(id)) {
+        const rawExp = gerh ? gerh(item) : 'auto';
+        const expAuto = rawExp === 'auto';
+        const expSize = expAuto ? (measured.current.get('e:' + id) ?? expEst) : (rawExp as number);
+        slots.push({ type: 'expanded', index: i, key: 'e:' + id, auto: expAuto });
+        offsets.push(cursor);
+        cursor += expSize;
+      }
+    }
+
+    return { slots, offsets, startById, totalSize: cursor };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items, expandedSignature, estimatedRowHeight, measureVersion, trackBy]);
+
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) {
+      return;
+    }
+    setViewport(el.clientHeight || DEFAULT_VIEWPORT);
+    setScrollTop(el.scrollTop);
+    const ro = new ResizeObserver(() => setViewport(el.clientHeight || DEFAULT_VIEWPORT));
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [scrollContainerRef]);
+
+  const layoutRef = useRef(layout);
+  layoutRef.current = layout;
+
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) {
+      return;
+    }
+    const onScroll = () => {
+      const top = el.scrollTop;
+      setScrollTop(top);
+      const { slots, offsets } = layoutRef.current;
+      const idx = findFloorIndex(offsets, top);
+      for (let i = idx; i < slots.length; i++) {
+        if (slots[i].type === 'data') {
+          anchor.current = { id: slots[i].key.slice(2), top: offsets[i] - top };
+          break;
+        }
+      }
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [scrollContainerRef]);
+
+  useLayoutEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el || !anchor.current) {
+      return;
+    }
+    const newStart = layout.startById.get(anchor.current.id);
+    if (newStart === undefined) {
+      return;
+    }
+    const desiredTop = newStart - anchor.current.top;
+    if (Math.abs(desiredTop - el.scrollTop) > 0.5) {
+      el.scrollTop = desiredTop;
+      setScrollTop(desiredTop);
+    }
+  }, [measureVersion, layout, scrollContainerRef]);
+
+  const measureRef = useCallback(
+    (key: string, auto: boolean) => (node: HTMLElement | null) => {
+      const existing = observers.current.get(key);
+      if (!node) {
+        if (existing) {
+          existing.ro.disconnect();
+          observers.current.delete(key);
+        }
+        return;
+      }
+      // Fixed-height slots are never observed — they never pay measurement cost.
+      if (!auto) {
+        return;
+      }
+      if (existing && existing.node === node) {
+        return;
+      }
+      if (existing) {
+        existing.ro.disconnect();
+      }
+      const ro = new ResizeObserver(() => {
+        const h = node.getBoundingClientRect().height;
+        const prev = measured.current.get(key);
+        if (prev === undefined || Math.abs(prev - h) > 0.5) {
+          measured.current.set(key, h);
+          setMeasureVersion(v => v + 1);
+        }
+      });
+      ro.observe(node);
+      observers.current.set(key, { node, ro });
+    },
+    []
+  );
+
+  useEffect(() => {
+    const map = observers.current;
+    return () => {
+      map.forEach(({ ro }) => ro.disconnect());
+      map.clear();
+    };
+  }, []);
+
+  const {
+    slots: windowedSlots,
+    firstIndex,
+    lastIndex,
+  } = useMemo(() => {
+    const { slots, offsets, totalSize } = layout;
+    if (slots.length === 0) {
+      return { slots: [] as PositionedSlot[], firstIndex: -1, lastIndex: -1 };
+    }
+    const effectiveViewport = viewport || DEFAULT_VIEWPORT;
+    const firstVisible = findFloorIndex(offsets, scrollTop);
+    const lastVisible = findFloorIndex(offsets, scrollTop + effectiveViewport);
+    const startIdx = Math.max(0, firstVisible - overscan);
+    const endIdx = Math.min(slots.length - 1, lastVisible + overscan);
+
+    const positioned: PositionedSlot[] = [];
+    let firstData = -1;
+    let lastData = -1;
+    for (let i = startIdx; i <= endIdx; i++) {
+      const start = offsets[i];
+      const size = (i + 1 < offsets.length ? offsets[i + 1] : totalSize) - start;
+      positioned.push({ ...slots[i], start, size });
+      if (slots[i].type === 'data') {
+        if (firstData === -1) {
+          firstData = slots[i].index;
+        }
+        lastData = slots[i].index;
+      }
+    }
+    return { slots: positioned, firstIndex: firstData, lastIndex: lastData };
+  }, [layout, scrollTop, viewport, overscan]);
+
+  const scrollToEnd = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [scrollContainerRef]);
+
+  const scrollToIndex = useCallback(
+    (index: number) => {
+      const el = scrollContainerRef.current;
+      if (!el || index < 0 || index >= items.length) {
+        return;
+      }
+      const id = trackBy(items[index]);
+      const start = layout.startById.get(id);
+      if (start !== undefined) {
+        el.scrollTop = start;
+      }
+    },
+    [scrollContainerRef, items, trackBy, layout]
+  );
+
+  const isPinnedToEnd = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (!el) {
+      return false;
+    }
+    return el.scrollHeight - (el.scrollTop + el.clientHeight) <= 1;
+  }, [scrollContainerRef]);
+
+  return {
+    slots: windowedSlots,
+    totalSize: layout.totalSize,
+    firstIndex,
+    lastIndex,
+    measureRef,
+    scrollToEnd,
+    scrollToIndex,
+    isPinnedToEnd,
+  };
+}


### PR DESCRIPTION
## Summary
P5 rework of the composable (F1-A2) VirtualTable prototype on the Brazil-mirrored `dev-v3-gethinw-virtualtable-composable` branch.

- **Default styling now matches Cloudscape `Table`** by reusing Table's own design tokens (header surface + thead divider, column-header typography, per-row divider, selected-row surface, sticky-header look, default single-line truncate = Table `wrapLines=false` + opt-in `.cell-wrap`). No always-on row-hover surface (Table has no default general row hover).
- **Native scrollbar only** — no `::-webkit-scrollbar` / overlay / synthetic scrollbar.
- `dev-v3-*` branch prefix so it mirrors into the internal Brazil AwsUi-v3.

Local gates green: `npm run build` (exit 0), full `npm run lint` (0 errors), unit + a11y tests (4 suites / 56 tests).

## Supersedes
This supersedes the P4 draft PR #4739 (head `virtualtable-F1-A2`) — a GitHub PR head branch cannot be repointed, so #4739 can be closed as superseded.

## Human-gated (out of scope)
- Official Cloudscape API review + design/release sign-off
- `aria-live` node -> internal `LiveRegion` documenter follow-up
- Full-run CI coverage thresholds