### PR TITLE
feat: add collapsible option groups to Select and Multiselect

### DIFF
--- a/pages/select/collapsible-groups.page.tsx
+++ b/pages/select/collapsible-groups.page.tsx
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+
+import Box from '~components/box';
+import Multiselect, { MultiselectProps } from '~components/multiselect';
+import Select, { SelectProps } from '~components/select';
+import SpaceBetween from '~components/space-between';
+
+const options: Array<SelectProps.Option | SelectProps.OptionGroup> = [
+  {
+    label: 'Fruits',
+    options: [
+      { value: 'apple', label: 'Apple' },
+      { value: 'banana', label: 'Banana' },
+      { value: 'orange', label: 'Orange' },
+    ],
+  },
+  {
+    label: 'Vegetables',
+    options: [
+      { value: 'carrot', label: 'Carrot' },
+      { value: 'potato', label: 'Potato' },
+      { value: 'onion', label: 'Onion', disabled: true },
+    ],
+  },
+  { value: 'other', label: 'Other (ungrouped)' },
+  {
+    label: 'Dairy',
+    options: [
+      { value: 'milk', label: 'Milk' },
+      { value: 'cheese', label: 'Cheese' },
+    ],
+  },
+];
+
+export default function CollapsibleGroupsPage() {
+  const [selectedOption, setSelectedOption] = React.useState<SelectProps.Option | null>(null);
+  const [selectedOptions, setSelectedOptions] = React.useState<ReadonlyArray<MultiselectProps.Option>>([]);
+
+  return (
+    <article>
+      <Box padding="l">
+        <h1>Select / Multiselect collapsible groups</h1>
+        <SpaceBetween size="l">
+          <div>
+            <Box variant="h2">Select with collapsibleGroups</Box>
+            <Box margin={{ bottom: 'xxs' }} color="text-label">
+              <label htmlFor="collapsible-select">Choose item</label>
+            </Box>
+            <Select
+              controlId="collapsible-select"
+              collapsibleGroups={true}
+              filteringType="auto"
+              filteringPlaceholder="Find item"
+              filteringAriaLabel="Find item"
+              options={options}
+              selectedOption={selectedOption}
+              placeholder="Choose an item"
+              ariaLabel="Choose item"
+              selectedAriaLabel="Selected"
+              onChange={({ detail }) => setSelectedOption(detail.selectedOption)}
+            />
+          </div>
+
+          <div>
+            <Box variant="h2">Multiselect with collapsibleGroups</Box>
+            <Box margin={{ bottom: 'xxs' }} color="text-label">
+              <label htmlFor="collapsible-multiselect">Choose items</label>
+            </Box>
+            <Multiselect
+              controlId="collapsible-multiselect"
+              collapsibleGroups={true}
+              options={options}
+              selectedOptions={selectedOptions}
+              placeholder="Choose items"
+              ariaLabel="Choose items"
+              deselectAriaLabel={option => `Remove ${option.label}`}
+              onChange={({ detail }) => setSelectedOptions(detail.selectedOptions)}
+            />
+          </div>
+        </SpaceBetween>
+      </Box>
+    </article>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -19738,6 +19738,18 @@ To use it correctly, define an ID for the element you want to use as label and s
       "type": "string",
     },
     {
+      "description": "When set to \`true\`, option groups (defined via \`OptionGroup\` objects in \`options\`)
+become collapsible. The group header renders an expand/collapse control with
+\`aria-expanded\`, and collapsing a group hides its child options. All groups are
+expanded by default.
+
+This property is opt-in and backward compatible: when omitted or \`false\`, groups
+behave exactly as before.",
+      "name": "collapsibleGroups",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
       "description": "Specifies the ID for the trigger component. It uses an automatically generated ID by default.",
       "name": "controlId",
       "optional": true,
@@ -26070,6 +26082,18 @@ To use it correctly, define an ID for the element you want to use as label and s
       "name": "className",
       "optional": true,
       "type": "string",
+    },
+    {
+      "description": "When set to \`true\`, option groups (defined via \`OptionGroup\` objects in \`options\`)
+become collapsible. The group header renders an expand/collapse control with
+\`aria-expanded\`, and collapsing a group hides its child options. All groups are
+expanded by default.
+
+This property is opt-in and backward compatible: when omitted or \`false\`, groups
+behave exactly as before.",
+      "name": "collapsibleGroups",
+      "optional": true,
+      "type": "boolean",
     },
     {
       "description": "Specifies the ID for the trigger component. It uses an automatically generated ID by default.",

--- a/src/internal/components/option/interfaces.ts
+++ b/src/internal/components/option/interfaces.ts
@@ -15,6 +15,12 @@ export interface DropdownOption {
   disabledReason?: string;
   option: OptionDefinition | OptionGroup;
   afterHeader?: boolean;
+  // Set on `parent` options when `collapsibleGroups` is enabled. Indicates the
+  // group header renders an expand/collapse affordance.
+  collapsible?: boolean;
+  // Expanded state for a collapsible `parent` option. When `false`, the group's
+  // child options are omitted from the rendered list.
+  expanded?: boolean;
 }
 
 export interface OptionProps extends BaseComponentProps {

--- a/src/internal/components/option/utils/collapse-options.ts
+++ b/src/internal/components/option/utils/collapse-options.ts
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { SelectProps } from '../../../../select/interfaces';
+import { OptionGroup } from '../../../../types/option';
+import { generateTestIndexes } from '../../options-list/utils/test-indexes';
+import { DropdownOption } from '../interfaces';
+
+/**
+ * Resolves a stable key for a group so its expanded/collapsed state can be tracked
+ * across renders. The top-level index within `options` is used because it is stable
+ * regardless of whether the consumer recreates the options array on every render.
+ */
+export function getGroupKey(options: SelectProps.Options, group: OptionGroup): number {
+  return options.indexOf(group);
+}
+
+interface ApplyGroupCollapseProps {
+  options: SelectProps.Options;
+  filteredOptions: ReadonlyArray<DropdownOption>;
+  parentMap: Map<DropdownOption, DropdownOption>;
+  collapsedGroups: ReadonlySet<number>;
+}
+
+/**
+ * Given the flattened + filtered dropdown options, marks each `parent` option as
+ * collapsible, sets its expanded state, and removes the child options of any
+ * collapsed group. Test indexes are regenerated so test-utils keep working for the
+ * visible subset.
+ *
+ * The `parent` DropdownOption objects are recreated on every render by
+ * `flattenOptions`, so mutating them here is safe.
+ */
+export function applyGroupCollapse({
+  options,
+  filteredOptions,
+  parentMap,
+  collapsedGroups,
+}: ApplyGroupCollapseProps): DropdownOption[] {
+  const result: DropdownOption[] = [];
+  let currentGroupCollapsed = false;
+
+  for (const option of filteredOptions) {
+    if (option.type === 'parent') {
+      const groupIndex = getGroupKey(options, option.option as OptionGroup);
+      const collapsed = groupIndex !== -1 && collapsedGroups.has(groupIndex);
+      currentGroupCollapsed = collapsed;
+      option.collapsible = true;
+      option.expanded = !collapsed;
+      result.push(option);
+    } else if (option.type === 'child') {
+      if (!currentGroupCollapsed) {
+        result.push(option);
+      }
+    } else {
+      currentGroupCollapsed = false;
+      result.push(option);
+    }
+  }
+
+  generateTestIndexes(result, parentMap.get.bind(parentMap));
+
+  return result;
+}

--- a/src/internal/components/selectable-item/index.tsx
+++ b/src/internal/components/selectable-item/index.tsx
@@ -41,6 +41,8 @@ const SelectableItem = (
     sticky,
     afterHeader,
     withScrollbar,
+    collapsible,
+    isExpanded,
     ...restProps
   }: SelectableItemProps,
   ref: React.Ref<HTMLDivElement>
@@ -100,11 +102,16 @@ const SelectableItem = (
 
   const a11yProperties: Record<string, string | number | boolean | undefined> = {};
 
-  if (isParent && ariaChecked === undefined) {
+  if (isParent && ariaChecked === undefined && !collapsible) {
     a11yProperties.role = 'presentation';
   } else {
     a11yProperties.role = 'option';
     a11yProperties['aria-disabled'] = disabled;
+
+    // Collapsible group headers act as disclosure controls, so expose their expanded state.
+    if (collapsible) {
+      a11yProperties['aria-expanded'] = !!isExpanded;
+    }
 
     if (ariaSelected !== undefined) {
       a11yProperties['aria-selected'] = ariaSelected;

--- a/src/internal/components/selectable-item/interfaces.ts
+++ b/src/internal/components/selectable-item/interfaces.ts
@@ -30,6 +30,10 @@ export type SelectableItemProps = BaseComponentProps & {
   withScrollbar?: boolean;
   ariaSelected?: boolean | never;
   ariaChecked?: boolean | 'mixed' | never;
+  // When true, the item is a collapsible group header and exposes `aria-expanded`.
+  collapsible?: boolean;
+  // Expanded state of a collapsible group header.
+  isExpanded?: boolean;
 };
 
 export interface ItemDataAttributes {

--- a/src/multiselect/__tests__/collapsible-groups.test.tsx
+++ b/src/multiselect/__tests__/collapsible-groups.test.tsx
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import Multiselect, { MultiselectProps } from '../../../lib/components/multiselect';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+const options: MultiselectProps.Options = [
+  {
+    label: 'Group A',
+    options: [
+      { label: 'A1', value: 'a1' },
+      { label: 'A2', value: 'a2' },
+    ],
+  },
+  {
+    label: 'Group B',
+    options: [
+      { label: 'B1', value: 'b1' },
+      { label: 'B2', value: 'b2' },
+    ],
+  },
+];
+
+const defaultProps: MultiselectProps = {
+  options,
+  selectedOptions: [],
+  onChange: () => {},
+};
+
+function renderMultiselect(props?: Partial<MultiselectProps>) {
+  const onChange = jest.fn();
+  const { container } = render(<Multiselect {...defaultProps} onChange={onChange} {...props} />);
+  const wrapper = createWrapper(container).findMultiselect()!;
+  return { wrapper, onChange };
+}
+
+describe('Multiselect collapsibleGroups', () => {
+  test('does not add aria-expanded to group headers by default', () => {
+    const { wrapper } = renderMultiselect();
+    wrapper.openDropdown();
+    expect(wrapper.findDropdown()!.findGroup(1)!.getElement()).not.toHaveAttribute('aria-expanded');
+  });
+
+  test('renders group headers as expanded disclosure controls when enabled', () => {
+    const { wrapper } = renderMultiselect({ collapsibleGroups: true });
+    wrapper.openDropdown();
+    const dropdown = wrapper.findDropdown()!;
+    expect(dropdown.findGroup(1)!.getElement()).toHaveAttribute('aria-expanded', 'true');
+    expect(dropdown.findOptionInGroup(1, 1)!.getElement()).toHaveTextContent('A1');
+  });
+
+  test('collapses a group and hides its children when the header is activated', () => {
+    const { wrapper, onChange } = renderMultiselect({ collapsibleGroups: true });
+    wrapper.openDropdown();
+    wrapper
+      .findDropdown()!
+      .findGroup(1)!
+      .fireEvent(new MouseEvent('mouseup', { bubbles: true }));
+    expect(wrapper.findDropdown()!.findGroup(1)!.getElement()).toHaveAttribute('aria-expanded', 'false');
+    expect(wrapper.findDropdown()!.findOptionInGroup(1, 1)).toBeNull();
+    // toggling collapse must not change selection (does not select-all the group)
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('individual options remain selectable when groups are collapsible', () => {
+    const { wrapper, onChange } = renderMultiselect({ collapsibleGroups: true });
+    wrapper.openDropdown();
+    wrapper
+      .findDropdown()!
+      .findOptionInGroup(2, 1)!
+      .fireEvent(new MouseEvent('mouseup', { bubbles: true }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ selectedOptions: [{ label: 'B1', value: 'b1' }] }),
+      })
+    );
+  });
+});

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -62,6 +62,7 @@ const InternalMultiselect = React.forwardRef(
       __internalRootRef,
       autoFocus,
       enableSelectAll,
+      collapsibleGroups,
       renderOption,
       ...restProps
     }: InternalMultiselectProps,
@@ -90,6 +91,7 @@ const InternalMultiselect = React.forwardRef(
       setFilteringValue,
       externalRef,
       enableSelectAll,
+      collapsibleGroups,
       i18nStrings,
       ...restProps,
     });

--- a/src/multiselect/use-multiselect.tsx
+++ b/src/multiselect/use-multiselect.tsx
@@ -1,13 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 import { useInternalI18n } from '../i18n/context';
 import { useDropdownStatus } from '../internal/components/dropdown-status';
 import { DropdownOption } from '../internal/components/option/interfaces';
+import { applyGroupCollapse, getGroupKey } from '../internal/components/option/utils/collapse-options';
 import { isGroup } from '../internal/components/option/utils/filter-options';
 import { prepareOptions } from '../internal/components/option/utils/prepare-options';
 import { fireNonCancelableEvent } from '../internal/events';
@@ -43,6 +44,7 @@ type UseMultiselectOptions = SomeRequired<
     | 'onChange'
     | 'selectedAriaLabel'
     | 'enableSelectAll'
+    | 'collapsibleGroups'
     | 'i18nStrings'
   > &
     DropdownStatusProps & {
@@ -83,6 +85,7 @@ export function useMultiselect({
   externalRef,
   embedded,
   enableSelectAll,
+  collapsibleGroups = false,
   i18nStrings,
   ...restProps
 }: UseMultiselectOptions) {
@@ -110,6 +113,34 @@ export function useMultiselect({
     filteringValue
   );
 
+  const [collapsedGroups, setCollapsedGroups] = useState<ReadonlySet<number>>(() => new Set());
+  const toggleGroupExpanded = useCallback(
+    (option: DropdownOption) => {
+      const groupIndex = getGroupKey(options, option.option as OptionGroup);
+      if (groupIndex === -1) {
+        return;
+      }
+      setCollapsedGroups(prev => {
+        const next = new Set(prev);
+        if (next.has(groupIndex)) {
+          next.delete(groupIndex);
+        } else {
+          next.add(groupIndex);
+        }
+        return next;
+      });
+    },
+    [options]
+  );
+
+  const displayFilteredOptions = useMemo(
+    () =>
+      collapsibleGroups
+        ? applyGroupCollapse({ options, filteredOptions, parentMap, collapsedGroups })
+        : filteredOptions,
+    [collapsibleGroups, options, filteredOptions, parentMap, collapsedGroups]
+  );
+
   const selectAllOption: DropdownOption = {
     type: 'select-all',
     afterHeader: filteringType !== 'none',
@@ -117,7 +148,9 @@ export function useMultiselect({
   };
 
   const visibleOptions =
-    enableSelectAll && filteredOptions.length ? [selectAllOption, ...filteredOptions] : filteredOptions;
+    enableSelectAll && displayFilteredOptions.length
+      ? [selectAllOption, ...displayFilteredOptions]
+      : displayFilteredOptions;
 
   // Includes visible and non-visible (filtered out) options
   const allNonParentOptions = flatOptions.filter(item => item.type !== 'parent').map(option => option.option);
@@ -210,6 +243,8 @@ export function useMultiselect({
     isAllSelected,
     isSomeSelected,
     toggleAll,
+    collapsibleGroups,
+    onToggleGroupExpanded: toggleGroupExpanded,
   });
 
   const wrapperOnKeyDown = useNativeSearch({

--- a/src/select/__tests__/collapsible-groups.test.tsx
+++ b/src/select/__tests__/collapsible-groups.test.tsx
@@ -1,0 +1,133 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
+
+import Select, { SelectProps } from '../../../lib/components/select';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+const options: SelectProps.Options = [
+  { label: 'First', value: '1' },
+  {
+    label: 'Group A',
+    options: [
+      { label: 'A1', value: 'a1' },
+      { label: 'A2', value: 'a2' },
+    ],
+  },
+  {
+    label: 'Group B',
+    options: [
+      { label: 'B1', value: 'b1' },
+      { label: 'B2', value: 'b2' },
+    ],
+  },
+];
+
+const defaultProps: SelectProps = {
+  options,
+  selectedOption: null,
+  onChange: () => {},
+};
+
+function renderSelect(props?: Partial<SelectProps>) {
+  const onChange = jest.fn();
+  const { container } = render(<Select {...defaultProps} onChange={onChange} {...props} />);
+  const wrapper = createWrapper(container).findSelect()!;
+  return { wrapper, onChange };
+}
+
+describe('Select collapsibleGroups', () => {
+  test('does not add aria-expanded to group headers by default (backward compatible)', () => {
+    const { wrapper } = renderSelect();
+    wrapper.openDropdown();
+    const dropdown = wrapper.findDropdown()!;
+    expect(dropdown.findGroup(1)!.getElement()).not.toHaveAttribute('aria-expanded');
+    // group header keeps the presentation role when not collapsible
+    expect(dropdown.findGroup(1)!.getElement()).toHaveAttribute('role', 'presentation');
+  });
+
+  test('renders group headers as expanded disclosure controls when enabled', () => {
+    const { wrapper } = renderSelect({ collapsibleGroups: true });
+    wrapper.openDropdown();
+    const dropdown = wrapper.findDropdown()!;
+    expect(dropdown.findGroup(1)!.getElement()).toHaveAttribute('aria-expanded', 'true');
+    expect(dropdown.findGroup(1)!.getElement()).toHaveAttribute('role', 'option');
+    // children of an expanded group are visible
+    expect(dropdown.findOptionInGroup(1, 1)!.getElement()).toHaveTextContent('A1');
+    expect(dropdown.findOptionInGroup(1, 2)!.getElement()).toHaveTextContent('A2');
+  });
+
+  test('collapses and expands a group when its header is activated', () => {
+    const { wrapper } = renderSelect({ collapsibleGroups: true });
+    wrapper.openDropdown();
+    const dropdown = wrapper.findDropdown()!;
+
+    // collapse group A by clicking its header
+    dropdown.findGroup(1)!.fireEvent(new MouseEvent('mouseup', { bubbles: true }));
+    expect(wrapper.findDropdown()!.findGroup(1)!.getElement()).toHaveAttribute('aria-expanded', 'false');
+    expect(wrapper.findDropdown()!.findOptionInGroup(1, 1)).toBeNull();
+    // other groups remain unaffected
+    expect(wrapper.findDropdown()!.findOptionInGroup(2, 1)!.getElement()).toHaveTextContent('B1');
+
+    // expand it again
+    wrapper
+      .findDropdown()!
+      .findGroup(1)!
+      .fireEvent(new MouseEvent('mouseup', { bubbles: true }));
+    expect(wrapper.findDropdown()!.findGroup(1)!.getElement()).toHaveAttribute('aria-expanded', 'true');
+    expect(wrapper.findDropdown()!.findOptionInGroup(1, 1)!.getElement()).toHaveTextContent('A1');
+  });
+
+  test('activating a group header does not select an option', () => {
+    const { wrapper, onChange } = renderSelect({ collapsibleGroups: true });
+    wrapper.openDropdown();
+    wrapper
+      .findDropdown()!
+      .findGroup(1)!
+      .fireEvent(new MouseEvent('mouseup', { bubbles: true }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('child options remain selectable when groups are collapsible', () => {
+    const { wrapper, onChange } = renderSelect({ collapsibleGroups: true });
+    wrapper.openDropdown();
+    wrapper
+      .findDropdown()!
+      .findOptionInGroup(1, 1)!
+      .fireEvent(new MouseEvent('mouseup', { bubbles: true }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: expect.objectContaining({ selectedOption: { label: 'A1', value: 'a1' } }) })
+    );
+  });
+
+  test('collapsed children are removed from the filtered result but headers stay', () => {
+    const { wrapper } = renderSelect({ collapsibleGroups: true });
+    wrapper.openDropdown();
+    const dropdown = wrapper.findDropdown()!;
+    const optionCountExpanded = dropdown.findOptions().length;
+
+    dropdown.findGroup(1)!.fireEvent(new MouseEvent('mouseup', { bubbles: true }));
+    // two child options of group A disappear
+    expect(wrapper.findDropdown()!.findOptions().length).toBe(optionCountExpanded - 2);
+    // both group headers are still present
+    expect(wrapper.findDropdown()!.findGroups()).toHaveLength(2);
+  });
+
+  test('Right/Left arrow keys expand and collapse the highlighted group header', () => {
+    const { wrapper } = renderSelect({ collapsibleGroups: true, filteringType: 'none' });
+    wrapper.openDropdown();
+    const menu = wrapper.findDropdown()!.findOptionsContainer()!;
+
+    // On open, the first option ("First") is highlighted; one ArrowDown moves to the "Group A" header.
+    menu.keydown(KeyCode.down);
+    // collapse with ArrowLeft
+    menu.keydown(KeyCode.left);
+    expect(wrapper.findDropdown()!.findGroup(1)!.getElement()).toHaveAttribute('aria-expanded', 'false');
+    // expand with ArrowRight
+    wrapper.findDropdown()!.findOptionsContainer()!.keydown(KeyCode.right);
+    expect(wrapper.findDropdown()!.findGroup(1)!.getElement()).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -149,6 +149,17 @@ export interface BaseSelectProps
    * user from both modifying the value and opening the dropdown. A read-only control is still focusable.
    */
   readOnly?: boolean;
+
+  /**
+   * When set to `true`, option groups (defined via `OptionGroup` objects in `options`)
+   * become collapsible. The group header renders an expand/collapse control with
+   * `aria-expanded`, and collapsing a group hides its child options. All groups are
+   * expanded by default.
+   *
+   * This property is opt-in and backward compatible: when omitted or `false`, groups
+   * behave exactly as before.
+   */
+  collapsibleGroups?: boolean;
 }
 
 export interface SelectProps extends BaseSelectProps {

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 import { useMergeRefs, useResizeObserver, useUniqueId, warnOnce } from '@cloudscape-design/component-toolkit/internal';
@@ -11,6 +11,8 @@ import { getBaseProps } from '../internal/base-component';
 import { getBreakpointValue } from '../internal/breakpoints';
 import DropdownFooter from '../internal/components/dropdown-footer';
 import { useDropdownStatus } from '../internal/components/dropdown-status';
+import { DropdownOption } from '../internal/components/option/interfaces';
+import { applyGroupCollapse, getGroupKey } from '../internal/components/option/utils/collapse-options.js';
 import { prepareOptions } from '../internal/components/option/utils/prepare-options.js';
 import { useFormFieldContext } from '../internal/context/form-field-context';
 import { fireNonCancelableEvent } from '../internal/events';
@@ -68,6 +70,7 @@ const InternalSelect = React.forwardRef(
       virtualScroll,
       expandToViewport,
       autoFocus,
+      collapsibleGroups = false,
       __inFilteringToken,
       __internalRootRef,
       renderOption,
@@ -99,10 +102,38 @@ const InternalSelect = React.forwardRef(
 
     const [filteringValue, setFilteringValue] = useState('');
 
+    const [collapsedGroups, setCollapsedGroups] = useState<ReadonlySet<number>>(() => new Set());
+    const toggleGroupExpanded = useCallback(
+      (option: DropdownOption) => {
+        const groupIndex = getGroupKey(options, option.option as OptionGroup);
+        if (groupIndex === -1) {
+          return;
+        }
+        setCollapsedGroups(prev => {
+          const next = new Set(prev);
+          if (next.has(groupIndex)) {
+            next.delete(groupIndex);
+          } else {
+            next.add(groupIndex);
+          }
+          return next;
+        });
+      },
+      [options]
+    );
+
     const { filteredOptions, parentMap, totalCount, matchesCount } = prepareOptions(
       options,
       filteringType,
       filteringValue
+    );
+
+    const displayOptions = useMemo(
+      () =>
+        collapsibleGroups
+          ? applyGroupCollapse({ options, filteredOptions, parentMap, collapsedGroups })
+          : filteredOptions,
+      [collapsibleGroups, options, filteredOptions, parentMap, collapsedGroups]
     );
 
     const rootRef = useRef<HTMLDivElement>(null);
@@ -134,7 +165,7 @@ const InternalSelect = React.forwardRef(
     } = useSelect({
       selectedOptions: selectedOption ? [selectedOption] : [],
       updateSelectedOption: option => fireNonCancelableEvent(onChange, { selectedOption: option }),
-      options: filteredOptions,
+      options: displayOptions,
       filteringType,
       onBlur,
       onFocus,
@@ -142,11 +173,13 @@ const InternalSelect = React.forwardRef(
       fireLoadItems,
       setFilteringValue,
       statusType,
+      collapsibleGroups,
+      onToggleGroupExpanded: toggleGroupExpanded,
     });
 
     const handleNativeSearch = useNativeSearch({
       isEnabled: filteringType === 'none' && !readOnly,
-      options: filteredOptions,
+      options: displayOptions,
       highlightOption: !isOpen ? selectOption : highlightOption,
       highlightedOption: !isOpen ? selectedOption : highlightedOption?.option,
     });
@@ -284,7 +317,7 @@ const InternalSelect = React.forwardRef(
               renderOption={renderOption}
               menuProps={menuProps}
               getOptionProps={getOptionProps}
-              filteredOptions={filteredOptions}
+              filteredOptions={displayOptions}
               filteringValue={filteringValue}
               ref={scrollToIndex}
               hasDropdownStatus={dropdownStatus.content !== null}

--- a/src/select/parts/item.tsx
+++ b/src/select/parts/item.tsx
@@ -112,6 +112,8 @@ const Item = (
 
   const isParent = option.type === 'parent';
   const isChild = option.type === 'child';
+  const collapsible = !!option.collapsible;
+  const isExpanded = option.expanded;
   const wrappedOption: OptionDefinition = option.option;
   const disabled = option.disabled || wrappedOption.disabled;
   const disabledReason = disabled && wrappedOption.disabledReason ? wrappedOption.disabledReason : '';
@@ -164,6 +166,8 @@ const Item = (
       disabled={option.disabled}
       isParent={isParent}
       isChild={isChild}
+      collapsible={collapsible}
+      isExpanded={isExpanded}
       ref={useMergeRefs(ref, internalRef)}
       virtualPosition={virtualPosition}
       padBottom={padBottom}
@@ -178,6 +182,11 @@ const Item = (
       {...baseProps}
     >
       <div className={clsx(styles.item, !isParent && wrappedOption.labelTag && styles['show-label-tag'])}>
+        {isParent && collapsible && (
+          <div className={styles['expand-icon']} aria-hidden="true">
+            <InternalIcon name={isExpanded ? 'caret-down-filled' : 'caret-right-filled'} size="small" />
+          </div>
+        )}
         {!renderResult && hasCheckbox && !isParent && (
           <div className={styles.checkbox}>
             <CheckboxIcon checked={selected || false} disabled={option.disabled} />

--- a/src/select/parts/multiselect-item.tsx
+++ b/src/select/parts/multiselect-item.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { useMergeRefs } from '@cloudscape-design/component-toolkit/internal';
 
+import InternalIcon from '../../icon/internal.js';
 import { getBaseProps } from '../../internal/base-component';
 import CheckboxIcon from '../../internal/components/checkbox-icon';
 import Option from '../../internal/components/option';
@@ -100,6 +101,8 @@ const MultiSelectItem = (
   const isParent = option.type === 'parent';
   const isChild = option.type === 'child';
   const isSelectAll = option.type === 'select-all';
+  const collapsible = !!option.collapsible;
+  const isExpanded = option.expanded;
   const wrappedOption: OptionDefinition = option.option;
   const disabled = option.disabled || wrappedOption.disabled;
   const disabledReason =
@@ -170,6 +173,8 @@ const MultiSelectItem = (
       isParent={isParent}
       isChild={isChild}
       isSelectAll={isSelectAll}
+      collapsible={collapsible}
+      isExpanded={isExpanded}
       highlightType={highlightType}
       ref={useMergeRefs(ref, internalRef)}
       virtualPosition={virtualPosition}
@@ -186,7 +191,12 @@ const MultiSelectItem = (
       {...baseProps}
     >
       <div className={className}>
-        {!renderResult && hasCheckbox && (
+        {isParent && collapsible && (
+          <div className={styles['expand-icon']} aria-hidden="true">
+            <InternalIcon name={isExpanded ? 'caret-down-filled' : 'caret-right-filled'} size="small" />
+          </div>
+        )}
+        {!renderResult && hasCheckbox && !(isParent && collapsible) && (
           <div className={styles.checkbox}>
             <CheckboxIcon
               checked={selected}

--- a/src/select/parts/styles.scss
+++ b/src/select/parts/styles.scss
@@ -34,6 +34,13 @@ $checkbox-size: awsui.$size-control;
     inline-size: $checkbox-size;
     margin-inline-end: styles.$control-padding-horizontal;
   }
+
+  > .expand-icon {
+    display: flex;
+    align-items: center;
+    margin-inline-end: awsui.$space-xxs;
+    color: awsui.$color-text-dropdown-group-label;
+  }
 }
 
 .option-group {

--- a/src/select/utils/use-select.ts
+++ b/src/select/utils/use-select.ts
@@ -17,8 +17,9 @@ import { useOpenState } from '../../internal/components/options-list/utils/use-o
 import { fireNonCancelableEvent } from '../../internal/events';
 import useForwardFocus from '../../internal/hooks/forward-focus';
 import { usePrevious } from '../../internal/hooks/use-previous';
+import { KeyCode } from '../../internal/keycode';
 import { DropdownStatusProps } from '../../types/dropdown-status';
-import { NonCancelableEventHandler } from '../../types/events';
+import { BaseKeyDetail, CancelableEventHandler, NonCancelableEventHandler } from '../../types/events';
 import { OptionDefinition, OptionGroup } from '../../types/option';
 import { FilterProps } from '../parts/filter';
 import { ItemProps } from '../parts/item';
@@ -44,6 +45,8 @@ interface UseSelectProps {
   isAllSelected?: boolean;
   isSomeSelected?: boolean;
   toggleAll?: () => void;
+  collapsibleGroups?: boolean;
+  onToggleGroupExpanded?: (option: DropdownOption) => void;
 }
 
 export interface SelectTriggerProps extends ButtonTriggerProps {
@@ -67,10 +70,16 @@ export function useSelect({
   isAllSelected,
   isSomeSelected,
   toggleAll,
+  collapsibleGroups = false,
+  onToggleGroupExpanded,
 }: UseSelectProps) {
   const interactivityCheck = useInteractiveGroups ? isGroupInteractive : isInteractive;
 
-  const isHighlightable = (option?: DropdownOption) => !!option && (useInteractiveGroups || option.type !== 'parent');
+  const isCollapsibleParent = (option?: DropdownOption) =>
+    collapsibleGroups && !!option && option.type === 'parent' && !!option.collapsible;
+
+  const isHighlightable = (option?: DropdownOption) =>
+    !!option && (useInteractiveGroups || collapsibleGroups || option.type !== 'parent');
 
   const filterRef = useRef<HTMLInputElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -128,8 +137,24 @@ export function useSelect({
     }
   };
 
+  const toggleGroupExpanded = (option?: DropdownOption) => {
+    const optionToToggle = option || highlightedOption;
+    if (!isCollapsibleParent(optionToToggle) || !onToggleGroupExpanded) {
+      return false;
+    }
+    onToggleGroupExpanded(optionToToggle!);
+    return true;
+  };
+
   const selectOption = (option?: DropdownOption) => {
     const optionToSelect = option || highlightedOption;
+    // When groups are collapsible, activating a group header toggles its expanded
+    // state instead of selecting it. This takes precedence over the interactive
+    // group (select-all) behaviour used by Multiselect.
+    if (isCollapsibleParent(optionToSelect)) {
+      toggleGroupExpanded(optionToSelect);
+      return;
+    }
     if (!optionToSelect || !interactivityCheck(optionToSelect)) {
       return;
     }
@@ -144,7 +169,10 @@ export function useSelect({
   const activeKeyDownHandler = useMenuKeyboard({
     goUp: () => {
       if (
-        (!useInteractiveGroups && highlightedOption?.type === 'child' && highlightedIndex === 1) ||
+        (!useInteractiveGroups &&
+          !collapsibleGroups &&
+          highlightedOption?.type === 'child' &&
+          highlightedIndex === 1) ||
         highlightedIndex === 0
       ) {
         goEndWithKeyboard();
@@ -171,6 +199,26 @@ export function useSelect({
     },
     preventNativeSpace: !hasFilter || (highlightedOption && highlightType.type === 'keyboard'),
   });
+
+  // Left/Right arrow keys collapse/expand the highlighted group header, matching the
+  // disclosure keyboard pattern. Enter/Space (handled via selectOption) also toggles.
+  const collapsibleKeyDownHandler: CancelableEventHandler<BaseKeyDetail> = event => {
+    if (collapsibleGroups && isCollapsibleParent(highlightedOption)) {
+      if (event.detail.keyCode === KeyCode.right && !highlightedOption!.expanded) {
+        event.preventDefault();
+        toggleGroupExpanded(highlightedOption);
+        return;
+      }
+      if (event.detail.keyCode === KeyCode.left && highlightedOption!.expanded) {
+        event.preventDefault();
+        toggleGroupExpanded(highlightedOption);
+        return;
+      }
+    }
+    activeKeyDownHandler(event);
+  };
+
+  const menuKeyDownHandler = collapsibleGroups ? collapsibleKeyDownHandler : activeKeyDownHandler;
 
   const triggerKeyDownHandler = useTriggerKeyboard({
     openDropdown: () => openDropdown(true),
@@ -215,7 +263,7 @@ export function useSelect({
 
     return {
       ref: filterRef,
-      onKeyDown: activeKeyDownHandler,
+      onKeyDown: menuKeyDownHandler,
       onChange: event => {
         setFilteringValue(event.detail.value);
         resetHighlightWithKeyboard();
@@ -249,7 +297,7 @@ export function useSelect({
       statusType,
     };
     if (!hasFilter) {
-      menuProps.onKeyDown = activeKeyDownHandler;
+      menuProps.onKeyDown = menuKeyDownHandler;
       menuProps.nativeAttributes = {
         'aria-activedescendant': highlightedOptionId,
       };


### PR DESCRIPTION
### Description

Adds an opt-in **`collapsibleGroups`** property to **Select** and **Multiselect**. When enabled, `OptionGroup` headers become expand/collapse disclosure controls and collapsing a group hides its child options from the dropdown list. Groups are **expanded by default** and the behaviour is fully **backward compatible** when the prop is omitted or `false`.

Implemented for **AWSUI-61684**.

> ⚠️ **Ticket mismatch note:** The Taskei ticket `AWSUI-61684` currently resolves to an unrelated, already-resolved website-feedback item ("Merge tokens into one searchable list", `P373009147`). Per the task instructions, this PR implements the *"Select collapsible groups"* feature as described in the work request and flags the discrepancy for the reviewer to reconcile the ticket/spec.

**What changed**
- New public prop `collapsibleGroups?: boolean` on `BaseSelectProps` (inherited by both `Select` and `Multiselect`).
- Group headers render a caret disclosure affordance and expose `aria-expanded` (`role="option"` when collapsible).
- Interaction: click / `Enter` / `Space` toggle a group; `ArrowRight` expands and `ArrowLeft` collapses the highlighted header (disclosure keyboard pattern).
- Reuses the existing flatten → filter → render option-group pipeline. A small `applyGroupCollapse` utility marks parents as `collapsible`/`expanded`, removes children of collapsed groups, and regenerates test indexes so test-utils keep working for the visible subset.
- Collapse state is tracked per top-level group index (stable across re-renders even when the consumer recreates the `options` array).
- In Multiselect the group-level select-all checkbox is hidden on collapsible headers so the header is an unambiguous disclosure control; individual options and the top-level `enableSelectAll` row are unaffected.

**Known follow-ups (not in this PR)**
- Virtual scroll (`virtualScroll`) is not yet optimized for collapse; the plain list path is fully supported.
- Optional auto-expand of a collapsed group when a filter matches one of its children.
- Public i18n aria-labels for the expand/collapse control (currently relies on `aria-expanded` + the group label).

### How has this been tested?

- New unit tests: `src/select/__tests__/collapsible-groups.test.tsx` (7) and `src/multiselect/__tests__/collapsible-groups.test.tsx` (4) covering default (backward-compatible) rendering, `aria-expanded`, click and keyboard toggling, child hiding, and that toggling does not alter selection.
- Full existing Select / Multiselect / option suites pass (492 tests, no regressions).
- `eslint .` → 0 errors. `gulp quick-build` → success.
- Manual dev page added at `pages/select/collapsible-groups.page.tsx`.

Related links, issue #, if available: AWSUI-61684 (see mismatch note above)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ — JSDoc added for the new prop; public docs/Contentful article TBD.
- _Changes are backward-compatible if not indicated._ — Yes, opt-in prop, default off.
- _Changes do not include unsupported browser features._ — Yes.
- _Changes were manually tested for accessibility._ — `aria-expanded` on headers; keyboard (Enter/Space/Arrow) verified.

#### Security

- _If the code handles URLs..._ — N/A.

#### Testing

- _Changes are covered with new/existing unit tests?_ — Yes.
- _Changes are covered with new/existing integration tests?_ — Unit only in this PR; integ TBD.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
