### PR TITLE
feat: allow property filter custom forms to submit tokens

### DIFF
--- a/pages/property-filter/custom-form-submit.page.tsx
+++ b/pages/property-filter/custom-form-submit.page.tsx
@@ -1,0 +1,107 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import { useCollection } from '@cloudscape-design/collection-hooks';
+
+import { I18nProvider } from '~components/i18n';
+import messages from '~components/i18n/messages/all.en';
+import Input from '~components/input';
+import PropertyFilter from '~components/property-filter';
+import { PropertyFilterProps } from '~components/property-filter/interfaces';
+
+import { i18nStrings } from './common-props';
+
+interface Item {
+  name: string;
+  score: number;
+}
+
+const allItems: Item[] = [
+  { name: 'alpha', score: 10 },
+  { name: 'beta', score: 20 },
+  { name: 'gamma', score: 30 },
+  { name: 'delta', score: 40 },
+];
+
+// Custom form using a Cloudscape Input. The standard Input does not submit the property filter form on
+// "Enter" by itself, so we use the injected `submit` callback to apply the token on "Enter" — mirroring
+// the built-in behaviour of components such as DatePicker.
+function ScoreForm({ value, onChange, submit }: PropertyFilterProps.ExtendedOperatorFormProps<string>) {
+  return (
+    <Input
+      type="number"
+      value={value ?? ''}
+      placeholder="Enter a score, then press Enter"
+      onChange={event => onChange(event.detail.value)}
+      onKeyDown={event => {
+        // keyCode 13 === Enter
+        if (event.detail.keyCode === 13) {
+          event.preventDefault();
+          submit?.();
+        }
+      }}
+    />
+  );
+}
+
+const filteringProperties: PropertyFilterProps.FilteringProperty[] = [
+  {
+    key: 'name',
+    propertyLabel: 'Name',
+    groupValuesLabel: 'Name values',
+    operators: ['=', '!=', ':', '!:'],
+  },
+  {
+    key: 'score',
+    propertyLabel: 'Score',
+    groupValuesLabel: 'Score values',
+    operators: [
+      { operator: '=', form: ScoreForm, match: (itemValue, tokenValue) => String(itemValue) === String(tokenValue) },
+      { operator: '>', form: ScoreForm, match: (itemValue, tokenValue) => Number(itemValue) > Number(tokenValue) },
+      { operator: '<', form: ScoreForm, match: (itemValue, tokenValue) => Number(itemValue) < Number(tokenValue) },
+    ],
+  },
+];
+
+export default function CustomFormSubmitDemo() {
+  const [query, setQuery] = useState<PropertyFilterProps.Query>({ tokens: [], operation: 'and' });
+  const { items, propertyFilterProps } = useCollection(allItems, {
+    propertyFiltering: { filteringProperties },
+  });
+
+  return (
+    <I18nProvider locale="en" messages={[messages]}>
+      <div style={{ padding: 20 }}>
+        <h1>Property Filter — Custom Form Submit Demo</h1>
+        <p>
+          Type <code>Score =</code> (or <code>Score &gt;</code> / <code>Score &lt;</code>), enter a number in the custom
+          form, and press <kbd>Enter</kbd> to apply the token without clicking the Apply button. The same works when
+          editing an existing token.
+        </p>
+
+        <PropertyFilter
+          {...propertyFilterProps}
+          query={query}
+          onChange={event => {
+            propertyFilterProps.onChange(event);
+            setQuery(event.detail);
+          }}
+          i18nStrings={i18nStrings}
+        />
+
+        <h2>
+          Filtered items ({items.length} / {allItems.length})
+        </h2>
+        <pre>{JSON.stringify(query, null, 2)}</pre>
+        <ul>
+          {items.map((item, i) => (
+            <li key={i}>
+              {item.name} — {item.score}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </I18nProvider>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -23120,7 +23120,7 @@ exports[`Components definition for property-filter matches the snapshot: propert
                 {
                   "name": "operators",
                   "optional": true,
-                  "type": "ReadonlyArray<string | PropertyFilterOperatorExtended<TokenValue>>",
+                  "type": "ReadonlyArray<string | PropertyFilterOperatorExtendedAugmented<TokenValue>>",
                 },
                 {
                   "name": "propertyLabel",

--- a/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
+++ b/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { act, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 
 import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
@@ -207,5 +207,143 @@ describe('extended operators', () => {
     expect(wrapper.findTokens()).toHaveLength(2);
     expect(wrapper.findTokens()[0].getElement()).toHaveTextContent('index = EQ1');
     expect(wrapper.findTokens()[1].getElement()).toHaveTextContent('index != NEQ2');
+  });
+});
+
+describe('extended operator form submit', () => {
+  // Custom form that lifts its value via onChange and applies it via the injected `submit` callback,
+  // either through a dedicated button or by pressing "Enter" inside the input.
+  const submittableProperty: FilteringProperty = {
+    key: 'index',
+    operators: [
+      {
+        operator: '=',
+        form: ({ value, onChange, submit }) => (
+          <div>
+            <input
+              data-testid="custom-input"
+              value={value ?? ''}
+              onChange={event => onChange(event.target.value)}
+              onKeyDown={event => {
+                if (event.key === 'Enter' || event.keyCode === 13) {
+                  submit?.();
+                }
+              }}
+            />
+            <button data-testid="custom-submit" onClick={() => submit?.()}>
+              apply
+            </button>
+          </div>
+        ),
+      },
+    ],
+    propertyLabel: 'index',
+    groupValuesLabel: 'index value',
+  };
+  const submittableProps = { filteringProperties: [submittableProperty] };
+
+  test('custom form receives a submit callback in the dropdown flow', () => {
+    const { propertyFilterWrapper: wrapper, pageWrapper } = renderComponent(submittableProps);
+    wrapper.setInputValue('index =');
+    expect(pageWrapper.find('[data-testid="custom-submit"]')).not.toBe(null);
+  });
+
+  test('custom form submit applies the token in the dropdown flow (submit button)', () => {
+    const onChange = jest.fn();
+    const { propertyFilterWrapper: wrapper, pageWrapper } = renderComponent({ ...submittableProps, onChange });
+
+    wrapper.setInputValue('index =');
+    const input = pageWrapper.find('[data-testid="custom-input"]')!.getElement() as HTMLInputElement;
+    act(() => {
+      fireEvent.change(input, { target: { value: 'abc' } });
+    });
+    act(() => pageWrapper.find('[data-testid="custom-submit"]')!.click());
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { operation: 'and', tokens: [{ propertyKey: 'index', operator: '=', value: 'abc' }] },
+      })
+    );
+    expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
+    expect(wrapper.findNativeInput().getElement()).toHaveFocus();
+  });
+
+  test('custom form submit applies the token in the dropdown flow (Enter key)', () => {
+    const onChange = jest.fn();
+    const { propertyFilterWrapper: wrapper, pageWrapper } = renderComponent({ ...submittableProps, onChange });
+
+    wrapper.setInputValue('index =');
+    const input = pageWrapper.find('[data-testid="custom-input"]')!.getElement() as HTMLInputElement;
+    act(() => {
+      fireEvent.change(input, { target: { value: 'xyz' } });
+    });
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Enter', keyCode: 13 });
+    });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { operation: 'and', tokens: [{ propertyKey: 'index', operator: '=', value: 'xyz' }] },
+      })
+    );
+    expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
+  });
+
+  test('custom form submit applies changes from the token editor', () => {
+    const onChange = jest.fn();
+    const { propertyFilterWrapper: wrapper, pageWrapper } = renderComponent({
+      ...submittableProps,
+      onChange,
+      query: { tokens: [{ propertyKey: 'index', value: 'abc', operator: '=' }], operation: 'and' },
+    });
+
+    const [contentWrapper] = openTokenEditor(wrapper, 0);
+    const input = contentWrapper.find('[data-testid="custom-input"]')!.getElement() as HTMLInputElement;
+    act(() => {
+      fireEvent.change(input, { target: { value: 'def' } });
+    });
+    act(() => pageWrapper.find('[data-testid="custom-submit"]')!.click());
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { operation: 'and', tokens: [{ propertyKey: 'index', operator: '=', value: 'def' }] },
+      })
+    );
+  });
+
+  test('submit is optional: forms that ignore it keep working', () => {
+    // Regression guard for backward compatibility: a form that never calls submit still applies via the
+    // built-in submit button.
+    const onChange = jest.fn();
+    const property: FilteringProperty = {
+      key: 'index',
+      operators: [
+        {
+          operator: '=',
+          form: ({ value, onChange }) => (
+            <input data-testid="legacy-input" value={value ?? ''} onChange={event => onChange(event.target.value)} />
+          ),
+        },
+      ],
+      propertyLabel: 'index',
+      groupValuesLabel: 'index value',
+    };
+    const { propertyFilterWrapper: wrapper, pageWrapper } = renderComponent({
+      filteringProperties: [property],
+      onChange,
+    });
+
+    wrapper.setInputValue('index =');
+    const input = pageWrapper.find('[data-testid="legacy-input"]')!.getElement() as HTMLInputElement;
+    act(() => {
+      fireEvent.change(input, { target: { value: 'legacy' } });
+    });
+    act(() => wrapper.findPropertySubmitButton()!.click());
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { operation: 'and', tokens: [{ propertyKey: 'index', operator: '=', value: 'legacy' }] },
+      })
+    );
   });
 });

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -7,7 +7,6 @@ import {
   PropertyFilterOperation,
   PropertyFilterOperator,
   PropertyFilterOperatorExtended,
-  PropertyFilterOperatorForm,
   PropertyFilterOperatorFormat,
   PropertyFilterOperatorFormProps,
   PropertyFilterOption,
@@ -252,17 +251,50 @@ export interface PropertyFilterFreeTextFiltering {
   defaultOperator?: PropertyFilterOperator;
 }
 
+// TODO: replace with PropertyFilterOperatorFormProps from collection-hooks once the `submit` property is released.
+// Extends the collection-hooks operator form props with a `submit` callback that lets a custom form
+// apply its value as a token programmatically (for example, on the "Enter" key).
+export interface PropertyFilterOperatorFormPropsExtended<TokenValue>
+  extends PropertyFilterOperatorFormProps<TokenValue> {
+  /**
+   * Applies the current form value as a filtering token, equivalent to activating the form's built-in
+   * submit ("Apply") action. Use it to submit a custom form programmatically, for example from an
+   * `onKeyDown` handler that reacts to the "Enter" key inside an input.
+   *
+   * The value that gets applied is the last one propagated through `onChange`. Make sure to call
+   * `onChange` before `submit` so that the intended value is used.
+   */
+  submit?: () => void;
+}
+// TODO: replace with PropertyFilterOperatorForm from collection-hooks once the `submit` property is released.
+export type PropertyFilterOperatorFormExtended<TokenValue> = React.FC<
+  PropertyFilterOperatorFormPropsExtended<TokenValue>
+>;
+
+// TODO: replace with PropertyFilterOperatorExtended from collection-hooks once the `submit` property is released.
+// Mirrors the collection-hooks operator, but uses the augmented form renderer so that custom forms
+// receive the `submit` callback.
+export interface PropertyFilterOperatorExtendedAugmented<TokenValue>
+  extends Omit<PropertyFilterOperatorExtended<TokenValue>, 'form'> {
+  form?: PropertyFilterOperatorFormExtended<TokenValue>;
+}
+// TODO: replace with PropertyFilterProperty from collection-hooks once the `submit` property is released.
+export interface PropertyFilterPropertyAugmented<TokenValue = any>
+  extends Omit<PropertyFilterProperty<TokenValue>, 'operators'> {
+  operators?: readonly (PropertyFilterOperator | PropertyFilterOperatorExtendedAugmented<TokenValue>)[];
+}
+
 export namespace PropertyFilterProps {
   export type Token = PropertyFilterToken;
   export type TokenGroup = PropertyFilterTokenGroup;
   export type JoinOperation = PropertyFilterOperation;
   export type ComparisonOperator = PropertyFilterOperator;
-  export type ExtendedOperator<TokenValue> = PropertyFilterOperatorExtended<TokenValue>;
-  export type ExtendedOperatorFormProps<TokenValue> = PropertyFilterOperatorFormProps<TokenValue>;
-  export type ExtendedOperatorForm<TokenValue> = PropertyFilterOperatorForm<TokenValue>;
+  export type ExtendedOperator<TokenValue> = PropertyFilterOperatorExtendedAugmented<TokenValue>;
+  export type ExtendedOperatorFormProps<TokenValue> = PropertyFilterOperatorFormPropsExtended<TokenValue>;
+  export type ExtendedOperatorForm<TokenValue> = PropertyFilterOperatorFormExtended<TokenValue>;
   export type ExtendedOperatorFormat<TokenValue> = PropertyFilterOperatorFormat<TokenValue>;
   export type FilteringOption = PropertyFilterOption;
-  export type FilteringProperty = PropertyFilterProperty;
+  export type FilteringProperty = PropertyFilterPropertyAugmented;
   export type FreeTextFiltering = PropertyFilterFreeTextFiltering;
   export type Query = PropertyFilterQuery;
   export type StatusType = DropdownStatusProps.StatusType;
@@ -372,8 +404,8 @@ export type Token = PropertyFilterProps.Token;
 export type TokenGroup = PropertyFilterProps.TokenGroup;
 export type JoinOperation = PropertyFilterProps.JoinOperation;
 export type ComparisonOperator = PropertyFilterProps.ComparisonOperator;
-export type ExtendedOperator<TokenValue> = PropertyFilterOperatorExtended<TokenValue>;
-export type ExtendedOperatorForm<TokenValue> = PropertyFilterOperatorForm<TokenValue>;
+export type ExtendedOperator<TokenValue> = PropertyFilterOperatorExtendedAugmented<TokenValue>;
+export type ExtendedOperatorForm<TokenValue> = PropertyFilterOperatorFormExtended<TokenValue>;
 export type FilteringOption = PropertyFilterProps.FilteringOption;
 export type FilteringProperty = PropertyFilterProps.FilteringProperty;
 export type Query = PropertyFilterProps.Query;

--- a/src/property-filter/internal-interfaces.ts
+++ b/src/property-filter/internal-interfaces.ts
@@ -4,12 +4,15 @@
 import {
   PropertyFilterOperation,
   PropertyFilterOperator,
-  PropertyFilterOperatorForm,
   PropertyFilterProperty,
   PropertyFilterTokenType,
 } from '@cloudscape-design/collection-hooks';
 
-import { ComparisonOperator, PropertyFilterTextOperatorExtended } from './interfaces';
+import {
+  ComparisonOperator,
+  PropertyFilterOperatorFormExtended,
+  PropertyFilterTextOperatorExtended,
+} from './interfaces';
 
 // Utility types
 
@@ -22,7 +25,7 @@ export interface InternalFilteringProperty<TokenValue = any> {
   defaultOperator: PropertyFilterOperator;
   getTokenType: (operator?: PropertyFilterOperator) => PropertyFilterTokenType;
   getValueFormatter: (operator?: PropertyFilterOperator) => null | ((value: any) => string);
-  getValueFormRenderer: (operator?: PropertyFilterOperator) => null | PropertyFilterOperatorForm<TokenValue>;
+  getValueFormRenderer: (operator?: PropertyFilterOperator) => null | PropertyFilterOperatorFormExtended<TokenValue>;
   getOperatorDescription: (operator?: PropertyFilterOperator) => string | null;
   // Original property used in callbacks.
   externalProperty: PropertyFilterProperty;

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -367,6 +367,16 @@ const PropertyFilterInternal = React.forwardRef(
     const operatorForm = propertyStep && propertyStep.property.getValueFormRenderer(propertyStep.operator);
     const isEnumValue = propertyStep?.property.getTokenType(propertyStep.operator) === 'enum';
 
+    // Applies a custom-form token and resets the input. Shared by the dropdown footer button and the
+    // `submit` callback exposed to custom operator forms, so that programmatic submission (e.g. on the
+    // "Enter" key) behaves identically to clicking the "Apply" button.
+    const submitCustomFormToken = (token: InternalToken) => {
+      addToken(token);
+      setFilteringText('');
+      inputRef.current?.focus({ preventDropdown: true });
+      inputRef.current?.close();
+    };
+
     const searchResultsId = useUniqueId('property-filter-search-results');
     const constraintTextId = useUniqueId('property-filter-constraint');
     const textboxAriaDescribedBy = filteringConstraintText
@@ -409,6 +419,13 @@ const PropertyFilterInternal = React.forwardRef(
                           operatorForm={operatorForm}
                           value={customFormValue}
                           onChange={setCustomFormValue}
+                          submit={() =>
+                            submitCustomFormToken({
+                              property: propertyStep.property,
+                              operator: propertyStep.operator,
+                              value: customFormValue,
+                            })
+                          }
                         />
                       ) : (
                         <PropertyEditorContentEnum
@@ -434,12 +451,7 @@ const PropertyFilterInternal = React.forwardRef(
                             inputRef.current?.close();
                             inputRef.current?.focus({ preventDropdown: true });
                           }}
-                          onSubmit={token => {
-                            addToken(token);
-                            setFilteringText('');
-                            inputRef.current?.focus({ preventDropdown: true });
-                            inputRef.current?.close();
-                          }}
+                          onSubmit={submitCustomFormToken}
                         />
                       ),
                     }

--- a/src/property-filter/property-editor.tsx
+++ b/src/property-filter/property-editor.tsx
@@ -27,6 +27,7 @@ export function PropertyEditorContentCustom<TokenValue = any>({
   filter,
   value,
   onChange,
+  submit,
   operatorForm,
 }: {
   property: InternalFilteringProperty;
@@ -34,6 +35,7 @@ export function PropertyEditorContentCustom<TokenValue = any>({
   filter: string;
   value: null | TokenValue;
   onChange: (value: null | TokenValue) => void;
+  submit: () => void;
   operatorForm: ExtendedOperatorForm<TokenValue>;
 }) {
   const labelId = useUniqueId();
@@ -45,7 +47,7 @@ export function PropertyEditorContentCustom<TokenValue = any>({
 
       <div className={styles['property-editor-form']}>
         <FormFieldContext.Provider value={{ ariaLabelledby: labelId }}>
-          {operatorForm({ value, onChange, operator, filter })}
+          {operatorForm({ value, onChange, operator, filter, submit })}
         </FormFieldContext.Provider>
       </div>
     </div>

--- a/src/property-filter/token-editor-inputs.tsx
+++ b/src/property-filter/token-editor-inputs.tsx
@@ -138,17 +138,18 @@ interface ValueInputProps {
   i18nStrings: I18nStringsInternal;
   onChangeValue: (value: unknown) => void;
   onLoadItems?: NonCancelableEventHandler<LoadItemsDetail>;
+  onSubmit?: () => void;
   operator: undefined | ComparisonOperator;
   property: null | InternalFilteringProperty;
   value: unknown;
 }
 
 export function ValueInput(props: ValueInputProps) {
-  const { property, operator, value, onChangeValue } = props;
+  const { property, operator, value, onChangeValue, onSubmit } = props;
   const OperatorForm = property?.propertyKey && operator && property?.getValueFormRenderer(operator);
 
   if (OperatorForm) {
-    return <OperatorForm value={value} onChange={onChangeValue} operator={operator} />;
+    return <OperatorForm value={value} onChange={onChangeValue} operator={operator} submit={onSubmit} />;
   }
   if (property && operator && property.getTokenType(operator) === 'enum') {
     return <ValueInputEnum {...props} property={property} operator={operator} />;

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -174,6 +174,7 @@ export function TokenEditor({
             operator={groups[index].operator}
             value={groups[index].value}
             onChangeValue={groups[index].onChangeValue}
+            onSubmit={onSubmit}
             asyncProps={asyncProps}
             filteringOptions={filteringOptions}
             onLoadItems={onLoadItems}


### PR DESCRIPTION
### Description

Adds a `submit` callback to the props passed to Property Filter custom operator forms, letting a custom form apply its value as a filtering token programmatically — for example, on the <kbd>Enter</kbd> key. This resolves [#3562](https://github.com/cloudscape-design/components/issues/3562): the standard `Input` does not submit the property filter form on Enter by itself, and previously there was no way to trigger submission from within the customizable JSX.

**What changed**
- `PropertyFilterProps.ExtendedOperatorFormProps` now includes an optional `submit?: () => void`. Custom forms call it to apply the current value (the last value propagated via `onChange`), equivalent to activating the built-in "Apply" action.
- The callback is wired into **both** custom-form render sites:
  - the filtering dropdown flow (`property-editor` → `internal`), reusing the same token-apply logic as the dropdown footer's Apply button;
  - the token editor flow (`token-editor` → `token-editor-inputs`), triggering the editor's existing submit.
- The components-package operator/property types (`ExtendedOperator`, `FilteringProperty`) are locally augmented to reference the extended form renderer, so inline `operators: [{ form }]` definitions receive `submit` with correct typing. This follows the existing `// TODO: replace with … from collection-hooks once released` convention in `property-filter/interfaces.ts` (mirrors `PropertyFilterFreeTextFiltering`). The underlying request ultimately belongs in `@cloudscape-design/collection-hooks`.

**Backward compatibility**: `submit` is optional and additive. Existing custom forms that ignore it are unaffected (regression-guarded by a unit test).

Related links, issue #, if available: https://github.com/cloudscape-design/components/issues/3562 (internal: AWSUI-60879)

### How has this been tested?

- New unit tests in `property-filter-extended-operators.test.tsx` covering: `submit` availability in the dropdown flow; applying a token via a custom submit button and via the <kbd>Enter</kbd> key in the dropdown flow; applying edits from the token editor; and a backward-compatibility guard for forms that never call `submit`.
- Added a dev page `pages/property-filter/custom-form-submit.page.tsx` demonstrating a Cloudscape `Input` that submits on Enter.
- `npm run quick-build` (TypeScript compile) — green.
- `eslint` on all changed files — green (0 errors).
- Full `property-filter` unit suite — 350/350 passing; documenter API snapshot regenerated.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
