### PR TITLE
feat(tabs): add overflowBehavior for scrollable/dropdown tab overflow

### DIFF
--- a/pages/tabs/overflow-behavior.page.tsx
+++ b/pages/tabs/overflow-behavior.page.tsx
@@ -1,0 +1,89 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import { Select, SpaceBetween } from '~components';
+import Tabs, { TabsProps } from '~components/tabs';
+
+const manyTabs: Array<TabsProps.Tab> = Array.from({ length: 12 }, (_, i) => ({
+  id: `tab-${i + 1}`,
+  label: `Tab ${i + 1}`,
+  content: `Content for Tab ${i + 1}`,
+}));
+
+const fewTabs: Array<TabsProps.Tab> = [
+  { id: 'first', label: 'First tab', content: 'First tab content' },
+  { id: 'second', label: 'Second tab', content: 'Second tab content' },
+  { id: 'third', label: 'Third tab', content: 'Third tab content' },
+];
+
+export default function TabsOverflowPage() {
+  const [activeTabId, setActiveTabId] = useState('tab-1');
+  const [overflowBehavior, setOverflowBehavior] = useState<TabsProps.OverflowBehavior>('dropdown');
+
+  return (
+    <SpaceBetween size="l">
+      <h1>Tabs — overflow behavior</h1>
+
+      <Select
+        options={[
+          { value: 'scroll', label: 'scroll (default)' },
+          { value: 'dropdown', label: 'dropdown' },
+        ]}
+        selectedOption={{ value: overflowBehavior }}
+        onChange={e => setOverflowBehavior(e.detail.selectedOption.value as TabsProps.OverflowBehavior)}
+        inlineLabelText="overflowBehavior"
+      />
+
+      <h2>Many tabs — overflow visible</h2>
+      <div style={{ maxWidth: 400, border: '1px dashed #aaa', padding: 8 }}>
+        <Tabs
+          id="overflow-tabs"
+          tabs={manyTabs}
+          activeTabId={activeTabId}
+          onChange={e => setActiveTabId(e.detail.activeTabId)}
+          overflowBehavior={overflowBehavior}
+          i18nStrings={{
+            scrollLeftAriaLabel: 'Scroll left',
+            scrollRightAriaLabel: 'Scroll right',
+            overflowMenuAriaLabel: 'More tabs',
+          }}
+          ariaLabel="Overflow tabs demo"
+        />
+      </div>
+
+      <h2>Few tabs — no overflow</h2>
+      <div style={{ maxWidth: 600, border: '1px dashed #aaa', padding: 8 }}>
+        <Tabs
+          id="no-overflow-tabs"
+          tabs={fewTabs}
+          overflowBehavior={overflowBehavior}
+          i18nStrings={{
+            scrollLeftAriaLabel: 'Scroll left',
+            scrollRightAriaLabel: 'Scroll right',
+            overflowMenuAriaLabel: 'More tabs',
+          }}
+          ariaLabel="No overflow tabs demo"
+        />
+      </div>
+
+      <h2>Container variant — overflow</h2>
+      <div style={{ maxWidth: 400 }}>
+        <Tabs
+          id="container-overflow-tabs"
+          variant="container"
+          tabs={manyTabs}
+          activeTabId={activeTabId}
+          onChange={e => setActiveTabId(e.detail.activeTabId)}
+          overflowBehavior={overflowBehavior}
+          i18nStrings={{
+            scrollLeftAriaLabel: 'Scroll left',
+            scrollRightAriaLabel: 'Scroll right',
+            overflowMenuAriaLabel: 'More tabs',
+          }}
+          ariaLabel="Container overflow tabs demo"
+        />
+      </div>
+    </SpaceBetween>
+  );
+}

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -541,6 +541,7 @@ export interface I18nFormatArgTypes {
     'i18nStrings.scrollLeftAriaLabel': never;
     'i18nStrings.scrollRightAriaLabel': never;
     'i18nStrings.tabsWithActionsAriaRoleDescription': never;
+    'i18nStrings.overflowMenuAriaLabel': never;
   };
   'tag-editor': {
     'i18nStrings.keyPlaceholder': never;

--- a/src/tabs/__tests__/overflow-behavior.test.tsx
+++ b/src/tabs/__tests__/overflow-behavior.test.tsx
@@ -1,0 +1,173 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { act, render } from '@testing-library/react';
+
+import Tabs, { TabsProps } from '../../../lib/components/tabs';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+import tabStyles from '../../../lib/components/tabs/styles.css.js';
+
+// Mock IntersectionObserver (not available in jsdom)
+let mockObserverCallback: IntersectionObserverCallback | null = null;
+
+class MockIntersectionObserver implements IntersectionObserver {
+  root: Element | Document | null = null;
+  rootMargin = '';
+  thresholds: ReadonlyArray<number> = [];
+
+  constructor(callback: IntersectionObserverCallback) {
+    mockObserverCallback = callback;
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+function triggerIntersection(container: HTMLElement, hiddenTabIds: string[]) {
+  if (!mockObserverCallback) {
+    return;
+  }
+  const tabItems = Array.from(container.querySelectorAll('[data-tab-id]'));
+  const entries = tabItems.map(el => {
+    const tabId = (el as HTMLElement).dataset.tabId ?? '';
+    return {
+      target: el,
+      intersectionRatio: hiddenTabIds.includes(tabId) ? 0.5 : 1,
+      isIntersecting: !hiddenTabIds.includes(tabId),
+      boundingClientRect: {} as DOMRectReadOnly,
+      intersectionRect: {} as DOMRectReadOnly,
+      rootBounds: null,
+      time: 0,
+    };
+  }) as IntersectionObserverEntry[];
+  act(() => {
+    mockObserverCallback!(entries, {} as IntersectionObserver);
+  });
+}
+
+beforeEach(() => {
+  mockObserverCallback = null;
+  (global as any).IntersectionObserver = MockIntersectionObserver;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const tabs: Array<TabsProps.Tab> = [
+  { id: 'tab-1', label: 'Tab 1', content: 'Content 1' },
+  { id: 'tab-2', label: 'Tab 2', content: 'Content 2' },
+  { id: 'tab-3', label: 'Tab 3', content: 'Content 3' },
+  { id: 'tab-4', label: 'Tab 4', content: 'Content 4' },
+  { id: 'tab-5', label: 'Tab 5', content: 'Content 5' },
+];
+
+function renderTabs(props: Partial<TabsProps> = {}) {
+  const result = render(
+    <Tabs
+      tabs={tabs}
+      ariaLabel="Test tabs"
+      i18nStrings={{ overflowMenuAriaLabel: 'More tabs', scrollLeftAriaLabel: 'Left', scrollRightAriaLabel: 'Right' }}
+      {...props}
+    />
+  );
+  return { ...result, wrapper: createWrapper(result.container).findTabs()! };
+}
+
+describe('Tabs — overflowBehavior prop', () => {
+  describe('default (scroll) behavior', () => {
+    it('does not render an overflow dropdown', () => {
+      const { wrapper } = renderTabs({ overflowBehavior: 'scroll' });
+      expect(wrapper.findOverflowDropdown()).toBeNull();
+    });
+
+    it('renders all tabs in the tab list', () => {
+      const { wrapper } = renderTabs({ overflowBehavior: 'scroll' });
+      expect(wrapper.findTabLinks()).toHaveLength(tabs.length);
+    });
+  });
+
+  describe('dropdown overflow behavior', () => {
+    it('does not render the overflow dropdown when all tabs are visible', () => {
+      const { wrapper, container } = renderTabs({ overflowBehavior: 'dropdown' });
+      // No hidden tabs → no dropdown
+      triggerIntersection(container, []);
+      expect(wrapper.findOverflowDropdown()).toBeNull();
+    });
+
+    it('renders the overflow dropdown when some tabs are clipped', () => {
+      const { wrapper, container } = renderTabs({ overflowBehavior: 'dropdown' });
+      triggerIntersection(container, ['tab-4', 'tab-5']);
+      expect(wrapper.findOverflowDropdown()).not.toBeNull();
+    });
+
+    it('renders all tabs in the tab list regardless of overflow', () => {
+      const { wrapper } = renderTabs({ overflowBehavior: 'dropdown' });
+      expect(wrapper.findTabLinks()).toHaveLength(tabs.length);
+    });
+
+    it('applies the overflow dropdown mode CSS class to the tab list', () => {
+      const { container } = renderTabs({ overflowBehavior: 'dropdown' });
+      const tabList = container.querySelector('[role="tablist"]');
+      // The CSS module class name for dropdown overflow mode
+      expect(tabList?.classList.contains(tabStyles['tabs-header-list-dropdown-overflow'])).toBe(true);
+    });
+
+    it('does not apply the overflow dropdown CSS class when using scroll mode', () => {
+      const { container } = renderTabs({ overflowBehavior: 'scroll' });
+      const tabList = container.querySelector('[role="tablist"]');
+      expect(tabList?.classList.contains(tabStyles['tabs-header-list-dropdown-overflow'])).toBe(false);
+    });
+
+    it('uses the overflowMenuAriaLabel i18n string for the dropdown trigger', () => {
+      const { wrapper, container } = renderTabs({
+        overflowBehavior: 'dropdown',
+        i18nStrings: {
+          overflowMenuAriaLabel: 'Show more tabs',
+          scrollLeftAriaLabel: 'Left',
+          scrollRightAriaLabel: 'Right',
+        },
+      });
+      triggerIntersection(container, ['tab-5']);
+      const dropdown = wrapper.findOverflowDropdown();
+      expect(dropdown).not.toBeNull();
+      const triggerButton = dropdown!.findNativeButton().getElement();
+      expect(triggerButton).toHaveAttribute('aria-label', 'Show more tabs');
+    });
+
+    it('selecting a tab from the overflow dropdown fires onChange', () => {
+      const onChange = jest.fn();
+      const { wrapper, container } = renderTabs({ overflowBehavior: 'dropdown', onChange });
+      triggerIntersection(container, ['tab-4', 'tab-5']);
+
+      const dropdown = wrapper.findOverflowDropdown();
+      expect(dropdown).not.toBeNull();
+      dropdown!.openDropdown();
+      dropdown!.findItemById('tab-4')!.click();
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ detail: expect.objectContaining({ activeTabId: 'tab-4' }) })
+      );
+    });
+  });
+
+  describe('interface', () => {
+    it('accepts overflowBehavior="scroll" without errors', () => {
+      expect(() => renderTabs({ overflowBehavior: 'scroll' })).not.toThrow();
+    });
+
+    it('accepts overflowBehavior="dropdown" without errors', () => {
+      expect(() => renderTabs({ overflowBehavior: 'dropdown' })).not.toThrow();
+    });
+
+    it('defaults to scroll behavior when overflowBehavior is not set', () => {
+      const { container } = renderTabs();
+      const tabList = container.querySelector('[role="tablist"]');
+      expect(tabList?.classList.contains(tabStyles['tabs-header-list-dropdown-overflow'])).toBe(false);
+    });
+  });
+});

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -34,7 +34,7 @@ function firstEnabledTab(tabs: ReadonlyArray<TabsProps.Tab>) {
 function shouldRenderTabContent(tab: TabsProps.Tab, viewedTabs: Set<string>) {
   switch (tab.contentRenderStrategy) {
     case 'active':
-      return false; // rendering active tab is handled directly in component
+      return false;
     case 'eager':
       return true;
     case 'lazy':
@@ -56,13 +56,14 @@ export default function Tabs({
   keyboardActivationMode = 'automatic',
   actions,
   style,
+  overflowBehavior = 'scroll',
   ...rest
 }: TabsProps) {
   for (const tab of tabs) {
     checkSafeUrl('Tabs', tab.href);
   }
   const { __internalRootRef } = useBaseComponent('Tabs', {
-    props: { disableContentPaddings, variant, fitHeight, keyboardActivationMode },
+    props: { disableContentPaddings, variant, fitHeight, keyboardActivationMode, overflowBehavior },
     metadata: {
       hasActions: tabs.some(tab => !!tab.action),
       hasHeaderActions: !!actions,
@@ -156,6 +157,7 @@ export default function Tabs({
       i18nStrings={i18nStrings}
       keyboardActivationMode={keyboardActivationMode}
       style={style}
+      overflowBehavior={overflowBehavior}
     />
   );
 

--- a/src/tabs/interfaces.ts
+++ b/src/tabs/interfaces.ts
@@ -104,6 +104,13 @@ export interface TabsProps extends BaseComponentProps {
   keyboardActivationMode?: 'automatic' | 'manual';
 
   /**
+   * Controls how the tab bar behaves when tabs overflow the available width.
+   * - `'scroll'` (default): Scroll buttons appear on each side of the tab bar to allow scrolling through tabs.
+   * - `'dropdown'`: A "More" dropdown button appears at the end of the tab bar listing all tabs that do not fit.
+   */
+  overflowBehavior?: TabsProps.OverflowBehavior;
+
+  /**
    * An object containing CSS properties to customize the tabs' visual appearance.
    * Refer to the [style](/components/tabs/?tabId=style) tab for more details.
    * @awsuiSystem core
@@ -112,6 +119,8 @@ export interface TabsProps extends BaseComponentProps {
 }
 export namespace TabsProps {
   export type Variant = 'default' | 'container' | 'stacked';
+
+  export type OverflowBehavior = 'scroll' | 'dropdown';
 
   export interface Tab {
     /**
@@ -199,6 +208,11 @@ export namespace TabsProps {
      * with role="application" to provide further information on the purpose of this component
      */
     tabsWithActionsAriaRoleDescription?: string;
+    /**
+     * Label for the overflow dropdown button shown when `overflowBehavior="dropdown"` and some tabs do not fit.
+     * Defaults to "More".
+     */
+    overflowMenuAriaLabel?: string;
   }
 
   export interface Style {

--- a/src/tabs/tab-header-bar.scss
+++ b/src/tabs/tab-header-bar.scss
@@ -292,3 +292,19 @@ $label-horizontal-spacing: awsui.$space-xs;
 .tabs-tab-focusable {
   /* used to manage focusable logic */
 }
+
+// Dropdown overflow mode: clip the tab list instead of scrolling
+.tabs-header-list-dropdown-overflow {
+  overflow: hidden;
+  flex-wrap: nowrap;
+}
+
+// Container for the overflow "more" dropdown button
+.overflow-dropdown-container {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  padding-block: awsui.$space-scaled-s;
+  padding-inline: awsui.$space-xxs;
+  border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-control-disabled;
+}

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -15,6 +15,7 @@ import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-tool
 
 import { ButtonProps } from '../button/interfaces';
 import { InternalButton } from '../button/internal';
+import InternalButtonDropdown from '../button-dropdown/internal';
 import { useInternalI18n } from '../i18n/context';
 import { getAllFocusables } from '../internal/components/focus-lock/utils';
 import { hasModifierKeys, isPlainLeftClick } from '../internal/events';
@@ -86,6 +87,7 @@ interface TabHeaderBarProps {
   keyboardActivationMode: Required<TabsProps['keyboardActivationMode']>;
   actions?: TabsProps['actions'];
   style?: TabsProps['style'];
+  overflowBehavior?: TabsProps['overflowBehavior'];
 }
 
 export function TabHeaderBar({
@@ -100,6 +102,7 @@ export function TabHeaderBar({
   keyboardActivationMode,
   actions,
   style,
+  overflowBehavior = 'scroll',
 }: TabHeaderBarProps) {
   const headerBarRef = useRef<HTMLUListElement>(null);
   const activeTabHeaderRef = useRef<null | HTMLElement>(null);
@@ -133,12 +136,12 @@ export function TabHeaderBar({
         role: 'tablist',
       };
 
+  // Dropdown overflow: track which tab elements are fully visible
+  const [overflowTabIds, setOverflowTabIds] = useState<Set<string>>(new Set());
+  const tabItemRefs = useRef<Map<string, HTMLElement>>(new Map());
+
   useEffect(() => {
     if (hadActionOrDismissible && !hasActionOrDismissible) {
-      // when tabs becomes non-dismissible (e.g. when all dismissible tabs are removed),
-      // the hasActionOrDismissible is changing which causing tabs to re-mount to the React tree,
-      // which, in turn, causes losing their refs, and the nextActive.focus() function inside handleDismiss does not focus on the next tab
-      // so this code does
       getNextFocusTarget()?.focus();
     }
   }, [hasActionOrDismissible, hadActionOrDismissible]);
@@ -151,6 +154,41 @@ export function TabHeaderBar({
     }
   }, [widthChange, tabs]);
 
+  // Dropdown overflow: use IntersectionObserver to detect which tabs are clipped
+  useEffect(() => {
+    if (overflowBehavior !== 'dropdown') {
+      return;
+    }
+    const container = headerBarRef.current;
+    if (!container) {
+      return;
+    }
+
+    const hidden = new Set<string>();
+
+    const observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          const tabId = (entry.target as HTMLElement).dataset.tabId;
+          if (!tabId) {
+            return;
+          }
+          if (entry.intersectionRatio < 0.95) {
+            hidden.add(tabId);
+          } else {
+            hidden.delete(tabId);
+          }
+        });
+        setOverflowTabIds(new Set(hidden));
+      },
+      { root: container, threshold: 0.95 }
+    );
+
+    tabItemRefs.current.forEach(el => observer.observe(el));
+
+    return () => observer.disconnect();
+  }, [overflowBehavior, tabs, widthChange]);
+
   const scrollIntoViewIfPossible = (smooth: boolean) => {
     if (!activeTabId) {
       return;
@@ -162,27 +200,18 @@ export function TabHeaderBar({
   };
 
   useEffect(() => {
-    // Delay scrollIntoView as the position is depending on parent elements
-    // (effects are called inside-out in the component tree).
-    // Wait one frame to allow parents to complete it's calculation.
     requestAnimationFrame(() => {
       scrollIntoViewIfPossible(false);
     });
-    // Non-smooth scrolling should not be called upon activeId change
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [horizontalOverflow, widthChange, tabs.length]);
 
   useEffect(() => {
     scrollIntoViewIfPossible(true);
-    // Smooth scrolling should only be called upon activeId change
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTabId]);
 
   useEffect(() => {
-    /*
-     When the selected tab changes and we are currently already focused on a tab,
-     move the focus to the newly selected tab.
-    */
     if (documentRef.current && headerBarRef.current?.contains(documentRef.current.activeElement)) {
       if (documentRef.current.activeElement !== activeTabHeaderRef.current) {
         activeTabHeaderRef.current?.focus({ preventScroll: true });
@@ -293,7 +322,6 @@ export function TabHeaderBar({
   }
   function focusElement(element: HTMLElement) {
     element.focus();
-    // If focusable element is a tab - fire the onChange for it.
     const tabsById = tabs.reduce((map, tab) => map.set(tab.id, tab), new Map<string, TabsProps.Tab>());
     for (const [tabId, focusTargetTabTriggerElement] of tabRefs.current.entries()) {
       const focusTargetTabLabelElement = focusTargetTabTriggerElement?.querySelector(`.${styles['tabs-tab-link']}`);
@@ -308,7 +336,6 @@ export function TabHeaderBar({
       }
     }
   }
-  // List all non-disabled and registered focusables: those are eligible for keyboard navigation.
   function getFocusablesFrom(target: HTMLElement) {
     function isElementRegistered(element: HTMLElement) {
       return navigationAPI.current?.isRegistered(element) ?? false;
@@ -325,10 +352,23 @@ export function TabHeaderBar({
 
   const TabList = hasActionOrDismissible ? 'div' : 'ul';
 
+  // Build dropdown items for overflowed tabs
+  const overflowDropdownItems = tabs
+    .filter(tab => overflowTabIds.has(tab.id))
+    .map(tab => ({
+      id: tab.id,
+      text: tab.label as string,
+      disabled: tab.disabled,
+    }));
+
+  const overflowMenuLabel = i18n('i18nStrings.overflowMenuAriaLabel', i18nStrings?.overflowMenuAriaLabel) ?? 'More';
+
+  const hasDropdownOverflow = overflowBehavior === 'dropdown' && overflowTabIds.size > 0;
+
   return (
     <div className={classes}>
       <div className={styles['tab-header-scroll-container']} ref={containerRef}>
-        {horizontalOverflow && (
+        {overflowBehavior === 'scroll' && horizontalOverflow && (
           <span ref={inlineStartOverflowButton} className={leftButtonClasses}>
             <InternalButton
               formAction="none"
@@ -349,7 +389,11 @@ export function TabHeaderBar({
         >
           <TabList
             {...tabActionAttributes}
-            className={clsx(styles['tabs-header-list'], analyticsSelectors['tabs-header-list'])}
+            className={clsx(
+              styles['tabs-header-list'],
+              analyticsSelectors['tabs-header-list'],
+              overflowBehavior === 'dropdown' && styles['tabs-header-list-dropdown-overflow']
+            )}
             aria-label={ariaLabel}
             aria-labelledby={ariaLabelledby}
             ref={headerBarRef as never}
@@ -358,10 +402,10 @@ export function TabHeaderBar({
             onFocus={onFocus}
             onBlur={onBlur}
           >
-            {tabs.map(renderTabHeader)}
+            {tabs.map((tab, index) => renderTabHeader(tab, index))}
           </TabList>
         </SingleTabStopNavigationProvider>
-        {horizontalOverflow && (
+        {overflowBehavior === 'scroll' && horizontalOverflow && (
           <span className={rightButtonClasses}>
             <InternalButton
               formAction="none"
@@ -371,6 +415,22 @@ export function TabHeaderBar({
               __focusable={true}
               onClick={() => onPaginationClick(headerBarRef, 'forward')}
               ariaLabel={i18n('i18nStrings.scrollRightAriaLabel', i18nStrings?.scrollRightAriaLabel)}
+            />
+          </span>
+        )}
+        {overflowBehavior === 'dropdown' && hasDropdownOverflow && (
+          <span className={clsx(styles['overflow-dropdown-container'], testUtilStyles['tabs-overflow-dropdown'])}>
+            <InternalButtonDropdown
+              items={overflowDropdownItems}
+              variant="icon"
+              iconName="ellipsis"
+              ariaLabel={overflowMenuLabel}
+              onItemClick={event => {
+                const tab = tabs.find(t => t.id === event.detail.id);
+                if (tab && !tab.disabled) {
+                  onChange({ activeTabId: tab.id, activeTabHref: tab.href });
+                }
+              }}
             />
           </span>
         )}
@@ -389,14 +449,12 @@ export function TabHeaderBar({
         return;
       }
 
-      // if the primary mouse button is clicked with a modifier key, the browser will handle opening a new tab
       const specialKey = !isPlainLeftClick(event);
       if (specialKey && tab.href) {
         return;
       }
 
       event.preventDefault();
-      // for browsers that do not focus buttons on button click
       if (!tab.href) {
         const clickedTabRef = tabRefs.current.get(tab.id) as undefined | HTMLButtonElement;
         if (clickedTabRef) {
@@ -516,10 +574,14 @@ export function TabHeaderBar({
 
     return (
       <TabItem
-        ref={(element: any) => tabRefs.current.set(tab.id, element as HTMLElement)}
+        ref={(element: any) => {
+          tabRefs.current.set(tab.id, element as HTMLElement);
+          tabItemRefs.current.set(tab.id, element as HTMLElement);
+        }}
         className={styles['tabs-tab']}
         role="presentation"
         key={tab.id}
+        data-tab-id={tab.id}
       >
         <div
           className={tabHeaderContainerClasses}
@@ -566,7 +628,6 @@ const TabTrigger = forwardRef(
     const children = (
       <>
         <span className={clsx(styles['tabs-tab-label'], analyticsSelectors['tab-label'])} ref={tabLabelRefObject}>
-          {/* The label is wrapped with span so that whitespaces inside don't get trimmed. */}
           <span>{tab.label}</span>
         </span>
         {isDisabledWithReason && (

--- a/src/tabs/test-classes/styles.scss
+++ b/src/tabs/test-classes/styles.scss
@@ -6,3 +6,7 @@
 .tab-dismiss-button {
   /* used in test-utils */
 }
+
+.tabs-overflow-dropdown {
+  /* used in test-utils */
+}

--- a/src/test-utils/dom/tabs/index.ts
+++ b/src/test-utils/dom/tabs/index.ts
@@ -3,6 +3,7 @@
 import { ComponentWrapper, createWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 
 import ButtonWrapper from '../button';
+import ButtonDropdownWrapper from '../button-dropdown';
 
 import styles from '../../../tabs/styles.selectors.js';
 import testUtilStyles from '../../../tabs/test-classes/styles.selectors.js';
@@ -127,5 +128,13 @@ export default class TabsWrapper extends ComponentWrapper<HTMLButtonElement> {
 
   findActions(): ElementWrapper | null {
     return this.find(`.${styles['actions-container']}`);
+  }
+
+  /**
+   * Finds the overflow dropdown button shown when `overflowBehavior="dropdown"` and some tabs are hidden.
+   * Returns null when there are no overflowing tabs or when `overflowBehavior` is not `"dropdown"`.
+   */
+  findOverflowDropdown(): ButtonDropdownWrapper | null {
+    return this.findComponent(`.${testUtilStyles['tabs-overflow-dropdown']}`, ButtonDropdownWrapper);
   }
 }


### PR DESCRIPTION
### Description

Adds a new `overflowBehavior` prop to `Tabs` to control how the tab bar behaves when tabs overflow the available width:

- `'scroll'` (default): existing behavior — scroll buttons appear on each side of the tab bar. Fully backward-compatible.
- `'dropdown'`: tabs that do not fit are clipped and surfaced through a "More" dropdown button rendered at the end of the tab bar. Selecting a tab from the dropdown activates it (fires `onChange`).

Overflow detection uses an `IntersectionObserver` scoped to the tab list to track which tab items are clipped. A new `i18nStrings.overflowMenuAriaLabel` string labels the dropdown trigger (defaults to "More").

Also adds a `findOverflowDropdown()` test-util and a dev page (`pages/tabs/overflow-behavior.page.tsx`).

Related links, issue #, if available: AWSUI-57899

### How has this been tested?

- New unit tests in `src/tabs/__tests__/overflow-behavior.test.tsx` (12 tests) covering default/scroll behavior, dropdown rendering when tabs are clipped, the dropdown-overflow CSS class, the `overflowMenuAriaLabel` i18n string, and `onChange` firing when selecting a tab from the dropdown.
- Full tabs unit suite green (121/121).
- ESLint clean on all changed files; `quick-build` succeeds.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
