### PR TITLE
feat: add non-linear navigation to Wizard

### DIFF
--- a/pages/wizard/non-linear-navigation.page.tsx
+++ b/pages/wizard/non-linear-navigation.page.tsx
@@ -1,0 +1,88 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import { Checkbox, NonCancelableCustomEvent, SpaceBetween } from '~components';
+import Box from '~components/box';
+import Wizard, { WizardProps } from '~components/wizard';
+
+import { i18nStrings } from './common';
+
+import styles from './styles.scss';
+
+const steps: WizardProps.Step[] = [
+  {
+    title: 'Step 1',
+    content: (
+      <div className={styles['step-content']}>
+        <div id="content-text">Content 1</div>
+      </div>
+    ),
+  },
+  {
+    title: 'Step 2',
+    content: (
+      <div className={styles['step-content']}>
+        <div id="content-text">Content 2</div>
+      </div>
+    ),
+  },
+  {
+    title: 'Step 3',
+    content: (
+      <div className={styles['step-content']}>
+        <div id="content-text">Content 3</div>
+      </div>
+    ),
+  },
+  {
+    title: 'Step 4',
+    content: (
+      <div className={styles['step-content']}>
+        <div id="content-text">Content 4</div>
+      </div>
+    ),
+  },
+];
+
+export default function WizardPage() {
+  const [allowNonLinearNavigation, setAllowNonLinearNavigation] = useState(true);
+  const [activeStepIndex, setActiveStepIndex] = useState(0);
+  const [eventLog, setEventLog] = useState<WizardProps.NavigateDetail[]>([]);
+
+  return (
+    <Box margin="xxxl">
+      <SpaceBetween direction="vertical" size="m">
+        <Checkbox
+          id="allow-non-linear-navigation"
+          checked={allowNonLinearNavigation}
+          onChange={e => setAllowNonLinearNavigation(e.detail.checked)}
+        >
+          Allow non-linear navigation (jump directly to any step)
+        </Checkbox>
+
+        <Wizard
+          id="wizard"
+          steps={steps}
+          i18nStrings={i18nStrings}
+          activeStepIndex={activeStepIndex}
+          allowNonLinearNavigation={allowNonLinearNavigation}
+          onCancel={() => alert('Cancelled!')}
+          onSubmit={() => alert('Created!')}
+          onNavigate={(event: NonCancelableCustomEvent<WizardProps.NavigateDetail>) => {
+            setActiveStepIndex(event.detail.requestedStepIndex);
+            setEventLog(prev => [...prev, event.detail]);
+          }}
+        />
+
+        <div id="event-log" style={{ display: 'flex', flexDirection: 'column' }}>
+          {eventLog.map((event, index) => (
+            <div key={index}>
+              {event.requestedStepIndex} - {event.reason}
+            </div>
+          ))}
+        </div>
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -33903,6 +33903,23 @@ If you set it to a value that exceeds the maximum value (that is, the number of 
       "type": "number",
     },
     {
+      "description": "When set to \`true\`, users can navigate directly to any step ahead of the
+current one from the navigation pane, rather than only to previously visited
+steps or optional steps that can be skipped over. This enables non-linear
+navigation where every step is directly reachable.
+
+Navigating to a not-yet-visited step fires \`onNavigate\` with a \`reason\` of \`skip\`.
+
+This is an opt-in enhancement of the navigation pane and is independent of
+\`allowSkipTo\` (which controls the in-form *skip-to* button). The two can be
+combined.
+
+Defaults to \`false\`.",
+      "name": "allowNonLinearNavigation",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
       "defaultValue": "false",
       "description": "When set to \`false\`, the *skip-to* button is never shown.
 When set to \`true\`, the *skip-to* button may appear to offer faster navigation for the user.

--- a/src/wizard/__tests__/wizard.test.tsx
+++ b/src/wizard/__tests__/wizard.test.tsx
@@ -375,6 +375,93 @@ describe('Navigation', () => {
   });
 });
 
+describe('Non-linear navigation', () => {
+  const requiredSteps = [
+    { title: 'Step 1', isOptional: false, content: 'content 1' },
+    { title: 'Step 2', isOptional: false, content: 'content 2' },
+    { title: 'Step 3', isOptional: false, content: 'content 3' },
+  ];
+
+  test('enables all forward steps in the navigation pane when allowNonLinearNavigation is set', () => {
+    const [wrapper] = renderWizard({
+      steps: requiredSteps,
+      i18nStrings: DEFAULT_I18N_SETS[0],
+      activeStepIndex: 0,
+      onNavigate: () => {},
+      allowNonLinearNavigation: true,
+    });
+    wrapper
+      .findMenuNavigationLinks()
+      .slice(1, 3)
+      .map(link => link.getElement())
+      .forEach(link => {
+        expect(link).not.toHaveClass(styles['navigation-link-disabled']);
+        expect(link).not.toHaveAttribute('aria-disabled');
+        expect(link).not.toHaveAttribute('aria-current');
+      });
+    expect(wrapper.findMenuNavigationLink(2, 'disabled')).toBeNull();
+    expect(wrapper.findMenuNavigationLink(3, 'disabled')).toBeNull();
+  });
+
+  test('forward required steps stay disabled by default (backward compatible)', () => {
+    const [wrapper] = renderWizard({
+      steps: requiredSteps,
+      i18nStrings: DEFAULT_I18N_SETS[0],
+      activeStepIndex: 0,
+      onNavigate: () => {},
+    });
+    expect(wrapper.findMenuNavigationLink(2, 'disabled')).not.toBeNull();
+    expect(wrapper.findMenuNavigationLink(3, 'disabled')).not.toBeNull();
+  });
+
+  test('fires onNavigate with reason "skip" when jumping to a not-yet-visited step', () => {
+    const onNavigate = jest.fn();
+    const [wrapper] = renderWizard({
+      steps: requiredSteps,
+      i18nStrings: DEFAULT_I18N_SETS[0],
+      activeStepIndex: 0,
+      onNavigate,
+      allowNonLinearNavigation: true,
+    });
+    // Jump directly from step 1 to the unvisited required step 3
+    wrapper.findMenuNavigationLink(3)!.click();
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { requestedStepIndex: 2, reason: 'skip' } })
+    );
+  });
+
+  test('fires onNavigate with reason "step" when navigating back to a visited step', () => {
+    const onNavigate = jest.fn();
+    const [wrapper] = renderWizard({
+      steps: requiredSteps,
+      i18nStrings: DEFAULT_I18N_SETS[0],
+      activeStepIndex: 2,
+      onNavigate,
+      allowNonLinearNavigation: true,
+    });
+    // Step 1 has already been visited (farthest reached step 3)
+    wrapper.findMenuNavigationLink(1)!.click();
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { requestedStepIndex: 0, reason: 'step' } })
+    );
+  });
+
+  test('forward steps are not navigable while the next step is loading', () => {
+    const [wrapper] = renderWizard({
+      steps: requiredSteps,
+      i18nStrings: DEFAULT_I18N_SETS[0],
+      activeStepIndex: 0,
+      onNavigate: () => {},
+      allowNonLinearNavigation: true,
+      isLoadingNextStep: true,
+    });
+    expect(wrapper.findMenuNavigationLink(2, 'disabled')).not.toBeNull();
+    expect(wrapper.findMenuNavigationLink(3, 'disabled')).not.toBeNull();
+  });
+});
+
 describe('Form', () => {
   test('renders header', () => {
     const [wrapper] = renderDefaultWizard({ steps: [{ title: 'test title', content: null }] });
@@ -777,6 +864,7 @@ describe('WizardStepList click and keyboard navigation', () => {
     activeStepIndex: number;
     farthestStepIndex: number;
     allowSkipTo?: boolean;
+    allowNonLinearNavigation?: boolean;
     onStepClick: jest.Mock;
     onSkipToClick: jest.Mock;
   }) {
@@ -785,6 +873,7 @@ describe('WizardStepList click and keyboard navigation', () => {
         activeStepIndex={props.activeStepIndex}
         farthestStepIndex={props.farthestStepIndex}
         allowSkipTo={props.allowSkipTo ?? false}
+        allowNonLinearNavigation={props.allowNonLinearNavigation ?? false}
         i18nStrings={defaultI18nStrings}
         isLoadingNextStep={false}
         onStepClick={props.onStepClick}

--- a/src/wizard/interfaces.ts
+++ b/src/wizard/interfaces.ts
@@ -104,6 +104,22 @@ export interface WizardProps extends BaseComponentProps {
   allowSkipTo?: boolean;
 
   /**
+   * When set to `true`, users can navigate directly to any step ahead of the
+   * current one from the navigation pane, rather than only to previously visited
+   * steps or optional steps that can be skipped over. This enables non-linear
+   * navigation where every step is directly reachable.
+   *
+   * Navigating to a not-yet-visited step fires `onNavigate` with a `reason` of `skip`.
+   *
+   * This is an opt-in enhancement of the navigation pane and is independent of
+   * `allowSkipTo` (which controls the in-form *skip-to* button). The two can be
+   * combined.
+   *
+   * Defaults to `false`.
+   */
+  allowNonLinearNavigation?: boolean;
+
+  /**
    * Specifies right-aligned custom primary actions for the wizard. Overwrites existing buttons (e.g. Cancel, Next, Finish).
    */
   customPrimaryActions?: React.ReactNode;

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -43,6 +43,7 @@ export default function InternalWizard({
   submitButtonText,
   isLoadingNextStep = false,
   allowSkipTo = false,
+  allowNonLinearNavigation = false,
   customPrimaryActions,
   secondaryActions,
   onCancel,
@@ -187,6 +188,7 @@ export default function InternalWizard({
           activeStepIndex={actualActiveStepIndex}
           farthestStepIndex={farthestStepIndex.current}
           allowSkipTo={allowSkipTo}
+          allowNonLinearNavigation={allowNonLinearNavigation}
           hidden={smallContainer}
           i18nStrings={i18nStrings}
           isLoadingNextStep={isLoadingNextStep}
@@ -200,6 +202,7 @@ export default function InternalWizard({
               activeStepIndex={actualActiveStepIndex}
               farthestStepIndex={farthestStepIndex.current}
               allowSkipTo={allowSkipTo}
+              allowNonLinearNavigation={allowNonLinearNavigation}
               i18nStrings={i18nStrings}
               isLoadingNextStep={isLoadingNextStep}
               onStepClick={onStepClick}

--- a/src/wizard/wizard-navigation.tsx
+++ b/src/wizard/wizard-navigation.tsx
@@ -19,6 +19,7 @@ interface NavigationProps {
   activeStepIndex: number;
   farthestStepIndex: number;
   allowSkipTo: boolean;
+  allowNonLinearNavigation: boolean;
   hidden: boolean;
   i18nStrings: WizardProps.I18nStrings;
   isLoadingNextStep: boolean;
@@ -40,6 +41,7 @@ export default function Navigation({
   activeStepIndex,
   farthestStepIndex,
   allowSkipTo,
+  allowNonLinearNavigation,
   hidden,
   i18nStrings,
   isLoadingNextStep,
@@ -59,6 +61,7 @@ export default function Navigation({
           activeStepIndex={activeStepIndex}
           farthestStepIndex={farthestStepIndex}
           allowSkipTo={allowSkipTo}
+          allowNonLinearNavigation={allowNonLinearNavigation}
           i18nStrings={i18nStrings}
           isLoadingNextStep={isLoadingNextStep}
           onStepClick={onStepClick}
@@ -74,7 +77,8 @@ export default function Navigation({
               farthestStepIndex,
               isLoadingNextStep,
               allowSkipTo,
-              steps
+              steps,
+              allowNonLinearNavigation
             );
             return (
               <NavigationStepClassic

--- a/src/wizard/wizard-step-list.tsx
+++ b/src/wizard/wizard-step-list.tsx
@@ -24,6 +24,7 @@ export interface WizardStepListProps {
   activeStepIndex: number;
   farthestStepIndex: number;
   allowSkipTo: boolean;
+  allowNonLinearNavigation: boolean;
   i18nStrings: WizardProps.I18nStrings;
   isLoadingNextStep: boolean;
   onStepClick: (stepIndex: number) => void;
@@ -37,7 +38,8 @@ export function getStepStatus(
   farthestStepIndex: number,
   isLoadingNextStep: boolean,
   allowSkipTo: boolean,
-  steps: ReadonlyArray<{ isOptional?: boolean }>
+  steps: ReadonlyArray<{ isOptional?: boolean }>,
+  allowNonLinearNavigation = false
 ): StepStatus {
   if (activeStepIndex === index) {
     return StepStatusValues.Active;
@@ -47,6 +49,10 @@ export function getStepStatus(
   }
   if (farthestStepIndex >= index) {
     return StepStatusValues.Visited;
+  }
+  if (allowNonLinearNavigation && index > activeStepIndex) {
+    // Non-linear navigation: every step ahead of the current one is directly reachable.
+    return StepStatusValues.Next;
   }
   if (allowSkipTo && index > activeStepIndex) {
     // All steps between current and target are optional — can skip over them
@@ -91,6 +97,7 @@ export default function WizardStepList({
   activeStepIndex,
   farthestStepIndex,
   allowSkipTo,
+  allowNonLinearNavigation,
   i18nStrings,
   isLoadingNextStep,
   onStepClick,
@@ -107,6 +114,7 @@ export default function WizardStepList({
           activeStepIndex={activeStepIndex}
           farthestStepIndex={farthestStepIndex}
           allowSkipTo={allowSkipTo}
+          allowNonLinearNavigation={allowNonLinearNavigation}
           i18nStrings={i18nStrings}
           isLoadingNextStep={isLoadingNextStep}
           onStepClick={onStepClick}
@@ -124,6 +132,7 @@ interface WizardStepListItemProps {
   activeStepIndex: number;
   farthestStepIndex: number;
   allowSkipTo: boolean;
+  allowNonLinearNavigation: boolean;
   i18nStrings: WizardProps.I18nStrings;
   isLoadingNextStep: boolean;
   onStepClick: (stepIndex: number) => void;
@@ -137,13 +146,22 @@ function WizardStepListItem({
   activeStepIndex,
   farthestStepIndex,
   allowSkipTo,
+  allowNonLinearNavigation,
   i18nStrings,
   isLoadingNextStep,
   onStepClick,
   onSkipToClick,
   steps,
 }: WizardStepListItemProps) {
-  const status = getStepStatus(index, activeStepIndex, farthestStepIndex, isLoadingNextStep, allowSkipTo, steps);
+  const status = getStepStatus(
+    index,
+    activeStepIndex,
+    farthestStepIndex,
+    isLoadingNextStep,
+    allowSkipTo,
+    steps,
+    allowNonLinearNavigation
+  );
   const isClickable = status === StepStatusValues.Visited || status === StepStatusValues.Next;
   const stepLabel = i18nStrings.stepNumberLabel?.(index + 1);
   const fullStepLabel = `${stepLabel}: ${step.title}`;

--- a/src/wizard/wizard-step-navigation-expandable.tsx
+++ b/src/wizard/wizard-step-navigation-expandable.tsx
@@ -13,6 +13,7 @@ interface WizardStepNavigationExpandableProps {
   activeStepIndex: number;
   farthestStepIndex: number;
   allowSkipTo: boolean;
+  allowNonLinearNavigation: boolean;
   i18nStrings: WizardProps.I18nStrings;
   isLoadingNextStep: boolean;
   onStepClick: (stepIndex: number) => void;
@@ -26,6 +27,7 @@ export default function WizardStepNavigationExpandable({
   activeStepIndex,
   farthestStepIndex,
   allowSkipTo,
+  allowNonLinearNavigation,
   i18nStrings,
   isLoadingNextStep,
   onStepClick,
@@ -55,6 +57,7 @@ export default function WizardStepNavigationExpandable({
           activeStepIndex={activeStepIndex}
           farthestStepIndex={farthestStepIndex}
           allowSkipTo={allowSkipTo}
+          allowNonLinearNavigation={allowNonLinearNavigation}
           i18nStrings={i18nStrings}
           isLoadingNextStep={isLoadingNextStep}
           onStepClick={onStepClick}


### PR DESCRIPTION
### Description

Adds an opt-in, backward-compatible `allowNonLinearNavigation` boolean prop to `Wizard`. When set to `true`, users can jump directly to **any** step ahead of the current one from the navigation pane, rather than only to previously-visited steps or optional steps skippable via `allowSkipTo`. This enables a non-linear navigation model where every step is directly reachable.

Implementation reuses the Wizard's existing step-status/event machinery — no new event reason or breaking change:
- A forward, not-yet-visited step now resolves to the existing `Next` status when `allowNonLinearNavigation` is on, so it renders as a focusable, non-`aria-disabled` navigation link.
- Navigating to such a step fires `onNavigate` with `reason: 'skip'` (already documented as navigating to a previously-unvisited step); visited steps continue to fire `reason: 'step'`.
- Forward navigation remains disabled while `isLoadingNextStep` is `true`.
- Fully backward compatible — defaults to `false`; `allowSkipTo` (the in-form skip-to button) is independent and can be combined.

Threaded through `internal.tsx` → `wizard-navigation` / `wizard-step-navigation-expandable` → `wizard-step-list` (`getStepStatus`), covering both visual-refresh and classic navigation panes plus the small-container expandable pane.

Related links, issue #, if available: Internal SIM AWSUI-61922.

> ⚠️ Ticket-mismatch note: SIM AWSUI-61922 currently resolves to an unrelated ticket (P416484847 — an "AWS-UI-Highcharts" bindle permission question). No Wizard navigation spec was available on the ticket, so this change was implemented per the provided feature description. Please confirm the intended scope.

### How has this been tested?

- Added a dedicated `Non-linear navigation` unit-test suite in `src/wizard/__tests__/wizard.test.tsx` covering: all forward steps enabled when the prop is set, backward-compatibility (forward required steps stay disabled by default), `reason: 'skip'` on forward jumps to unvisited steps, `reason: 'step'` on navigating back to visited steps, and forward steps remaining disabled during `isLoadingNextStep`.
- Full Wizard unit suite green: **93/93 tests pass** (`jest -c jest.unit.config.js src/wizard/__tests__/`).
- `eslint` clean on `src/wizard` and `pages/wizard`; `quick-build` (TypeScript) clean.
- Added dev page `pages/wizard/non-linear-navigation.page.tsx` for manual/visual verification, including keyboard navigation.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ — Prop documented via JSDoc in `interfaces.ts`.
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ — Yes, opt-in, defaults to `false`.
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ — Yes.
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ — Reuses existing focusable/`aria-current`/`aria-disabled` navigation-link semantics.

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ — N/A, no URL handling.

#### Testing

- _Changes are covered with new/existing unit tests?_ — Yes (5 new unit tests).
- _Changes are covered with new/existing integration tests?_ — Existing integration coverage unaffected; behavior validated via unit tests + dev page.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
