### PR TITLE
feat: DateRangePickerPresets standalone component (AWSUI-58799)

### DIFF
--- a/build-tools/utils/pluralize.js
+++ b/build-tools/utils/pluralize.js
@@ -28,6 +28,7 @@ const pluralizationMap = {
   DateInput: 'DateInputs',
   DatePicker: 'DatePickers',
   DateRangePicker: 'DateRangePickers',
+  DateRangePickerPresets: 'DateRangePickerPresets',
   Divider: 'Dividers',
   Drawer: 'Drawers',
   Dropdown: 'Dropdowns',

--- a/pages/date-range-picker-presets/index.page.tsx
+++ b/pages/date-range-picker-presets/index.page.tsx
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Box from '~components/box';
+import DateRangePickerPresets, { DateRangePickerPresetsProps } from '~components/date-range-picker-presets';
+import FormField from '~components/form-field';
+import Header from '~components/header';
+import SpaceBetween from '~components/space-between';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+const i18nStrings: DateRangePickerPresetsProps['i18nStrings'] = {
+  formatRelativeRange: ({ amount, unit }) => `Last ${amount} ${amount === 1 ? unit : `${unit}s`}`,
+  formatUnit: (unit, value) => (value === 1 ? unit : `${unit}s`),
+  relativeRangeSelectionHeading: 'Choose a range',
+  customRelativeRangeOptionLabel: 'Custom range',
+  customRelativeRangeOptionDescription: 'Set a custom range in the past',
+  customRelativeRangeDurationLabel: 'Duration',
+  customRelativeRangeDurationPlaceholder: 'Enter duration',
+  customRelativeRangeUnitLabel: 'Unit of time',
+};
+
+const relativeOptions: DateRangePickerPresetsProps['relativeOptions'] = [
+  { key: 'last-5-minutes', amount: 5, unit: 'minute', type: 'relative' },
+  { key: 'last-30-minutes', amount: 30, unit: 'minute', type: 'relative' },
+  { key: 'last-1-hour', amount: 1, unit: 'hour', type: 'relative' },
+  { key: 'last-6-hours', amount: 6, unit: 'hour', type: 'relative' },
+  { key: 'last-24-hours', amount: 24, unit: 'hour', type: 'relative' },
+];
+
+export default function DateRangePickerPresetsPage() {
+  const [value, setValue] = useState<DateRangePickerPresetsProps['value']>(null);
+
+  const handleChange: DateRangePickerPresetsProps['onChange'] = ({ detail }) => {
+    setValue(detail.value);
+  };
+
+  return (
+    <Box padding="l">
+      <SpaceBetween size="xl">
+        <Header variant="h1">DateRangePickerPresets — dev page</Header>
+
+        <ScreenshotArea>
+          <SpaceBetween size="l">
+            {/* --- Standard presets --- */}
+            <FormField label="Standard presets (with custom range)">
+              <DateRangePickerPresets
+                value={value}
+                relativeOptions={relativeOptions}
+                onChange={handleChange}
+                i18nStrings={i18nStrings}
+              />
+            </FormField>
+
+            <Box>
+              <b>Selected value:</b>
+              <Box variant="pre">{JSON.stringify(value, undefined, 2)}</Box>
+            </Box>
+
+            {/* --- No presets (custom range only) --- */}
+            <FormField label="No presets — custom range only">
+              <DateRangePickerPresets value={null} relativeOptions={[]} i18nStrings={i18nStrings} />
+            </FormField>
+
+            {/* --- Date-only mode --- */}
+            <FormField label="Date-only mode">
+              <DateRangePickerPresets
+                value={null}
+                relativeOptions={[
+                  { key: 'last-7-days', amount: 7, unit: 'day', type: 'relative' },
+                  { key: 'last-30-days', amount: 30, unit: 'day', type: 'relative' },
+                ]}
+                dateOnly={true}
+                i18nStrings={i18nStrings}
+              />
+            </FormField>
+
+            {/* --- Month granularity --- */}
+            <FormField label="Month granularity">
+              <DateRangePickerPresets
+                value={null}
+                relativeOptions={[
+                  { key: 'last-1-month', amount: 1, unit: 'month', type: 'relative' },
+                  { key: 'last-3-months', amount: 3, unit: 'month', type: 'relative' },
+                  { key: 'last-6-months', amount: 6, unit: 'month', type: 'relative' },
+                ]}
+                granularity="month"
+                i18nStrings={i18nStrings}
+              />
+            </FormField>
+
+            {/* --- Custom renderContent override --- */}
+            <FormField label="Custom renderContent override">
+              <DateRangePickerPresets
+                value={null}
+                relativeOptions={relativeOptions}
+                i18nStrings={i18nStrings}
+                renderContent={(_val, setVal) => (
+                  <SpaceBetween size="xs" direction="horizontal">
+                    {relativeOptions.map(option => (
+                      <button
+                        key={option.key}
+                        onClick={() => setVal(option)}
+                        style={{ cursor: 'pointer', padding: '4px 12px' }}
+                      >
+                        {i18nStrings.formatRelativeRange!(option)}
+                      </button>
+                    ))}
+                  </SpaceBetween>
+                )}
+              />
+            </FormField>
+          </SpaceBetween>
+        </ScreenshotArea>
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/pages/date-range-picker-presets/index.page.tsx
+++ b/pages/date-range-picker-presets/index.page.tsx
@@ -10,7 +10,7 @@ import SpaceBetween from '~components/space-between';
 
 import ScreenshotArea from '../utils/screenshot-area';
 
-const i18nStrings: DateRangePickerPresetsProps['i18nStrings'] = {
+const i18nStrings: NonNullable<DateRangePickerPresetsProps['i18nStrings']> = {
   formatRelativeRange: ({ amount, unit }) => `Last ${amount} ${amount === 1 ? unit : `${unit}s`}`,
   formatUnit: (unit, value) => (value === 1 ? unit : `${unit}s`),
   relativeRangeSelectionHeading: 'Choose a range',

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -12319,6 +12319,497 @@ with the input using \`ariaDescribedby\`.",
 }
 `;
 
+exports[`Components definition for date-range-picker-presets matches the snapshot: date-range-picker-presets 1`] = `
+{
+  "dashCaseName": "date-range-picker-presets",
+  "events": [
+    {
+      "cancelable": false,
+      "description": "Fired whenever the user selects or modifies a relative range.
+The event \`detail.value\` contains the newly chosen range.",
+      "detailInlineType": {
+        "name": "DateRangePickerPresetsProps.ChangeDetail",
+        "properties": [
+          {
+            "inlineType": {
+              "name": "DateRangePickerProps.RelativeValue",
+              "properties": [
+                {
+                  "name": "amount",
+                  "optional": false,
+                  "type": "number",
+                },
+                {
+                  "name": "key",
+                  "optional": true,
+                  "type": "string",
+                },
+                {
+                  "inlineType": {
+                    "name": "relative",
+                    "type": "union",
+                    "values": [
+                      "relative",
+                    ],
+                  },
+                  "name": "type",
+                  "optional": false,
+                  "type": "string",
+                },
+                {
+                  "inlineType": {
+                    "name": "DateRangePickerProps.TimeUnit",
+                    "type": "union",
+                    "values": [
+                      "day",
+                      "hour",
+                      "minute",
+                      "month",
+                      "second",
+                      "year",
+                      "week",
+                    ],
+                  },
+                  "name": "unit",
+                  "optional": false,
+                  "type": "string",
+                },
+              ],
+              "type": "object",
+            },
+            "name": "value",
+            "optional": false,
+            "type": "DateRangePickerProps.RelativeValue",
+          },
+        ],
+        "type": "object",
+      },
+      "detailType": "DateRangePickerPresetsProps.ChangeDetail",
+      "name": "onChange",
+    },
+  ],
+  "functions": [
+    {
+      "description": "Sets browser focus onto the first interactive element inside the component.",
+      "name": "focus",
+      "parameters": [],
+      "returnType": "void",
+    },
+  ],
+  "name": "DateRangePickerPresets",
+  "properties": [
+    {
+      "deprecatedTag": "Custom CSS is not supported. For testing and other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
+      "description": "Adds the specified classes to the root element of the component.",
+      "name": "className",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "description": "Specifies which time units to allow in the custom relative range control.
+When omitted, all units appropriate for the \`dateOnly\` / \`granularity\` setting are shown.",
+      "name": "customRelativeRangeUnits",
+      "optional": true,
+      "type": "Array<DateRangePickerProps.TimeUnit>",
+    },
+    {
+      "defaultValue": "false",
+      "description": "Hides time-based units (seconds, minutes, hours) from the custom-range unit
+selector and restricts presets to date-only units.
+
+Default: \`false\`.",
+      "name": "dateOnly",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
+      "defaultValue": "'day'",
+      "description": "Specifies the granularity at which users will be able to select a date.
+Defaults to \`day\`.",
+      "inlineType": {
+        "name": "DateGranularity",
+        "type": "union",
+        "values": [
+          "day",
+          "month",
+        ],
+      },
+      "name": "granularity",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "description": "An object containing all the necessary localized strings required by the component.
+Shares the same shape as \`DateRangePickerProps.I18nStrings\`.",
+      "i18nTag": true,
+      "inlineType": {
+        "name": "DateRangePickerProps.I18nStrings",
+        "properties": [
+          {
+            "name": "absoluteModeTitle",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "applyButtonLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "ariaDescribedby",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "ariaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "ariaLabelledby",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "cancelButtonLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "clearButtonLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "currentMonthAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "customRelativeRangeDurationLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "customRelativeRangeDurationPlaceholder",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "customRelativeRangeOptionDescription",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "customRelativeRangeOptionLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "customRelativeRangeUnitLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "dateConstraintText",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "dateTimeConstraintText",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "endDateLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "endMonthLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "endTimeLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "errorIconAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "inlineType": {
+              "name": "(value: DateRangePickerProps.RelativeValue) => string",
+              "parameters": [
+                {
+                  "name": "value",
+                  "type": "DateRangePickerProps.RelativeValue",
+                },
+              ],
+              "returnType": "string",
+              "type": "function",
+            },
+            "name": "formatRelativeRange",
+            "optional": true,
+            "type": "((value: DateRangePickerProps.RelativeValue) => string)",
+          },
+          {
+            "inlineType": {
+              "name": "(unit: DateRangePickerProps.TimeUnit, value: number) => string",
+              "parameters": [
+                {
+                  "name": "unit",
+                  "type": "DateRangePickerProps.TimeUnit",
+                },
+                {
+                  "name": "value",
+                  "type": "number",
+                },
+              ],
+              "returnType": "string",
+              "type": "function",
+            },
+            "name": "formatUnit",
+            "optional": true,
+            "type": "((unit: DateRangePickerProps.TimeUnit, value: number) => string)",
+          },
+          {
+            "name": "isoDateConstraintText",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "isoDatePlaceholder",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "isoDateTimeConstraintText",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "isoMonthConstraintText",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "modeSelectionLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "monthConstraintText",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "nextMonthAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "nextYearAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "previousMonthAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "previousYearAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "relativeModeTitle",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "relativeRangeSelectionHeading",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "relativeRangeSelectionMonthlyDescription",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "inlineType": {
+              "name": "(startDate: string, endDate: string) => string",
+              "parameters": [
+                {
+                  "name": "startDate",
+                  "type": "string",
+                },
+                {
+                  "name": "endDate",
+                  "type": "string",
+                },
+              ],
+              "returnType": "string",
+              "type": "function",
+            },
+            "name": "renderSelectedAbsoluteRangeAriaLive",
+            "optional": true,
+            "type": "((startDate: string, endDate: string) => string)",
+          },
+          {
+            "name": "slashedDateConstraintText",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "slashedDatePlaceholder",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "slashedDateTimeConstraintText",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "slashedMonthConstraintText",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "startDateLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "startMonthLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "startTimeLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "timePlaceholder",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "todayAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "i18nStrings",
+      "optional": true,
+      "type": "DateRangePickerProps.I18nStrings",
+    },
+    {
+      "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
+use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes). If you must
+use the \`id\` attribute, consider setting it on a parent element instead.",
+      "description": "Adds the specified ID to the root element of the component.",
+      "name": "id",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "defaultValue": "[]",
+      "description": "A list of relative time ranges shown as preset options.",
+      "name": "relativeOptions",
+      "optional": false,
+      "type": "ReadonlyArray<DateRangePickerProps.RelativeOption>",
+    },
+    {
+      "description": "Specifies custom content to fully override the presets UI.
+When provided, all default preset and custom-range controls are replaced.",
+      "inlineType": {
+        "name": "DateRangePickerProps.RelativeRangeControl",
+        "parameters": [
+          {
+            "name": "selectedRange",
+            "type": "DateRangePickerProps.RelativeValue | null",
+          },
+          {
+            "name": "setSelectedRange",
+            "type": "(value: DateRangePickerProps.RelativeValue) => void",
+          },
+        ],
+        "returnType": "React.ReactNode",
+        "type": "function",
+      },
+      "name": "renderContent",
+      "optional": true,
+      "type": "DateRangePickerProps.RelativeRangeControl",
+    },
+    {
+      "defaultValue": "null",
+      "description": "The current relative-range value. When \`null\` or \`undefined\`, no preset is selected.",
+      "inlineType": {
+        "name": "DateRangePickerProps.RelativeValue",
+        "properties": [
+          {
+            "name": "amount",
+            "optional": false,
+            "type": "number",
+          },
+          {
+            "name": "key",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "inlineType": {
+              "name": "relative",
+              "type": "union",
+              "values": [
+                "relative",
+              ],
+            },
+            "name": "type",
+            "optional": false,
+            "type": "string",
+          },
+          {
+            "inlineType": {
+              "name": "DateRangePickerProps.TimeUnit",
+              "type": "union",
+              "values": [
+                "day",
+                "hour",
+                "minute",
+                "month",
+                "second",
+                "year",
+                "week",
+              ],
+            },
+            "name": "unit",
+            "optional": false,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "value",
+      "optional": false,
+      "type": "DateRangePickerProps.RelativeValue | null",
+    },
+  ],
+  "regions": [],
+  "releaseStatus": "stable",
+}
+`;
+
 exports[`Components definition for divider matches the snapshot: divider 1`] = `
 {
   "dashCaseName": "divider",
@@ -40274,6 +40765,38 @@ wrapper.selectOptionByValue('option_1');
     {
       "methods": [
         {
+          "description": "Returns the custom-range duration input.",
+          "name": "findCustomRelativeRangeDuration",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "InputWrapper",
+          },
+        },
+        {
+          "description": "Returns the custom-range unit select.",
+          "name": "findCustomRelativeRangeUnit",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "SelectWrapper",
+          },
+        },
+        {
+          "description": "Returns the radio group containing the preset options.",
+          "name": "findRelativeRangeRadioGroup",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "RadioGroupWrapper",
+          },
+        },
+      ],
+      "name": "DateRangePickerPresetsWrapper",
+    },
+    {
+      "methods": [
+        {
           "description": "Returns the label element, or \`null\` if no label is set.",
           "name": "findLabel",
           "parameters": [],
@@ -50864,6 +51387,38 @@ The mode selector is only rendered as a Select on narrow viewports. On wide view
         },
       ],
       "name": "SelectWrapper",
+    },
+    {
+      "methods": [
+        {
+          "description": "Returns the custom-range duration input.",
+          "name": "findCustomRelativeRangeDuration",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "InputWrapper",
+          },
+        },
+        {
+          "description": "Returns the custom-range unit select.",
+          "name": "findCustomRelativeRangeUnit",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "SelectWrapper",
+          },
+        },
+        {
+          "description": "Returns the radio group containing the preset options.",
+          "name": "findRelativeRangeRadioGroup",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "RadioGroupWrapper",
+          },
+        },
+      ],
+      "name": "DateRangePickerPresetsWrapper",
     },
     {
       "methods": [

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-wrappers.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-wrappers.test.tsx.snap
@@ -37,6 +37,7 @@ import CopyToClipboardWrapper from './copy-to-clipboard';
 import DateInputWrapper from './date-input';
 import DatePickerWrapper from './date-picker';
 import DateRangePickerWrapper from './date-range-picker';
+import DateRangePickerPresetsWrapper from './date-range-picker-presets';
 import DividerWrapper from './divider';
 import DrawerWrapper from './drawer';
 import DropdownWrapper from './dropdown';
@@ -133,6 +134,7 @@ export { CopyToClipboardWrapper };
 export { DateInputWrapper };
 export { DatePickerWrapper };
 export { DateRangePickerWrapper };
+export { DateRangePickerPresetsWrapper };
 export { DividerWrapper };
 export { DrawerWrapper };
 export { DropdownWrapper };
@@ -987,6 +989,34 @@ findAllDateRangePickers(selector?: string): Array<DateRangePickerWrapper>;
  * @returns {DateRangePickerWrapper | null}
  */
 findClosestDateRangePicker(): DateRangePickerWrapper | null;
+/**
+ * Returns the wrapper of the first DateRangePickerPresets that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first DateRangePickerPresets.
+ * If no matching DateRangePickerPresets is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {DateRangePickerPresetsWrapper | null}
+ */
+findDateRangePickerPresets(selector?: string): DateRangePickerPresetsWrapper | null;
+
+/**
+ * Returns an array of DateRangePickerPresets wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the DateRangePickerPresets inside the current wrapper.
+ * If no matching DateRangePickerPresets is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<DateRangePickerPresetsWrapper>}
+ */
+findAllDateRangePickerPresets(selector?: string): Array<DateRangePickerPresetsWrapper>;
+
+/**
+ * Returns the wrapper of the closest parent DateRangePickerPresets for the current element,
+ * or the element itself if it is an instance of DateRangePickerPresets.
+ * If no DateRangePickerPresets is found, returns \`null\`.
+ *
+ * @returns {DateRangePickerPresetsWrapper | null}
+ */
+findClosestDateRangePickerPresets(): DateRangePickerPresetsWrapper | null;
 /**
  * Returns the wrapper of the first Divider that matches the specified CSS selector.
  * If no CSS selector is specified, returns the wrapper of the first Divider.
@@ -3203,6 +3233,19 @@ ElementWrapper.prototype.findDateRangePicker = function(selector) {
 ElementWrapper.prototype.findAllDateRangePickers = function(selector) {
   return this.findAllComponents(DateRangePickerWrapper, selector);
 };
+ElementWrapper.prototype.findDateRangePickerPresets = function(selector) {
+  let rootSelector = \`.\${DateRangePickerPresetsWrapper.rootSelector}\`;
+  if("legacyRootSelector" in DateRangePickerPresetsWrapper && DateRangePickerPresetsWrapper.legacyRootSelector){
+    rootSelector = \`:is(.\${DateRangePickerPresetsWrapper.rootSelector}, .\${DateRangePickerPresetsWrapper.legacyRootSelector})\`;
+  }
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DateRangePickerPresetsWrapper);
+};
+
+ElementWrapper.prototype.findAllDateRangePickerPresets = function(selector) {
+  return this.findAllComponents(DateRangePickerPresetsWrapper, selector);
+};
 ElementWrapper.prototype.findDivider = function(selector) {
   let rootSelector = \`.\${DividerWrapper.rootSelector}\`;
   if("legacyRootSelector" in DividerWrapper && DividerWrapper.legacyRootSelector){
@@ -4202,6 +4245,11 @@ ElementWrapper.prototype.findClosestDateRangePicker = function() {
   // https://github.com/microsoft/TypeScript/issues/29132
   return (this as any).findClosestComponent(DateRangePickerWrapper);
 };
+ElementWrapper.prototype.findClosestDateRangePickerPresets = function() {
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findClosestComponent(DateRangePickerPresetsWrapper);
+};
 ElementWrapper.prototype.findClosestDivider = function() {
   // casting to 'any' is needed to avoid this issue with generics
   // https://github.com/microsoft/TypeScript/issues/29132
@@ -4579,6 +4627,7 @@ import CopyToClipboardWrapper from './copy-to-clipboard';
 import DateInputWrapper from './date-input';
 import DatePickerWrapper from './date-picker';
 import DateRangePickerWrapper from './date-range-picker';
+import DateRangePickerPresetsWrapper from './date-range-picker-presets';
 import DividerWrapper from './divider';
 import DrawerWrapper from './drawer';
 import DropdownWrapper from './dropdown';
@@ -4675,6 +4724,7 @@ export { CopyToClipboardWrapper };
 export { DateInputWrapper };
 export { DatePickerWrapper };
 export { DateRangePickerWrapper };
+export { DateRangePickerPresetsWrapper };
 export { DividerWrapper };
 export { DrawerWrapper };
 export { DropdownWrapper };
@@ -5221,6 +5271,23 @@ findDateRangePicker(selector?: string): DateRangePickerWrapper;
  * @returns {MultiElementWrapper<DateRangePickerWrapper>}
  */
 findAllDateRangePickers(selector?: string): MultiElementWrapper<DateRangePickerWrapper>;
+/**
+ * Returns a wrapper that matches the DateRangePickerPresets with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches DateRangePickerPresets.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {DateRangePickerPresetsWrapper}
+ */
+findDateRangePickerPresets(selector?: string): DateRangePickerPresetsWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches DateRangePickerPresets with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches DateRangePickerPresets.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<DateRangePickerPresetsWrapper>}
+ */
+findAllDateRangePickerPresets(selector?: string): MultiElementWrapper<DateRangePickerPresetsWrapper>;
 /**
  * Returns a wrapper that matches the Dividers with the specified CSS selector.
  * If no CSS selector is specified, returns a wrapper that matches Dividers.
@@ -6710,6 +6777,19 @@ ElementWrapper.prototype.findDateRangePicker = function(selector) {
 
 ElementWrapper.prototype.findAllDateRangePickers = function(selector) {
   return this.findAllComponents(DateRangePickerWrapper, selector);
+};
+ElementWrapper.prototype.findDateRangePickerPresets = function(selector) {
+  let rootSelector = \`.\${DateRangePickerPresetsWrapper.rootSelector}\`;
+  if("legacyRootSelector" in DateRangePickerPresetsWrapper && DateRangePickerPresetsWrapper.legacyRootSelector){
+    rootSelector = \`:is(.\${DateRangePickerPresetsWrapper.rootSelector}, .\${DateRangePickerPresetsWrapper.legacyRootSelector})\`;
+  }
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, DateRangePickerPresetsWrapper);
+};
+
+ElementWrapper.prototype.findAllDateRangePickerPresets = function(selector) {
+  return this.findAllComponents(DateRangePickerPresetsWrapper, selector);
 };
 ElementWrapper.prototype.findDivider = function(selector) {
   let rootSelector = \`.\${DividerWrapper.rootSelector}\`;

--- a/src/date-range-picker-presets/__tests__/date-range-picker-presets.test.tsx
+++ b/src/date-range-picker-presets/__tests__/date-range-picker-presets.test.tsx
@@ -1,0 +1,206 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { act, render } from '@testing-library/react';
+
+import DateRangePickerPresets, { DateRangePickerPresetsProps } from '../../../lib/components/date-range-picker-presets';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import DateRangePickerPresetsWrapper from '../../../lib/components/test-utils/dom/date-range-picker-presets';
+
+const i18nStrings: DateRangePickerPresetsProps['i18nStrings'] = {
+  formatRelativeRange: ({ amount, unit }) => `Last ${amount} ${amount === 1 ? unit : `${unit}s`}`,
+  formatUnit: (unit, value) => (value === 1 ? unit : `${unit}s`),
+  relativeRangeSelectionHeading: 'Choose a range',
+  customRelativeRangeOptionLabel: 'Custom range',
+  customRelativeRangeOptionDescription: 'Set a custom range in the past',
+  customRelativeRangeDurationLabel: 'Duration',
+  customRelativeRangeDurationPlaceholder: 'Enter duration',
+  customRelativeRangeUnitLabel: 'Unit of time',
+};
+
+const relativeOptions: DateRangePickerPresetsProps['relativeOptions'] = [
+  { key: 'last-5-minutes', amount: 5, unit: 'minute', type: 'relative' },
+  { key: 'last-1-hour', amount: 1, unit: 'hour', type: 'relative' },
+  { key: 'last-6-hours', amount: 6, unit: 'hour', type: 'relative' },
+];
+
+function renderPresets(props: Partial<DateRangePickerPresetsProps> = {}) {
+  const { container } = render(
+    <DateRangePickerPresets value={null} relativeOptions={relativeOptions} i18nStrings={i18nStrings} {...props} />
+  );
+  return createWrapper(container).findComponent('div', DateRangePickerPresetsWrapper)!;
+}
+
+describe('DateRangePickerPresets', () => {
+  describe('rendering presets', () => {
+    test('renders a radio group with all provided relative options', () => {
+      const wrapper = renderPresets();
+      const radioGroup = wrapper.findRelativeRangeRadioGroup()!;
+      expect(radioGroup).not.toBeNull();
+      // 3 options + 1 custom = 4 radio buttons
+      expect(radioGroup.findButtons()).toHaveLength(4);
+    });
+
+    test('radio labels match formatRelativeRange output', () => {
+      const wrapper = renderPresets();
+      const radioGroup = wrapper.findRelativeRangeRadioGroup()!;
+      const labels = radioGroup.findButtons().map(b => b.findLabel().getElement().textContent);
+      expect(labels).toContain('Last 5 minutes');
+      expect(labels).toContain('Last 1 hour');
+      expect(labels).toContain('Last 6 hours');
+    });
+
+    test('renders a "Custom range" option appended to the presets', () => {
+      const wrapper = renderPresets();
+      const radioGroup = wrapper.findRelativeRangeRadioGroup()!;
+      const lastLabel = radioGroup.findButtons().at(-1)!.findLabel().getElement().textContent;
+      expect(lastLabel).toContain('Custom range');
+    });
+
+    test('renders with no preset options — custom range controls shown directly', () => {
+      const wrapper = renderPresets({ relativeOptions: [] });
+      // No radio group when there are no presets
+      expect(wrapper.findRelativeRangeRadioGroup()).toBeNull();
+      // Duration input and unit select are immediately visible
+      expect(wrapper.findCustomRelativeRangeDuration()).not.toBeNull();
+      expect(wrapper.findCustomRelativeRangeUnit()).not.toBeNull();
+    });
+
+    test('pre-selects the radio matching the provided value key', () => {
+      const wrapper = renderPresets({
+        value: { key: 'last-1-hour', amount: 1, unit: 'hour', type: 'relative' },
+      });
+      const radioGroup = wrapper.findRelativeRangeRadioGroup()!;
+      const hourRadio = radioGroup.findInputByValue('last-1-hour')!.getElement() as HTMLInputElement;
+      expect(hourRadio.checked).toBe(true);
+    });
+
+    test('does not show custom controls when a preset is selected', () => {
+      const wrapper = renderPresets({
+        value: { key: 'last-1-hour', amount: 1, unit: 'hour', type: 'relative' },
+      });
+      expect(wrapper.findCustomRelativeRangeDuration()).toBeNull();
+      expect(wrapper.findCustomRelativeRangeUnit()).toBeNull();
+    });
+  });
+
+  describe('onChange', () => {
+    test('fires onChange when a preset radio is selected', () => {
+      const onChange = jest.fn();
+      const wrapper = renderPresets({ onChange });
+      act(() => {
+        wrapper.findRelativeRangeRadioGroup()!.findInputByValue('last-5-minutes')!.click();
+      });
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: { value: { key: 'last-5-minutes', amount: 5, unit: 'minute', type: 'relative' } },
+        })
+      );
+    });
+
+    test('fires onChange with NaN amount when "Custom range" radio is selected', () => {
+      const onChange = jest.fn();
+      const wrapper = renderPresets({ onChange });
+      act(() => {
+        // Custom option is the last radio button
+        wrapper.findRelativeRangeRadioGroup()!.findButtons().at(-1)!.findLabel().click();
+      });
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const { value } = onChange.mock.calls[0][0].detail;
+      expect(value.type).toBe('relative');
+      expect(isNaN(value.amount)).toBe(true);
+    });
+
+    test('fires onChange when duration input is changed in custom mode', () => {
+      const onChange = jest.fn();
+      const wrapper = renderPresets({ relativeOptions: [], onChange });
+      act(() => {
+        wrapper.findCustomRelativeRangeDuration()!.setInputValue('7');
+      });
+      expect(onChange).toHaveBeenCalled();
+      const { value } = onChange.mock.calls[0][0].detail;
+      expect(value.amount).toBe(7);
+      expect(value.type).toBe('relative');
+    });
+  });
+
+  describe('custom range controls', () => {
+    test('shows duration and unit controls after selecting "Custom range"', () => {
+      const wrapper = renderPresets();
+      act(() => {
+        wrapper.findRelativeRangeRadioGroup()!.findButtons().at(-1)!.findLabel().click();
+      });
+      expect(wrapper.findCustomRelativeRangeDuration()).not.toBeNull();
+      expect(wrapper.findCustomRelativeRangeUnit()).not.toBeNull();
+    });
+  });
+
+  describe('dateOnly prop', () => {
+    test('does not show time-based units when dateOnly is true', () => {
+      const wrapper = renderPresets({ relativeOptions: [], dateOnly: true });
+      const unitSelect = wrapper.findCustomRelativeRangeUnit()!;
+      // Open the dropdown and check options don't include minute/hour/second
+      act(() => {
+        unitSelect.openDropdown();
+      });
+      const optionTexts = unitSelect
+        .findDropdown()!
+        .findOptions()
+        .map(o => o.getElement().textContent);
+      expect(optionTexts.some(t => t?.includes('minute'))).toBe(false);
+      expect(optionTexts.some(t => t?.includes('hour'))).toBe(false);
+      expect(optionTexts.some(t => t?.includes('second'))).toBe(false);
+    });
+  });
+
+  describe('granularity prop', () => {
+    test('restricts units to month/year when granularity is "month"', () => {
+      const wrapper = renderPresets({
+        relativeOptions: [{ key: 'last-1-month', amount: 1, unit: 'month', type: 'relative' }],
+        granularity: 'month',
+      });
+      const radioGroup = wrapper.findRelativeRangeRadioGroup()!;
+      const labels = radioGroup.findButtons().map(b => b.findLabel().getElement().textContent);
+      expect(labels).toContain('Last 1 month');
+    });
+
+    test('shows only month/year units in custom range when granularity is "month"', () => {
+      const wrapper = renderPresets({ relativeOptions: [], granularity: 'month' });
+      act(() => {
+        wrapper.findCustomRelativeRangeUnit()!.openDropdown();
+      });
+      const optionTexts = wrapper
+        .findCustomRelativeRangeUnit()!
+        .findDropdown()!
+        .findOptions()
+        .map(o => o.getElement().textContent);
+      expect(optionTexts.some(t => t?.includes('day'))).toBe(false);
+      expect(optionTexts.some(t => t?.includes('hour'))).toBe(false);
+    });
+  });
+
+  describe('renderContent prop', () => {
+    test('renders custom content instead of default presets UI when renderContent is provided', () => {
+      const renderContent: DateRangePickerPresetsProps['renderContent'] = () => (
+        <div data-testid="custom-ui">Custom Presets UI</div>
+      );
+      const { container } = render(
+        <DateRangePickerPresets
+          value={null}
+          relativeOptions={relativeOptions}
+          i18nStrings={i18nStrings}
+          renderContent={renderContent}
+        />
+      );
+      expect(container.querySelector('[data-testid="custom-ui"]')).not.toBeNull();
+      expect(container.querySelector('[data-testid="custom-ui"]')!.textContent).toBe('Custom Presets UI');
+    });
+
+    test('does not render the default radio group when renderContent is provided', () => {
+      const renderContent: DateRangePickerPresetsProps['renderContent'] = () => <div>override</div>;
+      const wrapper = renderPresets({ renderContent });
+      expect(wrapper.findRelativeRangeRadioGroup()).toBeNull();
+    });
+  });
+});

--- a/src/date-range-picker-presets/index.tsx
+++ b/src/date-range-picker-presets/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 'use client';
 import React, { Ref, useRef } from 'react';
+import clsx from 'clsx';
 
 import { DateRangePickerProps } from '../date-range-picker/interfaces';
 import RelativeRangePicker from '../date-range-picker/relative-range';
@@ -11,6 +12,8 @@ import useForwardFocus from '../internal/hooks/forward-focus';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { DateRangePickerPresetsProps } from './interfaces';
+
+import testutilStyles from '../date-range-picker/test-classes/styles.css.js';
 
 export { DateRangePickerPresetsProps };
 
@@ -43,7 +46,7 @@ const DateRangePickerPresets = React.forwardRef(
     };
 
     return (
-      <div ref={__internalRootRef} {...baseProps}>
+      <div ref={__internalRootRef} {...baseProps} className={clsx(baseProps.className, testutilStyles.root)}>
         <div ref={innerRef}>
           <RelativeRangePicker
             dateOnly={dateOnly}

--- a/src/date-range-picker-presets/index.tsx
+++ b/src/date-range-picker-presets/index.tsx
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+'use client';
+import React, { Ref, useRef } from 'react';
+
+import { DateRangePickerProps } from '../date-range-picker/interfaces';
+import RelativeRangePicker from '../date-range-picker/relative-range';
+import { getBaseProps } from '../internal/base-component';
+import { fireNonCancelableEvent } from '../internal/events';
+import useForwardFocus from '../internal/hooks/forward-focus';
+import useBaseComponent from '../internal/hooks/use-base-component';
+import { applyDisplayName } from '../internal/utils/apply-display-name';
+import { DateRangePickerPresetsProps } from './interfaces';
+
+export { DateRangePickerPresetsProps };
+
+const DateRangePickerPresets = React.forwardRef(
+  (
+    {
+      value = null,
+      relativeOptions = [],
+      onChange,
+      dateOnly = false,
+      i18nStrings,
+      customRelativeRangeUnits,
+      renderContent,
+      granularity = 'day',
+      ...rest
+    }: DateRangePickerPresetsProps,
+    ref: Ref<DateRangePickerPresetsProps.Ref>
+  ) => {
+    const { __internalRootRef } = useBaseComponent('DateRangePickerPresets', {
+      props: { dateOnly, granularity },
+    });
+
+    const innerRef = useRef<HTMLDivElement>(null);
+    useForwardFocus(ref, innerRef as React.RefObject<HTMLElement>);
+
+    const baseProps = getBaseProps(rest);
+
+    const handleChange = (range: DateRangePickerProps.RelativeValue) => {
+      fireNonCancelableEvent(onChange, { value: range });
+    };
+
+    return (
+      <div ref={__internalRootRef} {...baseProps}>
+        <div ref={innerRef}>
+          <RelativeRangePicker
+            dateOnly={dateOnly}
+            options={relativeOptions}
+            initialSelection={value}
+            onChange={handleChange}
+            i18nStrings={i18nStrings}
+            isSingleGrid={false}
+            customUnits={customRelativeRangeUnits}
+            granularity={granularity}
+            renderRelativeRangeContent={renderContent}
+          />
+        </div>
+      </div>
+    );
+  }
+);
+
+applyDisplayName(DateRangePickerPresets, 'DateRangePickerPresets');
+export default DateRangePickerPresets;

--- a/src/date-range-picker-presets/interfaces.ts
+++ b/src/date-range-picker-presets/interfaces.ts
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CalendarProps } from '../calendar/interfaces';
+import { DateRangePickerProps } from '../date-range-picker/interfaces';
+import { BaseComponentProps } from '../types/base-component';
+import { NonCancelableEventHandler } from '../types/events';
+
+export interface DateRangePickerPresetsProps extends BaseComponentProps, Pick<CalendarProps, 'granularity'> {
+  /**
+   * The current relative-range value. When `null` or `undefined`, no preset is selected.
+   */
+  value: DateRangePickerProps.RelativeValue | null;
+
+  /**
+   * A list of relative time ranges shown as preset options.
+   */
+  relativeOptions: ReadonlyArray<DateRangePickerProps.RelativeOption>;
+
+  /**
+   * Fired whenever the user selects or modifies a relative range.
+   * The event `detail.value` contains the newly chosen range.
+   */
+  onChange?: NonCancelableEventHandler<DateRangePickerPresetsProps.ChangeDetail>;
+
+  /**
+   * Hides time-based units (seconds, minutes, hours) from the custom-range unit
+   * selector and restricts presets to date-only units.
+   *
+   * Default: `false`.
+   */
+  dateOnly?: boolean;
+
+  /**
+   * An object containing all the necessary localized strings required by the component.
+   * Shares the same shape as `DateRangePickerProps.I18nStrings`.
+   * @i18n
+   */
+  i18nStrings?: DateRangePickerProps.I18nStrings;
+
+  /**
+   * Specifies which time units to allow in the custom relative range control.
+   * When omitted, all units appropriate for the `dateOnly` / `granularity` setting are shown.
+   */
+  customRelativeRangeUnits?: DateRangePickerProps.TimeUnit[];
+
+  /**
+   * Specifies custom content to fully override the presets UI.
+   * When provided, all default preset and custom-range controls are replaced.
+   */
+  renderContent?: DateRangePickerProps.RelativeRangeControl;
+}
+
+export namespace DateRangePickerPresetsProps {
+  export interface ChangeDetail {
+    /**
+     * The newly selected relative range.
+     */
+    value: DateRangePickerProps.RelativeValue;
+  }
+
+  export interface Ref {
+    /**
+     * Sets browser focus onto the first interactive element inside the component.
+     */
+    focus(): void;
+  }
+}

--- a/src/test-utils/dom/date-range-picker-presets/index.ts
+++ b/src/test-utils/dom/date-range-picker-presets/index.ts
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ComponentWrapper } from '@cloudscape-design/test-utils-core/dom';
+
+import InputWrapper from '../input';
+import RadioGroupWrapper from '../radio-group';
+import SelectWrapper from '../select';
+
+import testutilStyles from '../../../date-range-picker/test-classes/styles.selectors.js';
+
+export default class DateRangePickerPresetsWrapper extends ComponentWrapper {
+  static rootSelector: string = testutilStyles.root;
+
+  /**
+   * Returns the radio group containing the preset options.
+   */
+  findRelativeRangeRadioGroup(): RadioGroupWrapper | null {
+    return this.findComponent(`.${testutilStyles['relative-range-radio-group']}`, RadioGroupWrapper);
+  }
+
+  /**
+   * Returns the custom-range duration input.
+   */
+  findCustomRelativeRangeDuration(): InputWrapper | null {
+    return this.findComponent(`.${testutilStyles['custom-range-duration-input']}`, InputWrapper);
+  }
+
+  /**
+   * Returns the custom-range unit select.
+   */
+  findCustomRelativeRangeUnit(): SelectWrapper | null {
+    return this.findComponent(`.${testutilStyles['custom-range-unit-select']}`, SelectWrapper);
+  }
+}


### PR DESCRIPTION
## Summary

Implements **AWSUI-58799**: exposes the relative-range presets UI from `DateRangePicker` as a new standalone `DateRangePickerPresets` component, so consumers can embed preset selection without the full picker trigger/dropdown.

## What changed

| File | Purpose |
|------|---------|
| `src/date-range-picker-presets/interfaces.ts` | `DateRangePickerPresetsProps` — full typed API |
| `src/date-range-picker-presets/index.tsx` | Public component wrapping internal `RelativeRangePicker` |
| `src/test-utils/dom/date-range-picker-presets/` | Test-utils wrapper (`findRelativeRangeRadioGroup`, `findCustomRelativeRangeDuration`, `findCustomRelativeRangeUnit`) |
| `build-tools/utils/pluralize.js` | Register plural form so build tooling picks up the new component |
| `pages/date-range-picker-presets/index.page.tsx` | Dev page — 5 scenarios (standard, no-presets, date-only, month granularity, `renderContent` override) |
| `src/date-range-picker-presets/__tests__/` | 15 unit tests, all passing |

## API surface

```tsx
import DateRangePickerPresets, { DateRangePickerPresetsProps } from '@cloudscape-design/components/date-range-picker-presets';

<DateRangePickerPresets
  value={selectedRange}
  relativeOptions={[
    { key: 'last-5-minutes', amount: 5, unit: 'minute', type: 'relative' },
    { key: 'last-1-hour',    amount: 1, unit: 'hour',   type: 'relative' },
  ]}
  onChange={({ detail }) => setSelectedRange(detail.value)}
  i18nStrings={i18nStrings}
/>
```

### Key props
- **`value`** — controlled `RelativeValue | null`
- **`relativeOptions`** — preset list (same type as `DateRangePicker.relativeOptions`)
- **`onChange`** — fires `{ value: RelativeValue }`
- **`dateOnly`** — hides time units from custom range selector
- **`granularity`** — `'day'` (default) or `'month'`
- **`customRelativeRangeUnits`** — restrict available time units
- **`renderContent`** — fully override the presets UI (`RelativeRangeControl` type, same as `DateRangePicker.renderRelativeRangeContent`)
- **`i18nStrings`** — shared with `DateRangePickerProps.I18nStrings`

## Testing
- ✅ Build: `npm run quick-build` — clean
- ✅ TypeScript: `tsc --noEmit` — 0 errors
- ✅ ESLint: 0 errors, 0 warnings
- ✅ Unit tests: 15/15 passing

Refs: AWSUI-58799