### PR TITLE
feat: add secondaryAction prop to alert and flashbar

### DIFF
--- a/pages/alert/secondary-action.page.tsx
+++ b/pages/alert/secondary-action.page.tsx
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Dev page for AWSUI-58428: Alert/Flashbar secondary action
+import React, { useState } from 'react';
+
+import Alert from '~components/alert';
+import Button from '~components/button';
+import Flashbar, { FlashbarProps } from '~components/flashbar';
+import SpaceBetween from '~components/space-between';
+
+import ScreenshotArea from '../utils/screenshot-area';
+import { i18nStrings } from './common';
+
+export default function SecondaryActionPage() {
+  const [alertVisible, setAlertVisible] = useState(true);
+  const [flashItems, setFlashItems] = useState<FlashbarProps.MessageDefinition[]>([
+    {
+      id: 'flash-1',
+      type: 'info',
+      header: 'Flashbar with secondary action',
+      content: 'This flash message has both a primary and a secondary action button.',
+      action: <Button>Primary action</Button>,
+      secondaryAction: <Button>Secondary action</Button>,
+    },
+    {
+      id: 'flash-2',
+      type: 'error',
+      header: 'Error — secondary action only',
+      content: 'This flash message only has a secondary action.',
+      secondaryAction: <Button>Learn more</Button>,
+      dismissible: true,
+      onDismiss: () => setFlashItems(items => items.filter(i => i.id !== 'flash-2')),
+    },
+    {
+      id: 'flash-3',
+      type: 'success',
+      content: 'Success with both actions and dismiss.',
+      action: <Button>View details</Button>,
+      secondaryAction: <Button>Dismiss all</Button>,
+      dismissible: true,
+      dismissLabel: 'Dismiss',
+      onDismiss: () => setFlashItems(items => items.filter(i => i.id !== 'flash-3')),
+    },
+  ]);
+
+  return (
+    <article>
+      <h1>Alert / Flashbar — secondary action (AWSUI-58428)</h1>
+      <ScreenshotArea>
+        <SpaceBetween size="l">
+          <h2>Alert</h2>
+          <SpaceBetween size="s">
+            {alertVisible && (
+              <Alert
+                type="info"
+                header="Alert with primary and secondary action"
+                i18nStrings={i18nStrings}
+                dismissible={true}
+                onDismiss={() => setAlertVisible(false)}
+                action={<Button>Primary action</Button>}
+                secondaryAction={<Button>Secondary action</Button>}
+              >
+                This alert demonstrates the new <code>secondaryAction</code> prop alongside the existing{' '}
+                <code>action</code> prop.
+              </Alert>
+            )}
+            <Alert
+              type="warning"
+              header="Warning — secondary action only"
+              i18nStrings={i18nStrings}
+              secondaryAction={<Button>Learn more</Button>}
+            >
+              This alert only has a secondary action and no primary action.
+            </Alert>
+            <Alert
+              type="error"
+              header="Error — both actions"
+              i18nStrings={i18nStrings}
+              action={<Button variant="primary">Retry</Button>}
+              secondaryAction={<Button>View logs</Button>}
+            >
+              Both primary and secondary actions are present.
+            </Alert>
+            <Alert
+              type="success"
+              header="Success — no secondary action"
+              i18nStrings={i18nStrings}
+              action={<Button>Continue</Button>}
+            >
+              This alert only has the primary action (baseline — no regression).
+            </Alert>
+          </SpaceBetween>
+
+          <h2>Flashbar</h2>
+          <Flashbar items={flashItems} />
+        </SpaceBetween>
+      </ScreenshotArea>
+    </article>
+  );
+}

--- a/pages/alert/secondary-action.page.tsx
+++ b/pages/alert/secondary-action.page.tsx
@@ -29,6 +29,7 @@ export default function SecondaryActionPage() {
       content: 'This flash message only has a secondary action.',
       secondaryAction: <Button>Learn more</Button>,
       dismissible: true,
+      dismissLabel: 'Dismiss',
       onDismiss: () => setFlashItems(items => items.filter(i => i.id !== 'flash-2')),
     },
     {

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -655,6 +655,12 @@ An \`onButtonClick\` event is fired when the user clicks it.",
       "isDefault": false,
       "name": "header",
     },
+    {
+      "description": "Specifies a secondary action for the alert message, displayed alongside the primary action.
+Although it is technically possible to insert any content, our UX guidelines only allow you to add a button.",
+      "isDefault": false,
+      "name": "secondaryAction",
+    },
   ],
   "releaseStatus": "stable",
 }
@@ -34387,6 +34393,22 @@ The dismiss button is only rendered when the \`dismissible\` property is set to 
             ],
           },
         },
+        {
+          "description": "Returns the secondary action slot.
+
+The secondary action slot is only rendered when the \`secondaryAction\` property is set.",
+          "name": "findSecondaryActionSlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
       ],
       "name": "AlertWrapper",
     },
@@ -41045,6 +41067,22 @@ The dismiss button is only rendered when the \`dismissible\` property is set to 
             ],
           },
         },
+        {
+          "description": "Returns the secondary action slot.
+
+The secondary action slot is only rendered when the \`secondaryAction\` property is set.",
+          "name": "findSecondaryAction",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
       ],
       "name": "FlashWrapper",
     },
@@ -46702,6 +46740,17 @@ The dismiss button is only rendered when the \`dismissible\` property is set to 
             "name": "ElementWrapper",
           },
         },
+        {
+          "description": "Returns the secondary action slot.
+
+The secondary action slot is only rendered when the \`secondaryAction\` property is set.",
+          "name": "findSecondaryActionSlot",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
       ],
       "name": "AlertWrapper",
     },
@@ -51437,6 +51486,17 @@ The dismiss button is only rendered when the \`dismissible\` property is set to 
         },
         {
           "name": "findHeader",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns the secondary action slot.
+
+The secondary action slot is only rendered when the \`secondaryAction\` property is set.",
+          "name": "findSecondaryAction",
           "parameters": [],
           "returnType": {
             "isNullable": false,

--- a/src/alert/__tests__/alert.test.tsx
+++ b/src/alert/__tests__/alert.test.tsx
@@ -161,6 +161,40 @@ describe('Alert Component', () => {
     expect(wrapper.findActionSlot()!.findButton()!.getElement()).toHaveTextContent('Click');
   });
 
+  describe('secondaryAction', () => {
+    it('renders secondary action content', () => {
+      const { wrapper } = renderAlert({
+        children: 'Message body',
+        action: <Button>Primary</Button>,
+        secondaryAction: <Button>Secondary</Button>,
+      });
+      expect(wrapper.findSecondaryActionSlot()!.findButton()!.getElement()).toHaveTextContent('Secondary');
+    });
+
+    it('does not render secondary action slot when secondaryAction is not provided', () => {
+      const { wrapper } = renderAlert({ children: 'Message body' });
+      expect(wrapper.findSecondaryActionSlot()).toBeNull();
+    });
+
+    it('renders secondary action without a primary action', () => {
+      const { wrapper } = renderAlert({
+        children: 'Message body',
+        secondaryAction: <Button>Secondary only</Button>,
+      });
+      expect(wrapper.findSecondaryActionSlot()!.findButton()!.getElement()).toHaveTextContent('Secondary only');
+    });
+
+    it('renders both primary and secondary actions independently', () => {
+      const { wrapper } = renderAlert({
+        children: 'Message body',
+        action: <Button>Primary</Button>,
+        secondaryAction: <Button>Secondary</Button>,
+      });
+      expect(wrapper.findActionSlot()!.findButton()!.getElement()).toHaveTextContent('Primary');
+      expect(wrapper.findSecondaryActionSlot()!.findButton()!.getElement()).toHaveTextContent('Secondary');
+    });
+  });
+
   it('when both `buttonText` and `action` provided, prefers the latter', () => {
     const { wrapper } = renderAlert({
       children: 'Message body',

--- a/src/alert/actions-wrapper/__tests__/actions-wrapper.test.tsx
+++ b/src/alert/actions-wrapper/__tests__/actions-wrapper.test.tsx
@@ -22,7 +22,7 @@ const defaultProps = {
   action: null,
   buttonText: 'Action',
   onButtonClick: () => {},
-  testUtilClasses: { actionButton: '', actionSlot: '' },
+  testUtilClasses: { actionButton: '', actionSlot: '', secondaryActionSlot: '' },
   discoveredActions: [],
 };
 

--- a/src/alert/actions-wrapper/index.tsx
+++ b/src/alert/actions-wrapper/index.tsx
@@ -35,8 +35,9 @@ function createActionButton(
 
 interface ActionsWrapperProps {
   className: string;
-  testUtilClasses: { actionSlot: string; actionButton: string };
+  testUtilClasses: { actionSlot: string; actionButton: string; secondaryActionSlot: string };
   action: React.ReactNode;
+  secondaryAction?: React.ReactNode;
   discoveredActions: Array<React.ReactNode>;
   buttonText: React.ReactNode;
   wrappedClass?: string;
@@ -48,6 +49,7 @@ export const ActionsWrapper = ({
   className,
   testUtilClasses,
   action,
+  secondaryAction,
   discoveredActions,
   buttonText,
   wrappedClass,
@@ -76,13 +78,18 @@ export const ActionsWrapper = ({
     return () => observer.disconnect();
   });
   const actionButton = createActionButton(testUtilClasses, action, buttonText, onButtonClick);
-  if (!actionButton && discoveredActions.length === 0) {
+  const secondaryActionNode = secondaryAction ? (
+    <div className={testUtilClasses.secondaryActionSlot}>{secondaryAction}</div>
+  ) : null;
+
+  if (!actionButton && !secondaryActionNode && discoveredActions.length === 0) {
     return null;
   }
 
   return (
     <div ref={ref} className={clsx(styles.root, className, wrapped && wrappedClass)}>
       {actionButton}
+      {secondaryActionNode}
       {discoveredActions}
     </div>
   );

--- a/src/alert/interfaces.ts
+++ b/src/alert/interfaces.ts
@@ -135,6 +135,11 @@ export interface AlertProps extends BaseComponentProps {
    */
   action?: React.ReactNode;
   /**
+   * Specifies a secondary action for the alert message, displayed alongside the primary action.
+   * Although it is technically possible to insert any content, our UX guidelines only allow you to add a button.
+   */
+  secondaryAction?: React.ReactNode;
+  /**
    * Fired when the user clicks the close icon that is displayed
    * when the `dismissible` property is set to `true`.
    */

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -57,6 +57,7 @@ const InternalAlert = React.forwardRef(
       header,
       buttonText,
       action,
+      secondaryAction,
       onDismiss,
       onButtonClick,
       __internalRootRef,
@@ -229,8 +230,10 @@ const InternalAlert = React.forwardRef(
                   testUtilClasses={{
                     actionSlot: styles['action-slot'],
                     actionButton: styles['action-button'],
+                    secondaryActionSlot: styles['secondary-action-slot'],
                   }}
                   action={action}
+                  secondaryAction={secondaryAction}
                   discoveredActions={discoveredActions}
                   buttonText={buttonText}
                   onButtonClick={() => fireNonCancelableEvent(onButtonClick)}

--- a/src/alert/styles.scss
+++ b/src/alert/styles.scss
@@ -71,7 +71,8 @@
 }
 
 .action-slot,
-.action-button {
+.action-button,
+.secondary-action-slot {
   /* used in test-utils */
 }
 

--- a/src/flashbar/__tests__/flashbar.test.tsx
+++ b/src/flashbar/__tests__/flashbar.test.tsx
@@ -266,6 +266,53 @@ describe('Flashbar component', () => {
       expect(wrapper.findItems()[0].findAction()!.findButton()!.getElement()).toHaveTextContent('Click me');
     });
 
+    describe('secondaryAction', () => {
+      test('renders secondary action content', () => {
+        const wrapper = createFlashbarWrapper(
+          <Flashbar
+            items={[
+              {
+                content: 'The content',
+                action: <Button>Primary</Button>,
+                secondaryAction: <Button>Secondary</Button>,
+              },
+            ]}
+          />
+        );
+        expect(wrapper.findItems()[0].findSecondaryAction()!.findButton()!.getElement()).toHaveTextContent('Secondary');
+      });
+
+      test('does not render secondary action slot when secondaryAction is not provided', () => {
+        const wrapper = createFlashbarWrapper(<Flashbar items={[{ content: 'The content' }]} />);
+        expect(wrapper.findItems()[0].findSecondaryAction()).toBeNull();
+      });
+
+      test('renders secondary action without a primary action', () => {
+        const wrapper = createFlashbarWrapper(
+          <Flashbar items={[{ content: 'The content', secondaryAction: <Button>Secondary only</Button> }]} />
+        );
+        expect(wrapper.findItems()[0].findSecondaryAction()!.findButton()!.getElement()).toHaveTextContent(
+          'Secondary only'
+        );
+      });
+
+      test('renders both primary and secondary actions independently', () => {
+        const wrapper = createFlashbarWrapper(
+          <Flashbar
+            items={[
+              {
+                content: 'The content',
+                action: <Button>Primary</Button>,
+                secondaryAction: <Button>Secondary</Button>,
+              },
+            ]}
+          />
+        );
+        expect(wrapper.findItems()[0].findAction()!.findButton()!.getElement()).toHaveTextContent('Primary');
+        expect(wrapper.findItems()[0].findSecondaryAction()!.findButton()!.getElement()).toHaveTextContent('Secondary');
+      });
+    });
+
     test('when both `buttonText` and `action` provided, prefers the latter', () => {
       const wrapper = createFlashbarWrapper(
         <Flashbar

--- a/src/flashbar/flash.tsx
+++ b/src/flashbar/flash.tsx
@@ -128,6 +128,7 @@ export const Flash = React.forwardRef(
       dismissLabel,
       loading,
       action,
+      secondaryAction,
       buttonText,
       onButtonClick,
       onDismiss,
@@ -276,8 +277,13 @@ export const Flash = React.forwardRef(
           </div>
           <ActionsWrapper
             className={styles['action-button-wrapper']}
-            testUtilClasses={{ actionSlot: styles['action-slot'], actionButton: styles['action-button'] }}
+            testUtilClasses={{
+              actionSlot: styles['action-slot'],
+              actionButton: styles['action-button'],
+              secondaryActionSlot: styles['secondary-action-slot'],
+            }}
             action={action}
+            secondaryAction={secondaryAction}
             discoveredActions={discoveredActions}
             buttonText={buttonText}
             onButtonClick={onButtonClick}

--- a/src/flashbar/interfaces.ts
+++ b/src/flashbar/interfaces.ts
@@ -17,6 +17,7 @@ export namespace FlashbarProps {
     type?: FlashbarProps.Type;
     ariaRole?: FlashbarProps.AriaRole;
     action?: React.ReactNode;
+    secondaryAction?: React.ReactNode;
     id?: string;
     buttonText?: ButtonProps['children'];
     onButtonClick?: ButtonProps['onClick'];

--- a/src/flashbar/styles.scss
+++ b/src/flashbar/styles.scss
@@ -142,7 +142,8 @@
 }
 
 .action-button,
-.action-slot {
+.action-slot,
+.secondary-action-slot {
   /* Only used as a selector for test-utils */
 }
 

--- a/src/test-utils/dom/alert/index.ts
+++ b/src/test-utils/dom/alert/index.ts
@@ -45,4 +45,13 @@ export default class AlertWrapper extends ComponentWrapper {
   findActionSlot(): ElementWrapper | null {
     return this.findByClassName(styles['action-slot']);
   }
+
+  /**
+   * Returns the secondary action slot.
+   *
+   * The secondary action slot is only rendered when the `secondaryAction` property is set.
+   */
+  findSecondaryActionSlot(): ElementWrapper | null {
+    return this.findByClassName(styles['secondary-action-slot']);
+  }
 }

--- a/src/test-utils/dom/flashbar/flash.ts
+++ b/src/test-utils/dom/flashbar/flash.ts
@@ -34,6 +34,15 @@ export default class FlashWrapper extends ComponentWrapper {
     return this.findComponent(`.${styles['action-button']}`, ButtonWrapper);
   }
 
+  /**
+   * Returns the secondary action slot.
+   *
+   * The secondary action slot is only rendered when the `secondaryAction` property is set.
+   */
+  findSecondaryAction(): ElementWrapper | null {
+    return this.findByClassName(styles['secondary-action-slot']);
+  }
+
   findHeader(): ElementWrapper | null {
     return this.findByClassName(styles['flash-header']);
   }


### PR DESCRIPTION
## Summary

Implements AWSUI-58428: Alert/Flashbar — support a secondary action button alongside the primary `action`/buttons slot.

## Changes

### API
- **`AlertProps`**: new optional `secondaryAction?: React.ReactNode` prop
- **`FlashbarProps.MessageDefinition`**: new optional `secondaryAction?: React.ReactNode` field

### Implementation
- **`ActionsWrapper`** (`src/alert/actions-wrapper/index.tsx`): accepts `secondaryAction` and renders it in a dedicated `.secondary-action-slot` div after the primary action slot
- **`InternalAlert`** (`src/alert/internal.tsx`): destructures and forwards `secondaryAction` to `ActionsWrapper`
- **`Flash`** (`src/flashbar/flash.tsx`): destructures and forwards `secondaryAction` to `ActionsWrapper`
- **Styles**: adds `.secondary-action-slot` selector (test-utils anchor) to both `alert/styles.scss` and `flashbar/styles.scss`

### Test utilities
- **`AlertWrapper`**: adds `findSecondaryActionSlot()`
- **`FlashWrapper`**: adds `findSecondaryAction()`

### Tests
- Updated `actions-wrapper.test.tsx` to include `secondaryActionSlot` in `testUtilClasses`
- New `secondaryAction` describe block in `alert.test.tsx`: render, absence, standalone, combined
- New `secondaryAction` describe block in `flashbar.test.tsx`: render, absence, standalone, combined

### Dev page
- `pages/alert/secondary-action.page.tsx`: showcases Alert and Flashbar with primary+secondary, secondary-only, and no-secondary variants

## Test results
- All 332 alert/flashbar unit tests pass
- Snapshot tests updated and passing
- ESLint clean

Ref: AWSUI-58428