### PR TITLE
feat: add hideCloseButton prop to Modal (AWSUI-60884)

### DIFF
--- a/pages/modal/hide-close-button.page.tsx
+++ b/pages/modal/hide-close-button.page.tsx
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import { Button, Modal, SpaceBetween } from '~components';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+export default function () {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <article>
+      <h1>Modal without close button (AWSUI-60884)</h1>
+      <Button onClick={() => setVisible(true)}>Show forced-decision modal</Button>
+      <ScreenshotArea>
+        <Modal
+          header="Confirm deletion"
+          visible={visible}
+          hideCloseButton={true}
+          footer={
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button variant="link" onClick={() => setVisible(false)}>
+                Cancel
+              </Button>
+              <Button variant="primary" onClick={() => setVisible(false)}>
+                Delete
+              </Button>
+            </SpaceBetween>
+          }
+        >
+          This action is permanent and cannot be undone. Please confirm that you want to delete this resource.
+        </Modal>
+      </ScreenshotArea>
+    </article>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -19490,6 +19490,15 @@ plus the header height and the footer height.",
       "type": "number",
     },
     {
+      "description": "Hides the close (×) button in the modal header.
+Use for forced-decision dialogs where the user must explicitly choose an action
+from the footer rather than dismissing the modal freely.
+When set to \`true\`, the dialog can still be dismissed programmatically.",
+      "name": "hideCloseButton",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
       "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
 use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes). If you must
 use the \`id\` attribute, consider setting it on a parent element instead.",

--- a/src/modal/__tests__/modal.test.tsx
+++ b/src/modal/__tests__/modal.test.tsx
@@ -76,6 +76,38 @@ describe('Modal component', () => {
     });
   });
 
+  describe('hideCloseButton', () => {
+    it('shows the dismiss button by default', () => {
+      const wrapper = renderModal({});
+      expect(wrapper.findDismissButton()).not.toBe(null);
+    });
+
+    it('hides the dismiss button when hideCloseButton is true', () => {
+      const wrapper = renderModal({ hideCloseButton: true });
+      expect(wrapper.findDismissButton()).toBe(null);
+    });
+
+    it('shows the dismiss button when hideCloseButton is false', () => {
+      const wrapper = renderModal({ hideCloseButton: false });
+      expect(wrapper.findDismissButton()).not.toBe(null);
+    });
+
+    it('does not prevent overlay dismiss when hideCloseButton is true', () => {
+      const onDismissSpy = jest.fn();
+      const wrapper = renderModal({ hideCloseButton: true, onDismiss: onDismissSpy, visible: true });
+      fireEvent.mouseDown(wrapper.getElement());
+      fireEvent.click(wrapper.getElement());
+      expect(onDismissSpy).toHaveBeenCalledWith(expect.objectContaining({ detail: { reason: 'overlay' } }));
+    });
+
+    it('does not prevent ESC dismiss when hideCloseButton is true', () => {
+      const onDismissSpy = jest.fn();
+      const wrapper = renderModal({ hideCloseButton: true, onDismiss: onDismissSpy, visible: true });
+      act(() => wrapper.findDialog().keydown(KeyCode.escape));
+      expect(onDismissSpy).toHaveBeenCalledWith(expect.objectContaining({ detail: { reason: 'keyboard' } }));
+    });
+  });
+
   describe('visibility', () => {
     it('hides the modal by default', () => {
       const wrapper = renderModal();

--- a/src/modal/interfaces.ts
+++ b/src/modal/interfaces.ts
@@ -83,6 +83,13 @@ export interface ModalProps extends BaseComponentProps, BaseModalProps {
    */
   disableContentPaddings?: boolean;
   /**
+   * Hides the close (×) button in the modal header.
+   * Use for forced-decision dialogs where the user must explicitly choose an action
+   * from the footer rather than dismissing the modal freely.
+   * When set to `true`, the dialog can still be dismissed programmatically.
+   */
+  hideCloseButton?: boolean;
+  /**
    * Called when a user closes the modal by using the close icon button,
    * clicking outside of the modal, or pressing ESC.
    * The event detail contains the `reason`, which can be any of the following:

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -96,6 +96,7 @@ function PortaledModal({
   children,
   footer,
   disableContentPaddings,
+  hideCloseButton = false,
   position = 'center',
   onButtonClick = () => {},
   onDismiss,
@@ -281,20 +282,22 @@ function PortaledModal({
                       variant="h2"
                       __disableActionsWrapping={true}
                       actions={
-                        <div
-                          {...getAnalyticsMetadataAttribute({
-                            action: 'dismiss',
-                          } as Partial<GeneratedAnalyticsMetadataModalDismiss>)}
-                        >
-                          <InternalButton
-                            ariaLabel={closeAriaLabel}
-                            className={styles['dismiss-control']}
-                            variant="modal-dismiss"
-                            iconName="close"
-                            formAction="none"
-                            onClick={onCloseButtonClick}
-                          />
-                        </div>
+                        !hideCloseButton ? (
+                          <div
+                            {...getAnalyticsMetadataAttribute({
+                              action: 'dismiss',
+                            } as Partial<GeneratedAnalyticsMetadataModalDismiss>)}
+                          >
+                            <InternalButton
+                              ariaLabel={closeAriaLabel}
+                              className={styles['dismiss-control']}
+                              variant="modal-dismiss"
+                              iconName="close"
+                              formAction="none"
+                              onClick={onCloseButtonClick}
+                            />
+                          </div>
+                        ) : undefined
                       }
                     >
                       <span ref={headerTextRef} id={headerId} className={styles['header--text']}>


### PR DESCRIPTION
### Description

Add `hideCloseButton?: boolean` to `ModalProps`. When `true`, suppresses the header dismiss (×) button, enabling forced-decision dialogs where the user must choose an explicit action from the footer rather than freely dismissing the modal.

Overlay (`reason: 'overlay'`) and keyboard ESC (`reason: 'keyboard'`) dismiss paths are intentionally preserved — only the close button is hidden. Focus lock and `aria-labelledby` on the dialog are unaffected, keeping the modal accessible.

Related links, issue #, if available: AWSUI-60884

### How has this been tested?

- 5 new unit tests in `src/modal/__tests__/modal.test.tsx` covering:
  - Default: dismiss button visible
  - `hideCloseButton={true}`: dismiss button absent
  - `hideCloseButton={false}`: dismiss button visible
  - Overlay dismiss still fires when `hideCloseButton={true}`
  - ESC dismiss still fires when `hideCloseButton={true}`
- All 48 unit tests pass (`jest --config jest.unit.config.js src/modal/__tests__/modal.test.tsx`)
- Dev page added: `pages/modal/hide-close-button.page.tsx`
- ESLint clean on all changed files

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_ ✅
- _Changes are covered with new/existing integration tests?_ (integ tests require full build; see unit coverage above)
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.