### PR TITLE
feat: add tooltip prop to table column header definitions

### DIFF
--- a/pages/table/column-header-tooltip.page.tsx
+++ b/pages/table/column-header-tooltip.page.tsx
@@ -1,0 +1,97 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Box from '~components/box';
+import Header from '~components/header';
+import Link from '~components/link';
+import SpaceBetween from '~components/space-between';
+import StatusIndicator from '~components/status-indicator';
+import Table, { TableProps } from '~components/table';
+
+import ScreenshotArea from '../utils/screenshot-area';
+import { generateItems, Instance } from './generate-data';
+
+const allItems = generateItems(10);
+
+const columnDefinitions: TableProps.ColumnDefinition<Instance>[] = [
+  {
+    id: 'id',
+    header: 'ID',
+    cell: item => <Link href={`#${item.id}`}>{item.id}</Link>,
+    sortingField: 'id',
+    tooltip: 'The unique identifier for this instance.',
+  },
+  {
+    id: 'type',
+    header: 'Instance type',
+    cell: item => item.type,
+    sortingField: 'type',
+    tooltip: (
+      <SpaceBetween size="xs">
+        <Box variant="p">The hardware configuration of the instance.</Box>
+        <Link href="#" external={true}>
+          Learn more about instance types
+        </Link>
+      </SpaceBetween>
+    ),
+  },
+  {
+    id: 'dnsName',
+    header: 'DNS name',
+    cell: item => item.dnsName || '-',
+    sortingField: 'dnsName',
+    // No tooltip on this column — verifies optional behavior
+  },
+  {
+    id: 'imageId',
+    header: 'Image ID',
+    cell: item => item.imageId,
+    sortingField: 'imageId',
+    tooltip: 'The Amazon Machine Image (AMI) used to launch this instance.',
+  },
+  {
+    id: 'state',
+    header: 'State',
+    cell: item => (
+      <StatusIndicator type={item.state === 'RUNNING' ? 'success' : 'stopped'}>{item.state}</StatusIndicator>
+    ),
+    sortingField: 'state',
+    tooltip: 'Current operational state of the instance.',
+  },
+];
+
+export default function App() {
+  const [sortingColumn, setSortingColumn] = useState<TableProps.SortingColumn<Instance>>(columnDefinitions[0]);
+  const [sortingDescending, setSortingDescending] = useState(false);
+
+  return (
+    <ScreenshotArea>
+      <SpaceBetween size="l">
+        <Table
+          header={<Header headingTagOverride="h1">Table with column header tooltips</Header>}
+          columnDefinitions={columnDefinitions}
+          items={allItems}
+          sortingColumn={sortingColumn}
+          sortingDescending={sortingDescending}
+          onSortingChange={({ detail }) => {
+            setSortingColumn(detail.sortingColumn);
+            setSortingDescending(!!detail.isDescending);
+          }}
+          ariaLabels={{ tableLabel: 'Instances' }}
+        />
+
+        <Table
+          header={<Header headingTagOverride="h2">Resizable columns with tooltips</Header>}
+          columnDefinitions={columnDefinitions}
+          items={allItems}
+          resizableColumns={true}
+          ariaLabels={{
+            tableLabel: 'Instances resizable',
+            resizerRoleDescription: 'resize button',
+          }}
+        />
+      </SpaceBetween>
+    </ScreenshotArea>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -28517,7 +28517,8 @@ To target individual cells use \`columnDefinitions.verticalAlign\`, that takes p
 * \`isRowHeader\` (boolean) - Specifies that cells in this column should be used as row headers.
 * \`hasDynamicContent\` (boolean) - Specifies that cells in this column may have dynamic content. The contents will then be observed to update calculated column widths.
    This may have a negative performance impact, so should be used only if necessary. It has no effect if \`resizableColumns\` is set to \`true\`.
-* \`verticalAlign\` ('middle' | 'top') - Determines the alignment of the content in the table cell.",
+* \`verticalAlign\` ('middle' | 'top') - Determines the alignment of the content in the table cell.
+* \`tooltip\` (ReactNode) - Content to display in an info popover on the column header. When specified, an info icon button appears next to the header text.",
       "name": "columnDefinitions",
       "optional": false,
       "type": "ReadonlyArray<TableProps.ColumnDefinition<T>>",
@@ -44037,6 +44038,29 @@ Returns the current value of the input.",
           },
         },
         {
+          "description": "Returns the info popover trigger button for a column header, if present.",
+          "name": "findColumnHeaderInfo",
+          "parameters": [
+            {
+              "description": "1-based index of the column.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "colIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
           "description": "Returns column header cells from the table's header region.
 
 By default, returns all leaf-column headers (\`scope="col"\`).
@@ -53534,6 +53558,24 @@ In this case, use findContentEditableElement() instead.",
           "returnType": {
             "isNullable": false,
             "name": "CollectionPreferencesWrapper",
+          },
+        },
+        {
+          "description": "Returns the info popover trigger button for a column header, if present.",
+          "name": "findColumnHeaderInfo",
+          "parameters": [
+            {
+              "description": "1-based index of the column.",
+              "flags": {
+                "isOptional": false,
+              },
+              "name": "colIndex",
+              "typeName": "number",
+            },
+          ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
           },
         },
         {

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -653,6 +653,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_empty_wih1l",
     "awsui_header-cell-ascending_1spae",
     "awsui_header-cell-descending_1spae",
+    "awsui_header-cell-info-button_1spae",
     "awsui_header-controls_wih1l",
     "awsui_items-loader_115pt",
     "awsui_loading_wih1l",

--- a/src/table/__tests__/column-header-tooltip.test.tsx
+++ b/src/table/__tests__/column-header-tooltip.test.tsx
@@ -1,0 +1,187 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import Table, { TableProps } from '../../../lib/components/table';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+import headerCellStyles from '../../../lib/components/table/header-cell/styles.css.js';
+
+interface TestItem {
+  id: string;
+  name: string;
+  value: number;
+}
+
+const items: TestItem[] = [
+  { id: '1', name: 'Alpha', value: 10 },
+  { id: '2', name: 'Beta', value: 20 },
+];
+
+function renderTable(overrides: Partial<React.ComponentProps<typeof Table<TestItem>>> = {}) {
+  const defaultColumnDefinitions: TableProps.ColumnDefinition<TestItem>[] = [
+    {
+      id: 'id',
+      header: 'ID',
+      cell: (item: TestItem) => item.id,
+      tooltip: 'The unique identifier.',
+    },
+    {
+      id: 'name',
+      header: 'Name',
+      cell: (item: TestItem) => item.name,
+      tooltip: <span data-testid="rich-tooltip">Rich tooltip content</span>,
+    },
+    {
+      id: 'value',
+      header: 'Value',
+      cell: (item: TestItem) => item.value,
+      // No tooltip
+    },
+  ];
+  const { container } = render(
+    <Table<TestItem>
+      items={items}
+      columnDefinitions={defaultColumnDefinitions}
+      ariaLabels={{ tableLabel: 'Test table' }}
+      {...overrides}
+    />
+  );
+  return createWrapper(container).findTable()!;
+}
+
+describe('Table column header tooltip', () => {
+  describe('rendering', () => {
+    it('renders an info button when tooltip is provided', () => {
+      const wrapper = renderTable();
+      expect(wrapper.findColumnHeaderInfo(1)).not.toBeNull();
+      expect(wrapper.findColumnHeaderInfo(2)).not.toBeNull();
+    });
+
+    it('does not render an info button when tooltip is not provided', () => {
+      const wrapper = renderTable();
+      expect(wrapper.findColumnHeaderInfo(3)).toBeNull();
+    });
+
+    it('info button has accessible label derived from string header', () => {
+      const wrapper = renderTable();
+      const button = wrapper.findColumnHeaderInfo(1)!.getElement();
+      expect(button).toHaveAttribute('aria-label', 'ID - info');
+    });
+
+    it('info button has generic accessible label when header is not a string', () => {
+      const colDefs: TableProps.ColumnDefinition<TestItem>[] = [
+        {
+          id: 'id',
+          header: <span>Custom header</span>,
+          cell: (item: TestItem) => item.id,
+          tooltip: 'Tooltip text',
+        },
+      ];
+      const wrapper = renderTable({ columnDefinitions: colDefs });
+      const button = wrapper.findColumnHeaderInfo(1)!.getElement();
+      expect(button).toHaveAttribute('aria-label', 'info');
+    });
+
+    it('info button has type="button" to avoid form submission', () => {
+      const wrapper = renderTable();
+      const button = wrapper.findColumnHeaderInfo(1)!.getElement();
+      expect(button).toHaveAttribute('type', 'button');
+    });
+  });
+
+  describe('popover interaction', () => {
+    it('shows tooltip content when info button is clicked', () => {
+      const wrapper = renderTable();
+      const infoButton = wrapper.findColumnHeaderInfo(1)!.getElement();
+      fireEvent.click(infoButton);
+      expect(screen.getByText('The unique identifier.')).toBeInTheDocument();
+    });
+
+    it('supports rich ReactNode tooltip content', () => {
+      const wrapper = renderTable();
+      const infoButton = wrapper.findColumnHeaderInfo(2)!.getElement();
+      fireEvent.click(infoButton);
+      expect(screen.getByTestId('rich-tooltip')).toBeInTheDocument();
+    });
+
+    it('hides tooltip content before the button is clicked', () => {
+      renderTable();
+      expect(screen.queryByText('The unique identifier.')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('coexistence with sorting', () => {
+    it('renders info button alongside sortable column', () => {
+      const colDefs: TableProps.ColumnDefinition<TestItem>[] = [
+        {
+          id: 'id',
+          header: 'ID',
+          cell: (item: TestItem) => item.id,
+          sortingField: 'id',
+          tooltip: 'Sortable column tooltip',
+        },
+      ];
+      const wrapper = renderTable({ columnDefinitions: colDefs });
+      expect(wrapper.findColumnHeaderInfo(1)).not.toBeNull();
+      expect(wrapper.findColumnSortingArea(1)).not.toBeNull();
+    });
+
+    it('clicking sort area does not open tooltip', () => {
+      const colDefs2: TableProps.ColumnDefinition<TestItem>[] = [
+        {
+          id: 'id',
+          header: 'ID',
+          cell: (item: TestItem) => item.id,
+          sortingField: 'id',
+          tooltip: 'Sortable column tooltip',
+        },
+      ];
+      const wrapper = renderTable({ columnDefinitions: colDefs2 });
+      const sortArea = wrapper.findColumnSortingArea(1)!.getElement();
+      fireEvent.click(sortArea);
+      expect(screen.queryByText('Sortable column tooltip')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('coexistence with resizable columns', () => {
+    it('renders info button when resizableColumns is true', () => {
+      const wrapper = renderTable({ resizableColumns: true });
+      expect(wrapper.findColumnHeaderInfo(1)).not.toBeNull();
+      expect(wrapper.findColumnResizer(1)).not.toBeNull();
+    });
+  });
+
+  describe('coexistence with inline editing', () => {
+    it('renders info button alongside editable column', () => {
+      const editColDefs: TableProps.ColumnDefinition<TestItem>[] = [
+        {
+          id: 'id',
+          header: 'ID',
+          cell: (item: TestItem) => item.id,
+          tooltip: 'Editable column tooltip',
+          editConfig: {
+            ariaLabel: 'Edit ID',
+            editingCell: (item: TestItem, { currentValue, setValue }: TableProps.CellContext<string>) => (
+              <input value={currentValue ?? item.id} onChange={e => setValue(e.target.value)} />
+            ),
+          },
+        },
+      ];
+      const wrapper = renderTable({ columnDefinitions: editColDefs, submitEdit: async () => {} });
+      expect(wrapper.findColumnHeaderInfo(1)).not.toBeNull();
+    });
+  });
+
+  describe('CSS classes', () => {
+    it('info container has the expected CSS class', () => {
+      const wrapper = renderTable();
+      const infoContainer = wrapper
+        .findColumnHeaderInfo(1)!
+        .getElement()
+        .closest(`.${headerCellStyles['header-cell-info']}`);
+      expect(infoContainer).toBeInTheDocument();
+    });
+  });
+});

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -10,6 +10,7 @@ import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-tool
 import { useInternalI18n } from '../../i18n/context';
 import InternalIcon from '../../icon/internal';
 import { KeyCode } from '../../internal/keycode';
+import InternalPopover from '../../popover/internal';
 import { GeneratedAnalyticsMetadataTableSort } from '../analytics-metadata/interfaces';
 import { TableProps } from '../interfaces';
 import { Divider, Resizer } from '../resizer';
@@ -113,6 +114,8 @@ export function TableHeaderCell<ItemType>({
     updateColumn(columnId, entry.borderBoxWidth);
   });
 
+  const hasTooltip = !!column.tooltip;
+
   return (
     <TableThElement
       resizableStyle={resizableStyle}
@@ -196,6 +199,26 @@ export function TableHeaderCell<ItemType>({
           </span>
         )}
       </div>
+      {hasTooltip && (
+        <span className={styles['header-cell-info']} onClick={e => e.stopPropagation()}>
+          <InternalPopover
+            triggerType="custom"
+            size="medium"
+            position="top"
+            dismissButton={false}
+            renderWithPortal={true}
+            content={column.tooltip}
+          >
+            <button
+              type="button"
+              className={styles['header-cell-info-button']}
+              aria-label={`${typeof column.header === 'string' ? column.header + ' - ' : ''}info`}
+            >
+              <InternalIcon name="status-info" />
+            </button>
+          </InternalPopover>
+        </span>
+      )}
       {resizableColumns ? (
         <Resizer
           tabIndex={tabIndex}

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -292,13 +292,19 @@ settings icon in the pagination slot.
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
-  margin: 0;
+  padding-block: 0;
+  padding-inline: 0;
+  margin-block: 0;
+  margin-inline: 0;
   background: none;
-  border: none;
+  border-block: none;
+  border-inline: none;
   cursor: pointer;
   color: awsui.$color-text-interactive-default;
-  border-radius: awsui.$border-radius-button;
+  border-start-start-radius: awsui.$border-radius-button;
+  border-start-end-radius: awsui.$border-radius-button;
+  border-end-start-radius: awsui.$border-radius-button;
+  border-end-end-radius: awsui.$border-radius-button;
 
   &:hover {
     color: awsui.$color-text-interactive-hover;

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -280,3 +280,35 @@ settings icon in the pagination slot.
     @include cell-offset($cell-horizontal-padding);
   }
 }
+
+.header-cell-info {
+  display: inline-flex;
+  align-items: center;
+  margin-inline-start: awsui.$space-xxs;
+  vertical-align: middle;
+}
+
+.header-cell-info-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  margin: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: awsui.$color-text-interactive-default;
+  border-radius: awsui.$border-radius-button;
+
+  &:hover {
+    color: awsui.$color-text-interactive-hover;
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  @include focus-visible.when-visible {
+    @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
+  }
+}

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -134,6 +134,7 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * * `hasDynamicContent` (boolean) - Specifies that cells in this column may have dynamic content. The contents will then be observed to update calculated column widths.
    *    This may have a negative performance impact, so should be used only if necessary. It has no effect if `resizableColumns` is set to `true`.
    * * `verticalAlign` ('middle' | 'top') - Determines the alignment of the content in the table cell.
+   * * `tooltip` (ReactNode) - Content to display in an info popover on the column header. When specified, an info icon button appears next to the header text.
    */
   columnDefinitions: ReadonlyArray<TableProps.ColumnDefinition<T>>;
 
@@ -528,6 +529,11 @@ export namespace TableProps {
   export type ColumnDefinition<T> = {
     id?: string;
     header: React.ReactNode;
+    /**
+     * Content to display in an info popover on the column header.
+     * When specified, an info icon button appears next to the header text.
+     */
+    tooltip?: React.ReactNode;
     ariaLabel?(data: LabelData): string;
     width?: number | string;
     minWidth?: number | string;

--- a/src/test-utils/dom/table/index.ts
+++ b/src/test-utils/dom/table/index.ts
@@ -250,4 +250,17 @@ export default class TableWrapper extends ComponentWrapper {
     const selector = `.${progressiveLoadingStyles['items-loader']}[data-parentrow="${itemId}"]`;
     return this.find(selector);
   }
+
+  /**
+   * Returns the info popover trigger button for a column header, if present.
+   *
+   * @param colIndex 1-based index of the column.
+   */
+  findColumnHeaderInfo(colIndex: number): ElementWrapper | null {
+    return (
+      this.findActiveTHead().find(
+        `th[data-column-index="${colIndex}"] .${headerCellStyles['header-cell-info-button']}, tr:not([data-group-level]) > th:nth-child(${colIndex}) .${headerCellStyles['header-cell-info-button']}`
+      ) ?? null
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Implements AWSUI-57661 — adds a `tooltip` prop to `TableProps.ColumnDefinition` that lets consumers attach an info popover to any column header.

### Changes

- **`src/table/interfaces.tsx`** — adds `tooltip?: React.ReactNode` field to `ColumnDefinition<T>` with JSDoc
- **`src/table/header-cell/index.tsx`** — renders an info icon button + `InternalPopover` next to the header text when `column.tooltip` is present; click on the info button is isolated from the sorting click handler
- **`src/table/header-cell/styles.scss`** — adds `.header-cell-info` and `.header-cell-info-button` styles
- **`src/test-utils/dom/table/index.ts`** — adds `findColumnHeaderInfo(colIndex)` helper to `TableWrapper`
- **`pages/table/column-header-tooltip.page.tsx`** — dev page demonstrating string and rich ReactNode tooltips, sortable columns, and resizable columns
- **`src/table/__tests__/column-header-tooltip.test.tsx`** — 13 unit tests covering rendering, popover interaction, coexistence with sorting/resizable/editable columns, and CSS class assertions

### Testing

```
npx jest --config jest.unit.config.js src/table/__tests__/column-header-tooltip.test.tsx --no-coverage
# 13 passed, 0 failed

npx jest --config jest.unit.config.js src/table/__tests__/header-cell.test.tsx src/table/__tests__/table.test.tsx --no-coverage
# 31 passed, 0 failed
```

### Usage example

```tsx
const columnDefinitions: TableProps.ColumnDefinition<Item>[] = [
  {
    id: 'state',
    header: 'State',
    cell: item => item.state,
    tooltip: 'Current operational state of the instance.',
  },
  {
    id: 'cost',
    header: 'Monthly cost',
    cell: item => item.cost,
    tooltip: (
      <SpaceBetween size="xs">
        <Box variant="p">Estimated monthly cost based on current usage.</Box>
        <Link href="#" external>Learn more about pricing</Link>
      </SpaceBetween>
    ),
  },
];
```

Resolves AWSUI-57661