### PR TITLE
feat: add disabled prop to FileUpload component (AWSUI-61457)

### DIFF
--- a/pages/file-upload/disabled.page.tsx
+++ b/pages/file-upload/disabled.page.tsx
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import { FileUpload, Header } from '~components';
+import SpaceBetween from '~components/space-between';
+
+import { i18nStrings } from './shared';
+
+const file1 = new File([new Blob(['demo content 1'], { type: 'text/plain' })], 'contract-1.pdf');
+const file2 = new File([new Blob(['demo content 2'], { type: 'text/plain' })], 'contract-2.pdf');
+
+export default function FileUploadDisabledPage() {
+  const [files, setFiles] = useState([file1, file2]);
+
+  return (
+    <SpaceBetween size="l">
+      <Header variant="h1">FileUpload disabled</Header>
+
+      <Header variant="h2">Disabled – empty value</Header>
+      <FileUpload
+        disabled={true}
+        value={[]}
+        onChange={event => setFiles(event.detail.value)}
+        i18nStrings={i18nStrings}
+        constraintText="File size must not exceed 1 MB"
+      />
+
+      <Header variant="h2">Disabled – with files</Header>
+      <FileUpload
+        disabled={true}
+        multiple={true}
+        value={files}
+        onChange={event => setFiles(event.detail.value)}
+        showFileSize={true}
+        showFileLastModified={true}
+        i18nStrings={i18nStrings}
+        constraintText="File size must not exceed 1 MB"
+      />
+
+      <Header variant="h2">Enabled (for comparison)</Header>
+      <FileUpload
+        multiple={true}
+        value={files}
+        onChange={event => setFiles(event.detail.value)}
+        showFileSize={true}
+        showFileLastModified={true}
+        i18nStrings={i18nStrings}
+        constraintText="File size must not exceed 1 MB"
+      />
+    </SpaceBetween>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -13719,6 +13719,12 @@ is provided by its parent form field component.",
       "type": "string",
     },
     {
+      "description": "Specifies whether the file input control is disabled, which prevents the user from modifying the value.",
+      "name": "disabled",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
       "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
 use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes). If you must
 use the \`id\` attribute, consider setting it on a parent element instead.",
@@ -14064,6 +14070,13 @@ is provided by its parent form field component.",
       "name": "controlId",
       "optional": true,
       "type": "string",
+    },
+    {
+      "description": "Specifies whether the file upload control is disabled, which prevents the user from
+modifying the value and hides the remove buttons on file tokens.",
+      "name": "disabled",
+      "optional": true,
+      "type": "boolean",
     },
     {
       "description": "An array of file errors corresponding to the files in the \`value\`.",

--- a/src/file-input/interfaces.ts
+++ b/src/file-input/interfaces.ts
@@ -33,6 +33,11 @@ export interface FileInputProps extends BaseComponentProps, FormFieldCommonValid
   ariaRequired?: boolean;
 
   /**
+   * Specifies whether the file input control is disabled, which prevents the user from modifying the value.
+   */
+  disabled?: boolean;
+
+  /**
    * Specifies the native file input `multiple` attribute to allow users entering more than one file.
    */
   multiple?: boolean;

--- a/src/file-input/internal.tsx
+++ b/src/file-input/internal.tsx
@@ -37,6 +37,7 @@ const InternalFileInput = React.forwardRef(
       accept,
       ariaRequired,
       ariaLabel,
+      disabled = false,
       multiple = false,
       value,
       onChange,
@@ -87,6 +88,9 @@ const InternalFileInput = React.forwardRef(
     if (ariaRequired) {
       nativeAttributes['aria-required'] = true;
     }
+    if (disabled) {
+      nativeAttributes['aria-disabled'] = true;
+    }
 
     if (variant === 'icon' && !ariaLabel) {
       warnOnce('FileInput', 'Aria label is required with icon variant.');
@@ -136,6 +140,7 @@ const InternalFileInput = React.forwardRef(
           hidden={false}
           multiple={multiple}
           accept={accept}
+          disabled={disabled}
           onChange={onUploadInputChange}
           onFocus={onUploadInputFocus}
           onBlur={onUploadInputBlur}
@@ -150,6 +155,7 @@ const InternalFileInput = React.forwardRef(
           iconName="upload"
           variant={variant === 'icon' ? 'icon' : undefined}
           formAction="none"
+          disabled={disabled}
           onClick={onUploadButtonClick}
           className={clsx(styles['file-input-button'], {
             [styles['force-focus-outline-button']]: isFocused && variant === 'button',

--- a/src/file-upload/__tests__/file-upload.test.tsx
+++ b/src/file-upload/__tests__/file-upload.test.tsx
@@ -269,6 +269,60 @@ describe('Focusing behavior', () => {
   );
 });
 
+describe('disabled', () => {
+  test('native input is disabled when `disabled=true`', () => {
+    expect(render({ disabled: false }).findNativeInput().getElement()).not.toBeDisabled();
+    expect(render({ disabled: true }).findNativeInput().getElement()).toBeDisabled();
+  });
+
+  test('native input has aria-disabled when `disabled=true`', () => {
+    expect(render({ disabled: false }).findNativeInput().getElement()).not.toHaveAttribute('aria-disabled');
+    expect(render({ disabled: true }).findNativeInput().getElement()).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  test('upload button is disabled when `disabled=true`', () => {
+    expect(render({ disabled: false }).findUploadButton().getElement()).not.toBeDisabled();
+    expect(render({ disabled: true }).findUploadButton().getElement()).toBeDisabled();
+  });
+
+  test('onChange is not fired when disabled and a file is selected', () => {
+    const wrapper = render({ disabled: true, multiple: true });
+    const input = wrapper.findNativeInput().getElement();
+    Object.defineProperty(input, 'files', { value: [file1] });
+    fireEvent(input, new CustomEvent('change', { bubbles: true }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('file token remove buttons are hidden when `disabled=true`', () => {
+    const wrapper = render({ disabled: true, multiple: true, value: [file1, file2] });
+    expect(wrapper.findFileToken(1)!.findRemoveButton()).toBeNull();
+    expect(wrapper.findFileToken(2)!.findRemoveButton()).toBeNull();
+  });
+
+  test('file token remove buttons are visible when `disabled=false`', () => {
+    const wrapper = render({ disabled: false, multiple: true, value: [file1, file2] });
+    expect(wrapper.findFileToken(1)!.findRemoveButton()).not.toBeNull();
+    expect(wrapper.findFileToken(2)!.findRemoveButton()).not.toBeNull();
+  });
+
+  test('dropzone is not shown when dragging files and `disabled=true`', () => {
+    const wrapper = render({ disabled: true, multiple: true });
+    fireEvent(document, createDragEvent('dragover'));
+    expect(wrapper.findByClassName(FileDropzoneWrapper.rootSelector)).toBeNull();
+  });
+
+  test('a11y: disabled empty', async () => {
+    const wrapper = render({ disabled: true, value: [] });
+    await expect(wrapper.getElement()).toValidateA11y();
+  });
+
+  test('a11y: disabled with files', async () => {
+    const wrapper = render({ disabled: true, multiple: true, value: [file1, file2] });
+    await expect(wrapper.getElement()).toValidateA11y();
+  });
+});
+
 describe('i18n', () => {
   test('supports providing custom i18n strings', () => {
     const { container } = testingLibraryRender(

--- a/src/file-upload/interfaces.ts
+++ b/src/file-upload/interfaces.ts
@@ -15,6 +15,11 @@ export interface FileUploadProps extends BaseComponentProps, FormFieldCommonVali
    */
   ariaRequired?: boolean;
   /**
+   * Specifies whether the file upload control is disabled, which prevents the user from
+   * modifying the value and hides the remove buttons on file tokens.
+   */
+  disabled?: boolean;
+  /**
    * Show file size in the token. Use `i18nStrings.formatFileSize` to customize it.
    */
   showFileSize?: boolean;

--- a/src/file-upload/internal.tsx
+++ b/src/file-upload/internal.tsx
@@ -36,6 +36,7 @@ function InternalFileUpload(
   {
     accept,
     ariaRequired,
+    disabled = false,
     multiple = false,
     onChange,
     value,
@@ -85,6 +86,9 @@ function InternalFileUpload(
   }
 
   const handleFilesChange = (newFiles: File[]) => {
+    if (disabled) {
+      return;
+    }
     const newValue = multiple ? [...value, ...newFiles] : newFiles[0] ? newFiles.slice(0, 1) : [...value];
     fireNonCancelableEvent(onChange, { value: newValue });
   };
@@ -123,7 +127,7 @@ function InternalFileUpload(
       ref={tokenListRef}
     >
       <InternalBox>
-        {areFilesDragging ? (
+        {areFilesDragging && !disabled ? (
           <InternalFileDropzone onChange={event => handleFilesChange(event.detail.value)}>
             {i18n('i18nStrings.dropzoneText', i18nStrings?.dropzoneText?.(multiple), format =>
               format({ multiple: `${multiple}` })
@@ -134,6 +138,7 @@ function InternalFileUpload(
             ref={ref}
             accept={accept}
             ariaRequired={ariaRequired}
+            disabled={disabled}
             multiple={multiple}
             onChange={event => handleFilesChange(event.detail.value)}
             value={value}
@@ -187,6 +192,7 @@ function InternalFileUpload(
           showFileLastModified={metadata.showFileLastModified}
           showFileSize={metadata.showFileSize}
           showFileThumbnail={metadata.showFileThumbnail}
+          readOnly={disabled}
           i18nStrings={{
             removeFileAriaLabel: i18n(
               'i18nStrings.removeFileAriaLabel',


### PR DESCRIPTION
### Description

Add `disabled?: boolean` to the `FileUpload` component (and the underlying `FileInput`) to allow callers to prevent user interaction.

Related links, issue #, if available: AWSUI-61457

**Changes:**
- `FileUploadProps`: new optional `disabled?: boolean` prop (defaults to `false`)
- `FileInputProps`: new optional `disabled?: boolean` prop (propagated from FileUpload)
- Native `<input type="file">` receives `disabled` attribute → browser prevents interaction
- Decorative trigger button receives `disabled` → visual disabled styling via InternalButton
- `aria-disabled="true"` set on the native input for screen-reader consumers
- Dropzone suppressed while dragging when `disabled=true`
- File token remove buttons hidden via `readOnly` pass-through to `FileTokenGroup`
- `onChange` handler guarded to be a no-op when `disabled=true`
- Dev page: `pages/file-upload/disabled.page.tsx`
- Documenter snapshots updated for new prop

### How has this been tested?

- 11 new unit tests in `src/file-upload/__tests__/file-upload.test.tsx` covering:
  - Native input disabled attribute
  - `aria-disabled` on native input
  - Trigger button disabled state
  - `onChange` not fired when disabled
  - Remove buttons hidden on tokens when disabled
  - Dropzone suppressed when dragging while disabled
  - a11y validation (axe) for disabled empty and disabled-with-files states
- All 46 file-upload tests pass; all 63 file-upload + file-input tests pass
- Documenter snapshot tests updated and passing

<details>
   <summary>Review checklist</summary>

#### Correctness

- [x] Changes include appropriate documentation updates (JSDoc on new prop).
- [x] Changes are backward-compatible (new optional prop defaults to `false`).
- [x] Changes do not include unsupported browser features.
- [x] Changes were manually verified for accessibility (aria-disabled, axe tests pass).

#### Security

- No URL handling involved.

#### Testing

- [x] Changes are covered with new unit tests.
- [ ] Integration tests — not added in this PR; can be added as follow-up.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.