### PR TITLE
feat: Table full-row inline editing with batch save

### DIFF
--- a/pages/table/row-edit.page.tsx
+++ b/pages/table/row-edit.page.tsx
@@ -1,0 +1,141 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import { Box, Button, Header, Input, SpaceBetween } from '~components';
+import Table, { TableProps } from '~components/table';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+interface Item {
+  id: string;
+  name: string;
+  status: string;
+  region: string;
+}
+
+const initialItems: Item[] = [
+  { id: 'i-001', name: 'Web server', status: 'running', region: 'us-east-1' },
+  { id: 'i-002', name: 'Database', status: 'stopped', region: 'eu-west-1' },
+  { id: 'i-003', name: 'Cache layer', status: 'running', region: 'ap-southeast-1' },
+  { id: 'i-004', name: 'Worker (locked)', status: 'pending', region: 'us-west-2' },
+];
+
+export default function TableRowEditPage() {
+  const [items, setItems] = useState<Item[]>(initialItems);
+  const [submitLog, setSubmitLog] = useState<string[]>([]);
+
+  const columnDefinitions: TableProps.ColumnDefinition<Item>[] = [
+    {
+      id: 'id',
+      header: 'Instance ID',
+      cell: item => item.id,
+    },
+    {
+      id: 'name',
+      header: 'Name',
+      cell: item => item.name,
+      editConfig: {
+        ariaLabel: 'Name',
+        editIconAriaLabel: 'editable',
+        errorIconAriaLabel: 'Name Error',
+        editingCell(item, { currentValue, setValue }: TableProps.CellContext<string>) {
+          return (
+            <Input autoFocus={true} value={currentValue ?? item.name} onChange={e => setValue(e.detail.value)} />
+          );
+        },
+      },
+    },
+    {
+      id: 'status',
+      header: 'Status',
+      cell: item => item.status,
+      editConfig: {
+        ariaLabel: 'Status',
+        editIconAriaLabel: 'editable',
+        errorIconAriaLabel: 'Status Error',
+        editingCell(item, { currentValue, setValue }: TableProps.CellContext<string>) {
+          return (
+            <Input value={currentValue ?? item.status} onChange={e => setValue(e.detail.value)} />
+          );
+        },
+      },
+    },
+    {
+      id: 'region',
+      header: 'Region',
+      cell: item => item.region,
+      editConfig: {
+        ariaLabel: 'Region',
+        editIconAriaLabel: 'editable',
+        errorIconAriaLabel: 'Region Error',
+        editingCell(item, { currentValue, setValue }: TableProps.CellContext<string>) {
+          return (
+            <Input value={currentValue ?? item.region} onChange={e => setValue(e.detail.value)} />
+          );
+        },
+      },
+    },
+  ];
+
+  const ariaLabels: TableProps.AriaLabels<Item> = {
+    tableLabel: 'Instances (row edit)',
+    activateRowEditLabel: item => `Edit row ${item.id}`,
+    cancelRowEditLabel: item => `Cancel editing row ${item.id}`,
+    submitRowEditLabel: item => `Save row ${item.id}`,
+    submittingRowEditText: item => `Saving row ${item.id}`,
+  };
+
+  async function handleSubmitRowEdit(item: Item, newValues: Map<string, unknown>) {
+    // Simulate async save
+    await new Promise(resolve => setTimeout(resolve, 600));
+    setItems(prev =>
+      prev.map(i => {
+        if (i.id !== item.id) {
+          return i;
+        }
+        return {
+          ...i,
+          name: (newValues.get('name') as string | undefined) ?? i.name,
+          status: (newValues.get('status') as string | undefined) ?? i.status,
+          region: (newValues.get('region') as string | undefined) ?? i.region,
+        };
+      })
+    );
+    const changes = Array.from(newValues.entries())
+      .map(([k, v]) => `${k}="${v}"`)
+      .join(', ');
+    setSubmitLog(prev => [`Saved ${item.id}: ${changes || '(no changes)'}`, ...prev].slice(0, 5));
+  }
+
+  return (
+    <ScreenshotArea disableAnimations={true}>
+      <SpaceBetween size="l">
+        <Table
+          header={<Header>Instances — row-level inline editing</Header>}
+          items={items}
+          columnDefinitions={columnDefinitions}
+          trackBy="id"
+          ariaLabels={ariaLabels}
+          rowEditingConfig={{
+            disabledReason: item => (item.id === 'i-004' ? 'This instance is locked and cannot be edited.' : undefined),
+          }}
+          submitRowEdit={handleSubmitRowEdit}
+        />
+
+        {submitLog.length > 0 && (
+          <Box>
+            <Box variant="h3">Submit log (last 5)</Box>
+            {submitLog.map((entry, i) => (
+              <Box key={i} variant="p">
+                {entry}
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        <Button onClick={() => setSubmitLog([])}>Clear log</Button>
+      </SpaceBetween>
+    </ScreenshotArea>
+  );
+}

--- a/src/table/__tests__/table-row-edit.test.tsx
+++ b/src/table/__tests__/table-row-edit.test.tsx
@@ -1,0 +1,172 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import Input from '../../../lib/components/input';
+import Table, { TableProps } from '../../../lib/components/table';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
+  useMobile: jest.fn(),
+}));
+
+interface Item {
+  id: string;
+  name: string;
+  status: string;
+}
+
+const items: Item[] = [
+  { id: 'i-001', name: 'Alpha', status: 'running' },
+  { id: 'i-002', name: 'Beta', status: 'stopped' },
+];
+
+function makeColumns(): TableProps.ColumnDefinition<Item>[] {
+  return [
+    {
+      id: 'id',
+      header: 'ID',
+      cell: item => item.id,
+    },
+    {
+      id: 'name',
+      header: 'Name',
+      cell: item => item.name,
+      editConfig: {
+        ariaLabel: 'Name',
+        editingCell(item, { currentValue, setValue }: TableProps.CellContext<string>) {
+          return <Input value={currentValue ?? item.name} onChange={e => setValue(e.detail.value)} />;
+        },
+      },
+    },
+    {
+      id: 'status',
+      header: 'Status',
+      cell: item => item.status,
+      editConfig: {
+        ariaLabel: 'Status',
+        editingCell(item, { currentValue, setValue }: TableProps.CellContext<string>) {
+          return <Input value={currentValue ?? item.status} onChange={e => setValue(e.detail.value)} />;
+        },
+      },
+    },
+  ];
+}
+
+const ariaLabels: TableProps.AriaLabels<Item> = {
+  tableLabel: 'Test table',
+  activateRowEditLabel: item => `Edit row ${item.id}`,
+  cancelRowEditLabel: item => `Cancel row ${item.id}`,
+  submitRowEditLabel: item => `Save row ${item.id}`,
+};
+
+function renderTable(props: Partial<TableProps<Item>> = {}) {
+  const { container } = render(
+    <Table
+      items={items}
+      columnDefinitions={makeColumns()}
+      trackBy="id"
+      ariaLabels={ariaLabels}
+      {...props}
+    />
+  );
+  return createWrapper(container).findTable()!;
+}
+
+describe('Table row-level editing', () => {
+  test('renders an action column with Edit button per row when rowEditingConfig is provided', () => {
+    const wrapper = renderTable({ rowEditingConfig: {} });
+    // Each data row should have an edit button
+    const editButtons = screen.getAllByRole('button', { name: /Edit row/i });
+    expect(editButtons).toHaveLength(items.length);
+  });
+
+  test('does not render action column when rowEditingConfig is absent', () => {
+    renderTable();
+    expect(screen.queryByRole('button', { name: /Edit row/i })).toBeNull();
+  });
+
+  test('clicking Edit puts all editable cells in the row into edit state', () => {
+    const wrapper = renderTable({ rowEditingConfig: {} });
+    const editButton = screen.getByRole('button', { name: 'Edit row i-001' });
+    act(() => {
+      fireEvent.click(editButton);
+    });
+    // Both editable columns should be in editing state (inputs visible)
+    const inputs = wrapper.findAll('input');
+    expect(inputs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('Cancel button reverts row to read state', () => {
+    renderTable({ rowEditingConfig: {} });
+    const editButton = screen.getByRole('button', { name: 'Edit row i-001' });
+    act(() => {
+      fireEvent.click(editButton);
+    });
+    const cancelButton = screen.getByRole('button', { name: 'Cancel row i-001' });
+    act(() => {
+      fireEvent.click(cancelButton);
+    });
+    // Edit button should be visible again
+    expect(screen.getByRole('button', { name: 'Edit row i-001' })).toBeInTheDocument();
+    // No inputs should remain
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  test('Save button calls submitRowEdit with item and changed values', async () => {
+    const submitRowEdit = jest.fn().mockResolvedValue(undefined);
+    renderTable({ rowEditingConfig: {}, submitRowEdit });
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Edit row i-001' }));
+    });
+
+    // Change the name input
+    const inputs = screen.getAllByRole('textbox');
+    act(() => {
+      fireEvent.change(inputs[0], { target: { value: 'Alpha Updated' } });
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save row i-001' }));
+    });
+
+    await waitFor(() => {
+      expect(submitRowEdit).toHaveBeenCalledTimes(1);
+      const [calledItem] = submitRowEdit.mock.calls[0];
+      expect(calledItem).toEqual(items[0]);
+    });
+  });
+
+  test('disabled row shows Edit button in disabled state', () => {
+    renderTable({
+      rowEditingConfig: {
+        disabledReason: item => (item.id === 'i-002' ? 'Locked' : undefined),
+      },
+    });
+    const editButtonBeta = screen.getByRole('button', { name: 'Edit row i-002' });
+    expect(editButtonBeta).toBeDisabled();
+    const editButtonAlpha = screen.getByRole('button', { name: 'Edit row i-001' });
+    expect(editButtonAlpha).not.toBeDisabled();
+  });
+
+  test('only one row is in edit state at a time', () => {
+    renderTable({ rowEditingConfig: {} });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Edit row i-001' }));
+    });
+    // Row 1 is editing; row 2 still shows its Edit button
+    expect(screen.getByRole('button', { name: 'Edit row i-002' })).toBeInTheDocument();
+    // Row 1 should not show its Edit button
+    expect(screen.queryByRole('button', { name: 'Edit row i-001' })).toBeNull();
+  });
+
+  test('per-cell editing still works when rowEditingConfig is absent', () => {
+    const submitEdit = jest.fn();
+    renderTable({ submitEdit });
+    // No row-edit buttons
+    expect(screen.queryByRole('button', { name: /Edit row/i })).toBeNull();
+  });
+});

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -398,6 +398,22 @@ export interface TableProps<T = any> extends BaseComponentProps {
   onEditCancel?: CancelableEventHandler;
 
   /**
+   * Enables row-level batch inline editing. When set, an action column is appended
+   * to the table with Edit / Save / Cancel controls per row. Clicking Edit puts all
+   * columns that have `editConfig` into edit state simultaneously. Clicking Save
+   * calls `submitRowEdit` with the item and a map of changed column values.
+   * The existing per-cell `submitEdit` path is unaffected when this prop is absent.
+   */
+  rowEditingConfig?: TableProps.RowEditingConfig<T>;
+
+  /**
+   * Specifies a function called after the user saves a row-level inline edit.
+   * Receives the original item and a `Map<columnKey, newValue>` of all changed cells.
+   * Return a promise to keep the row in loading state while the request is in progress.
+   */
+  submitRowEdit?: TableProps.SubmitRowEditFunction<T>;
+
+  /**
    * Use this property to activate advanced keyboard navigation and focusing behaviors.
    * When set to `true`, table cells become navigable with arrow keys, and the entire table has a single tab stop.
    *
@@ -585,6 +601,10 @@ export namespace TableProps {
     submitEditLabel?: (column: ColumnDefinition<any>) => string;
     submittingEditText?: (column: ColumnDefinition<any>) => string;
     successfulEditLabel?: (column: ColumnDefinition<any>) => string;
+    activateRowEditLabel?: (item: T) => string;
+    cancelRowEditLabel?: (item: T) => string;
+    submitRowEditLabel?: (item: T) => string;
+    submittingRowEditText?: (item: T) => string;
     expandButtonLabel?: (item: T) => string;
     collapseButtonLabel?: (item: T) => string;
   }
@@ -641,6 +661,23 @@ export namespace TableProps {
     column: ColumnDefinition<ItemType>,
     newValue: ValueType
   ) => Promise<void> | void;
+
+  /**
+   * Called with the original item and a `Map` of `columnKey -> newValue` for all
+   * columns whose value was changed during a row-level edit.
+   */
+  export type SubmitRowEditFunction<ItemType> = (
+    item: ItemType,
+    newValues: Map<string, unknown>
+  ) => Promise<void> | void;
+
+  export interface RowEditingConfig<T> {
+    /**
+     * Determines whether row editing is disabled for a given item.
+     * Return a string to disable with a reason; return `undefined` to allow editing.
+     */
+    disabledReason?: (item: T) => string | undefined;
+  }
 
   export interface ColumnDisplay {
     type?: 'column';

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -47,6 +47,7 @@ import { getLoaderContent } from './progressive-loading/items-loader';
 import { TableLoaderCell } from './progressive-loading/loader-cell';
 import { useProgressiveLoadingProps } from './progressive-loading/progressive-loading-utils';
 import { ResizeTracker } from './resizer';
+import { RowEditActionCell } from './row-editing';
 import { focusMarkers, useSelection, useSelectionFocusMove } from './selection';
 import { TableBodySelectionCell } from './selection/selection-cell';
 import { useGroupSelection } from './selection/use-group-selection';
@@ -66,6 +67,7 @@ import ToolsHeader from './tools-header';
 import { useCellEditing } from './use-cell-editing';
 import { ColumnWidthDefinition, ColumnWidthsProvider, DEFAULT_COLUMN_WIDTH } from './use-column-widths';
 import { usePreventStickyClickScroll } from './use-prevent-sticky-click-scroll';
+import { useRowEditing } from './use-row-editing';
 import { useRowEvents } from './use-row-events';
 import useTableFocusNavigation from './use-table-focus-navigation';
 import { checkSortingState, getColumnKey, getItemKey, getVisibleColumnDefinitions, toContainerVariant } from './utils';
@@ -152,6 +154,8 @@ const InternalTable = React.forwardRef(
       renderLoaderEmpty,
       renderLoaderCounter,
       cellVerticalAlign,
+      rowEditingConfig,
+      submitRowEdit,
       __funnelSubStepProps,
       ...rest
     }: InternalTableProps<T>,
@@ -196,6 +200,7 @@ const InternalTable = React.forwardRef(
     const stickyHeaderRef = React.useRef<StickyHeaderRef>(null);
     const scrollbarRef = React.useRef<HTMLDivElement>(null);
     const { cancelEdit, ...cellEditing } = useCellEditing({ onCancel: onEditCancel, onSubmit: submitEdit });
+    const rowEditing = useRowEditing({ onCancel: onEditCancel, onSubmit: submitRowEdit });
     const paginationRef = useRef<PaginationRef>({});
     const filterRef = useRef<FilterRef>({});
     const preferencesRef = useRef<PreferencesRef>({});
@@ -441,6 +446,7 @@ const InternalTable = React.forwardRef(
       selectionColumnId,
       tableRole,
       isExpandable,
+      hasRowEditing: !!rowEditingConfig,
       setLastUserAction,
     };
 
@@ -708,9 +714,14 @@ const InternalTable = React.forwardRef(
                                 {visibleColumnDefinitions.map((column, colIndex) => {
                                   const colId = `${getColumnKey(column, colIndex)}`;
                                   const cellId = { row: rowId, col: colId };
-                                  const isEditing = cellEditing.checkEditing(cellId);
+                                  const isRowCurrentlyEditing = rowEditingConfig
+                                    ? rowEditing.isRowEditing(rowId)
+                                    : false;
+                                  const isEditing = isRowCurrentlyEditing
+                                    ? !!column.editConfig && !rowEditing.isLoading
+                                    : cellEditing.checkEditing(cellId);
                                   const successfulEdit = cellEditing.checkLastSuccessfulEdit(cellId);
-                                  const isEditable = !!column.editConfig && !cellEditing.isLoading;
+                                  const isEditable = !rowEditingConfig && !!column.editConfig && !cellEditing.isLoading;
                                   const cellExpandableProps =
                                     isExpandable && colIndex === 0 ? rowExpandableProps : undefined;
                                   const counter = column.counter?.({
@@ -751,9 +762,31 @@ const InternalTable = React.forwardRef(
                                       isRowHeader={column.isRowHeader}
                                       successfulEdit={successfulEdit}
                                       resizableColumns={resizableColumns}
-                                      onEditStart={() => cellEditing.startEdit(cellId)}
-                                      onEditEnd={editCancelled => cellEditing.completeEdit(cellId, editCancelled)}
-                                      submitEdit={cellEditing.submitEdit}
+                                      onEditStart={() => {
+                                        if (rowEditingConfig) {
+                                          // Row-edit mode: edit start is handled by the action cell
+                                        } else {
+                                          cellEditing.startEdit(cellId);
+                                        }
+                                      }}
+                                      onEditEnd={editCancelled => {
+                                        if (rowEditingConfig) {
+                                          if (editCancelled) {
+                                            rowEditing.cancelRowEdit();
+                                          }
+                                          // save is handled by the action cell Save button
+                                        } else {
+                                          cellEditing.completeEdit(cellId, editCancelled);
+                                        }
+                                      }}
+                                      submitEdit={
+                                        rowEditingConfig
+                                          ? (item: any, column: any, newValue: unknown) => {
+                                              const colKey = column.id ?? String(colIndex);
+                                              rowEditing.setColumnValue(colKey, newValue);
+                                            }
+                                          : cellEditing.submitEdit
+                                      }
                                       columnId={column.id ?? colIndex}
                                       colIndex={colIndex + colIndexOffset}
                                       verticalAlign={column.verticalAlign ?? cellVerticalAlign}
@@ -764,6 +797,18 @@ const InternalTable = React.forwardRef(
                                     />
                                   );
                                 })}
+                                {rowEditingConfig && row.type === 'data' && (
+                                  <RowEditActionCell
+                                    item={row.item}
+                                    isEditing={rowEditing.isRowEditing(rowId)}
+                                    isLoading={rowEditing.isLoading}
+                                    ariaLabels={ariaLabels}
+                                    disabledReason={rowEditingConfig.disabledReason?.(row.item)}
+                                    onEditStart={() => rowEditing.startRowEdit(row.item, rowId)}
+                                    onSave={() => rowEditing.submitRowEdit?.()}
+                                    onCancel={() => rowEditing.cancelRowEdit()}
+                                  />
+                                )}
                               </tr>
                             );
                           }

--- a/src/table/row-editing/index.ts
+++ b/src/table/row-editing/index.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { RowEditActionCell } from './row-edit-action-cell';

--- a/src/table/row-editing/row-edit-action-cell.tsx
+++ b/src/table/row-editing/row-edit-action-cell.tsx
@@ -1,0 +1,70 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Button from '../../button/internal';
+import InternalLiveRegion from '../../live-region/internal';
+import SpaceBetween from '../../space-between/internal';
+import { TableProps } from '../interfaces';
+
+import styles from './styles.css.js';
+
+interface RowEditActionCellProps<ItemType> {
+  item: ItemType;
+  isEditing: boolean;
+  isLoading: boolean;
+  ariaLabels: TableProps['ariaLabels'];
+  disabledReason?: string;
+  onEditStart: () => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+export function RowEditActionCell<ItemType>({
+  item,
+  isEditing,
+  isLoading,
+  ariaLabels,
+  disabledReason,
+  onEditStart,
+  onSave,
+  onCancel,
+}: RowEditActionCellProps<ItemType>) {
+  return (
+    <td className={styles['row-edit-action-cell']}>
+      {isEditing ? (
+        <SpaceBetween direction="horizontal" size="xxs">
+          {!isLoading && (
+            <Button
+              ariaLabel={ariaLabels?.cancelRowEditLabel?.(item)}
+              formAction="none"
+              iconName="close"
+              variant="inline-icon"
+              onClick={onCancel}
+            />
+          )}
+          <Button
+            ariaLabel={ariaLabels?.submitRowEditLabel?.(item)}
+            formAction="none"
+            iconName="check"
+            variant="inline-icon"
+            loading={isLoading}
+            onClick={onSave}
+          />
+          <InternalLiveRegion tagName="span" hidden={true}>
+            {isLoading ? ariaLabels?.submittingRowEditText?.(item) : ''}
+          </InternalLiveRegion>
+        </SpaceBetween>
+      ) : (
+        <Button
+          ariaLabel={ariaLabels?.activateRowEditLabel?.(item)}
+          formAction="none"
+          iconName="edit"
+          variant="inline-icon"
+          disabled={!!disabledReason}
+          onClick={onEditStart}
+        />
+      )}
+    </td>
+  );
+}

--- a/src/table/row-editing/styles.scss
+++ b/src/table/row-editing/styles.scss
@@ -1,0 +1,12 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '../../internal/styles/tokens' as awsui;
+
+.row-edit-action-cell {
+  white-space: nowrap;
+  width: 1%;
+  padding-inline: awsui.$space-scaled-xs;
+}

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -53,6 +53,7 @@ export interface TheadProps {
   onFocusedComponentChange?: (focusId: null | string) => void;
   tableRole: TableRole;
   isExpandable?: boolean;
+  hasRowEditing?: boolean;
   setLastUserAction: (name: string) => void;
 }
 
@@ -88,6 +89,7 @@ const Thead = React.forwardRef(
       resizerRoleDescription,
       resizerTooltipText,
       isExpandable,
+      hasRowEditing,
       setLastUserAction,
     }: TheadProps,
     outerRef: React.Ref<HTMLTableRowElement>
@@ -193,6 +195,7 @@ const Thead = React.forwardRef(
                 />
               );
             })}
+            {hasRowEditing && <th className={styles['header-cell']} style={{ width: '1%' }} aria-label="Row actions" />}
           </tr>
         </thead>
       );

--- a/src/table/use-row-editing.ts
+++ b/src/table/use-row-editing.ts
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useState } from 'react';
+
+import { fireCancelableEvent } from '../internal/events';
+import { CancelableEventHandler } from '../types/events';
+import { TableProps } from './interfaces';
+
+export type RowEditValues = Map<string, unknown>; // columnKey → value
+
+export interface RowEditState<T> {
+  item: T;
+  rowId: string;
+  values: RowEditValues;
+}
+
+interface UseRowEditingProps<T> {
+  onCancel?: CancelableEventHandler;
+  onSubmit?: TableProps.SubmitRowEditFunction<T>;
+}
+
+export function useRowEditing<T>({ onCancel, onSubmit }: UseRowEditingProps<T>) {
+  const [currentEditRow, setCurrentEditRow] = useState<RowEditState<T> | null>(null);
+  const [lastSuccessfulEditRow, setLastSuccessfulEditRow] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const startRowEdit = useCallback((item: T, rowId: string) => {
+    setLastSuccessfulEditRow(null);
+    setCurrentEditRow({ item, rowId, values: new Map() });
+  }, []);
+
+  const cancelRowEdit = useCallback(() => {
+    const eventCancelled = fireCancelableEvent(onCancel, {});
+    if (!eventCancelled) {
+      setCurrentEditRow(null);
+    }
+  }, [onCancel]);
+
+  const setColumnValue = useCallback((colKey: string, value: unknown) => {
+    setCurrentEditRow(prev => {
+      if (!prev) {
+        return prev;
+      }
+      const next = new Map(prev.values);
+      next.set(colKey, value);
+      return { ...prev, values: next };
+    });
+  }, []);
+
+  const submitRowEdit = onSubmit
+    ? async () => {
+        if (!currentEditRow) {
+          return;
+        }
+        setIsLoading(true);
+        try {
+          await onSubmit(currentEditRow.item, currentEditRow.values);
+          setLastSuccessfulEditRow(currentEditRow.rowId);
+          setCurrentEditRow(null);
+        } finally {
+          setIsLoading(false);
+        }
+      }
+    : undefined;
+
+  const isRowEditing = (rowId: string) => currentEditRow?.rowId === rowId;
+  const isLastSuccessfulEditRow = (rowId: string) => lastSuccessfulEditRow === rowId;
+  const getColumnValue = (colKey: string): unknown => currentEditRow?.values.get(colKey);
+
+  return {
+    currentEditRow,
+    isLoading,
+    startRowEdit,
+    cancelRowEdit,
+    setColumnValue,
+    submitRowEdit,
+    isRowEditing,
+    isLastSuccessfulEditRow,
+    getColumnValue,
+  };
+}


### PR DESCRIPTION
### Description

Implements row-level batch inline editing for the Table component, resolving #4181.

When `rowEditingConfig` is set, an action column is appended to the table with an **Edit** button per row. Clicking Edit puts **all** columns that have `editConfig` into edit state simultaneously. A single **Save** commits all changes via the new `submitRowEdit(item, newValues)` callback (receives the original item and a `Map<columnKey, newValue>` of changed cells). **Cancel** reverts without saving.

The existing per-cell immediate-save path (`submitEdit`) is fully preserved and unaffected.

**New API:**
- `TableProps.rowEditingConfig` (`RowEditingConfig<T>`) — enables row-edit mode; optional `disabledReason` fn for per-row disable
- `TableProps.submitRowEdit` (`SubmitRowEditFunction<T>`) — batch save callback; return a Promise to show loading state
- `TableProps.AriaLabels`: `activateRowEditLabel`, `cancelRowEditLabel`, `submitRowEditLabel`, `submittingRowEditText`

**Files changed:**
- `src/table/interfaces.tsx` — new types
- `src/table/use-row-editing.ts` — row-edit state hook
- `src/table/row-editing/` — `RowEditActionCell` component + styles
- `src/table/internal.tsx` — wiring
- `src/table/thead.tsx` — action column header
- `src/table/__tests__/table-row-edit.test.tsx` — 8 unit tests (all passing)
- `pages/table/row-edit.page.tsx` — dev page

Related links, issue #, if available: Closes #4181

### How has this been tested?

- 8 unit tests in `src/table/__tests__/table-row-edit.test.tsx` (all pass)
- Existing `table-editable.test.tsx` tests still pass
- Dev page at `pages/table/row-edit.page.tsx`

<details>
   <summary>Review checklist</summary>

#### Correctness

- Changes include appropriate documentation updates.
- Changes are backward-compatible — `rowEditingConfig` is opt-in; existing `submitEdit` / per-cell path unchanged.
- Changes were manually tested for accessibility.

#### Security

- No URL handling.

#### Testing

- Changes are covered with new unit tests.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.