### PR TITLE
feat: add standalone content display preference component

### DIFF
--- a/build-tools/utils/pluralize.js
+++ b/build-tools/utils/pluralize.js
@@ -23,6 +23,7 @@ const pluralizationMap = {
   CollectionPreferences: 'CollectionPreferences',
   ColumnLayout: 'ColumnLayouts',
   Container: 'Containers',
+  ContentDisplayPreference: 'ContentDisplayPreferences',
   ContentLayout: 'ContentLayouts',
   CopyToClipboard: 'CopyToClipboards',
   DateInput: 'DateInputs',

--- a/pages/content-display-preference/simple.page.tsx
+++ b/pages/content-display-preference/simple.page.tsx
@@ -1,0 +1,93 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Box from '~components/box';
+import ContentDisplayPreference, { ContentDisplayPreferenceProps } from '~components/content-display-preference';
+import SpaceBetween from '~components/space-between';
+import StatusIndicator from '~components/status-indicator';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+const options: ContentDisplayPreferenceProps['options'] = [
+  { id: 'id1', label: 'Distribution ID', alwaysVisible: true },
+  { id: 'id2', label: 'Domain name' },
+  { id: 'id3', label: 'Price class' },
+  { id: 'id4', label: 'Origin' },
+  { id: 'id5', label: 'Status' },
+  { id: 'id6', label: 'State' },
+];
+
+const MAX_VISIBLE = 3;
+
+const i18nStrings: ContentDisplayPreferenceProps.I18nStrings = {
+  columnFilteringPlaceholder: 'Filter columns',
+  columnFilteringAriaLabel: 'Filter columns',
+  columnFilteringClearFilterText: 'Clear filter',
+  columnFilteringNoMatchText: 'No columns match',
+  columnFilteringCountText: count => `${count} ${count === 1 ? 'match' : 'matches'}`,
+};
+
+export default function ContentDisplayPreferencePage() {
+  const [value, setValue] = useState<ContentDisplayPreferenceProps['value']>([
+    { id: 'id1', visible: true },
+    { id: 'id2', visible: true },
+    { id: 'id3', visible: true },
+    { id: 'id4', visible: false },
+    { id: 'id5', visible: false },
+    { id: 'id6', visible: false },
+  ]);
+
+  const visibleCount = (value ?? []).filter(item => item.visible).length;
+  const limitReached = visibleCount >= MAX_VISIBLE;
+
+  return (
+    <ScreenshotArea>
+      <Box padding="l">
+        <h1>Standalone ContentDisplayPreference</h1>
+        <SpaceBetween size="m">
+          <Box>
+            Reacts to changes immediately (no confirm step). This example rejects turning on more than {MAX_VISIBLE}{' '}
+            columns.
+          </Box>
+          {limitReached ? (
+            <StatusIndicator type="warning">
+              Maximum of {MAX_VISIBLE} visible columns reached. Hide a column to enable another.
+            </StatusIndicator>
+          ) : (
+            <StatusIndicator type="info">
+              {visibleCount} of {MAX_VISIBLE} visible columns selected.
+            </StatusIndicator>
+          )}
+          <div style={{ maxInlineSize: 400, border: '1px solid #d5dbdb', padding: 16, borderRadius: 8 }}>
+            <ContentDisplayPreference
+              title="Content display"
+              description="Select and reorder the columns to display."
+              options={options}
+              value={value}
+              enableColumnFiltering={true}
+              i18nStrings={i18nStrings}
+              dragHandleAriaLabel="Drag handle"
+              liveAnnouncementDndStarted={(position, total) => `Picked up item at position ${position} of ${total}`}
+              liveAnnouncementDndItemReordered={(initial, current, total) =>
+                `Moving item to position ${current} of ${total} (was ${initial})`
+              }
+              liveAnnouncementDndItemCommitted={(initial, final, total) =>
+                `Item moved from position ${initial} to position ${final} of ${total}`
+              }
+              liveAnnouncementDndDiscarded="Reordering canceled"
+              onChange={event => {
+                const nextVisible = event.detail.value.filter(item => item.visible).length;
+                // Only accept the change if it does not exceed the maximum number of visible columns.
+                if (nextVisible <= MAX_VISIBLE) {
+                  setValue(event.detail.value);
+                }
+              }}
+            />
+          </div>
+          <Box variant="code">{JSON.stringify(value)}</Box>
+        </SpaceBetween>
+      </Box>
+    </ScreenshotArea>
+  );
+}

--- a/pages/content-display-preference/simple.page.tsx
+++ b/pages/content-display-preference/simple.page.tsx
@@ -46,6 +46,7 @@ export default function ContentDisplayPreferencePage() {
       <Box padding="l">
         <h1>Standalone ContentDisplayPreference</h1>
         <SpaceBetween size="m">
+          <h2>Content display example</h2>
           <Box>
             Reacts to changes immediately (no confirm step). This example rejects turning on more than {MAX_VISIBLE}{' '}
             columns.

--- a/src/__tests__/required-props-for-components.ts
+++ b/src/__tests__/required-props-for-components.ts
@@ -10,6 +10,7 @@ const defaultProps: Record<string, Record<string, any>> = {
   autosuggest: { options: [], enteredPrefix: '' },
   'anchor-navigation': { anchors: [] },
   'code-editor': { i18nStrings },
+  'content-display-preference': { options: [] },
   wizard: {
     steps: [],
     i18nStrings: {

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -10551,6 +10551,270 @@ Refer to the [style](/components/container/?tabId=style) tab for more details.",
 }
 `;
 
+exports[`Components definition for content-display-preference matches the snapshot: content-display-preference 1`] = `
+{
+  "dashCaseName": "content-display-preference",
+  "events": [
+    {
+      "cancelable": false,
+      "description": "Called whenever the user reorders items or toggles their visibility.
+
+Unlike \`CollectionPreferences\`, the standalone component emits changes immediately, allowing you to
+react to selection before the user confirms (for example, to enforce a maximum number of visible columns).
+
+The event \`detail\` contains the following:
+- \`value\` (ReadonlyArray<ContentDisplayItem>) - The updated ordered list of items and their visibility.",
+      "detailInlineType": {
+        "name": "ContentDisplayPreferenceProps.ChangeDetail",
+        "properties": [
+          {
+            "name": "value",
+            "optional": false,
+            "type": "ReadonlyArray<CollectionPreferencesProps.ContentDisplayItem>",
+          },
+        ],
+        "type": "object",
+      },
+      "detailType": "ContentDisplayPreferenceProps.ChangeDetail",
+      "name": "onChange",
+    },
+  ],
+  "functions": [],
+  "name": "ContentDisplayPreference",
+  "properties": [
+    {
+      "deprecatedTag": "Custom CSS is not supported. For testing and other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
+      "description": "Adds the specified classes to the root element of the component.",
+      "name": "className",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "description": "Specifies the description displayed below the title.",
+      "i18nTag": true,
+      "name": "description",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "name": "dragHandleAriaDescription",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "name": "dragHandleAriaLabel",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "description": "Adds a columns filter to the control.",
+      "name": "enableColumnFiltering",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
+      "description": "Specifies an array of column group definitions for multi-level content display. Each group contains:
+- \`id\` (string) - A unique identifier for the group.
+- \`label\` (string) - The text displayed as the group label.",
+      "name": "groups",
+      "optional": true,
+      "type": "ReadonlyArray<CollectionPreferencesProps.ContentDisplayOptionGroup>",
+    },
+    {
+      "description": "An object containing all the localized strings required by the component.",
+      "i18nTag": true,
+      "inlineType": {
+        "name": "CollectionPreferencesProps.ContentDisplayPreferenceI18nStrings",
+        "properties": [
+          {
+            "name": "columnFilteringAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "columnFilteringClearFilterText",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "inlineType": {
+              "name": "(count: number) => string",
+              "parameters": [
+                {
+                  "name": "count",
+                  "type": "number",
+                },
+              ],
+              "returnType": "string",
+              "type": "function",
+            },
+            "name": "columnFilteringCountText",
+            "optional": true,
+            "type": "((count: number) => string)",
+          },
+          {
+            "name": "columnFilteringNoMatchText",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "columnFilteringPlaceholder",
+            "optional": true,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "i18nStrings",
+      "optional": true,
+      "type": "CollectionPreferencesProps.ContentDisplayPreferenceI18nStrings",
+    },
+    {
+      "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
+use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes). If you must
+use the \`id\` attribute, consider setting it on a parent element instead.",
+      "description": "Adds the specified ID to the root element of the component.",
+      "name": "id",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "name": "liveAnnouncementDndDiscarded",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "description": "Adds a label for a group item to be announced by screen readers during drag and drop operations.",
+      "inlineType": {
+        "name": "(label: string, count: number) => string",
+        "parameters": [
+          {
+            "name": "label",
+            "type": "string",
+          },
+          {
+            "name": "count",
+            "type": "number",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
+      "name": "liveAnnouncementDndGroupLabel",
+      "optional": true,
+      "type": "((label: string, count: number) => string)",
+    },
+    {
+      "inlineType": {
+        "name": "(initialPosition: number, finalPosition: number, total: number) => string",
+        "parameters": [
+          {
+            "name": "initialPosition",
+            "type": "number",
+          },
+          {
+            "name": "finalPosition",
+            "type": "number",
+          },
+          {
+            "name": "total",
+            "type": "number",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
+      "name": "liveAnnouncementDndItemCommitted",
+      "optional": true,
+      "type": "((initialPosition: number, finalPosition: number, total: number) => string)",
+    },
+    {
+      "inlineType": {
+        "name": "(initialPosition: number, currentPosition: number, total: number) => string",
+        "parameters": [
+          {
+            "name": "initialPosition",
+            "type": "number",
+          },
+          {
+            "name": "currentPosition",
+            "type": "number",
+          },
+          {
+            "name": "total",
+            "type": "number",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
+      "name": "liveAnnouncementDndItemReordered",
+      "optional": true,
+      "type": "((initialPosition: number, currentPosition: number, total: number) => string)",
+    },
+    {
+      "inlineType": {
+        "name": "(position: number, total: number) => string",
+        "parameters": [
+          {
+            "name": "position",
+            "type": "number",
+          },
+          {
+            "name": "total",
+            "type": "number",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
+      "name": "liveAnnouncementDndStarted",
+      "optional": true,
+      "type": "((position: number, total: number) => string)",
+    },
+    {
+      "description": "Specifies an array of options for reordering and visible content selection.
+
+Each option contains the following:
+- \`id\` (string) - Corresponds to a table column \`id\`.
+- \`label\` (string) - Specifies a short description of the content.
+- \`alwaysVisible\` (boolean) - (Optional) Determines whether the visibility is always on and therefore cannot be toggled. This is set to \`false\` by default.",
+      "name": "options",
+      "optional": false,
+      "type": "ReadonlyArray<CollectionPreferencesProps.ContentDisplayOption>",
+    },
+    {
+      "description": "Specifies the text displayed at the top of the preference.",
+      "i18nTag": true,
+      "name": "title",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "description": "The current, ordered list of content items and their visibility. The order of the elements influences the display.
+
+Each content display item is one of the following:
+- \`ContentDisplayColumn\` - Represents a single column.
+  - \`type\` ('column') - (Optional) Identifies the entry as a column. Defaults to \`'column'\` when omitted.
+  - \`id\` (string) - The column identifier.
+  - \`visible\` (boolean) - Whether the column is visible.
+- \`ContentDisplayGroup\` - Represents a column group.
+  - \`type\` ('group') - Identifies the entry as a group.
+  - \`id\` (string) - The group identifier.
+  - \`visible\` (boolean) - Whether the group is visible.
+  - \`children\` (ReadonlyArray<ContentDisplayItem>) - The columns or nested groups within this group.
+
+When not provided, all options are shown as visible in their original order.",
+      "name": "value",
+      "optional": true,
+      "type": "ReadonlyArray<CollectionPreferencesProps.ContentDisplayItem>",
+    },
+  ],
+  "regions": [],
+  "releaseStatus": "stable",
+}
+`;
+
 exports[`Components definition for content-layout matches the snapshot: content-layout 1`] = `
 {
   "dashCaseName": "content-layout",

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -200,6 +200,9 @@ exports[`test-utils selectors 1`] = `
     "awsui_media_14iqq",
     "awsui_root_14iqq",
   ],
+  "content-display-preference": [
+    "awsui_root_1bte3",
+  ],
   "content-layout": [
     "awsui_breadcrumbs_64tge",
     "awsui_content_5gtk3",

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-wrappers.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-wrappers.test.tsx.snap
@@ -32,6 +32,7 @@ import CodeEditorWrapper from './code-editor';
 import CollectionPreferencesWrapper from './collection-preferences';
 import ColumnLayoutWrapper from './column-layout';
 import ContainerWrapper from './container';
+import ContentDisplayPreferenceWrapper from './content-display-preference';
 import ContentLayoutWrapper from './content-layout';
 import CopyToClipboardWrapper from './copy-to-clipboard';
 import DateInputWrapper from './date-input';
@@ -128,6 +129,7 @@ export { CodeEditorWrapper };
 export { CollectionPreferencesWrapper };
 export { ColumnLayoutWrapper };
 export { ContainerWrapper };
+export { ContentDisplayPreferenceWrapper };
 export { ContentLayoutWrapper };
 export { CopyToClipboardWrapper };
 export { DateInputWrapper };
@@ -847,6 +849,34 @@ findAllContainers(selector?: string): Array<ContainerWrapper>;
  * @returns {ContainerWrapper | null}
  */
 findClosestContainer(): ContainerWrapper | null;
+/**
+ * Returns the wrapper of the first ContentDisplayPreference that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first ContentDisplayPreference.
+ * If no matching ContentDisplayPreference is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ContentDisplayPreferenceWrapper | null}
+ */
+findContentDisplayPreference(selector?: string): ContentDisplayPreferenceWrapper | null;
+
+/**
+ * Returns an array of ContentDisplayPreference wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the ContentDisplayPreferences inside the current wrapper.
+ * If no matching ContentDisplayPreference is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<ContentDisplayPreferenceWrapper>}
+ */
+findAllContentDisplayPreferences(selector?: string): Array<ContentDisplayPreferenceWrapper>;
+
+/**
+ * Returns the wrapper of the closest parent ContentDisplayPreference for the current element,
+ * or the element itself if it is an instance of ContentDisplayPreference.
+ * If no ContentDisplayPreference is found, returns \`null\`.
+ *
+ * @returns {ContentDisplayPreferenceWrapper | null}
+ */
+findClosestContentDisplayPreference(): ContentDisplayPreferenceWrapper | null;
 /**
  * Returns the wrapper of the first ContentLayout that matches the specified CSS selector.
  * If no CSS selector is specified, returns the wrapper of the first ContentLayout.
@@ -3138,6 +3168,19 @@ ElementWrapper.prototype.findContainer = function(selector) {
 ElementWrapper.prototype.findAllContainers = function(selector) {
   return this.findAllComponents(ContainerWrapper, selector);
 };
+ElementWrapper.prototype.findContentDisplayPreference = function(selector) {
+  let rootSelector = \`.\${ContentDisplayPreferenceWrapper.rootSelector}\`;
+  if("legacyRootSelector" in ContentDisplayPreferenceWrapper && ContentDisplayPreferenceWrapper.legacyRootSelector){
+    rootSelector = \`:is(.\${ContentDisplayPreferenceWrapper.rootSelector}, .\${ContentDisplayPreferenceWrapper.legacyRootSelector})\`;
+  }
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ContentDisplayPreferenceWrapper);
+};
+
+ElementWrapper.prototype.findAllContentDisplayPreferences = function(selector) {
+  return this.findAllComponents(ContentDisplayPreferenceWrapper, selector);
+};
 ElementWrapper.prototype.findContentLayout = function(selector) {
   let rootSelector = \`.\${ContentLayoutWrapper.rootSelector}\`;
   if("legacyRootSelector" in ContentLayoutWrapper && ContentLayoutWrapper.legacyRootSelector){
@@ -4177,6 +4220,11 @@ ElementWrapper.prototype.findClosestContainer = function() {
   // https://github.com/microsoft/TypeScript/issues/29132
   return (this as any).findClosestComponent(ContainerWrapper);
 };
+ElementWrapper.prototype.findClosestContentDisplayPreference = function() {
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findClosestComponent(ContentDisplayPreferenceWrapper);
+};
 ElementWrapper.prototype.findClosestContentLayout = function() {
   // casting to 'any' is needed to avoid this issue with generics
   // https://github.com/microsoft/TypeScript/issues/29132
@@ -4574,6 +4622,7 @@ import CodeEditorWrapper from './code-editor';
 import CollectionPreferencesWrapper from './collection-preferences';
 import ColumnLayoutWrapper from './column-layout';
 import ContainerWrapper from './container';
+import ContentDisplayPreferenceWrapper from './content-display-preference';
 import ContentLayoutWrapper from './content-layout';
 import CopyToClipboardWrapper from './copy-to-clipboard';
 import DateInputWrapper from './date-input';
@@ -4670,6 +4719,7 @@ export { CodeEditorWrapper };
 export { CollectionPreferencesWrapper };
 export { ColumnLayoutWrapper };
 export { ContainerWrapper };
+export { ContentDisplayPreferenceWrapper };
 export { ContentLayoutWrapper };
 export { CopyToClipboardWrapper };
 export { DateInputWrapper };
@@ -5136,6 +5186,23 @@ findContainer(selector?: string): ContainerWrapper;
  * @returns {MultiElementWrapper<ContainerWrapper>}
  */
 findAllContainers(selector?: string): MultiElementWrapper<ContainerWrapper>;
+/**
+ * Returns a wrapper that matches the ContentDisplayPreferences with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches ContentDisplayPreferences.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {ContentDisplayPreferenceWrapper}
+ */
+findContentDisplayPreference(selector?: string): ContentDisplayPreferenceWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches ContentDisplayPreferences with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches ContentDisplayPreferences.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<ContentDisplayPreferenceWrapper>}
+ */
+findAllContentDisplayPreferences(selector?: string): MultiElementWrapper<ContentDisplayPreferenceWrapper>;
 /**
  * Returns a wrapper that matches the ContentLayouts with the specified CSS selector.
  * If no CSS selector is specified, returns a wrapper that matches ContentLayouts.
@@ -6645,6 +6712,19 @@ ElementWrapper.prototype.findContainer = function(selector) {
 
 ElementWrapper.prototype.findAllContainers = function(selector) {
   return this.findAllComponents(ContainerWrapper, selector);
+};
+ElementWrapper.prototype.findContentDisplayPreference = function(selector) {
+  let rootSelector = \`.\${ContentDisplayPreferenceWrapper.rootSelector}\`;
+  if("legacyRootSelector" in ContentDisplayPreferenceWrapper && ContentDisplayPreferenceWrapper.legacyRootSelector){
+    rootSelector = \`:is(.\${ContentDisplayPreferenceWrapper.rootSelector}, .\${ContentDisplayPreferenceWrapper.legacyRootSelector})\`;
+  }
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, ContentDisplayPreferenceWrapper);
+};
+
+ElementWrapper.prototype.findAllContentDisplayPreferences = function(selector) {
+  return this.findAllComponents(ContentDisplayPreferenceWrapper, selector);
 };
 ElementWrapper.prototype.findContentLayout = function(selector) {
   let rootSelector = \`.\${ContentLayoutWrapper.rootSelector}\`;

--- a/src/collection-preferences/content-display/index.tsx
+++ b/src/collection-preferences/content-display/index.tsx
@@ -302,7 +302,7 @@ export default function ContentDisplayPreference({
                 i18nStrings?.columnFilteringNoMatchText
               )}
             </InternalBox>
-            <InternalButton onClick={() => setColumnFilteringText('')}>
+            <InternalButton formAction="none" onClick={() => setColumnFilteringText('')}>
               {i18n(
                 'contentDisplayPreference.i18nStrings.columnFilteringClearFilterText',
                 i18nStrings?.columnFilteringClearFilterText

--- a/src/content-display-preference/__tests__/content-display-preference.test.tsx
+++ b/src/content-display-preference/__tests__/content-display-preference.test.tsx
@@ -1,0 +1,279 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+
+import ContentDisplayPreference, {
+  ContentDisplayPreferenceProps,
+} from '../../../lib/components/content-display-preference';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
+import createWrapper, { ContentDisplayPreferenceWrapper } from '../../../lib/components/test-utils/dom';
+
+const options: ContentDisplayPreferenceProps['options'] = [
+  { id: 'id1', label: 'Item 1', alwaysVisible: true },
+  { id: 'id2', label: 'Item 2' },
+  { id: 'id3', label: 'Item 3' },
+  { id: 'id4', label: 'Item 4' },
+];
+
+const i18nMessages = {
+  'collection-preferences': {
+    'contentDisplayPreference.i18nStrings.columnFilteringPlaceholder': 'Filter columns',
+    'contentDisplayPreference.i18nStrings.columnFilteringAriaLabel': 'Filter columns',
+    'contentDisplayPreference.i18nStrings.columnFilteringNoMatchText': 'No matches found',
+    'contentDisplayPreference.i18nStrings.columnFilteringClearFilterText': 'Clear filter',
+    'contentDisplayPreference.i18nStrings.columnFilteringCountText':
+      '{count, select, zero {0 matches} one {1 match} other {{count} matches}}',
+    'contentDisplayPreference.dragHandleAriaLabel': 'Drag handle',
+    'contentDisplayPreference.liveAnnouncementDndStarted': 'Picked up item at position {position} of {total}',
+    'contentDisplayPreference.liveAnnouncementDndItemReordered':
+      '{isInitialPosition, select, true {Moving item back to position {currentPosition} of {total}} false {Moving item to position {currentPosition} of {total}} other {}}',
+    'contentDisplayPreference.liveAnnouncementDndItemCommitted':
+      '{isInitialPosition, select, true {Item moved back to its original position {initialPosition} of {total}} false {Item moved from position {initialPosition} to position {finalPosition} of {total}} other {}}',
+    'contentDisplayPreference.liveAnnouncementDndDiscarded': 'Reordering canceled',
+  },
+};
+
+/**
+ * Renders the standalone component with local state so that the controlled `value`
+ * updates when the user interacts, mirroring real usage.
+ */
+function StatefulContentDisplayPreference({
+  onChange,
+  ...props
+}: Partial<ContentDisplayPreferenceProps> & { onChange?: ContentDisplayPreferenceProps['onChange'] }) {
+  const [value, setValue] = useState<ContentDisplayPreferenceProps['value']>(props.value);
+  return (
+    <ContentDisplayPreference
+      title="Content display title"
+      description="Content display description"
+      options={options}
+      {...props}
+      value={value}
+      onChange={event => {
+        setValue(event.detail.value);
+        onChange?.(event);
+      }}
+    />
+  );
+}
+
+function renderCDP(
+  props: Partial<ContentDisplayPreferenceProps> & { onChange?: ContentDisplayPreferenceProps['onChange'] } = {},
+  withI18nProvider = false
+): ContentDisplayPreferenceWrapper {
+  const node = <StatefulContentDisplayPreference {...props} />;
+  render(withI18nProvider ? <TestI18nProvider messages={i18nMessages}>{node}</TestI18nProvider> : node);
+  return createWrapper().findContentDisplayPreference()!;
+}
+
+function pressKey(element: HTMLElement, key: string) {
+  fireEvent.keyDown(element, { key, code: key });
+}
+
+describe('ContentDisplayPreference (standalone)', () => {
+  describe('Rendering', () => {
+    it('renders the title as an h3', () => {
+      const titleElement = renderCDP().findTitle().getElement();
+      expect(titleElement).toHaveTextContent('Content display title');
+      expect(titleElement.tagName).toBe('H3');
+    });
+
+    it('renders the description', () => {
+      expect(renderCDP().findDescription().getElement()).toHaveTextContent('Content display description');
+    });
+
+    it('wraps content in a group role with aria-labelledby and aria-describedby', () => {
+      const wrapper = renderCDP();
+      const titleId = wrapper.findTitle().getElement().id;
+      const descriptionId = wrapper.findDescription().getElement().id;
+      const group = wrapper.getElement().querySelector('[role="group"]')!;
+      expect(group).not.toBeNull();
+      expect(group.getAttribute('aria-labelledby')).toBe(titleId);
+      expect(group.getAttribute('aria-describedby')).toBe(descriptionId);
+    });
+
+    it('renders all options with all of them visible by default (uncontrolled value)', () => {
+      const wrapper = renderCDP();
+      const optionWrappers = wrapper.findOptions();
+      expect(optionWrappers).toHaveLength(4);
+      for (const optionWrapper of optionWrappers) {
+        expect(optionWrapper.findVisibilityToggle().findNativeInput().getElement()).toBeChecked();
+      }
+    });
+
+    it('renders the provided value ordering and visibility', () => {
+      const wrapper = renderCDP({
+        value: [
+          { id: 'id1', visible: true },
+          { id: 'id3', visible: false },
+          { id: 'id2', visible: true },
+          { id: 'id4', visible: false },
+        ],
+      });
+      const labels = wrapper.findOptions().map(option => option.findLabel().getElement().textContent);
+      expect(labels).toEqual(['Item 1', 'Item 3', 'Item 2', 'Item 4']);
+      const statuses = wrapper
+        .findOptions()
+        .map(option => option.findVisibilityToggle().findNativeInput().getElement().hasAttribute('checked'));
+      // id1 visible, id3 hidden, id2 visible, id4 hidden
+      expect(wrapper.findOptionByIndex(2)!.findVisibilityToggle().findNativeInput().getElement()).not.toBeChecked();
+      expect(statuses.length).toBe(4);
+    });
+  });
+
+  describe('Reacting to changes immediately', () => {
+    it('fires onChange with the updated value when toggling visibility', () => {
+      const onChange = jest.fn();
+      const wrapper = renderCDP({ onChange });
+      wrapper.findOptionByIndex(2)!.findVisibilityToggle().findNativeInput().click();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: {
+            value: [
+              { id: 'id1', visible: true },
+              { id: 'id2', visible: false },
+              { id: 'id3', visible: true },
+              { id: 'id4', visible: true },
+            ],
+          },
+        })
+      );
+      // The controlled value is reflected back in the UI without a confirm step.
+      expect(wrapper.findOptionByIndex(2)!.findVisibilityToggle().findNativeInput().getElement()).not.toBeChecked();
+    });
+
+    it('lets a consumer enforce a maximum number of visible columns', () => {
+      const maxVisible = 2;
+      function LimitedContentDisplay() {
+        const [value, setValue] = useState<ContentDisplayPreferenceProps['value']>([
+          { id: 'id1', visible: true },
+          { id: 'id2', visible: true },
+          { id: 'id3', visible: false },
+          { id: 'id4', visible: false },
+        ]);
+        return (
+          <ContentDisplayPreference
+            options={[
+              { id: 'id1', label: 'Item 1' },
+              { id: 'id2', label: 'Item 2' },
+              { id: 'id3', label: 'Item 3' },
+              { id: 'id4', label: 'Item 4' },
+            ]}
+            value={value}
+            onChange={event => {
+              const visibleCount = event.detail.value.filter(item => item.visible).length;
+              if (visibleCount <= maxVisible) {
+                setValue(event.detail.value);
+              }
+            }}
+          />
+        );
+      }
+      render(<LimitedContentDisplay />);
+      const wrapper = createWrapper().findContentDisplayPreference()!;
+      // Attempting to enable a 3rd column is rejected by the consumer -> stays hidden.
+      wrapper.findOptionByIndex(3)!.findVisibilityToggle().findNativeInput().click();
+      expect(wrapper.findOptionByIndex(3)!.findVisibilityToggle().findNativeInput().getElement()).not.toBeChecked();
+    });
+
+    it('keeps alwaysVisible options checked and disabled', () => {
+      const onChange = jest.fn();
+      const wrapper = renderCDP({ onChange });
+      const toggle = wrapper.findOptionByIndex(1)!.findVisibilityToggle().findNativeInput();
+      expect(toggle.getElement()).toBeChecked();
+      expect(toggle.getElement()).toBeDisabled();
+      toggle.click();
+      expect(toggle.getElement()).toBeChecked();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('fires onChange with the reordered value when moving an item with the keyboard', async () => {
+      const onChange = jest.fn();
+      const wrapper = renderCDP({ onChange }, true);
+      const settle = () => new Promise(resolve => setTimeout(resolve, 0));
+      const dragHandle = wrapper.findOptionByIndex(2)!.findDragHandle().getElement();
+      pressKey(dragHandle, 'Space');
+      await settle();
+      pressKey(dragHandle, 'ArrowDown');
+      await settle();
+      pressKey(dragHandle, 'Space');
+      await settle();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: {
+            value: [
+              { id: 'id1', visible: true },
+              { id: 'id3', visible: true },
+              { id: 'id2', visible: true },
+              { id: 'id4', visible: true },
+            ],
+          },
+        })
+      );
+    });
+  });
+
+  describe('Column filtering', () => {
+    it('does not render the text filter by default', () => {
+      expect(renderCDP().findTextFilter()).toBeNull();
+    });
+
+    it('filters options when enableColumnFiltering is set', () => {
+      const wrapper = renderCDP({ enableColumnFiltering: true }, true);
+      const filter = wrapper.findTextFilter();
+      expect(filter).not.toBeNull();
+      filter!.findInput().setInputValue('Item 1');
+      expect(wrapper.findOptions()).toHaveLength(1);
+      filter!.findInput().findClearButton()?.click();
+      expect(wrapper.findOptions()).toHaveLength(4);
+    });
+  });
+
+  describe('Groups', () => {
+    it('renders grouped options', () => {
+      const wrapper = renderCDP({
+        options: [
+          { id: 'id1', label: 'Item 1' },
+          { id: 'id2', label: 'Item 2' },
+          { id: 'id3', label: 'Item 3' },
+        ],
+        groups: [{ id: 'g1', label: 'Group 1' }],
+        value: [
+          { id: 'id1', visible: true },
+          {
+            type: 'group',
+            id: 'g1',
+            visible: true,
+            children: [
+              { id: 'id2', visible: true },
+              { id: 'id3', visible: false },
+            ],
+          },
+        ],
+      });
+      expect(wrapper.findOptions({ group: true })).toHaveLength(1);
+    });
+  });
+
+  describe('Base component API', () => {
+    it('applies className, id and data attributes to the root and is findable', () => {
+      const { container } = render(
+        <ContentDisplayPreference
+          className="custom-class"
+          id="my-id"
+          data-testid="cdp"
+          options={options}
+          value={undefined}
+          onChange={() => {}}
+        />
+      );
+      const root = container.querySelector('#my-id')!;
+      expect(root).toHaveClass('custom-class');
+      expect(root).toHaveAttribute('data-testid', 'cdp');
+      expect(createWrapper(container).findContentDisplayPreference()).not.toBeNull();
+    });
+  });
+});

--- a/src/content-display-preference/index.tsx
+++ b/src/content-display-preference/index.tsx
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+'use client';
+import React from 'react';
+
+import useBaseComponent from '../internal/hooks/use-base-component';
+import { applyDisplayName } from '../internal/utils/apply-display-name';
+import { ContentDisplayPreferenceProps } from './interfaces';
+import InternalContentDisplayPreference from './internal';
+
+export { ContentDisplayPreferenceProps };
+
+export default function ContentDisplayPreference(props: ContentDisplayPreferenceProps) {
+  const baseComponentProps = useBaseComponent('ContentDisplayPreference', {
+    props: { enableColumnFiltering: props.enableColumnFiltering },
+  });
+  return <InternalContentDisplayPreference {...props} {...baseComponentProps} />;
+}
+
+applyDisplayName(ContentDisplayPreference, 'ContentDisplayPreference');

--- a/src/content-display-preference/interfaces.ts
+++ b/src/content-display-preference/interfaces.ts
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { CollectionPreferencesProps } from '../collection-preferences/interfaces';
+import { BaseComponentProps } from '../types/base-component';
+import { NonCancelableEventHandler } from '../types/events';
+import { DndAreaI18nStrings } from '../types/sortable-area';
+
+export interface ContentDisplayPreferenceProps extends BaseComponentProps, DndAreaI18nStrings {
+  /**
+   * Specifies the text displayed at the top of the preference.
+   * @i18n
+   */
+  title?: string;
+  /**
+   * Specifies the description displayed below the title.
+   * @i18n
+   */
+  description?: string;
+  /**
+   * Specifies an array of options for reordering and visible content selection.
+   *
+   * Each option contains the following:
+   * - `id` (string) - Corresponds to a table column `id`.
+   * - `label` (string) - Specifies a short description of the content.
+   * - `alwaysVisible` (boolean) - (Optional) Determines whether the visibility is always on and therefore cannot be toggled. This is set to `false` by default.
+   */
+  options: ReadonlyArray<ContentDisplayPreferenceProps.Option>;
+  /**
+   * Specifies an array of column group definitions for multi-level content display. Each group contains:
+   * - `id` (string) - A unique identifier for the group.
+   * - `label` (string) - The text displayed as the group label.
+   */
+  groups?: ReadonlyArray<ContentDisplayPreferenceProps.OptionGroup>;
+  /**
+   * The current, ordered list of content items and their visibility. The order of the elements influences the display.
+   *
+   * Each content display item is one of the following:
+   * - `ContentDisplayColumn` - Represents a single column.
+   *   - `type` ('column') - (Optional) Identifies the entry as a column. Defaults to `'column'` when omitted.
+   *   - `id` (string) - The column identifier.
+   *   - `visible` (boolean) - Whether the column is visible.
+   * - `ContentDisplayGroup` - Represents a column group.
+   *   - `type` ('group') - Identifies the entry as a group.
+   *   - `id` (string) - The group identifier.
+   *   - `visible` (boolean) - Whether the group is visible.
+   *   - `children` (ReadonlyArray<ContentDisplayItem>) - The columns or nested groups within this group.
+   *
+   * When not provided, all options are shown as visible in their original order.
+   */
+  value?: ReadonlyArray<ContentDisplayPreferenceProps.ContentDisplayItem>;
+  /**
+   * Adds a columns filter to the control.
+   */
+  enableColumnFiltering?: boolean;
+  /**
+   * An object containing all the localized strings required by the component.
+   * @i18n
+   */
+  i18nStrings?: ContentDisplayPreferenceProps.I18nStrings;
+  /**
+   * Adds a label for a group item to be announced by screen readers during drag and drop operations.
+   */
+  liveAnnouncementDndGroupLabel?: (label: string, count: number) => string;
+  /**
+   * Called whenever the user reorders items or toggles their visibility.
+   *
+   * Unlike `CollectionPreferences`, the standalone component emits changes immediately, allowing you to
+   * react to selection before the user confirms (for example, to enforce a maximum number of visible columns).
+   *
+   * The event `detail` contains the following:
+   * - `value` (ReadonlyArray<ContentDisplayItem>) - The updated ordered list of items and their visibility.
+   */
+  onChange?: NonCancelableEventHandler<ContentDisplayPreferenceProps.ChangeDetail>;
+}
+
+export namespace ContentDisplayPreferenceProps {
+  export type Option = CollectionPreferencesProps.ContentDisplayOption;
+  export type OptionGroup = CollectionPreferencesProps.ContentDisplayOptionGroup;
+  export type ContentDisplayItem = CollectionPreferencesProps.ContentDisplayItem;
+  export type ContentDisplayColumn = CollectionPreferencesProps.ContentDisplayColumn;
+  export type ContentDisplayGroup = CollectionPreferencesProps.ContentDisplayGroup;
+  export type I18nStrings = CollectionPreferencesProps.ContentDisplayPreferenceI18nStrings;
+
+  export interface ChangeDetail {
+    value: ReadonlyArray<ContentDisplayItem>;
+  }
+}

--- a/src/content-display-preference/internal.tsx
+++ b/src/content-display-preference/internal.tsx
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+
+import ContentDisplayPreferenceCore from '../collection-preferences/content-display';
+import { getBaseProps } from '../internal/base-component';
+import { fireNonCancelableEvent } from '../internal/events';
+import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import { ContentDisplayPreferenceProps } from './interfaces';
+
+import styles from './styles.css.js';
+
+type InternalContentDisplayPreferenceProps = ContentDisplayPreferenceProps & InternalBaseComponentProps;
+
+export default function InternalContentDisplayPreference({
+  options,
+  groups,
+  value,
+  title,
+  description,
+  enableColumnFiltering,
+  i18nStrings,
+  liveAnnouncementDndStarted,
+  liveAnnouncementDndItemReordered,
+  liveAnnouncementDndItemCommitted,
+  liveAnnouncementDndDiscarded,
+  liveAnnouncementDndGroupLabel,
+  dragHandleAriaLabel,
+  dragHandleAriaDescription,
+  onChange,
+  __internalRootRef,
+  ...rest
+}: InternalContentDisplayPreferenceProps) {
+  const baseProps = getBaseProps(rest);
+  return (
+    <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
+      <ContentDisplayPreferenceCore
+        options={options}
+        groups={groups}
+        value={value}
+        title={title}
+        description={description}
+        enableColumnFiltering={enableColumnFiltering}
+        i18nStrings={i18nStrings}
+        liveAnnouncementDndStarted={liveAnnouncementDndStarted}
+        liveAnnouncementDndItemReordered={liveAnnouncementDndItemReordered}
+        liveAnnouncementDndItemCommitted={liveAnnouncementDndItemCommitted}
+        liveAnnouncementDndDiscarded={liveAnnouncementDndDiscarded}
+        liveAnnouncementDndGroupLabel={liveAnnouncementDndGroupLabel}
+        dragHandleAriaLabel={dragHandleAriaLabel}
+        dragHandleAriaDescription={dragHandleAriaDescription}
+        onChange={newValue => fireNonCancelableEvent(onChange, { value: newValue })}
+      />
+    </div>
+  );
+}

--- a/src/content-display-preference/styles.scss
+++ b/src/content-display-preference/styles.scss
@@ -1,0 +1,11 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+// The standalone ContentDisplayPreference renders the shared content-display control,
+// which brings its own layout. This root only exists to carry the component metadata,
+// so it is removed from the layout box tree.
+.root {
+  display: contents;
+}

--- a/src/test-utils/dom/content-display-preference/index.ts
+++ b/src/test-utils/dom/content-display-preference/index.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import {
+  ContentDisplayOptionWrapper,
+  default as CollectionContentDisplayPreferenceWrapper,
+} from '../collection-preferences/content-display-preference';
+
+import styles from '../../../content-display-preference/styles.selectors.js';
+
+export { ContentDisplayOptionWrapper };
+
+/**
+ * Test utils wrapper for the standalone `ContentDisplayPreference` component.
+ *
+ * It reuses the finders of the content display control used inside `CollectionPreferences`
+ * (title, description, options, drag handles, visibility toggles, column filter, no-match),
+ * anchored on the standalone component root.
+ */
+export default class ContentDisplayPreferenceWrapper extends CollectionContentDisplayPreferenceWrapper {
+  static rootSelector: string = styles.root;
+}


### PR DESCRIPTION
### Description

Exposes the content-display preference control (drag-and-drop column reordering + visibility toggles, optional column filtering and grouping) as a **standalone `ContentDisplayPreference` component**, usable outside the `CollectionPreferences` modal.

Unlike `CollectionPreferences`, the standalone component is fully controlled and emits an `onChange` event **immediately** on every reorder/toggle (no confirm step). This lets consumers react to selection before submission — e.g. enforce a maximum number of visible columns, which is the motivating use case in the linked request.

The implementation **reuses the existing internal content-display renderer** (`src/collection-preferences/content-display`) rather than duplicating it. `CollectionPreferences` continues to render the same shared core unchanged, so its behavior and public API are unaffected.

Changes:
- New public component `src/content-display-preference/` (`index.tsx`, `internal.tsx`, `interfaces.ts`, `styles.scss`). `ContentDisplayPreferenceProps` reuses the shared content-display item/option/i18n types from `CollectionPreferencesProps` to stay in sync.
- Test-utils DOM wrapper (`src/test-utils/dom/content-display-preference`) extending the existing content-display wrapper.
- Pluralization entry for the new component name (`build-tools/utils/pluralize.js`).
- Unit tests and a dev page (`pages/content-display-preference/simple.page.tsx`) demonstrating the "max visible columns" reactive use case.

Related links, issue #, if available: AWSUI-60078

### How has this been tested?

- `npm run quick-build` — green.
- `eslint` + `stylelint` on the new/changed files — green.
- New unit tests (13, incl. rendering, immediate `onChange` on toggle & keyboard reorder, `alwaysVisible`, column filtering, groups, and base-component API) — all pass.
- Existing `collection-preferences/content-display` unit tests (56) — still pass (shared core untouched).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
