### PR TITLE
feat: add selectable variant to List component

### DIFF
--- a/pages/list/selectable.page.tsx
+++ b/pages/list/selectable.page.tsx
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import { Box, SpaceBetween } from '~components';
+import List, { ListProps } from '~components/list';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+interface Item {
+  id: string;
+  content: string;
+  description?: string;
+  disabled?: boolean;
+}
+
+const items: Item[] = [
+  { id: 'apples', content: 'Apples', description: 'Crisp and sweet' },
+  { id: 'bananas', content: 'Bananas', description: 'Rich in potassium' },
+  { id: 'cherries', content: 'Cherries', description: 'Currently out of stock', disabled: true },
+  { id: 'dates', content: 'Dates', description: 'Naturally sweet' },
+  { id: 'elderberries', content: 'Elderberries', description: 'Best cooked' },
+];
+
+const renderItem = (item: Item): ReturnType<ListProps<Item>['renderItem']> => ({
+  id: item.id,
+  content: item.content,
+  secondaryContent: item.description && <Box variant="small">{item.description}</Box>,
+});
+
+export default function SelectableListPage() {
+  const [singleSelected, setSingleSelected] = useState<ReadonlyArray<Item>>([items[0]]);
+  const [multiSelected, setMultiSelected] = useState<ReadonlyArray<Item>>([items[1], items[3]]);
+
+  return (
+    <ScreenshotArea>
+      <h1>Selectable list</h1>
+      <SpaceBetween size="l">
+        <div>
+          <h2 id="single-heading">Single selection</h2>
+          <List
+            ariaLabelledby="single-heading"
+            selectionType="single"
+            items={items}
+            renderItem={renderItem}
+            isItemDisabled={item => !!item.disabled}
+            selectedItems={singleSelected}
+            onSelectionChange={({ detail }) => setSingleSelected(detail.selectedItems)}
+          />
+          <Box variant="small">Selected: {singleSelected.map(item => item.content).join(', ') || 'none'}</Box>
+        </div>
+
+        <div>
+          <h2 id="multi-heading">Multi selection</h2>
+          <List
+            ariaLabelledby="multi-heading"
+            selectionType="multi"
+            items={items}
+            renderItem={renderItem}
+            isItemDisabled={item => !!item.disabled}
+            selectedItems={multiSelected}
+            onSelectionChange={({ detail }) => setMultiSelected(detail.selectedItems)}
+          />
+          <Box variant="small">Selected: {multiSelected.map(item => item.content).join(', ') || 'none'}</Box>
+        </div>
+      </SpaceBetween>
+    </ScreenshotArea>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -18588,6 +18588,23 @@ exports[`Components definition for list matches the snapshot: list 1`] = `
   "events": [
     {
       "cancelable": false,
+      "description": "Called when the selection changes. The event \`detail\` contains the updated \`selectedItems\`.",
+      "detailInlineType": {
+        "name": "ListProps.SelectionChangeDetail<T>",
+        "properties": [
+          {
+            "name": "selectedItems",
+            "optional": false,
+            "type": "ReadonlyArray<T>",
+          },
+        ],
+        "type": "object",
+      },
+      "detailType": "ListProps.SelectionChangeDetail<T>",
+      "name": "onSelectionChange",
+    },
+    {
+      "cancelable": false,
       "description": "Called when items are reordered in a sortable list.",
       "detailInlineType": {
         "name": "ListProps.SortingState<T>",
@@ -18741,6 +18758,24 @@ exports[`Components definition for list matches the snapshot: list 1`] = `
       "type": "DndAreaI18nStrings",
     },
     {
+      "description": "A function that determines whether a given item can be selected. Return \`true\` to
+prevent an item from being selected.",
+      "inlineType": {
+        "name": "(item: T) => boolean",
+        "parameters": [
+          {
+            "name": "item",
+            "type": "T",
+          },
+        ],
+        "returnType": "boolean",
+        "type": "function",
+      },
+      "name": "isItemDisabled",
+      "optional": true,
+      "type": "((item: T) => boolean)",
+    },
+    {
       "description": "The items to display in the list.",
       "name": "items",
       "optional": false,
@@ -18769,6 +18804,32 @@ exports[`Components definition for list matches the snapshot: list 1`] = `
       "name": "renderItem",
       "optional": false,
       "type": "(item: T) => { id: string; content: React.ReactNode; secondaryContent?: React.ReactNode; icon?: React.ReactNode; actions?: React.ReactNode; announcementLabel?: string | undefined; }",
+    },
+    {
+      "description": "The currently selected items. Use together with \`selectionType\` and \`onSelectionChange\`
+to control the selection state. Items are matched using the \`id\` returned by \`renderItem\`.",
+      "name": "selectedItems",
+      "optional": true,
+      "type": "ReadonlyArray<T>",
+    },
+    {
+      "description": "Enables item selection and defines the selection behavior:
+* \`single\` - Only one item can be selected at a time (renders as a radio control).
+* \`multi\` - Multiple items can be selected at a time (renders as a checkbox control).
+
+When set, the list is rendered as an ARIA \`listbox\` and each item as an \`option\`.
+Selection is not supported together with \`sortable\`; when both are provided, sorting takes precedence.",
+      "inlineType": {
+        "name": "ListProps.SelectionType",
+        "type": "union",
+        "values": [
+          "single",
+          "multi",
+        ],
+      },
+      "name": "selectionType",
+      "optional": true,
+      "type": "string",
     },
     {
       "description": "Makes the list sortable by enabling drag and drop functionality.",
@@ -41775,6 +41836,20 @@ The dismiss button is only rendered when the \`dismissible\` property is set to 
             ],
           },
         },
+        {
+          "description": "Returns all currently selected items. Only meaningful for selectable lists.",
+          "name": "findSelectedItems",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ListItemWrapper",
+              },
+            ],
+          },
+        },
       ],
       "name": "ListWrapper",
     },
@@ -41846,6 +41921,20 @@ The dismiss button is only rendered when the \`dismissible\` property is set to 
             "name": "StructuredItemWrapper.findSecondaryContent",
           },
           "name": "findSecondaryContent",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns the selection control (checkbox or radio) for a selectable list item, if present.",
+          "name": "findSelectionControl",
           "parameters": [],
           "returnType": {
             "isNullable": true,
@@ -51998,6 +52087,20 @@ The dismiss button is only rendered when the \`dismissible\` property is set to 
             ],
           },
         },
+        {
+          "description": "Returns all currently selected items. Only meaningful for selectable lists.",
+          "name": "findSelectedItems",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ListItemWrapper",
+              },
+            ],
+          },
+        },
       ],
       "name": "ListWrapper",
     },
@@ -52049,6 +52152,15 @@ The dismiss button is only rendered when the \`dismissible\` property is set to 
             "name": "StructuredItemWrapper.findSecondaryContent",
           },
           "name": "findSecondaryContent",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "description": "Returns the selection control (checkbox or radio) for a selectable list item, if present.",
+          "name": "findSelectionControl",
           "parameters": [],
           "returnType": {
             "isNullable": false,

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -469,6 +469,8 @@ exports[`test-utils selectors 1`] = `
   "list": [
     "awsui_item_rckk5",
     "awsui_root_rckk5",
+    "awsui_selected_rckk5",
+    "awsui_selection-control_rckk5",
   ],
   "live-region": [
     "awsui_root_1pc7b",

--- a/src/list/__tests__/list-selectable.test.tsx
+++ b/src/list/__tests__/list-selectable.test.tsx
@@ -1,0 +1,190 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+
+import { KeyCode } from '../../../lib/components/internal/keycode';
+import List, { ListProps } from '../../../lib/components/list';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import { ListItemWrapper } from '../../../lib/components/test-utils/dom/list';
+
+interface Item {
+  id: string;
+  content: string;
+  disabled?: boolean;
+}
+
+const defaultItems: Item[] = [
+  { id: 'item1', content: 'Item 1' },
+  { id: 'item2', content: 'Item 2' },
+  { id: 'item3', content: 'Item 3', disabled: true },
+  { id: 'item4', content: 'Item 4' },
+];
+
+const renderItemFn = (item: Item) => ({ id: item.id, content: item.content });
+
+const isSelected = (item: ListItemWrapper) => item.getElement().getAttribute('aria-selected') === 'true';
+
+function StatefulList(props: Partial<ListProps<Item>> & { selectionType: ListProps.SelectionType }) {
+  const [selectedItems, setSelectedItems] = useState<ReadonlyArray<Item>>(props.selectedItems ?? []);
+  return (
+    <List
+      items={defaultItems}
+      renderItem={renderItemFn}
+      isItemDisabled={item => !!item.disabled}
+      {...props}
+      selectedItems={selectedItems}
+      onSelectionChange={event => {
+        setSelectedItems(event.detail.selectedItems);
+        props.onSelectionChange?.(event);
+      }}
+    />
+  );
+}
+
+const renderList = (props: Partial<ListProps<Item>> & { selectionType: ListProps.SelectionType }) => {
+  const renderResult = render(<StatefulList {...props} />);
+  return {
+    wrapper: createWrapper(renderResult.container).findList()!,
+    rerender: renderResult.rerender,
+  };
+};
+
+describe('List - selectable variant', () => {
+  test('renders as a listbox with options when selectionType is set', () => {
+    const { wrapper } = renderList({ selectionType: 'multi' });
+    expect(wrapper.getElement()).toHaveAttribute('role', 'listbox');
+    const items = wrapper.findItems();
+    expect(items).toHaveLength(4);
+    items.forEach(item => expect(item.getElement()).toHaveAttribute('role', 'option'));
+  });
+
+  test('does not add listbox semantics when selectionType is not set (backward compatible)', () => {
+    const renderResult = render(<List items={defaultItems} renderItem={renderItemFn} />);
+    const wrapper = createWrapper(renderResult.container).findList()!;
+    expect(wrapper.getElement()).not.toHaveAttribute('role', 'listbox');
+    expect(wrapper.findItemByIndex(1)!.getElement()).not.toHaveAttribute('role', 'option');
+    expect(wrapper.findItemByIndex(1)!.findSelectionControl()).toBeNull();
+  });
+
+  test('sets aria-multiselectable for multi selection only', () => {
+    const { wrapper: multi } = renderList({ selectionType: 'multi' });
+    expect(multi.getElement()).toHaveAttribute('aria-multiselectable', 'true');
+
+    const { wrapper: single } = renderList({ selectionType: 'single' });
+    expect(single.getElement()).not.toHaveAttribute('aria-multiselectable');
+  });
+
+  test('renders a selection control for every item', () => {
+    const { wrapper } = renderList({ selectionType: 'multi' });
+    wrapper.findItems().forEach(item => expect(item.findSelectionControl()).not.toBeNull());
+  });
+
+  test('reflects the controlled selectedItems via aria-selected', () => {
+    const { wrapper } = renderList({ selectionType: 'multi', selectedItems: [defaultItems[0], defaultItems[3]] });
+    expect(isSelected(wrapper.findItemById('item1')!)).toBe(true);
+    expect(isSelected(wrapper.findItemById('item2')!)).toBe(false);
+    expect(isSelected(wrapper.findItemById('item4')!)).toBe(true);
+    expect(wrapper.findSelectedItems()).toHaveLength(2);
+  });
+
+  test('multi selection toggles items on click', () => {
+    const onSelectionChange = jest.fn();
+    const { wrapper } = renderList({ selectionType: 'multi', onSelectionChange });
+
+    wrapper.findItemById('item1')!.click();
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ detail: { selectedItems: [defaultItems[0]] } })
+    );
+    expect(isSelected(wrapper.findItemById('item1')!)).toBe(true);
+
+    wrapper.findItemById('item2')!.click();
+    expect(wrapper.findSelectedItems().map(i => i.getElement().getAttribute('data-testid'))).toEqual([
+      'item1',
+      'item2',
+    ]);
+
+    // toggling off
+    wrapper.findItemById('item1')!.click();
+    expect(isSelected(wrapper.findItemById('item1')!)).toBe(false);
+    expect(wrapper.findSelectedItems()).toHaveLength(1);
+  });
+
+  test('single selection replaces the selection and does not deselect on re-click', () => {
+    const onSelectionChange = jest.fn();
+    const { wrapper } = renderList({ selectionType: 'single', onSelectionChange });
+
+    wrapper.findItemById('item1')!.click();
+    expect(wrapper.findSelectedItems().map(i => i.getElement().getAttribute('data-testid'))).toEqual(['item1']);
+
+    wrapper.findItemById('item2')!.click();
+    expect(wrapper.findSelectedItems().map(i => i.getElement().getAttribute('data-testid'))).toEqual(['item2']);
+
+    onSelectionChange.mockClear();
+    // re-clicking the selected item keeps it selected and fires no event
+    wrapper.findItemById('item2')!.click();
+    expect(onSelectionChange).not.toHaveBeenCalled();
+    expect(isSelected(wrapper.findItemById('item2')!)).toBe(true);
+  });
+
+  test('does not select disabled items', () => {
+    const onSelectionChange = jest.fn();
+    const { wrapper } = renderList({ selectionType: 'multi', onSelectionChange });
+    const disabledItem = wrapper.findItemById('item3')!;
+    expect(disabledItem.getElement()).toHaveAttribute('aria-disabled', 'true');
+
+    disabledItem.click();
+    expect(onSelectionChange).not.toHaveBeenCalled();
+    expect(isSelected(disabledItem)).toBe(false);
+  });
+
+  test('toggles selection with Space and Enter keys', () => {
+    const { wrapper } = renderList({ selectionType: 'multi' });
+    const item1 = wrapper.findItemById('item1')!.getElement();
+
+    fireEvent.keyDown(item1, { keyCode: KeyCode.space });
+    expect(isSelected(wrapper.findItemById('item1')!)).toBe(true);
+
+    const item2 = wrapper.findItemById('item2')!.getElement();
+    fireEvent.keyDown(item2, { keyCode: KeyCode.enter });
+    expect(isSelected(wrapper.findItemById('item2')!)).toBe(true);
+  });
+
+  test('manages roving tabindex and arrow-key focus', () => {
+    const { wrapper } = renderList({ selectionType: 'single' });
+    const items = wrapper.findItems().map(i => i.getElement());
+
+    // first item is focusable by default
+    expect(items[0]).toHaveAttribute('tabindex', '0');
+    expect(items[1]).toHaveAttribute('tabindex', '-1');
+
+    fireEvent.keyDown(items[0], { keyCode: KeyCode.down });
+    expect(items[1]).toHaveAttribute('tabindex', '0');
+    expect(items[1]).toHaveFocus();
+
+    fireEvent.keyDown(items[1], { keyCode: KeyCode.up });
+    expect(items[0]).toHaveAttribute('tabindex', '0');
+    expect(items[0]).toHaveFocus();
+
+    fireEvent.keyDown(items[0], { keyCode: KeyCode.end });
+    expect(items[3]).toHaveFocus();
+
+    fireEvent.keyDown(items[3], { keyCode: KeyCode.home });
+    expect(items[0]).toHaveFocus();
+  });
+
+  test('sorting takes precedence over selection when both are set', () => {
+    const renderResult = render(
+      <List
+        items={defaultItems}
+        renderItem={renderItemFn}
+        selectionType="multi"
+        sortable={true}
+        onSortingChange={() => {}}
+      />
+    );
+    const wrapper = createWrapper(renderResult.container).findList()!;
+    expect(wrapper.getElement()).not.toHaveAttribute('role', 'listbox');
+    expect(wrapper.findItemByIndex(1)!.getElement()).not.toHaveAttribute('role', 'option');
+  });
+});

--- a/src/list/interfaces.ts
+++ b/src/list/interfaces.ts
@@ -57,6 +57,29 @@ export interface ListProps<T = any> {
    */
   sortDisabled?: boolean;
   /**
+   * Enables item selection and defines the selection behavior:
+   * * `single` - Only one item can be selected at a time (renders as a radio control).
+   * * `multi` - Multiple items can be selected at a time (renders as a checkbox control).
+   *
+   * When set, the list is rendered as an ARIA `listbox` and each item as an `option`.
+   * Selection is not supported together with `sortable`; when both are provided, sorting takes precedence.
+   */
+  selectionType?: ListProps.SelectionType;
+  /**
+   * The currently selected items. Use together with `selectionType` and `onSelectionChange`
+   * to control the selection state. Items are matched using the `id` returned by `renderItem`.
+   */
+  selectedItems?: ReadonlyArray<T>;
+  /**
+   * A function that determines whether a given item can be selected. Return `true` to
+   * prevent an item from being selected.
+   */
+  isItemDisabled?: (item: T) => boolean;
+  /**
+   * Called when the selection changes. The event `detail` contains the updated `selectedItems`.
+   */
+  onSelectionChange?: NonCancelableEventHandler<ListProps.SelectionChangeDetail<T>>;
+  /**
    * Removes padding around and inside list items.
    */
   disableItemPaddings?: boolean;
@@ -86,6 +109,12 @@ export interface ListProps<T = any> {
 export namespace ListProps {
   export interface SortingState<T> {
     items: ReadonlyArray<T>;
+  }
+
+  export type SelectionType = 'single' | 'multi';
+
+  export interface SelectionChangeDetail<T> {
+    selectedItems: ReadonlyArray<T>;
   }
 
   export type I18nStrings = DndAreaI18nStrings;

--- a/src/list/internal.tsx
+++ b/src/list/internal.tsx
@@ -1,10 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 import { useInternalI18n } from '../i18n/context';
 import { getBaseProps } from '../internal/base-component';
+import CheckboxIcon from '../internal/components/checkbox-icon';
 import InternalDragHandle from '../internal/components/drag-handle';
 import SortableArea from '../internal/components/sortable-area';
 import {
@@ -15,6 +16,7 @@ import {
 import InternalStructuredItem, { StructuredItemProps } from '../internal/components/structured-item';
 import { fireNonCancelableEvent } from '../internal/events';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import handleKey from '../internal/utils/handle-key';
 import { ListProps } from './interfaces';
 
 import styles from './styles.css.js';
@@ -29,11 +31,54 @@ const extractValidStructuredItemProps = ({ content, secondaryContent, icon, acti
   actions,
 });
 
+// Purely presentational selection control. Selection state is conveyed to
+// assistive technology via `aria-selected` on the enclosing `option`, so this
+// SVG is marked `aria-hidden`.
+function SelectionControl({
+  selectionType,
+  selected,
+  disabled,
+}: {
+  selectionType: ListProps.SelectionType;
+  selected: boolean;
+  disabled: boolean;
+}) {
+  return (
+    <span className={clsx(styles['selection-control'], testClasses['selection-control'])} aria-hidden="true">
+      {selectionType === 'multi' ? (
+        <CheckboxIcon checked={selected} disabled={disabled} />
+      ) : (
+        <svg viewBox="0 0 100 100" focusable="false" aria-hidden="true" className={styles['radio-icon']}>
+          <circle
+            className={clsx(styles['radio-border'], disabled && styles['radio-disabled'])}
+            strokeWidth={6.25}
+            cx={50}
+            cy={50}
+            r={46}
+          />
+          {selected && (
+            <circle
+              className={clsx(styles['radio-fill'], disabled && styles['radio-disabled'])}
+              cx={50}
+              cy={50}
+              r={25}
+            />
+          )}
+        </svg>
+      )}
+    </span>
+  );
+}
+
 export default function InternalList<T = any>({
   items,
   renderItem,
   sortable = false,
   sortDisabled = false,
+  selectionType,
+  selectedItems = [],
+  isItemDisabled,
+  onSelectionChange,
   tagOverride: Tag = sortable ? 'ol' : 'ul',
   ariaLabel,
   ariaLabelledby,
@@ -47,6 +92,43 @@ export default function InternalList<T = any>({
 }: InternalListProps<T>) {
   const baseProps = getBaseProps(rest);
   const i18n = useInternalI18n('list');
+
+  // Selection is only active for non-sortable lists.
+  const selectable = !!selectionType && !sortable;
+
+  const itemRefs = useRef<Array<HTMLLIElement | null>>([]);
+  const selectedIds = new Set(selectedItems.map(item => renderItem(item).id));
+  const firstSelectedIndex = items?.findIndex(item => selectedIds.has(renderItem(item).id)) ?? -1;
+  const [focusedIndex, setFocusedIndex] = useState(firstSelectedIndex > 0 ? firstSelectedIndex : 0);
+
+  const moveFocus = (nextIndex: number) => {
+    if (!items || items.length === 0) {
+      return;
+    }
+    const clamped = Math.max(0, Math.min(nextIndex, items.length - 1));
+    setFocusedIndex(clamped);
+    itemRefs.current[clamped]?.focus();
+  };
+
+  const toggleSelection = (item: T) => {
+    if (!onSelectionChange) {
+      return;
+    }
+    const id = renderItem(item).id;
+    let nextSelected: Array<T>;
+    if (selectionType === 'multi') {
+      nextSelected = selectedIds.has(id)
+        ? selectedItems.filter(selectedItem => renderItem(selectedItem).id !== id)
+        : [...selectedItems, item];
+    } else {
+      // Single selection: re-clicking the selected item keeps it selected.
+      if (selectedIds.has(id)) {
+        return;
+      }
+      nextSelected = [item];
+    }
+    fireNonCancelableEvent(onSelectionChange, { selectedItems: nextSelected });
+  };
 
   let contents: ReactNode;
   if (sortable) {
@@ -112,6 +194,74 @@ export default function InternalList<T = any>({
         }}
       />
     );
+  } else if (selectable) {
+    contents = items?.map((item, index) => {
+      const { id, ...structuredItemProps } = renderItem(item);
+      const selected = selectedIds.has(id);
+      const disabled = isItemDisabled?.(item) ?? false;
+
+      const onToggle = () => {
+        setFocusedIndex(index);
+        if (!disabled) {
+          toggleSelection(item);
+        }
+      };
+
+      return (
+        <li
+          key={id}
+          ref={element => {
+            itemRefs.current[index] = element;
+          }}
+          data-testid={id}
+          role="option"
+          aria-selected={selected}
+          aria-disabled={disabled || undefined}
+          tabIndex={index === focusedIndex ? 0 : -1}
+          className={clsx(
+            styles.item,
+            testClasses.item,
+            styles['selectable-item'],
+            selected && styles.selected,
+            selected && testClasses.selected,
+            disabled && styles['item-disabled'],
+            disablePaddings && styles['disable-paddings'],
+            disableItemPaddings && styles['disable-item-paddings']
+          )}
+          onClick={onToggle}
+          onKeyDown={event =>
+            handleKey(event as any, {
+              onBlockEnd: () => {
+                event.preventDefault();
+                moveFocus(index + 1);
+              },
+              onBlockStart: () => {
+                event.preventDefault();
+                moveFocus(index - 1);
+              },
+              onHome: () => {
+                event.preventDefault();
+                moveFocus(0);
+              },
+              onEnd: () => {
+                event.preventDefault();
+                moveFocus(items.length - 1);
+              },
+              onActivate: () => {
+                event.preventDefault();
+                onToggle();
+              },
+            })
+          }
+        >
+          <SelectionControl selectionType={selectionType!} selected={selected} disabled={disabled} />
+          <InternalStructuredItem
+            {...extractValidStructuredItemProps(structuredItemProps)}
+            disablePaddings={disableItemPaddings}
+          />
+        </li>
+      );
+    });
   } else {
     contents = items?.map(item => {
       const { id, ...structuredItemProps } = renderItem(item);
@@ -140,6 +290,8 @@ export default function InternalList<T = any>({
       ref={__internalRootRef}
       {...baseProps}
       className={clsx(baseProps.className, styles.root, testClasses.root)}
+      role={selectable ? 'listbox' : undefined}
+      aria-multiselectable={selectable && selectionType === 'multi' ? true : undefined}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
       aria-describedby={ariaDescribedby}

--- a/src/list/styles.scss
+++ b/src/list/styles.scss
@@ -37,3 +37,56 @@
     column-gap: awsui.$space-xxs;
   }
 }
+
+.selectable-item {
+  display: flex;
+  align-items: flex-start;
+  column-gap: awsui.$space-xs;
+  cursor: pointer;
+
+  &:not(.disable-item-paddings) {
+    padding-inline: awsui.$space-scaled-xs;
+  }
+
+  &.item-disabled {
+    cursor: default;
+  }
+
+  &.selected {
+    background-color: awsui.$color-background-item-selected;
+  }
+
+  &:focus {
+    outline: none;
+  }
+  &:focus-visible {
+    @include styles.focus-highlight(
+      2px,
+      awsui.$border-radius-control-default-focus-ring,
+      0 0 0 2px awsui.$color-border-item-focused
+    );
+  }
+}
+
+.selection-control {
+  display: flex;
+  align-items: center;
+  block-size: awsui.$line-height-body-m;
+  flex-shrink: 0;
+}
+
+.radio-icon {
+  inline-size: 14px;
+  block-size: 14px;
+}
+.radio-border {
+  fill: awsui.$color-background-control-default;
+  stroke: awsui.$color-border-control-default;
+}
+.radio-fill {
+  fill: awsui.$color-background-control-checked;
+}
+.radio-disabled {
+  fill: awsui.$color-background-control-disabled;
+  stroke: awsui.$color-background-control-disabled;
+}

--- a/src/list/test-classes/styles.scss
+++ b/src/list/test-classes/styles.scss
@@ -4,6 +4,8 @@
 */
 
 .root,
-.item {
+.item,
+.selection-control,
+.selected {
   /* used in test-utils */
 }

--- a/src/test-utils/dom/list/index.ts
+++ b/src/test-utils/dom/list/index.ts
@@ -11,6 +11,12 @@ export class ListItemWrapper extends StructuredItemWrapper {
   findDragHandle(): ElementWrapper | null {
     return this.findByClassName(dragHandleStyles.root);
   }
+  /**
+   * Returns the selection control (checkbox or radio) for a selectable list item, if present.
+   */
+  findSelectionControl(): ElementWrapper | null {
+    return this.findByClassName(styles['selection-control']);
+  }
 }
 
 export default class ListWrapper extends ComponentWrapper {
@@ -35,5 +41,11 @@ export default class ListWrapper extends ComponentWrapper {
    */
   findItemById(id: string): ListItemWrapper | null {
     return this.findComponent(`.${styles.item}[data-testid="${id}"]`, ListItemWrapper);
+  }
+  /**
+   * Returns all currently selected items. Only meaningful for selectable lists.
+   */
+  findSelectedItems(): Array<ListItemWrapper> {
+    return this.findAllByClassName(styles.selected).map(wrapper => new ListItemWrapper(wrapper.getElement()));
   }
 }


### PR DESCRIPTION
### Description

Adds an opt-in **selectable variant** to the `List` component (SIM AWSUI-62052), enabling users to choose from a set of predefined options without reaching for `Table` or `Cards` for simple selectable lists.

New (fully backward-compatible) props:

- `selectionType?: 'single' | 'multi'` — enables selection. When unset, `List` behaves exactly as before.
- `selectedItems?: ReadonlyArray<T>` — controlled selection (items matched by the `id` returned from `renderItem`).
- `onSelectionChange?: NonCancelableEventHandler<ListProps.SelectionChangeDetail<T>>` — fires with the updated `selectedItems`.
- `isItemDisabled?: (item: T) => boolean` — prevents selection of individual items.

Behavior / accessibility:

- When `selectionType` is set (and the list is not `sortable`), the container renders as `role="listbox"` with `aria-multiselectable` for multi-select, and each item renders as `role="option"` with `aria-selected` / `aria-disabled`.
- Keyboard support: roving `tabindex`, Up/Down/Home/End to move focus, Space/Enter to toggle selection.
- `multi` renders a checkbox control (reusing the internal `CheckboxIcon`); `single` renders a radio control. Controls are `aria-hidden` since state is conveyed via `aria-selected`.
- Selection is not combined with `sortable`; when both are provided, sorting takes precedence.

Test-utils: `ListItemWrapper.findSelectionControl()` and `ListWrapper.findSelectedItems()` added (dom + selectors).

Related links, issue #, if available: AWSUI-62052

### How has this been tested?

- New unit test suite `src/list/__tests__/list-selectable.test.tsx` (11 tests): listbox/option roles, `aria-multiselectable`, controlled selection, single vs multi toggle semantics, disabled items, Space/Enter toggle, roving tabindex + arrow-key focus, and sortable-takes-precedence. All 31 List unit tests pass.
- New dev page `pages/list/selectable.page.tsx` demonstrating controlled single and multi selection with disabled items.
- `quick-build`, `eslint`, and `stylelint` are green. Documenter API + test-utils snapshots regenerated.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
