### PR TITLE
feat: Add description support for PropertyFilter free text operators

### DIFF
--- a/pages/property-filter/property-filter-editor-permutations.page.tsx
+++ b/pages/property-filter/property-filter-editor-permutations.page.tsx
@@ -103,6 +103,7 @@ const defaultProps: Omit<TokenEditorProps, 'i18nStrings'> = {
     disabled: false,
     operators: [':', '!:'],
     defaultOperator: ':',
+    getOperatorDescription: () => null,
   },
   filteringProperties: [nameProperty, dateProperty],
   filteringOptions: [

--- a/pages/property-filter/property-filter-freetext-operator.page.tsx
+++ b/pages/property-filter/property-filter-freetext-operator.page.tsx
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { useCollection } from '@cloudscape-design/collection-hooks';
+
+import { I18nProvider } from '~components/i18n';
+import messages from '~components/i18n/messages/all.en';
+import PropertyFilter from '~components/property-filter';
+import { PropertyFilterProps } from '~components/property-filter/interfaces';
+
+interface Item {
+  name: string;
+  env: string;
+  owner: string;
+}
+
+const allItems: Item[] = [
+  { name: 'app-web-prod', env: 'production', owner: 'alice' },
+  { name: 'app-api-prod', env: 'production', owner: 'bob' },
+  { name: 'app-worker-staging', env: 'staging', owner: 'alice' },
+  { name: 'app-web-dev', env: 'development', owner: 'charlie' },
+  { name: 'svc-auth-prod', env: 'production', owner: 'bob' },
+  { name: 'svc-data-staging', env: 'staging', owner: 'charlie' },
+];
+
+const filteringProperties: PropertyFilterProps.FilteringProperty[] = [
+  { key: 'name', propertyLabel: 'Name', groupValuesLabel: 'Name values', operators: ['=', '!=', ':', '!:'] },
+  { key: 'env', propertyLabel: 'Environment', groupValuesLabel: 'Environment values', operators: ['=', '!='] },
+  { key: 'owner', propertyLabel: 'Owner', groupValuesLabel: 'Owner values', operators: ['=', '!='] },
+];
+
+const filteringOptions: PropertyFilterProps.FilteringOption[] = [...new Set(allItems.map(i => i.name))]
+  .map(v => ({ propertyKey: 'name', value: v }))
+  .concat([...new Set(allItems.map(i => i.env))].map(v => ({ propertyKey: 'env', value: v })))
+  .concat([...new Set(allItems.map(i => i.owner))].map(v => ({ propertyKey: 'owner', value: v })));
+
+// Free-text filtering that lets consumers control the operator used for free text:
+// - `defaultOperator: '='` makes plain typed text an exact-match token instead of the default "contains".
+// - each operator carries a custom `description` shown in the operator dropdown.
+// - `~` is a custom free-text operator string with its own `match` function and `description`.
+const freeTextFiltering: PropertyFilterProps.FreeTextFiltering = {
+  defaultOperator: '=',
+  operators: [
+    { operator: '=', description: 'Exact match' },
+    { operator: ':', description: 'Contains' },
+    { operator: '^', description: 'Starts with' },
+    {
+      operator: '~',
+      description: 'Matches regular expression',
+      match: (itemValue: unknown, tokenValue: unknown) => {
+        try {
+          return new RegExp(String(tokenValue)).test(String(itemValue));
+        } catch {
+          return String(itemValue).toLowerCase().includes(String(tokenValue).toLowerCase());
+        }
+      },
+    },
+  ],
+};
+
+export default function FreeTextOperatorDemo() {
+  const { items, propertyFilterProps } = useCollection(allItems, {
+    propertyFiltering: { filteringProperties },
+  });
+
+  return (
+    <I18nProvider locale="en" messages={[messages]}>
+      <div style={{ padding: 20 }}>
+        <h1>Property Filter — Free-text operator demo</h1>
+        <p>
+          Open the operator dropdown of a free-text token (or create one by typing) to see consumer-controlled operators
+          with custom descriptions, including the custom <code>~</code> operator.
+        </p>
+
+        <PropertyFilter
+          {...propertyFilterProps}
+          filteringOptions={filteringOptions}
+          freeTextFiltering={freeTextFiltering}
+          i18nStrings={{
+            filteringAriaLabel: 'Filter instances',
+            dismissAriaLabel: 'Dismiss',
+            filteringPlaceholder: 'Filter instances',
+            groupValuesText: 'Values',
+            groupPropertiesText: 'Properties',
+            operatorsText: 'Operators',
+            operationAndText: 'and',
+            operationOrText: 'or',
+            operatorContainsText: 'Contains',
+            operatorDoesNotContainText: 'Does not contain',
+            operatorEqualsText: 'Equals',
+            operatorDoesNotEqualText: 'Does not equal',
+            operatorStartsWithText: 'Starts with',
+            operatorDoesNotStartWithText: 'Does not start with',
+            editTokenHeader: 'Edit filter',
+            propertyText: 'Property',
+            operatorText: 'Operator',
+            valueText: 'Value',
+            cancelActionText: 'Cancel',
+            applyActionText: 'Apply',
+            allPropertiesLabel: 'All properties',
+            clearFiltersText: 'Clear filters',
+            removeTokenButtonAriaLabel: token =>
+              `Remove filter, ${token.propertyLabel} ${token.operator} ${token.value}`,
+            enteredTextLabel: text => `Use: "${text}"`,
+          }}
+        />
+
+        <h2>
+          Filtered items ({items.length} / {allItems.length})
+        </h2>
+        <h3>Current query</h3>
+        <pre>{JSON.stringify(propertyFilterProps.query, null, 2)}</pre>
+        <table style={{ borderCollapse: 'collapse', width: '100%', marginTop: 8 }}>
+          <thead>
+            <tr>
+              <th style={{ border: '1px solid #ccc', padding: 8, textAlign: 'left' }}>Name</th>
+              <th style={{ border: '1px solid #ccc', padding: 8, textAlign: 'left' }}>Environment</th>
+              <th style={{ border: '1px solid #ccc', padding: 8, textAlign: 'left' }}>Owner</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item, i) => (
+              <tr key={i}>
+                <td style={{ border: '1px solid #ccc', padding: 8 }}>{item.name}</td>
+                <td style={{ border: '1px solid #ccc', padding: 8 }}>{item.env}</td>
+                <td style={{ border: '1px solid #ccc', padding: 8 }}>{item.owner}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </I18nProvider>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -23382,7 +23382,7 @@ Use the \`onLoadItems\` event to perform a recovery action (for example, retryin
     {
       "description": "An object configuring the operators for free text filtering, which has the following properties:
 
-* operators [Array]: A list of all operators supported for free text filtering. Each entry is either an operator string, or an object with an \`operator\` string and an optional \`match\` function \`(item, text) => boolean\` for custom matching. Custom operator strings are supported and are appended after the built-in operators. If you omit the contains operator because your API does not support it, make sure to set \`defaultOperator\` to a supported operator from this list.
+* operators [Array]: A list of all operators supported for free text filtering. Each entry is either an operator string, or an object with an \`operator\` string and the following optional properties: a \`match\` function \`(item, text) => boolean\` for custom matching, and a \`description\` string shown next to the operator in the operator dropdown. Custom operator strings are supported and are appended after the built-in operators. If you omit the contains operator because your API does not support it, make sure to set \`defaultOperator\` to a supported operator from this list.
 * defaultOperator [ComparisonOperator]: An optional parameter that changes the default operator used for free text filtering. Use this parameter only if your API does not support "contains" free test filtering terms.",
       "inlineType": {
         "name": "PropertyFilterFreeTextFiltering",

--- a/src/property-filter/__tests__/property-filter-controller.test.ts
+++ b/src/property-filter/__tests__/property-filter-controller.test.ts
@@ -68,6 +68,7 @@ const defaultFreeTextFiltering: InternalFreeTextFiltering = {
   disabled: false,
   operators: [':', '!:'],
   defaultOperator: ':',
+  getOperatorDescription: () => null,
 };
 
 const customGroupText: readonly GroupText[] = [

--- a/src/property-filter/__tests__/property-filter-token-editor.test.tsx
+++ b/src/property-filter/__tests__/property-filter-token-editor.test.tsx
@@ -272,6 +272,48 @@ describe.each([false, true])('token editor, expandToViewport=%s', expandToViewpo
       ).toEqual(['=Equals', '!=Does not equal', ':Contains', '!:Does not contain']);
     });
 
+    test('uses custom descriptions provided for free text operators', () => {
+      renderComponent({
+        freeTextFiltering: {
+          operators: [
+            { operator: '=', description: 'Exact match' },
+            { operator: ':', description: 'Includes' },
+            // custom operator string with a description and no built-in i18n fallback
+            { operator: '~', description: 'Matches regex' },
+          ],
+        },
+        query: { tokens: [{ value: 'first', operator: '=' }], operation: 'or' },
+      });
+      const editor = openEditor(0, { expandToViewport });
+      // The token trigger shows the operator symbol together with its custom description.
+      expect(editor.operatorField().getElement()).toHaveTextContent('=Exact match');
+      act(() => editor.operatorSelect().openDropdown());
+      expect(
+        editor
+          .operatorSelect()
+          .findDropdown()
+          .findOptions()!
+          .map(optionWrapper => optionWrapper.getElement().textContent)
+      ).toEqual(['=Exact match', ':Includes', '~Matches regex']);
+    });
+
+    test('falls back to the built-in description when no custom free text description is provided', () => {
+      renderComponent({
+        // Mixed: `=` carries a custom description, `:` relies on the built-in i18n description.
+        freeTextFiltering: { operators: [{ operator: '=', description: 'Exact match' }, ':'] },
+        query: { tokens: [{ value: 'first', operator: ':' }], operation: 'or' },
+      });
+      const editor = openEditor(0, { expandToViewport });
+      act(() => editor.operatorSelect().openDropdown());
+      expect(
+        editor
+          .operatorSelect()
+          .findDropdown()
+          .findOptions()!
+          .map(optionWrapper => optionWrapper.getElement().textContent)
+      ).toEqual(['=Exact match', ':Contains']);
+    });
+
     test('enables client-side filtering on property options', () => {
       renderComponent({
         query: { tokens: [{ propertyKey: 'string', value: 'first', operator: ':' }], operation: 'or' },

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -144,7 +144,7 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
   /**
    * An object configuring the operators for free text filtering, which has the following properties:
    *
-   * * operators [Array]: A list of all operators supported for free text filtering. Each entry is either an operator string, or an object with an `operator` string and an optional `match` function `(item, text) => boolean` for custom matching. Custom operator strings are supported and are appended after the built-in operators. If you omit the contains operator because your API does not support it, make sure to set `defaultOperator` to a supported operator from this list.
+   * * operators [Array]: A list of all operators supported for free text filtering. Each entry is either an operator string, or an object with an `operator` string and the following optional properties: a `match` function `(item, text) => boolean` for custom matching, and a `description` string shown next to the operator in the operator dropdown. Custom operator strings are supported and are appended after the built-in operators. If you omit the contains operator because your API does not support it, make sure to set `defaultOperator` to a supported operator from this list.
    * * defaultOperator [ComparisonOperator]: An optional parameter that changes the default operator used for free text filtering. Use this parameter only if your API does not support "contains" free test filtering terms.
    */
   freeTextFiltering?: PropertyFilterProps.FreeTextFiltering;
@@ -245,6 +245,12 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
 export interface PropertyFilterTextOperatorExtended {
   operator: PropertyFilterOperator;
   match?: (item: unknown, text: string) => boolean;
+  /**
+   * A human-readable description shown next to the operator in the operator dropdown. Use it to describe a
+   * custom free-text operator (for example `~` as "Matches regex"), or to override the built-in description
+   * of a predefined operator (for example, describing `=` as "Exact match" for free text filtering).
+   */
+  description?: string;
 }
 // TODO: replace with PropertyFilterFreeTextFiltering from collection-hooks once it is released
 export interface PropertyFilterFreeTextFiltering {

--- a/src/property-filter/internal-interfaces.ts
+++ b/src/property-filter/internal-interfaces.ts
@@ -40,6 +40,7 @@ export interface InternalFreeTextFiltering {
   disabled: boolean;
   operators: readonly (PropertyFilterOperator | PropertyFilterTextOperatorExtended)[];
   defaultOperator: PropertyFilterOperator;
+  getOperatorDescription: (operator: PropertyFilterOperator) => string | null;
 }
 
 export interface InternalToken<TokenValue = any> {

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -29,6 +29,7 @@ import {
   ExtendedOperator,
   FilteringProperty,
   PropertyFilterProps,
+  PropertyFilterTextOperatorExtended,
   Ref,
   Token,
   TokenGroup,
@@ -187,10 +188,16 @@ const PropertyFilterInternal = React.forwardRef(
         tokens: (enableTokenGroups && query.tokenGroups ? query.tokenGroups : query.tokens).map(transformToken),
       };
 
+      const freeTextOperators = freeTextFiltering?.operators ?? [':', '!:'];
+      const extendedFreeTextOperators = freeTextOperators.reduce(
+        (acc, operator) => (typeof operator === 'object' ? acc.set(operator.operator, operator) : acc),
+        new Map<PropertyFilterOperator, PropertyFilterTextOperatorExtended>()
+      );
       const internalFreeText: InternalFreeTextFiltering = {
         disabled: disableFreeTextFiltering,
-        operators: freeTextFiltering?.operators ?? [':', '!:'],
+        operators: freeTextOperators,
         defaultOperator: freeTextFiltering?.defaultOperator ?? ':',
+        getOperatorDescription: operator => extendedFreeTextOperators.get(operator)?.description ?? null,
       };
 
       return { internalProperties: [...propertyByKey.values()], internalOptions, internalQuery, internalFreeText };

--- a/src/property-filter/token-editor-inputs.tsx
+++ b/src/property-filter/token-editor-inputs.tsx
@@ -103,6 +103,12 @@ export function OperatorInput({
     if (property) {
       return operatorToDescription(op, i18nStrings, property);
     }
+    // Prefer an explicit free-text operator description when the consumer provides one.
+    const freeTextDescription = freeTextFiltering.getOperatorDescription(op);
+    if (freeTextDescription) {
+      return freeTextDescription;
+    }
+    // Fall back to reusing a matching property operator description, then to the built-in i18n string.
     const freeTextProperty = filteringProperties.find(prop => prop.getOperatorDescription(op) !== null);
     return operatorToDescription(op, i18nStrings, freeTextProperty);
   };


### PR DESCRIPTION
### Description

Let consumers control the operator used for free-text filtering in `PropertyFilter`, and expose it for custom handling.

The base `freeTextFiltering` API (`operators`, `defaultOperator`) already lets consumers pick which operators are available for free text and which is the default (for example `contains` vs `equals` vs `starts-with`). However, free-text operators could not carry a consumer-provided **description** the way property operators can (`PropertyFilterProps.FilteringProperty` operators accept `description`). As a result:

- Custom free-text operator strings (for example `~`) showed an **empty** description in the operator dropdown.
- Consumers could not override the built-in description of a predefined free-text operator.
- The token editor worked around this with a fragile heuristic that searched **all** filtering properties for one that happened to define a custom description for the same operator, then reused it for free text.

This PR adds an opt-in `description` field to the free-text extended operator object and wires it through the token editor operator dropdown, mirroring the existing property-operator `description` pattern.

**What changed**
- `PropertyFilterTextOperatorExtended` now accepts an optional `description` string.
- `InternalFreeTextFiltering` gains a `getOperatorDescription(operator)` resolver, built from the extended free-text operators in `internal.tsx` (same pattern as `InternalFilteringProperty.getOperatorDescription`).
- `OperatorInput` (token editor) prefers the explicit free-text description, then falls back to the previous property-reuse heuristic, then to the built-in i18n string — so existing behavior is preserved.

**Backward compatibility:** fully backward compatible — `description` is a new optional field; when omitted, the built-in i18n descriptions are used exactly as before.

Related links, issue #: SIM AWSUI-61808.

> ⚠️ **Ticket mismatch note:** SIM/Taskei `AWSUI-61808` currently resolves to *"More flexible board components"* (Core / Roadmap), which is unrelated to the PropertyFilter free-text operator work described in the task. This PR was implemented per the provided task description (free-text operator control / custom handling) rather than the board-components ticket content. Flagging so the ticket link can be corrected.

### How has this been tested?

- **Unit tests** (`src/property-filter/__tests__/property-filter-token-editor.test.tsx`):
  - `uses custom descriptions provided for free text operators` — verifies the free-text operator dropdown (and token trigger) shows consumer-provided descriptions, including for a custom `~` operator with no built-in i18n fallback.
  - `falls back to the built-in description when no custom free text description is provided` — verifies mixed operators (custom description + built-in) resolve correctly.
- Full `src/property-filter` unit suite: **349 passed / 17 suites**.
- `quick-build` (TypeScript + styles): green.
- `eslint` on all changed files: no errors.
- **Dev page** for manual/visual testing: `pages/property-filter/property-filter-freetext-operator.page.tsx` demonstrates `defaultOperator: '='`, custom descriptions on `=`/`:`/`^`, and a custom `~` free-text operator with a `match` function and description.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ — JSDoc updated for `freeTextFiltering.operators` and the new `description` field.
- _Changes are backward-compatible if not indicated._ — Yes, new optional field only.
- _Changes do not include unsupported browser features._ — Yes.
- _Changes were manually tested for accessibility._ — Operator descriptions surface in the existing Select control; token trigger text updated accordingly.

#### Security

- _If the code handles URLs: all URLs are validated through the `checkSafeUrl` function._ — N/A (no URL handling).

#### Testing

- _Changes are covered with new/existing unit tests?_ — Yes (2 new unit tests + existing suite).
- _Changes are covered with new/existing integration tests?_ — Existing integration tests unaffected; a dev page is provided for manual verification.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
