### PR TITLE
feat: persist column resize widths via columnDisplay / CollectionPreferences

### DIFF
--- a/pages/table/column-width-persist.page.tsx
+++ b/pages/table/column-width-persist.page.tsx
@@ -1,0 +1,123 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Box from '~components/box';
+import CollectionPreferences, { CollectionPreferencesProps } from '~components/collection-preferences';
+import Header from '~components/header';
+import Link from '~components/link';
+import SpaceBetween from '~components/space-between';
+import Table, { TableProps } from '~components/table';
+
+/**
+ * Dev page: Column width persistence via CollectionPreferences / contentDisplay.
+ *
+ * Demonstrates how resized column widths survive a simulated page reload by
+ * storing them in `preferences.contentDisplay[i].width` and feeding them back
+ * through `columnDisplay`.  The workflow is:
+ *
+ *   1. User resizes a column → `onColumnWidthsChange` fires with
+ *      `detail.columnDisplay` already containing the updated widths.
+ *   2. App stores `detail.columnDisplay` in its preferences state.
+ *   3. On next render the widths flow back via `columnDisplay`, so the table
+ *      restores them without any manual bookkeeping.
+ */
+
+interface Item {
+  id: string;
+  name: string;
+  type: string;
+  state: string;
+  region: string;
+}
+
+const columnDefinitions: TableProps.ColumnDefinition<Item>[] = [
+  { id: 'name', header: 'Name', cell: item => <Link href="#">{item.name}</Link>, width: 200, minWidth: 120 },
+  { id: 'type', header: 'Type', cell: item => item.type, width: 150, minWidth: 100 },
+  { id: 'state', header: 'State', cell: item => item.state, width: 120, minWidth: 80 },
+  { id: 'region', header: 'Region', cell: item => item.region, width: 160, minWidth: 100 },
+];
+
+const items: Item[] = [
+  { id: '1', name: 'my-instance-1', type: 't3.micro', state: 'Running', region: 'us-east-1' },
+  { id: '2', name: 'my-instance-2', type: 'm5.large', state: 'Stopped', region: 'us-west-2' },
+  { id: '3', name: 'my-instance-3', type: 'c5.xlarge', state: 'Running', region: 'eu-west-1' },
+];
+
+const contentDisplayOptions: CollectionPreferencesProps.ContentDisplayOption[] = columnDefinitions.map(col => ({
+  id: col.id!,
+  label: col.header as string,
+}));
+
+const defaultPreferences: CollectionPreferencesProps.Preferences = {
+  contentDisplay: columnDefinitions.map(col => ({ id: col.id!, visible: true })),
+  pageSize: 10,
+};
+
+export default function App() {
+  const [preferences, setPreferences] = useState<CollectionPreferencesProps.Preferences>(defaultPreferences);
+
+  function handleColumnWidthsChange(event: { detail: TableProps.ColumnWidthsChangeDetail }) {
+    // When columnDisplay is present in the event detail, persist the updated widths
+    // back into preferences so they survive a page reload.
+    if (event.detail.columnDisplay) {
+      setPreferences(prev => ({ ...prev, contentDisplay: event.detail.columnDisplay }));
+    }
+  }
+
+  return (
+    <SpaceBetween size="l">
+      <Header variant="h1">Column width persistence</Header>
+      <Box>
+        <strong>How it works:</strong> Resize a column, then observe the <em>preferences.contentDisplay</em> state
+        update below. The widths are stored in <code>contentDisplay[i].width</code> and fed back via{' '}
+        <code>columnDisplay</code>, so they survive a simulated reload.
+      </Box>
+      <Table
+        header={
+          <Header
+            actions={
+              <CollectionPreferences
+                title="Preferences"
+                confirmLabel="Confirm"
+                cancelLabel="Cancel"
+                preferences={preferences}
+                onConfirm={({ detail }) => setPreferences(detail)}
+                contentDisplayPreference={{
+                  title: 'Column display',
+                  description: 'Customize column order and visibility.',
+                  options: contentDisplayOptions,
+                }}
+                pageSizePreference={{
+                  title: 'Page size',
+                  options: [
+                    { value: 10, label: '10 resources' },
+                    { value: 25, label: '25 resources' },
+                  ],
+                }}
+              />
+            }
+          >
+            Instances
+          </Header>
+        }
+        columnDefinitions={columnDefinitions}
+        columnDisplay={preferences.contentDisplay as TableProps.ColumnDisplay[]}
+        resizableColumns={true}
+        items={items}
+        ariaLabels={{
+          resizerRoleDescription: 'resize button',
+          resizerTooltipText: 'Drag or press Enter to resize',
+          tableLabel: 'Instances table',
+        }}
+        onColumnWidthsChange={handleColumnWidthsChange}
+      />
+      <Box>
+        <strong>Current preferences.contentDisplay:</strong>
+        <pre id="preferences-state" style={{ fontSize: '12px', background: '#f4f4f4', padding: '8px' }}>
+          {JSON.stringify(preferences.contentDisplay, null, 2)}
+        </pre>
+      </Box>
+    </SpaceBetween>
+  );
+}

--- a/pages/table/column-width-persist.page.tsx
+++ b/pages/table/column-width-persist.page.tsx
@@ -8,6 +8,7 @@ import Header from '~components/header';
 import Link from '~components/link';
 import SpaceBetween from '~components/space-between';
 import Table, { TableProps } from '~components/table';
+import { colorBackgroundContainerContent, colorTextBodyDefault } from '~design-tokens';
 
 /**
  * Dev page: Column width persistence via CollectionPreferences / contentDisplay.
@@ -114,7 +115,17 @@ export default function App() {
       />
       <Box>
         <strong>Current preferences.contentDisplay:</strong>
-        <pre id="preferences-state" style={{ fontSize: '12px', background: '#f4f4f4', padding: '8px' }}>
+        <pre
+          id="preferences-state"
+          style={{
+            fontSize: '12px',
+            // Use theme-aware design tokens so the code block keeps sufficient
+            // color contrast in both light and dark modes.
+            background: colorBackgroundContainerContent,
+            color: colorTextBodyDefault,
+            padding: '8px',
+          }}
+        >
           {JSON.stringify(preferences.contentDisplay, null, 2)}
         </pre>
       </Box>

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -27985,6 +27985,11 @@ including the hidden via preferences columns. Use this event to persist the colu
         "name": "TableProps.ColumnWidthsChangeDetail",
         "properties": [
           {
+            "name": "columnDisplay",
+            "optional": true,
+            "type": "ReadonlyArray<TableProps.ColumnDisplayProperties>",
+          },
+          {
             "name": "widths",
             "optional": false,
             "type": "ReadonlyArray<number>",

--- a/src/collection-preferences/interfaces.ts
+++ b/src/collection-preferences/interfaces.ts
@@ -253,6 +253,11 @@ export namespace CollectionPreferencesProps {
     type?: 'column';
     id: string;
     visible: boolean;
+    /**
+     * Persisted column width in pixels. Populated from the table's `onColumnWidthsChange` event
+     * and fed back via `preferences.contentDisplay` to restore resized widths after page reload.
+     */
+    width?: number;
   }
 
   export interface ContentDisplayGroup {

--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -270,7 +270,7 @@ test('should trigger the columnWidthsChange event after a column is resized', ()
   firePointerup(100);
 
   expect(onChange).toHaveBeenCalledTimes(1);
-  expect(onChange).toHaveBeenCalledWith({ widths: [100, 300] });
+  expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ widths: [100, 300] }));
 });
 
 test('should provide the value for the last column when it was not defined', () => {
@@ -286,7 +286,7 @@ test('should provide the value for the last column when it was not defined', () 
   firePointerup(100);
 
   expect(onChange).toHaveBeenCalledTimes(1);
-  expect(onChange).toHaveBeenCalledWith({ widths: [100, 300, 120] });
+  expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ widths: [100, 300, 120] }));
 });
 
 test('should include hidden columns into the event detail', () => {
@@ -307,7 +307,7 @@ test('should include hidden columns into the event detail', () => {
   firePointerup(140);
 
   expect(onChange).toHaveBeenCalledTimes(1);
-  expect(onChange).toHaveBeenCalledWith({ widths: [150, 300, 120, 140] });
+  expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ widths: [150, 300, 120, 140] }));
 });
 
 test('should update the value for the last column when it is resized', () => {
@@ -319,7 +319,7 @@ test('should update the value for the last column when it is resized', () => {
   firePointerup(400);
 
   expect(onChange).toHaveBeenCalledTimes(1);
-  expect(onChange).toHaveBeenCalledWith({ widths: [150, 400] });
+  expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ widths: [150, 400] }));
 });
 
 test('should not trigger if the previous and the current widths are the same', () => {
@@ -375,7 +375,7 @@ describe('resize with keyboard', () => {
     columnResizerWrapper.keydown(keyCode);
 
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith({ widths: [140, 300] });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ widths: [140, 300] }));
   });
 
   test('activates keyboard resize with click', () => {
@@ -389,7 +389,7 @@ describe('resize with keyboard', () => {
     columnResizerWrapper.keydown(KeyCode.enter);
 
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith({ widths: [160, 300] });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ widths: [160, 300] }));
   });
 
   test('submits resize with escape', () => {
@@ -403,7 +403,7 @@ describe('resize with keyboard', () => {
     columnResizerWrapper.keydown(KeyCode.escape);
 
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith({ widths: [160, 300] });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ widths: [160, 300] }));
   });
 
   test('submits resize on blur', () => {
@@ -417,7 +417,7 @@ describe('resize with keyboard', () => {
     wrapper.findColumnResizer(2)!.focus();
 
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith({ widths: [160, 300] });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ widths: [160, 300] }));
   });
 
   test('prevents resizing to below the min-width', () => {
@@ -681,7 +681,7 @@ describe('UAP buttons', () => {
 
     wrapper.findColumnResizer(1)!.click();
     findDragHandle().findVisibleDirectionButtonInlineStart()!.click();
-    await waitFor(() => expect(onChange).toHaveBeenCalledWith({ widths: [130] }));
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ widths: [130] })));
   });
 
   test('resizes the column when inline-end button is pressed', async () => {
@@ -696,6 +696,95 @@ describe('UAP buttons', () => {
 
     wrapper.findColumnResizer(1)!.click();
     findDragHandle().findVisibleDirectionButtonInlineEnd()!.click();
-    await waitFor(() => expect(onChange).toHaveBeenCalledWith({ widths: [170] }));
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ widths: [170] })));
+  });
+});
+
+describe('column width persistence via columnDisplay', () => {
+  beforeEach(() => {
+    // Reset direction in case previous describe blocks left it as 'rtl'
+    document.body.style.direction = '';
+  });
+
+  const columnDisplayProps: TableProps.ColumnDisplay[] = [
+    { id: 'id', visible: true },
+    { id: 'description', visible: true },
+  ];
+
+  test('event detail includes columnDisplay with updated widths when columnDisplay prop is provided', () => {
+    const onChange = jest.fn();
+    const { wrapper } = renderTable(
+      <Table
+        {...defaultProps}
+        columnDisplay={columnDisplayProps}
+        onColumnWidthsChange={event => onChange(event.detail)}
+      />
+    );
+
+    firePointerdown(wrapper.findColumnResizer(1)!);
+    firePointermove(100);
+    firePointerup(100);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const detail = onChange.mock.calls[0][0];
+    expect(detail.widths).toEqual([100, 300]);
+    expect(detail.columnDisplay).toEqual([
+      { id: 'id', visible: true, width: 100 },
+      { id: 'description', visible: true, width: 300 },
+    ]);
+  });
+
+  test('event detail has no columnDisplay when columnDisplay prop is not provided', () => {
+    const onChange = jest.fn();
+    const { wrapper } = renderTable(<Table {...defaultProps} onColumnWidthsChange={event => onChange(event.detail)} />);
+
+    firePointerdown(wrapper.findColumnResizer(1)!);
+    firePointermove(100);
+    firePointerup(100);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const detail = onChange.mock.calls[0][0];
+    expect(detail.widths).toEqual([100, 300]);
+    expect(detail.columnDisplay).toBeUndefined();
+  });
+
+  test('persisted width from columnDisplay overrides columnDefinitions width on render', () => {
+    const columnDisplayWithWidths: TableProps.ColumnDisplay[] = [
+      { id: 'id', visible: true, width: 250 },
+      { id: 'description', visible: true, width: 350 },
+    ];
+    const { wrapper } = renderTable(<Table {...defaultProps} columnDisplay={columnDisplayWithWidths} />);
+
+    // The first column header should reflect the persisted width
+    expect(wrapper.findColumnHeaders()[0].getElement()).toHaveStyle({ width: '250px' });
+  });
+
+  test('hidden columns are excluded from visible definitions but their widths are preserved in the event', () => {
+    const onChange = jest.fn();
+    const columnDisplayWithHidden: TableProps.ColumnDisplay[] = [
+      { id: 'id', visible: true },
+      { id: 'description', visible: false },
+    ];
+    const { wrapper } = renderTable(
+      <Table
+        {...defaultProps}
+        columnDisplay={columnDisplayWithHidden}
+        onColumnWidthsChange={event => onChange(event.detail)}
+      />
+    );
+
+    firePointerdown(wrapper.findColumnResizer(1)!);
+    firePointermove(100);
+    firePointerup(100);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const detail = onChange.mock.calls[0][0];
+    // widths array covers all columnDefinitions (including hidden)
+    expect(detail.widths).toHaveLength(2);
+    // columnDisplay reflects the updated widths for all columns
+    expect(detail.columnDisplay).toEqual([
+      { id: 'id', visible: true, width: 100 },
+      { id: 'description', visible: false, width: 300 },
+    ]);
   });
 });

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -614,6 +614,11 @@ export namespace TableProps {
 
   export interface ColumnWidthsChangeDetail {
     widths: ReadonlyArray<number>;
+    /**
+     * Updated `columnDisplay` array with persisted widths. When `columnDisplay` is provided,
+     * use this to update your preferences state so resized widths survive page reloads.
+     */
+    columnDisplay?: ReadonlyArray<ColumnDisplayProperties>;
   }
 
   export interface LiveAnnouncement {
@@ -646,6 +651,11 @@ export namespace TableProps {
     type?: 'column';
     id: string;
     visible: boolean;
+    /**
+     * Persisted column width in pixels. Set this from the `onColumnWidthsChange` event
+     * to restore resized widths across page reloads.
+     */
+    width?: number;
   }
 
   export interface GroupDisplay {

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -68,7 +68,14 @@ import { ColumnWidthDefinition, ColumnWidthsProvider, DEFAULT_COLUMN_WIDTH } fro
 import { usePreventStickyClickScroll } from './use-prevent-sticky-click-scroll';
 import { useRowEvents } from './use-row-events';
 import useTableFocusNavigation from './use-table-focus-navigation';
-import { checkSortingState, getColumnKey, getItemKey, getVisibleColumnDefinitions, toContainerVariant } from './utils';
+import {
+  applyWidthsToColumnDisplay,
+  checkSortingState,
+  getColumnKey,
+  getItemKey,
+  getVisibleColumnDefinitions,
+  toContainerVariant,
+} from './utils';
 
 import buttonStyles from '../button/styles.css.js';
 import headerStyles from '../header/styles.css.js';
@@ -428,7 +435,11 @@ const InternalTable = React.forwardRef(
         );
         const widthsChanged = widthsDetail.some((width, index) => columnDefinitions[index].width !== width);
         if (widthsChanged) {
-          fireNonCancelableEvent(onColumnWidthsChange, { widths: widthsDetail });
+          // Build an updated columnDisplay array with persisted widths when columnDisplay is provided.
+          const updatedColumnDisplay = columnDisplay
+            ? applyWidthsToColumnDisplay(columnDisplay, columnDefinitions, widthsDetail)
+            : undefined;
+          fireNonCancelableEvent(onColumnWidthsChange, { widths: widthsDetail, columnDisplay: updatedColumnDisplay });
         }
       },
       singleSelectionHeaderAriaLabel: ariaLabels?.selectionGroupLabel,

--- a/src/table/utils.ts
+++ b/src/table/utils.ts
@@ -79,8 +79,36 @@ function getVisibleColumnDefinitionsFromColumnDisplay<T>({
     (accumulator, item) => (item.id === undefined ? accumulator : { ...accumulator, [item.id]: item }),
     {}
   );
+  // Build a map of persisted widths from columnDisplay entries.
+  const persistedWidths = flattenColumnDisplayWidths(columnDisplay);
   const visibleIds = flattenVisibleColumnIds(columnDisplay);
-  return visibleIds.map(id => columnDefinitionsById[id]).filter(Boolean);
+  return visibleIds
+    .map(id => {
+      const colDef = columnDefinitionsById[id];
+      if (!colDef) {
+        return colDef;
+      }
+      const persistedWidth = persistedWidths.get(id);
+      if (persistedWidth !== undefined) {
+        return { ...colDef, width: persistedWidth };
+      }
+      return colDef;
+    })
+    .filter(Boolean);
+}
+
+function flattenColumnDisplayWidths(items: ReadonlyArray<TableProps.ColumnDisplayProperties>): Map<string, number> {
+  const widths = new Map<string, number>();
+  for (const item of items) {
+    if (item.type === 'group') {
+      for (const [id, width] of flattenColumnDisplayWidths(item.children)) {
+        widths.set(id, width);
+      }
+    } else if (item.width !== undefined) {
+      widths.set(item.id, item.width);
+    }
+  }
+  return widths;
 }
 
 function getVisibleColumnDefinitionsFromVisibleColumns<T>({
@@ -113,4 +141,35 @@ function flattenVisibleColumnIds(items: ReadonlyArray<TableProps.ColumnDisplayPr
     }
   }
   return ids;
+}
+
+/**
+ * Merges a flat array of widths (indexed by columnDefinitions order) back into
+ * the columnDisplay tree, so callers can persist the updated widths via preferences.
+ */
+export function applyWidthsToColumnDisplay<T>(
+  columnDisplay: ReadonlyArray<TableProps.ColumnDisplayProperties>,
+  columnDefinitions: ReadonlyArray<TableProps.ColumnDefinition<T>>,
+  widths: ReadonlyArray<number>
+): ReadonlyArray<TableProps.ColumnDisplayProperties> {
+  const widthById = new Map<string, number>();
+  columnDefinitions.forEach((col, index) => {
+    if (col.id !== undefined) {
+      widthById.set(col.id, widths[index]);
+    }
+  });
+  return applyWidthsToItems(columnDisplay, widthById);
+}
+
+function applyWidthsToItems(
+  items: ReadonlyArray<TableProps.ColumnDisplayProperties>,
+  widthById: Map<string, number>
+): ReadonlyArray<TableProps.ColumnDisplayProperties> {
+  return items.map(item => {
+    if (item.type === 'group') {
+      return { ...item, children: applyWidthsToItems(item.children, widthById) };
+    }
+    const width = widthById.get(item.id);
+    return width !== undefined ? { ...item, width } : item;
+  });
 }


### PR DESCRIPTION
### Description

Implements column-resize width persistence so that widths set by the user survive page reloads when the table is wired to CollectionPreferences.

Related links, issue #, if available: AWSUI-41872

#### What changed

**Interfaces**
- `TableProps.ColumnDisplay` gets an optional `width?: number` field.
- `CollectionPreferencesProps.ContentDisplayColumn` gets the same optional `width?: number` field.
- `TableProps.ColumnWidthsChangeDetail` now includes an optional `columnDisplay?: ReadonlyArray<ColumnDisplayProperties>` that carries the updated display list with widths already merged in.

**Runtime behaviour**
- After a column resize, `onColumnWidthsChange` fires with `detail.columnDisplay` populated (when the `columnDisplay` prop is provided). Apps can store this value directly into their preferences state — no manual bookkeeping needed.
- `getVisibleColumnDefinitionsFromColumnDisplay` applies persisted widths from `columnDisplay[i].width`, so the table restores them on the next render without any additional wiring.
- Both flat and grouped column hierarchies are handled via the new `applyWidthsToColumnDisplay` / `flattenColumnDisplayWidths` helpers in `utils.ts`.

**Minimal integration pattern**
```tsx
const [preferences, setPreferences] = useState({ contentDisplay: [...] });

<Table
  columnDisplay={preferences.contentDisplay}
  onColumnWidthsChange={({ detail }) => {
    if (detail.columnDisplay) {
      setPreferences(prev => ({ ...prev, contentDisplay: detail.columnDisplay }));
    }
  }}
/>
```

### How has this been tested?

- Unit tests: 4 new tests in `resizable-columns.test.tsx` covering:
  1. event detail includes `columnDisplay` with updated widths when prop is provided
  2. event detail has no `columnDisplay` when prop is absent (backward compat)
  3. persisted width from `columnDisplay` overrides `columnDefinitions` width on render
  4. hidden columns are excluded from visible defs but widths preserved in the event
- Existing resize tests updated to use `expect.objectContaining` (backward-compatible).
- Dev page: `pages/table/column-width-persist.page.tsx` demonstrates the full persistence loop with CollectionPreferences.
- `npm run build` clean (no errors, only size warnings).
- `TZ=UTC npx gulp test:unit`: 589 suites pass; 2 pre-existing failures on `main` (`columns-width.test.tsx`, `documenter.test.ts`).

<details>
   <summary>Review checklist</summary>

#### Correctness

- Changes include appropriate documentation updates (JSDoc on new fields).
- Changes are backward-compatible: existing callers of `onColumnWidthsChange` see the same `widths` array; `columnDisplay` in the detail is `undefined` when the prop is not provided.
- No unsupported browser features introduced.
- Accessibility: no interactive elements added; resize behaviour unchanged.

#### Security

- No URL handling introduced.

#### Testing

- Changes are covered with new unit tests (4 new tests).
- Integration test coverage: existing resizable-columns integ tests continue to apply.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.