### PR TITLE
feat: Table bulk inline edit (v0, AWSUI-56121) [WIP]

### DIFF
--- a/pages/table/bulk-editable.page.tsx
+++ b/pages/table/bulk-editable.page.tsx
@@ -1,0 +1,141 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import { Box, Button, Header, Input, SpaceBetween, StatusIndicator } from '~components';
+import Table, { TableProps } from '~components/table';
+// WIP (AWSUI-56121): the bulk-editing controller is not yet public API. This dev page
+// imports it directly to demonstrate the intended UX until it is wired into the Table
+// render path (see follow-ups in the PR description).
+import { useBulkEditing } from '~components/table/use-bulk-editing';
+
+import { DistributionInfo, initialItems } from './editable-data';
+
+const ariaLabels: TableProps.AriaLabels<DistributionInfo> = {
+  tableLabel: 'Distributions',
+  activateEditLabel: (column, item) => `Edit ${item.Id} ${column.header}`,
+  cancelEditLabel: column => `Cancel editing ${column.header}`,
+  submitEditLabel: column => `Submit edit ${column.header}`,
+  submittingEditText: () => 'Loading edit response',
+  successfulEditLabel: () => 'Edit successful',
+};
+
+export default function BulkEditablePage() {
+  const [items, setItems] = useState(initialItems);
+  const [lastCommit, setLastCommit] = useState<string>('');
+
+  const bulkEditConfig: TableProps.BulkEditConfig<DistributionInfo> = {
+    activateBulkEditLabel: 'Edit all rows',
+    submitBulkEditLabel: 'Save all changes',
+    cancelBulkEditLabel: 'Discard all changes',
+    onSubmit: async ({ changes }) => {
+      // Simulate a server round-trip.
+      await new Promise(resolve => setTimeout(resolve, 600));
+      setItems(prev =>
+        prev.map(item => {
+          const itemChanges = changes.filter(change => change.item.Id === item.Id);
+          if (itemChanges.length === 0) {
+            return item;
+          }
+          const updated = { ...item };
+          for (const change of itemChanges) {
+            (updated as Record<string, unknown>)[change.column.id!] = change.newValue;
+          }
+          return updated;
+        })
+      );
+      setLastCommit(`Committed ${changes.length} cell change(s) at ${new Date().toLocaleTimeString()}`);
+    },
+  };
+
+  // WIP: standalone controller wired to a plain <Table> with editable columns.
+  const bulkEditing = useBulkEditing<DistributionInfo>({
+    items,
+    trackBy: 'Id',
+    columnDefinitions: [],
+    bulkEdit: bulkEditConfig,
+  });
+
+  const editableColumn = (
+    id: keyof DistributionInfo & string,
+    header: string
+  ): TableProps.ColumnDefinition<DistributionInfo> => ({
+    id,
+    header,
+    minWidth: 200,
+    cell: item => {
+      const rowId = item.Id;
+      if (!bulkEditing.isActive) {
+        return String(item[id] ?? '');
+      }
+      const { isDirty, value } = bulkEditing.getCellValue(rowId, id);
+      const current = isDirty ? String(value ?? '') : String(item[id] ?? '');
+      return (
+        <Input
+          value={current}
+          ariaLabel={`${header} for ${rowId}`}
+          onChange={event => bulkEditing.setCellValue(rowId, id, event.detail.value)}
+        />
+      );
+    },
+  });
+
+  const columnDefinitions: TableProps.ColumnDefinition<DistributionInfo>[] = [
+    { id: 'Id', header: 'Distribution ID', width: 180, cell: item => item.Id },
+    editableColumn('DomainName', 'Domain name'),
+    editableColumn('Origin', 'Origin'),
+    editableColumn('Status', 'Status'),
+  ];
+
+  return (
+    <Box margin="s">
+      <SpaceBetween size="m">
+        <Header
+          variant="h1"
+          actions={
+            !bulkEditing.isActive ? (
+              <Button data-testid="start-bulk-edit" onClick={() => bulkEditing.startBulkEdit()}>
+                {bulkEditConfig.activateBulkEditLabel}
+              </Button>
+            ) : (
+              <SpaceBetween size="xs" direction="horizontal">
+                <Button
+                  data-testid="cancel-bulk-edit"
+                  disabled={bulkEditing.isSubmitting}
+                  onClick={() => bulkEditing.discardBulkEdit()}
+                >
+                  {bulkEditConfig.cancelBulkEditLabel}
+                </Button>
+                <Button
+                  data-testid="submit-bulk-edit"
+                  variant="primary"
+                  loading={bulkEditing.isSubmitting}
+                  disabled={!bulkEditing.hasChanges}
+                  onClick={() => bulkEditing.submitBulkEdit()}
+                >
+                  {bulkEditConfig.submitBulkEditLabel} ({bulkEditing.dirtyCellCount})
+                </Button>
+              </SpaceBetween>
+            )
+          }
+        >
+          Bulk inline edit (WIP)
+        </Header>
+
+        {lastCommit && (
+          <StatusIndicator type="success" data-testid="last-commit">
+            {lastCommit}
+          </StatusIndicator>
+        )}
+
+        <Table
+          trackBy="Id"
+          items={items}
+          columnDefinitions={columnDefinitions}
+          ariaLabels={ariaLabels}
+          bulkEdit={bulkEditConfig}
+        />
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/pages/table/bulk-editable.page.tsx
+++ b/pages/table/bulk-editable.page.tsx
@@ -122,11 +122,11 @@ export default function BulkEditablePage() {
           Bulk inline edit (WIP)
         </Header>
 
-        {lastCommit && (
+        {lastCommit ? (
           <StatusIndicator type="success" data-testid="last-commit">
             {lastCommit}
           </StatusIndicator>
-        )}
+        ) : null}
 
         <Table
           trackBy="Id"

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -28443,6 +28443,60 @@ in tables with data grouping.
       "type": "TableProps.AriaLabels<T>",
     },
     {
+      "description": "**(WIP - AWSUI-56121)** Opt-in configuration that enables bulk inline editing, allowing
+multiple editable cells to be edited simultaneously and committed together, rather than
+one cell at a time. This is additive to per-column \`editConfig\`: a column must define
+\`editConfig\` to participate in bulk editing.
+
+The configuration object consists of:
+* \`onSubmit\` ((detail: BulkEditSubmitDetail<T>) => Promise<void> | void) - Called when the user commits
+  all pending edits. Receives every changed cell as a \`BulkEditChange\`. Return a promise to keep the
+  table in a submitting state while the request is in progress.
+* \`activateBulkEditLabel\` (optional, string) - Label for the control that enters bulk-edit mode.
+* \`submitBulkEditLabel\` (optional, string) - Label for the control that commits all pending edits.
+* \`cancelBulkEditLabel\` (optional, string) - Label for the control that discards all pending edits.",
+      "inlineType": {
+        "name": "TableProps.BulkEditConfig<T, unknown>",
+        "properties": [
+          {
+            "name": "activateBulkEditLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "cancelBulkEditLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "inlineType": {
+              "name": "(detail: TableProps.BulkEditSubmitDetail<ItemType, ValueType>) => void | Promise<void>",
+              "parameters": [
+                {
+                  "name": "detail",
+                  "type": "TableProps.BulkEditSubmitDetail<ItemType, ValueType>",
+                },
+              ],
+              "returnType": "void | Promise<void>",
+              "type": "function",
+            },
+            "name": "onSubmit",
+            "optional": false,
+            "type": "(detail: TableProps.BulkEditSubmitDetail<ItemType, ValueType>) => void | Promise<void>",
+          },
+          {
+            "name": "submitBulkEditLabel",
+            "optional": true,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "bulkEdit",
+      "optional": true,
+      "type": "TableProps.BulkEditConfig<T, unknown>",
+    },
+    {
       "defaultValue": "'middle'",
       "description": "Determines the alignment of the content inside table cells.
 This property affects all cells, including the ones in the selection column.

--- a/src/table/__tests__/use-bulk-editing.test.tsx
+++ b/src/table/__tests__/use-bulk-editing.test.tsx
@@ -1,0 +1,103 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { act, renderHook } from '../../__tests__/render-hook';
+import { TableProps } from '../interfaces';
+import { useBulkEditing } from '../use-bulk-editing';
+
+interface Item {
+  id: string;
+  name: string;
+  size: number;
+}
+
+const items: Item[] = [
+  { id: 'i-1', name: 'alpha', size: 1 },
+  { id: 'i-2', name: 'beta', size: 2 },
+];
+
+const columnDefinitions: TableProps.ColumnDefinition<Item>[] = [
+  { id: 'name', header: 'Name', cell: item => item.name, editConfig: { editingCell: () => null } },
+  { id: 'size', header: 'Size', cell: item => item.size, editConfig: { editingCell: () => null } },
+];
+
+function setup(bulkEdit?: TableProps.BulkEditConfig<Item>) {
+  return renderHook(() => useBulkEditing<Item>({ items, trackBy: 'id', columnDefinitions, bulkEdit }));
+}
+
+describe('useBulkEditing (WIP AWSUI-56121)', () => {
+  test('is disabled and inactive when no bulkEdit config is provided', () => {
+    const { result } = setup(undefined);
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.isActive).toBe(false);
+
+    act(() => result.current.startBulkEdit());
+    // Cannot enter bulk-edit mode when disabled.
+    expect(result.current.isActive).toBe(false);
+  });
+
+  test('enters and exits bulk-edit mode', () => {
+    const { result } = setup({ onSubmit: () => {} });
+    expect(result.current.isActive).toBe(false);
+
+    act(() => result.current.startBulkEdit());
+    expect(result.current.isActive).toBe(true);
+    expect(result.current.hasChanges).toBe(false);
+
+    act(() => result.current.discardBulkEdit());
+    expect(result.current.isActive).toBe(false);
+  });
+
+  test('tracks dirty cells and clears them', () => {
+    const { result } = setup({ onSubmit: () => {} });
+    act(() => result.current.startBulkEdit());
+
+    act(() => result.current.setCellValue('i-1', 'name', 'ALPHA'));
+    act(() => result.current.setCellValue('i-2', 'size', 20));
+    expect(result.current.dirtyCellCount).toBe(2);
+    expect(result.current.hasChanges).toBe(true);
+    expect(result.current.getCellValue('i-1', 'name')).toEqual({ isDirty: true, value: 'ALPHA' });
+    expect(result.current.getCellValue('i-1', 'size')).toEqual({ isDirty: false, value: undefined });
+
+    act(() => result.current.clearCellValue('i-1', 'name'));
+    expect(result.current.dirtyCellCount).toBe(1);
+    expect(result.current.getCellValue('i-1', 'name').isDirty).toBe(false);
+  });
+
+  test('collectChanges resolves row ids and column ids back to items/columns', () => {
+    const { result } = setup({ onSubmit: () => {} });
+    act(() => result.current.startBulkEdit());
+    act(() => result.current.setCellValue('i-2', 'name', 'BETA'));
+
+    const changes = result.current.collectChanges();
+    expect(changes).toHaveLength(1);
+    expect(changes[0].item).toEqual(items[1]);
+    expect(changes[0].column.id).toBe('name');
+    expect(changes[0].newValue).toBe('BETA');
+  });
+
+  test('submitBulkEdit calls onSubmit with all changes and exits mode', async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    const { result } = setup({ onSubmit });
+    act(() => result.current.startBulkEdit());
+    act(() => result.current.setCellValue('i-1', 'name', 'ALPHA'));
+    act(() => result.current.setCellValue('i-1', 'size', 9));
+
+    await act(async () => {
+      await result.current.submitBulkEdit();
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const detail = onSubmit.mock.calls[0][0];
+    expect(detail.changes).toHaveLength(2);
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.dirtyCellCount).toBe(0);
+  });
+
+  test('falls back to row index when trackBy is not provided', () => {
+    const { result } = renderHook(() =>
+      useBulkEditing<Item>({ items, columnDefinitions, bulkEdit: { onSubmit: () => {} } })
+    );
+    expect(result.current.getRowId(items[0], 0)).toBe('0');
+    expect(result.current.getRowId(items[1], 1)).toBe('1');
+  });
+});

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -398,6 +398,22 @@ export interface TableProps<T = any> extends BaseComponentProps {
   onEditCancel?: CancelableEventHandler;
 
   /**
+   * **(WIP - AWSUI-56121)** Opt-in configuration that enables bulk inline editing, allowing
+   * multiple editable cells to be edited simultaneously and committed together, rather than
+   * one cell at a time. This is additive to per-column `editConfig`: a column must define
+   * `editConfig` to participate in bulk editing.
+   *
+   * The configuration object consists of:
+   * * `onSubmit` ((detail: BulkEditSubmitDetail<T>) => Promise<void> | void) - Called when the user commits
+   *   all pending edits. Receives every changed cell as a `BulkEditChange`. Return a promise to keep the
+   *   table in a submitting state while the request is in progress.
+   * * `activateBulkEditLabel` (optional, string) - Label for the control that enters bulk-edit mode.
+   * * `submitBulkEditLabel` (optional, string) - Label for the control that commits all pending edits.
+   * * `cancelBulkEditLabel` (optional, string) - Label for the control that discards all pending edits.
+   */
+  bulkEdit?: TableProps.BulkEditConfig<T>;
+
+  /**
    * Use this property to activate advanced keyboard navigation and focusing behaviors.
    * When set to `true`, table cells become navigable with arrow keys, and the entire table has a single tab stop.
    *
@@ -641,6 +657,43 @@ export namespace TableProps {
     column: ColumnDefinition<ItemType>,
     newValue: ValueType
   ) => Promise<void> | void;
+
+  /**
+   * **(WIP - AWSUI-56121)** A single pending cell change collected during bulk inline editing.
+   */
+  export interface BulkEditChange<ItemType, ValueType = unknown> {
+    /** The item (row) whose cell was edited. */
+    item: ItemType;
+    /** The column definition of the edited cell. */
+    column: ColumnDefinition<ItemType>;
+    /** The pending value the user entered for the cell. */
+    newValue: ValueType;
+  }
+
+  /**
+   * **(WIP - AWSUI-56121)** Detail object passed to `bulkEdit.onSubmit` when the user commits all pending edits.
+   */
+  export interface BulkEditSubmitDetail<ItemType, ValueType = unknown> {
+    /** All cells that were changed while bulk-edit mode was active. */
+    changes: ReadonlyArray<BulkEditChange<ItemType, ValueType>>;
+  }
+
+  /**
+   * **(WIP - AWSUI-56121)** Configuration for the opt-in bulk inline editing mode.
+   */
+  export interface BulkEditConfig<ItemType, ValueType = unknown> {
+    /**
+     * Called when the user commits all pending edits. Return a promise to keep the table
+     * in a submitting state while the request is in progress.
+     */
+    onSubmit: (detail: BulkEditSubmitDetail<ItemType, ValueType>) => Promise<void> | void;
+    /** Label for the control that enters bulk-edit mode. */
+    activateBulkEditLabel?: string;
+    /** Label for the control that commits all pending edits. */
+    submitBulkEditLabel?: string;
+    /** Label for the control that discards all pending edits. */
+    cancelBulkEditLabel?: string;
+  }
 
   export interface ColumnDisplay {
     type?: 'column';

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -63,6 +63,7 @@ import {
 } from './table-role';
 import Thead, { TheadProps } from './thead';
 import ToolsHeader from './tools-header';
+import { useBulkEditing } from './use-bulk-editing';
 import { useCellEditing } from './use-cell-editing';
 import { ColumnWidthDefinition, ColumnWidthsProvider, DEFAULT_COLUMN_WIDTH } from './use-column-widths';
 import { usePreventStickyClickScroll } from './use-prevent-sticky-click-scroll';
@@ -133,6 +134,7 @@ const InternalTable = React.forwardRef(
       stripedRows,
       contentDensity,
       submitEdit,
+      bulkEdit,
       onEditCancel,
       resizableColumns,
       onColumnWidthsChange,
@@ -196,6 +198,9 @@ const InternalTable = React.forwardRef(
     const stickyHeaderRef = React.useRef<StickyHeaderRef>(null);
     const scrollbarRef = React.useRef<HTMLDivElement>(null);
     const { cancelEdit, ...cellEditing } = useCellEditing({ onCancel: onEditCancel, onSubmit: submitEdit });
+    // WIP (AWSUI-56121): opt-in bulk inline editing controller. When `bulkEdit` is not provided
+    // the controller is disabled (`isActive` is always false) and has no effect on rendering.
+    const bulkEditing = useBulkEditing({ items: allItems, trackBy, columnDefinitions, bulkEdit });
     const paginationRef = useRef<PaginationRef>({});
     const filterRef = useRef<FilterRef>({});
     const preferencesRef = useRef<PreferencesRef>({});
@@ -710,7 +715,8 @@ const InternalTable = React.forwardRef(
                                   const cellId = { row: rowId, col: colId };
                                   const isEditing = cellEditing.checkEditing(cellId);
                                   const successfulEdit = cellEditing.checkLastSuccessfulEdit(cellId);
-                                  const isEditable = !!column.editConfig && !cellEditing.isLoading;
+                                  const isEditable =
+                                    !!column.editConfig && (bulkEditing.isActive || !cellEditing.isLoading);
                                   const cellExpandableProps =
                                     isExpandable && colIndex === 0 ? rowExpandableProps : undefined;
                                   const counter = column.counter?.({

--- a/src/table/use-bulk-editing.ts
+++ b/src/table/use-bulk-editing.ts
@@ -1,0 +1,175 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useMemo, useState } from 'react';
+
+import { TableProps } from './interfaces';
+import { getTrackableValue } from './utils';
+
+/**
+ * WIP (AWSUI-56121): Bulk inline editing for Table.
+ *
+ * This hook is a v0 building block that layers a "bulk edit mode" on top of the
+ * existing single-cell inline-edit (`editConfig`) machinery. Instead of editing
+ * one cell at a time and committing immediately, the consumer can enter a mode
+ * where several cells become editable at once, accumulate pending ("dirty")
+ * changes, and commit them all together via a single callback.
+ *
+ * The hook is intentionally UI-agnostic: it only owns the mode + dirty-cell
+ * state. Rendering of the editable cells is expected to reuse the existing
+ * inline-editor pieces (`editConfig.editingCell`, `CellContext`).
+ */
+
+/** A composite key identifying a single cell by its (tracked) row id and column id. */
+function toCellKey(rowId: string, columnId: string): string {
+  // Row/column ids can contain arbitrary characters; the separator is escaped to
+  // keep the composite key collision-free.
+  return `${rowId.replace(/\|/g, '||')}|:|${columnId.replace(/\|/g, '||')}`;
+}
+
+interface UseBulkEditingProps<T> {
+  items: ReadonlyArray<T>;
+  trackBy?: TableProps.TrackBy<T>;
+  columnDefinitions: ReadonlyArray<TableProps.ColumnDefinition<T>>;
+  bulkEdit?: TableProps.BulkEditConfig<T>;
+}
+
+export function useBulkEditing<T>({ items, trackBy, columnDefinitions, bulkEdit }: UseBulkEditingProps<T>) {
+  const [isActive, setIsActive] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  // Map of cellKey -> pending value. Only cells the user actually touched are stored.
+  const [dirtyCells, setDirtyCells] = useState<Map<string, unknown>>(() => new Map());
+
+  const enabled = !!bulkEdit;
+
+  const getRowId = useCallback(
+    (item: T, index: number): string => {
+      // Without `trackBy` there is no stable identity, so fall back to the row index.
+      if (!trackBy) {
+        return String(index);
+      }
+      const tracked = getTrackableValue(trackBy, item);
+      return tracked !== undefined && tracked !== null ? String(tracked) : String(index);
+    },
+    [trackBy]
+  );
+
+  const startBulkEdit = useCallback(() => {
+    if (!enabled) {
+      return;
+    }
+    setDirtyCells(new Map());
+    setIsActive(true);
+  }, [enabled]);
+
+  const discardBulkEdit = useCallback(() => {
+    setDirtyCells(new Map());
+    setIsActive(false);
+  }, []);
+
+  const setCellValue = useCallback((rowId: string, columnId: string, value: unknown) => {
+    setDirtyCells(prev => {
+      const next = new Map(prev);
+      next.set(toCellKey(rowId, columnId), value);
+      return next;
+    });
+  }, []);
+
+  const clearCellValue = useCallback((rowId: string, columnId: string) => {
+    setDirtyCells(prev => {
+      if (!prev.has(toCellKey(rowId, columnId))) {
+        return prev;
+      }
+      const next = new Map(prev);
+      next.delete(toCellKey(rowId, columnId));
+      return next;
+    });
+  }, []);
+
+  const getCellValue = useCallback(
+    (rowId: string, columnId: string): { isDirty: boolean; value: unknown } => {
+      const key = toCellKey(rowId, columnId);
+      return { isDirty: dirtyCells.has(key), value: dirtyCells.get(key) };
+    },
+    [dirtyCells]
+  );
+
+  const dirtyCellCount = dirtyCells.size;
+  const hasChanges = dirtyCellCount > 0;
+
+  /**
+   * Reconstructs the list of pending edits into a consumer-friendly shape,
+   * resolving row ids and column ids back to the original item / column objects.
+   */
+  const collectChanges = useCallback((): Array<TableProps.BulkEditChange<T>> => {
+    if (dirtyCells.size === 0) {
+      return [];
+    }
+    const itemById = new Map<string, T>();
+    items.forEach((item, index) => itemById.set(getRowId(item, index), item));
+    const columnById = new Map<string, TableProps.ColumnDefinition<T>>();
+    columnDefinitions.forEach((column, index) => columnById.set(column.id ?? String(index), column));
+
+    const changes: Array<TableProps.BulkEditChange<T>> = [];
+    dirtyCells.forEach((value, key) => {
+      const [rawRow, rawColumn] = key.split('|:|');
+      const rowId = rawRow.replace(/\|\|/g, '|');
+      const columnId = rawColumn.replace(/\|\|/g, '|');
+      const item = itemById.get(rowId);
+      const column = columnById.get(columnId);
+      if (item !== undefined && column !== undefined) {
+        changes.push({ item, column, newValue: value });
+      }
+    });
+    return changes;
+  }, [dirtyCells, items, columnDefinitions, getRowId]);
+
+  const submitBulkEdit = useCallback(async () => {
+    if (!bulkEdit?.onSubmit) {
+      discardBulkEdit();
+      return;
+    }
+    const changes = collectChanges();
+    setIsSubmitting(true);
+    try {
+      await bulkEdit.onSubmit({ changes });
+      setDirtyCells(new Map());
+      setIsActive(false);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [bulkEdit, collectChanges, discardBulkEdit]);
+
+  return useMemo(
+    () => ({
+      enabled,
+      isActive: enabled && isActive,
+      isSubmitting,
+      hasChanges,
+      dirtyCellCount,
+      getRowId,
+      startBulkEdit,
+      discardBulkEdit,
+      submitBulkEdit,
+      setCellValue,
+      clearCellValue,
+      getCellValue,
+      collectChanges,
+    }),
+    [
+      enabled,
+      isActive,
+      isSubmitting,
+      hasChanges,
+      dirtyCellCount,
+      getRowId,
+      startBulkEdit,
+      discardBulkEdit,
+      submitBulkEdit,
+      setCellValue,
+      clearCellValue,
+      getCellValue,
+      collectChanges,
+    ]
+  );
+}


### PR DESCRIPTION
### Description

**[WIP / v0 — do not merge]** First-cut (v0) of an opt-in **bulk inline editing** mode for `Table`, tracked by SIM **AWSUI-56121**. Bulk inline edit lets users edit multiple editable cells at once (a "bulk edit mode") and commit them together via a single callback, rather than editing one cell at a time.

This is an epic-sized, multi-week feature; this PR is a coherent, buildable starting point that layers on top of the existing single-cell inline-edit (`editConfig`) machinery. It is **additive and opt-in** — with no `bulkEdit` prop the Table behaves exactly as before (verified: the only behavioral tie-in is gated on `bulkEditing.isActive`, which is always `false` when disabled).

> ⚠️ **Ticket mismatch note:** `https://taskei.amazon.dev/tasks/AWSUI-56121` currently resolves to an **unrelated Aperture Form Submission** record (a VPC console CLASS satisfaction survey, ticket `V1491224149`), **not** a Table bulk-inline-edit feature request. This PR was implemented against the feature description provided in the task, not the resolved ticket content. Please re-point the SIM ID before this leaves WIP.

Related links, issue #: AWSUI-56121 (see mismatch note above)

### What's included (v0 / done)

- **`useBulkEditing` hook** (`src/table/use-bulk-editing.ts`) — the core, UI-agnostic state machine:
  - enter / exit bulk-edit mode (`startBulkEdit` / `discardBulkEdit`)
  - dirty-cell tracking keyed by `(rowId, columnId)` with `setCellValue` / `clearCellValue` / `getCellValue`
  - `collectChanges()` resolves pending edits back to `{ item, column, newValue }`
  - `submitBulkEdit()` — commit-all with a submitting state, calls `bulkEdit.onSubmit({ changes })`
  - `trackBy`-aware row identity with row-index fallback
- **Public API additions** (`src/table/interfaces.tsx`), fully JSDoc'd:
  - `bulkEdit?: TableProps.BulkEditConfig<T>` prop
  - `TableProps.BulkEditConfig`, `TableProps.BulkEditSubmitDetail`, `TableProps.BulkEditChange`
- **Minimal, additive wiring** in `internal.tsx` — instantiates the controller behind the opt-in prop; no-op when `bulkEdit` is absent.
- **Dev page** (`pages/table/bulk-editable.page.tsx`) demonstrating the intended UX (Edit all → cells become inputs → Save all / Discard all), reusing existing input pieces.
- **Unit tests** (`src/table/__tests__/use-bulk-editing.test.tsx`) — 6 tests covering enable/disable, enter/exit, dirty tracking, change collection, commit-all, and trackBy fallback.
- **Documenter snapshot** updated for the new public `bulkEdit` prop.

### Remaining work (follow-ups, not in this PR)

- [ ] Wire the controller into the Table **render path** so editable cells render `editConfig.editingCell` editors automatically in bulk mode (today the dev page renders editors itself).
- [ ] Built-in bulk-edit **toolbar/affordance** (activate / save-all / discard-all controls) + `ariaLabels` integration.
- [ ] **Per-cell validation** aggregation using existing `editConfig.validation`, and surfacing errors before/after commit-all.
- [ ] Keyboard navigation, focus management, and screen-reader announcements for bulk mode.
- [ ] `disabledReason` handling and per-cell "dirty"/"error" visual states.
- [ ] Partial-failure handling in `onSubmit` (keep failed cells dirty).
- [ ] Integration tests + a11y tests; component test-utils selectors for bulk mode.
- [ ] Design/API review sign-off before the prop is treated as stable (currently marked WIP in JSDoc).

### How has this been tested?

- `eslint` (Node v24) on all changed/new files — **clean**.
- `npm run quick-build` (TypeScript) — **pass**.
- `npm run build` (full build incl. definitions generation) — **pass**.
- `jest -c jest.unit.config.js`:
  - `src/table/__tests__/use-bulk-editing.test.tsx` — **6/6 pass**
  - `src/table/__tests__/table-editable.test.tsx` (regression) — **5/5 pass**
  - `src/__tests__/snapshot-tests/documenter.test.ts` — **97/97 pass** (snapshot updated for `bulkEdit`)

Reviewers can open the `Table/bulk-editable` dev page to try the flow.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
