### PR TITLE
feat: keep and expand ancestor rows when filtering expandable tables

### DIFF
--- a/pages/table/expandable-rows-filter-highlight.page.tsx
+++ b/pages/table/expandable-rows-filter-highlight.page.tsx
@@ -1,0 +1,148 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useMemo, useState } from 'react';
+
+import { Box, Checkbox, Header, Input, SpaceBetween, Table, TableProps } from '~components';
+import I18nProvider from '~components/i18n';
+import messages from '~components/i18n/messages/all.en';
+
+interface Node {
+  id: string;
+  name: string;
+  type: string;
+  size: string;
+  children?: Node[];
+}
+
+// A small static hierarchy so the page does not depend on collection-hooks tree filtering.
+const data: Node[] = [
+  {
+    id: 'eu',
+    name: 'eu-west-1',
+    type: 'region',
+    size: '—',
+    children: [
+      {
+        id: 'eu-prod',
+        name: 'production',
+        type: 'cluster',
+        size: '—',
+        children: [
+          { id: 'eu-prod-db1', name: 'orders-db', type: 'instance', size: 'r5.large' },
+          { id: 'eu-prod-db2', name: 'payments-db', type: 'instance', size: 'r5.xlarge' },
+        ],
+      },
+      {
+        id: 'eu-staging',
+        name: 'staging',
+        type: 'cluster',
+        size: '—',
+        children: [{ id: 'eu-staging-db1', name: 'orders-db-staging', type: 'instance', size: 't3.medium' }],
+      },
+    ],
+  },
+  {
+    id: 'us',
+    name: 'us-east-1',
+    type: 'region',
+    size: '—',
+    children: [
+      {
+        id: 'us-prod',
+        name: 'production',
+        type: 'cluster',
+        size: '—',
+        children: [
+          { id: 'us-prod-db1', name: 'analytics-db', type: 'instance', size: 'r5.2xlarge' },
+          { id: 'us-prod-db2', name: 'orders-db', type: 'instance', size: 'r5.large' },
+        ],
+      },
+    ],
+  },
+];
+
+const columnDefinitions: TableProps.ColumnDefinition<Node>[] = [
+  { id: 'name', header: 'Name', cell: item => item.name, isRowHeader: true },
+  { id: 'type', header: 'Type', cell: item => item.type },
+  { id: 'size', header: 'Size', cell: item => item.size },
+];
+
+const getItemChildren = (item: Node) => item.children ?? [];
+
+function subtreeHasMatch(item: Node, isMatched: (item: Node) => boolean): boolean {
+  return isMatched(item) || getItemChildren(item).some(child => subtreeHasMatch(child, isMatched));
+}
+
+export default function ExpandableFilterHighlightPage() {
+  const [filteringText, setFilteringText] = useState('');
+  const [expandedItems, setExpandedItems] = useState<ReadonlyArray<Node>>([]);
+  const [highlightMatched, setHighlightMatched] = useState(true);
+
+  const isItemMatched = useMemo(() => {
+    const query = filteringText.trim().toLowerCase();
+    return (item: Node) => query.length > 0 && item.name.toLowerCase().includes(query);
+  }, [filteringText]);
+
+  // Keep parent rows of matching descendants visible: only surface roots whose subtree contains a match.
+  const items = useMemo(() => {
+    if (filteringText.trim().length === 0) {
+      return data;
+    }
+    return data.filter(root => subtreeHasMatch(root, isItemMatched));
+  }, [filteringText, isItemMatched]);
+
+  return (
+    <I18nProvider messages={[messages]} locale="en">
+      <Box padding="l">
+        <SpaceBetween size="l">
+          <Header
+            variant="h1"
+            description="AWSUI-61158: keep and auto-expand ancestor rows when filtering expandable tables"
+          >
+            Expandable table filter highlight
+          </Header>
+
+          <SpaceBetween size="s" direction="horizontal">
+            <div style={{ width: 320 }}>
+              <Input
+                value={filteringText}
+                onChange={e => setFilteringText(e.detail.value)}
+                placeholder="Filter by name (e.g. orders-db)"
+                ariaLabel="Filter databases"
+                type="search"
+              />
+            </div>
+            <Checkbox checked={highlightMatched} onChange={e => setHighlightMatched(e.detail.checked)}>
+              Highlight & auto-expand matches
+            </Checkbox>
+          </SpaceBetween>
+
+          <Table
+            columnDefinitions={columnDefinitions}
+            items={items}
+            trackBy="id"
+            variant="container"
+            header={<Header>Databases</Header>}
+            ariaLabels={{
+              tableLabel: 'Databases',
+              expandButtonLabel: () => 'Expand row',
+              collapseButtonLabel: () => 'Collapse row',
+            }}
+            expandableRows={{
+              getItemChildren,
+              isItemExpandable: item => getItemChildren(item).length > 0,
+              expandedItems,
+              onExpandableItemToggle: ({ detail }) =>
+                setExpandedItems(prev =>
+                  detail.expanded ? [...prev, detail.item] : prev.filter(i => i.id !== detail.item.id)
+                ),
+              highlightMatched,
+              isItemMatched,
+            }}
+            empty={<Box textAlign="center">No matches</Box>}
+          />
+        </SpaceBetween>
+      </Box>
+    </I18nProvider>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -28587,7 +28587,12 @@ The value is passed as \`itemsCount\` property to the \`ariaLabels.allItemsSelec
 * \`getSelectedItemsCount\` (optional, (Item) => number) - Use it to indicate the number of selected resources nested under the given item.
 The value is passed as \`selectedItemsCount\` property to the \`columnDefinitions[index].counter\` and \`ariaLabels.itemSelectionLabel\` functions.
 * \`totalSelectedItemsCount\` (optional, number) - Use it to indicate the total number of selected resources in the table.
-The value is passed as \`selectedItemsCount\` property to the \`ariaLabels.allItemsSelectionLabel\`.",
+The value is passed as \`selectedItemsCount\` property to the \`ariaLabels.allItemsSelectionLabel\`.
+* \`highlightMatched\` (optional, boolean) - When set to \`true\` (together with \`isItemMatched\`), the table keeps ancestor
+rows of matching descendants visible, automatically expands those ancestors so the matches are reachable, and visually
+highlights the matched rows. This is opt-in and backward compatible; when omitted the expandable rows behave as before.
+* \`isItemMatched\` (optional, (Item) => boolean) - A predicate returning \`true\` for items that match the currently applied
+filter. Used together with \`highlightMatched\` to determine which ancestors to auto-expand and which rows to highlight.",
       "inlineType": {
         "name": "TableProps.ExpandableRows<T>",
         "properties": [
@@ -28666,6 +28671,11 @@ The value is passed as \`selectedItemsCount\` property to the \`ariaLabels.allIt
             "type": "TableProps.GroupSelectionState<T>",
           },
           {
+            "name": "highlightMatched",
+            "optional": true,
+            "type": "boolean",
+          },
+          {
             "inlineType": {
               "name": "(item: T) => boolean",
               "parameters": [
@@ -28680,6 +28690,22 @@ The value is passed as \`selectedItemsCount\` property to the \`ariaLabels.allIt
             "name": "isItemExpandable",
             "optional": false,
             "type": "(item: T) => boolean",
+          },
+          {
+            "inlineType": {
+              "name": "(item: T) => boolean",
+              "parameters": [
+                {
+                  "name": "item",
+                  "type": "T",
+                },
+              ],
+              "returnType": "boolean",
+              "type": "function",
+            },
+            "name": "isItemMatched",
+            "optional": true,
+            "type": "((item: T) => boolean)",
           },
           {
             "inlineType": {
@@ -44335,6 +44361,21 @@ Note: when used with collection-hooks the \`trackBy\` is set automatically from 
           },
         },
         {
+          "description": "Returns rows highlighted as matching the current filter. Only relevant for expandable tables
+using \`expandableRows.highlightMatched\`.",
+          "name": "findMatchedRows",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
           "name": "findPagination",
           "parameters": [],
           "returnType": {
@@ -53752,6 +53793,21 @@ Note: when used with collection-hooks the \`trackBy\` is set automatically from 
           "returnType": {
             "isNullable": false,
             "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns rows highlighted as matching the current filter. Only relevant for expandable tables
+using \`expandableRows.highlightMatched\`.",
+          "name": "findMatchedRows",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
           },
         },
         {

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -659,6 +659,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_resizer_x7peu",
     "awsui_root_1s55x",
     "awsui_root_wih1l",
+    "awsui_row-match-highlight_wih1l",
     "awsui_row-selected_wih1l",
     "awsui_row_wih1l",
     "awsui_table_wih1l",

--- a/src/table/__tests__/expandable-rows-filter-highlight.test.tsx
+++ b/src/table/__tests__/expandable-rows-filter-highlight.test.tsx
@@ -1,0 +1,191 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import Table, { TableProps } from '../../../lib/components/table';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+interface Instance {
+  name: string;
+  children?: Instance[];
+}
+
+const columnDefinitions: TableProps.ColumnDefinition<Instance>[] = [{ header: 'name', cell: item => item.name }];
+
+const nestedItems: Instance[] = [
+  {
+    name: 'Root-1',
+    children: [
+      { name: 'Nested-1.1', children: [] },
+      { name: 'Nested-1.2' },
+      { name: 'Nested-1.3', children: [{ name: 'Nested-1.3.1' }, { name: 'Nested-1.3.2' }] },
+    ],
+  },
+  {
+    name: 'Root-2',
+    children: [{ name: 'Nested-2.1' }, { name: 'Nested-2.2' }],
+  },
+];
+
+function renderTable(props: Partial<TableProps<Instance>> & { items: readonly Instance[] }) {
+  const mergedProps = { columnDefinitions, ...props } as TableProps<Instance>;
+  const { container } = render(<Table {...mergedProps} />);
+  return createWrapper(container).findTable()!;
+}
+
+const baseExpandableRows = {
+  isItemExpandable: (item: Instance) => !!item.children && item.children.length > 0,
+  getItemChildren: (item: Instance) => item.children ?? [],
+  expandedItems: [] as Instance[],
+  onExpandableItemToggle: () => {},
+};
+
+function rowTexts(table: ReturnType<typeof renderTable>) {
+  return table.findRows().map(r => r.find('td')!.getElement().textContent);
+}
+
+describe('Expandable rows filter highlight', () => {
+  test('auto-expands ancestors of a matching descendant so the match becomes reachable', () => {
+    const table = renderTable({
+      items: nestedItems,
+      trackBy: item => item.name,
+      expandableRows: {
+        ...baseExpandableRows,
+        highlightMatched: true,
+        isItemMatched: item => item.name === 'Nested-1.3.2',
+      },
+    });
+
+    // Root-1 and Nested-1.3 are ancestors of the match and are auto-expanded; Root-2 stays collapsed.
+    expect(rowTexts(table)).toEqual([
+      'Root-1',
+      'Nested-1.1',
+      'Nested-1.2',
+      'Nested-1.3',
+      'Nested-1.3.1',
+      'Nested-1.3.2',
+      'Root-2',
+    ]);
+  });
+
+  test('highlights only the matched rows', () => {
+    const table = renderTable({
+      items: nestedItems,
+      trackBy: item => item.name,
+      expandableRows: {
+        ...baseExpandableRows,
+        highlightMatched: true,
+        isItemMatched: item => item.name === 'Nested-1.3.2',
+      },
+    });
+
+    const matched = table.findMatchedRows();
+    expect(matched).toHaveLength(1);
+    expect(matched[0].find('td')!.getElement().textContent).toBe('Nested-1.3.2');
+  });
+
+  test('highlights every matching row at multiple levels', () => {
+    const table = renderTable({
+      items: nestedItems,
+      trackBy: item => item.name,
+      expandableRows: {
+        ...baseExpandableRows,
+        highlightMatched: true,
+        // Match a parent and a deeply nested child in different subtrees.
+        isItemMatched: item => item.name === 'Nested-1.3' || item.name === 'Nested-2.2',
+      },
+    });
+
+    expect(table.findMatchedRows().map(r => r.find('td')!.getElement().textContent)).toEqual([
+      'Nested-1.3',
+      'Nested-2.2',
+    ]);
+    // Root-2 is auto-expanded because Nested-2.2 matches.
+    expect(rowTexts(table)).toContain('Nested-2.2');
+  });
+
+  test('auto-expanded ancestors report aria-expanded="true"', () => {
+    const table = renderTable({
+      items: nestedItems,
+      trackBy: item => item.name,
+      expandableRows: {
+        ...baseExpandableRows,
+        highlightMatched: true,
+        isItemMatched: item => item.name === 'Nested-1.3.2',
+      },
+    });
+
+    // Row 1 = Root-1 (auto-expanded), row 4 = Nested-1.3 (auto-expanded).
+    expect(table.findExpandToggle(1)!.getElement()).toHaveAttribute('aria-expanded', 'true');
+    expect(table.findExpandToggle(4)!.getElement()).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('toggling an auto-expanded ancestor fires onExpandableItemToggle with expanded=false', () => {
+    const onExpandableItemToggle = jest.fn();
+    const table = renderTable({
+      items: nestedItems,
+      trackBy: item => item.name,
+      expandableRows: {
+        ...baseExpandableRows,
+        onExpandableItemToggle,
+        highlightMatched: true,
+        isItemMatched: item => item.name === 'Nested-1.3.2',
+      },
+    });
+
+    table.findExpandToggle(1)!.click();
+    expect(onExpandableItemToggle).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: expect.objectContaining({ expanded: false }) })
+    );
+  });
+
+  test('is backward compatible: without highlightMatched no auto-expansion or highlighting occurs', () => {
+    const table = renderTable({
+      items: nestedItems,
+      trackBy: item => item.name,
+      expandableRows: {
+        ...baseExpandableRows,
+        // isItemMatched provided but highlightMatched not enabled -> no effect.
+        isItemMatched: item => item.name === 'Nested-1.3.2',
+      },
+    });
+
+    expect(rowTexts(table)).toEqual(['Root-1', 'Root-2']);
+    expect(table.findMatchedRows()).toHaveLength(0);
+  });
+
+  test('does not auto-expand subtrees without matches', () => {
+    const table = renderTable({
+      items: nestedItems,
+      trackBy: item => item.name,
+      expandableRows: {
+        ...baseExpandableRows,
+        highlightMatched: true,
+        isItemMatched: item => item.name === 'Nested-2.1',
+      },
+    });
+
+    // Only Root-2's subtree is expanded; Root-1 stays collapsed.
+    expect(rowTexts(table)).toEqual(['Root-1', 'Root-2', 'Nested-2.1', 'Nested-2.2']);
+    expect(table.findMatchedRows().map(r => r.find('td')!.getElement().textContent)).toEqual(['Nested-2.1']);
+  });
+
+  test('manually expanded items remain expanded alongside auto-expanded ancestors', () => {
+    const table = renderTable({
+      items: nestedItems,
+      trackBy: item => item.name,
+      expandableRows: {
+        ...baseExpandableRows,
+        expandedItems: [nestedItems[1]], // Root-2 expanded manually
+        highlightMatched: true,
+        isItemMatched: item => item.name === 'Nested-1.3.2',
+      },
+    });
+
+    const texts = rowTexts(table);
+    // Root-2 stays expanded (manual) and Root-1 subtree auto-expands to reveal the match.
+    expect(texts).toContain('Nested-2.1');
+    expect(texts).toContain('Nested-1.3.2');
+  });
+});

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -221,6 +221,12 @@ $cell-negative-space-vertical: 2px;
   &-shaded {
     background: awsui.$color-background-cell-shaded;
   }
+  // Highlight for rows that match the currently applied filter in expandable tables.
+  // Applied only when `expandableRows.highlightMatched` is enabled. Kept as a background-only
+  // treatment (no border changes) to avoid row height shifts. Selection takes precedence.
+  &-match-highlight:not(.body-cell-selected) {
+    background: awsui.$color-background-status-info;
+  }
   &.has-striped-rows:not(.body-cell-selected):not(.body-cell-last-row) {
     border-block-end-color: awsui.$color-border-cell-shaded;
   }

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -36,6 +36,7 @@ export interface TableTdElementProps {
   onBlur?: () => void;
   children?: React.ReactNode;
   isEvenRow?: boolean;
+  isMatched?: boolean;
   stripedRows?: boolean;
   isSelection?: boolean;
   hasSelection?: boolean;
@@ -77,6 +78,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
       onFocus,
       onBlur,
       isEvenRow,
+      isMatched,
       stripedRows,
       isSelection,
       hasSelection,
@@ -132,6 +134,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
           isSelected && styles['body-cell-selected'],
           isNextSelected && styles['body-cell-next-selected'],
           isPrevSelected && styles['body-cell-prev-selected'],
+          isMatched && styles['body-cell-match-highlight'],
           !isEvenRow && stripedRows && styles['body-cell-shaded'],
           stripedRows && styles['has-striped-rows'],
           isVisualRefresh && styles['is-visual-refresh'],

--- a/src/table/expandable-rows/expandable-rows-utils.ts
+++ b/src/table/expandable-rows/expandable-rows-utils.ts
@@ -9,6 +9,7 @@ import { ItemSet } from '../selection/utils';
 interface ExpandableItemProps<T> extends ExpandableItemDetail<T> {
   isExpandable: boolean;
   isExpanded: boolean;
+  isMatched: boolean;
   onExpandableItemToggle: () => void;
   expandButtonLabel?: string;
   collapseButtonLabel?: string;
@@ -33,6 +34,9 @@ export interface InternalExpandableRowsProps<T> {
   onGroupSelectionChange?: TableProps.OnGroupSelectionChange<T>;
   totalItemsCount?: number;
   totalSelectedItemsCount?: number;
+  // Number of items (at any nesting level) that satisfy `expandableRows.isItemMatched`.
+  // Only meaningful when `highlightMatched` is enabled; otherwise 0.
+  matchedItemsCount: number;
 }
 
 export function useExpandableTableProps<T>({
@@ -51,6 +55,46 @@ export function useExpandableTableProps<T>({
 
   const expandedSet = new ItemSet(trackBy, expandableRows?.expandedItems ?? []);
 
+  // Filter highlighting (opt-in, backward compatible): when `highlightMatched` is enabled and an
+  // `isItemMatched` predicate is provided, we keep ancestor rows of matching descendants visible,
+  // auto-expand those ancestors so the matches are reachable, and flag matched rows for highlighting.
+  const highlightMatched = isExpandable && !!expandableRows?.highlightMatched && !!expandableRows?.isItemMatched;
+  const matchedSet = new ItemSet<T>(trackBy, []);
+  const autoExpandedSet = new ItemSet<T>(trackBy, []);
+  let matchedItemsCount = 0;
+
+  if (highlightMatched) {
+    const isItemMatched = expandableRows!.isItemMatched!;
+    // Traverse the full tree (regardless of the current expansion state) to discover matched items
+    // and every ancestor on the path to a match. Ancestors are collected into `autoExpandedSet` so
+    // that the visible traversal below reveals the matches.
+    const collectMatches = (item: T): boolean => {
+      const children = expandableRows!.getItemChildren(item);
+      let subtreeHasMatch = false;
+      if (isItemMatched(item)) {
+        matchedSet.put(item);
+        matchedItemsCount++;
+        subtreeHasMatch = true;
+      }
+      let hasMatchingDescendant = false;
+      for (const child of children) {
+        if (collectMatches(child)) {
+          hasMatchingDescendant = true;
+        }
+      }
+      if (hasMatchingDescendant) {
+        autoExpandedSet.put(item);
+        subtreeHasMatch = true;
+      }
+      return subtreeHasMatch;
+    };
+    items.forEach(item => collectMatches(item));
+  }
+
+  // An item is "effectively expanded" when the consumer expanded it, or when it is auto-expanded to
+  // reveal a matching descendant during filtering.
+  const isEffectivelyExpanded = (item: T) => expandedSet.has(item) || autoExpandedSet.has(item);
+
   let allItems = items;
   const itemToDetail = new Map<T, ExpandableItemDetail<T>>();
   const getItemLevel = (item: T) => itemToDetail.get(item)?.level ?? 0;
@@ -68,7 +112,7 @@ export function useExpandableTableProps<T>({
           traverse(
             child,
             { level: detail.level + 1, setSize: children.length, posInSet: index + 1, parent: item },
-            expandedSet.has(item)
+            isEffectivelyExpanded(item)
           )
         );
       }
@@ -79,7 +123,7 @@ export function useExpandableTableProps<T>({
 
     for (let index = 0; index < visibleItems.length; index++) {
       const item = visibleItems[index];
-      if (expandedSet.has(item)) {
+      if (isEffectivelyExpanded(item)) {
         let insertionIndex = index + 1;
         for (insertionIndex; insertionIndex < visibleItems.length; insertionIndex++) {
           const insertionItem = visibleItems[insertionIndex];
@@ -96,14 +140,16 @@ export function useExpandableTableProps<T>({
 
   const getExpandableItemProps = (item: T): ExpandableItemProps<T> => {
     const { level = 1, setSize = 1, posInSet = 1, parent = null, children = [] } = itemToDetail.get(item) ?? {};
+    const isExpanded = isEffectivelyExpanded(item);
     return {
       level,
       setSize,
       posInSet,
       isExpandable: expandableRows?.isItemExpandable(item) ?? true,
-      isExpanded: expandedSet.has(item),
+      isExpanded,
+      isMatched: matchedSet.has(item),
       onExpandableItemToggle: () =>
-        fireNonCancelableEvent(expandableRows?.onExpandableItemToggle, { item, expanded: !expandedSet.has(item) }),
+        fireNonCancelableEvent(expandableRows?.onExpandableItemToggle, { item, expanded: !isExpanded }),
       expandButtonLabel: i18n('ariaLabels.expandButtonLabel', ariaLabels?.expandButtonLabel?.(item)),
       collapseButtonLabel: i18n('ariaLabels.collapseButtonLabel', ariaLabels?.collapseButtonLabel?.(item)),
       parent,
@@ -122,5 +168,6 @@ export function useExpandableTableProps<T>({
     onGroupSelectionChange: expandableRows?.onGroupSelectionChange,
     totalItemsCount: expandableRows?.totalItemsCount,
     totalSelectedItemsCount: expandableRows?.totalSelectedItemsCount,
+    matchedItemsCount,
   };
 }

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -426,6 +426,11 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * The value is passed as `selectedItemsCount` property to the `columnDefinitions[index].counter` and `ariaLabels.itemSelectionLabel` functions.
    * * `totalSelectedItemsCount` (optional, number) - Use it to indicate the total number of selected resources in the table.
    * The value is passed as `selectedItemsCount` property to the `ariaLabels.allItemsSelectionLabel`.
+   * * `highlightMatched` (optional, boolean) - When set to `true` (together with `isItemMatched`), the table keeps ancestor
+   * rows of matching descendants visible, automatically expands those ancestors so the matches are reachable, and visually
+   * highlights the matched rows. This is opt-in and backward compatible; when omitted the expandable rows behave as before.
+   * * `isItemMatched` (optional, (Item) => boolean) - A predicate returning `true` for items that match the currently applied
+   * filter. Used together with `highlightMatched` to determine which ancestors to auto-expand and which rows to highlight.
    */
   expandableRows?: TableProps.ExpandableRows<T>;
 
@@ -668,6 +673,8 @@ export namespace TableProps {
     totalItemsCount?: number;
     getSelectedItemsCount?: (item: T) => number;
     totalSelectedItemsCount?: number;
+    highlightMatched?: boolean;
+    isItemMatched?: (item: T) => boolean;
   }
 
   export type OnExpandableItemToggle<T> = NonCancelableEventHandler<ExpandableItemToggleDetail<T>>;

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -662,6 +662,7 @@ const InternalTable = React.forwardRef(
                             isPrevSelected: hasSelection && !isFirstRow && isRowSelected(allRows[rowIndex - 1]),
                             isNextSelected: hasSelection && !isLastDataRow && isRowSelected(allRows[rowIndex + 1]),
                             isEvenRow: rowIndex % 2 === 0,
+                            isMatched: !!rowExpandableProps?.isMatched,
                             stripedRows,
                             hasSelection,
                             hasFooter,
@@ -673,7 +674,11 @@ const InternalTable = React.forwardRef(
                             return (
                               <tr
                                 key={rowId}
-                                className={clsx(styles.row, sharedCellProps.isSelected && styles['row-selected'])}
+                                className={clsx(
+                                  styles.row,
+                                  sharedCellProps.isSelected && styles['row-selected'],
+                                  sharedCellProps.isMatched && styles['row-match-highlight']
+                                )}
                                 onFocus={({ currentTarget }) => {
                                   // When an element inside table row receives focus we want to adjust the scroll.
                                   // However, that behavior is unwanted when the focus is received as result of a click

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -229,7 +229,8 @@ filter search icon.
 
 .thead-active,
 .row,
-.row-selected {
+.row-selected,
+.row-match-highlight {
   /* used in test-utils */
 }
 

--- a/src/test-utils/dom/table/index.ts
+++ b/src/test-utils/dom/table/index.ts
@@ -110,6 +110,14 @@ export default class TableWrapper extends ComponentWrapper {
   }
 
   /**
+   * Returns rows highlighted as matching the current filter. Only relevant for expandable tables
+   * using `expandableRows.highlightMatched`.
+   */
+  findMatchedRows(): Array<ElementWrapper> {
+    return this.findAllByClassName(styles['row-match-highlight']);
+  }
+
+  /**
    * Alias for findEmptySlot method for compatibility with previous versions
    * @deprecated
    */


### PR DESCRIPTION
### Description

Adds an opt-in enhancement to `Table` with `expandableRows`: when the data is filtered, ancestor rows of matching descendants stay visible, those ancestors are **auto-expanded** so the matches are reachable, and the matched rows are visually **highlighted**.

Addresses **AWSUI-61158** ("Filter highlights in expandable table"): with expandable rows + property filtering today, matches nested inside collapsed parents are not reachable and it is unclear which rows actually matched. This change makes matches immediately discoverable without breaking existing behavior.

New (optional) `expandableRows` sub-properties on `TableProps.ExpandableRows`:
- `highlightMatched?: boolean` — turns the behavior on.
- `isItemMatched?: (item) => boolean` — predicate identifying which items match the current filter. Used to decide which ancestors to auto-expand and which rows to highlight.

Both are optional and default to the previous behavior, so this is fully backward compatible.

Implementation notes:
- The logic lives in `useExpandableTableProps` (`src/table/expandable-rows/expandable-rows-utils.ts`): a full-tree pass collects matched items and every ancestor on the path to a match into an auto-expand set; the visible-row traversal then treats an item as expanded when it is either consumer-expanded or auto-expanded (`isEffectivelyExpanded`).
- Matched rows receive a `row-match-highlight` marker (and a background-only cell treatment via `color-background-status-info`, so no row-height shift; selection still takes precedence).
- Auto-expanded ancestors report `aria-expanded="true"` and toggling one fires `onExpandableItemToggle` with `expanded: false`, keeping the consumer's `expandedItems` model authoritative.
- Added `findMatchedRows()` to the table test-utils DOM wrapper.

Related links, issue #, if available: AWSUI-61158

### How has this been tested?

- New unit test suite `src/table/__tests__/expandable-rows-filter-highlight.test.tsx` (8 tests, all passing) covering auto-expansion of ancestors, single/multi-level highlighting, `aria-expanded`, toggle semantics, backward compatibility, no expansion of non-matching subtrees, and coexistence with manually expanded items.
- Existing `expandable-rows` + `group-selection` suites re-run green (42 tests) — no regressions.
- New dev page `pages/table/expandable-rows-filter-highlight.page.tsx` for manual/visual testing (type in the filter to see ancestors auto-expand and matches highlight; toggle the behavior off to compare).
- `eslint`, `stylelint`, `quick-build`, and `tsc` (pages) all green.

Reviewers can run: `TZ=UTC npx jest --config jest.unit.config.js src/table/__tests__/expandable-rows-filter-highlight.test.tsx` and open the new dev page via `npm start`.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ (interface JSDoc updated)
- _Changes are backward-compatible if not indicated, see `CONTRIBUTING.md`._ (opt-in, default behavior unchanged)
- _Changes do not include unsupported browser features, see `CONTRIBUTING.md`._
- _Changes were manually tested for accessibility, see accessibility guidelines._ (aria-expanded verified)

#### Security

- _If the code handles URLs: all URLs are validated through the `checkSafeUrl` function._ (n/a — no URLs)

#### Testing

- _Changes are covered with new/existing unit tests?_ (yes)
- _Changes are covered with new/existing integration tests?_ (unit + dev page; no integ added)
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
