### PR TITLE
chore: Adds package json exports for test-utils dom wrappers

### DIFF
--- a/build-tools/tasks/package-json.js
+++ b/build-tools/tasks/package-json.js
@@ -51,6 +51,11 @@ function getComponentsExports() {
     result[`./${component}`] = `./${component}/index.js`;
   }
 
+  // Per-component test-utils DOM wrappers (e.g. `.../test-utils/dom/button`).
+  for (const component of listPublicItems('src/test-utils/dom')) {
+    result[`./test-utils/dom/${component}`] = `./test-utils/dom/${component}/index.js`;
+  }
+
   // Internationalization and messages
   result['./i18n'] = './i18n/index.js';
   result[`./i18n/messages/all.all`] = `./i18n/messages/all.all.js`;


### PR DESCRIPTION
### Description

Make individual test-utils dom wrappers exported via package.json exports. These are necessary for extending test utils when building component libraries on top of Cloudscape.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
