### PR TITLE
feat: add Master/Detail pattern (v0) [WIP]

### DIFF
--- a/pages/master-detail/simple.page.tsx
+++ b/pages/master-detail/simple.page.tsx
@@ -1,0 +1,148 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import AppLayout from '~components/app-layout';
+import Box from '~components/box';
+import ContentLayout from '~components/content-layout';
+import Header from '~components/header';
+import MasterDetailLayout from '~components/internal/components/master-detail-layout';
+import KeyValuePairs from '~components/key-value-pairs';
+import SpaceBetween from '~components/space-between';
+import StatusIndicator from '~components/status-indicator';
+import Table from '~components/table';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+interface Instance {
+  id: string;
+  name: string;
+  type: string;
+  state: 'running' | 'stopped' | 'pending';
+  zone: string;
+  publicDns: string;
+}
+
+const INSTANCES: ReadonlyArray<Instance> = [
+  {
+    id: 'i-01a2',
+    name: 'web-server-1',
+    type: 't3.medium',
+    state: 'running',
+    zone: 'us-east-1a',
+    publicDns: 'ec2-1.compute.amazonaws.com',
+  },
+  {
+    id: 'i-02b3',
+    name: 'web-server-2',
+    type: 't3.medium',
+    state: 'running',
+    zone: 'us-east-1b',
+    publicDns: 'ec2-2.compute.amazonaws.com',
+  },
+  { id: 'i-03c4', name: 'batch-worker', type: 'c5.large', state: 'stopped', zone: 'us-east-1a', publicDns: '—' },
+  {
+    id: 'i-04d5',
+    name: 'db-primary',
+    type: 'r5.xlarge',
+    state: 'running',
+    zone: 'us-east-1c',
+    publicDns: 'ec2-4.compute.amazonaws.com',
+  },
+  { id: 'i-05e6', name: 'db-replica', type: 'r5.xlarge', state: 'pending', zone: 'us-east-1c', publicDns: '—' },
+];
+
+const STATE_TYPE: Record<Instance['state'], 'success' | 'stopped' | 'in-progress'> = {
+  running: 'success',
+  stopped: 'stopped',
+  pending: 'in-progress',
+};
+
+function InstanceDetail({ instance }: { instance: Instance }) {
+  return (
+    <SpaceBetween size="l">
+      <Header variant="h2">{instance.name}</Header>
+      <KeyValuePairs
+        columns={2}
+        items={[
+          { label: 'Instance ID', value: instance.id },
+          { label: 'Instance type', value: instance.type },
+          {
+            label: 'State',
+            value: <StatusIndicator type={STATE_TYPE[instance.state]}>{instance.state}</StatusIndicator>,
+          },
+          { label: 'Availability zone', value: instance.zone },
+          { label: 'Public DNS', value: instance.publicDns },
+        ]}
+      />
+    </SpaceBetween>
+  );
+}
+
+/**
+ * Dev/demo page for the Master/Detail pattern (v0).
+ *
+ * Demonstrates a list/master pane (Table) alongside a detail pane driven by the
+ * selected item, composed with the experimental `MasterDetailLayout` helper.
+ * Selecting a row updates the detail pane; the helper collapses to a single
+ * column on narrow container widths (resize the browser to observe).
+ */
+export default function MasterDetailSimplePage() {
+  const [selectedInstance, setSelectedInstance] = useState<Instance | null>(null);
+
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        contentType="table"
+        toolsHide={true}
+        navigationHide={true}
+        ariaLabels={{ navigation: 'Navigation', notifications: 'Notifications', tools: 'Tools' }}
+        content={
+          <ContentLayout header={<Header variant="h1">Master/Detail pattern (WIP v0)</Header>}>
+            <MasterDetailLayout
+              hasSelection={selectedInstance !== null}
+              onClearSelection={() => setSelectedInstance(null)}
+              masterAriaLabel="Instances list"
+              detailAriaLabel="Instance details"
+              backLabel="Back to instances"
+              master={
+                <Table<Instance>
+                  variant="container"
+                  selectionType="single"
+                  trackBy="id"
+                  items={INSTANCES}
+                  selectedItems={selectedInstance ? [selectedInstance] : []}
+                  onSelectionChange={({ detail }) => setSelectedInstance(detail.selectedItems[0] ?? null)}
+                  ariaLabels={{
+                    selectionGroupLabel: 'Instance selection',
+                    itemSelectionLabel: (_data, row) => row.name,
+                    tableLabel: 'Instances',
+                  }}
+                  header={<Header counter={`(${INSTANCES.length})`}>Instances</Header>}
+                  columnDefinitions={[
+                    { id: 'name', header: 'Name', cell: item => item.name, isRowHeader: true },
+                    { id: 'type', header: 'Type', cell: item => item.type },
+                    {
+                      id: 'state',
+                      header: 'State',
+                      cell: item => <StatusIndicator type={STATE_TYPE[item.state]}>{item.state}</StatusIndicator>,
+                    },
+                  ]}
+                />
+              }
+              detail={selectedInstance && <InstanceDetail instance={selectedInstance} />}
+              detailPlaceholder={
+                <Box textAlign="center" color="text-body-secondary" padding={{ vertical: 'xxl' }}>
+                  <b>No instance selected</b>
+                  <Box variant="p" color="text-body-secondary">
+                    Select an instance from the list to view its details.
+                  </Box>
+                </Box>
+              }
+            />
+          </ContentLayout>
+        }
+      />
+    </ScreenshotArea>
+  );
+}

--- a/src/internal/components/master-detail-layout/README.md
+++ b/src/internal/components/master-detail-layout/README.md
@@ -1,0 +1,57 @@
+<!--
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+-->
+
+# MasterDetailLayout (experimental, internal — WIP v0)
+
+`MasterDetailLayout` is a first-cut, **internal** layout helper for the
+**Master/Detail** pattern: a list/master pane (typically a `Table` or `Cards`
+collection) sits alongside a detail pane that reflects the currently selected
+item. Selecting an item updates the detail view. On narrow container widths the
+layout collapses to a single column.
+
+> **Status:** WIP v0. This lives under `src/internal/components` and is **not**
+> part of the public API. It is intentionally additive and opt-in so we can
+> iterate on the pattern before committing to a public surface.
+
+## Why a composition helper (and not a full component yet)
+
+The Master/Detail pattern is fundamentally a *composition* of existing
+Cloudscape primitives (`AppLayout`, `Table`/`Cards`, `KeyValuePairs`, etc.).
+The only reusable, non-trivial piece is the two-column layout + responsive
+collapse, which this helper owns. Concrete master and detail content stay with
+the consumer. See `pages/master-detail/simple.page.tsx` for a worked example.
+
+## API (v0)
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `master` | `React.ReactNode` | The list/master pane (e.g. a `Table`). |
+| `detail` | `React.ReactNode` | Detail content for the selected item. |
+| `hasSelection` | `boolean` | Whether an item is selected. Drives the narrow-view switch. |
+| `detailPlaceholder` | `React.ReactNode` | Empty state shown in the detail pane when nothing is selected. |
+| `onClearSelection` | `() => void` | If provided, renders a "back to list" control in the narrow layout. |
+| `masterAriaLabel` / `detailAriaLabel` | `string` | Accessible labels for the two regions. |
+| `backLabel` | `string` | Label for the back control. Defaults to `"Back"`. |
+| `narrowBreakpoint` | `number` | Container width (px) below which it collapses. Defaults to `688`. |
+
+The pure `resolveMasterDetailView({ isNarrow, hasSelection, canClearSelection })`
+helper is exported for testing and reuse.
+
+## Responsive behavior
+
+- **Wide** container: master and detail render side by side.
+- **Narrow** container: a single pane renders — the detail pane when an item is
+  selected (with an optional back control), otherwise the master pane.
+
+Width is observed with `useContainerQuery` from `@cloudscape-design/component-toolkit`.
+
+## Known limitations / follow-ups (out of scope for v0)
+
+- No keyboard focus management when switching panes on narrow widths.
+- No URL/deep-link syncing of the selected item.
+- Detail pane is inline; a `SplitPanel`/drawer-based variant is not yet offered.
+- No public API, i18n messages, test-utils wrapper, or documenter definitions.
+- No visual-regression / integration (`__integ__`) coverage yet.
+- Column ratio and minimum widths are fixed; not yet configurable.

--- a/src/internal/components/master-detail-layout/__tests__/master-detail-layout.test.tsx
+++ b/src/internal/components/master-detail-layout/__tests__/master-detail-layout.test.tsx
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import MasterDetailLayout, {
+  DEFAULT_NARROW_BREAKPOINT,
+  resolveMasterDetailView,
+} from '../../../../../lib/components/internal/components/master-detail-layout';
+
+describe('resolveMasterDetailView', () => {
+  test('wide layout shows both panes and no back button', () => {
+    expect(resolveMasterDetailView({ isNarrow: false, hasSelection: false, canClearSelection: true })).toEqual({
+      showMaster: true,
+      showDetail: true,
+      showBackButton: false,
+    });
+    expect(resolveMasterDetailView({ isNarrow: false, hasSelection: true, canClearSelection: true })).toEqual({
+      showMaster: true,
+      showDetail: true,
+      showBackButton: false,
+    });
+  });
+
+  test('narrow layout without selection shows only the master pane', () => {
+    expect(resolveMasterDetailView({ isNarrow: true, hasSelection: false, canClearSelection: true })).toEqual({
+      showMaster: true,
+      showDetail: false,
+      showBackButton: false,
+    });
+  });
+
+  test('narrow layout with selection shows only the detail pane', () => {
+    expect(resolveMasterDetailView({ isNarrow: true, hasSelection: true, canClearSelection: true })).toEqual({
+      showMaster: false,
+      showDetail: true,
+      showBackButton: true,
+    });
+  });
+
+  test('narrow layout with selection hides the back button when selection cannot be cleared', () => {
+    expect(resolveMasterDetailView({ isNarrow: true, hasSelection: true, canClearSelection: false })).toEqual({
+      showMaster: false,
+      showDetail: true,
+      showBackButton: false,
+    });
+  });
+});
+
+describe('MasterDetailLayout', () => {
+  const renderLayout = (props: Partial<React.ComponentProps<typeof MasterDetailLayout>> = {}) =>
+    render(
+      <MasterDetailLayout
+        master={<div>MASTER</div>}
+        detail={<div>DETAIL</div>}
+        detailPlaceholder={<div>PLACEHOLDER</div>}
+        hasSelection={false}
+        masterAriaLabel="Items"
+        detailAriaLabel="Item details"
+        {...props}
+      />
+    );
+
+  test('exposes a sensible default breakpoint', () => {
+    expect(DEFAULT_NARROW_BREAKPOINT).toBeGreaterThan(0);
+  });
+
+  test('renders both regions in the default (wide) layout', () => {
+    renderLayout({ hasSelection: true });
+    expect(screen.getByLabelText('Items')).toBeInTheDocument();
+    expect(screen.getByLabelText('Item details')).toBeInTheDocument();
+    expect(screen.getByText('MASTER')).toBeInTheDocument();
+    expect(screen.getByText('DETAIL')).toBeInTheDocument();
+  });
+
+  test('renders the placeholder in the detail pane when nothing is selected', () => {
+    renderLayout({ hasSelection: false });
+    expect(screen.getByText('PLACEHOLDER')).toBeInTheDocument();
+    expect(screen.queryByText('DETAIL')).not.toBeInTheDocument();
+  });
+
+  test('does not render a back control in the wide layout even when clearable', () => {
+    const onClearSelection = jest.fn();
+    renderLayout({ hasSelection: true, onClearSelection, backLabel: 'Back to list' });
+    expect(screen.queryByText('Back to list')).not.toBeInTheDocument();
+    expect(onClearSelection).not.toHaveBeenCalled();
+    // sanity: detail content is still visible in the wide layout
+    expect(screen.getByText('DETAIL')).toBeInTheDocument();
+    fireEvent.resize(window);
+  });
+});

--- a/src/internal/components/master-detail-layout/index.tsx
+++ b/src/internal/components/master-detail-layout/index.tsx
@@ -1,0 +1,105 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+
+import { useContainerQuery } from '@cloudscape-design/component-toolkit';
+
+import InternalButton from '../../../button/internal';
+import { MasterDetailLayoutProps, MasterDetailView } from './interfaces';
+
+import styles from './styles.css.js';
+import testClasses from './test-classes/styles.css.js';
+
+export { MasterDetailLayoutProps };
+
+/**
+ * Default container width (px) below which the layout collapses to a single column.
+ */
+export const DEFAULT_NARROW_BREAKPOINT = 688;
+
+/**
+ * Pure helper deciding which panes are visible for a given state. Extracted from
+ * the component so the responsive branching can be unit tested without a DOM
+ * layout engine (jsdom does not measure element widths).
+ *
+ * - Wide layout: master and detail render side by side.
+ * - Narrow layout: a single pane renders. The detail pane is shown when an item
+ *   is selected, otherwise the master (list) pane is shown. When a selection can
+ *   be cleared, a "back to list" control is offered in the detail pane.
+ */
+export function resolveMasterDetailView({
+  isNarrow,
+  hasSelection,
+  canClearSelection,
+}: {
+  isNarrow: boolean;
+  hasSelection: boolean;
+  canClearSelection: boolean;
+}): MasterDetailView {
+  if (!isNarrow) {
+    return { showMaster: true, showDetail: true, showBackButton: false };
+  }
+  if (hasSelection) {
+    return { showMaster: false, showDetail: true, showBackButton: canClearSelection };
+  }
+  return { showMaster: true, showDetail: false, showBackButton: false };
+}
+
+/**
+ * MasterDetailLayout — an experimental, internal layout helper that composes the
+ * Master/Detail pattern (a list/master pane alongside a detail pane for the
+ * selected item) on top of existing Cloudscape layout primitives.
+ *
+ * This is a first-cut (v0) building block: it owns the two-column layout and the
+ * responsive collapse to a single column, while remaining agnostic about the
+ * concrete master (Table, Cards, ...) and detail content, which are provided by
+ * the consumer. It is intentionally additive and not part of the public API.
+ */
+export default function MasterDetailLayout({
+  master,
+  detail,
+  hasSelection,
+  detailPlaceholder,
+  onClearSelection,
+  masterAriaLabel,
+  detailAriaLabel,
+  backLabel = 'Back',
+  narrowBreakpoint = DEFAULT_NARROW_BREAKPOINT,
+}: MasterDetailLayoutProps) {
+  // Only collapse once we have a positive measurement below the breakpoint. A
+  // 0-width (unmeasured / SSR / degenerate) container keeps the wide layout,
+  // which avoids a flash-of-narrow before the first measurement is available.
+  const [isNarrow, ref] = useContainerQuery(
+    entry => entry.contentBoxWidth > 0 && entry.contentBoxWidth < narrowBreakpoint,
+    [narrowBreakpoint]
+  );
+
+  const { showMaster, showDetail, showBackButton } = resolveMasterDetailView({
+    isNarrow: isNarrow ?? false,
+    hasSelection,
+    canClearSelection: !!onClearSelection,
+  });
+
+  return (
+    <div ref={ref} className={clsx(styles.root, testClasses.root, isNarrow && styles.narrow)}>
+      {showMaster && (
+        <section className={clsx(styles.master, testClasses.master)} aria-label={masterAriaLabel}>
+          {master}
+        </section>
+      )}
+      {showDetail && (
+        <section className={clsx(styles.detail, testClasses.detail)} aria-label={detailAriaLabel}>
+          {showBackButton && (
+            <div className={clsx(styles['back-button'], testClasses['back-button'])}>
+              <InternalButton variant="link" iconName="angle-left" onClick={() => onClearSelection?.()}>
+                {backLabel}
+              </InternalButton>
+            </div>
+          )}
+          {hasSelection ? detail : detailPlaceholder}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/internal/components/master-detail-layout/interfaces.ts
+++ b/src/internal/components/master-detail-layout/interfaces.ts
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+export interface MasterDetailLayoutProps {
+  /**
+   * Master pane content — typically a Table or Cards collection acting as the
+   * list of items the user can select from.
+   */
+  master: React.ReactNode;
+
+  /**
+   * Detail pane content for the currently selected item. Only shown when
+   * `hasSelection` is `true`; otherwise `detailPlaceholder` is rendered.
+   */
+  detail: React.ReactNode;
+
+  /**
+   * Whether an item is currently selected. This drives the responsive
+   * (single-column) behavior: in the narrow layout the detail pane is shown
+   * when `true`, and the master (list) pane is shown when `false`.
+   */
+  hasSelection: boolean;
+
+  /**
+   * Content rendered in the detail pane when nothing is selected (empty state).
+   */
+  detailPlaceholder?: React.ReactNode;
+
+  /**
+   * Called when the user activates the "back to list" control in the narrow
+   * layout. Providing this callback renders the control.
+   */
+  onClearSelection?: () => void;
+
+  /** Accessible label for the master (list) region. */
+  masterAriaLabel?: string;
+
+  /** Accessible label for the detail region. */
+  detailAriaLabel?: string;
+
+  /** Text for the "back to list" control shown in the narrow layout. Defaults to "Back". */
+  backLabel?: string;
+
+  /**
+   * Container width (in px) below which the layout collapses to a single
+   * column. Defaults to {@link DEFAULT_NARROW_BREAKPOINT}.
+   */
+  narrowBreakpoint?: number;
+}
+
+export interface MasterDetailView {
+  /** Whether the master (list) pane should render. */
+  showMaster: boolean;
+  /** Whether the detail pane should render. */
+  showDetail: boolean;
+  /** Whether the "back to list" control should render inside the detail pane. */
+  showBackButton: boolean;
+}

--- a/src/internal/components/master-detail-layout/styles.scss
+++ b/src/internal/components/master-detail-layout/styles.scss
@@ -1,0 +1,33 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+@use '../../styles' as styles;
+@use '../../styles/tokens' as awsui;
+
+.root {
+  @include styles.styles-reset;
+  display: grid;
+  // Master column has a sensible minimum and takes ~1/3, detail takes the rest.
+  grid-template-columns: minmax(280px, 1fr) 2fr;
+  gap: awsui.$space-scaled-l;
+  inline-size: 100%;
+  align-items: start;
+
+  &.narrow {
+    // Collapse to a single column on narrow containers.
+    grid-template-columns: 1fr;
+  }
+}
+
+.master {
+  min-inline-size: 0;
+}
+
+.detail {
+  min-inline-size: 0;
+}
+
+.back-button {
+  margin-block-end: awsui.$space-scaled-s;
+}

--- a/src/internal/components/master-detail-layout/test-classes/styles.scss
+++ b/src/internal/components/master-detail-layout/test-classes/styles.scss
@@ -1,0 +1,11 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.root,
+.master,
+.detail,
+.back-button {
+  /* used in test-utils */
+}


### PR DESCRIPTION
### Description

**[WIP] First-cut (v0) of the Master/Detail layout pattern.** Opening as a **draft** to
gather early feedback on the approach — this is a foundation, not a finished feature.

The Master/Detail pattern places a list/master pane (e.g. a `Table`) alongside a detail
pane that reflects the selected item; selecting an item updates the detail view, and the
layout collapses to a single column on narrow widths.

This v0 is delivered as a **documented composition + a small internal layout helper**,
rather than a new public component, because the pattern is fundamentally a composition of
existing primitives (`AppLayout`, `Table`/`Cards`, `KeyValuePairs`, …). The only reusable,
non-trivial piece — the two-column layout plus responsive collapse — is owned by the helper.

Everything here is **additive and opt-in**, and lives under `src/internal` so it carries
**no public API surface** (no documenter definitions, i18n messages, or test-utils wrappers).

#### What's included (done in v0)

- `src/internal/components/master-detail-layout/` — experimental internal helper:
  - `MasterDetailLayout` composes existing layout primitives; owns the two-column grid and
    the responsive collapse to a single column (via `useContainerQuery`).
  - Narrow layout shows a single pane: the detail pane when an item is selected (with an
    optional "back to list" control), otherwise the master pane.
  - Exported pure helper `resolveMasterDetailView(...)` for the pane-visibility branching.
  - `styles.scss` (+ `test-classes`) and a `README.md` documenting the pattern & API.
- `pages/master-detail/simple.page.tsx` — dev/demo page: a `Table` (single-select) master
  → `KeyValuePairs` detail, inside `AppLayout` + `ContentLayout`, with an empty state.
- Unit tests: 8 tests covering the pure view resolver (all branches) + rendering
  (wide layout, empty-state placeholder, no back-control in wide layout).

#### Remaining work (out of scope for v0 — follow-ups)

- Keyboard focus management when switching panes on narrow widths.
- URL / deep-link syncing of the selected item.
- A `SplitPanel`/drawer-based detail variant in addition to the inline detail pane.
- Configurable column ratio / minimum widths.
- Decision on graduating to a public API (then: interfaces, i18n, test-utils, documenter,
  API docs) — or keeping it as a documented composition/recipe.
- `__integ__` integration tests and visual-regression coverage.
- Broader examples (Cards master, bulk actions, filtering/pagination in the master pane).

> ⚠️ **Ticket mismatch note:** The referenced SIM `AWSUI-55031` does **not** describe a
> Master/Detail pattern — it resolves to an unrelated "Aperture Form Submission" customer
> feedback record (a "Yes" on the Side navigation `testing` docs tab, 2024-08-09). This PR
> was implemented against the provided task description for the Master/Detail pattern; the
> ticket reference should be corrected/re-linked.

Related links, issue #, if available: n/a (see ticket-mismatch note above)

### How has this been tested?

- `npx eslint` on the new files — clean (auto-formatted with prettier).
- `npx stylelint` on the new SCSS — clean.
- `npm run quick-build` — success.
- Unit tests (`jest.unit.config.js`) — **8/8 passing**.
- `npm run build` (full: pages, themeable, docs, size-limit, test-definitions) — success
  (only pre-existing entrypoint asset-size warnings, unrelated to this change).
- Manual: `npm start` → open the "master-detail/simple" dev page; select rows to update
  the detail pane; resize the window to observe the single-column collapse.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ — README + dev page added.
- _Changes are backward-compatible if not indicated._ — Yes; additive, internal-only, no public API.
- _Changes do not include unsupported browser features._ — Uses existing primitives + `useContainerQuery`.
- _Changes were manually tested for accessibility._ — Regions labelled; full a11y pass is a follow-up.

#### Security

- _If the code handles URLs: all URLs are validated through `checkSafeUrl`._ — N/A, no URL handling.

#### Testing

- _Changes are covered with new/existing unit tests?_ — Yes (8 new unit tests).
- _Changes are covered with new/existing integration tests?_ — Not yet (follow-up).
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
