### PR TITLE
feat: support disabling specific dates in DatePicker

### DIFF
--- a/pages/date-picker/disabled-dates.page.tsx
+++ b/pages/date-picker/disabled-dates.page.tsx
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useState } from 'react';
+
+import { Box, DatePicker, DatePickerProps, FormField, SpaceBetween } from '~components';
+
+import i18nStrings from './i18n-strings';
+
+// Helper: build a Date from the YYYY-MM-DD string the calendar passes in.
+// The `date` argument is always at the start of the day in the local timezone.
+
+// Example 1: disable weekends (a recurring set of "specific dates").
+const isWeekday: DatePickerProps.IsDateEnabledFunction = date => {
+  const day = date.getDay();
+  return day !== 0 && day !== 6;
+};
+
+// Example 2: disable a fixed date range (e.g. a company shutdown period).
+const shutdownStart = new Date(2018, 0, 10); // 2018-01-10
+const shutdownEnd = new Date(2018, 0, 20); // 2018-01-20
+const isOutsideShutdown: DatePickerProps.IsDateEnabledFunction = date => date < shutdownStart || date > shutdownEnd;
+const shutdownDisabledReason: DatePickerProps.DateDisabledReasonFunction = () =>
+  'Bookings are closed during the January maintenance window (Jan 10–20).';
+
+// Example 3: disable everything before today (only future dates selectable).
+const startOfToday = () => {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+};
+const isNotInPast: DatePickerProps.IsDateEnabledFunction = date => date >= startOfToday();
+
+export default function DisabledDatesPage() {
+  const [weekdayValue, setWeekdayValue] = useState('');
+  const [shutdownValue, setShutdownValue] = useState('2018-01-05');
+  const [futureValue, setFutureValue] = useState('');
+
+  return (
+    <Box padding="l">
+      <SpaceBetween direction="vertical" size="l">
+        <h1>Date picker — disable specific dates and date ranges</h1>
+
+        <FormField
+          label="Weekdays only"
+          description="Weekend dates are disabled and can neither be clicked nor selected via keyboard."
+        >
+          <DatePicker
+            id="weekdays-only"
+            value={weekdayValue}
+            onChange={({ detail }) => setWeekdayValue(detail.value)}
+            isDateEnabled={isWeekday}
+            i18nStrings={i18nStrings}
+            openCalendarAriaLabel={selectedDate =>
+              'Choose date' + (selectedDate ? `, selected date is ${selectedDate}` : '')
+            }
+            placeholder="YYYY/MM/DD"
+          />
+        </FormField>
+
+        <FormField
+          label="Excludes a maintenance window (with disabled reason)"
+          description="Dates between Jan 10 and Jan 20, 2018 are disabled and announce a reason on focus/hover."
+        >
+          <DatePicker
+            id="maintenance-window"
+            value={shutdownValue}
+            onChange={({ detail }) => setShutdownValue(detail.value)}
+            isDateEnabled={isOutsideShutdown}
+            dateDisabledReason={shutdownDisabledReason}
+            i18nStrings={i18nStrings}
+            openCalendarAriaLabel={selectedDate =>
+              'Choose date' + (selectedDate ? `, selected date is ${selectedDate}` : '')
+            }
+            placeholder="YYYY/MM/DD"
+          />
+        </FormField>
+
+        <FormField label="Future dates only" description="All dates before today are disabled.">
+          <DatePicker
+            id="future-only"
+            value={futureValue}
+            onChange={({ detail }) => setFutureValue(detail.value)}
+            isDateEnabled={isNotInPast}
+            i18nStrings={i18nStrings}
+            openCalendarAriaLabel={selectedDate =>
+              'Choose date' + (selectedDate ? `, selected date is ${selectedDate}` : '')
+            }
+            placeholder="YYYY/MM/DD"
+          />
+        </FormField>
+
+        <Box variant="code">{JSON.stringify({ weekdayValue, shutdownValue, futureValue }, undefined, 2)}</Box>
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/src/calendar/grid/index.tsx
+++ b/src/calendar/grid/index.tsx
@@ -138,7 +138,9 @@ export default function Grid({
               const isFocusable = !!focusableDate && isSameDate(date, focusableDate);
               const isSelected = !!selectedDate && isSameDate(date, selectedDate);
               const isEnabled = !isDateEnabled || isDateEnabled(date);
-              const disabledReason = dateDisabledReason(date);
+              // Per the public API contract, `dateDisabledReason` is only relevant (and only invoked)
+              // for dates that are not enabled.
+              const disabledReason = !isEnabled ? dateDisabledReason(date) : '';
               const isDisabledWithReason = !isEnabled && !!disabledReason;
               const isCurrentDate = isSameDate(date, new Date());
 

--- a/src/date-picker/__tests__/date-picker-disabled-dates.test.tsx
+++ b/src/date-picker/__tests__/date-picker-disabled-dates.test.tsx
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import DatePicker, { DatePickerProps } from '../../../lib/components/date-picker';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+const defaultProps: DatePickerProps = {
+  todayAriaLabel: 'Today',
+  nextMonthAriaLabel: 'Next Month',
+  previousMonthAriaLabel: 'Previous Month',
+  value: '2018-03-01',
+  onChange: () => {},
+  openCalendarAriaLabel: selectedDate => 'Choose Date' + (selectedDate ? `, selected date is ${selectedDate}` : ''),
+};
+
+function renderDatePicker(props: DatePickerProps = defaultProps) {
+  const { container } = render(
+    <div>
+      <button data-testid="outside" />
+      <DatePicker {...props} />
+    </div>
+  );
+  const wrapper = createWrapper(container).findDatePicker()!;
+  return { wrapper };
+}
+
+describe('DatePicker - disabling specific dates and date ranges', () => {
+  // Disable a contiguous range (a "date range"): March 10th–20th, 2018.
+  const rangeStart = new Date(2018, 2, 10);
+  const rangeEnd = new Date(2018, 2, 20);
+  const isOutsideRange: DatePickerProps.IsDateEnabledFunction = date => date < rangeStart || date > rangeEnd;
+
+  test('cannot select a date inside a disabled range', () => {
+    const onChangeSpy = jest.fn();
+    const { wrapper } = renderDatePicker({ ...defaultProps, isDateEnabled: isOutsideRange, onChange: onChangeSpy });
+    wrapper.findOpenCalendarButton().click();
+
+    // March 15th, 2018 falls inside the disabled range.
+    wrapper.findCalendar()!.findDateAt(3, 5).click();
+
+    expect(onChangeSpy).not.toHaveBeenCalled();
+    expect(wrapper.findNativeInput().getElement().value).toBe('2018/03/01');
+  });
+
+  test('can select a date outside a disabled range', () => {
+    const onChangeSpy = jest.fn();
+    const { wrapper } = renderDatePicker({ ...defaultProps, isDateEnabled: isOutsideRange, onChange: onChangeSpy });
+    wrapper.findOpenCalendarButton().click();
+
+    // March 25th, 2018 (row 5, Sunday) falls after the disabled range and is selectable.
+    wrapper.findCalendar()!.findDateAt(5, 1).click();
+
+    expect(onChangeSpy).toHaveBeenCalledWith(expect.objectContaining({ detail: { value: '2018-03-25' } }));
+  });
+
+  test('marks disabled dates with aria-disabled and enabled dates without it', () => {
+    const { wrapper } = renderDatePicker({ ...defaultProps, isDateEnabled: isOutsideRange });
+    wrapper.findOpenCalendarButton().click();
+
+    // March 15th (row 3) is disabled, March 25th (row 5) is enabled.
+    expect(wrapper.findCalendar()!.findDateAt(3, 5).getElement()).toHaveAttribute('aria-disabled', 'true');
+    expect(wrapper.findCalendar()!.findDateAt(5, 1).getElement()).toHaveAttribute('aria-disabled', 'false');
+  });
+
+  describe('dateDisabledReason contract', () => {
+    test('is not invoked for enabled dates and is invoked for disabled dates', () => {
+      const dateDisabledReason = jest.fn<string, [Date]>(() => 'Unavailable');
+      const { wrapper } = renderDatePicker({
+        ...defaultProps,
+        isDateEnabled: isOutsideRange,
+        dateDisabledReason,
+      });
+      wrapper.findOpenCalendarButton().click();
+
+      // Every date the reason function was asked about must be a disabled one.
+      expect(dateDisabledReason).toHaveBeenCalled();
+      for (const [date] of dateDisabledReason.mock.calls) {
+        expect(isOutsideRange(date)).toBe(false);
+      }
+    });
+
+    test('exposes the disabled reason on a disabled date within the range', () => {
+      const { wrapper } = renderDatePicker({
+        ...defaultProps,
+        isDateEnabled: isOutsideRange,
+        dateDisabledReason: () => 'Unavailable during maintenance',
+      });
+      wrapper.findOpenCalendarButton().click();
+
+      const disabledCell = wrapper.findCalendar()!.findDateAt(3, 5);
+      disabledCell.focus();
+      expect(disabledCell.findDisabledReason()!.getElement()).toHaveTextContent('Unavailable during maintenance');
+    });
+  });
+});

--- a/src/date-picker/interfaces.ts
+++ b/src/date-picker/interfaces.ts
@@ -120,6 +120,10 @@ export namespace DatePickerProps {
     (date: Date): boolean;
   }
 
+  export interface DateDisabledReasonFunction {
+    (date: Date): string;
+  }
+
   export interface OpenCalendarAriaLabel {
     (selectedDate: string | null): string;
   }


### PR DESCRIPTION
### Description

Adds first-class support for **disabling specific dates and date ranges** in `DatePicker` (and the underlying `Calendar` grid it renders).

`DatePicker`/`Calendar` already expose `isDateEnabled?: (date: Date) => boolean` and `dateDisabledReason?: (date: Date) => string`, so the core predicate API is unchanged and fully backward compatible. This PR closes the remaining gaps around that capability:

- **API-contract fix (`src/calendar/grid/index.tsx`):** `dateDisabledReason` is now only invoked for dates that are *not* enabled, matching its documented contract (_"only when `isDateEnabled` returns `false`"_). Previously it was called for every rendered cell, which could surprise consumers whose reason callback assumes it only runs for disabled dates. Rendering/behavior for disabled dates is unchanged.
- **New dev page (`pages/date-picker/disabled-dates.page.tsx`):** demonstrates three common scenarios — disabling weekends (a recurring set of specific dates), disabling a fixed maintenance date-range with a `dateDisabledReason`, and disabling all past dates.
- **New unit tests (`src/date-picker/__tests__/date-picker-disabled-dates.test.tsx`):** cover a disabled date *range* (not selectable via click, selectable outside the range), `aria-disabled` rendering for a11y, the disabled-reason tooltip, and the `dateDisabledReason` contract above.

Disabled dates remain non-selectable and are exposed to assistive technology via `aria-disabled` (with a focusable tooltip when a reason is provided), so the accessibility behavior is preserved.

Related links, issue #, if available: n/a (SIM: AWSUI-59501)

### How has this been tested?

- `npm run quick-build` — succeeds.
- `TZ=UTC jest src/date-picker src/calendar` — **222 passed** (incl. 5 new tests).
- `eslint` on all changed files — clean.
- Manual review via the new `date-picker/disabled-dates` dev page.

No public interfaces changed, so the component documenter snapshot is unaffected. Changes are backward compatible.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ — dev page added; no public API change.
- _Changes are backward-compatible if not indicated._ — yes, no interface changes.
- _Changes do not include unsupported browser features._ — yes.
- _Changes were manually tested for accessibility._ — `aria-disabled` + disabled-reason tooltip verified.

#### Security

- _If the code handles URLs: all URLs are validated through `checkSafeUrl`._ — n/a, no URL handling.

#### Testing

- _Changes are covered with new/existing unit tests?_ — yes (new test file + existing suites green).
- _Changes are covered with new/existing integration tests?_ — existing calendar integ coverage applies; new dev page enables manual/integ testing.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
