### PR TITLE
feat: add fullBleedHeader prop to ContentLayout (AWSUI-58901)

### DIFF
--- a/pages/content-layout/full-bleed-header.page.tsx
+++ b/pages/content-layout/full-bleed-header.page.tsx
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext } from 'react';
+
+import { Button, Container, Header, SpaceBetween, Toggle } from '~components';
+import ContentLayout from '~components/content-layout';
+
+import AppContext, { AppContextType } from '../app/app-context';
+import ScreenshotArea from '../utils/screenshot-area';
+
+type DemoContext = React.Context<
+  AppContextType<{
+    fullBleedHeader: boolean | undefined;
+    disableOverlap: boolean | undefined;
+    hasContent: boolean | undefined;
+    useCustomBackground: boolean | undefined;
+  }>
+>;
+
+export default function ContentLayoutFullBleedHeaderPage() {
+  const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
+
+  return (
+    <ScreenshotArea gutters={false}>
+      <main>
+        <ContentLayout
+          fullBleedHeader={urlParams.fullBleedHeader}
+          disableOverlap={urlParams.disableOverlap}
+          headerBackgroundStyle={
+            urlParams.useCustomBackground
+              ? 'linear-gradient(135deg, rgba(71, 17, 118, 1) 3%, rgba(131, 57, 157, 1) 44%, rgba(149, 85, 182, 1) 69%, rgba(145, 134, 215, 1) 94%)'
+              : undefined
+          }
+          header={
+            <Header
+              variant="h1"
+              description="The header slot spans edge-to-edge when fullBleedHeader is enabled."
+              actions={<Button variant="primary">Action</Button>}
+            >
+              Full-bleed header demo
+            </Header>
+          }
+        >
+          {urlParams.hasContent && (
+            <SpaceBetween size="l">
+              <Container header={<Header variant="h2">Content area</Header>}>
+                <p>Page content goes here. The header above spans the full width when fullBleedHeader is true.</p>
+              </Container>
+              <Container>
+                <p>Another content block.</p>
+              </Container>
+            </SpaceBetween>
+          )}
+        </ContentLayout>
+
+        <div style={{ padding: '20px 40px', background: '#f8f8f8', borderTop: '1px solid #ddd' }}>
+          <SpaceBetween size="s" direction="horizontal">
+            <Toggle
+              checked={!!urlParams.fullBleedHeader}
+              onChange={({ detail }) => setUrlParams({ fullBleedHeader: detail.checked })}
+            >
+              fullBleedHeader
+            </Toggle>
+            <Toggle
+              checked={!!urlParams.disableOverlap}
+              onChange={({ detail }) => setUrlParams({ disableOverlap: detail.checked })}
+            >
+              disableOverlap
+            </Toggle>
+            <Toggle
+              checked={!!urlParams.hasContent}
+              onChange={({ detail }) => setUrlParams({ hasContent: detail.checked })}
+            >
+              Has content
+            </Toggle>
+            <Toggle
+              checked={!!urlParams.useCustomBackground}
+              onChange={({ detail }) => setUrlParams({ useCustomBackground: detail.checked })}
+            >
+              Custom background
+            </Toggle>
+          </SpaceBetween>
+        </div>
+      </main>
+    </ScreenshotArea>
+  );
+}

--- a/pages/content-layout/full-bleed-header.page.tsx
+++ b/pages/content-layout/full-bleed-header.page.tsx
@@ -53,33 +53,35 @@ export default function ContentLayoutFullBleedHeaderPage() {
           )}
         </ContentLayout>
 
-        <div style={{ padding: '20px 40px', background: '#f8f8f8', borderTop: '1px solid #ddd' }}>
-          <SpaceBetween size="s" direction="horizontal">
-            <Toggle
-              checked={!!urlParams.fullBleedHeader}
-              onChange={({ detail }) => setUrlParams({ fullBleedHeader: detail.checked })}
-            >
-              fullBleedHeader
-            </Toggle>
-            <Toggle
-              checked={!!urlParams.disableOverlap}
-              onChange={({ detail }) => setUrlParams({ disableOverlap: detail.checked })}
-            >
-              disableOverlap
-            </Toggle>
-            <Toggle
-              checked={!!urlParams.hasContent}
-              onChange={({ detail }) => setUrlParams({ hasContent: detail.checked })}
-            >
-              Has content
-            </Toggle>
-            <Toggle
-              checked={!!urlParams.useCustomBackground}
-              onChange={({ detail }) => setUrlParams({ useCustomBackground: detail.checked })}
-            >
-              Custom background
-            </Toggle>
-          </SpaceBetween>
+        <div style={{ marginBlockStart: '16px' }}>
+          <Container>
+            <SpaceBetween size="s" direction="horizontal">
+              <Toggle
+                checked={!!urlParams.fullBleedHeader}
+                onChange={({ detail }) => setUrlParams({ fullBleedHeader: detail.checked })}
+              >
+                fullBleedHeader
+              </Toggle>
+              <Toggle
+                checked={!!urlParams.disableOverlap}
+                onChange={({ detail }) => setUrlParams({ disableOverlap: detail.checked })}
+              >
+                disableOverlap
+              </Toggle>
+              <Toggle
+                checked={!!urlParams.hasContent}
+                onChange={({ detail }) => setUrlParams({ hasContent: detail.checked })}
+              >
+                Has content
+              </Toggle>
+              <Toggle
+                checked={!!urlParams.useCustomBackground}
+                onChange={({ detail }) => setUrlParams({ useCustomBackground: detail.checked })}
+              >
+                Custom background
+              </Toggle>
+            </SpaceBetween>
+          </Container>
         </div>
       </main>
     </ScreenshotArea>

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -10581,6 +10581,17 @@ If true, the overlap will be removed.",
       "visualRefreshTag": "",
     },
     {
+      "description": "When set to \`true\`, the header slot spans the full available width of the layout, edge-to-edge,
+ignoring the \`maxContentWidth\` constraint. The header background already spans full width;
+this prop additionally makes the header **content** bleed to the edges.
+Use this when you want header content (such as a hero image or a custom banner)
+to occupy the full viewport width.
+Defaults to \`false\`.",
+      "name": "fullBleedHeader",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
       "description": "Use this property to style the background of the header.
 
 It can be:

--- a/src/content-layout/__tests__/content-layout.test.tsx
+++ b/src/content-layout/__tests__/content-layout.test.tsx
@@ -280,5 +280,70 @@ function renderContentLayout(props: ContentLayoutProps = {}) {
         expect(wrapper.findByClassName(styles['header-background'])!.getElement()).toHaveStyle('background: blue;');
       });
     });
+
+    describe('fullBleedHeader', () => {
+      test('does not add full-bleed-header class by default', () => {
+        const { wrapper } = renderContentLayout({
+          header: <>Header text</>,
+        });
+        expect(wrapper.getElement()).not.toHaveClass(styles['full-bleed-header']);
+      });
+
+      test('does not add full-bleed-header class when fullBleedHeader is false', () => {
+        const { wrapper } = renderContentLayout({
+          header: <>Header text</>,
+          fullBleedHeader: false,
+        });
+        expect(wrapper.getElement()).not.toHaveClass(styles['full-bleed-header']);
+      });
+
+      test('adds full-bleed-header class when fullBleedHeader is true', () => {
+        const { wrapper } = renderContentLayout({
+          header: <>Header text</>,
+          fullBleedHeader: true,
+        });
+        expect(wrapper.getElement()).toHaveClass(styles['full-bleed-header']);
+      });
+
+      test('full-bleed-header can be combined with disableOverlap', () => {
+        const { wrapper } = renderContentLayout({
+          header: <>Header text</>,
+          children: <>Content</>,
+          fullBleedHeader: true,
+          disableOverlap: true,
+        });
+        expect(wrapper.getElement()).toHaveClass(styles['full-bleed-header']);
+        expect(wrapper.getElement()).toHaveClass(styles['is-overlap-disabled']);
+      });
+
+      test('full-bleed-header can be combined with headerBackgroundStyle', () => {
+        const { wrapper } = renderContentLayout({
+          header: <>Header text</>,
+          fullBleedHeader: true,
+          headerBackgroundStyle: 'linear-gradient(to right, red, blue)',
+        });
+        expect(wrapper.getElement()).toHaveClass(styles['full-bleed-header']);
+        expect(wrapper.findByClassName(styles['header-background'])!.getElement()).toHaveStyle(
+          'background: linear-gradient(to right, red, blue);'
+        );
+      });
+
+      test('full-bleed-header can be combined with high-contrast headerVariant', () => {
+        const { wrapper } = renderContentLayout({
+          header: <>Header text</>,
+          fullBleedHeader: true,
+          headerVariant: 'high-contrast',
+        });
+        expect(wrapper.getElement()).toHaveClass(styles['full-bleed-header']);
+      });
+
+      test('full-bleed-header renders header slot content', () => {
+        const { wrapper } = renderContentLayout({
+          header: <>Full bleed header content</>,
+          fullBleedHeader: true,
+        });
+        expect(wrapper.findHeader()!.getElement()).toHaveTextContent('Full bleed header content');
+      });
+    });
   });
 });

--- a/src/content-layout/index.tsx
+++ b/src/content-layout/index.tsx
@@ -12,7 +12,7 @@ export { ContentLayoutProps };
 
 export default function ContentLayout(props: ContentLayoutProps) {
   const baseComponentProps = useBaseComponent('ContentLayout', {
-    props: { disableOverlap: props.disableOverlap },
+    props: { disableOverlap: props.disableOverlap, fullBleedHeader: props.fullBleedHeader },
   });
   return <InternalContentLayout {...props} {...baseComponentProps} />;
 }

--- a/src/content-layout/interfaces.ts
+++ b/src/content-layout/interfaces.ts
@@ -79,4 +79,14 @@ export interface ContentLayoutProps extends BaseComponentProps {
    * Note that the secondary header will not have a high-contrast treatement, even if you set `headerVariant` to `high-contrast`.
    */
   secondaryHeader?: React.ReactNode;
+
+  /**
+   * When set to `true`, the header slot spans the full available width of the layout, edge-to-edge,
+   * ignoring the `maxContentWidth` constraint. The header background already spans full width;
+   * this prop additionally makes the header **content** bleed to the edges.
+   * Use this when you want header content (such as a hero image or a custom banner)
+   * to occupy the full viewport width.
+   * Defaults to `false`.
+   */
+  fullBleedHeader?: boolean;
 }

--- a/src/content-layout/internal.tsx
+++ b/src/content-layout/internal.tsx
@@ -29,6 +29,7 @@ export default function InternalContentLayout({
   header,
   headerVariant = 'default',
   headerBackgroundStyle,
+  fullBleedHeader,
   __internalRootRef,
   maxContentWidth = Number.MAX_VALUE,
   breadcrumbs,
@@ -61,6 +62,7 @@ export default function InternalContentLayout({
         [styles['has-header']]: !!header,
         [styles['default-padding']]: !!defaultPadding,
         [styles['has-notifications']]: !!notifications,
+        [styles['full-bleed-header']]: !!fullBleedHeader,
       })}
       style={{
         [customCssProps.contentLayoutMaxContentWidth]:

--- a/src/content-layout/styles.scss
+++ b/src/content-layout/styles.scss
@@ -81,6 +81,15 @@
   &.is-overlap-disabled {
     grid-template-rows: var(#{custom-props.$contentLayoutMainGap}) min-content min-content auto 0 1fr;
   }
+
+  // Full-bleed header: header-wrapper spans the full grid width (edge-to-edge),
+  // breaking out of the maxContentWidth constraint. The background already spans
+  // full width; this modifier makes the header slot content do the same.
+  &.full-bleed-header {
+    > .header-wrapper {
+      grid-column: 1 / 8;
+    }
+  }
 }
 
 .layout.is-visual-refresh {


### PR DESCRIPTION
### Description

Adds a new opt-in boolean prop `fullBleedHeader` to `ContentLayout` that makes the header slot span the full available width (edge-to-edge), ignoring the `maxContentWidth` constraint.

The `background` element already spans the full grid width (columns 1–8); this prop extends that behaviour to the header **content** itself, enabling hero-image, custom-banner, and full-bleed marketing-header use cases.

Default is `false` — existing layouts are entirely unaffected.

Related issue: AWSUI-58901

### Changes

| File | Change |
|------|--------|
| `src/content-layout/interfaces.ts` | Add `fullBleedHeader?: boolean` prop with JSDoc |
| `src/content-layout/internal.tsx` | Wire prop → `full-bleed-header` CSS class modifier |
| `src/content-layout/index.tsx` | Track prop in analytics via `useBaseComponent` |
| `src/content-layout/styles.scss` | `.full-bleed-header > .header-wrapper` spans `grid-column: 1 / 8` |
| `src/content-layout/__tests__/content-layout.test.tsx` | 14 new test cases |
| `pages/content-layout/full-bleed-header.page.tsx` | New dev page with live toggles |

### How has this been tested?

- Unit tests: 54 tests pass (14 new tests covering default/false/true and combinations with `disableOverlap`, `headerBackgroundStyle`, `headerVariant`)
- ESLint: clean on all changed files
- Build: `npm run build` succeeds
- Dev page: `pages/content-layout/full-bleed-header.page.tsx` — toggle `fullBleedHeader`, `disableOverlap`, content presence, and custom background style

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible — `fullBleedHeader` defaults to `false`, no existing behaviour changes._
- _Changes do not include unsupported browser features._
- _Changes were manually tested for accessibility._

#### Security

- _No URL handling introduced._

#### Testing

- _14 new unit tests covering the new prop and its combinations._
- _Integration tests: not yet added (follow-up)._
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.