### PR TITLE
fix: table header background ignores container-level dark mode

### DIFF
--- a/pages/table/dark-mode-container.page.tsx
+++ b/pages/table/dark-mode-container.page.tsx
@@ -1,0 +1,112 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression test page for GitHub issue #4111:
+ * "Table header ignores container-level dark mode"
+ *
+ * Verifies that the table's sticky header and <thead> background-color tokens
+ * resolve correctly when `.awsui-dark-mode` is applied to a container ancestor
+ * rather than to <body>.
+ *
+ * Expected behaviour: the sticky header background matches the table body
+ * background in both light and dark mode regardless of where `.awsui-dark-mode`
+ * is placed in the DOM hierarchy.
+ */
+import React from 'react';
+
+import Header from '~components/header';
+import SpaceBetween from '~components/space-between';
+import Table, { TableProps } from '~components/table';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+const columns: TableProps.ColumnDefinition<{ id: string; name: string; type: string }>[] = [
+  { id: 'id', header: 'ID', cell: item => item.id },
+  { id: 'name', header: 'Name', cell: item => item.name },
+  { id: 'type', header: 'Type', cell: item => item.type },
+];
+
+const items = [
+  { id: '1', name: 'Alpha', type: 'A' },
+  { id: '2', name: 'Beta', type: 'B' },
+  { id: '3', name: 'Gamma', type: 'C' },
+  { id: '4', name: 'Delta', type: 'D' },
+  { id: '5', name: 'Epsilon', type: 'E' },
+];
+
+/**
+ * Wrapper that applies `.awsui-dark-mode` at the container level (not body).
+ * This is the scenario that was broken by #4111.
+ */
+function ContainerDarkMode({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="awsui-dark-mode awsui-visual-refresh"
+      style={{ padding: 16, background: '#232f3e' /* approximate dark bg */ }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default function DarkModeContainerPage() {
+  return (
+    <ScreenshotArea disableAnimations={true}>
+      <SpaceBetween size="l">
+        <h1>Table header — container-level dark mode (issue #4111)</h1>
+
+        <section>
+          <h2>1. Dark mode on &lt;body&gt; (baseline — should always work)</h2>
+          <p>The table below is inside a light-mode page. The sticky header should show the light background token.</p>
+          <Table
+            header={<Header>Light mode table (baseline)</Header>}
+            columnDefinitions={columns}
+            items={items}
+            stickyHeader={true}
+          />
+        </section>
+
+        <section>
+          <h2>2. Dark mode on a container ancestor (regression test for #4111)</h2>
+          <p>
+            The <code>.awsui-dark-mode</code> class is on the wrapper div, not on <code>&lt;body&gt;</code>. The sticky
+            header and <code>&lt;thead&gt;</code> background should match the dark token, not fall back to the light{' '}
+            <code>#fafafa</code> value.
+          </p>
+          <ContainerDarkMode>
+            <Table
+              header={<Header>Container-level dark mode table</Header>}
+              columnDefinitions={columns}
+              items={items}
+              stickyHeader={true}
+            />
+          </ContainerDarkMode>
+        </section>
+
+        <section>
+          <h2>3. Sticky columns — container-level dark mode</h2>
+          <p>
+            Sticky column header cells also use <code>color-background-table-header</code>. They should also respect
+            container-level dark mode.
+          </p>
+          <ContainerDarkMode>
+            <Table
+              header={<Header>Container dark mode — sticky columns</Header>}
+              columnDefinitions={[
+                { id: 'id', header: 'ID', cell: item => item.id, width: 80, isRowHeader: true },
+                { id: 'name', header: 'Name', cell: item => item.name, width: 200 },
+                { id: 'type', header: 'Type', cell: item => item.type, width: 200 },
+                { id: 'extra1', header: 'Extra 1', cell: () => '—', width: 200 },
+                { id: 'extra2', header: 'Extra 2', cell: () => '—', width: 200 },
+              ]}
+              items={items}
+              stickyHeader={true}
+              stickyColumns={{ first: 1 }}
+            />
+          </ContainerDarkMode>
+        </section>
+      </SpaceBetween>
+    </ScreenshotArea>
+  );
+}

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -6,6 +6,7 @@
 @use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use '../../internal/styles/tokens' as awsui;
 @use '../../internal/styles' as styles;
+@use '../../internal/styles/utils/theming' as theming;
 
 $cell-horizontal-padding: awsui.$space-scaled-l;
 
@@ -137,6 +138,26 @@ $cell-horizontal-padding: awsui.$space-scaled-l;
       @include styles.with-direction('rtl') {
         box-shadow: awsui.$shadow-sticky-column-first;
         clip-path: inset(0 -24px 0 0);
+      }
+    }
+  }
+
+  // Ensure the header cell background token resolves correctly when
+  // .awsui-dark-mode is on a container ancestor rather than <body>.
+  // The dark-mode-only mixin generates a higher-specificity selector that
+  // correctly scopes the token when dark mode is applied at the container level.
+  @include theming.dark-mode-only {
+    background: awsui.$color-background-table-header;
+
+    &-variant-full-page {
+      background: awsui.$color-background-layout-main;
+    }
+
+    &.sticky-cell {
+      background: awsui.$color-background-table-header;
+
+      &.table-variant-full-page {
+        background: awsui.$color-background-layout-main;
       }
     }
   }

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -5,6 +5,7 @@
 
 @use '../internal/styles/index' as styles;
 @use '../internal/styles/tokens' as awsui;
+@use '../internal/styles/utils/theming' as theming;
 @use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use '../container/shared' as container;
 
@@ -182,6 +183,18 @@ filter search icon.
   }
   &.table-has-header {
     border-block-start: awsui.$border-divider-list-width solid awsui.$color-border-container-divider;
+  }
+
+  // Ensure the sticky header background token resolves correctly when
+  // .awsui-dark-mode is on a container ancestor rather than <body>.
+  // The dark-mode-only mixin generates a higher-specificity selector that
+  // correctly scopes the token when dark mode is applied at the container level.
+  @include theming.dark-mode-only {
+    background: awsui.$color-background-table-header;
+
+    &.variant-full-page {
+      background: awsui.$color-background-layout-main;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #4111

When `.awsui-dark-mode` is applied to a **container ancestor** rather than `<body>`, the sticky table header and `<thead>` background-color were not updating to the dark value — they showed the light fallback (`#fafafa`) instead.

## Root cause

The design token CSS custom properties are defined inside `@layer awsui-base-theme { body { ... } }`. The dark-mode override block is also nested inside this `body` rule, so the token override is set on the `.awsui-dark-mode` element. While CSS custom properties cascade, the `@layer` interaction with unlayered component styles means an explicit `dark-mode-only` rule is needed in the component SCSS to guarantee correct token resolution when dark mode is scoped to a container.

## Fix

Use the `dark-mode-only()` mixin (from `internal/styles/utils/theming`) in:

- `src/table/styles.scss` — for `.header-secondary` (the sticky header wrapper div)
- `src/table/header-cell/styles.scss` — for `.header-cell`, `.header-cell.sticky-cell`, and full-page variant backgrounds

This generates `.awsui-dark-mode .header-secondary` and `.awsui-dark-mode .header-cell` rules that correctly win the cascade for container-level dark mode.

## Dev page

Added `pages/table/dark-mode-container.page.tsx` as a regression test page showing:
1. Baseline light-mode table
2. Table inside a `.awsui-dark-mode` container div (the failing scenario)
3. Table with sticky columns inside a `.awsui-dark-mode` container div

## Testing

- Build: ✅ passes (`npm run build`)
- Unit tests: ✅ 589 suites, 13168 passed, 162 skipped, 0 failed (`gulp test:unit`)