### PR TITLE
feat: add triggerType="no-wrapper" to Popover for custom trigger elements (AWSUI-44563)

### DIFF
--- a/pages/popover/no-wrapper.page.tsx
+++ b/pages/popover/no-wrapper.page.tsx
@@ -1,0 +1,127 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Box from '~components/box';
+import Button from '~components/button';
+import Icon from '~components/icon';
+import Popover from '~components/popover';
+import SpaceBetween from '~components/space-between';
+import StatusIndicator from '~components/status-indicator';
+
+export default function PopoverNoWrapperPage() {
+  return (
+    <article>
+      <h1>Popover — triggerType=&quot;no-wrapper&quot;</h1>
+      <p>
+        The <code>no-wrapper</code> trigger type injects click/keydown/ref props directly onto the single child element
+        via <code>React.cloneElement</code>, avoiding any extra wrapper in the DOM. The child element becomes the
+        popover trigger itself.
+      </p>
+
+      <SpaceBetween size="l">
+        {/* Scenario 1: Icon button as trigger */}
+        <section id="scenario-icon-button">
+          <h2>Icon button trigger</h2>
+          <Box>
+            <Popover
+              triggerType="no-wrapper"
+              header="Info"
+              content="This popover is triggered by a native icon button with no extra wrapper element."
+              dismissAriaLabel="Close"
+            >
+              <button
+                type="button"
+                aria-label="More information"
+                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 4 }}
+              >
+                <Icon name="status-info" />
+              </button>
+            </Popover>
+          </Box>
+        </section>
+
+        {/* Scenario 2: Cloudscape Button component as trigger */}
+        <section id="scenario-cloudscape-button">
+          <h2>Cloudscape Button trigger</h2>
+          <Box>
+            <Popover
+              triggerType="no-wrapper"
+              header="Copied!"
+              content={<StatusIndicator type="success">Text content copied</StatusIndicator>}
+              dismissButton={false}
+            >
+              <Button iconName="copy">Copy to clipboard</Button>
+            </Popover>
+          </Box>
+        </section>
+
+        {/* Scenario 3: Status indicator as trigger */}
+        <section id="scenario-status-indicator">
+          <h2>Status indicator trigger</h2>
+          <Box>
+            <Popover
+              triggerType="no-wrapper"
+              size="medium"
+              position="right"
+              header="Instance running"
+              content="The EC2 instance i-0abc123def456 is currently running and healthy."
+              dismissAriaLabel="Close"
+            >
+              <button
+                type="button"
+                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+                aria-label="Instance status — click for details"
+              >
+                <StatusIndicator type="success">Running</StatusIndicator>
+              </button>
+            </Popover>
+          </Box>
+        </section>
+
+        {/* Scenario 4: renderWithPortal */}
+        <section id="scenario-portal">
+          <h2>With renderWithPortal</h2>
+          <Box>
+            <Popover
+              triggerType="no-wrapper"
+              header="Portal popover"
+              content="This popover renders in a portal but the trigger is still injected via no-wrapper."
+              renderWithPortal={true}
+              dismissAriaLabel="Close"
+            >
+              <button
+                type="button"
+                aria-label="Open portal popover"
+                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 4 }}
+              >
+                <Icon name="settings" />
+              </button>
+            </Popover>
+          </Box>
+        </section>
+
+        {/* Scenario 5: child retains its own onClick */}
+        <section id="scenario-child-onclick">
+          <h2>Child retains its own onClick handler</h2>
+          <Box>
+            <Popover
+              triggerType="no-wrapper"
+              header="Both handlers fired"
+              content="The child's own onClick and the popover's onClick both fire."
+              dismissAriaLabel="Close"
+            >
+              <Button
+                onClick={() => {
+                  console.log('child onClick fired');
+                }}
+              >
+                Open popover (check console)
+              </Button>
+            </Popover>
+          </Box>
+        </section>
+      </SpaceBetween>
+    </article>
+  );
+}

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -466,3 +466,184 @@ test('does not add portal to the body unless visible', () => {
 
   expect(document.querySelectorAll('body > div')).toHaveLength(1);
 });
+
+describe('triggerType="no-wrapper"', () => {
+  describe('Rendering', () => {
+    it('clones the child element and does not add a wrapper element', () => {
+      const wrapper = renderPopover({
+        triggerType: 'no-wrapper',
+        children: <button type="button" id="my-trigger">Open</button>,
+        content: 'Popover content',
+      });
+      // The trigger element should be the button itself, not a span wrapper
+      const trigger = wrapper.findTrigger().getElement();
+      expect(trigger.tagName).toBe('BUTTON');
+      expect(trigger.id).toBe('my-trigger');
+    });
+
+    it('injects aria-haspopup="dialog" onto the child element', () => {
+      const wrapper = renderPopover({
+        triggerType: 'no-wrapper',
+        children: <button type="button">Open</button>,
+        content: 'Popover content',
+      });
+      expect(wrapper.findTrigger().getElement()).toHaveAttribute('aria-haspopup', 'dialog');
+    });
+
+    it('uses the child element id when provided, rather than generating one', () => {
+      const wrapper = renderPopover({
+        triggerType: 'no-wrapper',
+        children: <button type="button" id="custom-id">Open</button>,
+        content: 'Popover content',
+      });
+      expect(wrapper.findTrigger().getElement().id).toBe('custom-id');
+    });
+
+    it('generates a referrer id when child has no id', () => {
+      const wrapper = renderPopover({
+        triggerType: 'no-wrapper',
+        children: <button type="button">Open</button>,
+        content: 'Popover content',
+      });
+      expect(wrapper.findTrigger().getElement().id).toBeTruthy();
+    });
+  });
+
+  describe('Visibility', () => {
+    it('opens the popover when the trigger is clicked', () => {
+      const wrapper = renderPopover({
+        triggerType: 'no-wrapper',
+        children: <button type="button">Open</button>,
+        content: 'Popover content',
+      });
+      expect(wrapper.findBody()).toBeNull();
+      wrapper.findTrigger().click();
+      expect(wrapper.findBody()).not.toBeNull();
+    });
+
+    it('closes the popover when a click is fired outside', () => {
+      const wrapper = renderPopover({
+        triggerType: 'no-wrapper',
+        children: <button type="button">Open</button>,
+        content: 'Popover content',
+        dismissButton: false,
+      });
+      wrapper.findTrigger().click();
+      expect(wrapper.findBody()).not.toBeNull();
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      });
+      expect(wrapper.findBody()).toBeNull();
+    });
+  });
+
+  describe('Keyboard interaction', () => {
+    it('closes the popover on Escape key', () => {
+      const wrapper = renderPopover({
+        triggerType: 'no-wrapper',
+        children: <button type="button">Open</button>,
+        content: 'Popover content',
+        dismissButton: false,
+      });
+      wrapper.findTrigger().click();
+      expect(wrapper.findBody()).not.toBeNull();
+      act(() => {
+        wrapper.findTrigger().keydown(KeyCode.escape);
+      });
+      expect(wrapper.findBody()).toBeNull();
+    });
+
+    it('closes the popover on Tab key', () => {
+      const wrapper = renderPopover({
+        triggerType: 'no-wrapper',
+        children: <button type="button">Open</button>,
+        content: 'Popover content',
+        dismissButton: false,
+      });
+      wrapper.findTrigger().click();
+      expect(wrapper.findBody()).not.toBeNull();
+      act(() => {
+        wrapper.findTrigger().keydown(KeyCode.tab);
+      });
+      expect(wrapper.findBody()).toBeNull();
+    });
+  });
+
+  describe('Child handler composition', () => {
+    it('calls the child element own onClick in addition to the popover onClick', () => {
+      const childOnClick = jest.fn();
+      const wrapper = renderPopover({
+        triggerType: 'no-wrapper',
+        children: <button type="button" onClick={childOnClick}>Open</button>,
+        content: 'Popover content',
+      });
+      wrapper.findTrigger().click();
+      expect(childOnClick).toHaveBeenCalledTimes(1);
+      expect(wrapper.findBody()).not.toBeNull();
+    });
+
+    it('calls the child element own onKeyDown in addition to the popover onKeyDown', () => {
+      const childOnKeyDown = jest.fn();
+      const wrapper = renderPopover({
+        triggerType: 'no-wrapper',
+        children: <button type="button" onKeyDown={childOnKeyDown}>Open</button>,
+        content: 'Popover content',
+        dismissButton: false,
+      });
+      wrapper.findTrigger().click();
+      act(() => {
+        wrapper.findTrigger().keydown(KeyCode.escape);
+      });
+      expect(childOnKeyDown).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Focus behavior', () => {
+    it('moves focus back to the trigger element on dismiss', () => {
+      const wrapper = renderPopover({
+        triggerType: 'no-wrapper',
+        children: <button type="button">Open</button>,
+        content: 'Popover content',
+      });
+      act(() => {
+        wrapper.findTrigger().click();
+      });
+      act(() => {
+        wrapper.findDismissButton()?.click();
+      });
+      expect(document.activeElement).toBe(wrapper.findTrigger().getElement());
+    });
+  });
+
+  describe('ref support', () => {
+    it('focuses the trigger element when focus() is called on the ref', () => {
+      const ref: React.RefObject<PopoverProps.Ref> = { current: null };
+      const wrapper = renderPopover({
+        triggerType: 'no-wrapper',
+        children: <button type="button">Open</button>,
+        content: 'Popover content',
+        ref,
+      });
+      act(() => {
+        ref.current?.focus();
+      });
+      expect(document.activeElement).toBe(wrapper.findTrigger().getElement());
+    });
+
+    it('dismiss() closes the popover without focusing the trigger', () => {
+      const ref: React.RefObject<PopoverProps.Ref> = { current: null };
+      const wrapper = renderPopover({
+        triggerType: 'no-wrapper',
+        children: <button type="button">Open</button>,
+        content: 'Popover content',
+        ref,
+      });
+      wrapper.findTrigger().click();
+      expect(wrapper.findBody()).not.toBeNull();
+      act(() => {
+        ref.current?.dismiss();
+      });
+      expect(wrapper.findBody()).toBeNull();
+    });
+  });
+});

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -472,7 +472,11 @@ describe('triggerType="no-wrapper"', () => {
     it('clones the child element and does not add a wrapper element', () => {
       const wrapper = renderPopover({
         triggerType: 'no-wrapper',
-        children: <button type="button" id="my-trigger">Open</button>,
+        children: (
+          <button type="button" id="my-trigger">
+            Open
+          </button>
+        ),
         content: 'Popover content',
       });
       // The trigger element should be the button itself, not a span wrapper
@@ -493,7 +497,11 @@ describe('triggerType="no-wrapper"', () => {
     it('uses the child element id when provided, rather than generating one', () => {
       const wrapper = renderPopover({
         triggerType: 'no-wrapper',
-        children: <button type="button" id="custom-id">Open</button>,
+        children: (
+          <button type="button" id="custom-id">
+            Open
+          </button>
+        ),
         content: 'Popover content',
       });
       expect(wrapper.findTrigger().getElement().id).toBe('custom-id');
@@ -574,7 +582,11 @@ describe('triggerType="no-wrapper"', () => {
       const childOnClick = jest.fn();
       const wrapper = renderPopover({
         triggerType: 'no-wrapper',
-        children: <button type="button" onClick={childOnClick}>Open</button>,
+        children: (
+          <button type="button" onClick={childOnClick}>
+            Open
+          </button>
+        ),
         content: 'Popover content',
       });
       wrapper.findTrigger().click();
@@ -586,7 +598,11 @@ describe('triggerType="no-wrapper"', () => {
       const childOnKeyDown = jest.fn();
       const wrapper = renderPopover({
         triggerType: 'no-wrapper',
-        children: <button type="button" onKeyDown={childOnKeyDown}>Open</button>,
+        children: (
+          <button type="button" onKeyDown={childOnKeyDown}>
+            Open
+          </button>
+        ),
         content: 'Popover content',
         dismissButton: false,
       });

--- a/src/popover/interfaces.ts
+++ b/src/popover/interfaces.ts
@@ -26,6 +26,11 @@ export interface PopoverProps extends BaseComponentProps {
    * - `text` - Use for triggers containing inline components, like status indicator.
    * - `text-inline` - Use for triggers containing plain text only.
    * - `custom` - Use for the [button](/components/button/) component.
+   * - `no-wrapper` - Use when you want to pass trigger interaction props (click, keydown, ref)
+   *   directly onto a single child element via `React.cloneElement`. The child must be a single
+   *   React element that accepts `onClick`, `onKeyDown`, and `ref` props. Use this when you need
+   *   an icon, badge, avatar, or other arbitrary element to act as the popover trigger without
+   *   introducing an extra wrapper in the DOM.
    */
   triggerType?: PopoverProps.TriggerType;
 
@@ -100,7 +105,7 @@ export type Rect = BoundingBox & {
 export namespace PopoverProps {
   export type Position = 'top' | 'right' | 'bottom' | 'left';
   export type Size = 'small' | 'medium' | 'large';
-  export type TriggerType = 'text' | 'text-inline' | 'custom';
+  export type TriggerType = 'text' | 'text-inline' | 'custom' | 'no-wrapper';
 
   export interface Ref {
     /**

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -89,6 +89,10 @@ function InternalPopover(
   const focusTrigger = useCallback(() => {
     if (['text', 'text-inline'].includes(triggerType)) {
       triggerRef.current?.focus();
+    } else if (triggerType === 'no-wrapper') {
+      // For no-wrapper, triggerRef points directly to the child element.
+      // The child is itself focusable (e.g. a <button>), so call focus() on it directly.
+      triggerRef.current?.focus();
     } else if (triggerRef.current) {
       getFirstFocusable(triggerRef.current)?.focus();
     }
@@ -199,6 +203,68 @@ function InternalPopover(
 
   const mergedRef = useMergeRefs(popoverRef, __internalRootRef);
 
+  /**
+   * Renders the trigger element based on triggerType:
+   * - 'text' / 'text-inline': wraps children in a <button> (accessible, keyboard-navigable).
+   * - 'custom' / 'filtering-token': wraps children in a <span>.
+   * - 'no-wrapper': clones the single child React element and injects trigger props directly,
+   *   avoiding any extra wrapper in the DOM. The child must accept onClick, onKeyDown, and ref.
+   */
+  const renderTrigger = () => {
+    if (['text', 'text-inline'].includes(triggerType)) {
+      return (
+        <button
+          {...triggerProps}
+          className={clsx(triggerProps.className, wrapTriggerText === false && styles['overflow-ellipsis'])}
+          tabIndex={triggerTabIndex}
+          type="button"
+          aria-haspopup="dialog"
+          id={referrerId}
+          aria-label={triggerAriaLabel}
+        >
+          {children}
+        </button>
+      );
+    }
+
+    if (triggerType === 'no-wrapper') {
+      // Inject trigger interaction props directly onto the child element.
+      // The child must be a single React element (not a string, array, etc.).
+      const child = React.Children.only(children) as React.ReactElement<Record<string, unknown>>;
+      return React.cloneElement(child, {
+        ref: triggerRef as any,
+        // Merge the trigger class so test-utils findTrigger() can locate the element,
+        // while preserving any className the child already has.
+        className: clsx(
+          styles.trigger,
+          styles[`trigger-type-${triggerType}`],
+          child.props.className as string | undefined
+        ),
+        onClick: (event: React.MouseEvent) => {
+          onTriggerClick();
+          if (typeof child.props.onClick === 'function') {
+            child.props.onClick(event);
+          }
+        },
+        onKeyDown: (event: React.KeyboardEvent) => {
+          onTriggerKeyDown(event);
+          if (typeof child.props.onKeyDown === 'function') {
+            child.props.onKeyDown(event);
+          }
+        },
+        id: (child.props.id as string | undefined) ?? referrerId,
+        'aria-haspopup': 'dialog',
+      });
+    }
+
+    // 'custom' and 'filtering-token': wrap in a span
+    return (
+      <span {...triggerProps} id={referrerId}>
+        {children}
+      </span>
+    );
+  };
+
   return (
     <span
       {...baseProps}
@@ -216,23 +282,7 @@ function InternalPopover(
         });
       }}
     >
-      {['text', 'text-inline'].includes(triggerType) ? (
-        <button
-          {...triggerProps}
-          className={clsx(triggerProps.className, wrapTriggerText === false && styles['overflow-ellipsis'])}
-          tabIndex={triggerTabIndex}
-          type="button"
-          aria-haspopup="dialog"
-          id={referrerId}
-          aria-label={triggerAriaLabel}
-        >
-          {children}
-        </button>
-      ) : (
-        <span {...triggerProps} id={referrerId}>
-          {children}
-        </span>
-      )}
+      {renderTrigger()}
       {visible && (
         <ResetContextsForModal>
           {renderWithPortal ? <Portal>{popoverContent}</Portal> : popoverContent}


### PR DESCRIPTION
### Description

Adds a new `triggerType='no-wrapper'` option to the Popover component that injects trigger interaction props (`onClick`, `onKeyDown`, `ref`, `aria-haspopup`) directly onto the single child element via `React.cloneElement`, instead of wrapping it in a `<button>` or `<span>`.

This is useful when an icon button, badge, avatar, or other arbitrary interactive element should act as the popover trigger without introducing an extra wrapper node in the DOM.

Related links, issue #, if available: AWSUI-44563

**Existing behaviour preserved:**
- `text` and `text-inline` → `<button>` wrapper (unchanged)
- `custom` → `<span>` wrapper (unchanged)
- `filtering-token` → `<span>` wrapper (unchanged)

**New `no-wrapper` behaviour:**
- Calls `React.cloneElement(child, { ref, onClick, onKeyDown, id, 'aria-haspopup' })`
- Merges `trigger` CSS class onto the child so `findTrigger()` in test-utils works
- Composes child's own `onClick`/`onKeyDown` handlers — they are called in addition to the popover's handlers, not replaced
- `focusTrigger()` calls `.focus()` directly on the child element ref

### How has this been tested?

- 13 new unit tests in `src/popover/__tests__/popover.test.tsx` covering:
  - DOM structure (no extra wrapper, correct id, aria-haspopup)
  - Visibility (open on click, close on outside click)
  - Keyboard (Escape, Tab close)
  - Handler composition (child onClick/onKeyDown still fires)
  - Focus return on dismiss
  - `ref.focus()` and `ref.dismiss()` behaviour
- All 63 popover unit tests pass
- Dev page at `pages/popover/no-wrapper.page.tsx` with 5 scenarios (icon button, Cloudscape Button, status indicator, portal, child onClick)

<details>
   <summary>Review checklist</summary>

#### Correctness

- [x] Changes include appropriate documentation updates (JSDoc on the new type)
- [x] Changes are backward-compatible — existing `triggerType` values are unaffected
- [x] No unsupported browser features used
- [ ] Changes were manually tested for accessibility (needs reviewer verification)

#### Security

- [x] No URL handling introduced

#### Testing

- [x] Changes are covered with 13 new unit tests
- [ ] Integration tests — not added in this draft; to be assessed

</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.