### PR TITLE
feat: add divider prop to SpaceBetween (AWSUI-49384)

### DIFF
--- a/pages/space-between/divider.page.tsx
+++ b/pages/space-between/divider.page.tsx
@@ -1,0 +1,103 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Box from '~components/box';
+import Container from '~components/container';
+import Header from '~components/header';
+import SpaceBetween from '~components/space-between';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+const Item = ({ label }: { label: string }) => (
+  <Box padding="s" color="inherit">
+    <Box variant="awsui-key-label">{label}</Box>
+    <div>Some content here</div>
+  </Box>
+);
+
+export default function SpaceBetweenDividerPage() {
+  return (
+    <ScreenshotArea disableAnimations={true}>
+      <h1>SpaceBetween — divider</h1>
+
+      <SpaceBetween size="l">
+        <Container header={<Header variant="h2">Vertical + divider (size s)</Header>}>
+          <SpaceBetween size="s" divider={true}>
+            <Item label="Item one" />
+            <Item label="Item two" />
+            <Item label="Item three" />
+          </SpaceBetween>
+        </Container>
+
+        <Container header={<Header variant="h2">Vertical + divider (size m)</Header>}>
+          <SpaceBetween size="m" divider={true}>
+            <Item label="Item one" />
+            <Item label="Item two" />
+            <Item label="Item three" />
+          </SpaceBetween>
+        </Container>
+
+        <Container header={<Header variant="h2">Vertical + divider (size l)</Header>}>
+          <SpaceBetween size="l" divider={true}>
+            <Item label="Item one" />
+            <Item label="Item two" />
+            <Item label="Item three" />
+          </SpaceBetween>
+        </Container>
+
+        <Container header={<Header variant="h2">Horizontal + divider (size s)</Header>}>
+          <SpaceBetween size="s" direction="horizontal" divider={true}>
+            <Item label="Item one" />
+            <Item label="Item two" />
+            <Item label="Item three" />
+          </SpaceBetween>
+        </Container>
+
+        <Container header={<Header variant="h2">Horizontal + divider (size m)</Header>}>
+          <SpaceBetween size="m" direction="horizontal" divider={true}>
+            <Item label="Item one" />
+            <Item label="Item two" />
+            <Item label="Item three" />
+          </SpaceBetween>
+        </Container>
+
+        <Container header={<Header variant="h2">Vertical + divider — single child (no divider rendered)</Header>}>
+          <SpaceBetween size="m" divider={true}>
+            <Item label="Only child" />
+          </SpaceBetween>
+        </Container>
+
+        <Container header={<Header variant="h2">Vertical without divider (baseline)</Header>}>
+          <SpaceBetween size="m">
+            <Item label="Item one" />
+            <Item label="Item two" />
+            <Item label="Item three" />
+          </SpaceBetween>
+        </Container>
+
+        <Container header={<Header variant="h2">Vertical + divider — with null/empty children</Header>}>
+          <SpaceBetween size="m" divider={true}>
+            <Item label="Item one" />
+            {null}
+            <Item label="Item two" />
+            {undefined}
+            <Item label="Item three" />
+          </SpaceBetween>
+        </Container>
+
+        <Container header={<Header variant="h2">Horizontal + divider — alignItems center</Header>}>
+          <SpaceBetween size="m" direction="horizontal" divider={true} alignItems="center">
+            <Box variant="awsui-key-label">Short</Box>
+            <div>
+              <div>Taller</div>
+              <div>content</div>
+              <div>here</div>
+            </div>
+            <Box variant="awsui-key-label">Short</Box>
+          </SpaceBetween>
+        </Container>
+      </SpaceBetween>
+    </ScreenshotArea>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -27429,6 +27429,14 @@ exports[`Components definition for space-between matches the snapshot: space-bet
       "type": "string",
     },
     {
+      "description": "When set to \`true\`, renders a visual divider line between each child element.
+The divider is oriented perpendicular to the layout direction:
+a horizontal line for \`direction="vertical"\` and a vertical line for \`direction="horizontal"\`.",
+      "name": "divider",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
       "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
 use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes). If you must
 use the \`id\` attribute, consider setting it on a parent element instead.",

--- a/src/space-between/__tests__/space-between.test.tsx
+++ b/src/space-between/__tests__/space-between.test.tsx
@@ -106,3 +106,138 @@ describe('native attributes', () => {
     expect(container.firstChild).toHaveClass('additional-class');
   });
 });
+
+describe('divider', () => {
+  it('does not render dividers when divider prop is not set', () => {
+    const { container } = render(
+      <SpaceBetween size="m">
+        <button id="one" />
+        <button id="two" />
+        <button id="three" />
+      </SpaceBetween>
+    );
+    expect(container.querySelectorAll(`.${styles.divider}`)).toHaveLength(0);
+  });
+
+  it('does not render dividers when divider={false}', () => {
+    const { container } = render(
+      <SpaceBetween size="m" divider={false}>
+        <button id="one" />
+        <button id="two" />
+        <button id="three" />
+      </SpaceBetween>
+    );
+    expect(container.querySelectorAll(`.${styles.divider}`)).toHaveLength(0);
+  });
+
+  it('renders N-1 dividers for N children in vertical direction', () => {
+    const { container } = render(
+      <SpaceBetween size="m" direction="vertical" divider={true}>
+        <button id="one" />
+        <button id="two" />
+        <button id="three" />
+      </SpaceBetween>
+    );
+    const dividers = container.querySelectorAll(`.${styles.divider}`);
+    expect(dividers).toHaveLength(2);
+  });
+
+  it('renders N-1 dividers for N children in horizontal direction', () => {
+    const { container } = render(
+      <SpaceBetween size="m" direction="horizontal" divider={true}>
+        <button id="one" />
+        <button id="two" />
+        <button id="three" />
+      </SpaceBetween>
+    );
+    const dividers = container.querySelectorAll(`.${styles.divider}`);
+    expect(dividers).toHaveLength(2);
+  });
+
+  it('renders no dividers for a single child', () => {
+    const { container } = render(
+      <SpaceBetween size="m" divider={true}>
+        <button id="only" />
+      </SpaceBetween>
+    );
+    expect(container.querySelectorAll(`.${styles.divider}`)).toHaveLength(0);
+  });
+
+  it('renders no dividers when there are no children', () => {
+    const { container } = render(<SpaceBetween size="m" divider={true} />);
+    expect(container.querySelectorAll(`.${styles.divider}`)).toHaveLength(0);
+  });
+
+  it('applies divider-vertical class in vertical direction', () => {
+    const { container } = render(
+      <SpaceBetween size="m" direction="vertical" divider={true}>
+        <button />
+        <button />
+      </SpaceBetween>
+    );
+    const dividers = container.querySelectorAll(`.${styles.divider}`);
+    expect(dividers).toHaveLength(1);
+    expect(dividers[0]).toHaveClass(styles['divider-vertical']);
+    expect(dividers[0]).not.toHaveClass(styles['divider-horizontal']);
+  });
+
+  it('applies divider-horizontal class in horizontal direction', () => {
+    const { container } = render(
+      <SpaceBetween size="m" direction="horizontal" divider={true}>
+        <button />
+        <button />
+      </SpaceBetween>
+    );
+    const dividers = container.querySelectorAll(`.${styles.divider}`);
+    expect(dividers).toHaveLength(1);
+    expect(dividers[0]).toHaveClass(styles['divider-horizontal']);
+    expect(dividers[0]).not.toHaveClass(styles['divider-vertical']);
+  });
+
+  it('places dividers between children, not before the first or after the last', () => {
+    const { container } = render(
+      <SpaceBetween size="m" divider={true}>
+        <button id="one" />
+        <button id="two" />
+        <button id="three" />
+      </SpaceBetween>
+    );
+    const root = container.firstChild as HTMLElement;
+    const directChildren = Array.from(root.children);
+
+    // Expected order: child, divider, child, divider, child
+    // Each "child" is wrapped in a div.child; each divider is a div.divider
+    expect(directChildren).toHaveLength(5);
+    expect(directChildren[0]).toHaveClass(styles.child);
+    expect(directChildren[1]).toHaveClass(styles.divider);
+    expect(directChildren[2]).toHaveClass(styles.child);
+    expect(directChildren[3]).toHaveClass(styles.divider);
+    expect(directChildren[4]).toHaveClass(styles.child);
+  });
+
+  it('still renders children content correctly when divider is enabled', () => {
+    const { container } = render(
+      <SpaceBetween size="m" divider={true}>
+        <button id="button-one" />
+        <button id="button-two" />
+      </SpaceBetween>
+    );
+    const wrapper = createWrapper(container).findSpaceBetween()!;
+    const content = wrapper.findAll('button');
+    expect(content).toHaveLength(2);
+    expect(content[0].getElement()).toHaveAttribute('id', 'button-one');
+    expect(content[1].getElement()).toHaveAttribute('id', 'button-two');
+  });
+
+  it('uses default vertical direction when direction is not specified', () => {
+    const { container } = render(
+      <SpaceBetween size="m" divider={true}>
+        <button />
+        <button />
+      </SpaceBetween>
+    );
+    const dividers = container.querySelectorAll(`.${styles.divider}`);
+    expect(dividers).toHaveLength(1);
+    expect(dividers[0]).toHaveClass(styles['divider-vertical']);
+  });
+});

--- a/src/space-between/index.tsx
+++ b/src/space-between/index.tsx
@@ -12,7 +12,7 @@ export { SpaceBetweenProps };
 
 export default function SpaceBetween({ direction = 'vertical', ...props }: SpaceBetweenProps) {
   const baseComponentProps = useBaseComponent('SpaceBetween', {
-    props: { alignItems: props.alignItems, direction, size: props.size },
+    props: { alignItems: props.alignItems, direction, divider: props.divider, size: props.size },
   });
   return <InternalSpaceBetween direction={direction} {...props} {...baseComponentProps} />;
 }

--- a/src/space-between/interfaces.ts
+++ b/src/space-between/interfaces.ts
@@ -28,6 +28,13 @@ export interface SpaceBetweenProps extends BaseComponentProps {
   alignItems?: SpaceBetweenProps.AlignItems;
 
   /**
+   * When set to `true`, renders a visual divider line between each child element.
+   * The divider is oriented perpendicular to the layout direction:
+   * a horizontal line for `direction="vertical"` and a vertical line for `direction="horizontal"`.
+   */
+  divider?: boolean;
+
+  /**
    * Attributes to add to the native element.
    * Some attributes will be automatically combined with internal attribute values:
    * - `className` will be appended.

--- a/src/space-between/internal.tsx
+++ b/src/space-between/internal.tsx
@@ -22,6 +22,7 @@ const InternalSpaceBetween = forwardRef(
       size,
       children,
       alignItems,
+      divider,
       nativeAttributes,
       __internalRootRef,
       ...props
@@ -51,14 +52,16 @@ const InternalSpaceBetween = forwardRef(
         )}
         ref={mergedRef}
       >
-        {flattenedChildren.map(child => {
+        {flattenedChildren.map((child, index) => {
           // If this react child is a primitive value, the key will be undefined
           const key = child && typeof child === 'object' ? (child as Record<'key', unknown>).key : undefined;
+          const isFirst = index === 0;
 
           return (
-            <div key={key ? String(key) : undefined} className={styles.child}>
-              {child}
-            </div>
+            <React.Fragment key={key ? String(key) : index}>
+              {divider && !isFirst && <div className={clsx(styles.divider, styles[`divider-${direction}`])} />}
+              <div className={styles.child}>{child}</div>
+            </React.Fragment>
           );
         })}
       </WithNativeAttributes>

--- a/src/space-between/styles.scss
+++ b/src/space-between/styles.scss
@@ -41,6 +41,25 @@ $sizes-vertical: (
 }
 
 /*
+ * Divider between children
+ */
+
+.divider {
+  /* used in test-utils */
+}
+
+.divider-vertical {
+  border-block-start: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+  inline-size: 100%;
+}
+
+.divider-horizontal {
+  border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+  block-size: auto;
+  align-self: stretch;
+}
+
+/*
  * Horizontal variant
  */
 


### PR DESCRIPTION
## Summary

Implements AWSUI-49384: adds an optional `divider` boolean prop to the `SpaceBetween` component that renders a visual separator line between each child element.

## Changes

### `src/space-between/interfaces.ts`
- Added `divider?: boolean` prop to `SpaceBetweenProps`

### `src/space-between/index.tsx`
- Pass `divider` to `useBaseComponent` analytics tracking

### `src/space-between/internal.tsx`
- Render a `<div className={styles.divider}` between each adjacent pair of children when `divider={true}`
- Divider direction follows the layout direction: `divider-vertical` for `direction="vertical"`, `divider-horizontal` for `direction="horizontal"`
- No divider rendered before the first child or after the last child
- No divider rendered when there is only one child or no children

### `src/space-between/styles.scss`
- Added `.divider`, `.divider-vertical`, and `.divider-horizontal` CSS classes
- Vertical divider: `border-block-start` using `awsui.$border-divider-section-width` and `awsui.$color-border-divider-default` design tokens
- Horizontal divider: `border-inline-start` with `align-self: stretch` so it fills the full height of the flex row

### `pages/space-between/divider.page.tsx` _(new)_
- Dev page showing all combinations: vertical/horizontal directions, multiple sizes, single child, null children, and `alignItems` interaction

### `src/space-between/__tests__/space-between.test.tsx`
- 9 new tests covering: no dividers by default, `divider={false}`, N−1 dividers for N children, single child, no children, correct direction class, DOM ordering (child/divider/child/…), content integrity, and default direction

## Testing
- 17/17 unit tests pass
- ESLint: clean
- Stylelint: clean
- TypeScript: no new errors (1 pre-existing unrelated error in `app-layout`)

## References
- SIM: AWSUI-49384