### PR TITLE
feat: support expand/collapse all for expandable rows

### DIFF
--- a/pages/table/expandable-rows-expand-collapse-all.page.tsx
+++ b/pages/table/expandable-rows-expand-collapse-all.page.tsx
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useRef, useState } from 'react';
+
+import { Box, Button, Header, SpaceBetween, Table, TableProps } from '~components';
+
+interface Item {
+  name: string;
+  children?: Item[];
+}
+
+const items: Item[] = [
+  {
+    name: 'Root-1',
+    children: [
+      { name: 'Nested-1.1' },
+      {
+        name: 'Nested-1.2',
+        children: [{ name: 'Nested-1.2.1' }, { name: 'Nested-1.2.2' }],
+      },
+    ],
+  },
+  {
+    name: 'Root-2',
+    children: [
+      { name: 'Nested-2.1' },
+      {
+        name: 'Nested-2.2',
+        children: [{ name: 'Nested-2.2.1', children: [{ name: 'Nested-2.2.1.1' }] }],
+      },
+    ],
+  },
+  { name: 'Root-3 (leaf)' },
+];
+
+const columnDefinitions: TableProps.ColumnDefinition<Item>[] = [
+  { id: 'name', header: 'Name', cell: item => item.name },
+];
+
+export default function ExpandCollapseAllPage() {
+  const tableRef = useRef<TableProps.Ref>(null);
+  const [expandedItems, setExpandedItems] = useState<ReadonlyArray<Item>>([]);
+
+  return (
+    <Box padding="l">
+      <SpaceBetween size="l">
+        <Header variant="h1">Table expand / collapse all</Header>
+
+        <SpaceBetween size="xs" direction="horizontal">
+          <Button data-testid="expand-all" onClick={() => tableRef.current?.expandAll?.()}>
+            Expand all
+          </Button>
+          <Button data-testid="collapse-all" onClick={() => tableRef.current?.collapseAll?.()}>
+            Collapse all
+          </Button>
+          <Box variant="span" padding={{ top: 'xxs' }} data-testid="expanded-count">
+            Expanded: {expandedItems.length}
+          </Box>
+        </SpaceBetween>
+
+        <Table
+          ref={tableRef}
+          columnDefinitions={columnDefinitions}
+          items={items}
+          trackBy="name"
+          ariaLabels={{
+            tableLabel: 'Expand/collapse all demo',
+            expandButtonLabel: item => `Expand ${item?.name}`,
+            collapseButtonLabel: item => `Collapse ${item?.name}`,
+          }}
+          expandableRows={{
+            getItemChildren: item => item.children ?? [],
+            isItemExpandable: item => !!item.children && item.children.length > 0,
+            expandedItems,
+            onExpandableItemToggle: ({ detail }) =>
+              setExpandedItems(prev => {
+                const next = prev.filter(item => item.name !== detail.item.name);
+                return detail.expanded ? [...next, detail.item] : next;
+              }),
+            onExpandAllToggle: ({ detail }) => setExpandedItems(detail.expandedItems),
+          }}
+        />
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -28161,6 +28161,25 @@ The event detail contains the current sortingColumn and isDescending.",
       "returnType": "void",
     },
     {
+      "description": "Collapses all expanded rows in the table.
+
+This only has an effect when \`expandableRows\` is defined together with
+\`expandableRows.onExpandAllToggle\`, which receives an empty set of expanded items.",
+      "name": "collapseAll",
+      "parameters": [],
+      "returnType": "void",
+    },
+    {
+      "description": "Expands all expandable rows in the table, including nested rows at every level.
+
+This only has an effect when \`expandableRows\` is defined together with
+\`expandableRows.onExpandAllToggle\`, which receives the complete set of
+expandable items so the controlled \`expandableRows.expandedItems\` state can be updated.",
+      "name": "expandAll",
+      "parameters": [],
+      "returnType": "void",
+    },
+    {
       "description": "When the sticky header is enabled and you call this function, the table
 scroll parent scrolls to reveal the first row of the table.",
       "name": "scrollToTop",
@@ -28573,6 +28592,9 @@ By default, the keyboard navigation is active for tables with expandable rows.",
 * \`isItemExpandable\` ((Item) => boolean) - Use it for items that can be expanded to show nested data.
 * \`expandedItems\` (Item[]) - Use it to represent the expanded state of items.
 * \`onExpandableItemToggle\` (TableProps.OnExpandableItemToggle<Item>) - Called when an item's expand toggle is clicked.
+* \`onExpandAllToggle\` (optional, TableProps.OnExpandAllToggle<Item>) - Called when the table's \`expandAll\` or \`collapseAll\`
+imperative ref methods are invoked. The event detail contains \`expanded\` (boolean) and \`expandedItems\` (Item[]) -- the complete
+set of items to reflect in \`expandedItems\`. Use it to update the controlled \`expandedItems\` state for bulk expand/collapse.
 * \`groupSelection\` (optional, GroupSelectionState<Item>) - Tree-like selection state for tables with grouped data. When defined, the
 properties \`selectionType\` and \`selectedItems\` no longer apply. It reads as (assuming item "a.1" is nested under "a"):
  * \`{ inverted: false, toggledItems: [] }\` - no items are selected;
@@ -28696,6 +28718,22 @@ The value is passed as \`selectedItemsCount\` property to the \`ariaLabels.allIt
             "name": "onExpandableItemToggle",
             "optional": false,
             "type": "TableProps.OnExpandableItemToggle<T>",
+          },
+          {
+            "inlineType": {
+              "name": "TableProps.OnExpandAllToggle<T>",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": "NonCancelableCustomEvent<Detail>",
+                },
+              ],
+              "returnType": "void",
+              "type": "function",
+            },
+            "name": "onExpandAllToggle",
+            "optional": true,
+            "type": "TableProps.OnExpandAllToggle<T>",
           },
           {
             "inlineType": {

--- a/src/table/__tests__/expandable-rows.test.tsx
+++ b/src/table/__tests__/expandable-rows.test.tsx
@@ -313,3 +313,84 @@ describe('Expandable rows', () => {
     expect(table).not.toBe(null);
   });
 });
+
+describe('Expand/collapse all', () => {
+  // Expandable nodes are those that are expandable AND actually have children to reveal.
+  const expandableNodes = [nestedItems[0], nestedItems[0].children![2], nestedItems[1]];
+
+  function renderTableWithRef(expandableRows: TableProps.ExpandableRows<Instance>) {
+    const ref = React.createRef<TableProps.Ref>();
+    render(
+      <Table ref={ref} columnDefinitions={columnDefinitions} items={nestedItems} expandableRows={expandableRows} />
+    );
+    return ref;
+  }
+
+  const baseExpandableRows: TableProps.ExpandableRows<Instance> = {
+    isItemExpandable: item => !!item.children && item.children.length > 0,
+    expandedItems: [],
+    getItemChildren: item => item.children ?? [],
+    onExpandableItemToggle: () => {},
+  };
+
+  test('expandAll fires onExpandAllToggle with all expandable nodes across the whole tree', () => {
+    const onExpandAllToggle = jest.fn();
+    const ref = renderTableWithRef({ ...baseExpandableRows, onExpandAllToggle });
+
+    ref.current!.expandAll!();
+
+    expect(onExpandAllToggle).toHaveBeenCalledTimes(1);
+    expect(onExpandAllToggle).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { expanded: true, expandedItems: expandableNodes } })
+    );
+  });
+
+  test('collapseAll fires onExpandAllToggle with an empty expandedItems array', () => {
+    const onExpandAllToggle = jest.fn();
+    const ref = renderTableWithRef({
+      ...baseExpandableRows,
+      expandedItems: flatten(nestedItems),
+      onExpandAllToggle,
+    });
+
+    ref.current!.collapseAll!();
+
+    expect(onExpandAllToggle).toHaveBeenCalledTimes(1);
+    expect(onExpandAllToggle).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { expanded: false, expandedItems: [] } })
+    );
+  });
+
+  test('expandAll only includes nodes for which isItemExpandable returns true', () => {
+    const onExpandAllToggle = jest.fn();
+    // Mark Root-1 (and its subtree) as not expandable; only Root-2 remains expandable.
+    const ref = renderTableWithRef({
+      ...baseExpandableRows,
+      isItemExpandable: item => item.name === 'Root-2',
+      onExpandAllToggle,
+    });
+
+    ref.current!.expandAll!();
+
+    expect(onExpandAllToggle).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { expanded: true, expandedItems: [nestedItems[1]] } })
+    );
+  });
+
+  test('expandAll and collapseAll are no-ops when onExpandAllToggle is not provided', () => {
+    const ref = renderTableWithRef(baseExpandableRows);
+    expect(() => {
+      ref.current!.expandAll!();
+      ref.current!.collapseAll!();
+    }).not.toThrow();
+  });
+
+  test('expandAll and collapseAll do not throw when expandableRows is not set', () => {
+    const ref = React.createRef<TableProps.Ref>();
+    render(<Table ref={ref} columnDefinitions={columnDefinitions} items={nestedItems} />);
+    expect(() => {
+      ref.current!.expandAll!();
+      ref.current!.collapseAll!();
+    }).not.toThrow();
+  });
+});

--- a/src/table/expandable-rows/expandable-rows-utils.ts
+++ b/src/table/expandable-rows/expandable-rows-utils.ts
@@ -28,6 +28,8 @@ export interface InternalExpandableRowsProps<T> {
   isExpandable: boolean;
   allItems: readonly T[];
   getExpandableItemProps(item: T): ExpandableItemProps<T>;
+  expandAllItems(): void;
+  collapseAllItems(): void;
   hasGroupSelection: boolean;
   groupSelection: TableProps.GroupSelectionState<T>;
   onGroupSelectionChange?: TableProps.OnGroupSelectionChange<T>;
@@ -113,10 +115,40 @@ export function useExpandableTableProps<T>({
     };
   };
 
+  // Collects every expandable node in the whole tree (regardless of the current expanded state), so that
+  // consumers can expand all rows at once. A node counts as expandable when `isItemExpandable` returns true
+  // for it and it actually has children to reveal.
+  const getAllExpandableItems = (): T[] => {
+    const result: T[] = [];
+    if (!isExpandable) {
+      return result;
+    }
+    const visit = (item: T) => {
+      const children = expandableRows.getItemChildren(item);
+      if ((expandableRows.isItemExpandable(item) ?? true) && children.length > 0) {
+        result.push(item);
+      }
+      children.forEach(visit);
+    };
+    items.forEach(visit);
+    return result;
+  };
+
+  const expandAllItems = () =>
+    fireNonCancelableEvent(expandableRows?.onExpandAllToggle, {
+      expanded: true,
+      expandedItems: getAllExpandableItems(),
+    });
+
+  const collapseAllItems = () =>
+    fireNonCancelableEvent(expandableRows?.onExpandAllToggle, { expanded: false, expandedItems: [] });
+
   return {
     isExpandable,
     allItems,
     getExpandableItemProps,
+    expandAllItems,
+    collapseAllItems,
     hasGroupSelection: !!expandableRows?.groupSelection,
     groupSelection: expandableRows?.groupSelection ?? { inverted: false, toggledItems: [] },
     onGroupSelectionChange: expandableRows?.onGroupSelectionChange,

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -411,6 +411,9 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * * `isItemExpandable` ((Item) => boolean) - Use it for items that can be expanded to show nested data.
    * * `expandedItems` (Item[]) - Use it to represent the expanded state of items.
    * * `onExpandableItemToggle` (TableProps.OnExpandableItemToggle<Item>) - Called when an item's expand toggle is clicked.
+   * * `onExpandAllToggle` (optional, TableProps.OnExpandAllToggle<Item>) - Called when the table's `expandAll` or `collapseAll`
+   * imperative ref methods are invoked. The event detail contains `expanded` (boolean) and `expandedItems` (Item[]) -- the complete
+   * set of items to reflect in `expandedItems`. Use it to update the controlled `expandedItems` state for bulk expand/collapse.
    * * `groupSelection` (optional, GroupSelectionState<Item>) - Tree-like selection state for tables with grouped data. When defined, the
    * properties `selectionType` and `selectedItems` no longer apply. It reads as (assuming item "a.1" is nested under "a"):
    *  * `{ inverted: false, toggledItems: [] }` - no items are selected;
@@ -634,6 +637,23 @@ export namespace TableProps {
      * Dismiss an inline edit if currently active.
      */
     cancelEdit?(): void;
+
+    /**
+     * Expands all expandable rows in the table, including nested rows at every level.
+     *
+     * This only has an effect when `expandableRows` is defined together with
+     * `expandableRows.onExpandAllToggle`, which receives the complete set of
+     * expandable items so the controlled `expandableRows.expandedItems` state can be updated.
+     */
+    expandAll?(): void;
+
+    /**
+     * Collapses all expanded rows in the table.
+     *
+     * This only has an effect when `expandableRows` is defined together with
+     * `expandableRows.onExpandAllToggle`, which receives an empty set of expanded items.
+     */
+    collapseAll?(): void;
   }
 
   export type SubmitEditFunction<ItemType, ValueType = unknown> = (
@@ -662,6 +682,7 @@ export namespace TableProps {
     isItemExpandable: (item: T) => boolean;
     expandedItems: ReadonlyArray<T>;
     onExpandableItemToggle: OnExpandableItemToggle<T>;
+    onExpandAllToggle?: OnExpandAllToggle<T>;
     groupSelection?: GroupSelectionState<T>;
     onGroupSelectionChange?: OnGroupSelectionChange<T>;
     getItemsCount?: (item: T) => number;
@@ -675,6 +696,20 @@ export namespace TableProps {
   export interface ExpandableItemToggleDetail<T> {
     item: T;
     expanded: boolean;
+  }
+
+  export type OnExpandAllToggle<T> = NonCancelableEventHandler<ExpandAllToggleDetail<T>>;
+
+  export interface ExpandAllToggleDetail<T> {
+    /**
+     * `true` when the table requested to expand all expandable rows, `false` when it requested to collapse them.
+     */
+    expanded: boolean;
+    /**
+     * The complete set of items that should be reflected in `expandableRows.expandedItems` after the operation.
+     * When expanding, this contains every expandable node in the tree; when collapsing, this is an empty array.
+     */
+    expandedItems: ReadonlyArray<T>;
   }
 
   export type OnGroupSelectionChange<T> = NonCancelableEventHandler<GroupSelectionChangeDetail<T>>;

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -180,7 +180,7 @@ const InternalTable = React.forwardRef(
       trackBy,
       ariaLabels,
     });
-    const { allItems, isExpandable } = expandableRows;
+    const { allItems, isExpandable, expandAllItems, collapseAllItems } = expandableRows;
     const { allRows } = useProgressiveLoadingProps({ getLoadingStatus, expandableRows });
     const selectionType = expandableRows.hasGroupSelection ? ('group' as const) : externalSelectionType;
 
@@ -289,8 +289,10 @@ const InternalTable = React.forwardRef(
       () => ({
         scrollToTop: stickyHeaderRef.current?.scrollToTop || (() => undefined),
         cancelEdit,
+        expandAll: expandAllItems,
+        collapseAll: collapseAllItems,
       }),
-      [cancelEdit]
+      [cancelEdit, expandAllItems, collapseAllItems]
     );
 
     const wrapperRefObject = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
### Description

Adds an **expand-all / collapse-all** capability to `Table`'s `expandableRows` API, so consumers can expand or collapse every expandable node in a tree at once (e.g. from a header control or toolbar button) instead of toggling rows one by one.

Because `expandableRows.expandedItems` is a controlled prop, the feature is exposed as two imperative ref methods that hand the resulting item set back to the consumer to store in state:

- **`ref.expandAll()`** — traverses the whole tree via `getItemChildren` and fires `expandableRows.onExpandAllToggle` with the complete set of expandable nodes (`{ expanded: true, expandedItems }`). A node counts as expandable when `isItemExpandable` returns `true` for it and it has children.
- **`ref.collapseAll()`** — fires `expandableRows.onExpandAllToggle` with `{ expanded: false, expandedItems: [] }`.

New public API:

- `TableProps.Ref.expandAll()` and `TableProps.Ref.collapseAll()` (optional methods, alongside the existing `scrollToTop` / `cancelEdit`).
- `TableProps.ExpandableRows.onExpandAllToggle` (optional) with detail type `TableProps.ExpandAllToggleDetail<T>` (`{ expanded, expandedItems }`), and the `TableProps.OnExpandAllToggle<T>` handler type.

The traversal and event wiring live in the existing `useExpandableTableProps` hook, following the established `onExpandableItemToggle` pattern. The change is fully backward-compatible — the new props/methods are optional and calling the ref methods without `onExpandAllToggle` (or without `expandableRows`) is a safe no-op.

Related links, issue #, if available: AWSUI-59222

### How has this been tested?

- **Unit tests** — extended `src/table/__tests__/expandable-rows.test.tsx` with an `Expand/collapse all` suite covering: full-tree collection of expandable nodes, empty set on collapse, respecting `isItemExpandable`, and no-op behaviour when `onExpandAllToggle` / `expandableRows` are absent. Full table suite green: **439/439 passing**.
- **Documenter snapshot** — regenerated component definitions and updated `documenter.test.ts.snap` (additions only) so the new public API is documented.
- **Dev page** — added `pages/table/expandable-rows-expand-collapse-all.page.tsx` with "Expand all" / "Collapse all" buttons wired to the ref for manual verification.
- **ESLint** and **`gulp quick-build`** (TypeScript compile) both pass clean.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
