### PR TITLE
feat: allow React nodes in headerDescription (AWSUI-59750)

### DIFF
--- a/pages/expandable-section/description-links.page.tsx
+++ b/pages/expandable-section/description-links.page.tsx
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import ExpandableSection from '~components/expandable-section';
+import Link from '~components/link';
+import SpaceBetween from '~components/space-between';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+export default function DescriptionLinksPage() {
+  return (
+    <article>
+      <h1>ExpandableSection — headerDescription with links</h1>
+      <ScreenshotArea>
+        <SpaceBetween size="l">
+          <h2>Container variant — description with inline link</h2>
+          <ExpandableSection
+            variant="container"
+            headerText="Bucket versioning"
+            headerDescription={
+              <>
+                Enable versioning to keep multiple versions of an object. <Link href="#learn-more">Learn more</Link>
+              </>
+            }
+            defaultExpanded={true}
+          >
+            Versioning content here.
+          </ExpandableSection>
+
+          <h2>Default variant — description with inline link</h2>
+          <ExpandableSection
+            variant="default"
+            headerText="Advanced settings"
+            headerDescription={
+              <>
+                These settings affect billing. <Link href="#pricing">See pricing</Link>
+              </>
+            }
+          >
+            Advanced settings content here.
+          </ExpandableSection>
+
+          <h2>Footer variant — description with inline link</h2>
+          <ExpandableSection
+            variant="footer"
+            headerText="Additional options"
+            headerDescription={
+              <>
+                Optional configuration. <Link href="#docs">Read the docs</Link>
+              </>
+            }
+          >
+            Footer content here.
+          </ExpandableSection>
+
+          <h2>Stacked variant — description with inline link</h2>
+          <ExpandableSection
+            variant="stacked"
+            headerText="Network settings"
+            headerDescription={
+              <>
+                Configure VPC and subnets. <Link href="#vpc-docs">VPC documentation</Link>
+              </>
+            }
+          >
+            Network settings content here.
+          </ExpandableSection>
+
+          <h2>String description (backward-compatible)</h2>
+          <ExpandableSection
+            variant="container"
+            headerText="Tags"
+            headerDescription="A tag is a label that you assign to an AWS resource."
+          >
+            Tags content here.
+          </ExpandableSection>
+        </SpaceBetween>
+      </ScreenshotArea>
+    </article>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -13471,12 +13471,6 @@ Behaves similar to the Header component counter.",
       "type": "string",
     },
     {
-      "description": "Supplementary text below the heading. Use with the container, default or footer variants.",
-      "name": "headerDescription",
-      "optional": true,
-      "type": "string",
-    },
-    {
       "description": "Overrides the default [HTML heading tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements).
 Use with the container variant (which defaults to H2) or default/footer variants (which default to DIV). Using this
 property does not change the visual appearance of the component. Note that this only works with the \`headerText\`
@@ -13548,6 +13542,11 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "description": "Actions for the header. Use with the default or container variant.",
       "isDefault": false,
       "name": "headerActions",
+    },
+    {
+      "description": "Content displayed below the heading. Accepts a string or React nodes (for example, a link). Use with the container, default or footer variants.",
+      "isDefault": false,
+      "name": "headerDescription",
     },
     {
       "description": "The area next to the heading, used to display an Info link. Use with the container variant.",

--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -86,6 +86,22 @@ describe('Expandable Section', () => {
         });
       }
     });
+    describe('populates description slot with React nodes', () => {
+      for (const variant of variantsWithDescription) {
+        test(`${variant} variant renders a link inside headerDescription`, () => {
+          const wrapper = renderExpandableSection({
+            variant,
+            headerText: 'Test Header',
+            headerDescription: <Link href="#learn-more">Learn more</Link>,
+          });
+          const description = wrapper.findHeaderDescription();
+          expect(description).not.toBeNull();
+          const link = description!.findLink();
+          expect(link).not.toBeNull();
+          expect(link!.getElement()).toHaveTextContent('Learn more');
+        });
+      }
+    });
     describe('populates info links slot correctly', () => {
       for (const variant of containerizedVariants) {
         test(`${variant} variant`, () => {
@@ -497,6 +513,19 @@ describe('headerText', () => {
         });
         const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
         expect(headerButton).toHaveAccessibleDescription('Expand to see more content');
+      });
+      test('set aria description when headerDescription is a React node', () => {
+        const wrapper = renderExpandableSection({
+          variant,
+          headerText: 'Header component',
+          headerDescription: (
+            <>
+              See the <Link href="#docs">documentation</Link> for details.
+            </>
+          ),
+        });
+        const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
+        expect(headerButton).toHaveAccessibleDescription('See the documentation for details.');
       });
       test('button should be under heading', () => {
         const wrapper = renderExpandableSection({

--- a/src/expandable-section/interfaces.ts
+++ b/src/expandable-section/interfaces.ts
@@ -71,9 +71,9 @@ export interface ExpandableSectionProps extends BaseComponentProps {
   headerText?: React.ReactNode;
 
   /**
-   * Supplementary text below the heading. Use with the container, default or footer variants.
+   * Content displayed below the heading. Accepts a string or React nodes (for example, a link). Use with the container, default or footer variants.
    */
-  headerDescription?: string;
+  headerDescription?: React.ReactNode;
 
   /**
    * Specifies secondary text that's displayed to the right of the heading title. Use with the container variant.


### PR DESCRIPTION
### Description

Allow inline elements (e.g. links) in the `headerDescription` prop by widening its type from `string` to `React.ReactNode`.

Previously, `headerDescription` only accepted a plain string, which prevented callers from embedding interactive or styled inline elements such as `<Link>` in the description area below the section heading. This change makes the prop accept any React node while remaining fully backward-compatible — all existing string values continue to work unchanged.

Related links, issue #: AWSUI-59750

**Files changed:**
- `src/expandable-section/interfaces.ts` — prop type `string → React.ReactNode`; updated JSDoc
- `src/expandable-section/__tests__/expandable-section.test.tsx` — new tests for node descriptions and aria-describedby with nodes
- `pages/expandable-section/description-links.page.tsx` — dev page demonstrating the feature across all supported variants

### How has this been tested?

- `npm run build` — clean (webpack size warnings only, no errors)
- `npx jest -c jest.unit.config.js src/expandable-section/__tests__/expandable-section.test.tsx` — **106/106 tests pass**
- `npx eslint` on all changed files — no warnings or errors
- Dev page `description-links.page.tsx` covers container, default, footer, stacked variants with link nodes and a plain-string backward-compat case

<details>
   <summary>Review checklist</summary>

#### Correctness

- Changes include appropriate documentation updates (JSDoc updated).
- Changes are backward-compatible: `string` is assignable to `React.ReactNode`, so all existing usages remain valid.
- No new browser APIs introduced.
- The description is rendered inside a `<span>` with an id wired to `aria-describedby` on the expand button; this works correctly with React nodes since the DOM text content is still readable by assistive technology.

#### Security

- No URL handling introduced.

#### Testing

- New unit tests cover the React node case for every supported variant.
- New unit tests verify `aria-describedby` accessible description resolves correctly for a React node description.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.