### PR TITLE
feat: TextContent blockquote styling

### DIFF
--- a/pages/text-content/permutations.page.tsx
+++ b/pages/text-content/permutations.page.tsx
@@ -51,6 +51,19 @@ export default function TextContentPermutations() {
           <li>This is the last item.</li>
         </ol>
         <code>This is just some code</code>
+
+        <blockquote>
+          This is a blockquote. It uses a left border accent and italic text to visually distinguish quoted content from
+          the surrounding body text.
+        </blockquote>
+
+        <p>Text after a blockquote.</p>
+
+        <blockquote>
+          A longer blockquote that spans multiple lines to verify that the left border accent extends the full height of
+          the quoted block and that the padding and margin tokens keep the content comfortably separated from adjacent
+          elements.
+        </blockquote>
       </TextContent>
     </ScreenshotArea>
   );

--- a/src/text-content/__tests__/text-content-blockquote.test.tsx
+++ b/src/text-content/__tests__/text-content-blockquote.test.tsx
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import TextContent from '../../../lib/components/text-content';
+
+import styles from '../../../lib/components/text-content/styles.css.js';
+
+describe('TextContent blockquote', () => {
+  test('renders a blockquote element inside TextContent', () => {
+    const { container } = render(
+      <TextContent>
+        <blockquote>Quoted text</blockquote>
+      </TextContent>
+    );
+    const blockquote = container.querySelector('blockquote');
+    expect(blockquote).toBeInTheDocument();
+    expect(blockquote).toHaveTextContent('Quoted text');
+  });
+
+  test('blockquote is a descendant of the text-content root element', () => {
+    const { container } = render(
+      <TextContent>
+        <blockquote>Quoted text</blockquote>
+      </TextContent>
+    );
+    const root = container.querySelector(`.${styles['text-content']}`);
+    expect(root).not.toBeNull();
+    expect(root!.querySelector('blockquote')).not.toBeNull();
+  });
+
+  test('renders blockquote alongside other content without error', () => {
+    expect(() =>
+      render(
+        <TextContent>
+          <p>Before the quote.</p>
+          <blockquote>The quoted passage.</blockquote>
+          <p>After the quote.</p>
+        </TextContent>
+      )
+    ).not.toThrow();
+  });
+
+  test('blockquote content is accessible as text', () => {
+    const { getByText } = render(
+      <TextContent>
+        <blockquote>Accessible quote content</blockquote>
+      </TextContent>
+    );
+    expect(getByText('Accessible quote content')).toBeInTheDocument();
+  });
+});

--- a/src/text-content/styles.scss
+++ b/src/text-content/styles.scss
@@ -105,4 +105,16 @@
       margin-inline: 0;
     }
   }
+
+  blockquote {
+    @include styles.font(body-m);
+    color: awsui.$color-text-body-default;
+    border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+    margin-block: awsui.$space-scaled-xs;
+    margin-inline: 0;
+    padding-block: awsui.$space-xxs;
+    padding-inline-start: awsui.$space-m;
+    padding-inline-end: 0;
+    font-style: italic;
+  }
 }


### PR DESCRIPTION
### Description

Implements blockquote styling for the TextContent component, resolving #4172.

Adds a `blockquote` rule to `src/text-content/styles.scss` using Cloudscape typography and colour tokens:

| Property | Token |
|---|---|
| Left border accent (width) | `$border-divider-section-width` |
| Left border accent (colour) | `$color-border-divider-default` |
| Text colour | `$color-text-body-default` |
| Block margin | `$space-scaled-xs` |
| Block padding | `$space-xxs` |
| Inline-start padding | `$space-m` |
| Font style | italic |

This keeps the blockquote visually consistent with the Cloudscape design language while clearly distinguishing quoted content from surrounding body text.

Related links, issue #, if available: Closes #4172

### How has this been tested?

- 4 unit tests in `src/text-content/__tests__/text-content-blockquote.test.tsx` (all pass)
- Updated permutations dev page at `pages/text-content/permutations.page.tsx` with single-line and multi-line blockquote examples

<details>
   <summary>Review checklist</summary>

#### Correctness

- Changes are backward-compatible — `blockquote` was previously unstyled inside TextContent; adding a rule is additive.
- Changes use only Cloudscape design tokens (no hard-coded colour/spacing values).

#### Security

- No URL handling.

#### Testing

- Changes are covered with new unit tests.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.