### PR TITLE
feat: add rowActions prop for per-row actions menu (AWSUI-53401)

### DIFF
--- a/pages/table/row-actions.page.tsx
+++ b/pages/table/row-actions.page.tsx
@@ -1,0 +1,112 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Box from '~components/box';
+import ButtonDropdown from '~components/button-dropdown';
+import Header from '~components/header';
+import SpaceBetween from '~components/space-between';
+import Table, { TableProps } from '~components/table';
+
+import ScreenshotArea from '../utils/screenshot-area';
+import { generateItems, Instance } from './generate-data';
+import { columnsConfig, selectionLabels } from './shared-configs';
+
+const items = generateItems(8);
+
+const simpleColumns = [columnsConfig[0], columnsConfig[1], columnsConfig[3]];
+
+export default function TableRowActionsPage() {
+  const [lastAction, setLastAction] = useState<string | null>(null);
+
+  const rowActionsConfig: TableProps.RowActionsConfig<Instance> = {
+    items: item => [
+      { id: 'view', text: 'View details' },
+      { id: 'connect', text: 'Connect', disabled: item.state !== 'RUNNING' },
+      { id: 'stop', text: 'Stop', disabled: item.state !== 'RUNNING' },
+      { id: 'terminate', text: 'Terminate', variant: 'warning' as any },
+    ],
+    onItemClick: (detail, item) => {
+      setLastAction(`${detail.id} on ${item.id}`);
+    },
+    ariaLabel: item => `Actions for ${item.id}`,
+  };
+
+  const rowActionsWithDisable: TableProps.RowActionsConfig<Instance> = {
+    items: () => [
+      { id: 'start', text: 'Start' },
+      { id: 'stop', text: 'Stop' },
+    ],
+    onItemClick: (detail, item) => {
+      setLastAction(`${detail.id} on ${item.id}`);
+    },
+    disabled: item => item.state === 'TERMINATED',
+    ariaLabel: item => `Actions for ${item.id}`,
+  };
+
+  return (
+    <Box padding="m">
+      <h1>Table with row-level actions menu (rowActions prop)</h1>
+
+      {lastAction && (
+        <Box margin={{ bottom: 'm' }}>
+          <strong data-testid="last-action">Last action: {lastAction}</strong>
+        </Box>
+      )}
+
+      <ScreenshotArea>
+        <SpaceBetween size="xl">
+          {/* Basic usage */}
+          <Table
+            data-testid="table-row-actions-basic"
+            ariaLabels={selectionLabels}
+            header={<Header>Table with row actions (basic)</Header>}
+            columnDefinitions={simpleColumns}
+            items={items}
+            rowActions={rowActionsConfig}
+          />
+
+          {/* With selection */}
+          <Table
+            data-testid="table-row-actions-with-selection"
+            ariaLabels={selectionLabels}
+            header={
+              <Header
+                actions={
+                  <ButtonDropdown items={[{ id: 'bulk-delete', text: 'Delete selected' }]}>Actions</ButtonDropdown>
+                }
+              >
+                Table with row actions + selection
+              </Header>
+            }
+            columnDefinitions={simpleColumns}
+            items={items}
+            selectionType="multi"
+            rowActions={rowActionsConfig}
+          />
+
+          {/* With disabled trigger per row */}
+          <Table
+            data-testid="table-row-actions-disabled"
+            ariaLabels={selectionLabels}
+            header={<Header>Table with row actions (disabled for terminated instances)</Header>}
+            columnDefinitions={simpleColumns}
+            items={items}
+            rowActions={rowActionsWithDisable}
+          />
+
+          {/* With sticky last column */}
+          <Table
+            data-testid="table-row-actions-sticky"
+            ariaLabels={selectionLabels}
+            header={<Header>Table with row actions (sticky last column)</Header>}
+            columnDefinitions={[...columnsConfig]}
+            items={items}
+            rowActions={rowActionsConfig}
+            stickyColumns={{ last: 1 }}
+          />
+        </SpaceBetween>
+      </ScreenshotArea>
+    </Box>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -28940,6 +28940,90 @@ the table items array is empty.",
       "type": "boolean",
     },
     {
+      "description": "Configures a per-row actions menu (kebab / inline-icon ButtonDropdown) rendered as the last column.
+* \`items\` ((item: T) => ButtonDropdownProps.ItemOrGroup[]) - Returns the dropdown items for the given row.
+* \`onItemClick\` ((detail: ButtonDropdownProps.ItemClickDetails, item: T) => void) - Called when the user clicks an item.
+* \`ariaLabel\` ((item: T) => string) - Provides an accessible label for the trigger button of each row. Defaults to "Actions".
+* \`disabled\` ((item: T) => boolean) - Disables the actions menu trigger for a given row.",
+      "inlineType": {
+        "name": "TableProps.RowActionsConfig<T>",
+        "properties": [
+          {
+            "inlineType": {
+              "name": "(item: T) => string",
+              "parameters": [
+                {
+                  "name": "item",
+                  "type": "T",
+                },
+              ],
+              "returnType": "string",
+              "type": "function",
+            },
+            "name": "ariaLabel",
+            "optional": true,
+            "type": "((item: T) => string)",
+          },
+          {
+            "inlineType": {
+              "name": "(item: T) => boolean",
+              "parameters": [
+                {
+                  "name": "item",
+                  "type": "T",
+                },
+              ],
+              "returnType": "boolean",
+              "type": "function",
+            },
+            "name": "disabled",
+            "optional": true,
+            "type": "((item: T) => boolean)",
+          },
+          {
+            "inlineType": {
+              "name": "(item: T) => ReadonlyArray<ButtonDropdownProps.ItemOrGroup>",
+              "parameters": [
+                {
+                  "name": "item",
+                  "type": "T",
+                },
+              ],
+              "returnType": "ReadonlyArray<ButtonDropdownProps.ItemOrGroup>",
+              "type": "function",
+            },
+            "name": "items",
+            "optional": false,
+            "type": "(item: T) => ReadonlyArray<ButtonDropdownProps.ItemOrGroup>",
+          },
+          {
+            "inlineType": {
+              "name": "(detail: ButtonDropdownProps.ItemClickDetails, item: T) => void",
+              "parameters": [
+                {
+                  "name": "detail",
+                  "type": "ButtonDropdownProps.ItemClickDetails",
+                },
+                {
+                  "name": "item",
+                  "type": "T",
+                },
+              ],
+              "returnType": "void",
+              "type": "function",
+            },
+            "name": "onItemClick",
+            "optional": false,
+            "type": "(detail: ButtonDropdownProps.ItemClickDetails, item: T) => void",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "rowActions",
+      "optional": true,
+      "type": "TableProps.RowActionsConfig<T>",
+    },
+    {
       "defaultValue": "[]",
       "description": "List of selected items.",
       "name": "selectedItems",

--- a/src/table/__tests__/row-actions.test.tsx
+++ b/src/table/__tests__/row-actions.test.tsx
@@ -1,0 +1,203 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import Table, { TableProps } from '../../../lib/components/table';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+interface Item {
+  id: number;
+  name: string;
+  active: boolean;
+}
+
+const columnDefinitions: TableProps.ColumnDefinition<Item>[] = [
+  { id: 'id', header: 'ID', cell: item => item.id },
+  { id: 'name', header: 'Name', cell: item => item.name },
+];
+
+const items: Item[] = [
+  { id: 1, name: 'Alpha', active: true },
+  { id: 2, name: 'Beta', active: false },
+  { id: 3, name: 'Gamma', active: true },
+];
+
+function buildRowActions(
+  onItemClick: jest.Mock,
+  overrides?: Partial<TableProps.RowActionsConfig<Item>>
+): TableProps.RowActionsConfig<Item> {
+  return {
+    items: () => [
+      { id: 'edit', text: 'Edit' },
+      { id: 'delete', text: 'Delete' },
+    ],
+    onItemClick,
+    ...overrides,
+  };
+}
+
+function renderTable(props: Partial<TableProps<Item>> = {}) {
+  const { container } = render(
+    <Table items={items} columnDefinitions={columnDefinitions} ariaLabels={{ tableLabel: 'Test table' }} {...props} />
+  );
+  return createWrapper(container).findTable()!;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Rendering
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('Table rowActions', () => {
+  describe('rendering', () => {
+    it('renders no extra column when rowActions is not provided', () => {
+      const wrapper = renderTable();
+      // 2 defined columns → 2 header cells
+      expect(wrapper.findColumnHeaders()).toHaveLength(2);
+    });
+
+    it('renders an extra column header when rowActions is provided', () => {
+      const wrapper = renderTable({ rowActions: buildRowActions(jest.fn()) });
+      // 2 defined columns + 1 actions column
+      expect(wrapper.findColumnHeaders()).toHaveLength(3);
+    });
+
+    it('renders one actions button per data row', () => {
+      const wrapper = renderTable({ rowActions: buildRowActions(jest.fn()) });
+      const rows = wrapper.findRows();
+      expect(rows).toHaveLength(items.length);
+      rows.forEach(row => {
+        const buttons = row.findAll('button');
+        expect(buttons.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('uses the default aria-label "Actions" when ariaLabel is not specified', () => {
+      renderTable({ rowActions: buildRowActions(jest.fn()) });
+      const actionButtons = screen.getAllByRole('button', { name: 'Actions' });
+      expect(actionButtons).toHaveLength(items.length);
+    });
+
+    it('uses a custom aria-label when ariaLabel is specified', () => {
+      renderTable({
+        rowActions: buildRowActions(jest.fn(), {
+          ariaLabel: item => `Actions for ${item.name}`,
+        }),
+      });
+      expect(screen.getByRole('button', { name: 'Actions for Alpha' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Actions for Beta' })).toBeInTheDocument();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Interaction
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('interaction', () => {
+    it('calls onItemClick with the correct detail and item when an action is clicked', () => {
+      const onItemClick = jest.fn();
+      renderTable({ rowActions: buildRowActions(onItemClick) });
+
+      // Open the dropdown for the first row
+      const [firstRowButton] = screen.getAllByRole('button', { name: 'Actions' });
+      act(() => {
+        fireEvent.click(firstRowButton);
+      });
+
+      // Click "Edit"
+      const editOption = screen.getByRole('menuitem', { name: 'Edit' });
+      act(() => {
+        fireEvent.click(editOption);
+      });
+
+      expect(onItemClick).toHaveBeenCalledTimes(1);
+      const [detail, item] = onItemClick.mock.calls[0];
+      expect(detail.id).toBe('edit');
+      expect(item).toEqual(items[0]);
+    });
+
+    it('calls onItemClick with the item corresponding to the clicked row', () => {
+      const onItemClick = jest.fn();
+      renderTable({ rowActions: buildRowActions(onItemClick) });
+
+      // Open the dropdown for the SECOND row
+      const actionButtons = screen.getAllByRole('button', { name: 'Actions' });
+      act(() => {
+        fireEvent.click(actionButtons[1]);
+      });
+
+      const deleteOption = screen.getByRole('menuitem', { name: 'Delete' });
+      act(() => {
+        fireEvent.click(deleteOption);
+      });
+
+      expect(onItemClick).toHaveBeenCalledTimes(1);
+      const [detail, item] = onItemClick.mock.calls[0];
+      expect(detail.id).toBe('delete');
+      expect(item).toEqual(items[1]);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Disabled state
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('disabled', () => {
+    it('disables the trigger button for rows where disabled() returns true', () => {
+      renderTable({
+        rowActions: buildRowActions(jest.fn(), {
+          disabled: item => !item.active,
+        }),
+      });
+
+      const actionButtons = screen.getAllByRole('button', { name: 'Actions' });
+      // items[0] active=true → enabled
+      expect(actionButtons[0]).not.toBeDisabled();
+      // items[1] active=false → disabled
+      expect(actionButtons[1]).toBeDisabled();
+      // items[2] active=true → enabled
+      expect(actionButtons[2]).not.toBeDisabled();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Empty items list
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('empty items list', () => {
+    it('disables the trigger when items() returns an empty array', () => {
+      renderTable({
+        rowActions: buildRowActions(jest.fn(), {
+          items: () => [],
+        }),
+      });
+
+      const actionButtons = screen.getAllByRole('button', { name: 'Actions' });
+      actionButtons.forEach(btn => expect(btn).toBeDisabled());
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Column count with selection
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('column count with selectionType', () => {
+    it('renders data columns + actions column header alongside selection', () => {
+      const wrapper = renderTable({
+        rowActions: buildRowActions(jest.fn()),
+        selectionType: 'multi',
+      });
+      // selection(1) + 2 data columns + 1 actions column = 4 header cells
+      expect(wrapper.findColumnHeaders()).toHaveLength(4);
+    });
+
+    it('renders actions buttons for every row even with multi selection', () => {
+      renderTable({
+        rowActions: buildRowActions(jest.fn()),
+        selectionType: 'multi',
+      });
+      const actionButtons = screen.getAllByRole('button', { name: 'Actions' });
+      expect(actionButtons).toHaveLength(items.length);
+    });
+  });
+});

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import { ButtonDropdownProps } from '../button-dropdown/interfaces';
 import { BaseComponentProps } from '../types/base-component';
 import { CancelableEventHandler, NonCancelableEventHandler } from '../types/events';
 import { Optional } from '../types/utils';
@@ -462,6 +463,14 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * Renders loader counter that is appended to the loader content in all loader states.
    */
   renderLoaderCounter?: (detail: TableProps.RenderLoaderCounterDetail<T>) => React.ReactNode;
+  /**
+   * Configures a per-row actions menu (kebab / inline-icon ButtonDropdown) rendered as the last column.
+   * * `items` ((item: T) => ButtonDropdownProps.ItemOrGroup[]) - Returns the dropdown items for the given row.
+   * * `onItemClick` ((detail: ButtonDropdownProps.ItemClickDetails, item: T) => void) - Called when the user clicks an item.
+   * * `ariaLabel` ((item: T) => string) - Provides an accessible label for the trigger button of each row. Defaults to "Actions".
+   * * `disabled` ((item: T) => boolean) - Disables the actions menu trigger for a given row.
+   */
+  rowActions?: TableProps.RowActionsConfig<T>;
 }
 
 export namespace TableProps {
@@ -539,6 +548,13 @@ export namespace TableProps {
     hasDynamicContent?: boolean;
     cell(item: T): React.ReactNode;
   } & SortingColumn<T>;
+
+  export interface RowActionsConfig<T> {
+    items: (item: T) => ReadonlyArray<ButtonDropdownProps.ItemOrGroup>;
+    onItemClick: (detail: ButtonDropdownProps.ItemClickDetails, item: T) => void;
+    ariaLabel?: (item: T) => string;
+    disabled?: (item: T) => boolean;
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export interface GroupDefinition<T = any> {

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -47,6 +47,7 @@ import { getLoaderContent } from './progressive-loading/items-loader';
 import { TableLoaderCell } from './progressive-loading/loader-cell';
 import { useProgressiveLoadingProps } from './progressive-loading/progressive-loading-utils';
 import { ResizeTracker } from './resizer';
+import { rowActionsColumnId, TableRowActionsCell } from './row-actions';
 import { focusMarkers, useSelection, useSelectionFocusMove } from './selection';
 import { TableBodySelectionCell } from './selection/selection-cell';
 import { useGroupSelection } from './selection/use-group-selection';
@@ -76,6 +77,7 @@ import styles from './styles.css.js';
 
 const GRID_NAVIGATION_PAGE_SIZE = 10;
 const SELECTION_COLUMN_WIDTH = 54;
+const ROW_ACTIONS_COLUMN_WIDTH = 54;
 const selectionColumnId = Symbol('selection-column-id');
 
 type InternalTableProps<T> = SomeRequired<
@@ -152,6 +154,7 @@ const InternalTable = React.forwardRef(
       renderLoaderEmpty,
       renderLoaderCounter,
       cellVerticalAlign,
+      rowActions,
       __funnelSubStepProps,
       ...rest
     }: InternalTableProps<T>,
@@ -385,13 +388,17 @@ const InternalTable = React.forwardRef(
         widths.push({ ...visibleColumnDefinitions[columnIndex], id: columnId });
         ids.push(columnId);
       }
+      if (rowActions) {
+        widths.push({ id: rowActionsColumnId, width: ROW_ACTIONS_COLUMN_WIDTH });
+        ids.push(rowActionsColumnId);
+      }
       return { visibleColumnWidthsWithSelection: widths, visibleColumnIdsWithSelection: ids };
-    }, [hasSelection, visibleColumnDefinitions]);
+    }, [hasSelection, visibleColumnDefinitions, rowActions]);
 
     const stickyState = useStickyColumns({
       visibleColumns: visibleColumnIdsWithSelection,
       stickyColumnsFirst: (stickyColumns?.first ?? 0) + (stickyColumns?.first && hasSelection ? 1 : 0),
-      stickyColumnsLast: stickyColumns?.last || 0,
+      stickyColumnsLast: (stickyColumns?.last || 0) + (rowActions ? 1 : 0),
     });
 
     const hasStickyColumns = !!((stickyColumns?.first ?? 0) + (stickyColumns?.last ?? 0) > 0);
@@ -437,11 +444,12 @@ const InternalTable = React.forwardRef(
       stripedRows,
       stickyState,
       stickyColumnsFirst: stickyColumns?.first ?? 0,
-      stickyColumnsLast: stickyColumns?.last ?? 0,
+      stickyColumnsLast: (stickyColumns?.last ?? 0) + (rowActions ? 1 : 0),
       selectionColumnId,
       tableRole,
       isExpandable,
       setLastUserAction,
+      rowActions,
     };
 
     usePreventStickyClickScroll(wrapperRefObject);
@@ -471,7 +479,7 @@ const InternalTable = React.forwardRef(
     const toolsHeaderWrapper = useMergeRefs(toolsHeaderPerformanceMarkRef, toolsHeaderWrapperMeasureRef);
 
     const colIndexOffset = selectionType ? 1 : 0;
-    const totalColumnsCount = visibleColumnDefinitions.length + colIndexOffset;
+    const totalColumnsCount = visibleColumnDefinitions.length + colIndexOffset + (rowActions ? 1 : 0);
     const headerRowCount = columnGroupsLayout?.rows.length || 1;
 
     return (
@@ -764,6 +772,18 @@ const InternalTable = React.forwardRef(
                                     />
                                   );
                                 })}
+
+                                {rowActions && row.type === 'data' && (
+                                  <TableRowActionsCell
+                                    item={row.item}
+                                    rowActions={rowActions}
+                                    {...sharedCellProps}
+                                    columnId={rowActionsColumnId}
+                                    colIndex={visibleColumnDefinitions.length + colIndexOffset}
+                                    verticalAlign={cellVerticalAlign}
+                                    tableVariant={computedVariant}
+                                  />
+                                )}
                               </tr>
                             );
                           }

--- a/src/table/row-actions/index.tsx
+++ b/src/table/row-actions/index.tsx
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import InternalButtonDropdown from '../../button-dropdown/internal';
+import { TableTdElement, TableTdElementProps } from '../body-cell/td-element';
+import { TableProps } from '../interfaces';
+
+// Symbol used as the column ID for the row-actions column (avoids string collisions).
+export const rowActionsColumnId = Symbol('row-actions-column-id');
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Body cell
+// ──────────────────────────────────────────────────────────────────────────────
+
+interface TableRowActionsBodyCellProps<T>
+  extends Omit<TableTdElementProps, 'children' | 'colIndex' | 'wrapLines' | 'isEditable' | 'isEditing'> {
+  item: T;
+  rowActions: TableProps.RowActionsConfig<T>;
+  colIndex: number;
+}
+
+export function TableRowActionsCell<T>({ item, rowActions, colIndex, ...tdProps }: TableRowActionsBodyCellProps<T>) {
+  const { items, onItemClick, ariaLabel, disabled } = rowActions;
+  const dropdownItems = items(item);
+  const triggerAriaLabel = ariaLabel ? ariaLabel(item) : 'Actions';
+  const isDisabled = disabled ? disabled(item) : false;
+
+  return (
+    <TableTdElement {...tdProps} colIndex={colIndex} wrapLines={false} isEditable={false} isEditing={false}>
+      <InternalButtonDropdown
+        variant="inline-icon"
+        iconName="ellipsis"
+        ariaLabel={triggerAriaLabel}
+        items={dropdownItems}
+        disabled={isDisabled || dropdownItems.length === 0}
+        expandToViewport={true}
+        onItemClick={event => {
+          event.preventDefault();
+          onItemClick(event.detail, item);
+        }}
+      />
+    </TableTdElement>
+  );
+}

--- a/src/table/row-actions/styles.scss
+++ b/src/table/row-actions/styles.scss
@@ -1,12 +1,12 @@
 /*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
 
 .row-actions-cell {
   /* Narrow fixed width so the column stays compact */
-  width: 54px;
-  min-width: 54px;
+  inline-size: 54px;
+  min-inline-size: 54px;
   text-align: center;
   padding-inline: 4px;
 }

--- a/src/table/row-actions/styles.scss
+++ b/src/table/row-actions/styles.scss
@@ -1,0 +1,12 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.row-actions-cell {
+  /* Narrow fixed width so the column stays compact */
+  width: 54px;
+  min-width: 54px;
+  text-align: center;
+  padding-inline: 4px;
+}

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -241,8 +241,8 @@ filter search icon.
 
 /* Row-actions column */
 .row-actions-cell {
-  width: 54px;
-  min-width: 54px;
+  inline-size: 54px;
+  min-inline-size: 54px;
   text-align: center;
   padding-inline: awsui.$space-xxs;
 }

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -238,3 +238,21 @@ filter search icon.
   padding-inline: 0;
   border-block-end: none;
 }
+
+/* Row-actions column */
+.row-actions-cell {
+  width: 54px;
+  min-width: 54px;
+  text-align: center;
+  padding-inline: awsui.$space-xxs;
+}
+
+.row-actions-header-label {
+  /* Visually hidden — column is identified by position; screen readers read the aria-label on each button */
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -11,8 +11,10 @@ import { getGroupColumnIds, getGroupSplit } from './column-groups/split-utils';
 import { ColumnGroupsLayout } from './column-groups/utils';
 import { TableHeaderCell } from './header-cell';
 import { TableGroupHeaderCell } from './header-cell/group-header-cell';
+import { TableThElement } from './header-cell/th-element';
 import { TableProps } from './interfaces';
 import { InternalSelectionType } from './internal-interfaces';
+import { rowActionsColumnId } from './row-actions';
 import { focusMarkers, ItemSelectionProps } from './selection';
 import { TableHeaderSelectionCell } from './selection/selection-cell';
 import { StickyColumnsModel } from './sticky-columns';
@@ -54,6 +56,7 @@ export interface TheadProps {
   tableRole: TableRole;
   isExpandable?: boolean;
   setLastUserAction: (name: string) => void;
+  rowActions?: TableProps.RowActionsConfig<any>;
 }
 
 const Thead = React.forwardRef(
@@ -89,6 +92,7 @@ const Thead = React.forwardRef(
       resizerTooltipText,
       isExpandable,
       setLastUserAction,
+      rowActions,
     }: TheadProps,
     outerRef: React.Ref<HTMLTableRowElement>
   ) => {
@@ -189,10 +193,23 @@ const Thead = React.forwardRef(
                   resizerTooltipText={resizerTooltipText}
                   isExpandable={colIndex === 0 && isExpandable}
                   hasDynamicContent={hidden && !resizableColumns && column.hasDynamicContent}
-                  isLast={colIndex === columnDefinitions.length - 1}
+                  isLast={colIndex === columnDefinitions.length - 1 && !rowActions}
                 />
               );
             })}
+
+            {rowActions ? (
+              <TableThElement
+                {...commonCellProps}
+                columnId={rowActionsColumnId}
+                colIndex={selectionType ? columnDefinitions.length + 1 : columnDefinitions.length}
+                cellRef={node => setCell(sticky, rowActionsColumnId, node)}
+                sortingDisabled={true}
+                isLast={true}
+              >
+                <span className={styles['row-actions-header-label']}>Actions</span>
+              </TableThElement>
+            ) : null}
           </tr>
         </thead>
       );


### PR DESCRIPTION
## Summary

Adds a first-class `rowActions` prop to the Table component that renders a dedicated per-row actions menu (inline-icon ButtonDropdown / kebab) as the last column.

Closes / implements: **AWSUI-53401**

## Motivation

Teams consistently add a manual actions column using `cell: item => <ButtonDropdown variant="inline-icon" ... />`. This PR promotes that pattern to a first-class prop, giving the component control over column width, sticky behaviour, accessibility labels, and disabled state.

## API

```ts
interface TableProps.RowActionsConfig<T> {
  /** Returns dropdown items for a given row. */
  items: (item: T) => ReadonlyArray<ButtonDropdownProps.ItemOrGroup>;
  /** Called when the user clicks an item. */
  onItemClick: (detail: ButtonDropdownProps.ItemClickDetails, item: T) => void;
  /** Accessible label for the trigger button (default: "Actions"). */
  ariaLabel?: (item: T) => string;
  /** Disable the trigger button for a given row. */
  disabled?: (item: T) => boolean;
}
```

Usage:
```tsx
<Table
  columnDefinitions={columns}
  items={items}
  rowActions={{
    items: item => [
      { id: 'edit',   text: 'Edit' },
      { id: 'delete', text: 'Delete', disabled: !item.canDelete },
    ],
    onItemClick: (detail, item) => handleAction(detail.id, item),
    ariaLabel: item => `Actions for ${item.name}`,
  }}
/>
```

## Changes

| File | Change |
|------|--------|
| `src/table/interfaces.tsx` | `RowActionsConfig<T>` type + `rowActions` prop on `TableProps` |
| `src/table/row-actions/index.tsx` | New `TableRowActionsCell` body-cell component + `rowActionsColumnId` symbol |
| `src/table/internal.tsx` | Wire `rowActions` into width/sticky tracking; render cell after regular columns |
| `src/table/thead.tsx` | Render visually-hidden-label `<th>` for the actions column |
| `src/table/styles.scss` | `.row-actions-header-label` visually-hidden utility class |
| `pages/table/row-actions.page.tsx` | Dev page with 4 table variants |
| `src/table/__tests__/row-actions.test.tsx` | 11 unit tests (all pass) |

## Test results

```
Test Suites: 31 passed, 31 total
Tests:       445 passed, 445 total   (0 regressions)
```

ESLint: clean