### PR TITLE
feat: add disabledReason support to link and inline-link button variants (AWSUI-60908)

### DIFF
--- a/pages/button/disabled-reason.page.tsx
+++ b/pages/button/disabled-reason.page.tsx
@@ -33,6 +33,21 @@ export default function ButtonsScenario() {
           iconName="star"
           ariaLabel="Disabled reason icon button"
         />
+        <Button variant="link" disabled={true} disabledReason="disabled reason" data-testid="link-button">
+          Link button
+        </Button>
+        <Button
+          variant="link"
+          disabled={true}
+          disabledReason="disabled reason"
+          href="https://smth.com"
+          data-testid="link-button-with-href"
+        >
+          Link button with href
+        </Button>
+        <Button variant="inline-link" disabled={true} disabledReason="disabled reason" data-testid="inline-link-button">
+          Inline link button
+        </Button>
       </ScreenshotArea>
     </article>
   );

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -5583,7 +5583,7 @@ The text will also be added to the \`title\` attribute of the button.",
     {
       "description": "Provides a reason why the button is disabled (only when \`disabled\` is \`true\`).
 If provided, the button becomes focusable.
-Applicable for all button variants, except link.",
+Applicable for all button variants.",
       "name": "disabledReason",
       "optional": true,
       "type": "string",

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -184,145 +184,133 @@ describe('Button Component', () => {
     });
   });
 
-  describe.each(['link', 'inline-link'] as const)(
-    'disabled with reason ignored for %s variant (not applicable)',
+  describe.each(['primary', 'normal', 'icon', 'link', 'inline-link'] as const)(
+    'disabled with reason %s variant',
     variant => {
-      test('does not make a link button focusable when disabledReason is set', () => {
-        const wrapper = renderButton({
+      describe.each([true, false] as const)('with href %s', withHref => {
+        const defaultProps = {
           variant,
-          href: 'https://example.com',
-          disabled: true,
-          disabledReason: 'reason',
+          href: withHref ? 'https://smth.com' : undefined,
+        };
+        test('renders button as normal when disabledReason is set and button is not disabled', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: false, disabledReason: 'reason' });
+
+          expect(wrapper.getElement()).not.toHaveAttribute('disabled');
+          expect(wrapper.getElement()).not.toHaveAttribute('aria-disabled');
         });
-        expect(wrapper.getElement()).toHaveAttribute('tabIndex', '-1');
+
+        test('does not add disabled attribute when disabled with reason', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          expect(wrapper.getElement()).not.toHaveAttribute('disabled');
+          expect(wrapper.getElement()).toHaveAttribute('aria-disabled');
+        });
+
+        test('has no tooltip open by default', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          expect(wrapper.findDisabledReason()).toBe(null);
+        });
+
+        test('has no tooltip without disabledReason', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true });
+
+          wrapper.getElement()!.focus();
+
+          expect(wrapper.findDisabledReason()).toBeNull();
+        });
+
+        test('open tooltip on focus', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          wrapper.getElement()!.focus();
+
+          expect(wrapper.findDisabledReason()).not.toBeNull();
+          expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+        });
+
+        test('closes tooltip on blur', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          wrapper.getElement()!.focus();
+
+          expect(wrapper.findDisabledReason()).not.toBeNull();
+          expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+
+          wrapper.getElement()!.blur();
+
+          expect(wrapper.findDisabledReason()).toBeNull();
+        });
+
+        test('open tooltip on mouseenter', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          fireEvent.mouseEnter(wrapper.getElement());
+
+          expect(wrapper.findDisabledReason()).not.toBeNull();
+          expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+        });
+
+        test('close tooltip on mouseleave', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          fireEvent.mouseEnter(wrapper.getElement());
+
+          expect(wrapper.findDisabledReason()).not.toBeNull();
+          expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+
+          fireEvent.mouseLeave(wrapper.getElement());
+
+          expect(wrapper.findDisabledReason()).toBeNull();
+        });
+
+        test('close tooltip on Esc keydown', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          fireEvent.mouseEnter(wrapper.getElement());
+
+          expect(wrapper.findDisabledReason()).not.toBeNull();
+          expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+
+          fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
+          expect(wrapper.findDisabledReason()).toBeNull();
+        });
+
+        test('has no aria-describedby by default', () => {
+          const wrapper = renderButton({ ...defaultProps });
+
+          expect(wrapper.getElement()).not.toHaveAttribute('aria-describedby');
+        });
+
+        test('has no aria-describedby without disabledReason', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true });
+
+          expect(wrapper.getElement()).not.toHaveAttribute('aria-describedby');
+        });
+
+        test('has aria-describedby with disabledReason', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          expect(wrapper.getElement()).toHaveAttribute('aria-describedby');
+        });
+
+        test('has hidden element (linked to aria-describedby) with disabledReason', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          expect(wrapper.find('span[hidden]')!.getElement()).toHaveTextContent('reason');
+        });
+
+        test('does not trigger onClick handler when disabled with reason', () => {
+          const onClick = jest.fn();
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason', onClick });
+
+          wrapper.click();
+
+          expect(onClick).not.toHaveBeenCalled();
+        });
       });
     }
   );
-
-  describe.each(['primary', 'normal', 'icon'] as const)('disabled with reason %s variant', variant => {
-    describe.each([true, false] as const)('with href %s', withHref => {
-      const defaultProps = {
-        variant,
-        href: withHref ? 'https://smth.com' : undefined,
-      };
-      test('renders button as normal when disabledReason is set and button is not disabled', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: false, disabledReason: 'reason' });
-
-        expect(wrapper.getElement()).not.toHaveAttribute('disabled');
-        expect(wrapper.getElement()).not.toHaveAttribute('aria-disabled');
-      });
-
-      test('does not add disabled attribute when disabled with reason', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        expect(wrapper.getElement()).not.toHaveAttribute('disabled');
-        expect(wrapper.getElement()).toHaveAttribute('aria-disabled');
-      });
-
-      test('has no tooltip open by default', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        expect(wrapper.findDisabledReason()).toBe(null);
-      });
-
-      test('has no tooltip without disabledReason', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true });
-
-        wrapper.getElement()!.focus();
-
-        expect(wrapper.findDisabledReason()).toBeNull();
-      });
-
-      test('open tooltip on focus', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        wrapper.getElement()!.focus();
-
-        expect(wrapper.findDisabledReason()).not.toBeNull();
-        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
-      });
-
-      test('closes tooltip on blur', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        wrapper.getElement()!.focus();
-
-        expect(wrapper.findDisabledReason()).not.toBeNull();
-        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
-
-        wrapper.getElement()!.blur();
-
-        expect(wrapper.findDisabledReason()).toBeNull();
-      });
-
-      test('open tooltip on mouseenter', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        fireEvent.mouseEnter(wrapper.getElement());
-
-        expect(wrapper.findDisabledReason()).not.toBeNull();
-        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
-      });
-
-      test('close tooltip on mouseleave', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        fireEvent.mouseEnter(wrapper.getElement());
-
-        expect(wrapper.findDisabledReason()).not.toBeNull();
-        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
-
-        fireEvent.mouseLeave(wrapper.getElement());
-
-        expect(wrapper.findDisabledReason()).toBeNull();
-      });
-
-      test('close tooltip on Esc keydown', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        fireEvent.mouseEnter(wrapper.getElement());
-
-        expect(wrapper.findDisabledReason()).not.toBeNull();
-        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
-
-        fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
-        expect(wrapper.findDisabledReason()).toBeNull();
-      });
-
-      test('has no aria-describedby by default', () => {
-        const wrapper = renderButton({ ...defaultProps });
-
-        expect(wrapper.getElement()).not.toHaveAttribute('aria-describedby');
-      });
-
-      test('has no aria-describedby without disabledReason', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true });
-
-        expect(wrapper.getElement()).not.toHaveAttribute('aria-describedby');
-      });
-
-      test('has aria-describedby with disabledReason', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        expect(wrapper.getElement()).toHaveAttribute('aria-describedby');
-      });
-
-      test('has hidden element (linked to aria-describedby) with disabledReason', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        expect(wrapper.find('span[hidden]')!.getElement()).toHaveTextContent('reason');
-      });
-
-      test('does not trigger onClick handler when disabled with reason', () => {
-        const onClick = jest.fn();
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason', onClick });
-
-        wrapper.click();
-
-        expect(onClick).not.toHaveBeenCalled();
-      });
-    });
-  });
 
   describe('iconName property', () => {
     test('does not render icon element when no icon provided', () => {

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -18,7 +18,7 @@ export interface BaseButtonProps {
   /**
    * Provides a reason why the button is disabled (only when `disabled` is `true`).
    * If provided, the button becomes focusable.
-   * Applicable for all button variants, except link.
+   * Applicable for all button variants.
    */
   disabledReason?: string;
   /**

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -114,7 +114,13 @@ export const InternalButton = React.forwardRef(
     const target = targetOverride ?? (external ? '_blank' : undefined);
     const isNotInteractive = loading || disabled;
     const isDisabledWithReason =
-      (variant === 'normal' || variant === 'primary' || variant === 'icon') && !!disabledReason && disabled;
+      (variant === 'normal' ||
+        variant === 'primary' ||
+        variant === 'icon' ||
+        variant === 'link' ||
+        variant === 'inline-link') &&
+      !!disabledReason &&
+      disabled;
 
     const hasAriaDisabled = (loading && !disabled) || (disabled && __focusable) || isDisabledWithReason;
     const shouldHaveContent =


### PR DESCRIPTION
### Description

Extends `disabledReason` support to `variant="link"` and `variant="inline-link"` button variants. Previously, `disabledReason` was only supported for `normal`, `primary`, and `icon` variants — link variants were explicitly excluded.

When `disabled={true}` and `disabledReason` is set on a link/inline-link button, the button:
- Becomes focusable (not hidden from keyboard navigation)
- Shows a tooltip on hover and focus with the reason text
- Sets `aria-disabled` instead of removing the element from tab order
- Matches the existing behaviour of other supported variants exactly

Related links, issue #, if available: AWSUI-60908

### How has this been tested?

- Updated `src/button/__tests__/button.test.tsx`: removed the `link`/`inline-link` "not applicable" block and added both variants to the `describe.each` suite covering all `disabledReason` behaviours (tooltip on focus/hover, aria-describedby, hidden description element, click suppression, etc.). All 257 button tests pass.
- Added `link` and `inline-link` examples to `pages/button/disabled-reason.page.tsx` for manual/screenshot testing.
- Full build passes (`npm run build`).
- ESLint + Prettier clean.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ ✅ JSDoc updated to remove the "except link" exclusion.
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ ✅ Additive only — existing behaviour unchanged for all other variants.
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ ✅ No new browser APIs used.
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ ✅ Follows the same aria-disabled + aria-describedby pattern as existing variants.

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ ✅ No new URL handling introduced.

#### Testing

- _Changes are covered with new/existing unit tests?_ ✅ 257 button tests pass, including new link/inline-link coverage.
- _Changes are covered with new/existing integration tests?_ ⬜ Integration tests not added in this PR.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.