### PR TITLE
feat: wrap expandable section header actions on narrow widths

### DIFF
--- a/pages/expandable-section/header-actions-wrap.page.tsx
+++ b/pages/expandable-section/header-actions-wrap.page.tsx
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Button from '~components/button';
+import ExpandableSection from '~components/expandable-section';
+import SpaceBetween from '~components/space-between';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+// AWSUI-60837: On narrow containers the header actions should stay inline and let the
+// header text wrap first, only dropping underneath the title when there is genuinely
+// not enough room — instead of overflowing or clipping the content.
+
+const actions = (
+  <SpaceBetween direction="horizontal" size="xs">
+    <Button variant="inline-link" ariaLabel="Edit">
+      Edit
+    </Button>
+    <Button variant="inline-link" ariaLabel="Remove">
+      Remove
+    </Button>
+  </SpaceBetween>
+);
+
+const widths = [640, 360, 240, 160];
+
+export default function HeaderActionsWrapPage() {
+  return (
+    <article>
+      <h1>Expandable section header actions wrapping (AWSUI-60837)</h1>
+      <p>
+        Each block below renders the same expandable sections at a progressively narrower width. The header text should
+        wrap while the actions stay inline; the actions should only drop underneath the title on the very narrow widths
+        rather than clipping.
+      </p>
+      <ScreenshotArea>
+        <SpaceBetween size="l">
+          {widths.map(width => (
+            <div key={width} data-testid={`width-${width}`}>
+              <h2>Container width: {width}px</h2>
+              <div style={{ inlineSize: width, border: '1px dashed #879596', padding: 8 }}>
+                <SpaceBetween size="s">
+                  <ExpandableSection
+                    variant="default"
+                    headerText="Volume 4 (Custom) (64 GiB, EBS, General Purpose SSD (gp3))"
+                    headerActions={actions}
+                    defaultExpanded={true}
+                  >
+                    Configuration form here.
+                  </ExpandableSection>
+
+                  <ExpandableSection
+                    variant="default"
+                    headerText="Advanced network configuration"
+                    headerActions={
+                      <Button variant="inline-link" ariaLabel="Manage">
+                        Manage
+                      </Button>
+                    }
+                  >
+                    Single action, medium-length header text.
+                  </ExpandableSection>
+
+                  <ExpandableSection
+                    variant="inline"
+                    headerText="Supercalifragilisticexpialidocious-configuration-identifier-name"
+                    headerActions={actions}
+                  >
+                    Inline variant with an intentionally long unbreakable token in the header text.
+                  </ExpandableSection>
+                </SpaceBetween>
+              </div>
+            </div>
+          ))}
+        </SpaceBetween>
+      </ScreenshotArea>
+    </article>
+  );
+}

--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -12,6 +12,8 @@ import Header from '../../../lib/components/header';
 import Link from '../../../lib/components/link';
 import createWrapper, { ExpandableSectionWrapper } from '../../../lib/components/test-utils/dom';
 
+import styles from '../../../lib/components/expandable-section/styles.css.js';
+
 jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
   ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
   warnOnce: jest.fn(),
@@ -384,6 +386,44 @@ describe('Expandable Section', () => {
         });
       });
     });
+  });
+});
+
+describe('header actions wrapping (AWSUI-60837)', () => {
+  const actionsWrappingVariants: ExpandableSectionProps.Variant[] = ['default', 'inline'];
+
+  for (const variant of actionsWrappingVariants) {
+    test(`renders the header actions wrapper alongside the heading for the ${variant} variant`, () => {
+      const wrapper = renderExpandableSection({
+        variant,
+        headerText: 'A very long expandable section header text that should wrap on narrow widths',
+        headerActions: <Button>Action</Button>,
+      });
+      const actionsWrapper = wrapper.findHeader().findByClassName(styles['header-actions-wrapper']);
+      expect(actionsWrapper).toBeTruthy();
+      // The heading and the actions live inside the same wrapper so they can reflow together
+      // (heading text wraps first, actions only drop below when there is no room).
+      expect(actionsWrapper!.findByClassName(styles['header-wrapper'])).toBeTruthy();
+      expect(actionsWrapper!.getElement()).toHaveTextContent('Action');
+      expect(actionsWrapper!.getElement()).toHaveTextContent('A very long expandable section header text');
+    });
+  }
+
+  test('does not render the header actions wrapper when there are no header actions', () => {
+    const wrapper = renderExpandableSection({
+      variant: 'default',
+      headerText: 'No actions here',
+    });
+    expect(wrapper.findHeader().findByClassName(styles['header-actions-wrapper'])).toBeNull();
+  });
+
+  test('keeps the header text node discoverable for the default variant with actions', () => {
+    const wrapper = renderExpandableSection({
+      variant: 'default',
+      headerText: 'Header text',
+      headerActions: <Button>Action</Button>,
+    });
+    expect(wrapper.findHeaderText()?.getElement()).toHaveTextContent('Header text');
   });
 });
 

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -260,6 +260,24 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
   flex-wrap: wrap;
   column-gap: awsui.$space-xs;
   row-gap: awsui.$space-scaled-xxxs;
+
+  // AWSUI-60837: Let the heading shrink and wrap its text so that the header
+  // actions stay inline on narrow widths (wrapping the header text first), and
+  // only wrap underneath the title when there is genuinely not enough room,
+  // instead of overflowing or clipping the content.
+  > .header-wrapper {
+    flex: 1 1 auto;
+    min-inline-size: 0;
+
+    > .header-button {
+      min-inline-size: 0;
+
+      > .header-text {
+        min-inline-size: 0;
+        overflow-wrap: break-word;
+      }
+    }
+  }
 }
 
 .content {


### PR DESCRIPTION
### Description

Allow `ExpandableSection` header actions (the `headerActions` slot) to wrap gracefully on narrow container widths instead of overflowing/clipping.

For the non-container variants that render the `headerActions` slot (`default`, `inline`), the header row (`.header-actions-wrapper`) already sets `flex-wrap: wrap`, but the heading (`.header-wrapper`) could not shrink below its content min-size (`min-width: auto`). On narrow widths this pushed the actions off-screen / clipped the content rather than degrading gracefully.

This change lets the heading shrink and wrap its text (`flex: 1 1 auto` + `min-inline-size: 0` down the title flex chain, plus `overflow-wrap: break-word` on the header text). The result:

- On moderately narrow widths the header **text wraps first** while the **actions stay inline**.
- On very narrow widths the **actions wrap underneath the title** — instead of overflowing or clipping.

Scope is limited to the `.header-actions-wrapper` path (default / inline variants). The `container` variant (which routes through the `Header` component), `navigation`, and the `compact` variant (chart popovers, intentionally non-wrapping) are untouched. No public API / prop was added — this is a pure, backward-compatible layout hardening of an existing responsive behavior.

Related links, issue #, if available: AWSUI-60837

> Ticket-vs-description note: The SIM ticket AWSUI-60837 ("Allow expandable section header actions to stay inline, wrap header text instead") frames the ask as keeping actions inline and wrapping the header text, and mentions the container-header responsive breakpoint being "too small when widths are always going to be small". The task description for this change frames it as "actions wrap under the title on narrow widths instead of overflowing". Both intents converge on this SCSS fix: the heading now wraps its text first (actions stay inline), and only when there is genuinely no room do the actions drop below the title. The container-variant breakpoint tuning (owned by the `Header` component) is intentionally out of scope here and noted for follow-up.

### How has this been tested?

- `npm run quick-build` — green
- Unit tests: `jest src/expandable-section/__tests__` — 182 passed (4 new tests covering the header-actions wrapper for the `default` and `inline` variants, and absence of the wrapper when there are no actions)
- `eslint` and `stylelint` on the changed files — green
- Added a dev page (`pages/expandable-section/header-actions-wrap.page.tsx`) rendering the sections at 640 / 360 / 240 / 160 px to visually verify wrapping behavior

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
