### PR TITLE
feat: add Comparison Table (v0) [WIP]

### DIFF
--- a/build-tools/utils/pluralize.js
+++ b/build-tools/utils/pluralize.js
@@ -22,6 +22,7 @@ const pluralizationMap = {
   CodeEditor: 'CodeEditors',
   CollectionPreferences: 'CollectionPreferences',
   ColumnLayout: 'ColumnLayouts',
+  ComparisonTable: 'ComparisonTables',
   Container: 'Containers',
   ContentLayout: 'ContentLayouts',
   CopyToClipboard: 'CopyToClipboards',

--- a/pages/comparison-table/simple.page.tsx
+++ b/pages/comparison-table/simple.page.tsx
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+
+import Box from '~components/box';
+import ComparisonTable, { ComparisonTableProps } from '~components/comparison-table';
+import SpaceBetween from '~components/space-between';
+import StatusIndicator from '~components/status-indicator';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+const attributes: ComparisonTableProps['attributes'] = [
+  { id: 'engine', label: 'Database engine' },
+  { id: 'vcpu', label: 'vCPU' },
+  { id: 'memory', label: 'Memory' },
+  {
+    id: 'multiAz',
+    label: 'Multi-AZ',
+    render: value => (
+      <StatusIndicator type={value ? 'success' : 'stopped'}>{value ? 'Enabled' : 'Disabled'}</StatusIndicator>
+    ),
+  },
+  { id: 'storage', label: 'Max storage' },
+];
+
+const entities: ComparisonTableProps['entities'] = [
+  {
+    id: 'db-r6g',
+    title: 'db.r6g.large',
+    data: { engine: 'MySQL', vcpu: 2, memory: '16 GiB', multiAz: true, storage: '64 TiB' },
+  },
+  {
+    id: 'db-r6g-xl',
+    title: 'db.r6g.xlarge',
+    data: { engine: 'MySQL', vcpu: 4, memory: '32 GiB', multiAz: true, storage: '64 TiB' },
+  },
+  {
+    id: 'db-r6g-2xl',
+    title: 'db.r6g.2xlarge',
+    data: { engine: 'MySQL', vcpu: 8, memory: '64 GiB', multiAz: false, storage: '64 TiB' },
+  },
+];
+
+export default function ComparisonTablePage() {
+  const [highlight, setHighlight] = React.useState(true);
+  const [sticky, setSticky] = React.useState(true);
+
+  return (
+    <>
+      <h1>Comparison table (WIP)</h1>
+      <SpaceBetween size="l">
+        <SpaceBetween direction="horizontal" size="m">
+          <label>
+            <input type="checkbox" checked={highlight} onChange={e => setHighlight(e.target.checked)} /> Highlight
+            differences
+          </label>
+          <label>
+            <input type="checkbox" checked={sticky} onChange={e => setSticky(e.target.checked)} /> Sticky attribute
+            column
+          </label>
+        </SpaceBetween>
+
+        <ScreenshotArea>
+          <ComparisonTable
+            ariaLabel="Instance type comparison"
+            attributeColumnHeader="Attribute"
+            attributes={attributes}
+            entities={entities}
+            highlightDifferences={highlight}
+            stickyAttributeColumn={sticky}
+          />
+        </ScreenshotArea>
+
+        <Box variant="h2">Empty state</Box>
+        <ComparisonTable attributes={[]} entities={[]} ariaLabel="Empty comparison" />
+      </SpaceBetween>
+    </>
+  );
+}

--- a/src/__tests__/required-props-for-components.ts
+++ b/src/__tests__/required-props-for-components.ts
@@ -6,6 +6,7 @@ export { defaultSplitPanelContextProps } from '../split-panel/__tests__/helpers'
 const defaultProps: Record<string, Record<string, any>> = {
   tabs: { tabs: [] },
   table: { columnDefinitions: [] },
+  'comparison-table': { attributes: [], entities: [] },
   cards: { cardDefinition: {} },
   autosuggest: { options: [], enteredPrefix: '' },
   'anchor-navigation': { anchors: [] },

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -10214,6 +10214,115 @@ and the maximum number of columns as defined by the \`columns\` property.",
 }
 `;
 
+exports[`Components definition for comparison-table matches the snapshot: comparison-table 1`] = `
+{
+  "dashCaseName": "comparison-table",
+  "description": "ComparisonTable renders a side-by-side comparison of two or more entities: attributes are
+rendered as rows, entities as columns, with a sticky attribute column and optional
+highlighting of rows whose values differ across entities.
+
+This is a work-in-progress (v0) component built as a thin, opt-in composition over the
+existing Table component.",
+  "events": [],
+  "functions": [],
+  "name": "ComparisonTable",
+  "properties": [
+    {
+      "description": "Provides an accessible name for the underlying table, announced by assistive technology.",
+      "name": "ariaLabel",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "defaultValue": "''",
+      "description": "Header text rendered above the sticky attribute (first) column.
+Defaults to an empty string.",
+      "name": "attributeColumnHeader",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "description": "The attributes to compare across entities. Each attribute is rendered as a **row**.
+
+The order of this array is the order the rows appear in. Use the \`render\` function on an
+attribute to customize how the value for each entity is displayed.",
+      "name": "attributes",
+      "optional": false,
+      "type": "ReadonlyArray<ComparisonTableProps.Attribute>",
+    },
+    {
+      "deprecatedTag": "Custom CSS is not supported. For testing and other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
+      "description": "Adds the specified classes to the root element of the component.",
+      "name": "className",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "description": "The entities being compared. Each entity is rendered as a **column** next to the sticky
+attribute column.
+
+Every entity exposes its per-attribute values through the \`data\` map, keyed by attribute \`id\`.",
+      "name": "entities",
+      "optional": false,
+      "type": "ReadonlyArray<ComparisonTableProps.Entity>",
+    },
+    {
+      "defaultValue": "false",
+      "description": "When \`true\`, attribute rows whose values are not identical across all entities are visually
+emphasized so differences stand out.
+
+Equality is determined with \`Object.is\` against the raw \`entity.data[attribute.id]\` values.
+Rows with a custom \`render\` are still compared using their raw \`data\` values, so keep the
+\`data\` values comparable (primitives) when relying on this feature.",
+      "name": "highlightDifferences",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
+      "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
+use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes). If you must
+use the \`id\` attribute, consider setting it on a parent element instead.",
+      "description": "Adds the specified ID to the root element of the component.",
+      "name": "id",
+      "optional": true,
+      "type": "string",
+    },
+    {
+      "defaultValue": "true",
+      "description": "Whether the attribute (first) column is pinned to the inline-start edge while the entity
+columns scroll horizontally. Defaults to \`true\`.",
+      "name": "stickyAttributeColumn",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
+      "defaultValue": "'container'",
+      "description": "The visual variant of the comparison table.
+
+- \`"container"\` (default) — renders inside a bordered container.
+- \`"embedded"\` — removes the outer container border for embedding in another surface.
+- \`"borderless"\` — removes borders entirely.
+- \`"stacked"\` — for use in a vertically stacked set of containers.",
+      "inlineType": {
+        "name": "ComparisonTableProps.Variant",
+        "type": "union",
+        "values": [
+          "container",
+          "embedded",
+          "stacked",
+          "borderless",
+        ],
+      },
+      "name": "variant",
+      "optional": true,
+      "type": "string",
+    },
+  ],
+  "regions": [],
+  "releaseStatus": "stable",
+}
+`;
+
 exports[`Components definition for container matches the snapshot: container 1`] = `
 {
   "dashCaseName": "container",
@@ -39174,6 +39283,53 @@ Note that, despite its typings, this may return null for group items since group
     {
       "methods": [
         {
+          "description": "Returns all attribute (row header) label elements.",
+          "name": "findAttributeLabels",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns all cells that are highlighted because their attribute row differs across entities.",
+          "name": "findHighlightedCells",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns all rendered rows of the underlying table (one per attribute).",
+          "name": "findRows",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "Array",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper<HTMLElement>",
+              },
+            ],
+          },
+        },
+      ],
+      "name": "ComparisonTableWrapper",
+    },
+    {
+      "methods": [
+        {
           "name": "findContent",
           "parameters": [],
           "returnType": {
@@ -50180,6 +50336,53 @@ Note that, despite its typings, this may return null for group items since group
         },
       ],
       "name": "ColumnLayoutWrapper",
+    },
+    {
+      "methods": [
+        {
+          "description": "Returns all attribute (row header) label elements.",
+          "name": "findAttributeLabels",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns all cells that are highlighted because their attribute row differs across entities.",
+          "name": "findHighlightedCells",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+        {
+          "description": "Returns all rendered rows of the underlying table (one per attribute).",
+          "name": "findRows",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "MultiElementWrapper",
+            "typeArguments": [
+              {
+                "name": "ElementWrapper",
+              },
+            ],
+          },
+        },
+      ],
+      "name": "ComparisonTableWrapper",
     },
     {
       "methods": [

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -191,6 +191,11 @@ exports[`test-utils selectors 1`] = `
     "awsui_column-layout_vvxn7",
     "awsui_item_zqq3x",
   ],
+  "comparison-table": [
+    "awsui_attribute-label_gfu3l",
+    "awsui_cell-highlighted_gfu3l",
+    "awsui_root_gfu3l",
+  ],
   "container": [
     "awsui_content-inner_1mwlm",
     "awsui_content-wrapper_14iqq",

--- a/src/comparison-table/__tests__/comparison-table.test.tsx
+++ b/src/comparison-table/__tests__/comparison-table.test.tsx
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import ComparisonTable, { ComparisonTableProps } from '../../../lib/components/comparison-table';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+const attributes: ComparisonTableProps['attributes'] = [
+  { id: 'engine', label: 'Engine' },
+  { id: 'vcpu', label: 'vCPU' },
+];
+
+const entities: ComparisonTableProps['entities'] = [
+  { id: 'a', title: 'Option A', data: { engine: 'MySQL', vcpu: 2 } },
+  { id: 'b', title: 'Option B', data: { engine: 'MySQL', vcpu: 4 } },
+];
+
+function renderComparisonTable(jsx: React.ReactElement) {
+  const { container } = render(jsx);
+  return createWrapper(container).findComparisonTable()!;
+}
+
+describe('ComparisonTable', () => {
+  test('renders and is findable via test-utils', () => {
+    const wrapper = renderComparisonTable(<ComparisonTable attributes={attributes} entities={entities} />);
+    expect(wrapper).not.toBeNull();
+  });
+
+  test('renders one row per attribute (attributes as rows)', () => {
+    const wrapper = renderComparisonTable(<ComparisonTable attributes={attributes} entities={entities} />);
+    expect(wrapper.findRows()).toHaveLength(attributes.length);
+  });
+
+  test('renders one column header per entity plus the attribute column', () => {
+    const wrapper = renderComparisonTable(<ComparisonTable attributes={attributes} entities={entities} />);
+    // Attribute column header + one per entity.
+    const headers = wrapper.getElement().querySelectorAll('thead th');
+    expect(headers.length).toBe(entities.length + 1);
+  });
+
+  test('renders attribute labels in the sticky attribute column', () => {
+    const wrapper = renderComparisonTable(<ComparisonTable attributes={attributes} entities={entities} />);
+    const labels = wrapper.findAttributeLabels().map(l => l.getElement().textContent);
+    expect(labels).toEqual(['Engine', 'vCPU']);
+  });
+
+  test('highlightDifferences emphasizes only differing rows', () => {
+    const wrapper = renderComparisonTable(
+      <ComparisonTable attributes={attributes} entities={entities} highlightDifferences={true} />
+    );
+    // "engine" is identical (MySQL/MySQL); "vcpu" differs (2 vs 4) => one differing row across 2 entity cells.
+    expect(wrapper.findHighlightedCells()).toHaveLength(2);
+  });
+
+  test('does not highlight anything when highlightDifferences is false', () => {
+    const wrapper = renderComparisonTable(
+      <ComparisonTable attributes={attributes} entities={entities} highlightDifferences={false} />
+    );
+    expect(wrapper.findHighlightedCells()).toHaveLength(0);
+  });
+
+  test('uses the render function to customize entity values', () => {
+    const wrapper = renderComparisonTable(
+      <ComparisonTable
+        attributes={[{ id: 'engine', label: 'Engine', render: value => <em>{`[${value}]`}</em> }]}
+        entities={entities}
+      />
+    );
+    expect(wrapper.getElement().textContent).toContain('[MySQL]');
+  });
+
+  test('renders without crashing when there are no attributes or entities', () => {
+    const wrapper = renderComparisonTable(<ComparisonTable attributes={[]} entities={[]} />);
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.findRows()).toHaveLength(0);
+  });
+});

--- a/src/comparison-table/index.tsx
+++ b/src/comparison-table/index.tsx
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+'use client';
+import React from 'react';
+
+import { getBaseProps } from '../internal/base-component';
+import useBaseComponent from '../internal/hooks/use-base-component';
+import { applyDisplayName } from '../internal/utils/apply-display-name';
+import { ComparisonTableProps } from './interfaces';
+import InternalComparisonTable from './internal';
+
+export { ComparisonTableProps };
+
+/**
+ * ComparisonTable renders a side-by-side comparison of two or more entities: attributes are
+ * rendered as rows, entities as columns, with a sticky attribute column and optional
+ * highlighting of rows whose values differ across entities.
+ *
+ * This is a work-in-progress (v0) component built as a thin, opt-in composition over the
+ * existing Table component.
+ */
+export default function ComparisonTable({
+  attributes,
+  entities,
+  attributeColumnHeader = '',
+  stickyAttributeColumn = true,
+  highlightDifferences = false,
+  variant = 'container',
+  ariaLabel,
+  ...rest
+}: ComparisonTableProps) {
+  const baseComponentProps = useBaseComponent('ComparisonTable', {
+    props: { stickyAttributeColumn, highlightDifferences, variant },
+    metadata: { attributesCount: attributes.length, entitiesCount: entities.length },
+  });
+  const baseProps = getBaseProps(rest);
+
+  return (
+    <InternalComparisonTable
+      {...baseProps}
+      {...baseComponentProps}
+      attributes={attributes}
+      entities={entities}
+      attributeColumnHeader={attributeColumnHeader}
+      stickyAttributeColumn={stickyAttributeColumn}
+      highlightDifferences={highlightDifferences}
+      variant={variant}
+      ariaLabel={ariaLabel}
+    />
+  );
+}
+
+applyDisplayName(ComparisonTable, 'ComparisonTable');

--- a/src/comparison-table/interfaces.ts
+++ b/src/comparison-table/interfaces.ts
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { BaseComponentProps } from '../types/base-component';
+
+export interface ComparisonTableProps extends BaseComponentProps {
+  /**
+   * The attributes to compare across entities. Each attribute is rendered as a **row**.
+   *
+   * The order of this array is the order the rows appear in. Use the `render` function on an
+   * attribute to customize how the value for each entity is displayed.
+   */
+  attributes: ReadonlyArray<ComparisonTableProps.Attribute>;
+
+  /**
+   * The entities being compared. Each entity is rendered as a **column** next to the sticky
+   * attribute column.
+   *
+   * Every entity exposes its per-attribute values through the `data` map, keyed by attribute `id`.
+   */
+  entities: ReadonlyArray<ComparisonTableProps.Entity>;
+
+  /**
+   * Header text rendered above the sticky attribute (first) column.
+   * Defaults to an empty string.
+   */
+  attributeColumnHeader?: string;
+
+  /**
+   * Whether the attribute (first) column is pinned to the inline-start edge while the entity
+   * columns scroll horizontally. Defaults to `true`.
+   */
+  stickyAttributeColumn?: boolean;
+
+  /**
+   * When `true`, attribute rows whose values are not identical across all entities are visually
+   * emphasized so differences stand out.
+   *
+   * Equality is determined with `Object.is` against the raw `entity.data[attribute.id]` values.
+   * Rows with a custom `render` are still compared using their raw `data` values, so keep the
+   * `data` values comparable (primitives) when relying on this feature.
+   */
+  highlightDifferences?: boolean;
+
+  /**
+   * Provides an accessible name for the underlying table, announced by assistive technology.
+   */
+  ariaLabel?: string;
+
+  /**
+   * The visual variant of the comparison table.
+   *
+   * - `"container"` (default) — renders inside a bordered container.
+   * - `"embedded"` — removes the outer container border for embedding in another surface.
+   * - `"borderless"` — removes borders entirely.
+   * - `"stacked"` — for use in a vertically stacked set of containers.
+   */
+  variant?: ComparisonTableProps.Variant;
+}
+
+export namespace ComparisonTableProps {
+  export type Variant = 'container' | 'embedded' | 'borderless' | 'stacked';
+
+  export interface Attribute {
+    /**
+     * Unique identifier for the attribute. Used to look up each entity's value via
+     * `entity.data[id]` and as the React key for the row.
+     */
+    id: string;
+
+    /**
+     * The label rendered in the sticky attribute column for this row.
+     */
+    label: React.ReactNode;
+
+    /**
+     * Optional custom renderer for an entity's value for this attribute. Receives the raw value
+     * (`entity.data[id]`) and the full entity. When omitted, the raw value is rendered as-is.
+     */
+    render?: (value: React.ReactNode, entity: ComparisonTableProps.Entity) => React.ReactNode;
+  }
+
+  export interface Entity {
+    /**
+     * Unique identifier for the entity. Used as the column id and React key.
+     */
+    id: string;
+
+    /**
+     * The column header for this entity (for example, the resource name).
+     */
+    title: React.ReactNode;
+
+    /**
+     * The entity's values, keyed by attribute `id`. Missing keys render as a placeholder.
+     */
+    data: Record<string, React.ReactNode>;
+  }
+}

--- a/src/comparison-table/internal.tsx
+++ b/src/comparison-table/internal.tsx
@@ -1,0 +1,103 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+
+import { getBaseProps } from '../internal/base-component';
+import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import { TableProps } from '../table/interfaces';
+import InternalTable from '../table/internal';
+import { ComparisonTableProps } from './interfaces';
+
+import styles from './styles.css.js';
+
+type InternalComparisonTableProps = ComparisonTableProps & InternalBaseComponentProps;
+
+const ATTRIBUTE_COLUMN_ID = 'awsui-comparison-table-attribute';
+
+// Computes the set of attribute ids whose values differ across the compared entities.
+// Comparison uses `Object.is` against the raw per-entity value, so it is reliable for
+// primitive values. Deep object comparison is intentionally out of scope for v0.
+function getDifferingAttributeIds(
+  attributes: ReadonlyArray<ComparisonTableProps.Attribute>,
+  entities: ReadonlyArray<ComparisonTableProps.Entity>
+): Set<string> {
+  const differing = new Set<string>();
+  if (entities.length < 2) {
+    return differing;
+  }
+  for (const attribute of attributes) {
+    const [firstEntity, ...restEntities] = entities;
+    const firstValue = firstEntity.data?.[attribute.id];
+    const allEqual = restEntities.every(entity => Object.is(entity.data?.[attribute.id], firstValue));
+    if (!allEqual) {
+      differing.add(attribute.id);
+    }
+  }
+  return differing;
+}
+
+export default function InternalComparisonTable({
+  attributes,
+  entities,
+  attributeColumnHeader = '',
+  stickyAttributeColumn = true,
+  highlightDifferences = false,
+  ariaLabel,
+  variant = 'container',
+  __internalRootRef,
+  ...rest
+}: InternalComparisonTableProps) {
+  const baseProps = getBaseProps(rest);
+
+  const differingAttributeIds = highlightDifferences
+    ? getDifferingAttributeIds(attributes, entities)
+    : new Set<string>();
+
+  const columnDefinitions: ReadonlyArray<TableProps.ColumnDefinition<ComparisonTableProps.Attribute>> = [
+    {
+      id: ATTRIBUTE_COLUMN_ID,
+      header: attributeColumnHeader,
+      isRowHeader: true,
+      cell: attribute => <span className={styles['attribute-label']}>{attribute.label}</span>,
+    },
+    ...entities.map(
+      (entity): TableProps.ColumnDefinition<ComparisonTableProps.Attribute> => ({
+        id: entity.id,
+        header: entity.title,
+        cell: attribute => {
+          const rawValue = entity.data?.[attribute.id];
+          const value = attribute.render ? attribute.render(rawValue, entity) : rawValue;
+          const isDifferent = differingAttributeIds.has(attribute.id);
+          return (
+            <span className={clsx(styles.cell, isDifferent && styles['cell-highlighted'])}>
+              {value === undefined || value === null ? '-' : value}
+            </span>
+          );
+        },
+      })
+    ),
+  ];
+
+  // `__internalRootRef` is spread (not written inline) so it bypasses the excess-property check
+  // against the public TableProps, while still landing on the underlying table root. This carries
+  // the ComparisonTable base-component metadata onto the rendered root element.
+  const internalBaseProps: InternalBaseComponentProps = { __internalRootRef };
+
+  const tableProps: Parameters<typeof InternalTable<ComparisonTableProps.Attribute>>[0] = {
+    ...baseProps,
+    ...internalBaseProps,
+    className: clsx(baseProps.className, styles.root),
+    variant,
+    items: [...attributes],
+    selectedItems: [],
+    firstIndex: 1,
+    cellVerticalAlign: 'top',
+    columnDefinitions,
+    trackBy: 'id',
+    stickyColumns: stickyAttributeColumn ? { first: 1 } : undefined,
+    ariaLabels: ariaLabel ? { tableLabel: ariaLabel } : undefined,
+  };
+
+  return <InternalTable {...tableProps} />;
+}

--- a/src/comparison-table/styles.scss
+++ b/src/comparison-table/styles.scss
@@ -1,0 +1,36 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '../internal/styles' as styles;
+@use '../internal/styles/tokens' as awsui;
+
+.root {
+  // Marker class applied to the underlying Table root so test-utils and consumers can target
+  // the comparison table specifically. Visual styling is inherited from Table.
+  inline-size: 100%;
+}
+
+.attribute-label {
+  font-weight: styles.$font-weight-bold;
+  color: awsui.$color-text-body-default;
+}
+
+.cell {
+  color: awsui.$color-text-body-default;
+}
+
+// Emphasis applied to a cell when its attribute row differs across entities.
+.cell-highlighted {
+  display: inline-block;
+  padding-block: awsui.$space-xxxs;
+  padding-inline: awsui.$space-xxs;
+  border-start-start-radius: awsui.$border-radius-badge;
+  border-start-end-radius: awsui.$border-radius-badge;
+  border-end-start-radius: awsui.$border-radius-badge;
+  border-end-end-radius: awsui.$border-radius-badge;
+  background-color: awsui.$color-background-status-warning;
+  color: awsui.$color-text-status-warning;
+  font-weight: styles.$font-weight-bold;
+}

--- a/src/test-utils/dom/comparison-table/index.ts
+++ b/src/test-utils/dom/comparison-table/index.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+
+import styles from '../../../comparison-table/styles.selectors.js';
+import tableStyles from '../../../table/styles.selectors.js';
+
+export default class ComparisonTableWrapper extends ComponentWrapper<HTMLElement> {
+  static rootSelector: string = styles.root;
+
+  /** Returns all attribute (row header) label elements. */
+  findAttributeLabels(): Array<ElementWrapper> {
+    return this.findAllByClassName(styles['attribute-label']);
+  }
+
+  /** Returns all cells that are highlighted because their attribute row differs across entities. */
+  findHighlightedCells(): Array<ElementWrapper> {
+    return this.findAllByClassName(styles['cell-highlighted']);
+  }
+
+  /** Returns all rendered rows of the underlying table (one per attribute). */
+  findRows(): Array<ElementWrapper> {
+    return this.findAllByClassName(tableStyles.row);
+  }
+}


### PR DESCRIPTION
### Description

**[WIP] First-cut (v0) of a Comparison Table component — tracking [AWSUI-59913](https://taskei.amazon.dev/tasks/AWSUI-59913).**

> ⚠️ This is an intentionally-scoped **v0 / work-in-progress** for an epic-sized effort. It is **additive and opt-in** and is **not** a finished feature. It exists to establish a coherent, buildable foundation and to gather early design/API feedback. Do **not** merge as-is.

Comparison Table lets customers compare two or more entities (resources) side-by-side: **attributes are rendered as rows, entities as columns**, with a **sticky attribute column** and optional **highlight-differences**. The requesting teams on the ticket are Amazon RDS (already using a bespoke version), Redshift, and DynamoDB.

#### Approach
Rather than reimplement a data grid, v0 is a thin, opt-in **composition over the existing `Table`** component (via `InternalTable`), so it inherits Table's rendering, sticky-column, and accessibility machinery. The public component transforms `attributes` + `entities` into Table `columnDefinitions`/`items`:
- Column 0 = the attribute label column, marked `isRowHeader` and pinned via `stickyColumns={{ first: 1 }}`.
- One column per entity; each cell resolves `entity.data[attribute.id]` (or a per-attribute `render`).
- `highlightDifferences` compares raw per-entity values (`Object.is`) and emphasizes cells in rows that are not identical across all entities.

#### What's done in this v0 ✅
- New public component `ComparisonTable` (`src/comparison-table/`): `index.tsx`, `internal.tsx`, `interfaces.ts`, `styles.scss`.
- Public interface `ComparisonTableProps` with full JSDoc — `attributes`, `entities`, `attributeColumnHeader`, `stickyAttributeColumn` (default `true`), `highlightDifferences` (default `false`), `variant`, `ariaLabel`, plus `Attribute` / `Entity` sub-interfaces.
- Core rendering: attributes-as-rows × entities-as-columns, sticky attribute column, optional highlight-differences, custom per-attribute `render`, empty-state safe.
- test-utils DOM wrapper (`findComparisonTable` / `findAllComparisonTables`, `findAttributeLabels`, `findHighlightedCells`, `findRows`).
- Dev page: `pages/comparison-table/simple.page.tsx` (toggles for highlight + sticky, plus an empty-state example).
- 8 unit tests covering find-ability, rows-per-attribute, header count, sticky labels, highlight on/off, custom render, empty state.
- Registered required-props entry and plural form; **documenter snapshot regenerated** for the new public API (purely additive, +203 lines).

#### Remaining work / follow-ups 🚧 (out of scope for this v0)
- **Design sign-off**: run the full Cloudscape component process (research → scope → API proposal → design iteration/validation) against the reference design on the ticket. API is provisional.
- **Row-level highlight**: current highlight styles the differing *cells*; move to a first-class row-level treatment and a11y annotation (needs a Table row-className/decoration hook — currently not a public Table capability).
- **Deep value comparison**: `highlightDifferences` uses `Object.is` on raw values; add a configurable comparator for objects/`ReactNode`.
- **Accessibility pass**: manual SR/keyboard testing, row-header semantics review, `ariaLabels` coverage beyond `tableLabel`, RTL check.
- **Selectors test-utils** wrapper (only DOM wrapper added so far), integration/a11y tests, and visual/permutation screenshot coverage.
- **Documentation**: usage guidelines (do/don't), examples, and website/Contentful content.
- **API breadth**: sorting/pinning entity columns, wrapping/vertical-align options, loading/empty slots, i18n, analytics metadata, and whether this should ship as a distinct component vs. a documented Table pattern.
- **Design tokens/visual polish** for the highlight treatment.

Related links, issue #, if available: AWSUI-59913 (Cloudscape contribution request: Comparison Table)

> **Ticket-mismatch note:** `AWSUI-59913` resolved correctly to the *Comparison Table* contribution request (not an unrelated/Aperture ticket), so implementation follows both the ticket and the task description. Medic metadata lookup returned "Ticket Not Found" for the SIM-T backend, which is expected for a Taskei feature-request ticket.

### How has this been tested?

Local, Node v24.15.0:
- `eslint` (touched files) — **pass**; `stylelint` (scss) — **pass**.
- `gulp quick-build` — **pass**.
- Unit tests: `src/comparison-table` — **8/8 pass**.
- Repo-wide consistency suites (`src/__tests__/functional-tests`, which iterate every component incl. the new one: base-props, ssr, use-base-component, use-telemetry, naming-convention, outer-form-submit, test-utils) — **1843/1843 pass**.
- Full `gulp build` (incl. static dev-pages compile) — **pass**.
- Documenter snapshot (`src/__tests__/snapshot-tests/documenter.test.ts`) regenerated and re-verified — **98/98 pass**.

Reviewers can explore the component via the dev page `comparison-table/simple` after `npm run quick-build` + `npm start`.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ — WIP: usage docs are a follow-up.
- _Changes are backward-compatible if not indicated._ — Yes: purely additive/opt-in, no existing API changed.
- _Changes do not include unsupported browser features._ — Yes (reuses Table only).
- _Changes were manually tested for accessibility._ — WIP: dedicated a11y pass is a follow-up.

#### Security

- _If the code handles URLs: all URLs are validated through `checkSafeUrl`._ — N/A (no URL handling).

#### Testing

- _Changes are covered with new/existing unit tests?_ — Yes (8 new unit tests + all consistency suites).
- _Changes are covered with new/existing integration tests?_ — WIP: integration/visual tests are a follow-up.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
