### PR TITLE
feat: add reset to defaults to collection preferences

### DIFF
--- a/pages/collection-preferences/reset-to-defaults.page.tsx
+++ b/pages/collection-preferences/reset-to-defaults.page.tsx
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+
+import Box from '~components/box';
+import CollectionPreferences, { CollectionPreferencesProps } from '~components/collection-preferences';
+
+import ScreenshotArea from '../utils/screenshot-area';
+import { contentDensityPreference, pageSizePreference, wrapLinesPreference } from './shared-configs';
+
+const defaultPreferences: CollectionPreferencesProps.Preferences = {
+  pageSize: 10,
+  wrapLines: false,
+  contentDensity: 'comfortable',
+};
+
+const resetToDefaults: CollectionPreferencesProps.ResetToDefaults = {
+  label: 'Reset to defaults',
+  preferences: defaultPreferences,
+};
+
+export default function CollectionPreferencesResetToDefaults() {
+  const [preferences, setPreferences] = React.useState<CollectionPreferencesProps.Preferences>({
+    pageSize: 50,
+    wrapLines: true,
+    contentDensity: 'compact',
+  });
+  const [lastReset, setLastReset] = React.useState<CollectionPreferencesProps.Preferences | null>(null);
+
+  return (
+    <>
+      <h1>CollectionPreferences with reset to defaults</h1>
+      <ScreenshotArea disableAnimations={true}>
+        <Box margin={{ bottom: 's' }}>
+          Current preferences: <span id="current-preferences">{JSON.stringify(preferences)}</span>
+        </Box>
+        <Box margin={{ bottom: 's' }}>
+          Last reset detail: <span id="last-reset">{lastReset ? JSON.stringify(lastReset) : 'none'}</span>
+        </Box>
+        <CollectionPreferences
+          className="cp-reset"
+          title="Preferences"
+          confirmLabel="Confirm"
+          cancelLabel="Cancel"
+          preferences={preferences}
+          pageSizePreference={pageSizePreference}
+          wrapLinesPreference={wrapLinesPreference}
+          contentDensityPreference={contentDensityPreference}
+          resetToDefaults={resetToDefaults}
+          onReset={({ detail }) => setLastReset(detail)}
+          onConfirm={({ detail }) => setPreferences(detail)}
+        />
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -9419,6 +9419,93 @@ The values for all configured preferences are present even if the user didn't ch
       "detailType": "CollectionPreferencesProps.Preferences<CustomPreferenceType>",
       "name": "onConfirm",
     },
+    {
+      "cancelable": false,
+      "description": "Called when the user restores the default preferences using the reset button in the modal footer.
+
+The event \`detail\` contains the default preferences the modal's working state was restored to
+(the same object supplied in \`resetToDefaults.preferences\`).",
+      "detailInlineType": {
+        "name": "CollectionPreferencesProps.Preferences<CustomPreferenceType>",
+        "properties": [
+          {
+            "inlineType": {
+              "name": ""compact" | "comfortable"",
+              "type": "union",
+              "values": [
+                "compact",
+                "comfortable",
+              ],
+            },
+            "name": "contentDensity",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "contentDisplay",
+            "optional": true,
+            "type": "ReadonlyArray<CollectionPreferencesProps.ContentDisplayItem>",
+          },
+          {
+            "inlineType": {
+              "name": "NonNullable<CustomPreferenceType>",
+              "type": "union",
+              "values": [
+                "CustomPreferenceType",
+                "{}",
+              ],
+            },
+            "name": "custom",
+            "optional": true,
+            "type": "NonNullable<CustomPreferenceType>",
+          },
+          {
+            "name": "pageSize",
+            "optional": true,
+            "type": "number",
+          },
+          {
+            "inlineType": {
+              "name": "StickyColumns",
+              "properties": [
+                {
+                  "name": "first",
+                  "optional": true,
+                  "type": "number",
+                },
+                {
+                  "name": "last",
+                  "optional": true,
+                  "type": "number",
+                },
+              ],
+              "type": "object",
+            },
+            "name": "stickyColumns",
+            "optional": true,
+            "type": "StickyColumns",
+          },
+          {
+            "name": "stripedRows",
+            "optional": true,
+            "type": "boolean",
+          },
+          {
+            "name": "visibleContent",
+            "optional": true,
+            "type": "ReadonlyArray<string>",
+          },
+          {
+            "name": "wrapLines",
+            "optional": true,
+            "type": "boolean",
+          },
+        ],
+        "type": "object",
+      },
+      "detailType": "CollectionPreferencesProps.Preferences<CustomPreferenceType>",
+      "name": "onReset",
+    },
   ],
   "functions": [],
   "name": "CollectionPreferences",
@@ -9924,6 +10011,116 @@ of the most recent getModalRoot call as an argument.",
       "name": "removeModalRoot",
       "optional": true,
       "type": "((container: HTMLElement | null) => void)",
+    },
+    {
+      "description": "Configures the built-in "reset to defaults" affordance.
+
+When set, the component displays a reset button in the modal footer that restores the modal's
+working state to the provided default preferences in a single action. The user still needs to
+confirm the change using the confirm button for it to take effect.
+
+It contains the following:
+- \`label\` (string) - Specifies the text displayed on the reset button.
+- \`preferences\` (CollectionPreferencesProps.Preferences) - Specifies the default preference values the modal
+  is restored to when the user activates the reset button.",
+      "i18nTag": true,
+      "inlineType": {
+        "name": "CollectionPreferencesProps.ResetToDefaults<CustomPreferenceType>",
+        "properties": [
+          {
+            "name": "label",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "inlineType": {
+              "name": "CollectionPreferencesProps.Preferences<CustomPreferenceType>",
+              "properties": [
+                {
+                  "inlineType": {
+                    "name": ""compact" | "comfortable"",
+                    "type": "union",
+                    "values": [
+                      "compact",
+                      "comfortable",
+                    ],
+                  },
+                  "name": "contentDensity",
+                  "optional": true,
+                  "type": "string",
+                },
+                {
+                  "name": "contentDisplay",
+                  "optional": true,
+                  "type": "ReadonlyArray<CollectionPreferencesProps.ContentDisplayItem>",
+                },
+                {
+                  "inlineType": {
+                    "name": "NonNullable<CustomPreferenceType>",
+                    "type": "union",
+                    "values": [
+                      "CustomPreferenceType",
+                      "{}",
+                    ],
+                  },
+                  "name": "custom",
+                  "optional": true,
+                  "type": "NonNullable<CustomPreferenceType>",
+                },
+                {
+                  "name": "pageSize",
+                  "optional": true,
+                  "type": "number",
+                },
+                {
+                  "inlineType": {
+                    "name": "StickyColumns",
+                    "properties": [
+                      {
+                        "name": "first",
+                        "optional": true,
+                        "type": "number",
+                      },
+                      {
+                        "name": "last",
+                        "optional": true,
+                        "type": "number",
+                      },
+                    ],
+                    "type": "object",
+                  },
+                  "name": "stickyColumns",
+                  "optional": true,
+                  "type": "StickyColumns",
+                },
+                {
+                  "name": "stripedRows",
+                  "optional": true,
+                  "type": "boolean",
+                },
+                {
+                  "name": "visibleContent",
+                  "optional": true,
+                  "type": "ReadonlyArray<string>",
+                },
+                {
+                  "name": "wrapLines",
+                  "optional": true,
+                  "type": "boolean",
+                },
+              ],
+              "type": "object",
+            },
+            "name": "preferences",
+            "optional": false,
+            "type": "CollectionPreferencesProps.Preferences<CustomPreferenceType>",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "resetToDefaults",
+      "optional": true,
+      "type": "CollectionPreferencesProps.ResetToDefaults<CustomPreferenceType>",
     },
     {
       "description": "Configures the sticky columns preference that can be set for both left and right columns.
@@ -38468,6 +38665,14 @@ To find a specific item use the \`findBreadcrumbLink(n)\` function as chaining \
           },
         },
         {
+          "name": "findResetButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ButtonWrapper",
+          },
+        },
+        {
           "name": "findStickyColumnsPreference",
           "parameters": [
             {
@@ -49644,6 +49849,14 @@ To find a specific item use the \`findBreadcrumbLink(n)\` function as chaining \
           "returnType": {
             "isNullable": false,
             "name": "PageSizePreferenceWrapper",
+          },
+        },
+        {
+          "name": "findResetButton",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ButtonWrapper",
           },
         },
         {

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -170,6 +170,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_page-size-form-field_tc96w",
     "awsui_page-size-radio-group_tc96w",
     "awsui_page-size_tc96w",
+    "awsui_reset-button_tc96w",
     "awsui_root_tc96w",
     "awsui_sticky-columns-first_tc96w",
     "awsui_sticky-columns-form-field_tc96w",

--- a/src/collection-preferences/__tests__/collection-preferences.test.tsx
+++ b/src/collection-preferences/__tests__/collection-preferences.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
-import CollectionPreferences from '../../../lib/components/collection-preferences';
+import CollectionPreferences, { CollectionPreferencesProps } from '../../../lib/components/collection-preferences';
 import TestI18nProvider from '../../../lib/components/i18n/testing';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { CollectionPreferencesWrapper } from '../../../lib/components/test-utils/dom';
@@ -305,5 +305,76 @@ describe('i18n', () => {
       'Custom content display description'
     );
     expect(modal.findContentDisplayPreference()!.find('[aria-label*="Custom drag handle"')).toBeTruthy();
+  });
+});
+
+describe('Collection preferences - Reset to defaults', () => {
+  const resetToDefaults: CollectionPreferencesProps.ResetToDefaults = {
+    label: 'Reset to defaults',
+    preferences: { pageSize: 10, wrapLines: false },
+  };
+
+  test('does not render the reset button when resetToDefaults is not provided', () => {
+    const wrapper = renderCollectionPreferences({});
+    wrapper.findTriggerButton().click();
+    expect(wrapper.findModal()!.findResetButton()).toBeNull();
+  });
+
+  test('renders the reset button with the provided label when resetToDefaults is set', () => {
+    const wrapper = renderCollectionPreferences({ resetToDefaults });
+    wrapper.findTriggerButton().click();
+    const resetButton = wrapper.findModal()!.findResetButton();
+    expect(resetButton).not.toBeNull();
+    expect(resetButton!.findTextRegion()!.getElement()).toHaveTextContent('Reset to defaults');
+  });
+
+  test('calls onReset with the default preferences when clicking the reset button', () => {
+    const onResetSpy = jest.fn();
+    const wrapper = renderCollectionPreferences({
+      resetToDefaults,
+      onReset: onResetSpy,
+      preferences: { pageSize: 50, wrapLines: true },
+    });
+    wrapper.findTriggerButton().click();
+    wrapper.findModal()!.findResetButton()!.click();
+    expect(onResetSpy).toHaveBeenCalledTimes(1);
+    expect(onResetSpy).toHaveBeenCalledWith(expect.objectContaining({ detail: { pageSize: 10, wrapLines: false } }));
+  });
+
+  test('does not throw when onReset is not provided', () => {
+    const wrapper = renderCollectionPreferences({ resetToDefaults });
+    wrapper.findTriggerButton().click();
+    expect(() => wrapper.findModal()!.findResetButton()!.click()).not.toThrow();
+  });
+
+  test('restores the working state so that confirm applies the default preferences', () => {
+    const onConfirmSpy = jest.fn();
+    const wrapper = renderCollectionPreferences({
+      resetToDefaults,
+      onConfirm: onConfirmSpy,
+      preferences: { pageSize: 50, wrapLines: true },
+    });
+    wrapper.findTriggerButton().click();
+    wrapper.findModal()!.findResetButton()!.click();
+    wrapper.findModal()!.findConfirmButton()!.click();
+    expect(onConfirmSpy).toHaveBeenCalledWith(expect.objectContaining({ detail: { pageSize: 10, wrapLines: false } }));
+  });
+
+  test('does not close the modal when clicking the reset button', () => {
+    const wrapper = renderCollectionPreferences({ resetToDefaults });
+    wrapper.findTriggerButton().click();
+    wrapper.findModal()!.findResetButton()!.click();
+    expect(wrapper.findModal()).not.toBeNull();
+  });
+
+  test('supports using resetToDefaults label from i18n provider', () => {
+    const { container } = render(
+      <TestI18nProvider messages={{ 'collection-preferences': { 'resetToDefaults.label': 'Custom reset' } }}>
+        <CollectionPreferences resetToDefaults={{ preferences: {} }} />
+      </TestI18nProvider>
+    );
+    const wrapper = createWrapper(container).findCollectionPreferences()!;
+    wrapper.findTriggerButton().click();
+    expect(wrapper.findModal()!.findResetButton()!.findTextRegion()!.getElement()).toHaveTextContent('Custom reset');
   });
 });

--- a/src/collection-preferences/index.tsx
+++ b/src/collection-preferences/index.tsx
@@ -64,6 +64,8 @@ export default function CollectionPreferences({
   getModalRoot,
   removeModalRoot,
   contentBefore,
+  resetToDefaults,
+  onReset,
   ...rest
 }: CollectionPreferencesProps) {
   const parentMetadata = useContext(CollectionPreferencesMetadata);
@@ -108,6 +110,12 @@ export default function CollectionPreferences({
     fireNonCancelableEvent(onCancel, {});
     setModalVisible(false);
     setTemporaryPreferences(copyPreferences(preferences || {}));
+  };
+
+  const onResetListener = () => {
+    const resetPreferences = copyPreferences(resetToDefaults?.preferences || {});
+    setTemporaryPreferences(resetPreferences);
+    fireNonCancelableEvent(onReset, resetPreferences);
   };
 
   const hasContentOnTheLeft = !!(
@@ -188,28 +196,64 @@ export default function CollectionPreferences({
             header={i18n('title', title)}
             referrerId={referrerId}
             footer={
-              <InternalBox float="right">
-                <InternalSpaceBetween direction="horizontal" size="xs">
+              resetToDefaults ? (
+                <div className={styles.footer}>
                   <InternalButton
-                    className={styles['cancel-button']}
+                    className={styles['reset-button']}
                     variant="link"
                     formAction="none"
-                    onClick={onCancelListener}
-                    analyticsAction="cancel"
+                    onClick={onResetListener}
+                    analyticsAction="reset"
                   >
-                    {i18n('cancelLabel', cancelLabel)}
+                    {i18n('resetToDefaults.label', resetToDefaults.label)}
                   </InternalButton>
-                  <InternalButton
-                    className={styles['confirm-button']}
-                    variant="primary"
-                    formAction="none"
-                    onClick={onConfirmListener}
-                    analyticsAction="confirm"
-                  >
-                    {i18n('confirmLabel', confirmLabel)}
-                  </InternalButton>
-                </InternalSpaceBetween>
-              </InternalBox>
+                  <InternalBox float="right">
+                    <InternalSpaceBetween direction="horizontal" size="xs">
+                      <InternalButton
+                        className={styles['cancel-button']}
+                        variant="link"
+                        formAction="none"
+                        onClick={onCancelListener}
+                        analyticsAction="cancel"
+                      >
+                        {i18n('cancelLabel', cancelLabel)}
+                      </InternalButton>
+                      <InternalButton
+                        className={styles['confirm-button']}
+                        variant="primary"
+                        formAction="none"
+                        onClick={onConfirmListener}
+                        analyticsAction="confirm"
+                      >
+                        {i18n('confirmLabel', confirmLabel)}
+                      </InternalButton>
+                    </InternalSpaceBetween>
+                  </InternalBox>
+                </div>
+              ) : (
+                <InternalBox float="right">
+                  <InternalSpaceBetween direction="horizontal" size="xs">
+                    <InternalButton
+                      className={styles['cancel-button']}
+                      variant="link"
+                      formAction="none"
+                      onClick={onCancelListener}
+                      analyticsAction="cancel"
+                    >
+                      {i18n('cancelLabel', cancelLabel)}
+                    </InternalButton>
+                    <InternalButton
+                      className={styles['confirm-button']}
+                      variant="primary"
+                      formAction="none"
+                      onClick={onConfirmListener}
+                      analyticsAction="confirm"
+                    >
+                      {i18n('confirmLabel', confirmLabel)}
+                    </InternalButton>
+                  </InternalSpaceBetween>
+                </InternalBox>
+              )
             }
             closeAriaLabel={closeAriaLabel || cancelLabel}
             size={hasContentOnTheLeft && hasContentOnTheRight ? 'large' : 'medium'}

--- a/src/collection-preferences/interfaces.ts
+++ b/src/collection-preferences/interfaces.ts
@@ -225,6 +225,27 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * Content displayed before the preferences. Use it to display additional information relating to the preferences.
    */
   contentBefore?: React.ReactNode;
+  /**
+   * Configures the built-in "reset to defaults" affordance.
+   *
+   * When set, the component displays a reset button in the modal footer that restores the modal's
+   * working state to the provided default preferences in a single action. The user still needs to
+   * confirm the change using the confirm button for it to take effect.
+   *
+   * It contains the following:
+   * - `label` (string) - Specifies the text displayed on the reset button.
+   * - `preferences` (CollectionPreferencesProps.Preferences) - Specifies the default preference values the modal
+   *   is restored to when the user activates the reset button.
+   * @i18n
+   */
+  resetToDefaults?: CollectionPreferencesProps.ResetToDefaults<CustomPreferenceType>;
+  /**
+   * Called when the user restores the default preferences using the reset button in the modal footer.
+   *
+   * The event `detail` contains the default preferences the modal's working state was restored to
+   * (the same object supplied in `resetToDefaults.preferences`).
+   */
+  onReset?: NonCancelableEventHandler<CollectionPreferencesProps.Preferences<CustomPreferenceType>>;
 }
 
 export namespace CollectionPreferencesProps {
@@ -237,6 +258,11 @@ export namespace CollectionPreferencesProps {
     stickyColumns?: StickyColumns;
     contentDisplay?: ReadonlyArray<ContentDisplayItem>;
     custom?: CustomPreferenceType;
+  }
+
+  export interface ResetToDefaults<CustomPreferenceType = any> {
+    label?: string;
+    preferences: Preferences<CustomPreferenceType>;
   }
 
   export interface ContentDisplayPreference extends DndAreaI18nStrings {

--- a/src/collection-preferences/styles.scss
+++ b/src/collection-preferences/styles.scss
@@ -13,9 +13,18 @@
 .trigger-button,
 .cancel-button,
 .confirm-button,
+.reset-button,
 .custom,
 .content-before {
   /* used in test-utils */
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  inline-size: 100%;
+  gap: awsui.$space-xs;
 }
 
 .second-column-small {

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -118,6 +118,7 @@ export interface I18nFormatArgTypes {
     title: never;
     confirmLabel: never;
     cancelLabel: never;
+    'resetToDefaults.label': never;
     'pageSizePreference.title': never;
     'wrapLinesPreference.label': never;
     'wrapLinesPreference.description': never;

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -97,6 +97,7 @@
     "title": "Preferences",
     "confirmLabel": "Confirm",
     "cancelLabel": "Cancel",
+    "resetToDefaults.label": "Reset to defaults",
     "pageSizePreference.title": "Page size",
     "wrapLinesPreference.label": "Wrap lines",
     "wrapLinesPreference.description": "Select to see all the text and wrap the lines",

--- a/src/test-utils/dom/collection-preferences/index.ts
+++ b/src/test-utils/dom/collection-preferences/index.ts
@@ -23,6 +23,10 @@ class PreferencesModalWrapper extends ModalWrapper {
     return this.findComponent(`.${styles['confirm-button']}`, ButtonWrapper);
   }
 
+  findResetButton(): ButtonWrapper | null {
+    return this.findComponent(`.${styles['reset-button']}`, ButtonWrapper);
+  }
+
   findWrapLinesPreference(): CheckboxWrapper | null {
     return this.findComponent(`.${styles['wrap-lines']}`, CheckboxWrapper);
   }


### PR DESCRIPTION
### Description

Adds an opt-in "Reset to defaults" affordance to `CollectionPreferences`, resolving [AWSUI-61145](https://taskei.amazon.dev/tasks/AWSUI-61145). Customers can now restore a table's/cards' default preferences in a single action instead of undoing each change individually.

**What changed**

- New optional `resetToDefaults` config: `{ label?: string; preferences: CollectionPreferencesProps.Preferences }`. When set, a **link-style reset button is rendered in the modal footer** (left-aligned), matching the placement requested by customers in the ticket. When it is not set, the footer is unchanged.
- New optional `onReset` callback (`NonCancelableEventHandler<Preferences>`) fired when the user activates the reset button. The `detail` contains the default preferences the modal's working state was restored to.
- Clicking reset restores the modal's **working (temporary) state** to `resetToDefaults.preferences`; the user still confirms via the existing confirm button for the change to take effect. The modal does not close on reset.
- i18n: the reset label is wired through the `collection-preferences` namespace as `resetToDefaults.label` (default English "Reset to defaults"), with a matching entry in `messages-types.ts`.
- `findResetButton()` added to the `CollectionPreferences` test-utils DOM wrapper.

**Backward compatibility**: fully opt-in. No behavior change unless `resetToDefaults` is provided; existing props/events are untouched.

Related links, issue #, if available: AWSUI-61145

### How has this been tested?

- New unit tests in `collection-preferences.test.tsx` (7 cases): button not rendered when opt-out; rendered with label; `onReset` fired with default preferences; no throw when `onReset` omitted; confirm applies reset preferences; modal stays open on reset; i18n label override.
- Full `collection-preferences` unit suite green (113 tests across 9 files) — no regressions.
- Added a dev page (`pages/collection-preferences/reset-to-defaults.page.tsx`) with a live controlled example showing current preferences and last reset detail.
- `quick-build` (TypeScript), `eslint`, and `stylelint` all pass under Node v24.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
