### PR TITLE
chore: Add retries to retrieving deployment URL in visual regression workflow

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -71,22 +71,33 @@ jobs:
         id: hosts
         run: |
           DEPLOY_ENV="dev-pages-react18"
-          echo "Looking for deployment with environment '${DEPLOY_ENV}'..."
-          DEPLOY_ID=$(gh api \
-            "repos/${REPO}/deployments?environment=${DEPLOY_ENV}&per_page=5" \
-            --jq '.[0].id // empty' 2>/dev/null || true)
-          NEW_URL=""
-          if [ -n "$DEPLOY_ID" ]; then
-            NEW_URL=$(gh api \
-              "repos/${REPO}/deployments/${DEPLOY_ID}/statuses" \
-              --jq '[.[] | select(.state == "success")] | first | .environment_url // empty' 2>/dev/null || true)
-            echo "Found PR deployment: ID=${DEPLOY_ID}, URL=${NEW_URL}"
-          fi
-          if [ -z "$NEW_URL" ]; then
-            echo "::error::Could not resolve PR deployment URL"
-            exit 1
-          fi
-          echo "new=${NEW_URL}" >> "$GITHUB_OUTPUT"
+          MAX_ATTEMPTS=10
+          DELAY=15
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "Attempt ${attempt}/${MAX_ATTEMPTS}: looking for deployment with environment '${DEPLOY_ENV}'..."
+            DEPLOY_ID=$(gh api \
+              "repos/${REPO}/deployments?environment=${DEPLOY_ENV}&per_page=5" \
+              --jq '.[0].id // empty' 2>/dev/null || true)
+            NEW_URL=""
+            if [ -n "$DEPLOY_ID" ]; then
+              NEW_URL=$(gh api \
+                "repos/${REPO}/deployments/${DEPLOY_ID}/statuses" \
+                --jq '[.[] | select(.state == "success")] | first | .environment_url // empty' 2>/dev/null || true)
+            fi
+            if [ -n "$NEW_URL" ]; then
+              echo "Found PR deployment: ID=${DEPLOY_ID}, URL=${NEW_URL}"
+              echo "new=${NEW_URL}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo "Deployment URL not available yet (ID=${DEPLOY_ID:-not found}). Retrying in ${DELAY}s..."
+              sleep $DELAY
+            fi
+          done
+
+          echo "::error::Could not resolve PR deployment URL after ${MAX_ATTEMPTS} attempts"
+          exit 1
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
### Description

The deployment workflow can have a brief propagation delay between when the deploy job finishes and the deployment URL exists and is visible to the API query, causing occasional failures of the visual regression workflow ([example](https://github.com/cloudscape-design/components/actions/runs/29828340584?pr=4749)).

This PR adds retries for up to 2.5 minutes at 15 second intervals to make sure this race condition does not break this workflow.

### How has this been tested?

Visual regression checks as part of this PR. The step "Resolve PR deployment URL" already passed in both shards: [1](https://github.com/cloudscape-design/components/actions/runs/29905240841/job/88875774575?pr=4756), [2](https://github.com/cloudscape-design/components/actions/runs/29905240841/job/88875774567?pr=4756)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
