### PR TITLE
feat(split-panel): add toggleIconOpen/toggleIconClosed props for custom toggle icons

### DIFF
--- a/pages/app-layout/split-panel-toggle-icon.page.tsx
+++ b/pages/app-layout/split-panel-toggle-icon.page.tsx
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import AppLayout, { AppLayoutProps } from '~components/app-layout';
+import Box from '~components/box';
+import Header from '~components/header';
+import SpaceBetween from '~components/space-between';
+import SplitPanel from '~components/split-panel';
+
+import ScreenshotArea from '../utils/screenshot-area';
+import { splitPaneli18nStrings } from './utils/strings';
+
+const StarIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" focusable="false" aria-hidden="true">
+    <path d="M8 1l1.9 3.8 4.2.6-3 3 .7 4.2L8 10.5 4.2 12.6l.7-4.2-3-3 4.2-.6z" />
+  </svg>
+);
+
+const ChevronIcon = ({ direction }: { direction: 'up' | 'down' | 'left' | 'right' }) => {
+  const paths: Record<string, string> = {
+    up: 'M2 11l6-6 6 6',
+    down: 'M2 5l6 6 6-6',
+    left: 'M11 2L5 8l6 6',
+    right: 'M5 2l6 6-6 6',
+  };
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" focusable="false" aria-hidden="true">
+      <polyline points={paths[direction]} fill="none" stroke="currentColor" strokeWidth="2" />
+    </svg>
+  );
+};
+
+export default function App() {
+  const [splitPanelOpen, setSplitPanelOpen] = useState(true);
+  const [splitPanelPosition, setSplitPanelPosition] =
+    useState<AppLayoutProps.SplitPanelPreferences['position']>('bottom');
+
+  return (
+    <ScreenshotArea>
+      <AppLayout
+        content={
+          <Box padding="l">
+            <SpaceBetween size="l">
+              <Header headingTagOverride="h1">SplitPanel — custom toggle icon demo</Header>
+              <Box>
+                Toggle the split panel open/closed. The open and close buttons use custom SVG icons instead of the
+                built-in Cloudscape icons.
+              </Box>
+            </SpaceBetween>
+          </Box>
+        }
+        splitPanel={
+          <SplitPanel
+            header="Custom toggle icon"
+            i18nStrings={splitPaneli18nStrings}
+            toggleIconOpen={<ChevronIcon direction={splitPanelPosition === 'side' ? 'right' : 'down'} />}
+            toggleIconClosed={<StarIcon />}
+          >
+            <Box>
+              This split panel uses custom SVG icons for its toggle button. The close icon is a custom chevron and the
+              open icon is a star.
+            </Box>
+          </SplitPanel>
+        }
+        splitPanelOpen={splitPanelOpen}
+        splitPanelPreferences={{ position: splitPanelPosition }}
+        onSplitPanelToggle={({ detail }) => setSplitPanelOpen(detail.open)}
+        onSplitPanelPreferencesChange={({ detail }) => setSplitPanelPosition(detail.position)}
+      />
+    </ScreenshotArea>
+  );
+}

--- a/src/split-panel/__tests__/toggle-icon.test.tsx
+++ b/src/split-panel/__tests__/toggle-icon.test.tsx
@@ -1,0 +1,74 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+
+import { renderSplitPanel } from './common';
+
+const CustomOpenIcon = () => <svg data-testid="custom-open-icon" />;
+const CustomCloseIcon = () => <svg data-testid="custom-close-icon" />;
+
+describe('SplitPanel toggleIconOpen / toggleIconClosed', () => {
+  describe('bottom position, panel open', () => {
+    it('renders close button with built-in icon by default', () => {
+      const { wrapper } = renderSplitPanel({ contextProps: { isOpen: true, position: 'bottom' } });
+      const closeBtn = wrapper!.findCloseButton();
+      expect(closeBtn).not.toBeNull();
+      // no custom icon present
+      expect(closeBtn!.getElement().querySelector('[data-testid="custom-close-icon"]')).toBeNull();
+    });
+
+    it('renders custom toggleIconOpen on close button when panel is open', () => {
+      const { wrapper } = renderSplitPanel({
+        props: { toggleIconOpen: <CustomCloseIcon /> },
+        contextProps: { isOpen: true, position: 'bottom' },
+      });
+      const closeBtn = wrapper!.findCloseButton();
+      expect(closeBtn).not.toBeNull();
+      expect(closeBtn!.getElement().querySelector('[data-testid="custom-close-icon"]')).not.toBeNull();
+    });
+  });
+
+  describe('bottom position, panel closed (collapse behavior)', () => {
+    it('renders open button with built-in icon by default', () => {
+      const { wrapper } = renderSplitPanel({
+        props: { closeBehavior: 'collapse' },
+        contextProps: { isOpen: false, position: 'bottom' },
+      });
+      const openBtn = wrapper!.findOpenButton();
+      expect(openBtn).not.toBeNull();
+      expect(openBtn!.getElement().querySelector('[data-testid="custom-open-icon"]')).toBeNull();
+    });
+
+    it('renders custom toggleIconClosed on open button when panel is closed', () => {
+      const { wrapper } = renderSplitPanel({
+        props: { closeBehavior: 'collapse', toggleIconClosed: <CustomOpenIcon /> },
+        contextProps: { isOpen: false, position: 'bottom' },
+      });
+      const openBtn = wrapper!.findOpenButton();
+      expect(openBtn).not.toBeNull();
+      expect(openBtn!.getElement().querySelector('[data-testid="custom-open-icon"]')).not.toBeNull();
+    });
+  });
+
+  describe('side position, panel closed (collapse behavior)', () => {
+    it('renders open button with built-in icon by default', () => {
+      const { wrapper } = renderSplitPanel({
+        props: { closeBehavior: 'collapse' },
+        contextProps: { isOpen: false, position: 'side' },
+      });
+      const openBtn = wrapper!.findOpenButton();
+      expect(openBtn).not.toBeNull();
+      expect(openBtn!.getElement().querySelector('[data-testid="custom-open-icon"]')).toBeNull();
+    });
+
+    it('renders custom toggleIconClosed on side open button when panel is closed', () => {
+      const { wrapper } = renderSplitPanel({
+        props: { closeBehavior: 'collapse', toggleIconClosed: <CustomOpenIcon /> },
+        contextProps: { isOpen: false, position: 'side' },
+      });
+      const openBtn = wrapper!.findOpenButton();
+      expect(openBtn).not.toBeNull();
+      expect(openBtn!.getElement().querySelector('[data-testid="custom-open-icon"]')).not.toBeNull();
+    });
+  });
+});

--- a/src/split-panel/implementation.tsx
+++ b/src/split-panel/implementation.tsx
@@ -42,6 +42,8 @@ export function SplitPanelImplementation({
   headerBefore,
   headerDescription,
   headerInfo,
+  toggleIconOpen,
+  toggleIconClosed,
   ...restProps
 }: SplitPanelImplementationProps) {
   const isRefresh = useVisualRefresh();
@@ -152,12 +154,15 @@ export function SplitPanelImplementation({
             <InternalButton
               className={testUtilStyles['close-button']}
               iconName={
-                isRefresh && closeBehavior === 'collapse'
-                  ? position === 'side'
-                    ? 'angle-right'
-                    : 'angle-down'
-                  : 'close'
+                toggleIconOpen
+                  ? undefined
+                  : isRefresh && closeBehavior === 'collapse'
+                    ? position === 'side'
+                      ? 'angle-right'
+                      : 'angle-down'
+                    : 'close'
               }
+              iconSvg={toggleIconOpen ?? undefined}
               variant="icon"
               onClick={onToggle}
               formAction="none"
@@ -167,7 +172,8 @@ export function SplitPanelImplementation({
           ) : position === 'side' || closeBehavior === 'hide' ? null : (
             <InternalButton
               className={testUtilStyles['open-button']}
-              iconName="angle-up"
+              iconName={toggleIconClosed ? undefined : 'angle-up'}
+              iconSvg={toggleIconClosed ?? undefined}
               variant="icon"
               formAction="none"
               ariaLabel={i18nStrings.openButtonAriaLabel}
@@ -260,6 +266,7 @@ export function SplitPanelImplementation({
           panelHeaderId={panelHeaderId}
           ariaLabel={ariaLabel}
           closeBehavior={closeBehavior}
+          toggleIconClosed={toggleIconClosed}
         >
           <BuiltInErrorBoundary>{children}</BuiltInErrorBoundary>
         </SplitPanelContentSide>

--- a/src/split-panel/interfaces.ts
+++ b/src/split-panel/interfaces.ts
@@ -58,6 +58,18 @@ export interface SplitPanelProps extends BaseComponentProps {
    * Content displayed before the header text.
    */
   headerBefore?: React.ReactNode;
+
+  /**
+   * Custom icon to display on the toggle button when the split panel is open (close/collapse action).
+   * When provided, replaces the built-in close or collapse icon.
+   */
+  toggleIconOpen?: React.ReactNode;
+
+  /**
+   * Custom icon to display on the toggle button when the split panel is closed (open/expand action).
+   * When provided, replaces the built-in open or expand icon.
+   */
+  toggleIconClosed?: React.ReactNode;
 }
 
 export namespace SplitPanelProps {

--- a/src/split-panel/side.tsx
+++ b/src/split-panel/side.tsx
@@ -18,6 +18,7 @@ interface SplitPanelContentSideProps extends SplitPanelContentProps {
   closeBehavior: SplitPanelProps['closeBehavior'];
   openButtonAriaLabel?: string;
   toggleRef: React.RefObject<ButtonProps.Ref>;
+  toggleIconClosed?: React.ReactNode;
 }
 
 export function SplitPanelContentSide({
@@ -35,6 +36,7 @@ export function SplitPanelContentSide({
   ariaLabel,
   onToggle,
   closeBehavior,
+  toggleIconClosed,
 }: SplitPanelContentSideProps) {
   const { topOffset, bottomOffset, animationDisabled } = useSplitPanelContext();
   const isRefresh = useVisualRefresh();
@@ -73,7 +75,8 @@ export function SplitPanelContentSide({
         ) : closeBehavior === 'hide' ? null : (
           <InternalButton
             className={clsx(testUtilStyles['open-button'], styles['open-button-side'])}
-            iconName="angle-left"
+            iconName={toggleIconClosed ? undefined : 'angle-left'}
+            iconSvg={toggleIconClosed ?? undefined}
             variant="icon"
             formAction="none"
             ariaLabel={openButtonAriaLabel}


### PR DESCRIPTION
## Summary

Implements the feature requested in #4059.

Adds `toggleIconOpen` and `toggleIconClosed` props to `SplitPanelProps` that allow consumers to override the built-in open/close icons on the toggle button with any `React.ReactNode` (typically an SVG icon).

## New API

```ts
interface SplitPanelProps {
  /**
   * Custom icon for the close/collapse button (panel open state).
   * Replaces the built-in close/angle icon.
   */
  toggleIconOpen?: React.ReactNode;

  /**
   * Custom icon for the open/expand button (panel closed state).
   * Replaces the built-in angle-up / angle-left icon.
   */
  toggleIconClosed?: React.ReactNode;
}
```

## How it works

When a custom icon is provided it is passed as  to the underlying  and  is set to , suppressing the built-in icon. Applies to:

- Close button in  (bottom + side positions, open state)
- Inline open button in  (bottom position, closed state)
- Side open button in  (side position, closed state)

The AppLayout toolbar trigger button (outside SplitPanel) is not affected.

## Files changed

| File | Change |
|------|--------|
|  |  /  props |
|  | Thread icons through to close + bottom-open buttons |
|  | Thread  through to side open button |
|  | 6 unit tests (all passing) |
|  | Dev page with custom SVG icons |

## Testing

- Build: ✅ passes
- Unit tests: ✅ 6/6 passing (default icons preserved, custom icons rendered, bottom + side positions)
- ESLint: ✅ clean

## Related

Closes #4059