### PR TITLE
feat(table): add totalRow prop for sticky tfoot aggregation row

### DIFF
--- a/pages/table/total-row.page.tsx
+++ b/pages/table/total-row.page.tsx
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Badge from '~components/badge';
+import Box from '~components/box';
+import Header from '~components/header';
+import Table, { TableProps } from '~components/table';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+interface SalesItem {
+  product: string;
+  region: string;
+  units: number;
+  revenue: number;
+  returns: number;
+}
+
+const items: SalesItem[] = [
+  { product: 'Widget A', region: 'us-east-1', units: 120, revenue: 4800, returns: 5 },
+  { product: 'Widget B', region: 'eu-west-1', units: 85, revenue: 3400, returns: 2 },
+  { product: 'Gadget X', region: 'ap-southeast-1', units: 200, revenue: 12000, returns: 8 },
+  { product: 'Gadget Y', region: 'us-west-2', units: 60, revenue: 3600, returns: 1 },
+  { product: 'Doohickey', region: 'eu-central-1', units: 45, revenue: 2250, returns: 3 },
+];
+
+const totalUnits = items.reduce((sum, i) => sum + i.units, 0);
+const totalRevenue = items.reduce((sum, i) => sum + i.revenue, 0);
+const totalReturns = items.reduce((sum, i) => sum + i.returns, 0);
+
+const columnDefinitions: TableProps.ColumnDefinition<SalesItem>[] = [
+  {
+    id: 'product',
+    header: 'Product',
+    cell: item => item.product,
+    isRowHeader: true,
+  },
+  {
+    id: 'region',
+    header: 'Region',
+    cell: item => <Badge>{item.region}</Badge>,
+  },
+  {
+    id: 'units',
+    header: 'Units sold',
+    cell: item => item.units,
+  },
+  {
+    id: 'revenue',
+    header: 'Revenue ($)',
+    cell: item => `$${item.revenue.toLocaleString()}`,
+  },
+  {
+    id: 'returns',
+    header: 'Returns',
+    cell: item => item.returns,
+  },
+];
+
+const totalRow: TableProps.TotalRow = {
+  cells: [
+    {
+      columnId: 'product',
+      content: <Box fontWeight="bold">Total</Box>,
+    },
+    {
+      columnId: 'units',
+      content: <Box fontWeight="bold">{totalUnits}</Box>,
+    },
+    {
+      columnId: 'revenue',
+      content: <Box fontWeight="bold">${totalRevenue.toLocaleString()}</Box>,
+    },
+    {
+      columnId: 'returns',
+      content: <Box fontWeight="bold">{totalReturns}</Box>,
+    },
+  ],
+};
+
+export default function App() {
+  return (
+    <ScreenshotArea>
+      <Table<SalesItem>
+        header={<Header headingTagOverride="h1">Sales summary — total row demo</Header>}
+        columnDefinitions={columnDefinitions}
+        items={items}
+        totalRow={totalRow}
+        ariaLabels={{ tableLabel: 'Sales summary table' }}
+      />
+    </ScreenshotArea>
+  );
+}

--- a/src/table/__tests__/total-row.test.tsx
+++ b/src/table/__tests__/total-row.test.tsx
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import Table, { TableProps } from '../../../lib/components/table';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+interface Item {
+  id: number;
+  name: string;
+  value: number;
+}
+
+const columnDefinitions: TableProps.ColumnDefinition<Item>[] = [
+  { id: 'id', header: 'ID', cell: item => item.id },
+  { id: 'name', header: 'Name', cell: item => item.name },
+  { id: 'value', header: 'Value', cell: item => item.value },
+];
+
+const items: Item[] = [
+  { id: 1, name: 'Alpha', value: 100 },
+  { id: 2, name: 'Beta', value: 200 },
+  { id: 3, name: 'Gamma', value: 300 },
+];
+
+const totalRow: TableProps.TotalRow = {
+  cells: [
+    { columnId: 'name', content: 'Total' },
+    { columnId: 'value', content: '600' },
+  ],
+};
+
+function renderTable(props?: Partial<TableProps<Item>>) {
+  const { container } = render(<Table columnDefinitions={columnDefinitions} items={items} {...props} />);
+  return createWrapper(container).findTable()!;
+}
+
+describe('Table totalRow', () => {
+  test('renders no tfoot when totalRow is not provided', () => {
+    const wrapper = renderTable();
+    expect(wrapper.findTotalRow()).toBeNull();
+  });
+
+  test('renders tfoot row when totalRow is provided', () => {
+    const wrapper = renderTable({ totalRow });
+    expect(wrapper.findTotalRow()).not.toBeNull();
+  });
+
+  test('renders cell content for matching column ids', () => {
+    const wrapper = renderTable({ totalRow });
+    // column index 2 = name (1-based, no selection column)
+    expect(wrapper.findTotalRowCell(2)?.getElement().textContent).toBe('Total');
+    // column index 3 = value
+    expect(wrapper.findTotalRowCell(3)?.getElement().textContent).toBe('600');
+  });
+
+  test('renders empty cell for columns without a matching entry', () => {
+    const wrapper = renderTable({ totalRow });
+    // column index 1 = id — no cell defined
+    expect(wrapper.findTotalRowCell(1)?.getElement().textContent).toBe('');
+  });
+
+  test('renders tfoot as a <tfoot> element', () => {
+    const { container } = render(<Table columnDefinitions={columnDefinitions} items={items} totalRow={totalRow} />);
+    expect(container.querySelector('tfoot')).not.toBeNull();
+  });
+
+  test('renders ReactNode content in total row cells', () => {
+    const richTotalRow: TableProps.TotalRow = {
+      cells: [
+        { columnId: 'name', content: <strong data-testid="total-label">Grand Total</strong> },
+        { columnId: 'value', content: <span data-testid="total-value">600</span> },
+      ],
+    };
+    const { getByTestId } = render(
+      <Table columnDefinitions={columnDefinitions} items={items} totalRow={richTotalRow} />
+    );
+    expect(getByTestId('total-label').textContent).toBe('Grand Total');
+    expect(getByTestId('total-value').textContent).toBe('600');
+  });
+
+  test('renders correct number of total row cells (one per visible column)', () => {
+    const wrapper = renderTable({ totalRow });
+    const row = wrapper.findTotalRow()!;
+    // 3 columns, no selection type
+    expect(row.findAll('td').length).toBe(3);
+  });
+
+  test('renders an extra empty cell when selectionType is set', () => {
+    const wrapper = renderTable({ totalRow, selectionType: 'multi' });
+    const row = wrapper.findTotalRow()!;
+    // 3 data columns + 1 selection column
+    expect(row.findAll('td').length).toBe(4);
+  });
+});

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -462,6 +462,15 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * Renders loader counter that is appended to the loader content in all loader states.
    */
   renderLoaderCounter?: (detail: TableProps.RenderLoaderCounterDetail<T>) => React.ReactNode;
+  /**
+   * Specifies a total/footer row rendered in a <tfoot> element below the table body.
+   * Use it to display per-column aggregations (sums, averages, counts, etc.) or custom content.
+   *
+   * * `cells` (TotalRowCell[]) - An array of cell definitions. Each entry maps a column `id`
+   *   to the content to render in that column's total cell. Columns without a matching entry
+   *   render an empty cell.
+   */
+  totalRow?: TableProps.TotalRow;
 }
 
 export namespace TableProps {
@@ -709,8 +718,25 @@ export namespace TableProps {
   export interface SkeletonConfig {
     totalRows: number;
   }
-}
 
+  export interface TotalRowCell {
+    /**
+     * The `id` of the column definition this cell belongs to.
+     */
+    columnId: string;
+    /**
+     * The content to render inside the total row cell.
+     */
+    content: React.ReactNode;
+  }
+
+  export interface TotalRow {
+    /**
+     * Per-column cell definitions for the total row.
+     */
+    cells: ReadonlyArray<TotalRowCell>;
+  }
+}
 export type TableRow<T> = TableDataRow<T> | TableLoaderRow<T>;
 
 interface TableDataRow<T> {

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -61,6 +61,7 @@ import {
   GridNavigationProvider,
   TableRole,
 } from './table-role';
+import { Tfoot } from './tfoot';
 import Thead, { TheadProps } from './thead';
 import ToolsHeader from './tools-header';
 import { useCellEditing } from './use-cell-editing';
@@ -151,6 +152,7 @@ const InternalTable = React.forwardRef(
       renderLoaderError,
       renderLoaderEmpty,
       renderLoaderCounter,
+      totalRow,
       cellVerticalAlign,
       __funnelSubStepProps,
       ...rest
@@ -842,6 +844,16 @@ const InternalTable = React.forwardRef(
                         />
                       )}
                     </tbody>
+                    {totalRow && (
+                      <Tfoot
+                        totalRow={totalRow}
+                        visibleColumnDefinitions={visibleColumnDefinitions}
+                        selectionType={selectionType}
+                        stickyState={stickyState}
+                        tableRole={tableRole}
+                        colIndexOffset={colIndexOffset}
+                      />
+                    )}
                   </table>
                 </GridNavigationProvider>
 

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -238,3 +238,30 @@ filter search icon.
   padding-inline: 0;
   border-block-end: none;
 }
+
+/* Total / footer row */
+.tfoot {
+  /* Ensure tfoot sits below tbody */
+}
+
+.tfoot-row {
+  /* used in test-utils */
+}
+
+.tfoot-cell {
+  padding-block: awsui.$space-scaled-xs;
+  padding-inline: awsui.$space-table-header-horizontal;
+  border-block-start: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+  background: awsui.$color-background-table-header;
+  font-weight: awsui.$font-weight-heading-s;
+  color: awsui.$color-text-heading-default;
+  box-sizing: border-box;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  &.sticky-cell {
+    position: sticky;
+    z-index: 1;
+  }
+}

--- a/src/table/test-classes/styles.scss
+++ b/src/table/test-classes/styles.scss
@@ -6,3 +6,15 @@
 .body-cell-counter {
   /* used in test-utils */
 }
+
+.tfoot {
+  /* used in test-utils */
+}
+
+.tfoot-row {
+  /* used in test-utils */
+}
+
+.tfoot-cell {
+  /* used in test-utils */
+}

--- a/src/table/tfoot.tsx
+++ b/src/table/tfoot.tsx
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+
+import { TableProps } from './interfaces';
+import { StickyColumnsModel, useStickyCellStyles } from './sticky-columns';
+import { getTableCellRoleProps, TableRole } from './table-role';
+import { getColumnKey, getStickyClassNames } from './utils';
+
+import styles from './styles.css.js';
+import testUtilStyles from './test-classes/styles.css.js';
+
+interface TfootCellProps {
+  columnId: PropertyKey;
+  colIndex: number;
+  stickyState: StickyColumnsModel;
+  tableRole: TableRole;
+  children?: React.ReactNode;
+}
+
+function TfootCell({ columnId, colIndex, stickyState, tableRole, children }: TfootCellProps) {
+  const stickyStyles = useStickyCellStyles({
+    stickyColumns: stickyState,
+    columnId,
+    getClassName: props => getStickyClassNames(styles, props),
+  });
+
+  return (
+    <td
+      ref={stickyStyles.ref}
+      style={stickyStyles.style}
+      className={clsx(styles['tfoot-cell'], stickyStyles.className, testUtilStyles['tfoot-cell'])}
+      {...getTableCellRoleProps({ tableRole, isRowHeader: false, colIndex })}
+    >
+      {children}
+    </td>
+  );
+}
+
+export interface TfootProps<T> {
+  totalRow: TableProps.TotalRow;
+  visibleColumnDefinitions: ReadonlyArray<TableProps.ColumnDefinition<T>>;
+  /** Accepts the internal selection type which may include 'group' in addition to 'single' | 'multi' */
+  selectionType?: string;
+  stickyState: StickyColumnsModel;
+  tableRole: TableRole;
+  colIndexOffset: number;
+}
+
+export function Tfoot<T>({
+  totalRow,
+  visibleColumnDefinitions,
+  selectionType,
+  stickyState,
+  tableRole,
+  colIndexOffset,
+}: TfootProps<T>) {
+  const { cells } = totalRow;
+
+  return (
+    <tfoot className={clsx(styles.tfoot, testUtilStyles.tfoot)}>
+      <tr className={clsx(styles['tfoot-row'], testUtilStyles['tfoot-row'])}>
+        {selectionType && <td className={clsx(styles['tfoot-cell'], styles['selection-control'])} aria-hidden="true" />}
+        {visibleColumnDefinitions.map((column, colIndex) => {
+          const colKey = getColumnKey(column, colIndex);
+          const cell = cells?.find((c: TableProps.TotalRowCell) => c.columnId === column.id);
+          return (
+            <TfootCell
+              key={String(colKey)}
+              columnId={colKey}
+              colIndex={colIndex + colIndexOffset}
+              stickyState={stickyState}
+              tableRole={tableRole}
+            >
+              {cell?.content ?? null}
+            </TfootCell>
+          );
+        })}
+      </tr>
+    </tfoot>
+  );
+}

--- a/src/test-utils/dom/table/index.ts
+++ b/src/test-utils/dom/table/index.ts
@@ -250,4 +250,21 @@ export default class TableWrapper extends ComponentWrapper {
     const selector = `.${progressiveLoadingStyles['items-loader']}[data-parentrow="${itemId}"]`;
     return this.find(selector);
   }
+  /**
+   * Returns the total/footer row element, if present.
+   */
+  findTotalRow(): ElementWrapper | null {
+    return this.findNativeTable().find(`.${testUtilStyles['tfoot-row']}`);
+  }
+
+  /**
+   * Returns a total row cell by 1-based column index.
+   *
+   * @param columnIndex 1-based index of the column.
+   */
+  findTotalRowCell(columnIndex: number): ElementWrapper | null {
+    return this.findNativeTable().find(
+      `.${testUtilStyles['tfoot-row']} .${testUtilStyles['tfoot-cell']}:nth-child(${columnIndex})`
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Implements the feature requested in #3803.

Adds a `totalRow` prop to Table that renders a sticky `<tfoot>` row below the table body, with per-column cell content aligned to the column definitions.

## Changes

### New API

```ts
interface TableProps<T> {
  totalRow?: TableProps.TotalRow;
}

namespace TableProps {
  interface TotalRow {
    cells: ReadonlyArray<TotalRowCell>;
  }
  interface TotalRowCell {
    columnId: string;   // matches a column definition's id
    content: React.ReactNode;
  }
}
```

### Files changed

| File | Change |
|------|--------|
| `src/table/tfoot.tsx` | New `<Tfoot>` component with sticky-column support |
| `src/table/interfaces.tsx` | `TotalRow` / `TotalRowCell` types + `totalRow` prop |
| `src/table/internal.tsx` | Wire `<Tfoot>` into the `<table>` element |
| `src/table/styles.scss` | `tfoot-cell` styles (border, background, bold) |
| `src/table/test-classes/styles.scss` | Test-class selectors |
| `src/test-utils/dom/table/index.ts` | `findTotalRow()` / `findTotalRowCell(n)` helpers |
| `pages/table/total-row.page.tsx` | Dev page demonstrating aggregation cells |
| `src/table/__tests__/total-row.test.tsx` | 8 unit tests (all passing) |

## Testing

- Build: ✅ passes
- Unit tests: ✅ 8/8 passing
- ESLint: ✅ clean

## Related

Closes #3803