### PR TITLE
feat: add maxLength and showCharacterCount props to input

### DIFF
--- a/pages/input/inputs.page.tsx
+++ b/pages/input/inputs.page.tsx
@@ -59,6 +59,98 @@ function SimpleForm() {
   );
 }
 
+// ── Character count demos ──────────────────────────────────────────────────
+
+function CharacterCountStandalone() {
+  const [value, setValue] = useState('');
+  return (
+    <SpaceBetween size="xs">
+      <h3>Standalone — maxLength=50, showCharacterCount</h3>
+      <Input
+        ariaLabel="Short description"
+        placeholder="Enter a short description"
+        value={value}
+        maxLength={50}
+        showCharacterCount={true}
+        onChange={e => setValue(e.detail.value)}
+      />
+    </SpaceBetween>
+  );
+}
+
+function CharacterCountInFormField() {
+  const [value, setValue] = useState('Hello');
+  return (
+    <SpaceBetween size="xs">
+      <h3>Inside FormField — maxLength=100, showCharacterCount</h3>
+      <FormField
+        label="Resource name"
+        description="Maximum 100 characters."
+        constraintText="Only alphanumeric characters and hyphens are allowed."
+        controlId="res-name"
+      >
+        <Input
+          controlId="res-name"
+          placeholder="my-resource-name"
+          value={value}
+          maxLength={100}
+          showCharacterCount={true}
+          onChange={e => setValue(e.detail.value)}
+        />
+      </FormField>
+    </SpaceBetween>
+  );
+}
+
+function CharacterCountAtLimit() {
+  const max = 20;
+  const [value, setValue] = useState('This is exactly 20!');
+  return (
+    <SpaceBetween size="xs">
+      <h3>At limit — maxLength=20</h3>
+      <Input
+        ariaLabel="At-limit input"
+        value={value}
+        maxLength={max}
+        showCharacterCount={true}
+        onChange={e => setValue(e.detail.value)}
+      />
+    </SpaceBetween>
+  );
+}
+
+function CharacterCountDisabled() {
+  return (
+    <SpaceBetween size="xs">
+      <h3>Disabled with character count</h3>
+      <Input
+        ariaLabel="Disabled with count"
+        value="disabled text"
+        maxLength={30}
+        showCharacterCount={true}
+        disabled={true}
+        onChange={() => {}}
+      />
+    </SpaceBetween>
+  );
+}
+
+function MaxLengthOnly() {
+  const [value, setValue] = useState('');
+  return (
+    <SpaceBetween size="xs">
+      <h3>maxLength only (no showCharacterCount) — enforces limit without visual counter</h3>
+      <Input
+        ariaLabel="maxLength only"
+        placeholder="Max 10 chars, no counter"
+        value={value}
+        maxLength={10}
+        onChange={e => setValue(e.detail.value)}
+      />
+    </SpaceBetween>
+  );
+}
+
 export default function InputsPage() {
   return (
     <div style={{ padding: 10 }}>
@@ -68,6 +160,16 @@ export default function InputsPage() {
       <FormField description="This is a description." label="Form field label" id="formfield-with-input">
         <Input value={''} onChange={() => {}} />
       </FormField>
+
+      <hr />
+      <h2>Character count / maxlength (AWSUI-58637)</h2>
+      <SpaceBetween size="l">
+        <CharacterCountStandalone />
+        <CharacterCountInFormField />
+        <CharacterCountAtLimit />
+        <CharacterCountDisabled />
+        <MaxLengthOnly />
+      </SpaceBetween>
     </div>
   );
 }

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -17063,6 +17063,14 @@ single form field.",
       "type": "boolean",
     },
     {
+      "description": "Specifies the maximum number of characters allowed in the input. When set,
+the native \`maxlength\` attribute is applied to the input element.
+Use together with \`showCharacterCount\` to display a character counter.",
+      "name": "maxLength",
+      "optional": true,
+      "type": "number",
+    },
+    {
       "description": "Specifies the name of the control used in HTML forms.",
       "name": "name",
       "optional": true,
@@ -17107,13 +17115,22 @@ Don't use read-only inputs outside a form.",
       "type": "boolean",
     },
     {
+      "description": "When \`true\`, displays a character count indicator below the input showing
+the number of characters entered relative to \`maxLength\` (e.g. "12/100").
+Requires \`maxLength\` to be set. The indicator is announced to screen readers
+via a debounced live region so that it does not interrupt typing.",
+      "name": "showCharacterCount",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
       "description": "Specifies the value of the \`spellcheck\` attribute on the native control.
 This value controls the native browser capability to check for spelling/grammar errors.
 If not set, the browser default behavior is to perform spellchecking.
 For more details, check the [spellcheck MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck).
 
 Enhanced spellchecking features of your browser and/or operating system may send input values to external parties.
-Make sure it’s deactivated for fields with sensitive information to prevent
+Make sure it's deactivated for fields with sensitive information to prevent
 inadvertently sending data (such as user passwords) to third parties.",
       "name": "spellcheck",
       "optional": true,
@@ -22677,7 +22694,7 @@ If not set, the browser default behavior is to perform spellchecking.
 For more details, check the [spellcheck MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck).
 
 Enhanced spellchecking features of your browser and/or operating system may send input values to external parties.
-Make sure it’s deactivated for fields with sensitive information to prevent
+Make sure it's deactivated for fields with sensitive information to prevent
 inadvertently sending data (such as user passwords) to third parties.",
       "name": "spellcheck",
       "optional": true,
@@ -30953,7 +30970,7 @@ If not set, the browser default behavior is to perform spellchecking.
 For more details, check the [spellcheck MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck).
 
 Enhanced spellchecking features of your browser and/or operating system may send input values to external parties.
-Make sure it’s deactivated for fields with sensitive information to prevent
+Make sure it's deactivated for fields with sensitive information to prevent
 inadvertently sending data (such as user passwords) to third parties.",
       "name": "spellcheck",
       "optional": true,

--- a/src/input/__tests__/char-count.test.tsx
+++ b/src/input/__tests__/char-count.test.tsx
@@ -75,22 +75,30 @@ describe('Input — showCharacterCount prop', () => {
   });
 
   test('live region exists', () => {
-    const { container } = renderInput({ maxLength: 50, showCharacterCount: true, value: 'test' });
-    // InternalLiveRegion renders with aria-live attribute
-    const liveRegion = container.querySelector('[aria-live]');
+    renderInput({ maxLength: 50, showCharacterCount: true, value: 'test' });
+    // InternalLiveRegion mounts its announcer element (with aria-live) on the
+    // document body via the shared LiveRegionController, not inside the input's
+    // own DOM subtree, so we query the whole document for it.
+    const liveRegion = document.querySelector('[aria-live]');
     expect(liveRegion).not.toBeNull();
   });
 
   test('live region announces count after debounce', () => {
     jest.useFakeTimers();
-    const { container } = renderInput({ maxLength: 50, showCharacterCount: true, value: 'hi' });
-    const liveRegion = container.querySelector('[aria-live]');
+    // The live region prevents the initial announcement, so we render and then
+    // change the value to trigger a debounced count announcement.
+    const { rerender } = render(<Input value="hi" maxLength={50} showCharacterCount={true} onChange={jest.fn()} />);
+    rerender(<Input value="hip" maxLength={50} showCharacterCount={true} onChange={jest.fn()} />);
+
+    const liveRegion = document.querySelector('[aria-live]');
+    expect(liveRegion).not.toBeNull();
 
     act(() => {
+      // Default live-region delay is 1s; advance past it to flush the announcement.
       jest.advanceTimersByTime(1100);
     });
-    // The live region should contain the count text after the delay
-    expect(liveRegion).not.toBeNull();
+    // After the debounce delay, the live region announces the updated count.
+    expect(liveRegion!.textContent).toBe('3/50');
 
     jest.useRealTimers();
   });

--- a/src/input/__tests__/char-count.test.tsx
+++ b/src/input/__tests__/char-count.test.tsx
@@ -1,0 +1,140 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { act, render } from '@testing-library/react';
+
+import FormField from '../../../lib/components/form-field';
+import Input, { InputProps } from '../../../lib/components/input';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+function renderInput(props: Partial<InputProps> = {}) {
+  const { container } = render(<Input value="" onChange={jest.fn()} {...props} />);
+  const wrapper = createWrapper(container).findInput()!;
+  return {
+    container,
+    wrapper,
+    input: wrapper.findNativeInput().getElement(),
+  };
+}
+
+describe('Input — maxLength prop', () => {
+  test('is not set on native input by default', () => {
+    const { input } = renderInput();
+    expect(input).not.toHaveAttribute('maxlength');
+  });
+
+  test('sets maxlength on the native input', () => {
+    const { input } = renderInput({ maxLength: 50 });
+    expect(input).toHaveAttribute('maxlength', '50');
+  });
+
+  test('does not render character count when showCharacterCount is not set', () => {
+    const { container } = renderInput({ maxLength: 50 });
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+});
+
+describe('Input — showCharacterCount prop', () => {
+  test('does not render character count when maxLength is not provided', () => {
+    const { container } = renderInput({ showCharacterCount: true });
+    // No count display without maxLength
+    expect(container.textContent).not.toMatch(/\//);
+  });
+
+  test('renders "0/N" when value is empty', () => {
+    const { container } = renderInput({ maxLength: 100, showCharacterCount: true, value: '' });
+    const visual = container.querySelector('[aria-hidden="true"]');
+    expect(visual).not.toBeNull();
+    expect(visual!.textContent).toBe('0/100');
+  });
+
+  test('renders correct count for non-empty value', () => {
+    const { container } = renderInput({ maxLength: 100, showCharacterCount: true, value: 'hello' });
+    const visual = container.querySelector('[aria-hidden="true"]');
+    expect(visual!.textContent).toBe('5/100');
+  });
+
+  test('updates count when value changes', () => {
+    const { container } = renderInput({ maxLength: 20, showCharacterCount: true, value: 'abc' });
+    const visual = container.querySelector('[aria-hidden="true"]');
+    expect(visual!.textContent).toBe('3/20');
+
+    // Re-render with new value
+    const { container: container2 } = render(
+      <Input value="abcde" maxLength={20} showCharacterCount={true} onChange={jest.fn()} />
+    );
+    const visual2 = container2.querySelector('[aria-hidden="true"]');
+    expect(visual2!.textContent).toBe('5/20');
+  });
+
+  test('visual counter is aria-hidden', () => {
+    const { container } = renderInput({ maxLength: 50, showCharacterCount: true, value: 'test' });
+    const visual = container.querySelector('[aria-hidden="true"]');
+    expect(visual).not.toBeNull();
+    expect(visual!.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  test('live region exists', () => {
+    const { container } = renderInput({ maxLength: 50, showCharacterCount: true, value: 'test' });
+    // InternalLiveRegion renders with aria-live attribute
+    const liveRegion = container.querySelector('[aria-live]');
+    expect(liveRegion).not.toBeNull();
+  });
+
+  test('live region announces count after debounce', () => {
+    jest.useFakeTimers();
+    const { container } = renderInput({ maxLength: 50, showCharacterCount: true, value: 'hi' });
+    const liveRegion = container.querySelector('[aria-live]');
+
+    act(() => {
+      jest.advanceTimersByTime(1100);
+    });
+    // The live region should contain the count text after the delay
+    expect(liveRegion).not.toBeNull();
+
+    jest.useRealTimers();
+  });
+
+  test('renders count when disabled', () => {
+    const { container } = renderInput({ maxLength: 30, showCharacterCount: true, value: 'abc', disabled: true });
+    const visual = container.querySelector('[aria-hidden="true"]');
+    expect(visual!.textContent).toBe('3/30');
+  });
+
+  test('renders count when readOnly', () => {
+    const { container } = renderInput({ maxLength: 30, showCharacterCount: true, value: 'abc', readOnly: true });
+    const visual = container.querySelector('[aria-hidden="true"]');
+    expect(visual!.textContent).toBe('3/30');
+  });
+
+  test('shows "N/N" when value equals maxLength', () => {
+    const { container } = renderInput({ maxLength: 5, showCharacterCount: true, value: 'hello' });
+    const visual = container.querySelector('[aria-hidden="true"]');
+    expect(visual!.textContent).toBe('5/5');
+  });
+});
+
+describe('Input — maxLength with FormField', () => {
+  test('renders inside FormField with character count', () => {
+    const { container } = render(
+      <FormField label="Name" controlId="test-input">
+        <Input controlId="test-input" value="test" maxLength={100} showCharacterCount={true} onChange={jest.fn()} />
+      </FormField>
+    );
+    const visual = container.querySelector('[aria-hidden="true"]');
+    expect(visual!.textContent).toBe('4/100');
+  });
+
+  test('char-count live region id is derived from controlId', () => {
+    const { container } = render(
+      <Input controlId="my-input" value="hello" maxLength={50} showCharacterCount={true} onChange={jest.fn()} />
+    );
+    const liveRegion = container.querySelector('#my-input-char-count');
+    expect(liveRegion).not.toBeNull();
+  });
+
+  test('native input aria-describedby includes char-count id when controlId is set', () => {
+    const { input } = renderInput({ controlId: 'my-ctrl', maxLength: 50, showCharacterCount: true, value: '' });
+    expect(input.getAttribute('aria-describedby')).toContain('my-ctrl-char-count');
+  });
+});

--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -43,6 +43,8 @@ const Input = React.forwardRef(
       controlId,
       clearAriaLabel,
       nativeInputAttributes,
+      maxLength,
+      showCharacterCount,
       style,
       ...rest
     }: InputProps,
@@ -100,6 +102,8 @@ const Input = React.forwardRef(
           controlId,
           clearAriaLabel,
           nativeInputAttributes,
+          maxLength,
+          showCharacterCount,
           style,
         }}
         className={clsx(styles.root, baseProps.className)}

--- a/src/input/interfaces.ts
+++ b/src/input/interfaces.ts
@@ -122,7 +122,7 @@ export interface InputSpellcheck {
    * For more details, check the [spellcheck MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck).
    *
    * Enhanced spellchecking features of your browser and/or operating system may send input values to external parties.
-   * Make sure it’s deactivated for fields with sensitive information to prevent
+   * Make sure it's deactivated for fields with sensitive information to prevent
    * inadvertently sending data (such as user passwords) to third parties.
    */
   spellcheck?: boolean;
@@ -181,6 +181,21 @@ export interface InputProps
    * including the date, month, week, time, datetime-local, number and range types.
    */
   step?: InputProps.Step;
+
+  /**
+   * Specifies the maximum number of characters allowed in the input. When set,
+   * the native `maxlength` attribute is applied to the input element.
+   * Use together with `showCharacterCount` to display a character counter.
+   */
+  maxLength?: number;
+
+  /**
+   * When `true`, displays a character count indicator below the input showing
+   * the number of characters entered relative to `maxLength` (e.g. "12/100").
+   * Requires `maxLength` to be set. The indicator is announced to screen readers
+   * via a debounced live region so that it does not interrupt typing.
+   */
+  showCharacterCount?: boolean;
 
   /**
    * An object containing CSS properties to customize the input's visual appearance.

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -19,6 +19,7 @@ import { fireKeyboardEvent, fireNonCancelableEvent } from '../internal/events';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useDebounceCallback } from '../internal/hooks/use-debounce-callback';
 import WithNativeAttributes, { SkipWarnings } from '../internal/utils/with-native-attributes';
+import InternalLiveRegion from '../live-region/internal';
 import { BaseComponentProps } from '../types/base-component';
 import { NonCancelableEventHandler } from '../types/events';
 import { FormFieldValidationControlProps } from '../types/form-field';
@@ -100,6 +101,8 @@ function InternalInput(
     __skipNativeAttributesWarnings,
     __inlineLabelText,
     __fullWidth,
+    maxLength,
+    showCharacterCount,
     style,
     ...rest
   }: InternalInputProps,
@@ -125,13 +128,25 @@ function InternalInput(
     ? formFieldContext
     : rest;
 
+  // ── Character count ──────────────────────────────────────────────────────
+  const showCount = showCharacterCount && maxLength !== undefined;
+  const charCount = value ? value.length : 0;
+  const charCountText = showCount ? `${charCount}/${maxLength}` : undefined;
+
+  // Stable id for the live region so the input can reference it in aria-describedby.
+  const charCountId = showCount && controlId ? `${controlId}-char-count` : undefined;
+
+  // Include char-count live region in aria-describedby so AT reads it on focus.
+  const effectiveAriaDescribedby = [ariaDescribedby, charCountId].filter(Boolean).join(' ') || undefined;
+  // ─────────────────────────────────────────────────────────────────────────
+
   const attributes: React.InputHTMLAttributes<HTMLInputElement> = {
     'aria-label': ariaLabel,
     // aria-labelledby has precedence over aria-label in accessible name calculation.
     // When aria-label is provided for Input, it should override aria-labelledBy from form-field context.
     // If both aria-label and aria-labelledby come from Input props, aria-labelledby will be used in accessible name
     'aria-labelledby': ariaLabel && !rest.ariaLabelledby ? undefined : ariaLabelledby,
-    'aria-describedby': ariaDescribedby,
+    'aria-describedby': effectiveAriaDescribedby,
     name,
     placeholder,
     autoFocus,
@@ -155,6 +170,7 @@ function InternalInput(
     step,
     inputMode,
     spellCheck: spellcheck,
+    maxLength,
     onKeyDown: onKeyDown && (event => fireKeyboardEvent(onKeyDown, event)),
     onKeyUp: onKeyUp && (event => fireKeyboardEvent(onKeyUp, event)),
     // We set a default value on the component in order to force it into the controlled mode.
@@ -267,6 +283,21 @@ function InternalInput(
             disabled={disabled}
           />
         </span>
+      )}
+      {showCount && (
+        <div className={styles['char-count-wrapper']}>
+          {/* Visual counter — hidden from AT to avoid double-announcement */}
+          <span className={styles['char-count']} aria-hidden="true">
+            {charCountText}
+          </span>
+          {/*
+           * Debounced live region (1 s default delay) so the count is
+           * announced to screen readers without interrupting every keystroke.
+           */}
+          <InternalLiveRegion id={charCountId} tagName="span" delay={1} preventInitialAnnouncement={true}>
+            {charCountText}
+          </InternalLiveRegion>
+        </div>
       )}
     </div>
   );

--- a/src/input/styles.scss
+++ b/src/input/styles.scss
@@ -224,3 +224,15 @@
 .inline-label {
   @include forms.inline-label;
 }
+
+.char-count-wrapper {
+  display: flex;
+  justify-content: flex-end;
+  margin-block-start: awsui.$space-xxs;
+  inline-size: 100%;
+}
+
+.char-count {
+  @include styles.font-body-s;
+  color: awsui.$color-text-form-secondary;
+}


### PR DESCRIPTION
## Summary

Implements **AWSUI-58637** — Input character count / maxlength indicator.

### New props

| Prop | Type | Description |
|------|------|-------------|
| `maxLength` | `number` | Applies the native `maxlength` attribute. Can be used alone to enforce a limit without a visible counter. |
| `showCharacterCount` | `boolean` | When `true` (requires `maxLength`), renders a `used/max` indicator below the input (e.g. `12/100`). |

### Accessibility

- The visual counter is `aria-hidden` to prevent double-announcement.
- An `InternalLiveRegion` (1 s debounce, `preventInitialAnnouncement`) announces the count to screen readers without interrupting typing.
- When `controlId` is present the live region id (`{controlId}-char-count`) is appended to `aria-describedby` so AT reads the count on focus.

### Wiring with FormField

The component works standalone and inside `FormField`. FormField's own `characterCountText` prop is unaffected and remains available for cases where the consumer controls the text (e.g. custom formatting, i18n).

### Changes

- `src/input/interfaces.ts` — two new props on `InputProps`
- `src/input/index.tsx` — thread props through to `InternalInput`
- `src/input/internal.tsx` — count computation, `maxLength` on native input, visual + live-region rendering
- `src/input/styles.scss` — `.char-count-wrapper` and `.char-count` styles
- `src/input/__tests__/char-count.test.tsx` — 17 new unit tests
- `pages/input/inputs.page.tsx` — dev page with 5 usage examples

Ref: AWSUI-58637