### PR TITLE
feat: add table row group headers

### DIFF
--- a/pages/table/row-grouping.page.tsx
+++ b/pages/table/row-grouping.page.tsx
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Box from '~components/box';
+import Header from '~components/header';
+import SpaceBetween from '~components/space-between';
+import StatusIndicator from '~components/status-indicator';
+import Table, { TableProps } from '~components/table';
+
+interface Employee {
+  id: string;
+  name: string;
+  role: string;
+  department: string;
+  status: 'active' | 'on-leave';
+}
+
+const items: Employee[] = [
+  { id: '1', name: 'Alice Johnson', role: 'Frontend Engineer', department: 'Engineering', status: 'active' },
+  { id: '2', name: 'Bob Smith', role: 'Backend Engineer', department: 'Engineering', status: 'on-leave' },
+  { id: '3', name: 'Carol White', role: 'Engineering Manager', department: 'Engineering', status: 'active' },
+  { id: '4', name: 'Dan Brown', role: 'Product Manager', department: 'Product', status: 'active' },
+  { id: '5', name: 'Eve Davis', role: 'Product Designer', department: 'Product', status: 'active' },
+  { id: '6', name: 'Frank Miller', role: 'Account Executive', department: 'Sales', status: 'on-leave' },
+  { id: '7', name: 'Grace Lee', role: 'Sales Development Rep', department: 'Sales', status: 'active' },
+];
+
+const columnDefinitions: TableProps.ColumnDefinition<Employee>[] = [
+  { id: 'name', header: 'Name', cell: item => item.name, isRowHeader: true },
+  { id: 'role', header: 'Role', cell: item => item.role },
+  {
+    id: 'status',
+    header: 'Status',
+    cell: item => (
+      <StatusIndicator type={item.status === 'active' ? 'success' : 'stopped'}>
+        {item.status === 'active' ? 'Active' : 'On leave'}
+      </StatusIndicator>
+    ),
+  },
+];
+
+const rowGrouping: TableProps.RowGrouping<Employee> = {
+  getGroupId: item => item.department,
+  renderGroupHeader: ({ groupId, items }) => (
+    <SpaceBetween size="xs" direction="horizontal">
+      <Box variant="strong">{groupId}</Box>
+      <Box color="text-body-secondary">({items.length})</Box>
+    </SpaceBetween>
+  ),
+};
+
+export default function RowGroupingPage() {
+  const [selectedItems, setSelectedItems] = useState<Employee[]>([]);
+  return (
+    <Box padding="l">
+      <h1>Table row group headers</h1>
+      <SpaceBetween size="l">
+        <Table
+          header={<Header headingTagOverride="h2">Employees grouped by department</Header>}
+          columnDefinitions={columnDefinitions}
+          items={items}
+          trackBy="id"
+          selectionType="multi"
+          selectedItems={selectedItems}
+          onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+          rowGrouping={rowGrouping}
+          ariaLabels={{
+            selectionGroupLabel: 'Employee selection',
+            allItemsSelectionLabel: () => 'Select all employees',
+            itemSelectionLabel: (_data, item) => `Select ${item.name}`,
+            tableLabel: 'Employees',
+          }}
+        />
+
+        <Table
+          header={<Header headingTagOverride="h2">Grouped without selection</Header>}
+          columnDefinitions={columnDefinitions}
+          items={items}
+          trackBy="id"
+          rowGrouping={rowGrouping}
+          ariaLabels={{ tableLabel: 'Employees without selection' }}
+        />
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -28940,6 +28940,62 @@ the table items array is empty.",
       "type": "boolean",
     },
     {
+      "description": "Visually groups table rows under non-selectable group header rows. Use it to organize the items
+into sections without changing the flat data structure of \`items\`.
+
+The configuration contains:
+* \`getGroupId\` ((Item) => string) - Returns the group identifier for the given item. Consecutive
+items that share the same identifier form a group. A group header row is rendered above the first
+item of every group.
+* \`renderGroupHeader\` ((TableProps.RowGroupHeaderDetail<Item>) => ReactNode) - Renders the content
+of a group header row. It is called once per group with the group identifier and the list of items
+belonging to the group.
+
+The group header row spans all columns and is not selectable, editable, or expandable.
+The feature is opt-in and does not change the behavior of tables that do not define it.",
+      "inlineType": {
+        "name": "TableProps.RowGrouping<T>",
+        "properties": [
+          {
+            "inlineType": {
+              "name": "(item: T) => string",
+              "parameters": [
+                {
+                  "name": "item",
+                  "type": "T",
+                },
+              ],
+              "returnType": "string",
+              "type": "function",
+            },
+            "name": "getGroupId",
+            "optional": false,
+            "type": "(item: T) => string",
+          },
+          {
+            "inlineType": {
+              "name": "(detail: TableProps.RowGroupHeaderDetail<T>) => React.ReactNode",
+              "parameters": [
+                {
+                  "name": "detail",
+                  "type": "TableProps.RowGroupHeaderDetail<T>",
+                },
+              ],
+              "returnType": "React.ReactNode",
+              "type": "function",
+            },
+            "name": "renderGroupHeader",
+            "optional": false,
+            "type": "(detail: TableProps.RowGroupHeaderDetail<T>) => React.ReactNode",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "rowGrouping",
+      "optional": true,
+      "type": "TableProps.RowGrouping<T>",
+    },
+    {
       "defaultValue": "[]",
       "description": "List of selected items.",
       "name": "selectedItems",
@@ -44365,6 +44421,20 @@ Note: when used with collection-hooks the \`trackBy\` is set automatically from 
           },
         },
         {
+          "description": "Returns all group header rows rendered when the \`rowGrouping\` property is used.",
+          "name": "findRowGroupHeaders",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
           "name": "findRows",
           "parameters": [],
           "returnType": {
@@ -53777,6 +53847,20 @@ Note: when used with collection-hooks the \`trackBy\` is set automatically from 
           "returnType": {
             "isNullable": false,
             "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns all group header rows rendered when the \`rowGrouping\` property is used.",
+          "name": "findRowGroupHeaders",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
           },
         },
         {

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -651,6 +651,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_body-cell-editor_c6tup",
     "awsui_body-cell_c6tup",
     "awsui_empty_wih1l",
+    "awsui_group-header-row_wih1l",
     "awsui_header-cell-ascending_1spae",
     "awsui_header-cell-descending_1spae",
     "awsui_header-controls_wih1l",

--- a/src/table/__tests__/row-grouping.test.tsx
+++ b/src/table/__tests__/row-grouping.test.tsx
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Table, { TableProps } from '../../../lib/components/table';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+interface Item {
+  id: number;
+  name: string;
+  group: string;
+}
+
+const columns: TableProps.ColumnDefinition<Item>[] = [
+  { header: 'id', cell: item => item.id, isRowHeader: true },
+  { header: 'name', cell: item => item.name },
+];
+
+const items: Item[] = [
+  { id: 1, name: 'Apples', group: 'Fruit' },
+  { id: 2, name: 'Oranges', group: 'Fruit' },
+  { id: 3, name: 'Carrots', group: 'Vegetable' },
+  { id: 4, name: 'Potatoes', group: 'Vegetable' },
+  { id: 5, name: 'Bread', group: 'Bakery' },
+];
+
+const rowGrouping: TableProps.RowGrouping<Item> = {
+  getGroupId: item => item.group,
+  renderGroupHeader: ({ groupId, items }) => `${groupId} (${items.length})`,
+};
+
+function renderTable(props?: Partial<TableProps<Item>>) {
+  const { container } = render(<Table items={items} columnDefinitions={columns} trackBy="id" {...props} />);
+  return createWrapper(container).findTable()!;
+}
+
+describe('Table row grouping', () => {
+  test('does not render group header rows when rowGrouping is not set', () => {
+    const wrapper = renderTable();
+    expect(wrapper.findRowGroupHeaders()).toHaveLength(0);
+    expect(wrapper.findRows()).toHaveLength(5);
+  });
+
+  test('renders one group header per distinct group in order', () => {
+    const wrapper = renderTable({ rowGrouping });
+    const headers = wrapper.findRowGroupHeaders();
+    expect(headers).toHaveLength(3);
+    expect(headers.map(h => h.getElement().textContent)).toEqual(['Fruit (2)', 'Vegetable (2)', 'Bakery (1)']);
+  });
+
+  test('findRows excludes group header rows', () => {
+    const wrapper = renderTable({ rowGrouping });
+    expect(wrapper.findRows()).toHaveLength(5);
+  });
+
+  test('group header cell spans all columns (including selection column)', () => {
+    const wrapper = renderTable({ rowGrouping, selectionType: 'multi' });
+    const cell = wrapper.findRowGroupHeaders()[0].find('td')!.getElement();
+    // 2 data columns + 1 selection column = 3
+    expect(cell).toHaveAttribute('colspan', '3');
+  });
+
+  test('group header cell colspan matches column count without selection', () => {
+    const wrapper = renderTable({ rowGrouping });
+    const cell = wrapper.findRowGroupHeaders()[0].find('td')!.getElement();
+    expect(cell).toHaveAttribute('colspan', '2');
+  });
+
+  test('group header rows are not selectable (single spanning cell, no controls)', () => {
+    const wrapper = renderTable({ rowGrouping, selectionType: 'multi' });
+    const header = wrapper.findRowGroupHeaders()[0];
+    expect(header.findAll('td')).toHaveLength(1);
+    expect(header.findAll('input')).toHaveLength(0);
+  });
+
+  test('exposes the group id via data attribute', () => {
+    const wrapper = renderTable({ rowGrouping });
+    expect(wrapper.findRowGroupHeaders()[0].getElement()).toHaveAttribute('data-group-id', 'Fruit');
+    expect(wrapper.findRowGroupHeaders()[1].getElement()).toHaveAttribute('data-group-id', 'Vegetable');
+  });
+
+  test('creates separate groups for non-consecutive items with the same id', () => {
+    const wrapper = renderTable({
+      items: [
+        { id: 1, name: 'Apples', group: 'Fruit' },
+        { id: 2, name: 'Carrots', group: 'Vegetable' },
+        { id: 3, name: 'Oranges', group: 'Fruit' },
+      ],
+      rowGrouping,
+    });
+    const headers = wrapper.findRowGroupHeaders();
+    expect(headers.map(h => h.getElement().getAttribute('data-group-id'))).toEqual(['Fruit', 'Vegetable', 'Fruit']);
+  });
+
+  test('findRowGroupHeaders returns an empty array when no grouping is configured', () => {
+    const wrapper = renderTable();
+    expect(wrapper.findRowGroupHeaders()).toEqual([]);
+  });
+});

--- a/src/table/index.tsx
+++ b/src/table/index.tsx
@@ -53,6 +53,7 @@ const Table = React.forwardRef(
         },
         metadata: {
           expandableRows: !!props.expandableRows,
+          rowGrouping: !!props.rowGrouping,
           progressiveLoading: !!props.getLoadingStatus,
           hasSkeleton: !!props.skeleton,
           skeletonTotalRows: props.skeleton?.totalRows ?? null,

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -430,6 +430,23 @@ export interface TableProps<T = any> extends BaseComponentProps {
   expandableRows?: TableProps.ExpandableRows<T>;
 
   /**
+   * Visually groups table rows under non-selectable group header rows. Use it to organize the items
+   * into sections without changing the flat data structure of `items`.
+   *
+   * The configuration contains:
+   * * `getGroupId` ((Item) => string) - Returns the group identifier for the given item. Consecutive
+   * items that share the same identifier form a group. A group header row is rendered above the first
+   * item of every group.
+   * * `renderGroupHeader` ((TableProps.RowGroupHeaderDetail<Item>) => ReactNode) - Renders the content
+   * of a group header row. It is called once per group with the group identifier and the list of items
+   * belonging to the group.
+   *
+   * The group header row spans all columns and is not selectable, editable, or expandable.
+   * The feature is opt-in and does not change the behavior of tables that do not define it.
+   */
+  rowGrouping?: TableProps.RowGrouping<T>;
+
+  /**
    * A function that specifies the current status of loading more items. It is called once for the entire
    * table with `item=null` and then for each expanded item. The function result is one of the four possible states:
    * * `pending` - Indicates that no request in progress, but more options may be loaded.
@@ -668,6 +685,16 @@ export namespace TableProps {
     totalItemsCount?: number;
     getSelectedItemsCount?: (item: T) => number;
     totalSelectedItemsCount?: number;
+  }
+
+  export interface RowGrouping<T> {
+    getGroupId: (item: T) => string;
+    renderGroupHeader: (detail: RowGroupHeaderDetail<T>) => React.ReactNode;
+  }
+
+  export interface RowGroupHeaderDetail<T> {
+    groupId: string;
+    items: ReadonlyArray<T>;
   }
 
   export type OnExpandableItemToggle<T> = NonCancelableEventHandler<ExpandableItemToggleDetail<T>>;

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -47,6 +47,7 @@ import { getLoaderContent } from './progressive-loading/items-loader';
 import { TableLoaderCell } from './progressive-loading/loader-cell';
 import { useProgressiveLoadingProps } from './progressive-loading/progressive-loading-utils';
 import { ResizeTracker } from './resizer';
+import { GroupHeaderRow } from './row-grouping/group-header-row';
 import { focusMarkers, useSelection, useSelectionFocusMove } from './selection';
 import { TableBodySelectionCell } from './selection/selection-cell';
 import { useGroupSelection } from './selection/use-group-selection';
@@ -145,6 +146,7 @@ const InternalTable = React.forwardRef(
       columnDisplay,
       enableKeyboardNavigation,
       expandableRows: externalExpandableRows,
+      rowGrouping,
       getLoadingStatus,
       renderLoaderPending,
       renderLoaderLoading,
@@ -183,6 +185,41 @@ const InternalTable = React.forwardRef(
     const { allItems, isExpandable } = expandableRows;
     const { allRows } = useProgressiveLoadingProps({ getLoadingStatus, expandableRows });
     const selectionType = expandableRows.hasGroupSelection ? ('group' as const) : externalSelectionType;
+
+    // Row grouping: map each group id to its items (in items order) and mark which rows start a new group.
+    const groupedItemsById = useMemo(() => {
+      const map = new Map<string, T[]>();
+      if (rowGrouping) {
+        for (const item of allItems) {
+          const groupId = rowGrouping.getGroupId(item);
+          const existing = map.get(groupId);
+          if (existing) {
+            existing.push(item);
+          } else {
+            map.set(groupId, [item]);
+          }
+        }
+      }
+      return map;
+    }, [rowGrouping, allItems]);
+
+    const rowGroupStart = useMemo(() => {
+      const starts = new Array<boolean>(allRows.length).fill(false);
+      if (rowGrouping) {
+        let previousGroupId: string | undefined = undefined;
+        for (let i = 0; i < allRows.length; i++) {
+          const row = allRows[i];
+          if (row.type === 'data') {
+            const groupId = rowGrouping.getGroupId(row.item);
+            if (groupId !== previousGroupId) {
+              starts[i] = true;
+              previousGroupId = groupId;
+            }
+          }
+        }
+      }
+      return starts;
+    }, [rowGrouping, allRows]);
 
     const [containerWidth, wrapperMeasureRef] = useContainerQuery<number>(rect => rect.borderBoxWidth);
     const wrapperMeasureRefObject = useRef(null);
@@ -670,7 +707,24 @@ const InternalTable = React.forwardRef(
                           };
                           if (row.type === 'data') {
                             const rowId = `${getTableItemKey(row.item)}`;
-                            return (
+                            const isGroupStart = rowGroupStart[rowIndex];
+                            const groupId = rowGrouping && isGroupStart ? rowGrouping.getGroupId(row.item) : undefined;
+                            const groupHeaderRow =
+                              rowGrouping && groupId !== undefined ? (
+                                <GroupHeaderRow
+                                  groupId={groupId}
+                                  content={rowGrouping.renderGroupHeader({
+                                    groupId,
+                                    items: groupedItemsById.get(groupId) ?? [],
+                                  })}
+                                  totalColumnsCount={totalColumnsCount}
+                                  tableRole={tableRole}
+                                  rowIndex={rowIndex}
+                                  firstIndex={firstIndex}
+                                  headerRowCount={headerRowCount}
+                                />
+                              ) : null;
+                            const dataRowElement = (
                               <tr
                                 key={rowId}
                                 className={clsx(styles.row, sharedCellProps.isSelected && styles['row-selected'])}
@@ -765,6 +819,14 @@ const InternalTable = React.forwardRef(
                                   );
                                 })}
                               </tr>
+                            );
+                            return groupHeaderRow ? (
+                              <React.Fragment key={`group-${rowId}`}>
+                                {groupHeaderRow}
+                                {dataRowElement}
+                              </React.Fragment>
+                            ) : (
+                              dataRowElement
                             );
                           }
                           const loaderSelectionProps =

--- a/src/table/row-grouping/group-header-row.tsx
+++ b/src/table/row-grouping/group-header-row.tsx
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+
+import { getTableCellRoleProps, getTableRowRoleProps, TableRole } from '../table-role';
+
+import styles from '../styles.css.js';
+
+export interface GroupHeaderRowProps {
+  groupId: string;
+  content: React.ReactNode;
+  totalColumnsCount: number;
+  tableRole: TableRole;
+  rowIndex: number;
+  firstIndex?: number;
+  headerRowCount: number;
+}
+
+/**
+ * A non-selectable, non-editable table row that visually separates a group of data rows.
+ * It spans all visible columns (including the selection column when present) and is rendered
+ * above the first item of every group defined via `rowGrouping`.
+ */
+export function GroupHeaderRow({
+  groupId,
+  content,
+  totalColumnsCount,
+  tableRole,
+  rowIndex,
+  firstIndex,
+  headerRowCount,
+}: GroupHeaderRowProps) {
+  return (
+    <tr
+      className={clsx(styles.row, styles['group-header-row'])}
+      data-group-id={groupId}
+      {...getTableRowRoleProps({ tableRole, rowIndex, firstIndex, headerRowCount })}
+    >
+      <td
+        className={styles['group-header-cell']}
+        colSpan={totalColumnsCount}
+        {...getTableCellRoleProps({ tableRole, colIndex: 0 })}
+      >
+        <div className={styles['group-header-content']}>{content}</div>
+      </td>
+    </tr>
+  );
+}

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -233,6 +233,27 @@ filter search icon.
   /* used in test-utils */
 }
 
+.group-header-row {
+  /* used in test-utils */
+}
+
+.group-header-cell {
+  box-sizing: border-box;
+  padding-block: awsui.$space-scaled-xs;
+  padding-inline: awsui.$space-l;
+  border-block-end: awsui.$border-divider-list-width solid awsui.$color-border-divider-default;
+  background-color: awsui.$color-background-cell-shaded;
+  color: awsui.$color-text-body-secondary;
+  font-weight: styles.$font-weight-bold;
+  text-align: start;
+}
+
+.group-header-content {
+  display: flex;
+  align-items: center;
+  gap: awsui.$space-xxs;
+}
+
 .skeleton-loading-cell {
   padding-block: 0;
   padding-inline: 0;

--- a/src/test-utils/dom/table/index.ts
+++ b/src/test-utils/dom/table/index.ts
@@ -102,7 +102,14 @@ export default class TableWrapper extends ComponentWrapper {
   }
 
   findRows(): Array<ElementWrapper> {
-    return this.findNativeTable().findAll(`tr.${styles.row}:not([aria-hidden])`);
+    return this.findNativeTable().findAll(`tr.${styles.row}:not([aria-hidden]):not(.${styles['group-header-row']})`);
+  }
+
+  /**
+   * Returns all group header rows rendered when the `rowGrouping` property is used.
+   */
+  findRowGroupHeaders(): Array<ElementWrapper> {
+    return this.findNativeTable().findAll(`tr.${styles['group-header-row']}`);
   }
 
   findSelectedRows(): Array<ElementWrapper> {


### PR DESCRIPTION
### Description

Adds an opt-in `rowGrouping` property to `Table` that visually groups rows under non-selectable group header rows, without changing the flat `items` data structure.

`rowGrouping` accepts:
- `getGroupId(item)` — returns a group id for each item. Consecutive items sharing an id form a group.
- `renderGroupHeader({ groupId, items })` — renders the content of the group header row.

A group header row is rendered above the first item of each group. It spans all visible columns (including the selection column) via a single `colSpan` cell and is **not** selectable, editable, or expandable. Tables that do not set `rowGrouping` are entirely unaffected (backward compatible).

Implementation follows the existing Table row-rendering pattern in `internal.tsx` (grouping is precomputed with `useMemo`; a new `GroupHeaderRow` sub-component renders the spanning row, avoiding per-column hooks). A new `findRowGroupHeaders()` test-utils selector is added, and `findRows()` now excludes group header rows.

Related links, issue #, if available: SIM AWSUI-60452

> ⚠️ **Ticket mismatch note:** SIM `AWSUI-60452` (`V1690323767`) actually tracks an unrelated, already-closed a11y issue ("Aria-label required by accessibility is not able to be set on the AppLayout Toolbar"). This PR was implemented per the provided task description (Table row group headers), not the SIM contents.

### How has this been tested?

- New unit tests in `src/table/__tests__/row-grouping.test.tsx` (9 tests): group header rendering/ordering, colspan with & without selection, non-selectability, `data-group-id`, non-consecutive group ids, and `findRows` exclusion.
- Full existing Table unit suite passes (546 tests, 43 suites).
- Documenter and test-utils selector snapshots updated for the new prop/type/wrapper method.
- ESLint, Stylelint, `quick-build`, and full `build` all green (Node v24).
- New dev page `pages/table/row-grouping.page.tsx` for manual/visual verification (with and without selection).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
