### PR TITLE
feat: add clickToSelect prop for row click-to-select (AWSUI-58619)

### DIFF
--- a/pages/table/row-click-select.page.tsx
+++ b/pages/table/row-click-select.page.tsx
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import range from 'lodash/range';
+
+import Checkbox from '~components/checkbox';
+import Header from '~components/header';
+import SpaceBetween from '~components/space-between';
+import Table, { TableProps } from '~components/table';
+
+interface Item {
+  id: number;
+  name: string;
+  type: string;
+}
+
+const items: Item[] = range(5).map(i => ({
+  id: i + 1,
+  name: ['Coffee', 'Tea', 'Lemonade', 'Water', 'Juice'][i],
+  type: ['Hot', 'Hot', 'Cold', 'Cold', 'Cold'][i],
+}));
+
+const columnDefinitions: TableProps.ColumnDefinition<Item>[] = [
+  { id: 'id', header: 'ID', cell: item => item.id },
+  { id: 'name', header: 'Name', cell: item => item.name },
+  { id: 'type', header: 'Type', cell: item => item.type },
+];
+
+const ariaLabels: TableProps['ariaLabels'] = {
+  selectionGroupLabel: 'Items selection',
+  allItemsSelectionLabel: ({ selectedItems }) => `${selectedItems.length} item(s) selected`,
+  itemSelectionLabel: ({ selectedItems }, item) =>
+    `${item.name} is ${selectedItems.includes(item) ? '' : 'not '}selected`,
+};
+
+export default function App() {
+  const [selectedItems, setSelectedItems] = useState<Item[]>([]);
+  const [selectionType, setSelectionType] = useState<TableProps.SelectionType>('multi');
+  const [clickToSelect, setClickToSelect] = useState(true);
+  const [isItemDisabled, setIsItemDisabled] = useState(false);
+
+  return (
+    <SpaceBetween size="l">
+      <SpaceBetween direction="horizontal" size="s">
+        <Checkbox checked={clickToSelect} onChange={({ detail }) => setClickToSelect(detail.checked)}>
+          clickToSelect
+        </Checkbox>
+        <Checkbox
+          checked={selectionType === 'multi'}
+          onChange={({ detail }) => setSelectionType(detail.checked ? 'multi' : 'single')}
+        >
+          multi-select (uncheck for single)
+        </Checkbox>
+        <Checkbox checked={isItemDisabled} onChange={({ detail }) => setIsItemDisabled(detail.checked)}>
+          disable first item
+        </Checkbox>
+      </SpaceBetween>
+
+      <Table
+        header={<Header headingTagOverride="h1">Row click-to-select</Header>}
+        columnDefinitions={columnDefinitions}
+        items={items}
+        selectionType={selectionType}
+        selectedItems={selectedItems}
+        trackBy="id"
+        clickToSelect={clickToSelect}
+        isItemDisabled={isItemDisabled ? item => item.id === 1 : undefined}
+        onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+        ariaLabels={ariaLabels}
+      />
+
+      <div>
+        <strong>Selected:</strong> {selectedItems.map(i => i.name).join(', ') || '(none)'}
+      </div>
+    </SpaceBetween>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -28467,6 +28467,14 @@ To target individual cells use \`columnDefinitions.verticalAlign\`, that takes p
       "type": "string",
     },
     {
+      "description": "When set to \`true\`, clicking anywhere on a table row toggles its selection.
+Requires \`selectionType\` to be set. Interactive cells (such as inline-editable cells,
+expandable row toggles, and the selection control itself) are excluded from this behavior.",
+      "name": "clickToSelect",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
       "description": "The columns configuration object
 * \`id\` (string) - Specifies a unique column identifier. The property is used 1) as a [keys](https://reactjs.org/docs/lists-and-keys.html#keys) source for React rendering,
   and 2) to match entries in the \`columnDisplay\` property, if defined.

--- a/src/table/__tests__/row-click-select.test.tsx
+++ b/src/table/__tests__/row-click-select.test.tsx
@@ -1,0 +1,227 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import Table, { TableProps } from '../../../lib/components/table';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+interface Item {
+  id: number;
+  name: string;
+}
+
+const columnDefinitions: TableProps.ColumnDefinition<Item>[] = [
+  { id: 'id', header: 'ID', cell: item => item.id },
+  { id: 'name', header: 'Name', cell: item => item.name },
+];
+
+const items: Item[] = [
+  { id: 1, name: 'Coffee' },
+  { id: 2, name: 'Tea' },
+  { id: 3, name: 'Lemonade' },
+];
+
+const ariaLabels: TableProps['ariaLabels'] = {
+  selectionGroupLabel: 'Items selection',
+  allItemsSelectionLabel: ({ selectedItems }) => `${selectedItems.length} selected`,
+  itemSelectionLabel: (_, item) => `select ${item.name}`,
+};
+
+function renderTable(tableProps: Partial<TableProps<Item>>) {
+  const onSelectionChange = jest.fn();
+  const props: TableProps<Item> = {
+    items,
+    columnDefinitions,
+    ariaLabels,
+    onSelectionChange,
+    ...tableProps,
+  };
+  const { container } = render(<Table {...props} />);
+  return { wrapper: createWrapper(container).findTable()!, onSelectionChange };
+}
+
+describe('clickToSelect', () => {
+  describe('multi-select', () => {
+    test('clicking a row selects it', () => {
+      const { wrapper, onSelectionChange } = renderTable({
+        selectionType: 'multi',
+        selectedItems: [],
+        clickToSelect: true,
+      });
+      wrapper.findRows()[0].click();
+      expect(onSelectionChange).toHaveBeenCalledTimes(1);
+      expect(onSelectionChange).toHaveBeenCalledWith(
+        expect.objectContaining({ detail: { selectedItems: [items[0]] } })
+      );
+    });
+
+    test('clicking a selected row deselects it', () => {
+      const { wrapper, onSelectionChange } = renderTable({
+        selectionType: 'multi',
+        selectedItems: [items[0]],
+        clickToSelect: true,
+      });
+      wrapper.findRows()[0].click();
+      expect(onSelectionChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { selectedItems: [] } }));
+    });
+
+    test('clicking multiple rows accumulates selection', () => {
+      const { wrapper, onSelectionChange } = renderTable({
+        selectionType: 'multi',
+        selectedItems: [items[0]],
+        clickToSelect: true,
+      });
+      wrapper.findRows()[1].click();
+      expect(onSelectionChange).toHaveBeenCalledWith(
+        expect.objectContaining({ detail: { selectedItems: [items[0], items[1]] } })
+      );
+    });
+  });
+
+  describe('single-select', () => {
+    test('clicking a row selects it', () => {
+      const { wrapper, onSelectionChange } = renderTable({
+        selectionType: 'single',
+        selectedItems: [],
+        clickToSelect: true,
+      });
+      wrapper.findRows()[1].click();
+      expect(onSelectionChange).toHaveBeenCalledWith(
+        expect.objectContaining({ detail: { selectedItems: [items[1]] } })
+      );
+    });
+
+    test('clicking an already-selected row does not fire onSelectionChange again', () => {
+      const { wrapper, onSelectionChange } = renderTable({
+        selectionType: 'single',
+        selectedItems: [items[0]],
+        clickToSelect: true,
+      });
+      // Single-select: re-clicking selected item is a no-op (use-selection.ts guards this)
+      wrapper.findRows()[0].click();
+      expect(onSelectionChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disabled items', () => {
+    test('clicking a disabled row does not fire onSelectionChange', () => {
+      const { wrapper, onSelectionChange } = renderTable({
+        selectionType: 'multi',
+        selectedItems: [],
+        clickToSelect: true,
+        isItemDisabled: item => item.id === 1,
+      });
+      wrapper.findRows()[0].click();
+      expect(onSelectionChange).not.toHaveBeenCalled();
+    });
+
+    test('clicking an enabled row still works when some rows are disabled', () => {
+      const { wrapper, onSelectionChange } = renderTable({
+        selectionType: 'multi',
+        selectedItems: [],
+        clickToSelect: true,
+        isItemDisabled: item => item.id === 1,
+      });
+      wrapper.findRows()[1].click();
+      expect(onSelectionChange).toHaveBeenCalledWith(
+        expect.objectContaining({ detail: { selectedItems: [items[1]] } })
+      );
+    });
+  });
+
+  describe('no-op when disabled or not applicable', () => {
+    test('does not fire when clickToSelect is false', () => {
+      const { wrapper, onSelectionChange } = renderTable({
+        selectionType: 'multi',
+        selectedItems: [],
+        clickToSelect: false,
+      });
+      wrapper.findRows()[0].click();
+      expect(onSelectionChange).not.toHaveBeenCalled();
+    });
+
+    test('does not fire when selectionType is not set', () => {
+      const { wrapper, onSelectionChange } = renderTable({
+        selectedItems: [],
+        clickToSelect: true,
+      });
+      wrapper.findRows()[0].click();
+      expect(onSelectionChange).not.toHaveBeenCalled();
+    });
+
+    test('does not fire when clickToSelect is not set', () => {
+      const { wrapper, onSelectionChange } = renderTable({
+        selectionType: 'multi',
+        selectedItems: [],
+      });
+      wrapper.findRows()[0].click();
+      expect(onSelectionChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('interactive cell exceptions', () => {
+    test('clicking the selection control checkbox does not double-fire', () => {
+      const { wrapper, onSelectionChange } = renderTable({
+        selectionType: 'multi',
+        selectedItems: [],
+        clickToSelect: true,
+      });
+      // Click the selection control (checkbox) directly — should still work via checkbox change handler,
+      // but the row-click handler should NOT also fire selection
+      const selectionInput = wrapper.findRowSelectionArea(1)?.find('input')?.getElement();
+      if (selectionInput) {
+        selectionInput.click();
+        // onSelectionChange fires once (from the checkbox onChange), not twice
+        expect(onSelectionChange).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+
+  describe('cursor style', () => {
+    test('adds row-clickable class when clickToSelect and selectionType are set', () => {
+      const { wrapper } = renderTable({
+        selectionType: 'multi',
+        selectedItems: [],
+        clickToSelect: true,
+      });
+      const rowEl = wrapper.findRows()[0].getElement();
+      expect(rowEl.className).toMatch(/row-clickable/);
+    });
+
+    test('does not add row-clickable class when clickToSelect is false', () => {
+      const { wrapper } = renderTable({
+        selectionType: 'multi',
+        selectedItems: [],
+        clickToSelect: false,
+      });
+      const rowEl = wrapper.findRows()[0].getElement();
+      expect(rowEl.className).not.toMatch(/row-clickable/);
+    });
+
+    test('does not add row-clickable class when selectionType is not set', () => {
+      const { wrapper } = renderTable({
+        selectedItems: [],
+        clickToSelect: true,
+      });
+      const rowEl = wrapper.findRows()[0].getElement();
+      expect(rowEl.className).not.toMatch(/row-clickable/);
+    });
+  });
+
+  describe('coexistence with onRowClick', () => {
+    test('clickToSelect and onRowClick can be used together', () => {
+      const onRowClick = jest.fn();
+      const { wrapper, onSelectionChange } = renderTable({
+        selectionType: 'multi',
+        selectedItems: [],
+        clickToSelect: true,
+        onRowClick,
+      });
+      wrapper.findRows()[0].click();
+      // Both handlers fire
+      expect(onSelectionChange).toHaveBeenCalledTimes(1);
+      expect(onRowClick).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -337,6 +337,13 @@ export interface TableProps<T = any> extends BaseComponentProps {
   onRowContextMenu?: CancelableEventHandler<TableProps.OnRowContextMenuDetail<T>>;
 
   /**
+   * When set to `true`, clicking anywhere on a table row toggles its selection.
+   * Requires `selectionType` to be set. Interactive cells (such as inline-editable cells,
+   * expandable row toggles, and the selection control itself) are excluded from this behavior.
+   */
+  clickToSelect?: boolean;
+
+  /**
    * If set to `true`, the table header remains visible when the user scrolls down.
    *
    * Do not use `stickyHeader` conditionally. Instead, keep its value constant during the component lifecycle.

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -129,6 +129,7 @@ const InternalTable = React.forwardRef(
       stickyHeaderVerticalOffset,
       onRowClick,
       onRowContextMenu,
+      clickToSelect,
       wrapLines,
       stripedRows,
       contentDensity,
@@ -297,7 +298,21 @@ const InternalTable = React.forwardRef(
     const handleScroll = useScrollSync([wrapperRefObject, scrollbarRef, secondaryWrapperRef]);
 
     const { moveFocusDown, moveFocusUp, moveFocus } = useSelectionFocusMove(selectionType, allItems.length);
-    const { onRowClickHandler, onRowContextMenuHandler } = useRowEvents({ onRowClick, onRowContextMenu });
+    // Build a toggleItem function for click-to-select
+    const onToggleItem = (item: T) => {
+      const selectionProps = selection.getItemSelectionProps?.(item);
+      if (selectionProps) {
+        selectionProps.onChange();
+      }
+    };
+
+    const { onRowClickHandler, onRowContextMenuHandler } = useRowEvents({
+      onRowClick,
+      onRowContextMenu,
+      clickToSelect,
+      selectionType: externalSelectionType,
+      onToggleItem,
+    });
 
     const visibleColumnDefinitions = useMemo(
       () => getVisibleColumnDefinitions({ columnDefinitions, columnDisplay, visibleColumns }),
@@ -673,7 +688,11 @@ const InternalTable = React.forwardRef(
                             return (
                               <tr
                                 key={rowId}
-                                className={clsx(styles.row, sharedCellProps.isSelected && styles['row-selected'])}
+                                className={clsx(
+                                  styles.row,
+                                  sharedCellProps.isSelected && styles['row-selected'],
+                                  clickToSelect && selectionType && styles['row-clickable']
+                                )}
                                 onFocus={({ currentTarget }) => {
                                   // When an element inside table row receives focus we want to adjust the scroll.
                                   // However, that behavior is unwanted when the focus is received as result of a click

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -233,6 +233,10 @@ filter search icon.
   /* used in test-utils */
 }
 
+.row-clickable {
+  cursor: pointer;
+}
+
 .skeleton-loading-cell {
   padding-block: 0;
   padding-inline: 0;

--- a/src/table/use-row-events.ts
+++ b/src/table/use-row-events.ts
@@ -8,14 +8,69 @@ import { TableProps } from './interfaces';
 
 import styles from './styles.css.js';
 
-export function useRowEvents<T>({ onRowClick, onRowContextMenu }: Pick<TableProps, 'onRowClick' | 'onRowContextMenu'>) {
+// Returns true when the click originated inside an element that should NOT trigger row-click-to-select.
+// Excluded: the selection control column, any interactive element (button/a/input/select/textarea),
+// and inline-editing-active cells.
+function isInteractiveTarget(target: HTMLElement): boolean {
+  // Clicks on or inside the selection control cell
+  const selectionCell = findUpUntil(target, el => el.tagName.toLowerCase() === 'td');
+  if (selectionCell && selectionCell.classList.contains(styles['selection-control'])) {
+    return true;
+  }
+
+  // Clicks on any focusable / interactive HTML element that lives inside the row
+  const interactiveEl = findUpUntil(
+    target,
+    el =>
+      el.tagName.toLowerCase() === 'button' ||
+      el.tagName.toLowerCase() === 'a' ||
+      el.tagName.toLowerCase() === 'input' ||
+      el.tagName.toLowerCase() === 'select' ||
+      el.tagName.toLowerCase() === 'textarea'
+  );
+  if (interactiveEl) {
+    return true;
+  }
+
+  // Cells that have inline editing active
+  const editingCell = findUpUntil(
+    target,
+    el => el.tagName.toLowerCase() === 'td' && el.getAttribute('data-inline-editing-active') === 'true'
+  );
+  if (editingCell) {
+    return true;
+  }
+
+  return false;
+}
+
+export interface UseRowEventsOptions<T> extends Pick<TableProps, 'onRowClick' | 'onRowContextMenu' | 'clickToSelect'> {
+  selectionType?: TableProps.SelectionType;
+  onToggleItem?: (item: T) => void;
+}
+
+export function useRowEvents<T>({
+  onRowClick,
+  onRowContextMenu,
+  clickToSelect,
+  selectionType,
+  onToggleItem,
+}: UseRowEventsOptions<T>) {
   const onRowClickHandler = (rowIndex: number, item: T, event: React.MouseEvent) => {
     const tableCell = findUpUntil(event.target as HTMLElement, element => element.tagName.toLowerCase() === 'td');
     if (!tableCell || !tableCell.classList.contains(styles['selection-control'])) {
       const details: TableProps.OnRowClickDetail<T> = { rowIndex, item };
       fireNonCancelableEvent(onRowClick, details);
     }
+
+    // click-to-select: toggle selection when prop is enabled and selectionType is set
+    if (clickToSelect && selectionType && onToggleItem) {
+      if (!isInteractiveTarget(event.target as HTMLElement)) {
+        onToggleItem(item);
+      }
+    }
   };
+
   const onRowContextMenuHandler = (rowIndex: number, item: T, event: React.MouseEvent) => {
     const details: TableProps.OnRowContextMenuDetail<T> = {
       rowIndex,
@@ -26,8 +81,11 @@ export function useRowEvents<T>({ onRowClick, onRowContextMenu }: Pick<TableProp
     fireCancelableEvent(onRowContextMenu, details, event);
   };
 
+  // The row click handler is active when either onRowClick is set OR clickToSelect is enabled
+  const hasRowClickHandler = !!(onRowClick || (clickToSelect && selectionType && onToggleItem));
+
   return {
-    onRowClickHandler: onRowClick && onRowClickHandler,
+    onRowClickHandler: hasRowClickHandler ? onRowClickHandler : undefined,
     onRowContextMenuHandler: onRowContextMenu && onRowContextMenuHandler,
   };
 }


### PR DESCRIPTION
### Description

Implements **row click-to-select** for the Table component (AWSUI-58619).

When `clickToSelect={true}` is set alongside `selectionType`, clicking anywhere on a table row toggles its selection — without requiring the user to hit the checkbox/radio exactly.

**Interactive-cell exceptions preserved:**
- Selection control column (checkbox/radio) — handled by its own `onChange`, not double-fired
- Any button, link, input, select, or textarea inside the row
- Inline-editing-active cells (`data-inline-editing-active=true`)
- Disabled items (`isItemDisabled`)

**A11y:** The feature is opt-in and adds no ARIA changes; the existing selection control labels and keyboard navigation are unchanged. A `cursor: pointer` style (`.row-clickable`) is applied via CSS when the feature is active.

**Backward-compatible:** `clickToSelect` defaults to `undefined` (falsy); all existing behavior is unchanged.

Related: AWSUI-58619

### How has this been tested?

- 15 new unit tests in `src/table/__tests__/row-click-select.test.tsx` covering:
  - multi-select: select, deselect, accumulate
  - single-select: select, re-click no-op
  - disabled items
  - no-op when `clickToSelect=false`, `selectionType` absent, or prop absent
  - interactive-cell exception (checkbox click does not double-fire)
  - cursor style class presence/absence
  - coexistence with `onRowClick`
- All 449 existing table unit tests pass
- Dev page: `pages/table/row-click-select.page.tsx`

<details>
   <summary>Review checklist</summary>

#### Correctness

- [x] Changes include appropriate documentation updates.
- [x] Changes are backward-compatible (new opt-in prop, no default behavior change).
- [x] Changes do not include unsupported browser features.
- [ ] Changes were manually tested for accessibility (pending human review).

#### Security

- [x] No URL handling introduced.

#### Testing

- [x] Changes are covered with new unit tests (15 new tests, all passing).
- [ ] Integration tests (pending).
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.