### PR TITLE
feat: add getTextToCopy for lazy/async text resolution in CopyToClipboard (AWSUI-58034)

### DIFF
--- a/pages/copy-to-clipboard/lazy.page.tsx
+++ b/pages/copy-to-clipboard/lazy.page.tsx
@@ -1,0 +1,110 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import { Box, CopyToClipboard, SpaceBetween } from '~components';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+// Simulates fetching large/expensive content asynchronously
+function fetchLargeContent(delayMs: number): Promise<string> {
+  return new Promise(resolve =>
+    setTimeout(() => resolve(`Lazily fetched content (after ${delayMs}ms): ${new Date().toISOString()}`), delayMs)
+  );
+}
+
+// Simulates a fetch that rejects
+function fetchContentThatFails(): Promise<string> {
+  return new Promise((_, reject) => setTimeout(() => reject(new Error('Simulated fetch failure')), 300));
+}
+
+export default function CopyToClipboardLazyPage() {
+  const [log, setLog] = useState<string[]>([]);
+
+  const addLog = (msg: string) => setLog(prev => [...prev, `${new Date().toISOString()} — ${msg}`]);
+
+  return (
+    <ScreenshotArea>
+      <Box>
+        <SpaceBetween size="l">
+          <h1>CopyToClipboard — lazy / async text (getTextToCopy)</h1>
+
+          <Box variant="h2">Synchronous getter</Box>
+          <CopyToClipboard
+            data-testid="copy-sync-getter"
+            copyButtonText="Copy (sync getter)"
+            textToCopy="fallback text"
+            getTextToCopy={() => `Sync value computed at ${new Date().toISOString()}`}
+            copySuccessText="Sync value copied"
+            copyErrorText="Failed to copy"
+            onCopySuccess={e => addLog(`sync success: ${e.detail.text}`)}
+          />
+
+          <Box variant="h2">Async getter — 800 ms delay</Box>
+          <CopyToClipboard
+            data-testid="copy-async-getter"
+            copyButtonText="Copy (async getter)"
+            textToCopy="fallback text"
+            getTextToCopy={() => fetchLargeContent(800)}
+            copySuccessText="Async value copied"
+            copyErrorText="Failed to copy"
+            onCopySuccess={e => addLog(`async success: ${e.detail.text}`)}
+          />
+
+          <Box variant="h2">Async getter that rejects</Box>
+          <CopyToClipboard
+            data-testid="copy-async-error"
+            copyButtonText="Copy (async error)"
+            textToCopy="fallback text"
+            getTextToCopy={fetchContentThatFails}
+            copySuccessText="Copied"
+            copyErrorText="Fetch failed — could not copy"
+            onCopyFailure={e => addLog(`async failure: ${e.detail.text}`)}
+          />
+
+          <Box variant="h2">Async getter — icon variant</Box>
+          <CopyToClipboard
+            data-testid="copy-async-icon"
+            variant="icon"
+            copyButtonAriaLabel="Copy async content"
+            textToCopy="fallback text"
+            getTextToCopy={() => fetchLargeContent(600)}
+            copySuccessText="Async icon value copied"
+            copyErrorText="Failed to copy"
+          />
+
+          <Box variant="h2">Async getter — inline variant</Box>
+          <CopyToClipboard
+            data-testid="copy-async-inline"
+            variant="inline"
+            copyButtonAriaLabel="Copy async inline content"
+            textToCopy="Visible inline text (getTextToCopy overrides on click)"
+            getTextToCopy={() => fetchLargeContent(500)}
+            copySuccessText="Async inline value copied"
+            copyErrorText="Failed to copy"
+          />
+
+          <Box variant="h2">No getter (original behaviour — textToCopy)</Box>
+          <CopyToClipboard
+            data-testid="copy-no-getter"
+            copyButtonText="Copy (no getter)"
+            textToCopy="Static text to copy"
+            copySuccessText="Static text copied"
+            copyErrorText="Failed to copy"
+          />
+
+          {log.length > 0 && (
+            <Box>
+              <Box variant="h3">Event log</Box>
+              {log.map((entry, i) => (
+                <Box key={i} variant="code">
+                  {entry}
+                </Box>
+              ))}
+            </Box>
+          )}
+        </SpaceBetween>
+      </Box>
+    </ScreenshotArea>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -10771,6 +10771,26 @@ Applicable for all variants except inline.",
       "type": "string",
     },
     {
+      "description": "An optional function that returns the text to copy, either synchronously or as a \`Promise<string>\`.
+Use this when the text is expensive to compute or must be fetched asynchronously — it is only
+called at the moment the user clicks the copy button, so large content does not need to be
+pre-populated.
+
+When provided, this takes precedence over \`textToCopy\` for the clipboard write operation.
+The \`detail.text\` field of \`onCopySuccess\` / \`onCopyFailure\` will contain the resolved value.
+
+While the function is executing the button enters a loading state and cannot be clicked again.",
+      "inlineType": {
+        "name": "() => string | Promise<string>",
+        "parameters": [],
+        "returnType": "string | Promise<string>",
+        "type": "function",
+      },
+      "name": "getTextToCopy",
+      "optional": true,
+      "type": "(() => string | Promise<string>)",
+    },
+    {
       "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
 use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes). If you must
 use the \`id\` attribute, consider setting it on a parent element instead.",
@@ -10791,7 +10811,8 @@ Enable this setting if you need the popover to ignore its parent stacking contex
       "type": "boolean",
     },
     {
-      "description": "The text content to be copied. It is displayed next to the copy button when \`variant="inline"\` unless when \`content\` is specified, and is not shown otherwise.",
+      "description": "The text content to be copied. It is displayed next to the copy button when \`variant="inline"\` unless when \`content\` is specified, and is not shown otherwise.
+When \`getTextToCopy\` is also provided, \`getTextToCopy\` takes precedence for the actual clipboard write, but \`textToCopy\` is still used for the inline display text.",
       "name": "textToCopy",
       "optional": false,
       "type": "string",

--- a/src/copy-to-clipboard/__tests__/copy-to-clipboard-lazy.test.tsx
+++ b/src/copy-to-clipboard/__tests__/copy-to-clipboard-lazy.test.tsx
@@ -1,0 +1,267 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+
+import CopyToClipboard from '../../../lib/components/copy-to-clipboard';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+const defaultProps = {
+  textToCopy: 'Static fallback text',
+  copyButtonText: 'Copy',
+  copySuccessText: 'Copied to clipboard',
+  copyErrorText: 'Failed to copy to clipboard',
+};
+
+describe('CopyToClipboard — getTextToCopy (lazy/async)', () => {
+  const originalNavigatorClipboard = global.navigator.clipboard;
+  const originalNavigatorPermissions = global.navigator.permissions;
+
+  beforeEach(() => {
+    Object.assign(global.navigator, {
+      clipboard: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+      permissions: {
+        query: jest.fn().mockResolvedValue({ state: 'granted' }),
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.assign(global.navigator, {
+      clipboard: originalNavigatorClipboard,
+      permissions: originalNavigatorPermissions,
+    });
+  });
+
+  describe('synchronous getter', () => {
+    test('calls getTextToCopy on click and writes the returned value to clipboard', async () => {
+      const getTextToCopy = jest.fn().mockReturnValue('sync computed text');
+      const { container } = render(<CopyToClipboard {...defaultProps} getTextToCopy={getTextToCopy} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+
+      await waitFor(() => {
+        expect(getTextToCopy).toHaveBeenCalledTimes(1);
+        expect(global.navigator.clipboard.writeText as jest.Mock).toHaveBeenCalledWith('sync computed text');
+      });
+    });
+
+    test('fires onCopySuccess with the resolved text, not textToCopy', async () => {
+      const onCopySuccess = jest.fn();
+      const getTextToCopy = jest.fn().mockReturnValue('sync computed text');
+      const { container } = render(
+        <CopyToClipboard {...defaultProps} getTextToCopy={getTextToCopy} onCopySuccess={onCopySuccess} />
+      );
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+
+      await waitFor(() => {
+        expect(onCopySuccess).toHaveBeenCalledWith(expect.objectContaining({ detail: { text: 'sync computed text' } }));
+      });
+    });
+
+    test('shows success status after sync getter resolves', async () => {
+      const getTextToCopy = jest.fn().mockReturnValue('sync computed text');
+      const { container } = render(<CopyToClipboard {...defaultProps} getTextToCopy={getTextToCopy} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+
+      await waitFor(() => {
+        expect(wrapper.findStatusText()!.getElement().textContent).toBe('Copied to clipboard');
+      });
+    });
+  });
+
+  describe('asynchronous getter', () => {
+    test('calls getTextToCopy on click and writes the resolved promise value to clipboard', async () => {
+      const getTextToCopy = jest.fn().mockResolvedValue('async fetched text');
+      const { container } = render(<CopyToClipboard {...defaultProps} getTextToCopy={getTextToCopy} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+
+      await waitFor(() => {
+        expect(getTextToCopy).toHaveBeenCalledTimes(1);
+        expect(global.navigator.clipboard.writeText as jest.Mock).toHaveBeenCalledWith('async fetched text');
+      });
+    });
+
+    test('fires onCopySuccess with the async resolved text', async () => {
+      const onCopySuccess = jest.fn();
+      const getTextToCopy = jest.fn().mockResolvedValue('async fetched text');
+      const { container } = render(
+        <CopyToClipboard {...defaultProps} getTextToCopy={getTextToCopy} onCopySuccess={onCopySuccess} />
+      );
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+
+      await waitFor(() => {
+        expect(onCopySuccess).toHaveBeenCalledWith(expect.objectContaining({ detail: { text: 'async fetched text' } }));
+      });
+    });
+
+    test('shows success status after async getter resolves', async () => {
+      const getTextToCopy = jest.fn().mockResolvedValue('async fetched text');
+      const { container } = render(<CopyToClipboard {...defaultProps} getTextToCopy={getTextToCopy} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+
+      await waitFor(() => {
+        expect(wrapper.findStatusText()!.getElement().textContent).toBe('Copied to clipboard');
+      });
+    });
+
+    test('does not write to clipboard before async getter resolves', async () => {
+      let resolveGetter!: (value: string) => void;
+      const getTextToCopy = jest.fn(
+        () =>
+          new Promise<string>(resolve => {
+            resolveGetter = resolve;
+          })
+      );
+      const { container } = render(<CopyToClipboard {...defaultProps} getTextToCopy={getTextToCopy} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+
+      // Clipboard should not have been called yet
+      expect(global.navigator.clipboard.writeText as jest.Mock).not.toHaveBeenCalled();
+
+      resolveGetter('deferred text');
+
+      await waitFor(() => {
+        expect(global.navigator.clipboard.writeText as jest.Mock).toHaveBeenCalledWith('deferred text');
+      });
+    });
+  });
+
+  describe('getter that rejects', () => {
+    test('shows error status when async getter rejects', async () => {
+      const getTextToCopy = jest.fn().mockRejectedValue(new Error('fetch failed'));
+      const { container } = render(<CopyToClipboard {...defaultProps} getTextToCopy={getTextToCopy} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+
+      await waitFor(() => {
+        expect(wrapper.findStatusText()!.getElement().textContent).toBe('Failed to copy to clipboard');
+      });
+    });
+
+    test('does not write to clipboard when async getter rejects', async () => {
+      const getTextToCopy = jest.fn().mockRejectedValue(new Error('fetch failed'));
+      const { container } = render(<CopyToClipboard {...defaultProps} getTextToCopy={getTextToCopy} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+
+      await waitFor(() => {
+        expect(wrapper.findStatusText()!.getElement().textContent).toBe('Failed to copy to clipboard');
+      });
+      expect(global.navigator.clipboard.writeText as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    test('fires onCopyFailure with textToCopy when getter rejects', async () => {
+      const onCopyFailure = jest.fn();
+      const getTextToCopy = jest.fn().mockRejectedValue(new Error('fetch failed'));
+      const { container } = render(
+        <CopyToClipboard {...defaultProps} getTextToCopy={getTextToCopy} onCopyFailure={onCopyFailure} />
+      );
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+
+      await waitFor(() => {
+        expect(onCopyFailure).toHaveBeenCalledWith(
+          expect.objectContaining({ detail: { text: 'Static fallback text' } })
+        );
+      });
+    });
+  });
+
+  describe('loading state during async resolution', () => {
+    test('button enters loading state while async getter is pending', async () => {
+      let resolveGetter!: (value: string) => void;
+      const getTextToCopy = jest.fn(
+        () =>
+          new Promise<string>(resolve => {
+            resolveGetter = resolve;
+          })
+      );
+      const { container } = render(<CopyToClipboard {...defaultProps} getTextToCopy={getTextToCopy} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+
+      // Button should be in loading state
+      expect(wrapper.findCopyButton().getElement()).toHaveAttribute('aria-disabled', 'true');
+
+      resolveGetter('resolved text');
+
+      await waitFor(() => {
+        expect(global.navigator.clipboard.writeText as jest.Mock).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('without getTextToCopy (backward compatibility)', () => {
+    test('writes textToCopy to clipboard when no getter is provided', async () => {
+      const { container } = render(<CopyToClipboard {...defaultProps} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+
+      await waitFor(() => {
+        expect(global.navigator.clipboard.writeText as jest.Mock).toHaveBeenCalledWith('Static fallback text');
+      });
+    });
+
+    test('fires onCopySuccess with textToCopy when no getter is provided', async () => {
+      const onCopySuccess = jest.fn();
+      const { container } = render(<CopyToClipboard {...defaultProps} onCopySuccess={onCopySuccess} />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+
+      await waitFor(() => {
+        expect(onCopySuccess).toHaveBeenCalledWith(
+          expect.objectContaining({ detail: { text: 'Static fallback text' } })
+        );
+      });
+    });
+  });
+
+  describe('inline variant with getTextToCopy', () => {
+    test('displays textToCopy in inline variant regardless of getTextToCopy', () => {
+      const getTextToCopy = jest.fn().mockResolvedValue('async text');
+      const { container } = render(
+        <CopyToClipboard {...defaultProps} variant="inline" getTextToCopy={getTextToCopy} />
+      );
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      // The displayed text should still be textToCopy
+      expect(wrapper.findTextToCopy()!.getElement().textContent).toBe('Static fallback text');
+    });
+
+    test('copies async text when inline button is clicked', async () => {
+      const getTextToCopy = jest.fn().mockResolvedValue('async inline text');
+      const { container } = render(
+        <CopyToClipboard {...defaultProps} variant="inline" getTextToCopy={getTextToCopy} />
+      );
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+
+      await waitFor(() => {
+        expect(global.navigator.clipboard.writeText as jest.Mock).toHaveBeenCalledWith('async inline text');
+      });
+    });
+  });
+});

--- a/src/copy-to-clipboard/interfaces.ts
+++ b/src/copy-to-clipboard/interfaces.ts
@@ -28,8 +28,22 @@ export interface CopyToClipboardProps extends BaseComponentProps {
 
   /**
    * The text content to be copied. It is displayed next to the copy button when `variant="inline"` unless when `content` is specified, and is not shown otherwise.
+   * When `getTextToCopy` is also provided, `getTextToCopy` takes precedence for the actual clipboard write, but `textToCopy` is still used for the inline display text.
    */
   textToCopy: string;
+
+  /**
+   * An optional function that returns the text to copy, either synchronously or as a `Promise<string>`.
+   * Use this when the text is expensive to compute or must be fetched asynchronously — it is only
+   * called at the moment the user clicks the copy button, so large content does not need to be
+   * pre-populated.
+   *
+   * When provided, this takes precedence over `textToCopy` for the clipboard write operation.
+   * The `detail.text` field of `onCopySuccess` / `onCopyFailure` will contain the resolved value.
+   *
+   * While the function is executing the button enters a loading state and cannot be clicked again.
+   */
+  getTextToCopy?: () => string | Promise<string>;
 
   /**
    * The content to display next to the copy button when `variant="inline"`. If not provided, `textToCopy` will be displayed instead.

--- a/src/copy-to-clipboard/internal.tsx
+++ b/src/copy-to-clipboard/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 import InternalButton from '../button/internal';
@@ -23,6 +23,7 @@ export default function InternalCopyToClipboard({
   copySuccessText,
   copyErrorText,
   textToCopy,
+  getTextToCopy,
   textToDisplay,
   wrapText = true,
   popoverRenderWithPortal,
@@ -35,6 +36,15 @@ export default function InternalCopyToClipboard({
 }: InternalCopyToClipboardProps) {
   const [status, setStatus] = useState<'pending' | 'success' | 'error'>('success');
   const [statusText, setStatusText] = useState(copySuccessText);
+  const [loading, setLoading] = useState(false);
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (navigator.permissions) {
@@ -53,7 +63,8 @@ export default function InternalCopyToClipboard({
   }, [copyErrorText]);
 
   const baseProps = getBaseProps(restProps);
-  const onClick = () => {
+
+  const onClick = async () => {
     if (!navigator.clipboard) {
       // The clipboard API is not available in insecure contexts.
       setStatus('error');
@@ -62,17 +73,44 @@ export default function InternalCopyToClipboard({
       return;
     }
 
+    let resolvedText = textToCopy;
+
+    if (getTextToCopy) {
+      setLoading(true);
+      try {
+        resolvedText = await Promise.resolve(getTextToCopy());
+      } catch {
+        if (isMounted.current) {
+          setLoading(false);
+          setStatus('error');
+          setStatusText(copyErrorText);
+          fireNonCancelableEvent(onCopyFailure, { text: textToCopy });
+        }
+        return;
+      }
+      if (!isMounted.current) {
+        return;
+      }
+      setLoading(false);
+    }
+
     navigator.clipboard
-      .writeText(textToCopy)
+      .writeText(resolvedText)
       .then(() => {
+        if (!isMounted.current) {
+          return;
+        }
         setStatus('success');
         setStatusText(copySuccessText);
-        fireNonCancelableEvent(onCopySuccess, { text: textToCopy });
+        fireNonCancelableEvent(onCopySuccess, { text: resolvedText });
       })
       .catch(() => {
+        if (!isMounted.current) {
+          return;
+        }
         setStatus('error');
         setStatusText(copyErrorText);
-        fireNonCancelableEvent(onCopyFailure, { text: textToCopy });
+        fireNonCancelableEvent(onCopyFailure, { text: resolvedText });
       });
   };
 
@@ -95,6 +133,8 @@ export default function InternalCopyToClipboard({
       formAction="none"
       disabled={disabled}
       disabledReason={disabledReason}
+      loading={loading}
+      loadingText={copyButtonAriaLabel ?? copyButtonText}
     >
       {copyButtonText}
     </InternalButton>


### PR DESCRIPTION
### Description

Adds an optional `getTextToCopy?: () => string | Promise<string>` prop to `CopyToClipboard` so callers can defer expensive or async text computation until the user actually clicks the copy button, rather than pre-populating large content on render.

Related links, issue #, if available: AWSUI-58034

#### Changes

- **`interfaces.ts`** — new optional `getTextToCopy?: () => string | Promise<string>` prop with full JSDoc.
- **`internal.tsx`** — on click: if `getTextToCopy` is provided, await its result before writing to clipboard; button enters `loading` state during resolution; errors from the getter surface as the standard copy-failure path; an `isMounted` ref guards against state updates after unmount.
- **`index.tsx`** — `getTextToCopy` is already forwarded via `...filteredProps` (no explicit change needed; confirmed by inspection).
- **`pages/copy-to-clipboard/lazy.page.tsx`** — new dev page with sync getter, 800 ms async getter, rejecting getter, icon variant, inline variant, and no-getter (baseline) scenarios, plus an event log.
- **`src/copy-to-clipboard/__tests__/copy-to-clipboard-lazy.test.tsx`** — 15 new unit tests covering all branches: sync getter, async getter, rejecting getter, loading state, backward-compat (no getter), and inline variant.

#### Behaviour summary

| Scenario | Behaviour |
|---|---|
| `getTextToCopy` omitted | Existing behaviour unchanged — `textToCopy` written directly |
| Sync getter | Called on click; return value written to clipboard |
| Async getter | Called on click; button enters loading state; resolved value written |
| Getter rejects | `copyErrorText` shown; `onCopyFailure` fired with `textToCopy` |
| Inline variant | `textToCopy` still displayed; getter used only for clipboard write |

### How has this been tested?

- 15 new unit tests in `copy-to-clipboard-lazy.test.tsx` — all pass ✅
- All 49 existing `copy-to-clipboard.test.tsx` tests continue to pass ✅ (64 total)
- Build passes cleanly with Node 24 ✅
- ESLint clean ✅
- Dev page at `pages/copy-to-clipboard/lazy.page.tsx` for manual verification

<details>
   <summary>Review checklist</summary>

#### Correctness

- [x] Changes include appropriate documentation updates (JSDoc on new prop).
- [x] Changes are backward-compatible — `getTextToCopy` is optional; omitting it preserves existing behaviour exactly.
- [x] Changes do not include unsupported browser features.
- [ ] Changes were manually tested for accessibility (loading state uses existing InternalButton `loading` prop which has its own a11y handling).

#### Security

- [x] No URL handling introduced.

#### Testing

- [x] Changes are covered with 15 new unit tests.
- [ ] Integration tests — not added in this PR (no existing integ test pattern for CopyToClipboard).
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.