### PR TITLE
feat: wrap keyboard navigation across tab ends

### DIFF
--- a/pages/tabs/keyboard-wrap.page.tsx
+++ b/pages/tabs/keyboard-wrap.page.tsx
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Box from '~components/box';
+import SpaceBetween from '~components/space-between';
+import Tabs, { TabsProps } from '~components/tabs';
+
+// Demonstrates arrow-key wrap-around navigation in Tabs:
+// - Right arrow on the last (enabled) tab moves focus to the first tab.
+// - Left arrow on the first (enabled) tab moves focus to the last tab.
+// Disabled tabs are skipped, including when a disabled tab sits at either boundary.
+
+const contentFor = (label: string) => (
+  <Box padding="s">Content for {label}. Use Left/Right arrows to move between tabs and observe the wrap-around.</Box>
+);
+
+const basicTabs: Array<TabsProps.Tab> = [
+  { id: 'first', label: 'First tab', content: contentFor('First tab') },
+  { id: 'second', label: 'Second tab', content: contentFor('Second tab') },
+  { id: 'third', label: 'Third tab', content: contentFor('Third tab') },
+  { id: 'fourth', label: 'Fourth tab', content: contentFor('Fourth tab') },
+];
+
+const disabledBoundaryTabs: Array<TabsProps.Tab> = [
+  { id: 'first', label: 'First tab (disabled)', disabled: true, content: contentFor('First tab') },
+  { id: 'second', label: 'Second tab', content: contentFor('Second tab') },
+  { id: 'third', label: 'Third tab', content: contentFor('Third tab') },
+  { id: 'fourth', label: 'Fourth tab (disabled)', disabled: true, content: contentFor('Fourth tab') },
+];
+
+export default function TabsKeyboardWrapPage() {
+  return (
+    <Box padding="l">
+      <SpaceBetween size="xl">
+        <Box variant="h1">Tabs keyboard wrap-around</Box>
+
+        <div>
+          <Box variant="h2">Basic wrap</Box>
+          <Box color="text-body-secondary" padding={{ bottom: 's' }}>
+            Focus a tab, then press Right on the last tab to wrap to the first, or Left on the first tab to wrap to the
+            last.
+          </Box>
+          <Tabs tabs={basicTabs} ariaLabel="Basic wrap tabs" />
+        </div>
+
+        <div>
+          <Box variant="h2">Wrap with disabled tabs at the boundaries</Box>
+          <Box color="text-body-secondary" padding={{ bottom: 's' }}>
+            The first and last tabs are disabled. Wrapping skips them: Left from the first enabled tab lands on the last
+            enabled tab, and Right from the last enabled tab lands on the first enabled tab.
+          </Box>
+          <Tabs tabs={disabledBoundaryTabs} ariaLabel="Wrap with disabled boundary tabs" />
+        </div>
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/src/tabs/__tests__/tabs.test.tsx
+++ b/src/tabs/__tests__/tabs.test.tsx
@@ -784,6 +784,50 @@ describe('Tabs', () => {
       expect(wrapper.findActiveTab()!.getElement()).toHaveFocus();
     });
 
+    test('wraps to the last enabled tab on left arrow when the last tab is disabled', () => {
+      const tabsWithDisabledLast: Array<TabsProps.Tab> = [
+        { id: 'first', label: 'First tab' },
+        { id: 'second', label: 'Second tab' },
+        { id: 'third', label: 'Third tab' },
+        { id: 'fourth', label: 'Fourth tab', disabled: true },
+      ];
+      const wrapper = renderTabs(<Tabs tabs={tabsWithDisabledLast} />).wrapper;
+      wrapper.findActiveTab()!.getElement().focus();
+
+      // Left from the first tab wraps around, skipping the disabled last tab, to the last enabled one.
+      pressLeft(wrapper);
+      expect(wrapper.findActiveTab()!.getElement()).toHaveTextContent('Third tab');
+      expect(wrapper.findActiveTab()!.getElement()).toHaveFocus();
+
+      // Right from the last enabled tab wraps back to the first tab.
+      pressRight(wrapper);
+      expect(wrapper.findActiveTab()!.getElement()).toHaveTextContent('First tab');
+      expect(wrapper.findActiveTab()!.getElement()).toHaveFocus();
+    });
+
+    test('wraps to the first enabled tab on right arrow when the first tab is disabled', () => {
+      const tabsWithDisabledFirst: Array<TabsProps.Tab> = [
+        { id: 'first', label: 'First tab', disabled: true },
+        { id: 'second', label: 'Second tab' },
+        { id: 'third', label: 'Third tab' },
+        { id: 'fourth', label: 'Fourth tab' },
+      ];
+      const wrapper = renderTabs(<Tabs tabs={tabsWithDisabledFirst} />).wrapper;
+      // The default active/focused tab is the first enabled tab.
+      wrapper.findActiveTab()!.getElement().focus();
+      expect(wrapper.findActiveTab()!.getElement()).toHaveTextContent('Second tab');
+
+      // Left from the first enabled tab wraps around, skipping the disabled first tab, to the last one.
+      pressLeft(wrapper);
+      expect(wrapper.findActiveTab()!.getElement()).toHaveTextContent('Fourth tab');
+      expect(wrapper.findActiveTab()!.getElement()).toHaveFocus();
+
+      // Right from the last tab wraps forward, skipping the disabled first tab, to the first enabled one.
+      pressRight(wrapper);
+      expect(wrapper.findActiveTab()!.getElement()).toHaveTextContent('Second tab');
+      expect(wrapper.findActiveTab()!.getElement()).toHaveFocus();
+    });
+
     // eslint-disable-next-line jest/no-done-callback
     test('prevents the default anchor behaviour when clicked', done => {
       expect.assertions(1);

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -281,6 +281,10 @@ export function TabHeaderBar({
     handleKey(event as any, {
       onHome: () => focusElement(focusables[0]),
       onEnd: () => focusElement(focusables[focusables.length - 1]),
+      // Arrow-key navigation wraps around the ends of the tab strip: moving before the first
+      // focusable lands on the last, and moving past the last lands on the first. `focusables`
+      // only contains enabled/registered tabs (see getFocusablesFrom), so wrapping automatically
+      // skips disabled tabs, including when a disabled tab sits at either boundary.
       onInlineStart: () => focusElement(focusables[circleIndex(activeIndex - 1, [0, focusables.length - 1])]),
       onInlineEnd: () => focusElement(focusables[circleIndex(activeIndex + 1, [0, focusables.length - 1])]),
       onPageDown: () => inlineEndOverflow && onPaginationClick(headerBarRef, 'forward'),


### PR DESCRIPTION
### Description

Locks in and documents arrow-key **wrap-around** navigation for the Tabs component (SIM AWSUI-59085): pressing Right arrow on the last tab moves focus to the first tab, and Left arrow on the first tab moves focus to the last tab.

Investigation found that wrap-around is already the natural behavior — `TabHeaderBar.onKeyDown` uses `circleIndex(...)` over the list of focusable tabs, and `getFocusablesFrom` excludes disabled tabs. This PR therefore does not add a new prop (none is required for opt-in): it makes the contract explicit and regression-proof.

Changes:
- `src/tabs/tab-header-bar.tsx` — added a comment documenting the intentional wrap-around contract at the arrow-key handlers, so it isn't accidentally removed and clarifying that disabled tabs are skipped (including at the boundaries).
- `src/tabs/__tests__/tabs.test.tsx` — added two regression tests covering wrap-around when a **disabled tab sits at a boundary**: last tab disabled (Left from first wraps to last enabled) and first tab disabled (Right from last wraps to first enabled). Complements the existing `wraps activated tab around on arrow key press` test.
- `pages/tabs/keyboard-wrap.page.tsx` — new dev page demonstrating basic wrap and wrap with disabled tabs at both boundaries.

Related links, issue #, if available: SIM AWSUI-59085

### How has this been tested?

- `npm run quick-build` — green.
- `eslint .` — 0 errors (pre-existing warnings only, in untouched files).
- Unit tests: `jest --config jest.unit.config.js src/tabs/__tests__/tabs.test.tsx` — 97/97 passing, including the 3 wrap tests.
- Reviewers can exercise the new `pages/tabs/keyboard-wrap` dev page: focus a tab and press Left/Right at the strip ends; verify focus wraps and disabled tabs are skipped.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
