### PR TITLE
feat: add maxItems prop for BreadcrumbGroup static overflow collapse (AWSUI-54917)

### DIFF
--- a/pages/breadcrumb-group/max-items.page.tsx
+++ b/pages/breadcrumb-group/max-items.page.tsx
@@ -1,0 +1,110 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+
+import Box from '~components/box';
+import BreadcrumbGroup from '~components/breadcrumb-group';
+import SpaceBetween from '~components/space-between';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+const LONG_ITEMS = [
+  { text: 'Home', href: '#home' },
+  { text: 'Service', href: '#service' },
+  { text: 'Region', href: '#region' },
+  { text: 'Resource type', href: '#resource-type' },
+  { text: 'Resource name', href: '#resource-name' },
+];
+
+const SHORT_ITEMS = [
+  { text: 'Home', href: '#home' },
+  { text: 'Resource', href: '#resource' },
+];
+
+export default function BreadcrumbGroupMaxItemsPage() {
+  return (
+    <ScreenshotArea disableAnimations={true}>
+      <Box padding="xl">
+        <SpaceBetween size="xxl">
+          <h1>BreadcrumbGroup — maxItems collapse</h1>
+
+          <section>
+            <h2>maxItems=3 with 5 items (collapses 2 middle items)</h2>
+            <BreadcrumbGroup
+              ariaLabel="Breadcrumbs maxItems=3"
+              expandAriaLabel="Show path"
+              items={LONG_ITEMS}
+              maxItems={3}
+              data-testid="max-items-3"
+            />
+          </section>
+
+          <section>
+            <h2>maxItems=4 with 5 items (collapses 1 middle item)</h2>
+            <BreadcrumbGroup
+              ariaLabel="Breadcrumbs maxItems=4"
+              expandAriaLabel="Show path"
+              items={LONG_ITEMS}
+              maxItems={4}
+              data-testid="max-items-4"
+            />
+          </section>
+
+          <section>
+            <h2>maxItems=2 with 5 items (collapses all middle items — uses AllItemsDropdown)</h2>
+            <BreadcrumbGroup
+              ariaLabel="Breadcrumbs maxItems=2"
+              expandAriaLabel="Show path"
+              items={LONG_ITEMS}
+              maxItems={2}
+              data-testid="max-items-2"
+            />
+          </section>
+
+          <section>
+            <h2>maxItems=5 with 5 items (no collapse — items fit within cap)</h2>
+            <BreadcrumbGroup
+              ariaLabel="Breadcrumbs maxItems=5"
+              expandAriaLabel="Show path"
+              items={LONG_ITEMS}
+              maxItems={5}
+              data-testid="max-items-5-exact"
+            />
+          </section>
+
+          <section>
+            <h2>maxItems=10 with 5 items (no collapse — cap larger than item count)</h2>
+            <BreadcrumbGroup
+              ariaLabel="Breadcrumbs maxItems=10"
+              expandAriaLabel="Show path"
+              items={LONG_ITEMS}
+              maxItems={10}
+              data-testid="max-items-10"
+            />
+          </section>
+
+          <section>
+            <h2>maxItems=3 with 2 items (no collapse — fewer items than cap)</h2>
+            <BreadcrumbGroup
+              ariaLabel="Breadcrumbs short"
+              expandAriaLabel="Show path"
+              items={SHORT_ITEMS}
+              maxItems={3}
+              data-testid="max-items-short"
+            />
+          </section>
+
+          <section>
+            <h2>No maxItems (responsive collapse only — default behaviour)</h2>
+            <BreadcrumbGroup
+              ariaLabel="Breadcrumbs default"
+              expandAriaLabel="Show path"
+              items={LONG_ITEMS}
+              data-testid="max-items-none"
+            />
+          </section>
+        </SpaceBetween>
+      </Box>
+    </ScreenshotArea>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -5430,6 +5430,18 @@ not a link.",
       "optional": false,
       "type": "ReadonlyArray<T>",
     },
+    {
+      "description": "The maximum number of breadcrumb items to display before collapsing middle items into an
+overflow ellipsis. The first and last items are always visible. When the total number of
+items exceeds \`maxItems\`, middle items are hidden and can be revealed by activating the
+ellipsis control.
+
+Must be a positive integer ≥ 2. When omitted (default), no static item limit is applied
+and only the responsive (container-width-based) collapse is used.",
+      "name": "maxItems",
+      "optional": true,
+      "type": "number",
+    },
   ],
   "regions": [],
   "releaseStatus": "stable",

--- a/src/breadcrumb-group/__tests__/analytics-metadata.test.tsx
+++ b/src/breadcrumb-group/__tests__/analytics-metadata.test.tsx
@@ -24,6 +24,7 @@ jest.mock('../../../lib/components/breadcrumb-group/utils', () => ({
     minWidths: [100, 100, 100, 100],
     collapsed: 0,
   }),
+  getMaxItemsCollapsed: jest.fn().mockReturnValue(0),
 }));
 
 const labels = { ...ownLabels, ...buttonDropdownLabels };

--- a/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
@@ -339,3 +339,112 @@ describe('BreadcrumbGroup Component', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// maxItems — static overflow collapse (AWSUI-54917)
+// ---------------------------------------------------------------------------
+describe('maxItems prop', () => {
+  const fiveItems: BreadcrumbGroupProps.Item[] = [
+    { text: 'Home', href: '/home' },
+    { text: 'Service', href: '/service' },
+    { text: 'Region', href: '/region' },
+    { text: 'Resource type', href: '/resource-type' },
+    { text: 'Resource name', href: '/resource-name' },
+  ];
+
+  test('collapses middle items when maxItems < total items', () => {
+    // maxItems=3 → first + last always visible; 2 middle items hidden
+    const wrapper = renderBreadcrumbGroup({ items: fiveItems, maxItems: 3 });
+    // The ellipsis dropdown must be present and visible
+    expect(wrapper.findDropdown()).not.toBeNull();
+    // Collapsed items appear in the dropdown menu
+    const dropdown = wrapper.findDropdown()!;
+    dropdown.openDropdown();
+    // 2 items collapsed (Service, Region)
+    expect(dropdown.findItems()).toHaveLength(2);
+    expect(dropdown.findItems()[0].getElement()).toHaveTextContent('Service');
+    expect(dropdown.findItems()[1].getElement()).toHaveTextContent('Region');
+  });
+
+  test('first and last items are always visible when maxItems collapses middle', () => {
+    const wrapper = renderBreadcrumbGroup({ items: fiveItems, maxItems: 3 });
+    const links = wrapper.findBreadcrumbLinks();
+    // findBreadcrumbLinks returns all .breadcrumb .anchor elements — first and last must be there
+    expect(links[0].getElement()).toHaveTextContent('Home');
+    expect(links[links.length - 1].getElement()).toHaveTextContent('Resource name');
+  });
+
+  test('does not collapse when maxItems equals total items', () => {
+    const wrapper = renderBreadcrumbGroup({ items: fiveItems, maxItems: 5 });
+    const dropdown = wrapper.findDropdown()!;
+    dropdown.openDropdown();
+    // no items in the dropdown (ellipsis is hidden / no collapsed items)
+    expect(dropdown.findItems()).toHaveLength(0);
+  });
+
+  test('does not collapse when maxItems is greater than total items', () => {
+    const wrapper = renderBreadcrumbGroup({ items: fiveItems, maxItems: 10 });
+    const dropdown = wrapper.findDropdown()!;
+    dropdown.openDropdown();
+    expect(dropdown.findItems()).toHaveLength(0);
+  });
+
+  test('does not collapse when maxItems is undefined (default behaviour)', () => {
+    // With mock width=9999 nothing should collapse
+    const wrapper = renderBreadcrumbGroup({ items: fiveItems });
+    const dropdown = wrapper.findDropdown()!;
+    dropdown.openDropdown();
+    expect(dropdown.findItems()).toHaveLength(0);
+  });
+
+  test('collapses all middle items when maxItems=2', () => {
+    // 5 items, maxItems=2 → collapsed = 3 (all middles); collapsed === items.length - 1 → AllItemsDropdown
+    const wrapper = renderBreadcrumbGroup({ items: fiveItems, maxItems: 2 });
+    // AllItemsDropdown is rendered instead of the normal list — verify the collapsed-button trigger
+    expect(wrapper.getElement().querySelector('button')).not.toBeNull();
+  });
+
+  test('ellipsis button has the expandAriaLabel when maxItems collapses items', () => {
+    const wrapper = renderBreadcrumbGroup({
+      items: fiveItems,
+      maxItems: 3,
+      expandAriaLabel: 'Expand breadcrumbs',
+    });
+    const nativeButton = wrapper.findDropdown()?.findNativeButton();
+    expect(nativeButton?.getElement()).toHaveAttribute('aria-label', 'Expand breadcrumbs');
+  });
+
+  test('clicking a collapsed item fires onClick with the correct item', () => {
+    const handleClick = jest.fn();
+    const wrapper = renderBreadcrumbGroup({
+      items: fiveItems,
+      maxItems: 3,
+      onClick: event => {
+        event.preventDefault();
+        handleClick(event.detail.item);
+      },
+    });
+    const dropdown = wrapper.findDropdown()!;
+    dropdown.openDropdown();
+    // Click "Service" (first collapsed item)
+    dropdown.findItems()[0].click();
+    expect(handleClick).toHaveBeenCalledWith(fiveItems[1]);
+  });
+
+  test('works correctly with exactly 2 items (no collapse possible)', () => {
+    const twoItems = fiveItems.slice(0, 2);
+    const wrapper = renderBreadcrumbGroup({ items: twoItems, maxItems: 2 });
+    // With only 2 items and maxItems=2 there is nothing to collapse
+    const dropdown = wrapper.findDropdown()!;
+    dropdown.openDropdown();
+    expect(dropdown.findItems()).toHaveLength(0);
+  });
+
+  test('maxItems=4 with 5 items collapses exactly 1 middle item', () => {
+    const wrapper = renderBreadcrumbGroup({ items: fiveItems, maxItems: 4 });
+    const dropdown = wrapper.findDropdown()!;
+    dropdown.openDropdown();
+    expect(dropdown.findItems()).toHaveLength(1);
+    expect(dropdown.findItems()[0].getElement()).toHaveTextContent('Service');
+  });
+});

--- a/src/breadcrumb-group/__tests__/utils.test.ts
+++ b/src/breadcrumb-group/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { getItemsDisplayProperties } from '../utils';
+import { getItemsDisplayProperties, getMaxItemsCollapsed } from '../utils';
 
 describe('getItemsDisplayProperties', () => {
   test('does not break with zero items', () => {
@@ -63,5 +63,87 @@ describe('getItemsDisplayProperties', () => {
   ])('returns correct number of collapsed items (width: %d, collapsed: %d)', (navWidth, expectedCollapsed) => {
     const itemsWidths = [20, 300, 500, 50, 150, 1000];
     expect(getItemsDisplayProperties(itemsWidths, navWidth).collapsed).toEqual(expectedCollapsed);
+  });
+});
+
+describe('getMaxItemsCollapsed', () => {
+  describe('returns 0 when maxItems is not a meaningful constraint', () => {
+    test('maxItems undefined', () => {
+      expect(getMaxItemsCollapsed(5, undefined)).toBe(0);
+    });
+
+    test('maxItems less than 2', () => {
+      expect(getMaxItemsCollapsed(5, 1)).toBe(0);
+      expect(getMaxItemsCollapsed(5, 0)).toBe(0);
+      expect(getMaxItemsCollapsed(5, -1)).toBe(0);
+    });
+
+    test('maxItems equals total items — no collapse needed', () => {
+      expect(getMaxItemsCollapsed(5, 5)).toBe(0);
+    });
+
+    test('maxItems greater than total items — no collapse needed', () => {
+      expect(getMaxItemsCollapsed(5, 10)).toBe(0);
+      expect(getMaxItemsCollapsed(5, 6)).toBe(0);
+    });
+
+    test('zero items', () => {
+      expect(getMaxItemsCollapsed(0, 3)).toBe(0);
+    });
+
+    test('one item', () => {
+      expect(getMaxItemsCollapsed(1, 3)).toBe(0);
+    });
+
+    test('two items with maxItems=2 — no collapse', () => {
+      expect(getMaxItemsCollapsed(2, 2)).toBe(0);
+    });
+  });
+
+  describe('returns the correct number of collapsed items', () => {
+    test('5 items, maxItems=4 → collapse 1 middle item', () => {
+      expect(getMaxItemsCollapsed(5, 4)).toBe(1);
+    });
+
+    test('5 items, maxItems=3 → collapse 2 middle items', () => {
+      expect(getMaxItemsCollapsed(5, 3)).toBe(2);
+    });
+
+    test('5 items, maxItems=2 → collapse 3 middle items (max: all middles)', () => {
+      expect(getMaxItemsCollapsed(5, 2)).toBe(3);
+    });
+
+    test('6 items, maxItems=4 → collapse 2 middle items', () => {
+      expect(getMaxItemsCollapsed(6, 4)).toBe(2);
+    });
+
+    test('6 items, maxItems=2 → collapse 4 middle items (all middles)', () => {
+      expect(getMaxItemsCollapsed(6, 2)).toBe(4);
+    });
+
+    test('2 items, maxItems=2 → no collapse (only first and last)', () => {
+      expect(getMaxItemsCollapsed(2, 2)).toBe(0);
+    });
+
+    test('3 items, maxItems=2 → collapse 1 middle item', () => {
+      expect(getMaxItemsCollapsed(3, 2)).toBe(1);
+    });
+
+    test('fractional maxItems is floored', () => {
+      // maxItems=3.9 → floor → 3; 5 items → collapse 2
+      expect(getMaxItemsCollapsed(5, 3.9)).toBe(2);
+    });
+  });
+
+  describe('never collapses first or last item', () => {
+    test('maxItems=2 with many items collapses only middle items', () => {
+      // 10 items, maxItems=2 → keep first (0) and last (9), collapse 8 middles
+      expect(getMaxItemsCollapsed(10, 2)).toBe(8);
+    });
+
+    test('collapse count never exceeds totalItems - 2', () => {
+      // Even if maxItems=1 (invalid, returns 0), we verify the guard
+      expect(getMaxItemsCollapsed(5, 1)).toBe(0);
+    });
   });
 });

--- a/src/breadcrumb-group/implementation.tsx
+++ b/src/breadcrumb-group/implementation.tsx
@@ -30,7 +30,7 @@ import { BreadcrumbGroupProps, EllipsisDropdownProps } from './interfaces';
 import { InternalBreadcrumbGroupProps } from './internal-interfaces';
 import { BreadcrumbItem } from './item/item';
 import { BreadcrumbGroupSkeleton } from './skeleton';
-import { getEventDetail, getItemsDisplayProperties } from './utils';
+import { getEventDetail, getItemsDisplayProperties, getMaxItemsCollapsed } from './utils';
 
 import analyticsSelectors from './analytics-metadata/styles.css.js';
 import styles from './styles.css.js';
@@ -116,6 +116,7 @@ export function BreadcrumbGroupImplementation<T extends BreadcrumbGroupProps.Ite
   items = [],
   ariaLabel,
   expandAriaLabel,
+  maxItems,
   onClick,
   onFollow,
   __internalRootRef,
@@ -164,7 +165,12 @@ export function BreadcrumbGroupImplementation<T extends BreadcrumbGroupProps.Ite
     }
   }, [items, navWidth]);
 
-  const { collapsed } = getItemsDisplayProperties(itemsWidths.ghost, navWidth);
+  const { collapsed: responsiveCollapsed } = getItemsDisplayProperties(itemsWidths.ghost, navWidth);
+
+  // Static collapse from maxItems prop — takes the maximum of the two collapse counts so that
+  // both constraints are respected simultaneously.
+  const maxItemsCollapsed = getMaxItemsCollapsed(items.length, maxItems);
+  const collapsed = Math.max(responsiveCollapsed, maxItemsCollapsed);
 
   let breadcrumbItems = items.map((item, index) => {
     const isLast = index === items.length - 1;

--- a/src/breadcrumb-group/interfaces.ts
+++ b/src/breadcrumb-group/interfaces.ts
@@ -29,6 +29,18 @@ export interface BreadcrumbGroupProps<T extends BreadcrumbGroupProps.Item = Brea
    * @i18n
    */
   expandAriaLabel?: string;
+
+  /**
+   * The maximum number of breadcrumb items to display before collapsing middle items into an
+   * overflow ellipsis. The first and last items are always visible. When the total number of
+   * items exceeds `maxItems`, middle items are hidden and can be revealed by activating the
+   * ellipsis control.
+   *
+   * Must be a positive integer ≥ 2. When omitted (default), no static item limit is applied
+   * and only the responsive (container-width-based) collapse is used.
+   */
+  maxItems?: number;
+
   /**
    * Called when the user clicks on a breadcrumb item. Do not use this handler for navigation, use the `onFollow` event instead.
    */

--- a/src/breadcrumb-group/utils.ts
+++ b/src/breadcrumb-group/utils.ts
@@ -41,3 +41,27 @@ const computeNumberOfCollapsedItems = (itemWidths: Array<number>, navWidth: numb
   }
   return collapsedItems;
 };
+
+/**
+ * Compute the number of middle items to hide when `maxItems` is set.
+ *
+ * Rules:
+ * - The first item (index 0) is always visible.
+ * - The last item (index n-1) is always visible.
+ * - When `totalItems <= maxItems` nothing is hidden.
+ * - Otherwise `totalItems - maxItems` middle items (starting from index 1) are collapsed.
+ *
+ * Returns 0 when `maxItems` is undefined, not a finite number, or less than 2.
+ */
+export const getMaxItemsCollapsed = (totalItems: number, maxItems: number | undefined): number => {
+  if (maxItems === undefined || !Number.isFinite(maxItems) || maxItems < 2) {
+    return 0;
+  }
+  const cap = Math.floor(maxItems);
+  if (totalItems <= cap) {
+    return 0;
+  }
+  // We always keep the first and last item visible, so we can collapse at most totalItems - 2
+  // middle items.  The number of items to collapse is the excess beyond the cap.
+  return Math.min(totalItems - cap, totalItems - 2);
+};


### PR DESCRIPTION
## Summary

Implements the `maxItems` prop for `BreadcrumbGroup` as requested in AWSUI-54917.

When the total number of items exceeds `maxItems`, middle items are collapsed into the existing ellipsis/dropdown affordance. The first and last items are always visible.

The static `maxItems` collapse is applied on top of (not instead of) the existing responsive width-based collapse — both constraints are respected simultaneously (`collapsed = Math.max(responsiveCollapsed, maxItemsCollapsed)`).

## Changes

| File | Change |
|------|--------|
| `src/breadcrumb-group/interfaces.ts` | Add `maxItems?: number` prop with JSDoc |
| `src/breadcrumb-group/utils.ts` | Add `getMaxItemsCollapsed()` pure helper |
| `src/breadcrumb-group/implementation.tsx` | Apply `maxItems` collapse in render |
| `src/breadcrumb-group/__tests__/utils.test.ts` | Unit tests for `getMaxItemsCollapsed` |
| `src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx` | Component tests for `maxItems` |
| `src/breadcrumb-group/__tests__/analytics-metadata.test.tsx` | Update utils mock |
| `pages/breadcrumb-group/max-items.page.tsx` | Dev page for visual testing |

## Behaviour

- `maxItems` must be a positive integer ≥ 2; values < 2 are ignored (treated as undefined)
- When `totalItems <= maxItems`: no additional collapse
- When `totalItems > maxItems`: `totalItems - maxItems` middle items are hidden
- `maxItems=2` with many items: all middle items collapse → triggers `AllItemsDropdown` (same as full responsive collapse)
- Fractional values are floored

## Keyboard / A11y

Uses the existing `InternalButtonDropdown` ellipsis affordance which already provides:
- Full keyboard navigation (arrow keys, Enter, Escape)
- `aria-expanded` / `aria-haspopup` on the trigger
- i18n-aware `expandAriaLabel` prop

## Tests

```
Test Suites: 5 passed, 5 total
Tests:       95 passed, 95 total
```

Refs: AWSUI-54917