### PR TITLE
feat(side-navigation): external-link icon support and findExternalIcon test util (AWSUI-45812)

### DIFF
--- a/pages/side-navigation/external-link.page.tsx
+++ b/pages/side-navigation/external-link.page.tsx
@@ -1,0 +1,113 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useCallback, useState } from 'react';
+
+import SideNavigation, { SideNavigationProps } from '~components/side-navigation';
+
+const ITEMS: SideNavigationProps.Item[] = [
+  {
+    type: 'link',
+    text: 'Internal page',
+    href: '#/internal',
+  },
+  {
+    type: 'link',
+    text: 'External link (no aria label)',
+    href: 'https://aws.amazon.com/',
+    external: true,
+  },
+  {
+    type: 'link',
+    text: 'External link (with aria label)',
+    href: 'https://aws.amazon.com/documentation/',
+    external: true,
+    externalIconAriaLabel: 'Opens in a new tab',
+  },
+  {
+    type: 'link',
+    text: 'External link with info badge',
+    href: 'https://aws.amazon.com/new/',
+    external: true,
+    externalIconAriaLabel: 'Opens in a new tab',
+    info: <span>New</span>,
+  },
+  { type: 'divider' },
+  {
+    type: 'section',
+    text: 'Section with external links',
+    items: [
+      {
+        type: 'link',
+        text: 'External in section',
+        href: 'https://aws.amazon.com/pricing/',
+        external: true,
+        externalIconAriaLabel: 'Opens in a new tab',
+      },
+      {
+        type: 'link',
+        text: 'Internal in section',
+        href: '#/internal-section',
+      },
+    ],
+  },
+  {
+    type: 'link-group',
+    text: 'Link group',
+    href: '#/link-group',
+    items: [
+      {
+        type: 'link',
+        text: 'External in link group',
+        href: 'https://aws.amazon.com/blogs/',
+        external: true,
+        externalIconAriaLabel: 'Opens in a new tab',
+      },
+    ],
+  },
+  {
+    type: 'expandable-link-group',
+    text: 'Expandable link group',
+    href: '#/expandable',
+    defaultExpanded: true,
+    items: [
+      {
+        type: 'link',
+        text: 'External in expandable group',
+        href: 'https://aws.amazon.com/whats-new/',
+        external: true,
+        externalIconAriaLabel: 'Opens in a new tab',
+      },
+      {
+        type: 'link',
+        text: 'Internal in expandable group',
+        href: '#/internal-expandable',
+      },
+    ],
+  },
+];
+
+export default function SideNavigationExternalLinkPage() {
+  const [activeHref, setActiveHref] = useState<string>('#/internal');
+
+  const onFollow = useCallback((e: CustomEvent<SideNavigationProps.FollowDetail>) => {
+    if (!e.detail.external) {
+      setActiveHref(e.detail.href);
+      e.preventDefault();
+    }
+  }, []);
+
+  return (
+    <>
+      <h1>Side Navigation — External link icon</h1>
+      <SideNavigation
+        activeHref={activeHref}
+        header={{
+          href: '#/',
+          text: 'Service name',
+        }}
+        items={ITEMS}
+        onFollow={onFollow}
+      />
+    </>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -44573,6 +44573,19 @@ Note: when used with collection-hooks the \`trackBy\` is set automatically from 
           },
         },
         {
+          "name": "findExternalIcon",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
           "name": "findInfo",
           "parameters": [],
           "returnType": {
@@ -53927,6 +53940,14 @@ Note: when used with collection-hooks the \`trackBy\` is set automatically from 
           "returnType": {
             "isNullable": false,
             "name": "ExpandableSectionWrapper",
+          },
+        },
+        {
+          "name": "findExternalIcon",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
           },
         },
         {

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -596,6 +596,7 @@ exports[`test-utils selectors 1`] = `
   "side-navigation": [
     "awsui_divider_l0dv0",
     "awsui_expandable-link-group_l0dv0",
+    "awsui_external-icon_1fhsi",
     "awsui_header-link_l0dv0",
     "awsui_header_l0dv0",
     "awsui_info_1fhsi",

--- a/src/side-navigation/parts.tsx
+++ b/src/side-navigation/parts.tsx
@@ -552,7 +552,11 @@ function Link({ definition, activeHref, fireFollow, position, collapsed, activeT
         <span className={styles['link-text-wrapper']}>
           <span className={analyticsSelectors['link-text']}>{definition.text}</span>
           {definition.external && (
-            <span aria-label={renderedExternalIconAriaLabel} role={renderedExternalIconAriaLabel ? 'img' : undefined}>
+            <span
+              className={testUtilStyles['external-icon']}
+              aria-label={renderedExternalIconAriaLabel}
+              role={renderedExternalIconAriaLabel ? 'img' : undefined}
+            >
               <InternalIcon name="external" className={styles['external-icon']} />
             </span>
           )}

--- a/src/side-navigation/test-classes/styles.scss
+++ b/src/side-navigation/test-classes/styles.scss
@@ -9,3 +9,7 @@
 .item-icon {
   /* used in test-utils */
 }
+
+.external-icon {
+  /* used in test-utils */
+}

--- a/src/test-utils/dom/side-navigation/index.ts
+++ b/src/test-utils/dom/side-navigation/index.ts
@@ -67,6 +67,10 @@ export class SideNavigationItemWrapper extends ComponentWrapper {
     return this.findByClassName(testUtilStyles.info);
   }
 
+  findExternalIcon(): ElementWrapper | null {
+    return this.findByClassName(testUtilStyles['external-icon']);
+  }
+
   findSectionTitle(): ElementWrapper | null {
     return this.findSection()?.findHeader() ?? null;
   }


### PR DESCRIPTION
## Summary

Resolves **AWSUI-45812** — SideNavigation: show an external-link icon on items that open externally.

The core rendering logic (icon, `target="_blank"`, `rel="noopener noreferrer"`, analytics metadata) was already present in `parts.tsx`. This PR completes the feature by:

1. **Test-utils support** — adds `findExternalIcon()` to `SideNavigationItemWrapper` so tests can assert on the icon element directly, mirroring the pattern used by `Button`.
2. **Test-class selector** — adds `.external-icon` to `test-classes/styles.scss` and applies it to the icon wrapper `<span>` in `parts.tsx`.
3. **Dev page** — adds `pages/side-navigation/external-link.page.tsx` covering all item contexts (top-level, inside section, link-group, expandable-link-group) with and without `externalIconAriaLabel`.
4. **Snapshot updates** — updates documenter and test-utils-selectors snapshots to reflect the new `findExternalIcon` method.

## Changes

| File | Change |
|------|--------|
| `src/side-navigation/parts.tsx` | Apply `testUtilStyles['external-icon']` class to the external icon `<span>` |
| `src/side-navigation/test-classes/styles.scss` | Add `.external-icon` selector |
| `src/test-utils/dom/side-navigation/index.ts` | Add `findExternalIcon()` to `SideNavigationItemWrapper` |
| `pages/side-navigation/external-link.page.tsx` | New dev page for external link items |
| Snapshots | Updated to reflect new test-util method |

## Testing

- All 112 side-navigation unit tests pass ✅
- ESLint clean ✅
- Full build passes ✅

## Accessibility

- External icon `<span>` renders `role="img"` + `aria-label` when `externalIconAriaLabel` is provided (existing behaviour, unchanged)
- `target="_blank"` and `rel="noopener noreferrer"` set on external links (existing behaviour, unchanged)