### PR TITLE
feat: add openOnFocus prop to Autosuggest to control dropdown on focus

### DIFF
--- a/pages/autosuggest/open-on-focus.page.tsx
+++ b/pages/autosuggest/open-on-focus.page.tsx
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useRef, useState } from 'react';
+
+import { Autosuggest, AutosuggestProps, Box, SpaceBetween } from '~components';
+
+const options = [
+  { value: 'Option 0', description: 'description1' },
+  { value: 'Option 1', labelTag: 'tag' },
+  { value: 'Option 2' },
+  { value: 'Option 3', description: 'description2' },
+];
+const enteredTextLabel = (value: string) => `Use: ${value}`;
+
+function StatefulAutosuggest(props: Omit<AutosuggestProps, 'value' | 'onChange'>) {
+  const [value, setValue] = useState('');
+  return (
+    <Autosuggest
+      {...props}
+      value={value}
+      onChange={event => setValue(event.detail.value)}
+      options={options}
+      enteredTextLabel={enteredTextLabel}
+    />
+  );
+}
+
+export default function AutosuggestOpenOnFocusPage() {
+  const ref = useRef<AutosuggestProps.Ref>(null);
+  const [refValue, setRefValue] = useState('');
+
+  return (
+    <Box margin="m">
+      <h1>Autosuggest — openOnFocus</h1>
+      <SpaceBetween size="l">
+        <Box>
+          <h2>Default (openOnFocus=true)</h2>
+          <p>Focusing the input opens the dropdown immediately.</p>
+          <StatefulAutosuggest ariaLabel="default autosuggest" />
+        </Box>
+
+        <Box>
+          <h2>openOnFocus=false</h2>
+          <p>Focusing the input does NOT open the dropdown. Type or press arrow keys to open it.</p>
+          <StatefulAutosuggest ariaLabel="no open on focus" openOnFocus={false} />
+        </Box>
+
+        <Box>
+          <h2>openOnFocus=false + autoFocus</h2>
+          <p>Input receives focus on mount without opening the dropdown.</p>
+          <StatefulAutosuggest ariaLabel="autofocus no dropdown" openOnFocus={false} autoFocus={true} />
+        </Box>
+
+        <Box>
+          <h2>Programmatic focus without dropdown (openOnFocus=false)</h2>
+          <Autosuggest
+            ref={ref}
+            value={refValue}
+            onChange={event => setRefValue(event.detail.value)}
+            options={options}
+            enteredTextLabel={enteredTextLabel}
+            ariaLabel="programmatic focus"
+            openOnFocus={false}
+          />
+          <button id="focus-button" onClick={() => ref.current?.focus()}>
+            Focus via ref
+          </button>
+        </Box>
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -3779,6 +3779,16 @@ We do not support using this attribute to apply custom styling.",
       "type": "Omit<React.InputHTMLAttributes<HTMLInputElement>, "children"> & Record<\`data-\${string}\`, string>",
     },
     {
+      "defaultValue": "true",
+      "description": "Determines whether the dropdown opens when the input receives focus.
+Set to \`false\` to allow the input to be focused (for example, via \`autoFocus\`) without
+immediately opening the dropdown. The dropdown will still open on user input or when
+the user presses the arrow keys.",
+      "name": "openOnFocus",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
       "description": "Specifies an array of options that are displayed to the user as a dropdown list.
 The options can be grouped using \`OptionGroup\` objects.
 

--- a/src/autosuggest/__tests__/open-on-focus.test.tsx
+++ b/src/autosuggest/__tests__/open-on-focus.test.tsx
@@ -1,0 +1,131 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import { render } from '@testing-library/react';
+
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
+
+import Autosuggest, { AutosuggestProps } from '../../../lib/components/autosuggest';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+const defaultOptions: AutosuggestProps.Options = [
+  { value: '1', label: 'One' },
+  { value: '2', label: 'Two' },
+];
+
+const defaultProps: AutosuggestProps = {
+  enteredTextLabel: () => 'Use value',
+  value: '',
+  onChange: () => {},
+  options: defaultOptions,
+};
+
+function StatefulAutosuggest(props: AutosuggestProps) {
+  const [value, setValue] = useState(props.value);
+  return (
+    <Autosuggest
+      {...props}
+      value={value}
+      onChange={event => {
+        props.onChange?.(event);
+        setValue(event.detail.value);
+      }}
+    />
+  );
+}
+
+function renderAutosuggest(jsx: React.ReactElement) {
+  const { container } = render(jsx);
+  const wrapper = createWrapper(container).findAutosuggest()!;
+  return { container, wrapper };
+}
+
+describe('openOnFocus', () => {
+  test('dropdown opens on focus by default (openOnFocus=true)', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} />);
+    wrapper.focus();
+    expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+  });
+
+  test('dropdown does not open on focus when openOnFocus=false', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} openOnFocus={false} />);
+    wrapper.focus();
+    expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
+  });
+
+  test('onFocus event fires even when openOnFocus=false', () => {
+    const onFocus = jest.fn();
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} openOnFocus={false} onFocus={onFocus} />);
+    wrapper.focus();
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
+  test('dropdown opens on arrow-down key when openOnFocus=false', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} openOnFocus={false} />);
+    wrapper.focus();
+    expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
+
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+  });
+
+  test('dropdown opens on arrow-up key when openOnFocus=false', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} openOnFocus={false} />);
+    wrapper.focus();
+    expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
+
+    wrapper.findNativeInput().keydown(KeyCode.up);
+    expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+  });
+
+  test('dropdown opens on user input when openOnFocus=false', () => {
+    const { wrapper } = renderAutosuggest(<StatefulAutosuggest {...defaultProps} openOnFocus={false} />);
+    wrapper.focus();
+    expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
+
+    wrapper.setInputValue('O');
+    expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+  });
+
+  test('dropdown opens on click when openOnFocus=false', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} openOnFocus={false} />);
+    // Click on the native input triggers openDropdown via onClick handler
+    wrapper.findNativeInput().click();
+    expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+  });
+
+  test('options are visible after opening with arrow-down when openOnFocus=false', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} openOnFocus={false} />);
+    wrapper.focus();
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    expect(wrapper.findDropdown().findOptionByValue('1')!.getElement()).toHaveTextContent('One');
+    expect(wrapper.findDropdown().findOptionByValue('2')!.getElement()).toHaveTextContent('Two');
+  });
+
+  test('option can be selected after opening with arrow-down when openOnFocus=false', () => {
+    const onChange = jest.fn();
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} openOnFocus={false} onChange={onChange} />);
+    wrapper.focus();
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    wrapper.findNativeInput().keydown(KeyCode.enter);
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { value: '1' } }));
+  });
+
+  test('re-focusing does not open dropdown when openOnFocus=false', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} openOnFocus={false} />);
+    // First focus — should stay closed
+    wrapper.focus();
+    expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
+
+    // Open via arrow key, then close
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+    wrapper.findNativeInput().keydown(KeyCode.escape);
+    expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
+
+    // Blur and re-focus — should stay closed
+    document.body.focus();
+    wrapper.focus();
+    expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
+  });
+});

--- a/src/autosuggest/index.tsx
+++ b/src/autosuggest/index.tsx
@@ -21,6 +21,7 @@ const Autosuggest = React.forwardRef(
       statusType = 'finished',
       disableBrowserAutocorrect = false,
       hideEnteredTextOption = false,
+      openOnFocus = true,
       renderOption,
       ...props
     }: AutosuggestProps,
@@ -32,6 +33,7 @@ const Autosuggest = React.forwardRef(
         disableBrowserAutocorrect,
         expandToViewport: props.expandToViewport,
         filteringType,
+        openOnFocus,
         readOnly: props.readOnly,
         virtualScroll: props.virtualScroll,
         hideEnteredTextOption,
@@ -55,6 +57,7 @@ const Autosuggest = React.forwardRef(
         statusType={statusType}
         disableBrowserAutocorrect={disableBrowserAutocorrect}
         hideEnteredTextOption={hideEnteredTextOption}
+        openOnFocus={openOnFocus}
         {...externalProps}
         {...baseComponentProps}
         ref={ref}

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -160,6 +160,15 @@ export interface AutosuggestProps
   renderHighlightedAriaLive?: AutosuggestProps.ContainingOptionAndGroupString;
 
   /**
+   * Determines whether the dropdown opens when the input receives focus.
+   * Set to `false` to allow the input to be focused (for example, via `autoFocus`) without
+   * immediately opening the dropdown. The dropdown will still open on user input or when
+   * the user presses the arrow keys.
+   * @defaultValue true
+   */
+  openOnFocus?: boolean;
+
+  /**
    * An object containing CSS properties to customize the autosuggest's visual appearance.
    * Refer to the [style](/components/autosuggest/?tabId=style) tab for more details.
    * @awsuiSystem core

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -55,6 +55,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     expandToViewport,
     onSelect,
     renderHighlightedAriaLive,
+    openOnFocus = true,
     style,
     renderOption,
     __internalRootRef,
@@ -122,8 +123,10 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   };
 
   const handleFocus = () => {
-    autosuggestItemsHandlers.setShowAll(true);
-    autosuggestLoadMoreHandlers.fireLoadMoreOnInputFocus();
+    if (openOnFocus) {
+      autosuggestItemsHandlers.setShowAll(true);
+      autosuggestLoadMoreHandlers.fireLoadMoreOnInputFocus();
+    }
     fireNonCancelableEvent(onFocus, null);
   };
 
@@ -224,6 +227,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
       ariaControls={listId}
       ariaActivedescendant={highlightedOptionId}
       dropdownExpanded={shouldRenderDropdownContent}
+      openOnFocus={openOnFocus}
       style={style}
       dropdownContent={
         shouldRenderDropdownContent && (

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -52,6 +52,7 @@ interface AutosuggestInputProps
   dropdownFooter?: React.ReactNode;
   dropdownWidth?: number;
   loopFocus?: boolean;
+  openOnFocus?: boolean;
   onCloseDropdown?: NonCancelableEventHandler<null>;
   onDelayedInput?: NonCancelableEventHandler<BaseChangeDetail>;
   onPressArrowDown?: () => void;
@@ -98,6 +99,7 @@ const AutosuggestInput = React.forwardRef(
       dropdownFooter = null,
       dropdownWidth,
       loopFocus,
+      openOnFocus = true,
       nativeInputAttributes,
       onCloseDropdown,
       onDelayedInput,
@@ -157,8 +159,11 @@ const AutosuggestInput = React.forwardRef(
     };
 
     const handleFocus = () => {
-      if (!preventOpenOnFocusRef.current) {
+      if (!preventOpenOnFocusRef.current && openOnFocus) {
         openDropdown();
+        fireNonCancelableEvent(onFocus, null);
+      } else if (!preventOpenOnFocusRef.current) {
+        // openOnFocus=false: fire onFocus but don't open dropdown
         fireNonCancelableEvent(onFocus, null);
       }
       preventOpenOnFocusRef.current = false;


### PR DESCRIPTION
### Description

Add `openOnFocus?: boolean` (default `true`) to Autosuggest to allow focusing the input without immediately opening the dropdown.

This enables use-cases like `autoFocus` where the input should receive focus on mount without presenting the dropdown to the user. The dropdown still opens normally on user input (typing), arrow keys, and click.

Related issue: AWSUI-59622

### How has this been tested?

- 10 new unit tests in `src/autosuggest/__tests__/open-on-focus.test.tsx` covering:
  - Default behavior unchanged (`openOnFocus=true`)
  - Dropdown stays closed on focus when `openOnFocus=false`
  - `onFocus` event still fires when `openOnFocus=false`
  - Dropdown opens on arrow-down / arrow-up / user input / click when `openOnFocus=false`
  - Re-focusing after close does not reopen the dropdown
- Dev page at `pages/autosuggest/open-on-focus.page.tsx` with all four scenarios
- Full autosuggest test suite: 165/165 passing
- Build: clean (no errors)
- ESLint: clean (0 errors)

<details>
   <summary>Review checklist</summary>

#### Correctness

- [x] Changes include appropriate documentation updates.
- [x] Changes are backward-compatible (default `openOnFocus=true` preserves existing behavior).
- [x] Changes do not include unsupported browser features.
- [ ] Changes were manually tested for accessibility.

#### Security

- N/A (no URL handling)

#### Testing

- [x] Changes are covered with new unit tests.
- [ ] Changes are covered with integration tests.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.