### PR TITLE
chore: Sync i18n messages

### DIFF
--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -1,650 +1,682 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/* eslint-disable prettier/prettier */
 
 /** Auto-generated argument types based on "en" i18n strings. Do not edit manually. */
 export interface I18nFormatArgTypes {
-  '[charts]': {
-    loadingText: never;
-    errorText: never;
-    recoveryText: never;
-    'i18nStrings.filterLabel': never;
-    'i18nStrings.filterPlaceholder': never;
-    'i18nStrings.legendAriaLabel': never;
-    'i18nStrings.chartAriaRoleDescription': never;
-    'i18nStrings.xAxisAriaRoleDescription': never;
-    'i18nStrings.yAxisAriaRoleDescription': never;
-  };
-  alert: {
-    dismissAriaLabel: never;
-    'i18nStrings.successIconAriaLabel': never;
-    'i18nStrings.errorIconAriaLabel': never;
-    'i18nStrings.warningIconAriaLabel': never;
-    'i18nStrings.infoIconAriaLabel': never;
-    'i18nStrings.dismissAriaLabel': never;
-  };
-  'annotation-context': {
-    'i18nStrings.nextButtonText': never;
-    'i18nStrings.previousButtonText': never;
-    'i18nStrings.finishButtonText': never;
-    'i18nStrings.labelDismissAnnotation': never;
-    'i18nStrings.stepCounterText': {
-      stepNumber: string | number;
-      totalStepCount: string | number;
-    };
-    'i18nStrings.taskTitle': {
-      taskNumber: string | number;
-      taskTitle: string | number;
-    };
-    'i18nStrings.labelHotspot': {
-      openState: string;
-      stepNumber: string | number;
-      totalStepCount: string | number;
-    };
-  };
-  'app-layout': {
-    'ariaLabels.drawers': never;
-    'ariaLabels.drawersOverflow': never;
-    'ariaLabels.drawersOverflowWithBadge': never;
-    'ariaLabels.navigation': never;
-    'ariaLabels.navigationClose': never;
-    'ariaLabels.navigationToggle': never;
-    'ariaLabels.notifications': never;
-    'ariaLabels.tools': never;
-    'ariaLabels.toolsClose': never;
-    'ariaLabels.toolsToggle': never;
-  };
-  'area-chart': {
-    'i18nStrings.detailTotalLabel': never;
-  };
-  'attribute-editor': {
-    removeButtonText: never;
-    'i18nStrings.itemRemovedAriaLive': never;
-  };
-  autosuggest: {
-    errorIconAriaLabel: never;
-    selectedAriaLabel: never;
-    enteredTextLabel: {
-      value: string | number;
-    };
-    recoveryText: never;
-  };
-  'breadcrumb-group': {
-    expandAriaLabel: never;
-  };
-  button: {
-    'i18nStrings.externalIconAriaLabel': never;
-  };
-  calendar: {
-    nextMonthAriaLabel: never;
-    previousMonthAriaLabel: never;
-    todayAriaLabel: never;
-    'i18nStrings.nextYearAriaLabel': never;
-    'i18nStrings.previousYearAriaLabel': never;
-    'i18nStrings.currentMonthAriaLabel': never;
-  };
-  cards: {
-    'ariaLabels.selectionGroupLabel': never;
-  };
-  'code-editor': {
-    'i18nStrings.loadingState': never;
-    'i18nStrings.errorState': never;
-    'i18nStrings.errorStateRecovery': never;
-    'i18nStrings.editorGroupAriaLabel': never;
-    'i18nStrings.statusBarGroupAriaLabel': never;
-    'i18nStrings.cursorPosition': {
-      row: string | number;
-      column: string | number;
-    };
-    'i18nStrings.errorsTab': never;
-    'i18nStrings.warningsTab': never;
-    'i18nStrings.preferencesButtonAriaLabel': never;
-    'i18nStrings.paneCloseButtonAriaLabel': never;
-    'i18nStrings.preferencesModalHeader': never;
-    'i18nStrings.preferencesModalCancel': never;
-    'i18nStrings.preferencesModalConfirm': never;
-    'i18nStrings.preferencesModalWrapLines': never;
-    'i18nStrings.preferencesModalTheme': never;
-    'i18nStrings.preferencesModalThemeFilteringAriaLabel': never;
-    'i18nStrings.preferencesModalThemeFilteringPlaceholder': never;
-    'i18nStrings.preferencesModalLightThemes': never;
-    'i18nStrings.preferencesModalDarkThemes': never;
-    'i18nStrings.cursorPositionAriaLabel': {
-      row: string | number;
-    };
-    'i18nStrings.resizeHandleAriaLabel': never;
-    'i18nStrings.resizeHandleTooltipText': never;
-  };
-  'collection-preferences': {
-    title: never;
-    confirmLabel: never;
-    cancelLabel: never;
-    'pageSizePreference.title': never;
-    'wrapLinesPreference.label': never;
-    'wrapLinesPreference.description': never;
-    'stripedRowsPreference.label': never;
-    'stripedRowsPreference.description': never;
-    'contentDensityPreference.label': never;
-    'contentDensityPreference.description': never;
-    'stickyColumnsPreference.firstColumns.title': never;
-    'stickyColumnsPreference.firstColumns.description': never;
-    'stickyColumnsPreference.firstColumns.options[0].label': never;
-    'stickyColumnsPreference.firstColumns.options[1].label': never;
-    'stickyColumnsPreference.firstColumns.options[2].label': never;
-    'stickyColumnsPreference.lastColumns.title': never;
-    'stickyColumnsPreference.lastColumns.description': never;
-    'stickyColumnsPreference.lastColumns.options[0].label': never;
-    'stickyColumnsPreference.lastColumns.options[1].label': never;
-    'contentDisplayPreference.title': never;
-    'contentDisplayPreference.description': never;
-    'contentDisplayPreference.dragHandleAriaLabel': never;
-    'contentDisplayPreference.dragHandleAriaDescription': never;
-    'contentDisplayPreference.liveAnnouncementDndStarted': {
-      position: string | number;
-      total: string | number;
-    };
-    'contentDisplayPreference.liveAnnouncementDndDiscarded': never;
-    'contentDisplayPreference.liveAnnouncementDndGroupLabel': {
-      label: string;
-      count: number;
-    };
-    'contentDisplayPreference.i18nStrings.columnFilteringPlaceholder': never;
-    'contentDisplayPreference.i18nStrings.columnFilteringAriaLabel': never;
-    'contentDisplayPreference.i18nStrings.columnFilteringNoMatchText': never;
-    'contentDisplayPreference.i18nStrings.columnFilteringClearFilterText': never;
-    'contentDisplayPreference.liveAnnouncementDndItemReordered': {
-      isInitialPosition: string;
-      currentPosition: string | number;
-      total: string | number;
-    };
-    'contentDisplayPreference.liveAnnouncementDndItemCommitted': {
-      isInitialPosition: string;
-      initialPosition: string | number;
-      total: string | number;
-      finalPosition: string | number;
-    };
-    'contentDisplayPreference.i18nStrings.columnFilteringCountText': {
-      count: number;
-    };
-  };
-  'copy-to-clipboard': {
-    'i18nStrings.copyButtonText': never;
-  };
-  'date-picker': {
-    'i18nStrings.openCalendarAriaLabel': {
-      selectedDate: string;
-    };
-  };
-  'date-range-picker': {
-    'i18nStrings.relativeModeTitle': never;
-    'i18nStrings.absoluteModeTitle': never;
-    'i18nStrings.relativeRangeSelectionHeading': never;
-    'i18nStrings.relativeRangeSelectionMonthlyDescription': never;
-    'i18nStrings.cancelButtonLabel': never;
-    'i18nStrings.clearButtonLabel': never;
-    'i18nStrings.applyButtonLabel': never;
-    'i18nStrings.customRelativeRangeOptionLabel': never;
-    'i18nStrings.customRelativeRangeOptionDescription': never;
-    'i18nStrings.customRelativeRangeUnitLabel': never;
-    'i18nStrings.customRelativeRangeDurationLabel': never;
-    'i18nStrings.customRelativeRangeDurationPlaceholder': never;
-    'i18nStrings.previousMonthAriaLabel': never;
-    'i18nStrings.nextMonthAriaLabel': never;
-    'i18nStrings.previousYearAriaLabel': never;
-    'i18nStrings.nextYearAriaLabel': never;
-    'i18nStrings.currentMonthAriaLabel': never;
-    'i18nStrings.todayAriaLabel': never;
-    'i18nStrings.startMonthLabel': never;
-    'i18nStrings.startDateLabel': never;
-    'i18nStrings.startTimeLabel': never;
-    'i18nStrings.endMonthLabel': never;
-    'i18nStrings.endDateLabel': never;
-    'i18nStrings.endTimeLabel': never;
-    'i18nStrings.isoDatePlaceholder': never;
-    'i18nStrings.slashedDatePlaceholder': never;
-    'i18nStrings.timePlaceholder': never;
-    'i18nStrings.dateTimeConstraintText': never;
-    'i18nStrings.dateConstraintText': never;
-    'i18nStrings.slashedDateTimeConstraintText': never;
-    'i18nStrings.isoDateTimeConstraintText': never;
-    'i18nStrings.slashedDateConstraintText': never;
-    'i18nStrings.isoDateConstraintText': never;
-    'i18nStrings.slashedMonthConstraintText': never;
-    'i18nStrings.isoMonthConstraintText': never;
-    'i18nStrings.monthConstraintText': never;
-    'i18nStrings.errorIconAriaLabel': never;
-    'i18nStrings.renderSelectedAbsoluteRangeAriaLive': {
-      startDate: string | number;
-      endDate: string | number;
-    };
-    'i18nStrings.formatRelativeRange': {
-      unit: string;
-      amount: number;
-    };
-    'i18nStrings.formatUnit': {
-      unit: string;
-      amount: number;
-    };
-  };
-  drawer: {
-    'i18nStrings.loadingText': never;
-  };
-  'error-boundary': {
-    'i18nStrings.headerText'?: never;
-    'i18nStrings.descriptionText'?: {
-      hasFeedback: boolean;
-      Feedback: (chunks: React.ReactNode[]) => React.ReactNode;
-    };
-    'i18nStrings.refreshActionText'?: never;
-  };
-  'features-notification-drawer': {
-    'i18nStrings.title': never;
-    'i18nStrings.viewAll': never;
-    'ariaLabels.closeButton': never;
-    'ariaLabels.content': never;
-    'ariaLabels.triggerButton': never;
-    'ariaLabels.resizeHandle': never;
-  };
-  'file-token-group': {
-    'i18nStrings.limitShowFewer': never;
-    'i18nStrings.limitShowMore': never;
-    'i18nStrings.removeFileAriaLabel': {
-      fileIndex: string | number;
-      fileName: string;
-    };
-    'i18nStrings.errorIconAriaLabel': never;
-    'i18nStrings.warningIconAriaLabel': never;
-  };
-  'file-upload': {
-    'i18nStrings.limitShowFewer': never;
-    'i18nStrings.limitShowMore': never;
-    'i18nStrings.removeFileAriaLabel': {
-      fileIndex: string | number;
-      fileName: string;
-    };
-    'i18nStrings.errorIconAriaLabel': never;
-    'i18nStrings.warningIconAriaLabel': never;
-    'i18nStrings.uploadButtonText': {
-      multiple: string;
-    };
-    'i18nStrings.dropzoneText': {
-      multiple: string;
-    };
-  };
-  flashbar: {
-    'i18nStrings.ariaLabel': never;
-    'i18nStrings.errorIconAriaLabel': never;
-    'i18nStrings.inProgressIconAriaLabel': never;
-    'i18nStrings.infoIconAriaLabel': never;
-    'i18nStrings.notificationBarAriaLabel': never;
-    'i18nStrings.notificationBarText': never;
-    'i18nStrings.successIconAriaLabel': never;
-    'i18nStrings.warningIconAriaLabel': never;
-  };
-  'form-field': {
-    'i18nStrings.errorIconAriaLabel': never;
-    'i18nStrings.warningIconAriaLabel': never;
-  };
-  form: {
-    errorIconAriaLabel: never;
-  };
-  'help-panel': {
-    loadingText: never;
-  };
-  input: {
-    clearAriaLabel: never;
-  };
-  link: {
-    externalIconAriaLabel: never;
-  };
-  list: {
-    dragHandleAriaLabel: never;
-    dragHandleAriaDescription: never;
-    liveAnnouncementDndStarted: {
-      position: string | number;
-      total: string | number;
-    };
-    liveAnnouncementDndDiscarded: never;
-    liveAnnouncementDndItemReordered: {
-      isInitialPosition: string;
-      currentPosition: string | number;
-      total: string | number;
-    };
-    liveAnnouncementDndItemCommitted: {
-      isInitialPosition: string;
-      initialPosition: string | number;
-      total: string | number;
-      finalPosition: string | number;
-    };
-  };
-  modal: {
-    closeAriaLabel: never;
-  };
-  multiselect: {
-    deselectAriaLabel: {
-      option__label: string | number;
-    };
-    'i18nStrings.selectAllText': never;
-  };
-  pagination: {
-    'ariaLabels.nextPageLabel': never;
-    'ariaLabels.pageLabel': {
-      pageNumber: string | number;
-    };
-    'ariaLabels.previousPageLabel': never;
-    'ariaLabels.jumpToPageButtonLabel': never;
-    'i18nStrings.jumpToPageInputLabel': never;
-    'i18nStrings.jumpToPageError': never;
-    'i18nStrings.jumpToPageLoadingText': never;
-  };
-  'panel-resize-handle': {
-    'i18nStrings.resizeHandleAriaLabel': never;
-    'i18nStrings.resizeHandleTooltipText': never;
-  };
-  'pie-chart': {
-    'i18nStrings.detailsValue': never;
-    'i18nStrings.detailsPercentage': never;
-    'i18nStrings.chartAriaRoleDescription': never;
-    'i18nStrings.segmentAriaRoleDescription': never;
-  };
-  popover: {
-    dismissAriaLabel: never;
-  };
-  'prompt-input': {
-    'i18nStrings.actionButtonAriaLabel': never;
-    'i18nStrings.menuErrorIconAriaLabel': never;
-    'i18nStrings.menuRecoveryText': never;
-    'i18nStrings.menuLoadingText': never;
-    'i18nStrings.menuFinishedText': never;
-    'i18nStrings.menuErrorText': never;
-    'i18nStrings.selectedMenuItemAriaLabel': never;
-    'i18nStrings.tokenInsertedAriaLabel': {
-      token__label: string;
-    };
-    'i18nStrings.tokenPinnedAriaLabel': {
-      token__label: string;
-    };
-    'i18nStrings.tokenRemovedAriaLabel': {
-      token__label: string;
-    };
-  };
-  'property-filter': {
-    'i18nStrings.allPropertiesLabel': never;
-    'i18nStrings.applyActionText': never;
-    'i18nStrings.cancelActionText': never;
-    'i18nStrings.clearFiltersText': never;
-    'i18nStrings.editTokenHeader': never;
-    'i18nStrings.groupPropertiesText': never;
-    'i18nStrings.groupValuesText': never;
-    'i18nStrings.operationAndText': never;
-    'i18nStrings.operationOrText': never;
-    'i18nStrings.operatorContainsText': never;
-    'i18nStrings.operatorDoesNotContainText': never;
-    'i18nStrings.operatorDoesNotEqualText': never;
-    'i18nStrings.operatorEqualsText': never;
-    'i18nStrings.operatorGreaterOrEqualText': never;
-    'i18nStrings.operatorGreaterText': never;
-    'i18nStrings.operatorLessOrEqualText': never;
-    'i18nStrings.operatorLessText': never;
-    'i18nStrings.operatorStartsWithText': never;
-    'i18nStrings.operatorDoesNotStartWithText': never;
-    'i18nStrings.operatorText': never;
-    'i18nStrings.operatorsText': never;
-    'i18nStrings.propertyText': never;
-    'i18nStrings.removeTokenButtonAriaLabel': {
-      token__formattedText: string | number;
-    };
-    'i18nStrings.tokenEditorTokenActionsAriaLabel': {
-      token__formattedText: string | number;
-    };
-    'i18nStrings.tokenEditorTokenRemoveAriaLabel': {
-      token__formattedText: string | number;
-    };
-    'i18nStrings.tokenEditorTokenRemoveLabel': never;
-    'i18nStrings.tokenEditorTokenRemoveFromGroupLabel': never;
-    'i18nStrings.tokenEditorAddTokenActionsAriaLabel': never;
-    'i18nStrings.tokenEditorAddNewTokenLabel': never;
-    'i18nStrings.tokenEditorAddExistingTokenAriaLabel': {
-      token__formattedText: string | number;
-    };
-    'i18nStrings.tokenEditorAddExistingTokenLabel': {
-      token__propertyLabel: string | number;
-      token__operator: string | number;
-      token__value: string | number;
-    };
-    'i18nStrings.tokenLimitShowFewer': never;
-    'i18nStrings.tokenLimitShowMore': never;
-    'i18nStrings.valueText': never;
-    'i18nStrings.formatToken': {
-      token__operator: string;
-      token__propertyLabel: string | number;
-      token__value: string | number;
-    };
-    'i18nStrings.groupEditAriaLabel': {
-      group__formattedTokens__length: string;
-      group__formattedTokens0__formattedText: string | number;
-      group__operationLabel: string | number;
-      group__formattedTokens1__formattedText: string | number;
-      group__formattedTokens2__formattedText: string | number;
-      group__formattedTokens3__formattedText: string | number;
-    };
-  };
-  's3-resource-selector': {
-    'i18nStrings.inContextSelectPlaceholder': never;
-    'i18nStrings.inContextBrowseButton': never;
-    'i18nStrings.inContextViewButton': never;
-    'i18nStrings.inContextViewButtonAriaLabel': never;
-    'i18nStrings.inContextLoadingText': never;
-    'i18nStrings.inContextUriLabel': never;
-    'i18nStrings.inContextVersionSelectLabel': never;
-    'i18nStrings.modalTitle': never;
-    'i18nStrings.modalCancelButton': never;
-    'i18nStrings.modalSubmitButton': never;
-    'i18nStrings.modalBreadcrumbRootItem': never;
-    'i18nStrings.modalLastUpdatedText': never;
-    'i18nStrings.selectionBuckets': never;
-    'i18nStrings.selectionObjects': never;
-    'i18nStrings.selectionVersions': never;
-    'i18nStrings.selectionBucketsSearchPlaceholder': never;
-    'i18nStrings.selectionObjectsSearchPlaceholder': never;
-    'i18nStrings.selectionVersionsSearchPlaceholder': never;
-    'i18nStrings.selectionBucketsLoading': never;
-    'i18nStrings.selectionBucketsNoItems': never;
-    'i18nStrings.selectionObjectsLoading': never;
-    'i18nStrings.selectionObjectsNoItems': never;
-    'i18nStrings.selectionVersionsLoading': never;
-    'i18nStrings.selectionVersionsNoItems': never;
-    'i18nStrings.filteringNoMatches': never;
-    'i18nStrings.filteringCantFindMatch': never;
-    'i18nStrings.clearFilterButtonText': never;
-    'i18nStrings.columnBucketID': never;
-    'i18nStrings.columnBucketName': never;
-    'i18nStrings.columnBucketCreationDate': never;
-    'i18nStrings.columnBucketRegion': never;
-    'i18nStrings.columnObjectKey': never;
-    'i18nStrings.columnObjectLastModified': never;
-    'i18nStrings.columnObjectSize': never;
-    'i18nStrings.columnVersionID': never;
-    'i18nStrings.columnVersionLastModified': never;
-    'i18nStrings.columnVersionSize': never;
-    'i18nStrings.validationPathMustBegin': never;
-    'i18nStrings.validationBucketLowerCase': never;
-    'i18nStrings.validationBucketMustNotContain': never;
-    'i18nStrings.validationBucketLength': never;
-    'i18nStrings.validationBucketMustComplyDns': never;
-    'i18nStrings.labelSortedDescending': {
-      columnName: string | number;
-    };
-    'i18nStrings.labelSortedAscending': {
-      columnName: string | number;
-    };
-    'i18nStrings.labelNotSorted': {
-      columnName: string | number;
-    };
-    'i18nStrings.labelsBucketsSelection.selectionGroupLabel': never;
-    'i18nStrings.labelsBucketsSelection.itemSelectionLabel': {
-      item__Name: string | number;
-    };
-    'i18nStrings.labelsObjectsSelection.selectionGroupLabel': never;
-    'i18nStrings.labelsObjectsSelection.itemSelectionLabel': {
-      item__Key: string | number;
-    };
-    'i18nStrings.labelsVersionsSelection.selectionGroupLabel': never;
-    'i18nStrings.labelsVersionsSelection.itemSelectionLabel': {
-      item__VersionId: string | number;
-    };
-    'i18nStrings.labelFiltering': {
-      itemsType: string | number;
-    };
-    'i18nStrings.labelRefresh': never;
-    'i18nStrings.labelBreadcrumbs': never;
-    'i18nStrings.labelIconFolder': never;
-    'i18nStrings.labelIconObject': never;
-    'i18nStrings.filteringCounterText': {
-      count: number;
-    };
-  };
-  select: {
-    errorIconAriaLabel: never;
-    selectedAriaLabel: never;
-    recoveryText: never;
-  };
-  slider: {
-    'i18nStrings.valueTextRange': {
-      value: string | number;
-      previousValue: string | number;
-      nextValue: string | number;
-    };
-  };
-  'split-panel': {
-    'i18nStrings.closeButtonAriaLabel': never;
-    'i18nStrings.openButtonAriaLabel': never;
-    'i18nStrings.preferencesTitle': never;
-    'i18nStrings.preferencesPositionLabel': never;
-    'i18nStrings.preferencesPositionDescription': never;
-    'i18nStrings.preferencesPositionSide': never;
-    'i18nStrings.preferencesPositionBottom': never;
-    'i18nStrings.preferencesConfirm': never;
-    'i18nStrings.preferencesCancel': never;
-    'i18nStrings.resizeHandleAriaLabel': never;
-    'i18nStrings.resizeHandleTooltipText': never;
-  };
-  table: {
-    'ariaLabels.resizerRoleDescription': never;
-    'ariaLabels.submittingEditText': never;
-    'ariaLabels.successfulEditLabel': never;
-    'ariaLabels.expandButtonLabel': never;
-    'ariaLabels.collapseButtonLabel': never;
-    'columnDefinitions.editConfig.errorIconAriaLabel': never;
-    'columnDefinitions.editConfig.editIconAriaLabel': never;
-  };
-  tabs: {
-    'i18nStrings.scrollLeftAriaLabel': never;
-    'i18nStrings.scrollRightAriaLabel': never;
-    'i18nStrings.tabsWithActionsAriaRoleDescription': never;
-  };
-  'tag-editor': {
-    'i18nStrings.keyPlaceholder': never;
-    'i18nStrings.valuePlaceholder': never;
-    'i18nStrings.addButton': never;
-    'i18nStrings.removeButton': never;
-    'i18nStrings.removeButtonAriaLabel': {
-      tag__key: string | number;
-    };
-    'i18nStrings.undoButton': never;
-    'i18nStrings.undoPrompt': never;
-    'i18nStrings.loading': never;
-    'i18nStrings.keyHeader': never;
-    'i18nStrings.valueHeader': never;
-    'i18nStrings.optional': never;
-    'i18nStrings.keySuggestion': never;
-    'i18nStrings.valueSuggestion': never;
-    'i18nStrings.emptyTags': never;
-    'i18nStrings.tooManyKeysSuggestion': never;
-    'i18nStrings.tooManyValuesSuggestion': never;
-    'i18nStrings.keysSuggestionLoading': never;
-    'i18nStrings.keysSuggestionError': never;
-    'i18nStrings.valuesSuggestionLoading': never;
-    'i18nStrings.valuesSuggestionError': never;
-    'i18nStrings.emptyKeyError': never;
-    'i18nStrings.maxKeyCharLengthError': never;
-    'i18nStrings.maxValueCharLengthError': never;
-    'i18nStrings.duplicateKeyError': never;
-    'i18nStrings.invalidKeyError': never;
-    'i18nStrings.invalidValueError': never;
-    'i18nStrings.awsPrefixError': never;
-    'i18nStrings.tagLimitReached': {
-      tagLimit: number;
-    };
-    'i18nStrings.tagLimitExceeded': {
-      tagLimit: number;
-    };
-    'i18nStrings.tagLimit': {
-      tagLimitAvailable: string;
-      availableTags: number;
-      tagLimit: string | number;
-    };
-  };
-  'token-group': {
-    'i18nStrings.limitShowFewer': never;
-    'i18nStrings.limitShowMore': never;
-  };
-  'top-navigation': {
-    'i18nStrings.searchIconAriaLabel': never;
-    'i18nStrings.searchDismissIconAriaLabel': never;
-    'i18nStrings.overflowMenuTriggerText': never;
-    'i18nStrings.overflowMenuDismissIconAriaLabel': never;
-    'i18nStrings.overflowMenuBackIconAriaLabel': never;
-    'i18nStrings.overflowMenuTitleText': never;
-  };
-  'tree-view': {
-    'i18nStrings.expandButtonLabel': never;
-    'i18nStrings.collapseButtonLabel': never;
-  };
-  'tutorial-panel': {
-    'i18nStrings.loadingText': never;
-    'i18nStrings.tutorialListTitle': never;
-    'i18nStrings.tutorialListDownloadLinkText': never;
-    'i18nStrings.labelTutorialListDownloadLink': never;
-    'i18nStrings.tutorialCompletedText': never;
-    'i18nStrings.learnMoreLinkText': never;
-    'i18nStrings.startTutorialButtonText': never;
-    'i18nStrings.restartTutorialButtonText': never;
-    'i18nStrings.completionScreenTitle': never;
-    'i18nStrings.feedbackLinkText': never;
-    'i18nStrings.dismissTutorialButtonText': never;
-    'i18nStrings.taskTitle': {
-      taskNumber: string | number;
-      taskTitle: string | number;
-    };
-    'i18nStrings.stepTitle': {
-      stepNumber: string | number;
-      stepTitle: string | number;
-    };
-    'i18nStrings.labelExitTutorial': never;
-    'i18nStrings.labelTotalSteps': {
-      totalStepCount: string | number;
-    };
-    'i18nStrings.labelsTaskStatus.pending': never;
-    'i18nStrings.labelsTaskStatus.in-progress': never;
-    'i18nStrings.labelsTaskStatus.success': never;
-  };
-  wizard: {
-    'i18nStrings.stepNumberLabel': {
-      stepNumber: string | number;
-    };
-    'i18nStrings.collapsedStepsLabel': {
-      stepNumber: string | number;
-      stepsCount: string | number;
-    };
-    'i18nStrings.skipToButtonLabel': {
-      task__title: string | number;
-    };
-    'i18nStrings.navigationAriaLabel': never;
-    'i18nStrings.cancelButton': never;
-    'i18nStrings.previousButton': never;
-    'i18nStrings.nextButton': never;
-    'i18nStrings.optional': never;
-    'i18nStrings.nextButtonLoadingAnnouncement': never;
-    'i18nStrings.submitButtonLoadingAnnouncement': never;
-  };
+  "[charts]": {
+    "loadingText": never;
+    "errorText": never;
+    "recoveryText": never;
+    "i18nStrings.filterLabel": never;
+    "i18nStrings.filterPlaceholder": never;
+    "i18nStrings.legendAriaLabel": never;
+    "i18nStrings.chartAriaRoleDescription": never;
+    "i18nStrings.xAxisAriaRoleDescription": never;
+    "i18nStrings.yAxisAriaRoleDescription": never;
+  }
+  "alert": {
+    "dismissAriaLabel": never;
+    "i18nStrings.successIconAriaLabel": never;
+    "i18nStrings.errorIconAriaLabel": never;
+    "i18nStrings.warningIconAriaLabel": never;
+    "i18nStrings.infoIconAriaLabel": never;
+    "i18nStrings.dismissAriaLabel": never;
+  }
+  "annotation-context": {
+    "i18nStrings.nextButtonText": never;
+    "i18nStrings.previousButtonText": never;
+    "i18nStrings.finishButtonText": never;
+    "i18nStrings.labelDismissAnnotation": never;
+    "i18nStrings.stepCounterText": {
+      "stepNumber": string | number;
+      "totalStepCount": string | number;
+    }
+    "i18nStrings.taskTitle": {
+      "taskNumber": string | number;
+      "taskTitle": string | number;
+    }
+    "i18nStrings.labelHotspot": {
+      "openState": string;
+      "stepNumber": string | number;
+      "totalStepCount": string | number;
+    }
+  }
+  "app-layout": {
+    "ariaLabels.drawers": never;
+    "ariaLabels.drawersOverflow": never;
+    "ariaLabels.drawersOverflowWithBadge": never;
+    "ariaLabels.navigation": never;
+    "ariaLabels.navigationClose": never;
+    "ariaLabels.navigationToggle": never;
+    "ariaLabels.notifications": never;
+    "ariaLabels.tools": never;
+    "ariaLabels.toolsClose": never;
+    "ariaLabels.toolsToggle": never;
+  }
+  "area-chart": {
+    "i18nStrings.detailTotalLabel": never;
+  }
+  "attribute-editor": {
+    "removeButtonText": never;
+    "i18nStrings.itemRemovedAriaLive": never;
+  }
+  "autosuggest": {
+    "errorIconAriaLabel": never;
+    "selectedAriaLabel": never;
+    "enteredTextLabel": {
+      "value": string | number;
+    }
+    "recoveryText": never;
+  }
+  "breadcrumb-group": {
+    "expandAriaLabel": never;
+  }
+  "button-dropdown": {
+    "filteringResultsText": {
+      "matchesCount": string | number;
+      "totalCount": string | number;
+    }
+    "noMatch": never;
+    "i18nStrings.filteringItemAriaDescription": never;
+  }
+  "button": {
+    "i18nStrings.externalIconAriaLabel": never;
+  }
+  "calendar": {
+    "nextMonthAriaLabel": never;
+    "previousMonthAriaLabel": never;
+    "todayAriaLabel": never;
+    "i18nStrings.nextYearAriaLabel": never;
+    "i18nStrings.previousYearAriaLabel": never;
+    "i18nStrings.currentMonthAriaLabel": never;
+  }
+  "cards": {
+    "ariaLabels.selectionGroupLabel": never;
+  }
+  "code-editor": {
+    "i18nStrings.loadingState": never;
+    "i18nStrings.errorState": never;
+    "i18nStrings.errorStateRecovery": never;
+    "i18nStrings.editorGroupAriaLabel": never;
+    "i18nStrings.statusBarGroupAriaLabel": never;
+    "i18nStrings.cursorPosition": {
+      "row": string | number;
+      "column": string | number;
+    }
+    "i18nStrings.errorsTab": never;
+    "i18nStrings.warningsTab": never;
+    "i18nStrings.preferencesButtonAriaLabel": never;
+    "i18nStrings.paneCloseButtonAriaLabel": never;
+    "i18nStrings.preferencesModalHeader": never;
+    "i18nStrings.preferencesModalCancel": never;
+    "i18nStrings.preferencesModalConfirm": never;
+    "i18nStrings.preferencesModalWrapLines": never;
+    "i18nStrings.preferencesModalTheme": never;
+    "i18nStrings.preferencesModalThemeFilteringAriaLabel": never;
+    "i18nStrings.preferencesModalThemeFilteringPlaceholder": never;
+    "i18nStrings.preferencesModalLightThemes": never;
+    "i18nStrings.preferencesModalDarkThemes": never;
+    "i18nStrings.cursorPositionAriaLabel": {
+      "row": string | number;
+    }
+    "i18nStrings.resizeHandleAriaLabel": never;
+    "i18nStrings.resizeHandleTooltipText": never;
+  }
+  "collection-preferences": {
+    "title": never;
+    "confirmLabel": never;
+    "cancelLabel": never;
+    "pageSizePreference.title": never;
+    "wrapLinesPreference.label": never;
+    "wrapLinesPreference.description": never;
+    "stripedRowsPreference.label": never;
+    "stripedRowsPreference.description": never;
+    "contentDensityPreference.label": never;
+    "contentDensityPreference.description": never;
+    "stickyColumnsPreference.firstColumns.title": never;
+    "stickyColumnsPreference.firstColumns.description": never;
+    "stickyColumnsPreference.firstColumns.options[0].label": never;
+    "stickyColumnsPreference.firstColumns.options[1].label": never;
+    "stickyColumnsPreference.firstColumns.options[2].label": never;
+    "stickyColumnsPreference.lastColumns.title": never;
+    "stickyColumnsPreference.lastColumns.description": never;
+    "stickyColumnsPreference.lastColumns.options[0].label": never;
+    "stickyColumnsPreference.lastColumns.options[1].label": never;
+    "contentDisplayPreference.title": never;
+    "contentDisplayPreference.description": never;
+    "contentDisplayPreference.dragHandleAriaLabel": never;
+    "contentDisplayPreference.dragHandleAriaDescription": never;
+    "contentDisplayPreference.liveAnnouncementDndStarted": {
+      "position": string | number;
+      "total": string | number;
+    }
+    "contentDisplayPreference.liveAnnouncementDndDiscarded": never;
+    "contentDisplayPreference.i18nStrings.columnFilteringPlaceholder": never;
+    "contentDisplayPreference.i18nStrings.columnFilteringAriaLabel": never;
+    "contentDisplayPreference.i18nStrings.columnFilteringNoMatchText": never;
+    "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": never;
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": {
+      "isInitialPosition": string;
+      "currentPosition": string | number;
+      "total": string | number;
+    }
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": {
+      "isInitialPosition": string;
+      "initialPosition": string | number;
+      "total": string | number;
+      "finalPosition": string | number;
+    }
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": {
+      "count": number;
+      "label": string | number;
+    }
+    "contentDisplayPreference.i18nStrings.columnFilteringCountText": {
+      "count": number;
+    }
+  }
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": never;
+  }
+  "date-picker": {
+    "i18nStrings.openCalendarAriaLabel": {
+      "selectedDate": string;
+    }
+  }
+  "date-range-picker": {
+    "i18nStrings.relativeModeTitle": never;
+    "i18nStrings.absoluteModeTitle": never;
+    "i18nStrings.relativeRangeSelectionHeading": never;
+    "i18nStrings.relativeRangeSelectionMonthlyDescription": never;
+    "i18nStrings.cancelButtonLabel": never;
+    "i18nStrings.clearButtonLabel": never;
+    "i18nStrings.applyButtonLabel": never;
+    "i18nStrings.customRelativeRangeOptionLabel": never;
+    "i18nStrings.customRelativeRangeOptionDescription": never;
+    "i18nStrings.customRelativeRangeUnitLabel": never;
+    "i18nStrings.customRelativeRangeDurationLabel": never;
+    "i18nStrings.customRelativeRangeDurationPlaceholder": never;
+    "i18nStrings.previousMonthAriaLabel": never;
+    "i18nStrings.nextMonthAriaLabel": never;
+    "i18nStrings.previousYearAriaLabel": never;
+    "i18nStrings.nextYearAriaLabel": never;
+    "i18nStrings.currentMonthAriaLabel": never;
+    "i18nStrings.todayAriaLabel": never;
+    "i18nStrings.startMonthLabel": never;
+    "i18nStrings.startDateLabel": never;
+    "i18nStrings.startTimeLabel": never;
+    "i18nStrings.endMonthLabel": never;
+    "i18nStrings.endDateLabel": never;
+    "i18nStrings.endTimeLabel": never;
+    "i18nStrings.datePlaceholder": never;
+    "i18nStrings.isoDatePlaceholder": never;
+    "i18nStrings.slashedDatePlaceholder": never;
+    "i18nStrings.timePlaceholder": never;
+    "i18nStrings.dateTimeConstraintText": never;
+    "i18nStrings.dateConstraintText": never;
+    "i18nStrings.slashedDateTimeConstraintText": never;
+    "i18nStrings.isoDateTimeConstraintText": never;
+    "i18nStrings.slashedDateConstraintText": never;
+    "i18nStrings.isoDateConstraintText": never;
+    "i18nStrings.slashedMonthConstraintText": never;
+    "i18nStrings.isoMonthConstraintText": never;
+    "i18nStrings.monthConstraintText": never;
+    "i18nStrings.errorIconAriaLabel": never;
+    "i18nStrings.renderSelectedAbsoluteRangeAriaLive": {
+      "startDate": string | number;
+      "endDate": string | number;
+    }
+    "i18nStrings.formatRelativeRange": {
+      "unit": string;
+      "amount": number;
+    }
+    "i18nStrings.formatUnit": {
+      "unit": string;
+      "amount": number;
+    }
+  }
+  "drawer": {
+    "i18nStrings.loadingText": never;
+  }
+  "error-boundary": {
+    "i18nStrings.headerText": never;
+    "i18nStrings.descriptionText": {
+      "hasFeedback": string;
+    }
+    "i18nStrings.refreshActionText": never;
+  }
+  "features-notification-drawer": {
+    "i18nStrings.title": never;
+    "i18nStrings.viewAll": never;
+    "ariaLabels.closeButton": never;
+    "ariaLabels.content": never;
+    "ariaLabels.triggerButton": never;
+    "ariaLabels.resizeHandle": never;
+  }
+  "file-token-group": {
+    "i18nStrings.limitShowFewer": never;
+    "i18nStrings.limitShowMore": never;
+    "i18nStrings.removeFileAriaLabel": {
+      "fileIndex": string | number;
+      "fileName": string | number;
+    }
+    "i18nStrings.errorIconAriaLabel": never;
+    "i18nStrings.warningIconAriaLabel": never;
+  }
+  "file-upload": {
+    "i18nStrings.limitShowFewer": never;
+    "i18nStrings.limitShowMore": never;
+    "i18nStrings.removeFileAriaLabel": {
+      "fileIndex": string | number;
+    }
+    "i18nStrings.errorIconAriaLabel": never;
+    "i18nStrings.warningIconAriaLabel": never;
+    "i18nStrings.uploadButtonText": {
+      "multiple": string;
+    }
+    "i18nStrings.dropzoneText": {
+      "multiple": string;
+    }
+  }
+  "flashbar": {
+    "i18nStrings.ariaLabel": never;
+    "i18nStrings.errorIconAriaLabel": never;
+    "i18nStrings.inProgressIconAriaLabel": never;
+    "i18nStrings.infoIconAriaLabel": never;
+    "i18nStrings.notificationBarAriaLabel": never;
+    "i18nStrings.notificationBarText": never;
+    "i18nStrings.successIconAriaLabel": never;
+    "i18nStrings.warningIconAriaLabel": never;
+  }
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": never;
+    "i18nStrings.warningIconAriaLabel": never;
+  }
+  "form": {
+    "errorIconAriaLabel": never;
+  }
+  "help-panel": {
+    "loadingText": never;
+  }
+  "input": {
+    "clearAriaLabel": never;
+  }
+  "link": {
+    "externalIconAriaLabel": never;
+  }
+  "list": {
+    "dragHandleAriaLabel": never;
+    "dragHandleAriaDescription": never;
+    "liveAnnouncementDndStarted": {
+      "position": string | number;
+      "total": string | number;
+    }
+    "liveAnnouncementDndDiscarded": never;
+    "liveAnnouncementDndItemReordered": {
+      "isInitialPosition": string;
+      "currentPosition": string | number;
+      "total": string | number;
+    }
+    "liveAnnouncementDndItemCommitted": {
+      "isInitialPosition": string;
+      "initialPosition": string | number;
+      "total": string | number;
+      "finalPosition": string | number;
+    }
+  }
+  "modal": {
+    "closeAriaLabel": never;
+  }
+  "multiselect": {
+    "deselectAriaLabel": {
+      "option__label": string | number;
+    }
+    "i18nStrings.selectAllText": never;
+  }
+  "pagination": {
+    "ariaLabels.nextPageLabel": never;
+    "ariaLabels.pageLabel": {
+      "pageNumber": string | number;
+    }
+    "ariaLabels.previousPageLabel": never;
+    "ariaLabels.jumpToPageButtonLabel": never;
+    "i18nStrings.jumpToPageInputLabel": never;
+    "i18nStrings.jumpToPageError": never;
+    "i18nStrings.jumpToPageLoadingText": never;
+    "i18nStrings.pagesCompactText": {
+      "openEnd": string;
+      "currentPage": string | number;
+      "pagesCount": string | number;
+    }
+  }
+  "panel-resize-handle": {
+    "i18nStrings.resizeHandleAriaLabel": never;
+    "i18nStrings.resizeHandleTooltipText": never;
+  }
+  "pie-chart": {
+    "i18nStrings.detailsValue": never;
+    "i18nStrings.detailsPercentage": never;
+    "i18nStrings.chartAriaRoleDescription": never;
+    "i18nStrings.segmentAriaRoleDescription": never;
+  }
+  "popover": {
+    "dismissAriaLabel": never;
+  }
+  "prompt-input": {
+    "i18nStrings.actionButtonAriaLabel": never;
+    "i18nStrings.menuErrorIconAriaLabel": never;
+    "i18nStrings.menuRecoveryText": never;
+    "i18nStrings.menuLoadingText": never;
+    "i18nStrings.menuFinishedText": never;
+    "i18nStrings.menuErrorText": never;
+    "i18nStrings.selectedMenuItemAriaLabel": never;
+    "i18nStrings.tokenInsertedAriaLabel": {
+      "token__label": string | number;
+    }
+    "i18nStrings.tokenPinnedAriaLabel": {
+      "token__label": string | number;
+    }
+    "i18nStrings.tokenRemovedAriaLabel": {
+      "token__label": string | number;
+    }
+  }
+  "property-filter": {
+    "i18nStrings.allPropertiesLabel": never;
+    "i18nStrings.applyActionText": never;
+    "i18nStrings.cancelActionText": never;
+    "i18nStrings.clearFiltersText": never;
+    "i18nStrings.editTokenHeader": never;
+    "i18nStrings.groupPropertiesText": never;
+    "i18nStrings.groupValuesText": never;
+    "i18nStrings.operationAndText": never;
+    "i18nStrings.operationOrText": never;
+    "i18nStrings.operatorContainsText": never;
+    "i18nStrings.operatorDoesNotContainText": never;
+    "i18nStrings.operatorDoesNotEqualText": never;
+    "i18nStrings.operatorEqualsText": never;
+    "i18nStrings.operatorGreaterOrEqualText": never;
+    "i18nStrings.operatorGreaterText": never;
+    "i18nStrings.operatorLessOrEqualText": never;
+    "i18nStrings.operatorLessText": never;
+    "i18nStrings.operatorStartsWithText": never;
+    "i18nStrings.operatorDoesNotStartWithText": never;
+    "i18nStrings.operatorText": never;
+    "i18nStrings.operatorsText": never;
+    "i18nStrings.propertyText": never;
+    "i18nStrings.removeTokenButtonAriaLabel": {
+      "token__formattedText": string | number;
+    }
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": {
+      "token__formattedText": string | number;
+    }
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": {
+      "token__formattedText": string | number;
+    }
+    "i18nStrings.tokenEditorTokenRemoveLabel": never;
+    "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": never;
+    "i18nStrings.tokenEditorAddTokenActionsAriaLabel": never;
+    "i18nStrings.tokenEditorAddNewTokenLabel": never;
+    "i18nStrings.tokenEditorAddExistingTokenAriaLabel": {
+      "token__formattedText": string | number;
+    }
+    "i18nStrings.tokenEditorAddExistingTokenLabel": {
+      "token__propertyLabel": string | number;
+      "token__operator": string | number;
+      "token__value": string | number;
+    }
+    "i18nStrings.tokenLimitShowFewer": never;
+    "i18nStrings.tokenLimitShowMore": never;
+    "i18nStrings.valueText": never;
+    "i18nStrings.formatToken": {
+      "token__operator": string;
+      "token__propertyLabel": string | number;
+      "token__value": string | number;
+    }
+    "i18nStrings.groupEditAriaLabel": {
+      "group__formattedTokens__length": string;
+      "group__formattedTokens0__formattedText": string | number;
+      "group__operationLabel": string | number;
+      "group__formattedTokens1__formattedText": string | number;
+      "group__formattedTokens2__formattedText": string | number;
+      "group__formattedTokens3__formattedText": string | number;
+    }
+  }
+  "s3-resource-selector": {
+    "i18nStrings.inContextSelectPlaceholder": never;
+    "i18nStrings.inContextBrowseButton": never;
+    "i18nStrings.inContextViewButton": never;
+    "i18nStrings.inContextViewButtonAriaLabel": never;
+    "i18nStrings.inContextLoadingText": never;
+    "i18nStrings.inContextUriLabel": never;
+    "i18nStrings.inContextVersionSelectLabel": never;
+    "i18nStrings.modalTitle": never;
+    "i18nStrings.modalCancelButton": never;
+    "i18nStrings.modalSubmitButton": never;
+    "i18nStrings.modalBreadcrumbRootItem": never;
+    "i18nStrings.modalLastUpdatedText": never;
+    "i18nStrings.selectionBuckets": never;
+    "i18nStrings.selectionObjects": never;
+    "i18nStrings.selectionVersions": never;
+    "i18nStrings.selectionBucketsSearchPlaceholder": never;
+    "i18nStrings.selectionObjectsSearchPlaceholder": never;
+    "i18nStrings.selectionVersionsSearchPlaceholder": never;
+    "i18nStrings.selectionBucketsLoading": never;
+    "i18nStrings.selectionBucketsNoItems": never;
+    "i18nStrings.selectionObjectsLoading": never;
+    "i18nStrings.selectionObjectsNoItems": never;
+    "i18nStrings.selectionVersionsLoading": never;
+    "i18nStrings.selectionVersionsNoItems": never;
+    "i18nStrings.filteringNoMatches": never;
+    "i18nStrings.filteringCantFindMatch": never;
+    "i18nStrings.clearFilterButtonText": never;
+    "i18nStrings.columnBucketID": never;
+    "i18nStrings.columnBucketName": never;
+    "i18nStrings.columnBucketCreationDate": never;
+    "i18nStrings.columnBucketRegion": never;
+    "i18nStrings.columnObjectKey": never;
+    "i18nStrings.columnObjectLastModified": never;
+    "i18nStrings.columnObjectSize": never;
+    "i18nStrings.columnVersionID": never;
+    "i18nStrings.columnVersionLastModified": never;
+    "i18nStrings.columnVersionSize": never;
+    "i18nStrings.validationPathMustBegin": never;
+    "i18nStrings.validationBucketLowerCase": never;
+    "i18nStrings.validationBucketMustNotContain": never;
+    "i18nStrings.validationBucketLength": never;
+    "i18nStrings.validationBucketMustComplyDns": never;
+    "i18nStrings.labelSortedDescending": {
+      "columnName": string | number;
+    }
+    "i18nStrings.labelSortedAscending": {
+      "columnName": string | number;
+    }
+    "i18nStrings.labelNotSorted": {
+      "columnName": string | number;
+    }
+    "i18nStrings.labelsBucketsSelection.selectionGroupLabel": never;
+    "i18nStrings.labelsBucketsSelection.itemSelectionLabel": {
+      "item__Name": string | number;
+    }
+    "i18nStrings.labelsObjectsSelection.selectionGroupLabel": never;
+    "i18nStrings.labelsObjectsSelection.itemSelectionLabel": {
+      "item__Key": string | number;
+    }
+    "i18nStrings.labelsVersionsSelection.selectionGroupLabel": never;
+    "i18nStrings.labelsVersionsSelection.itemSelectionLabel": {
+      "item__VersionId": string | number;
+    }
+    "i18nStrings.labelFiltering": {
+      "itemsType": string | number;
+    }
+    "i18nStrings.labelRefresh": never;
+    "i18nStrings.labelBreadcrumbs": never;
+    "i18nStrings.labelIconFolder": never;
+    "i18nStrings.labelIconObject": never;
+    "i18nStrings.filteringCounterText": {
+      "count": number;
+    }
+  }
+  "select": {
+    "errorIconAriaLabel": never;
+    "selectedAriaLabel": never;
+    "recoveryText": never;
+  }
+  "slider": {
+    "i18nStrings.valueTextRange": {
+      "value": string | number;
+      "previousValue": string | number;
+      "nextValue": string | number;
+    }
+  }
+  "split-panel": {
+    "i18nStrings.closeButtonAriaLabel": never;
+    "i18nStrings.openButtonAriaLabel": never;
+    "i18nStrings.preferencesTitle": never;
+    "i18nStrings.preferencesPositionLabel": never;
+    "i18nStrings.preferencesPositionDescription": never;
+    "i18nStrings.preferencesPositionSide": never;
+    "i18nStrings.preferencesPositionBottom": never;
+    "i18nStrings.preferencesConfirm": never;
+    "i18nStrings.preferencesCancel": never;
+    "i18nStrings.resizeHandleAriaLabel": never;
+    "i18nStrings.resizeHandleTooltipText": never;
+  }
+  "table": {
+    "ariaLabels.resizerRoleDescription": never;
+    "ariaLabels.submittingEditText": never;
+    "ariaLabels.successfulEditLabel": never;
+    "ariaLabels.expandButtonLabel": never;
+    "ariaLabels.collapseButtonLabel": never;
+    "columnDefinitions.editConfig.errorIconAriaLabel": never;
+    "columnDefinitions.editConfig.editIconAriaLabel": never;
+    "i18nStrings.sortDropdownSortAscending": never;
+    "i18nStrings.sortDropdownSortDescending": never;
+    "i18nStrings.sortDropdownMultiColumnSortGroup": never;
+    "i18nStrings.sortDropdownAddToSortAscending": never;
+    "i18nStrings.sortDropdownAddToSortDescending": never;
+    "i18nStrings.sortDropdownRemoveFromSort": never;
+    "i18nStrings.sortDropdownAddToSortDisabledReason": never;
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": never;
+    "i18nStrings.clearSort": never;
+    "ariaLabels.sortAscending": never;
+    "ariaLabels.sortDescending": never;
+    "ariaLabels.liveAnnouncementSortOrder": {
+      "columns": string | number;
+    }
+    "ariaLabels.liveAnnouncementSortCleared": never;
+    "ariaLabels.sortPriority": {
+      "priority": string | number;
+    }
+    "ariaLabels.sortMenuTriggerLabel": never;
+  }
+  "tabs": {
+    "i18nStrings.scrollLeftAriaLabel": never;
+    "i18nStrings.scrollRightAriaLabel": never;
+    "i18nStrings.tabsWithActionsAriaRoleDescription": never;
+  }
+  "tag-editor": {
+    "i18nStrings.keyPlaceholder": never;
+    "i18nStrings.valuePlaceholder": never;
+    "i18nStrings.addButton": never;
+    "i18nStrings.removeButton": never;
+    "i18nStrings.removeButtonAriaLabel": {
+      "tag__key": string | number;
+    }
+    "i18nStrings.undoButton": never;
+    "i18nStrings.undoPrompt": never;
+    "i18nStrings.loading": never;
+    "i18nStrings.keyHeader": never;
+    "i18nStrings.valueHeader": never;
+    "i18nStrings.optional": never;
+    "i18nStrings.keySuggestion": never;
+    "i18nStrings.valueSuggestion": never;
+    "i18nStrings.emptyTags": never;
+    "i18nStrings.tooManyKeysSuggestion": never;
+    "i18nStrings.tooManyValuesSuggestion": never;
+    "i18nStrings.keysSuggestionLoading": never;
+    "i18nStrings.keysSuggestionError": never;
+    "i18nStrings.valuesSuggestionLoading": never;
+    "i18nStrings.valuesSuggestionError": never;
+    "i18nStrings.emptyKeyError": never;
+    "i18nStrings.maxKeyCharLengthError": never;
+    "i18nStrings.maxValueCharLengthError": never;
+    "i18nStrings.duplicateKeyError": never;
+    "i18nStrings.invalidKeyError": never;
+    "i18nStrings.invalidValueError": never;
+    "i18nStrings.awsPrefixError": never;
+    "i18nStrings.tagLimitReached": {
+      "tagLimit": number;
+    }
+    "i18nStrings.tagLimitExceeded": {
+      "tagLimit": number;
+    }
+    "i18nStrings.tagLimit": {
+      "tagLimitAvailable": string;
+      "availableTags": number;
+      "tagLimit": string | number;
+    }
+  }
+  "token-group": {
+    "i18nStrings.limitShowFewer": never;
+    "i18nStrings.limitShowMore": never;
+  }
+  "top-navigation": {
+    "i18nStrings.searchIconAriaLabel": never;
+    "i18nStrings.searchDismissIconAriaLabel": never;
+    "i18nStrings.overflowMenuTriggerText": never;
+    "i18nStrings.overflowMenuDismissIconAriaLabel": never;
+    "i18nStrings.overflowMenuBackIconAriaLabel": never;
+    "i18nStrings.overflowMenuTitleText": never;
+  }
+  "tree-view": {
+    "i18nStrings.expandButtonLabel": never;
+    "i18nStrings.collapseButtonLabel": never;
+  }
+  "tutorial-panel": {
+    "i18nStrings.loadingText": never;
+    "i18nStrings.tutorialListTitle": never;
+    "i18nStrings.tutorialListDownloadLinkText": never;
+    "i18nStrings.labelTutorialListDownloadLink": never;
+    "i18nStrings.tutorialCompletedText": never;
+    "i18nStrings.learnMoreLinkText": never;
+    "i18nStrings.startTutorialButtonText": never;
+    "i18nStrings.restartTutorialButtonText": never;
+    "i18nStrings.completionScreenTitle": never;
+    "i18nStrings.feedbackLinkText": never;
+    "i18nStrings.dismissTutorialButtonText": never;
+    "i18nStrings.taskTitle": {
+      "taskNumber": string | number;
+      "taskTitle": string | number;
+    }
+    "i18nStrings.stepTitle": {
+      "stepNumber": string | number;
+      "stepTitle": string | number;
+    }
+    "i18nStrings.labelExitTutorial": never;
+    "i18nStrings.labelTotalSteps": {
+      "totalStepCount": string | number;
+    }
+    "i18nStrings.labelsTaskStatus.pending": never;
+    "i18nStrings.labelsTaskStatus.in-progress": never;
+    "i18nStrings.labelsTaskStatus.success": never;
+  }
+  "wizard": {
+    "i18nStrings.stepNumberLabel": {
+      "stepNumber": string | number;
+    }
+    "i18nStrings.collapsedStepsLabel": {
+      "stepNumber": string | number;
+      "stepsCount": string | number;
+    }
+    "i18nStrings.skipToButtonLabel": {
+      "task__title": string | number;
+    }
+    "i18nStrings.navigationAriaLabel": never;
+    "i18nStrings.cancelButton": never;
+    "i18nStrings.previousButton": never;
+    "i18nStrings.nextButton": never;
+    "i18nStrings.optional": never;
+    "i18nStrings.nextButtonLoadingAnnouncement": never;
+    "i18nStrings.submitButtonLoadingAnnouncement": never;
+  }
 }

--- a/src/i18n/messages/all.ar.json
+++ b/src/i18n/messages/all.ar.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "عرض المسار"
   },
+  "button-dropdown": {
+    "filteringResultsText": "تم نفاد عدد {matchesCount} من {totalCount} من العناصر",
+    "noMatch": "لا توجد إجراءات مطابقة",
+    "i18nStrings.filteringItemAriaDescription": "استمر في الكتابة لتصفية النتائج."
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "تفتح الصفحة في علامة تبويب جديدة"
   },
@@ -125,6 +130,7 @@
     "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": "مسح عامل التصفية",
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {نقل العنصر مرة أخرى إلى الموضع {currentPosition} من أصل {total}} false {نقل العنصر إلى الموضع {currentPosition} من أصل {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {تم نقل العنصر مرة أخرى إلى موضعه الأصلي {initialPosition} من أصل {total}} false {تم نقل العنصر من الموضع {initialPosition} إلى الموضع {finalPosition} من أصل {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{count, plural, zero {{label}، 0 عنصر} one {{label}، عنصر واحد} other {{label}، {count} عناصر}}",
     "contentDisplayPreference.i18nStrings.columnFilteringCountText": "{count, plural, zero {لا توجد تطابقات} one {تطابق واحد} other {{count} تطابق}}"
   },
   "copy-to-clipboard": {
@@ -256,7 +262,8 @@
     "ariaLabels.jumpToPageButtonLabel": "الانتقال إلى الصفحة",
     "i18nStrings.jumpToPageInputLabel": "صفحة",
     "i18nStrings.jumpToPageError": "الصفحة خارج نطاق الوصول. جارٍ عرض آخر صفحة متاحة.",
-    "i18nStrings.jumpToPageLoadingText": "جار التحميل"
+    "i18nStrings.jumpToPageLoadingText": "جار التحميل",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} من {pagesCount} +} false {{currentPage} من {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "مقبض تغيير حجم اللوحة",
@@ -408,7 +415,22 @@
     "ariaLabels.expandButtonLabel": "توسيع",
     "ariaLabels.collapseButtonLabel": "تحجيم",
     "columnDefinitions.editConfig.errorIconAriaLabel": "خطأ",
-    "columnDefinitions.editConfig.editIconAriaLabel": "قابل للتعديل"
+    "columnDefinitions.editConfig.editIconAriaLabel": "قابل للتعديل",
+    "i18nStrings.sortDropdownSortAscending": "الترتيب تصاعديًّا",
+    "i18nStrings.sortDropdownSortDescending": "الترتيب تنازليًّا",
+    "i18nStrings.sortDropdownMultiColumnSortGroup": "ترتيب متعدد الأعمدة (Shift + Click)",
+    "i18nStrings.sortDropdownAddToSortAscending": "إضافة إلى الترتيب (تصاعديًا)",
+    "i18nStrings.sortDropdownAddToSortDescending": "إضافة إلى الترتيب (تنازليًّا)",
+    "i18nStrings.sortDropdownRemoveFromSort": "إزالة من الترتيب",
+    "i18nStrings.sortDropdownAddToSortDisabledReason": "تم بالفعل ترتيب هذا العمود",
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": "لم يتم ترتيب هذا العمود",
+    "i18nStrings.clearSort": "مسح الترتيب",
+    "ariaLabels.sortAscending": "تصاعديًا",
+    "ariaLabels.sortDescending": "تنازليًا",
+    "ariaLabels.liveAnnouncementSortOrder": "تم فرز الجدول حسب {columns}",
+    "ariaLabels.liveAnnouncementSortCleared": "تم إلغاء الفرز",
+    "ariaLabels.sortPriority": "أولوية الفرز {priority}",
+    "ariaLabels.sortMenuTriggerLabel": "خيارات الترتيب"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "التمرير إلى اليسار",

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Pfad anzeigen"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} von {totalCount} Artikeln",
+    "noMatch": "Keine übereinstimmenden Aktionen",
+    "i18nStrings.filteringItemAriaDescription": "Tippen Sie weiter, um die Ergebnisse zu filtern."
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "Wird in einer neuen Registerkarte geöffnet"
   },
@@ -125,6 +130,7 @@
     "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": "Filter löschen",
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Objekt zurück an die Position {currentPosition} von {total} verschieben} false {Objekt an Position {currentPosition} von {total} verschieben} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Das Objekt wurde zurück an seine ursprüngliche Position {initialPosition} von {total} verschoben} false {Das Objekt wurde von Position {initialPosition} zu Position {finalPosition} von {total} verschoben} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{count, plural, zero {{label}, 0 Elemente} one {{label}, 1 Element} other {{label}, {count} Elemente}}",
     "contentDisplayPreference.i18nStrings.columnFilteringCountText": "{count, plural, zero {0 Übereinstimmungen} one {1 Übereinstimmung} other {{count} Übereinstimmungen}}"
   },
   "copy-to-clipboard": {
@@ -164,13 +170,13 @@
     "i18nStrings.timePlaceholder": "hh:mm:ss",
     "i18nStrings.dateTimeConstraintText": "Verwenden Sie für Datum JJJJ/MM/TT. Verwenden Sie für die Zeit das 24-Stunden-Format.",
     "i18nStrings.dateConstraintText": "Verwenden Sie für Datum JJJJ/MM/TT.",
-    "i18nStrings.slashedDateTimeConstraintText": "Verwenden Sie für das Datum das Format JJJJ/MM/TT. Verwenden Sie für die Zeit das 24-Stunden-Format.",
+    "i18nStrings.slashedDateTimeConstraintText": "Verwenden Sie für Datum JJJJ/MM/TT. Verwenden Sie für die Zeit das 24-Stunden-Format.",
     "i18nStrings.isoDateTimeConstraintText": "Verwenden Sie für das Datum das Format JJJJ-MM-TT. Verwenden Sie für die Zeit das 24-Stunden-Format.",
-    "i18nStrings.slashedDateConstraintText": "Verwenden Sie für das Datum das Format JJJJ/MM/TT.",
+    "i18nStrings.slashedDateConstraintText": "Verwenden Sie für Datum JJJJ/MM/TT.",
     "i18nStrings.isoDateConstraintText": "Verwenden Sie für das Datum das Format JJJJ-MM-TT.",
     "i18nStrings.slashedMonthConstraintText": "Verwenden Sie für den Monat das Format JJJJ/MM.",
     "i18nStrings.isoMonthConstraintText": "Verwenden Sie für den Monat das Format JJJJ-MM.",
-    "i18nStrings.monthConstraintText": "Verwenden Sie für Monat JJJJ/MM.",
+    "i18nStrings.monthConstraintText": "Verwenden Sie für den Monat das Format JJJJ/MM.",
     "i18nStrings.errorIconAriaLabel": "Fehler",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Bereich ausgewählt von {startDate} bis {endDate}",
     "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {Letzte {amount} Sekunden} one {Letzte {amount} Sekunde} other {Letzte {amount} Sekunden}}} minute {{amount, plural, zero {Letzte {amount} Minuten} one {Letzte {amount} Minute} other {Letzte {amount} Minuten}}} hour {{amount, plural, zero {Letzte {amount} Stunden} one {Letzte {amount} Stunde} other {Letzte {amount} Stunden}}} day {{amount, plural, zero {Letzte {amount} Tage} one {Letzter {amount} Tag} other {Letzte {amount} Tage}}} week {{amount, plural, zero {Letzte {amount} Wochen} one {Letzte {amount} Woche} other {Letzte {amount} Wochen}}} month {{amount, plural, zero {Letzte {amount} Monate} one {Letzter {amount} Monat} other {Letzte {amount} Monate}}} year {{amount, plural, zero {Letzte {amount} Jahre} one {Letztes {amount} Jahr} other {Letzte {amount} Jahre}}} other {}}",
@@ -256,7 +262,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Zur Seite springen",
     "i18nStrings.jumpToPageInputLabel": "Seite",
     "i18nStrings.jumpToPageError": "Seite ist außerhalb des Bereichs. Zeigt die letzte verfügbare Seite an.",
-    "i18nStrings.jumpToPageLoadingText": "Wird geladen"
+    "i18nStrings.jumpToPageLoadingText": "Wird geladen",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} von {pagesCount}+} false {{currentPage} von {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Größe des Panels ändern",
@@ -408,7 +415,22 @@
     "ariaLabels.expandButtonLabel": "Erweitern",
     "ariaLabels.collapseButtonLabel": "Minimieren",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Fehler",
-    "columnDefinitions.editConfig.editIconAriaLabel": "bearbeitbar"
+    "columnDefinitions.editConfig.editIconAriaLabel": "bearbeitbar",
+    "i18nStrings.sortDropdownSortAscending": "Aufsteigend sortieren",
+    "i18nStrings.sortDropdownSortDescending": "Absteigend sortieren",
+    "i18nStrings.sortDropdownMultiColumnSortGroup": "Sortieren nach mehreren Spalten (Umschalttaste + Klick)",
+    "i18nStrings.sortDropdownAddToSortAscending": "Zur Sortierung hinzufügen (aufsteigend)",
+    "i18nStrings.sortDropdownAddToSortDescending": "Zur Sortierung hinzufügen (absteigend)",
+    "i18nStrings.sortDropdownRemoveFromSort": "Aus Sortierung entfernen",
+    "i18nStrings.sortDropdownAddToSortDisabledReason": "Diese Spalte ist bereits sortiert",
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": "Diese Spalte ist nicht sortiert",
+    "i18nStrings.clearSort": "Sortierung löschen",
+    "ariaLabels.sortAscending": "aufsteigend",
+    "ariaLabels.sortDescending": "absteigend",
+    "ariaLabels.liveAnnouncementSortOrder": "Tabelle sortiert nach {columns}",
+    "ariaLabels.liveAnnouncementSortCleared": "Sortierung gelöscht",
+    "ariaLabels.sortPriority": "Sortierpriorität {priority}",
+    "ariaLabels.sortMenuTriggerLabel": "Sortieroptionen"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Nach links scrollen",

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Show path"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} out of {totalCount} items",
+    "noMatch": "No matching actions",
+    "i18nStrings.filteringItemAriaDescription": "Keep typing to filter results."
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "Opens in a new tab"
   },
@@ -125,6 +130,7 @@
     "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": "Clear filter",
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Moving item back to position {currentPosition} of {total}} false {Moving item to position {currentPosition} of {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Item moved back to its original position {initialPosition} of {total}} false {Item moved from position {initialPosition} to position {finalPosition} of {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{count, plural, zero {{label}, 0 items} one {{label}, 1 item} other {{label}, {count} items}}",
     "contentDisplayPreference.i18nStrings.columnFilteringCountText": "{count, plural, zero {0 matches} one {1 match} other {{count} matches}}"
   },
   "copy-to-clipboard": {
@@ -158,23 +164,23 @@
     "i18nStrings.endMonthLabel": "End month",
     "i18nStrings.endDateLabel": "End date",
     "i18nStrings.endTimeLabel": "End time",
-    "i18nStrings.datePlaceholder": "DD/MM/YYYY",
-    "i18nStrings.isoDatePlaceholder": "YYYY-MM-DD",
+    "i18nStrings.datePlaceholder": "YYYY-MM-DD",
+    "i18nStrings.isoDatePlaceholder": "DD-MM-YYYY",
     "i18nStrings.slashedDatePlaceholder": "YYYY/MM/DD",
     "i18nStrings.timePlaceholder": "hh:mm:ss",
-    "i18nStrings.dateTimeConstraintText": "For date, use DD/MM/YYYY. For time, use 24-hr format.",
+    "i18nStrings.dateTimeConstraintText": "For date, use YYYY/MM/DD. For time, use 24 hr format.",
     "i18nStrings.dateConstraintText": "For date, use YYYY/MM/DD.",
-    "i18nStrings.slashedDateTimeConstraintText": "For date, use DD/MM/YYYY. For time, use 24-hr format.",
-    "i18nStrings.isoDateTimeConstraintText": "For date, use DD-MM-YYYY. For time, use 24-hr format.",
-    "i18nStrings.slashedDateConstraintText": "For date, use DD/MM/YYYY.",
-    "i18nStrings.isoDateConstraintText": "For date, use DD-MM-YYYY.",
-    "i18nStrings.slashedMonthConstraintText": "For month, use MM/YYYY.",
-    "i18nStrings.isoMonthConstraintText": "For month, use MM-YYYY.",
+    "i18nStrings.slashedDateTimeConstraintText": "For date, use YYYY/MM/DD. For time, use 24 hr format.",
+    "i18nStrings.isoDateTimeConstraintText": "For date, use YYYY-MM-DD. For time, use 24 hr format.",
+    "i18nStrings.slashedDateConstraintText": "For date, use YYYY/MM/DD.",
+    "i18nStrings.isoDateConstraintText": "For date, use YYYY-MM-DD.",
+    "i18nStrings.slashedMonthConstraintText": "For month, use YYYY/MM.",
+    "i18nStrings.isoMonthConstraintText": "For month, use YYYY-MM.",
     "i18nStrings.monthConstraintText": "For month, use YYYY/MM.",
     "i18nStrings.errorIconAriaLabel": "Error",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Range selected from {startDate} to {endDate}",
     "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {Last {amount} seconds} one {Last {amount} second} other {Last {amount} seconds}}} minute {{amount, plural, zero {Last {amount} minutes} one {Last {amount} minute} other {Last {amount} minutes}}} hour {{amount, plural, zero {Last {amount} hours} one {Last {amount} hour} other {Last {amount} hours}}} day {{amount, plural, zero {Last {amount} days} one {Last {amount} day} other {Last {amount} days}}} week {{amount, plural, zero {Last {amount} weeks} one {Last {amount} week} other {Last {amount} weeks}}} month {{amount, plural, zero {Last {amount} months} one {Last {amount} month} other {Last {amount} months}}} year {{amount, plural, zero {Last {amount} years} one {Last {amount} year} other {Last {amount} years}}} other {}}",
-    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {seconds} one {second} other {seconds}}} minute {{amount, plural, zero {minutes} one {minute} other {minutes}}} hour {{amount, plural, zero {hours} one {hour} other {hours}}} day {{amount, plural, zero {days} one {day} other {days}}} week {{amount, plural, zero {weeks} one {week} other {weeks}}} month {{amount, plural, zero {months} one {Month} other {months}}} year {{amount, plural, zero {years} one {year} other {years}}} other {}}"
+    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {seconds} one {second} other {seconds}}} minute {{amount, plural, zero {minutes} one {minute} other {minutes}}} hour {{amount, plural, zero {hours} one {hour} other {hours}}} day {{amount, plural, zero {days} one {day} other {days}}} week {{amount, plural, zero {weeks} one {week} other {weeks}}} month {{amount, plural, zero {months} one {month} other {months}}} year {{amount, plural, zero {years} one {year} other {years}}} other {}}"
   },
   "drawer": {
     "i18nStrings.loadingText": "Loading content"
@@ -256,7 +262,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Jump to page",
     "i18nStrings.jumpToPageInputLabel": "Page",
     "i18nStrings.jumpToPageError": "Page out of range. Showing the last available page.",
-    "i18nStrings.jumpToPageLoadingText": "Loading"
+    "i18nStrings.jumpToPageLoadingText": "Loading",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} of {pagesCount}+} false {{currentPage} of {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Panel resize handle",
@@ -408,7 +415,22 @@
     "ariaLabels.expandButtonLabel": "Expand",
     "ariaLabels.collapseButtonLabel": "Collapse",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Error",
-    "columnDefinitions.editConfig.editIconAriaLabel": "editable"
+    "columnDefinitions.editConfig.editIconAriaLabel": "editable",
+    "i18nStrings.sortDropdownSortAscending": "Sort ascending",
+    "i18nStrings.sortDropdownSortDescending": "Sort descending",
+    "i18nStrings.sortDropdownMultiColumnSortGroup": "Multi-column sort (Shift + Click)",
+    "i18nStrings.sortDropdownAddToSortAscending": "Add to sort (ascending)",
+    "i18nStrings.sortDropdownAddToSortDescending": "Add to sort (descending)",
+    "i18nStrings.sortDropdownRemoveFromSort": "Remove from sort",
+    "i18nStrings.sortDropdownAddToSortDisabledReason": "This column is already sorted",
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": "This column is not sorted",
+    "i18nStrings.clearSort": "Clear sort",
+    "ariaLabels.sortAscending": "ascending",
+    "ariaLabels.sortDescending": "descending",
+    "ariaLabels.liveAnnouncementSortOrder": "Table sorted by {columns}",
+    "ariaLabels.liveAnnouncementSortCleared": "Sorting cleared",
+    "ariaLabels.sortPriority": "sort priority {priority}",
+    "ariaLabels.sortMenuTriggerLabel": "Sort options"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Scroll left",

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Show path"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} out of {totalCount} items",
+    "noMatch": "No matching actions",
+    "i18nStrings.filteringItemAriaDescription": "Keep typing to filter results."
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "Opens in a new tab"
   },
@@ -119,13 +124,13 @@
     "contentDisplayPreference.dragHandleAriaDescription": "Use Space or Enter to activate drag for an item, then use the arrow keys to move the item's position. To complete the position move, use Space or Enter, or to discard the move, use Escape. You may need to toggle your browsing mode on your screen reader.",
     "contentDisplayPreference.liveAnnouncementDndStarted": "Picked up item at position {position} of {total}",
     "contentDisplayPreference.liveAnnouncementDndDiscarded": "Reordering canceled",
-    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{label}, {count, plural, one {1 item} other {{count} items}}",
     "contentDisplayPreference.i18nStrings.columnFilteringPlaceholder": "Filter columns",
     "contentDisplayPreference.i18nStrings.columnFilteringAriaLabel": "Filter columns",
     "contentDisplayPreference.i18nStrings.columnFilteringNoMatchText": "No matches found",
     "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": "Clear filter",
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Moving item back to position {currentPosition} of {total}} false {Moving item to position {currentPosition} of {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Item moved back to its original position {initialPosition} of {total}} false {Item moved from position {initialPosition} to position {finalPosition} of {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{count, plural, zero {{label}, 0 items} one {{label}, 1 item} other {{label}, {count} items}}",
     "contentDisplayPreference.i18nStrings.columnFilteringCountText": "{count, plural, zero {0 matches} one {1 match} other {{count} matches}}"
   },
   "copy-to-clipboard": {
@@ -257,7 +262,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Jump to page",
     "i18nStrings.jumpToPageInputLabel": "Page",
     "i18nStrings.jumpToPageError": "Page out of range. Showing last available page.",
-    "i18nStrings.jumpToPageLoadingText": "Loading"
+    "i18nStrings.jumpToPageLoadingText": "Loading",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} of {pagesCount}+} false {{currentPage} of {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Panel resize handle",
@@ -409,7 +415,22 @@
     "ariaLabels.expandButtonLabel": "Expand",
     "ariaLabels.collapseButtonLabel": "Collapse",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Error",
-    "columnDefinitions.editConfig.editIconAriaLabel": "editable"
+    "columnDefinitions.editConfig.editIconAriaLabel": "editable",
+    "i18nStrings.sortDropdownSortAscending": "Sort ascending",
+    "i18nStrings.sortDropdownSortDescending": "Sort descending",
+    "i18nStrings.sortDropdownMultiColumnSortGroup": "Multi-column sort (Shift + Click)",
+    "i18nStrings.sortDropdownAddToSortAscending": "Add to sort (ascending)",
+    "i18nStrings.sortDropdownAddToSortDescending": "Add to sort (descending)",
+    "i18nStrings.sortDropdownRemoveFromSort": "Remove from sort",
+    "i18nStrings.sortDropdownAddToSortDisabledReason": "This column is already sorted",
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": "This column is not sorted",
+    "i18nStrings.clearSort": "Clear sort",
+    "ariaLabels.sortAscending": "ascending",
+    "ariaLabels.sortDescending": "descending",
+    "ariaLabels.liveAnnouncementSortOrder": "Table sorted by {columns}",
+    "ariaLabels.liveAnnouncementSortCleared": "Sorting cleared",
+    "ariaLabels.sortPriority": "sort priority {priority}",
+    "ariaLabels.sortMenuTriggerLabel": "Sort options"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Scroll left",

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Mostrar ruta"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} de {totalCount} elementos",
+    "noMatch": "No hay acciones coincidentes",
+    "i18nStrings.filteringItemAriaDescription": "Siga escribiendo para filtrar los resultados."
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "Se abre en una pestaña nueva"
   },
@@ -125,6 +130,7 @@
     "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": "Quitar filtro",
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Mover el elemento de nuevo a la posición {currentPosition} de {total}} false {Mover el elemento a la posición {currentPosition} de {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {El artículo ha vuelto a su posición original {initialPosition} de {total}} false {El artículo se movió de la posición {initialPosition} a la posición {finalPosition} de {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{count, plural, zero {{label}, 0 elementos} one {{label}, 1 elemento} other {{label}, {count} elementos}}",
     "contentDisplayPreference.i18nStrings.columnFilteringCountText": "{count, plural, zero {0 coincidencias} one {1 coincidencia} other {{count} coincidencias}}"
   },
   "copy-to-clipboard": {
@@ -158,13 +164,13 @@
     "i18nStrings.endMonthLabel": "Mes de finalización",
     "i18nStrings.endDateLabel": "Fecha de finalización",
     "i18nStrings.endTimeLabel": "Hora de finalización",
-    "i18nStrings.datePlaceholder": "AAAA/MM/DD",
+    "i18nStrings.datePlaceholder": "AAAA-MM-DD",
     "i18nStrings.isoDatePlaceholder": "AAAA-MM-DD",
     "i18nStrings.slashedDatePlaceholder": "AAAA/MM/DD",
     "i18nStrings.timePlaceholder": "hh:mm:ss",
     "i18nStrings.dateTimeConstraintText": "Para la fecha, utilice AAAA/MM/DD. Para la hora, utilice el formato de 24 horas.",
     "i18nStrings.dateConstraintText": "Para la fecha, use el formato AAAA/MM/DD.",
-    "i18nStrings.slashedDateTimeConstraintText": "Para la fecha, use AAAA/MM/DD. Para la hora, use el formato de 24 horas.",
+    "i18nStrings.slashedDateTimeConstraintText": "Para la fecha, utilice AAAA/MM/DD. Para la hora, utilice el formato de 24 horas.",
     "i18nStrings.isoDateTimeConstraintText": "Para la fecha, use AAAA-MM-DD. Para la hora, use el formato de 24 horas.",
     "i18nStrings.slashedDateConstraintText": "Para la fecha, use el formato AAAA/MM/DD.",
     "i18nStrings.isoDateConstraintText": "Para la fecha, use el formato AAAA-MM-DD.",
@@ -256,7 +262,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Ir a la página",
     "i18nStrings.jumpToPageInputLabel": "Página",
     "i18nStrings.jumpToPageError": "Página fuera de rango. Se muestra la última página disponible.",
-    "i18nStrings.jumpToPageLoadingText": "Cargando"
+    "i18nStrings.jumpToPageLoadingText": "Cargando",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} de {pagesCount}+} false {{currentPage} de {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Controlador de cambio del tamaño del panel",
@@ -408,7 +415,22 @@
     "ariaLabels.expandButtonLabel": "Ampliar",
     "ariaLabels.collapseButtonLabel": "Contraer",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Error",
-    "columnDefinitions.editConfig.editIconAriaLabel": "editable"
+    "columnDefinitions.editConfig.editIconAriaLabel": "editable",
+    "i18nStrings.sortDropdownSortAscending": "Ordenar de forma ascendente",
+    "i18nStrings.sortDropdownSortDescending": "Ordenar de forma descendente",
+    "i18nStrings.sortDropdownMultiColumnSortGroup": "Ordenar por varias columnas (Mayús y clic)",
+    "i18nStrings.sortDropdownAddToSortAscending": "Agregar a la ordenación (ascendente)",
+    "i18nStrings.sortDropdownAddToSortDescending": "Agregar a la ordenación (descendente)",
+    "i18nStrings.sortDropdownRemoveFromSort": "Eliminar de la ordenación",
+    "i18nStrings.sortDropdownAddToSortDisabledReason": "Esta columna ya está ordenada",
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": "Esta columna no está ordenada",
+    "i18nStrings.clearSort": "Borrar ordenación",
+    "ariaLabels.sortAscending": "ascendente",
+    "ariaLabels.sortDescending": "descendente",
+    "ariaLabels.liveAnnouncementSortOrder": "Tabla ordenada por {columns}",
+    "ariaLabels.liveAnnouncementSortCleared": "Ordenación borrada",
+    "ariaLabels.sortPriority": "prioridad de ordenación {priority}",
+    "ariaLabels.sortMenuTriggerLabel": "Opciones de ordenación"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Desplácese hacia la izquierda",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Afficher le chemin"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} sur {totalCount} éléments",
+    "noMatch": "Aucune action correspondante",
+    "i18nStrings.filteringItemAriaDescription": "Continuez à taper pour filtrer les résultats."
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "S’ouvre dans un nouvel onglet"
   },
@@ -125,6 +130,7 @@
     "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": "Effacer le filtre",
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Remettre l'élément à la position {currentPosition} de {total}} false {Déplacer l'élément vers la position {currentPosition} de {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {L'élément a été replacé dans sa position initiale {initialPosition} de {total}} false {L'élément a été déplacé de la position {initialPosition} à {finalPosition} de {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{count, plural, zero {{label}, 0 éléments} one {{label}, 1 élément} other {{label}, {count} éléments}}",
     "contentDisplayPreference.i18nStrings.columnFilteringCountText": "{count, plural, zero {0 correspondances} one {1 correspondance} other {{count} correspondances}}"
   },
   "copy-to-clipboard": {
@@ -158,18 +164,18 @@
     "i18nStrings.endMonthLabel": "Mois de fin",
     "i18nStrings.endDateLabel": "Date de fin",
     "i18nStrings.endTimeLabel": "Heure de fin",
-    "i18nStrings.datePlaceholder": "JJ/MM/AAAA",
-    "i18nStrings.isoDatePlaceholder": "AAAA-MM-JJ",
+    "i18nStrings.datePlaceholder": "AAAA-MM-JJ",
+    "i18nStrings.isoDatePlaceholder": "JJ-MM-AAAA",
     "i18nStrings.slashedDatePlaceholder": "AAAA/MM/JJ",
     "i18nStrings.timePlaceholder": "hh:mm:ss",
-    "i18nStrings.dateTimeConstraintText": "Pour la date, utilisez le format AAAA/MM/JJ. Pour l'heure, utilisez le format 24 heures.",
+    "i18nStrings.dateTimeConstraintText": "Pour la date, utilisez le format AAAA/MM/JJ. Pour l'heure, utilisez le format 24 heures.",
     "i18nStrings.dateConstraintText": "Pour la date, utilisez le format AAAA/MM/JJ.",
-    "i18nStrings.slashedDateTimeConstraintText": "Pour la date, utilisez le format JJ/MM/AAAA. Pour l’heure, utilisez le format 24 heures.",
-    "i18nStrings.isoDateTimeConstraintText": "Pour la date, utilisez le format JJ-MM-AAAA. Pour l’heure, utilisez le format 24 heures.",
-    "i18nStrings.slashedDateConstraintText": "Pour la date, utilisez le format JJ/MM/AAAA.",
-    "i18nStrings.isoDateConstraintText": "Pour la date, utilisez le format JJ-MM-AAAA.",
-    "i18nStrings.slashedMonthConstraintText": "Pour le mois, utilisez le format MM/AAAA.",
-    "i18nStrings.isoMonthConstraintText": "Pour le mois, utilisez le format MM-AAAA.",
+    "i18nStrings.slashedDateTimeConstraintText": "Pour la date, utilisez le format AAAA/MM/JJ. Pour l'heure, utilisez le format 24 heures.",
+    "i18nStrings.isoDateTimeConstraintText": "Pour la date, utilisez le format AAAA-MM-JJ. Pour l’heure, utilisez le format 24 heures.",
+    "i18nStrings.slashedDateConstraintText": "Pour la date, utilisez le format AAAA/MM/JJ.",
+    "i18nStrings.isoDateConstraintText": "Pour la date, utilisez le format AAAA-MM-JJ.",
+    "i18nStrings.slashedMonthConstraintText": "Pour le mois, utilisez le format AAAA/MM.",
+    "i18nStrings.isoMonthConstraintText": "Pour le mois, utilisez le format YYYY-MM.",
     "i18nStrings.monthConstraintText": "Pour le mois, utilisez le format AAAA/MM.",
     "i18nStrings.errorIconAriaLabel": "Erreur",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Plage sélectionnée de {startDate} à {endDate}",
@@ -195,7 +201,7 @@
   "file-token-group": {
     "i18nStrings.limitShowFewer": "Afficher moins",
     "i18nStrings.limitShowMore": "Afficher plus",
-    "i18nStrings.removeFileAriaLabel": "Supprimer le fichier {fileIndex}, {fileName}",
+    "i18nStrings.removeFileAriaLabel": "Supprimer le fichier {fileIndex}, {fileName}",
     "i18nStrings.errorIconAriaLabel": "Erreur",
     "i18nStrings.warningIconAriaLabel": "Avertissement"
   },
@@ -256,7 +262,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Aller à la page",
     "i18nStrings.jumpToPageInputLabel": "Page",
     "i18nStrings.jumpToPageError": "Page hors de portée. Affichage de la dernière page disponible.",
-    "i18nStrings.jumpToPageLoadingText": "Chargement en cours"
+    "i18nStrings.jumpToPageLoadingText": "Chargement en cours",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} sur plus de {pagesCount}} false {{currentPage} sur {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Poignée de redimensionnement du panneau",
@@ -408,7 +415,22 @@
     "ariaLabels.expandButtonLabel": "Élargir",
     "ariaLabels.collapseButtonLabel": "Réduire",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Erreur",
-    "columnDefinitions.editConfig.editIconAriaLabel": "modifiable"
+    "columnDefinitions.editConfig.editIconAriaLabel": "modifiable",
+    "i18nStrings.sortDropdownSortAscending": "Trier par ordre croissant",
+    "i18nStrings.sortDropdownSortDescending": "Trier par ordre décroissant",
+    "i18nStrings.sortDropdownMultiColumnSortGroup": "Tri sur plusieurs colonnes (Maj + clic)",
+    "i18nStrings.sortDropdownAddToSortAscending": "Ajouter au tri (par ordre croissant)",
+    "i18nStrings.sortDropdownAddToSortDescending": "Ajouter au tri (par ordre décroissant)",
+    "i18nStrings.sortDropdownRemoveFromSort": "Supprimer du tri",
+    "i18nStrings.sortDropdownAddToSortDisabledReason": "Cette colonne est déjà triée",
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": "Cette colonne n’est pas triée",
+    "i18nStrings.clearSort": "Effacer le tri",
+    "ariaLabels.sortAscending": "croissant",
+    "ariaLabels.sortDescending": "décroissant",
+    "ariaLabels.liveAnnouncementSortOrder": "Tableau trié selon {columns}",
+    "ariaLabels.liveAnnouncementSortCleared": "Tri supprimé",
+    "ariaLabels.sortPriority": "priorité de tri {priority}",
+    "ariaLabels.sortMenuTriggerLabel": "Options de tri"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Faire défiler vers la gauche",

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Tampilkan jalur"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} dari {totalCount} item",
+    "noMatch": "Tidak ada tindakan yang cocok",
+    "i18nStrings.filteringItemAriaDescription": "Terus mengetik untuk memfilter hasil."
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "Buka di tab baru"
   },
@@ -125,6 +130,7 @@
     "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": "Hapus filter",
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Memindahkan item kembali ke posisi {currentPosition} dari {total}} false {Memindahkan item ke posisi {currentPosition} dari {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Item dipindahkan kembali ke posisi aslinya {initialPosition} dari {total}} false {Item dipindahkan dari posisi {initialPosition} ke posisi {finalPosition} dari {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{count, plural, zero {{label}, 0 item} one {{label}, 1 item} other {{label}, {count} item}}",
     "contentDisplayPreference.i18nStrings.columnFilteringCountText": "{count, plural, zero {0 kecocokan} one {1 kecocokan} other {{count} kecocokan}}"
   },
   "copy-to-clipboard": {
@@ -158,19 +164,19 @@
     "i18nStrings.endMonthLabel": "Bulan berakhir",
     "i18nStrings.endDateLabel": "Tanggal berakhir",
     "i18nStrings.endTimeLabel": "Waktu berakhir",
-    "i18nStrings.datePlaceholder": "HH-BB-TTTT",
+    "i18nStrings.datePlaceholder": "TTTT-BB-HH",
     "i18nStrings.isoDatePlaceholder": "TTTT-BB-HH",
     "i18nStrings.slashedDatePlaceholder": "TTTT/BB/HH",
     "i18nStrings.timePlaceholder": "jj:mm:dd",
-    "i18nStrings.dateTimeConstraintText": "Untuk tanggal, gunakan HH/BB/TTTT. Untuk waktu, gunakan format 24 jam.",
-    "i18nStrings.dateConstraintText": "Untuk tanggal, gunakan HH/BB/TTTT.",
-    "i18nStrings.slashedDateTimeConstraintText": "Untuk tanggal, gunakan HH/BB/TTTT. Untuk waktu, gunakan format 24 jam.",
-    "i18nStrings.isoDateTimeConstraintText": "Untuk tanggal, gunakan HH-BB-TTTT. Untuk waktu, gunakan format 24 jam.",
-    "i18nStrings.slashedDateConstraintText": "Untuk tanggal, gunakan HH/BB/TTTT.",
-    "i18nStrings.isoDateConstraintText": "Untuk tanggal, gunakan HH-BB-TTTT.",
-    "i18nStrings.slashedMonthConstraintText": "Untuk bulan, gunakan BB/TTTT.",
+    "i18nStrings.dateTimeConstraintText": "Untuk tanggal, gunakan TTTT/BB/HH. Untuk waktu, gunakan format 24 jam.",
+    "i18nStrings.dateConstraintText": "Untuk tanggal, gunakan TTTT/BB/HH.",
+    "i18nStrings.slashedDateTimeConstraintText": "Untuk tanggal, gunakan TTTT/BB/HH. Untuk waktu, gunakan format 24 jam.",
+    "i18nStrings.isoDateTimeConstraintText": "Untuk tanggal, gunakan TTTT-BB-HH. Untuk waktu, gunakan format 24 jam.",
+    "i18nStrings.slashedDateConstraintText": "Untuk tanggal, gunakan TTTT/BB/HH.",
+    "i18nStrings.isoDateConstraintText": "Untuk tanggal, gunakan TTTT-BB-HH.",
+    "i18nStrings.slashedMonthConstraintText": "Untuk bulan, gunakan TTTT/BB.",
     "i18nStrings.isoMonthConstraintText": "Untuk bulan, gunakan BB-TTTT.",
-    "i18nStrings.monthConstraintText": "Untuk bulan, gunakan BB/TTTT.",
+    "i18nStrings.monthConstraintText": "Untuk bulan, gunakan TTTT/BB.",
     "i18nStrings.errorIconAriaLabel": "Kesalahan",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Rentang dipilih dari {startDate} hingga {endDate}",
     "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {{amount} detik terakhir} one {{amount} detik terakhir} other {{amount} detik terakhir}}} minute {{amount, plural, zero {{amount} menit terakhir} one {{amount} menit terakhir} other {{amount} menit terakhir}}} hour {{amount, plural, zero {{amount} jam terakhir} one {{amount} jam terakhir} other {{amount} jam terakhir}}} day {{amount, plural, zero {{amount} hari terakhir} one {{amount} hari terakhir} other {{amount} hari terakhir}}} week {{amount, plural, zero {{amount} minggu terakhir} one {{amount} minggu terakhir} other {{amount} minggu terakhir}}} month {{amount, plural, zero {{amount} bulan terakhir} one {{amount} bulan terakhir} other {{amount} bulan terakhir}}} year {{amount, plural, zero {{amount} tahun terakhir} one {{amount} tahun terakhir} other {{amount} tahun terakhir}}} other {}}",
@@ -256,7 +262,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Langsung ke halaman",
     "i18nStrings.jumpToPageInputLabel": "Halaman",
     "i18nStrings.jumpToPageError": "Halaman di luar rentang. Menampilkan halaman terakhir yang tersedia.",
-    "i18nStrings.jumpToPageLoadingText": "Memuat"
+    "i18nStrings.jumpToPageLoadingText": "Memuat",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} dari {pagesCount}+} false {{currentPage} dari {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Handel pengubahan ukuran panel",
@@ -408,7 +415,22 @@
     "ariaLabels.expandButtonLabel": "Luaskan",
     "ariaLabels.collapseButtonLabel": "Ciutkan",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Kesalahan",
-    "columnDefinitions.editConfig.editIconAriaLabel": "dapat diedit"
+    "columnDefinitions.editConfig.editIconAriaLabel": "dapat diedit",
+    "i18nStrings.sortDropdownSortAscending": "Urutkan naik",
+    "i18nStrings.sortDropdownSortDescending": "Urutkan turun",
+    "i18nStrings.sortDropdownMultiColumnSortGroup": "Urutan multikolom (Shift + Klik)",
+    "i18nStrings.sortDropdownAddToSortAscending": "Tambahkan untuk mengurutkan (naik)",
+    "i18nStrings.sortDropdownAddToSortDescending": "Tambahkan untuk mengurutkan (turun)",
+    "i18nStrings.sortDropdownRemoveFromSort": "Hapus dari urutan",
+    "i18nStrings.sortDropdownAddToSortDisabledReason": "Kolom ini sudah diurutkan",
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": "Kolom ini belum diurutkan",
+    "i18nStrings.clearSort": "Hapus urutan",
+    "ariaLabels.sortAscending": "naik",
+    "ariaLabels.sortDescending": "turun",
+    "ariaLabels.liveAnnouncementSortOrder": "Tabel diurutkan berdasarkan {columns}",
+    "ariaLabels.liveAnnouncementSortCleared": "Pengurutan telah dihapus",
+    "ariaLabels.sortPriority": "urutkan prioritas {priority}",
+    "ariaLabels.sortMenuTriggerLabel": "Opsi urutan"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Gulir ke kiri",

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Mostra percorso"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} di {totalCount} articoli",
+    "noMatch": "Nessuna azione corrispondente",
+    "i18nStrings.filteringItemAriaDescription": "Continua a digitare per filtrare i risultati."
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "Si apre in una nuova scheda"
   },
@@ -125,6 +130,7 @@
     "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": "Cancella filtro",
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Spostamento dell'elemento di nuovo nella posizione {currentPosition} di {total}} false {Spostamento dell'elemento nella posizione {currentPosition} di {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {L'elemento è stato spostato di nuovo nella posizione originale {initialPosition} di {total}} false {Elemento spostato da una posizione {initialPosition} alla posizione {finalPosition} di {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{count, plural, zero {{label}, 0 elementi} one {{label}, 1 elemento} other {{label}, {count} elementi}}",
     "contentDisplayPreference.i18nStrings.columnFilteringCountText": "{count, plural, zero {0 corrispondenze} one {1 corrispondenza} other {{count} corrispondenze}}"
   },
   "copy-to-clipboard": {
@@ -158,19 +164,19 @@
     "i18nStrings.endMonthLabel": "Mese di fine",
     "i18nStrings.endDateLabel": "Data di fine",
     "i18nStrings.endTimeLabel": "Ora di fine",
-    "i18nStrings.datePlaceholder": "GG/MM/AAAA",
+    "i18nStrings.datePlaceholder": "AAAA-MM-GG",
     "i18nStrings.isoDatePlaceholder": "AAAA-MM-GG",
     "i18nStrings.slashedDatePlaceholder": "AAAA/MM/GG",
     "i18nStrings.timePlaceholder": "hh:mm:ss",
-    "i18nStrings.dateTimeConstraintText": "Per la data, utilizza il formato GG/MM/AAAA. Per l'ora, usa il formato 24 ore.",
-    "i18nStrings.dateConstraintText": "Per la data, utilizza il formato GG/MM/AAAA.",
-    "i18nStrings.slashedDateTimeConstraintText": "Per la data, utilizza il formato GG/MM/AAAA. Per l'ora, utilizza il formato 24 ore.",
-    "i18nStrings.isoDateTimeConstraintText": "Per la data, utilizza il formato GG-MM-AAAA. Per l'ora, usa il formato 24 ore.",
-    "i18nStrings.slashedDateConstraintText": "Per la data, utilizza il formato GG/MM/AAAA.",
-    "i18nStrings.isoDateConstraintText": "Per la data, utilizza il formato GG-MM-AAAA.",
-    "i18nStrings.slashedMonthConstraintText": "Per il mese, utilizza il formato MM/AAAA.",
-    "i18nStrings.isoMonthConstraintText": "Per il mese, utilizza il formato MM-AAAA.",
-    "i18nStrings.monthConstraintText": "Per il mese, utilizza il formato MM/AAAA.",
+    "i18nStrings.dateTimeConstraintText": "Per la data, utilizza il formato AAAA/MM/GG. Per l'ora, usa il formato 24 ore.",
+    "i18nStrings.dateConstraintText": "Per la data, utilizza il formato AAAA/MM/GG.",
+    "i18nStrings.slashedDateTimeConstraintText": "Per la data, utilizza il formato AAAA/MM/GG. Per l'ora, usa il formato 24 ore.",
+    "i18nStrings.isoDateTimeConstraintText": "Per la data, utilizza il formato AAAA-MM-GG. Per l'ora, usa il formato 24 ore.",
+    "i18nStrings.slashedDateConstraintText": "Per la data, utilizza il formato AAAA/MM/GG.",
+    "i18nStrings.isoDateConstraintText": "Per la data, utilizza il formato AAAA-MM-GG.",
+    "i18nStrings.slashedMonthConstraintText": "Per il mese, utilizza il formato AAAA/MM.",
+    "i18nStrings.isoMonthConstraintText": "Per il mese, utilizza il formato AAAA-MM.",
+    "i18nStrings.monthConstraintText": "Per il mese, utilizza il formato AAAA/MM.",
     "i18nStrings.errorIconAriaLabel": "Errore",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Intervallo selezionato da {startDate} a {endDate}",
     "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {Ultimi {amount} secondi} one {Ultimo secondo} other {Ultimi {amount} secondi}}} minute {{amount, plural, zero {Ultimi {amount} minuti} one {Ultimo minuto} other {Ultimi {amount} minuti}}} hour {{amount, plural, zero {Ultime {amount} ore} one {Ultima ora} other {Ultime {amount} ore}}} day {{amount, plural, zero {Ultimi {amount} giorni} one {Ultimo giorno} other {Ultimi {amount} giorni}}} week {{amount, plural, zero {Ultime {amount} settimane} one {Ultima settimana} other {Ultime {amount} settimane}}} month {{amount, plural, zero {Ultimi {amount} mesi} one {Ultimo mese} other {Ultimi {amount} mesi}}} year {{amount, plural, zero {Ultimi {amount} anni} one {Ultimo anno} other {Ultimi {amount} anni}}} other {}}",
@@ -235,7 +241,7 @@
     "externalIconAriaLabel": "Si apre in una nuova scheda"
   },
   "list": {
-    "dragHandleAriaLabel": "Maniglia di trascinamento",
+    "dragHandleAriaLabel": "Punto di trascinamento",
     "dragHandleAriaDescription": "Utilizza Spazio o Invio per attivare il trascinamento di un elemento, quindi usa i tasti freccia per spostare la posizione dell'elemento. Per completare lo spostamento della posizione, utilizza Spazio o Invio oppure per annullare lo spostamento, premi Esc.",
     "liveAnnouncementDndStarted": "Elemento raccolto nella posizione {position} di {total}",
     "liveAnnouncementDndDiscarded": "Riordinamento annullato",
@@ -256,7 +262,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Vai alla pagina",
     "i18nStrings.jumpToPageInputLabel": "Pagina",
     "i18nStrings.jumpToPageError": "Pagina fuori intervallo. Mostra l'ultima pagina disponibile.",
-    "i18nStrings.jumpToPageLoadingText": "Caricamento in corso"
+    "i18nStrings.jumpToPageLoadingText": "Caricamento in corso",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} di {pagesCount}+} false {{currentPage} di {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Maniglia di ridimensionamento del pannello",
@@ -408,7 +415,22 @@
     "ariaLabels.expandButtonLabel": "Espandi",
     "ariaLabels.collapseButtonLabel": "Comprimi",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Errore",
-    "columnDefinitions.editConfig.editIconAriaLabel": "modificabile"
+    "columnDefinitions.editConfig.editIconAriaLabel": "modificabile",
+    "i18nStrings.sortDropdownSortAscending": "Ordina in ordine crescente",
+    "i18nStrings.sortDropdownSortDescending": "Ordina in ordine decrescente",
+    "i18nStrings.sortDropdownMultiColumnSortGroup": "Ordinamento a più colonne (MAIUSC + clic)",
+    "i18nStrings.sortDropdownAddToSortAscending": "Aggiungi all’ordinamento (crescente)",
+    "i18nStrings.sortDropdownAddToSortDescending": "Aggiungi all’ordinamento (decrescente)",
+    "i18nStrings.sortDropdownRemoveFromSort": "Rimuovi dall’ordinamento",
+    "i18nStrings.sortDropdownAddToSortDisabledReason": "Questa colonna è già ordinata",
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": "Questa colonna non è ordinata",
+    "i18nStrings.clearSort": "Cancella l’ordinamento",
+    "ariaLabels.sortAscending": "ascendente",
+    "ariaLabels.sortDescending": "discendente",
+    "ariaLabels.liveAnnouncementSortOrder": "Tabella ordinata per {columns}",
+    "ariaLabels.liveAnnouncementSortCleared": "Ordinamento cancellato",
+    "ariaLabels.sortPriority": "priorità di ordinamento {priority}",
+    "ariaLabels.sortMenuTriggerLabel": "Opzioni di ordinamento"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Scorri a sinistra",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "パスの表示"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{totalCount} 件のうち {matchesCount} 件の商品",
+    "noMatch": "一致するアクションなし",
+    "i18nStrings.filteringItemAriaDescription": "入力を続けると結果が絞り込まれます。"
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "新しいタブで開く"
   },
@@ -125,6 +130,7 @@
     "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": "フィルターをクリア",
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {項目を位置 {currentPosition}/{total} に戻しています} false {項目を位置 {currentPosition}/{total} に移動しています} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {項目は元の位置 {initialPosition}/{total} に戻りました} false {項目が位置 {initialPosition} から位置 {finalPosition}/{total} に移動しました} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{count, plural, zero {{label}、0 個の項目} one {{label}、1 個の項目} other {{label}、{count} 個の項目}}",
     "contentDisplayPreference.i18nStrings.columnFilteringCountText": "{count, plural, zero {0 件の一致} one {1 件の一致} other {{count} 件の一致}}"
   },
   "copy-to-clipboard": {
@@ -158,19 +164,19 @@
     "i18nStrings.endMonthLabel": "終了月",
     "i18nStrings.endDateLabel": "終了日",
     "i18nStrings.endTimeLabel": "終了時刻",
-    "i18nStrings.datePlaceholder": "YYYY/MM/DD",
+    "i18nStrings.datePlaceholder": "YYYY-MM-DD",
     "i18nStrings.isoDatePlaceholder": "YYYY-MM-DD",
     "i18nStrings.slashedDatePlaceholder": "YYYY/MM/DD",
     "i18nStrings.timePlaceholder": "hh:mm:ss",
     "i18nStrings.dateTimeConstraintText": "日付には YYYY/MM/DD を使用します。時刻には 24 時間形式を使用します。",
-    "i18nStrings.dateConstraintText": "日付には YYYY/MM/DD を使用してください。",
+    "i18nStrings.dateConstraintText": "日付には YYYY/MM/DD を使用します。",
     "i18nStrings.slashedDateTimeConstraintText": "日付には YYYY/MM/DD を使用します。時刻には 24 時間形式を使用します。",
     "i18nStrings.isoDateTimeConstraintText": "日付には YYYY-MM-DD を使用します。時刻には 24 時間形式を使用します。",
-    "i18nStrings.slashedDateConstraintText": "日付には YYYY/MM/DD を使用してください。",
-    "i18nStrings.isoDateConstraintText": "日付には YYYY-MM-DD を使用してください。",
-    "i18nStrings.slashedMonthConstraintText": "月には YYYY/MM を使用してください。",
-    "i18nStrings.isoMonthConstraintText": "月には YYYY-MM を使用してください。",
-    "i18nStrings.monthConstraintText": "月には YYYY/MM を使用してください。",
+    "i18nStrings.slashedDateConstraintText": "日付には YYYY/MM/DD を使用します。",
+    "i18nStrings.isoDateConstraintText": "日付には YYYY-MM-DD を使用します。",
+    "i18nStrings.slashedMonthConstraintText": "月には YYYY/MM を使用します。",
+    "i18nStrings.isoMonthConstraintText": "月には YYYY-MM を使用します。",
+    "i18nStrings.monthConstraintText": "月には YYYY/MM を使用します。",
     "i18nStrings.errorIconAriaLabel": "エラー",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "{startDate} から {endDate} で選択された範囲",
     "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {直近 {amount} 秒間} one {直近 {amount} 秒間} other {直近 {amount} 秒間}}} minute {{amount, plural, zero {直近 {amount} 分間} one {直近 {amount} 分間} other {直近 {amount} 分間}}} hour {{amount, plural, zero {直近 {amount} 時間} one {直近 {amount} 時間} other {直近 {amount} 時間}}} day {{amount, plural, zero {直近 {amount} 日間} one {直近 {amount} 日間} other {直近 {amount} 日間}}} week {{amount, plural, zero {直近 {amount} 週間} one {直近 {amount} 週間} other {直近 {amount} 週間}}} month {{amount, plural, zero {直近 {amount} か月間} one {直近 {amount} か月間} other {直近 {amount} か月間}}} year {{amount, plural, zero {直近 {amount} 年間} one {直近 {amount} 年間} other {直近 {amount} 年間}}} other {}}",
@@ -256,7 +262,8 @@
     "ariaLabels.jumpToPageButtonLabel": "ページに移動",
     "i18nStrings.jumpToPageInputLabel": "ページ",
     "i18nStrings.jumpToPageError": "ページが範囲外です。最後に利用可能なページを表示しています。",
-    "i18nStrings.jumpToPageLoadingText": "ロード中"
+    "i18nStrings.jumpToPageLoadingText": "ロード中",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage}/{pagesCount}+} false {{currentPage}/{pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "パネルのサイズ変更ハンドル",
@@ -408,7 +415,22 @@
     "ariaLabels.expandButtonLabel": "展開する",
     "ariaLabels.collapseButtonLabel": "折りたたむ",
     "columnDefinitions.editConfig.errorIconAriaLabel": "エラー",
-    "columnDefinitions.editConfig.editIconAriaLabel": "編集可能"
+    "columnDefinitions.editConfig.editIconAriaLabel": "編集可能",
+    "i18nStrings.sortDropdownSortAscending": "昇順にソート",
+    "i18nStrings.sortDropdownSortDescending": "降順にソート",
+    "i18nStrings.sortDropdownMultiColumnSortGroup": "複数列ソート (Shift + Click)",
+    "i18nStrings.sortDropdownAddToSortAscending": "ソートに追加 (昇順)",
+    "i18nStrings.sortDropdownAddToSortDescending": "ソートに追加 (降順)",
+    "i18nStrings.sortDropdownRemoveFromSort": "ソートから削除",
+    "i18nStrings.sortDropdownAddToSortDisabledReason": "この列は既にソートされています",
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": "この列はソートされていません",
+    "i18nStrings.clearSort": "ソートをクリア",
+    "ariaLabels.sortAscending": "昇順",
+    "ariaLabels.sortDescending": "降順",
+    "ariaLabels.liveAnnouncementSortOrder": "表は {columns}でソートされています",
+    "ariaLabels.liveAnnouncementSortCleared": "ソートがクリアされました",
+    "ariaLabels.sortPriority": "ソートの優先順位 {priority}",
+    "ariaLabels.sortMenuTriggerLabel": "ソートオプション"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "左にスクロール",

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "경로 표시"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{totalCount}개 항목 중 {matchesCount}개",
+    "noMatch": "일치하는 작업 없음",
+    "i18nStrings.filteringItemAriaDescription": "결과를 필터링하려면 계속 입력하세요."
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "새 탭에서 열림"
   },
@@ -125,6 +130,7 @@
     "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": "필터 지우기",
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {{currentPosition}/{total} 위치로 항목 다시 이동} false {{currentPosition}/{total} 위치로 항목 이동} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {항목이 원래 위치인 {initialPosition}/{total} 위치로 다시 이동됨} false {항목이 {initialPosition}/{total} 위치에서 인 {finalPosition}/{total} 위치로 이동됨} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{count, plural, zero {{label}, 0개 항목} one {{label}, 1개 항목} other {{label}, {count}개 항목}}",
     "contentDisplayPreference.i18nStrings.columnFilteringCountText": "{count, plural, zero {0개 일치} one {1개 일치} other {{count}개 일치}}"
   },
   "copy-to-clipboard": {
@@ -256,7 +262,8 @@
     "ariaLabels.jumpToPageButtonLabel": "페이지로 이동",
     "i18nStrings.jumpToPageInputLabel": "페이지",
     "i18nStrings.jumpToPageError": "페이지가 범위를 벗어났습니다. 마지막으로 사용 가능한 페이지를 표시합니다.",
-    "i18nStrings.jumpToPageLoadingText": "로드 중"
+    "i18nStrings.jumpToPageLoadingText": "로드 중",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage}/{pagesCount}+} false {{currentPage}/{pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "패널 크기 조정 핸들",
@@ -307,7 +314,7 @@
     "i18nStrings.operatorsText": "연산자",
     "i18nStrings.propertyText": "속성",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__formattedText} 필터 제거",
-    "i18nStrings.tokenEditorTokenActionsAriaLabel": "필터 작업, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": "필터 작업, {token__formattedText} ",
     "i18nStrings.tokenEditorTokenRemoveAriaLabel": "필터 {token__formattedText} 제거",
     "i18nStrings.tokenEditorTokenRemoveLabel": "필터 제거",
     "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "그룹에서 필터 제거",
@@ -408,7 +415,22 @@
     "ariaLabels.expandButtonLabel": "확장",
     "ariaLabels.collapseButtonLabel": "축소",
     "columnDefinitions.editConfig.errorIconAriaLabel": "오류",
-    "columnDefinitions.editConfig.editIconAriaLabel": "편집 가능"
+    "columnDefinitions.editConfig.editIconAriaLabel": "편집 가능",
+    "i18nStrings.sortDropdownSortAscending": "오름차순 정렬",
+    "i18nStrings.sortDropdownSortDescending": "내림차순 정렬",
+    "i18nStrings.sortDropdownMultiColumnSortGroup": "복수 열 정렬(Shift 키를 누른 채 클릭)",
+    "i18nStrings.sortDropdownAddToSortAscending": "정렬에 추가(오름차순)",
+    "i18nStrings.sortDropdownAddToSortDescending": "정렬에 추가 (내림차순)",
+    "i18nStrings.sortDropdownRemoveFromSort": "정렬에서 제거",
+    "i18nStrings.sortDropdownAddToSortDisabledReason": "이 열은 이미 정렬되었습니다.",
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": "이 열은 정렬되지 않았습니다.",
+    "i18nStrings.clearSort": "정렬 지우기",
+    "ariaLabels.sortAscending": "오름차순",
+    "ariaLabels.sortDescending": "내림차순",
+    "ariaLabels.liveAnnouncementSortOrder": "{columns} 기준 테이블 정렬",
+    "ariaLabels.liveAnnouncementSortCleared": "정렬이 지워졌습니다.",
+    "ariaLabels.sortPriority": "정렬 우선 순위 {priority}",
+    "ariaLabels.sortMenuTriggerLabel": "정렬 옵션"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "왼쪽으로 스크롤",

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Mostrar caminho"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} de {totalCount} itens",
+    "noMatch": "Nenhuma ação correspondente",
+    "i18nStrings.filteringItemAriaDescription": "Continue digitando para filtrar os resultados."
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "Abre em uma nova guia"
   },
@@ -125,6 +130,7 @@
     "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": "Limpar filtro",
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Movendo o item de volta para a posição {currentPosition} de {total}} false {Movendo o item para a posição {currentPosition} de {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Item movido de volta à sua posição original {initialPosition} de {total}} false {Item movido da posição {initialPosition} para a posição {finalPosition} de {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{count, plural, zero {{label}, 0 itens} one {{label}, 1 item} other {{label}, {count} itens}}",
     "contentDisplayPreference.i18nStrings.columnFilteringCountText": "{count, plural, zero {0 correspondências} one {1 correspondência} other {{count} correspondências}}"
   },
   "copy-to-clipboard": {
@@ -158,7 +164,7 @@
     "i18nStrings.endMonthLabel": "Mês de término",
     "i18nStrings.endDateLabel": "Data de término",
     "i18nStrings.endTimeLabel": "Horário de término",
-    "i18nStrings.datePlaceholder": "AAAA/MM/DD",
+    "i18nStrings.datePlaceholder": "AAAA-MM-DD",
     "i18nStrings.isoDatePlaceholder": "AAAA-MM-DD",
     "i18nStrings.slashedDatePlaceholder": "AAAA/MM/DD",
     "i18nStrings.timePlaceholder": "hh:mm:ss",
@@ -167,9 +173,9 @@
     "i18nStrings.slashedDateTimeConstraintText": "Para a data, use o formato AAAA/MM/DD. Para o horário, use o formato de 24 horas.",
     "i18nStrings.isoDateTimeConstraintText": "Para a data, use o formato AAAA-MM-DD. Para o horário, use o formato de 24 horas.",
     "i18nStrings.slashedDateConstraintText": "Para data, use AAAA/MM/DD.",
-    "i18nStrings.isoDateConstraintText": "Para data, use AAAA-MM-DD.",
+    "i18nStrings.isoDateConstraintText": "Para a data, use AAAA-MM-DD.",
     "i18nStrings.slashedMonthConstraintText": "Para mês, use AAAA/MM.",
-    "i18nStrings.isoMonthConstraintText": "Para mês, use AAAA-MM.",
+    "i18nStrings.isoMonthConstraintText": "Para o mês, use AAAA-MM.",
     "i18nStrings.monthConstraintText": "Para mês, use AAAA/MM.",
     "i18nStrings.errorIconAriaLabel": "Erro",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Intervalo selecionado de {startDate} a {endDate}",
@@ -256,7 +262,8 @@
     "ariaLabels.jumpToPageButtonLabel": "Ir para a página",
     "i18nStrings.jumpToPageInputLabel": "Página",
     "i18nStrings.jumpToPageError": "Página fora do alcance. Mostrando a última página disponível.",
-    "i18nStrings.jumpToPageLoadingText": "Carregando"
+    "i18nStrings.jumpToPageLoadingText": "Carregando",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {mais {currentPage} de {pagesCount}} false {{currentPage} de {pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Alça de redimensionamento do painel",
@@ -408,7 +415,22 @@
     "ariaLabels.expandButtonLabel": "Expandir",
     "ariaLabels.collapseButtonLabel": "Recolher",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Erro",
-    "columnDefinitions.editConfig.editIconAriaLabel": "editável"
+    "columnDefinitions.editConfig.editIconAriaLabel": "editável",
+    "i18nStrings.sortDropdownSortAscending": "Classificar em ordem crescente",
+    "i18nStrings.sortDropdownSortDescending": "Classificar em ordem decrescente",
+    "i18nStrings.sortDropdownMultiColumnSortGroup": "Classificação em várias colunas (Shift + Click)",
+    "i18nStrings.sortDropdownAddToSortAscending": "Adicionar à classificação (ascendente)",
+    "i18nStrings.sortDropdownAddToSortDescending": "Adicionar à classificação (decrescente)",
+    "i18nStrings.sortDropdownRemoveFromSort": "Remover da classificação",
+    "i18nStrings.sortDropdownAddToSortDisabledReason": "Esta coluna já está classificada",
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": "Esta coluna não está classificada",
+    "i18nStrings.clearSort": "Limpar classificação",
+    "ariaLabels.sortAscending": "ordem crescente",
+    "ariaLabels.sortDescending": "ordem decrescente",
+    "ariaLabels.liveAnnouncementSortOrder": "Tabela classificada por {columns}",
+    "ariaLabels.liveAnnouncementSortCleared": "Classificação cancelada",
+    "ariaLabels.sortPriority": "prioridade de classificação {priority}",
+    "ariaLabels.sortMenuTriggerLabel": "Opções de classificação"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Rolar para a esquerda",

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -44,7 +44,7 @@
   },
   "attribute-editor": {
     "removeButtonText": "Kaldır",
-    "i18nStrings.itemRemovedAriaLive": "Öğe kaldırıldı"
+    "i18nStrings.itemRemovedAriaLive": "Öge kaldırıldı"
   },
   "autosuggest": {
     "errorIconAriaLabel": "Hata",
@@ -54,6 +54,11 @@
   },
   "breadcrumb-group": {
     "expandAriaLabel": "Yolu göster"
+  },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount}/{totalCount} öge",
+    "noMatch": "Eşleşen eylem yok",
+    "i18nStrings.filteringItemAriaDescription": "Sonuçları filtrelemek için yazmaya devam edin."
   },
   "button": {
     "i18nStrings.externalIconAriaLabel": "Yeni bir sekmede açılır"
@@ -67,7 +72,7 @@
     "i18nStrings.currentMonthAriaLabel": "Geçerli ay"
   },
   "cards": {
-    "ariaLabels.selectionGroupLabel": "Öğe seçimi"
+    "ariaLabels.selectionGroupLabel": "Öge seçimi"
   },
   "code-editor": {
     "i18nStrings.loadingState": "Kod düzenleyici yükleniyor",
@@ -116,15 +121,16 @@
     "contentDisplayPreference.title": "Sütun tercihleri",
     "contentDisplayPreference.description": "Sütunların görünürlüğünü ve sırasını özelleştirin.",
     "contentDisplayPreference.dragHandleAriaLabel": "Sürükleme tutamacı",
-    "contentDisplayPreference.dragHandleAriaDescription": "Bir öğe için sürüklemeyi etkinleştirmek üzere Boşluk veya Enter tuşunu ve öğenin konumunu taşımak için ok tuşlarını kullanın. Konum taşıma işlemini tamamlamak için Boşluk veya Enter tuşunu ya da taşıma işlemini iptal etmek için ESC tuşunu kullanın.",
-    "contentDisplayPreference.liveAnnouncementDndStarted": "Öğe {position}/{total} konumundan alındı",
+    "contentDisplayPreference.dragHandleAriaDescription": "Bir öğenin sürüklemesini etkinleştirmek için Boşluk veya Enter tuşlarını kullanın, ardından öğenin konumunu taşımak için ok tuşlarını kullanın. Konum hareketini tamamlamak için Boşluk veya Enter tuşunu kullanın veya hareketi iptal etmek için Escape öğesini kullanın. Ekran okuyucunuzda tarama modunuzu değiştirmeniz gerekebilir.",
+    "contentDisplayPreference.liveAnnouncementDndStarted": "Öge {position}/{total} konumundan alındı",
     "contentDisplayPreference.liveAnnouncementDndDiscarded": "Yeniden sıralama iptal edildi",
     "contentDisplayPreference.i18nStrings.columnFilteringPlaceholder": "Filtre sütunları",
     "contentDisplayPreference.i18nStrings.columnFilteringAriaLabel": "Filtre sütunları",
     "contentDisplayPreference.i18nStrings.columnFilteringNoMatchText": "Eşleşme bulunamadı",
     "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": "Filtreyi temizle",
-    "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Öğe {currentPosition}/{total} konumuna geri taşınıyor} false {Öğe {currentPosition}/{total} konumuna taşınıyor} other {}}",
-    "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Öğe ilk {initialPosition}/{total} konumuna geri taşındı} false {Öğe {initialPosition} konumundan {finalPosition}/{total} konumuna taşındı} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Öge {currentPosition}/{total} konumuna geri taşınıyor} false {Öge {currentPosition}/{total} konumuna taşınıyor} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Öge ilk {initialPosition}/{total} konumuna geri taşındı} false {Öge {initialPosition} konumundan {finalPosition}/{total} konumuna taşındı} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{count, plural, zero {{label}, 0 öğe} one {{label}, 1 öğe} other {{label}, {count} öğe}}",
     "contentDisplayPreference.i18nStrings.columnFilteringCountText": "{count, plural, zero {0 eşleşme} one {1 eşleşme} other {{count} eşleşme}}"
   },
   "copy-to-clipboard": {
@@ -158,15 +164,15 @@
     "i18nStrings.endMonthLabel": "Bitiş ayı",
     "i18nStrings.endDateLabel": "Bitiş tarihi",
     "i18nStrings.endTimeLabel": "Bitiş zamanı",
-    "i18nStrings.datePlaceholder": "YYYY/AA/GG",
+    "i18nStrings.datePlaceholder": "YYYY-AA-GG",
     "i18nStrings.isoDatePlaceholder": "YYYY-AA-GG",
     "i18nStrings.slashedDatePlaceholder": "YYYY/AA/GG",
-    "i18nStrings.timePlaceholder": "sa: dk: sn",
+    "i18nStrings.timePlaceholder": "sa:dk:sn",
     "i18nStrings.dateTimeConstraintText": "Tarih için YYYY/AA/GG kullanın. Zaman için 24 saat biçimini kullanın.",
-    "i18nStrings.dateConstraintText": "Tarih için YYYYY/AA/GG kullanın.",
+    "i18nStrings.dateConstraintText": "Tarih için YYYY/AA/GG kullanın.",
     "i18nStrings.slashedDateTimeConstraintText": "Tarih için YYYY/AA/GG kullanın. Zaman için 24 saat biçimini kullanın.",
     "i18nStrings.isoDateTimeConstraintText": "Tarih için YYYY-AA-GG kullanın. Zaman için 24 saat biçimini kullanın.",
-    "i18nStrings.slashedDateConstraintText": "Tarih için YYYYY/AA/GG kullanın.",
+    "i18nStrings.slashedDateConstraintText": "Tarih için YYYY/AA/GG kullanın.",
     "i18nStrings.isoDateConstraintText": "Tarih için YYYYY-AA-GG kullanın.",
     "i18nStrings.slashedMonthConstraintText": "Ay için YYYY/AA kullanın.",
     "i18nStrings.isoMonthConstraintText": "Ay için YYYY-AA kullanın.",
@@ -236,17 +242,17 @@
   },
   "list": {
     "dragHandleAriaLabel": "Sürükleme tutamacı",
-    "dragHandleAriaDescription": "Bir öğe için sürüklemeyi etkinleştirmek üzere Boşluk veya Enter tuşunu ve ögenin konumunu taşımak için ok tuşlarını kullanın. Konum taşıma işlemini tamamlamak için \"Boşluk\" veya \"Enter\" tuşunu ya da taşıma işlemini iptal etmek için \"ESC\" tuşunu kullanın.",
+    "dragHandleAriaDescription": "Bir öge için sürüklemeyi etkinleştirmek üzere Boşluk veya Enter tuşunu ve ögenin konumunu taşımak için ok tuşlarını kullanın. Konum taşıma işlemini tamamlamak için \"Boşluk\" veya \"Enter\" tuşunu ya da taşıma işlemini iptal etmek için \"ESC\" tuşunu kullanın.",
     "liveAnnouncementDndStarted": "Öge {position}/{total} konumundan alındı",
     "liveAnnouncementDndDiscarded": "Yeniden sıralama iptal edildi",
     "liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Öge {currentPosition}/{total} konumuna geri taşınıyor} false {Öge {currentPosition}/{total} konumuna taşınıyor} other {}}",
-    "liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Öge ilk {initialPosition}/{total} konumuna geri taşındı} false {Öğe {initialPosition} konumundan {finalPosition}/{total} konumuna taşındı} other {}}"
+    "liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Öge ilk {initialPosition}/{total} konumuna geri taşındı} false {Öge {initialPosition} konumundan {finalPosition}/{total} konumuna taşındı} other {}}"
   },
   "modal": {
     "closeAriaLabel": "Kalıcı iletişim kutusunu kapat"
   },
   "multiselect": {
-    "deselectAriaLabel": "{option__label} öğesini kaldır",
+    "deselectAriaLabel": "{option__label} ögesini kaldır",
     "i18nStrings.selectAllText": "Tümünü seç"
   },
   "pagination": {
@@ -255,8 +261,9 @@
     "ariaLabels.previousPageLabel": "Önceki sayfa",
     "ariaLabels.jumpToPageButtonLabel": "Sayfaya atla",
     "i18nStrings.jumpToPageInputLabel": "Sayfa",
-    "i18nStrings.jumpToPageError": "Aralık dışı sayfa. Mevcut son sayfa gösteriliyor.",
-    "i18nStrings.jumpToPageLoadingText": "Yükleniyor"
+    "i18nStrings.jumpToPageError": "Sayfa aralık dışında. Mevcut son sayfa gösteriliyor.",
+    "i18nStrings.jumpToPageLoadingText": "Yükleniyor",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage}/{pagesCount}+} false {{currentPage}/{pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "Panel yeniden boyutlandırma tutamacı",
@@ -275,9 +282,9 @@
     "i18nStrings.actionButtonAriaLabel": "İstemi gönder",
     "i18nStrings.menuErrorIconAriaLabel": "Hata",
     "i18nStrings.menuRecoveryText": "Yeniden dene",
-    "i18nStrings.menuLoadingText": "Öğeler yükleniyor",
+    "i18nStrings.menuLoadingText": "Ögeler yükleniyor",
     "i18nStrings.menuFinishedText": "Sonuçların sonu",
-    "i18nStrings.menuErrorText": "Öğeler getirilirken bir hata oluştu",
+    "i18nStrings.menuErrorText": "Ögeler getirilirken bir hata oluştu",
     "i18nStrings.selectedMenuItemAriaLabel": "Seçildi",
     "i18nStrings.tokenInsertedAriaLabel": "{token__label} eklendi",
     "i18nStrings.tokenPinnedAriaLabel": "{token__label} sabitlendi",
@@ -303,12 +310,12 @@
     "i18nStrings.operatorLessText": "Küçüktür",
     "i18nStrings.operatorStartsWithText": "İle başlar",
     "i18nStrings.operatorDoesNotStartWithText": "Şununla başlamıyor:",
-    "i18nStrings.operatorText": "Operatör",
-    "i18nStrings.operatorsText": "Operatörler",
+    "i18nStrings.operatorText": "İşleç",
+    "i18nStrings.operatorsText": "İşleçler",
     "i18nStrings.propertyText": "Özellik",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__formattedText} filtresini kaldır",
     "i18nStrings.tokenEditorTokenActionsAriaLabel": "Filtre eylemleri, {token__formattedText}",
-    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "Filtreyi kaldır, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "{token__formattedText} filtresini kaldır",
     "i18nStrings.tokenEditorTokenRemoveLabel": "Filtreyi kaldır",
     "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "Filtreyi gruptan kaldır",
     "i18nStrings.tokenEditorAddTokenActionsAriaLabel": "Filtre ekleme eylemleri",
@@ -386,7 +393,7 @@
     "recoveryText": "Yeniden dene"
   },
   "slider": {
-    "i18nStrings.valueTextRange": "{value},{previousValue} ve {nextValue} arasında"
+    "i18nStrings.valueTextRange": "{value}, {previousValue} ve {nextValue} arasında"
   },
   "split-panel": {
     "i18nStrings.closeButtonAriaLabel": "Paneli kapat",
@@ -408,7 +415,22 @@
     "ariaLabels.expandButtonLabel": "Genişlet",
     "ariaLabels.collapseButtonLabel": "Daralt",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Hata",
-    "columnDefinitions.editConfig.editIconAriaLabel": "düzenlenebilir"
+    "columnDefinitions.editConfig.editIconAriaLabel": "düzenlenebilir",
+    "i18nStrings.sortDropdownSortAscending": "Artan sıralama",
+    "i18nStrings.sortDropdownSortDescending": "Azalan sıralama",
+    "i18nStrings.sortDropdownMultiColumnSortGroup": "Çok sütunlu sıralama (Shift + Tıklama)",
+    "i18nStrings.sortDropdownAddToSortAscending": "Sıralamaya ekle (artan)",
+    "i18nStrings.sortDropdownAddToSortDescending": "Sıralamaya ekle (azalan)",
+    "i18nStrings.sortDropdownRemoveFromSort": "Sıralamadan kaldır",
+    "i18nStrings.sortDropdownAddToSortDisabledReason": "Bu sütun zaten sıralandı",
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": "Bu sütun sıralanmadı",
+    "i18nStrings.clearSort": "Sıralamayı temizle",
+    "ariaLabels.sortAscending": "artan",
+    "ariaLabels.sortDescending": "azalan",
+    "ariaLabels.liveAnnouncementSortOrder": "Tablo {columns} ölçütüne göre sıralandı",
+    "ariaLabels.liveAnnouncementSortCleared": "Sıralama temizlendi",
+    "ariaLabels.sortPriority": "sıralama önceliği {priority}",
+    "ariaLabels.sortMenuTriggerLabel": "Sıralama seçenekleri"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Sola kaydır",
@@ -416,11 +438,11 @@
     "i18nStrings.tabsWithActionsAriaRoleDescription": "Eylem içeren sekmeler"
   },
   "tag-editor": {
-    "i18nStrings.keyPlaceholder": "Enter tuşu",
+    "i18nStrings.keyPlaceholder": "Anahtar girin",
     "i18nStrings.valuePlaceholder": "Değer girin",
     "i18nStrings.addButton": "Yeni etiket ekle",
     "i18nStrings.removeButton": "Kaldır",
-    "i18nStrings.removeButtonAriaLabel": "{tag__key} öğesini kaldır",
+    "i18nStrings.removeButtonAriaLabel": "{tag__key} ögesini kaldır",
     "i18nStrings.undoButton": "Geri al",
     "i18nStrings.undoPrompt": "Değişiklikler kaydedildikten sonra bu etiket kaldırılacaktır",
     "i18nStrings.loading": "Bu kaynakla ilişkilendirilmiş etiketler yükleniyor",
@@ -454,7 +476,7 @@
   "top-navigation": {
     "i18nStrings.searchIconAriaLabel": "Ara",
     "i18nStrings.searchDismissIconAriaLabel": "Aramayı kapat",
-    "i18nStrings.overflowMenuTriggerText": "Daha",
+    "i18nStrings.overflowMenuTriggerText": "Daha fazla",
     "i18nStrings.overflowMenuDismissIconAriaLabel": "Menüyü kapat",
     "i18nStrings.overflowMenuBackIconAriaLabel": "Geri",
     "i18nStrings.overflowMenuTitleText": "Tümü"

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "显示路径"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} 个项目（共 {totalCount} 个）",
+    "noMatch": "没有匹配的操作",
+    "i18nStrings.filteringItemAriaDescription": "继续键入以筛选结果。"
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "在新选项卡中打开"
   },
@@ -125,6 +130,7 @@
     "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": "清除筛选条件",
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {正在将项目移回位置 {currentPosition}（共 {total} 个位置）} false {正在将项目移动到位置 {currentPosition}（共 {total} 个位置）} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {已将项目移回其原始位置 {initialPosition}（共 {total} 个位置）} false {已将项目从位置 {initialPosition} 移动到位置 {finalPosition}（共 {total} 个位置）} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{count, plural, zero {{label}，0 个项目} one {{label}，1 个项目} other {{label}，{count} 个项目}}",
     "contentDisplayPreference.i18nStrings.columnFilteringCountText": "{count, plural, zero {0 个匹配项} one {1 个匹配项} other {{count} 个匹配项}}"
   },
   "copy-to-clipboard": {
@@ -163,14 +169,14 @@
     "i18nStrings.slashedDatePlaceholder": "YYYY/MM/DD",
     "i18nStrings.timePlaceholder": "hh:mm:ss",
     "i18nStrings.dateTimeConstraintText": "对于日期，请使用 YYYY/MM/DD。对于时间，请使用 24 小时格式。",
-    "i18nStrings.dateConstraintText": "对于日期，使用 YYYY/MM/DD。",
+    "i18nStrings.dateConstraintText": "对于日期，请使用 YYYY/MM/DD。",
     "i18nStrings.slashedDateTimeConstraintText": "对于日期，请使用 YYYY/MM/DD。对于时间，请使用 24 小时格式。",
     "i18nStrings.isoDateTimeConstraintText": "对于日期，请使用 YYYY-MM-DD。对于时间，请使用 24 小时格式。",
-    "i18nStrings.slashedDateConstraintText": "对于日期，使用 YYYY/MM/DD。",
-    "i18nStrings.isoDateConstraintText": "对于日期，使用 YYYY-MM-DD。",
-    "i18nStrings.slashedMonthConstraintText": "对于月份，使用 YYYY/MM。",
-    "i18nStrings.isoMonthConstraintText": "对于月份，使用 YYYY-MM。",
-    "i18nStrings.monthConstraintText": "对于月份，使用 YYYY/MM。",
+    "i18nStrings.slashedDateConstraintText": "对于日期，请使用 YYYY/MM/DD。",
+    "i18nStrings.isoDateConstraintText": "对于日期，请使用 YYYY-MM-DD。",
+    "i18nStrings.slashedMonthConstraintText": "对于月份，请使用 YYYY/MM。",
+    "i18nStrings.isoMonthConstraintText": "对于月份，请使用 YYYY-MM。",
+    "i18nStrings.monthConstraintText": "对于月份，请使用 YYYY/MM。",
     "i18nStrings.errorIconAriaLabel": "错误",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "选定范围从 {startDate} 到 {endDate}",
     "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {过去 {amount} 秒} one {过去 {amount} 秒} other {过去 {amount} 秒}}} minute {{amount, plural, zero {过去 {amount} 分钟} one {过去 {amount} 分钟} other {过去 {amount} 分钟}}} hour {{amount, plural, zero {过去 {amount} 小时} one {过去 {amount} 小时} other {过去 {amount} 小时}}} day {{amount, plural, zero {过去 {amount} 天} one {过去 {amount} 天} other {过去 {amount} 天}}} week {{amount, plural, zero {过去 {amount} 周} one {过去 {amount} 周} other {过去 {amount} 周}}} month {{amount, plural, zero {过去 {amount} 月} one {过去 {amount} 月} other {过去 {amount} 月}}} year {{amount, plural, zero {过去 {amount} 年} one {过去 {amount} 年} other {过去 {amount} 年}}} other {}}",
@@ -256,7 +262,8 @@
     "ariaLabels.jumpToPageButtonLabel": "跳转到页面",
     "i18nStrings.jumpToPageInputLabel": "页面",
     "i18nStrings.jumpToPageError": "页面超出范围。显示最后一个可用页面。",
-    "i18nStrings.jumpToPageLoadingText": "正在加载"
+    "i18nStrings.jumpToPageLoadingText": "正在加载",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage} / {pagesCount}+} false {{currentPage}/{pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "面板大小调整手柄",
@@ -408,7 +415,22 @@
     "ariaLabels.expandButtonLabel": "展开",
     "ariaLabels.collapseButtonLabel": "折叠",
     "columnDefinitions.editConfig.errorIconAriaLabel": "错误",
-    "columnDefinitions.editConfig.editIconAriaLabel": "可编辑"
+    "columnDefinitions.editConfig.editIconAriaLabel": "可编辑",
+    "i18nStrings.sortDropdownSortAscending": "升序排序",
+    "i18nStrings.sortDropdownSortDescending": "降序排序",
+    "i18nStrings.sortDropdownMultiColumnSortGroup": "多列排序（按住 Shift 键点击）",
+    "i18nStrings.sortDropdownAddToSortAscending": "添加到排序（升序）",
+    "i18nStrings.sortDropdownAddToSortDescending": "添加到排序（降序）",
+    "i18nStrings.sortDropdownRemoveFromSort": "从排序中移除",
+    "i18nStrings.sortDropdownAddToSortDisabledReason": "此列已排序",
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": "此列未排序",
+    "i18nStrings.clearSort": "清除排序",
+    "ariaLabels.sortAscending": "升序",
+    "ariaLabels.sortDescending": "降序",
+    "ariaLabels.liveAnnouncementSortOrder": "表格已按 {columns} 排序",
+    "ariaLabels.liveAnnouncementSortCleared": "排序已清除",
+    "ariaLabels.sortPriority": "排序优先级 {priority}",
+    "ariaLabels.sortMenuTriggerLabel": "排序选项"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "向左滚动",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "顯示路徑"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} 個項目 (共 {totalCount} 個）",
+    "noMatch": "沒有相符的動作",
+    "i18nStrings.filteringItemAriaDescription": "繼續輸入以篩選結果。"
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "在新索引標籤中開啟"
   },
@@ -125,6 +130,7 @@
     "contentDisplayPreference.i18nStrings.columnFilteringClearFilterText": "清除篩選條件",
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {將項目移回 {currentPosition} 位置 (共 {total} 個位置)} false {將項目移到 {currentPosition} 位置 (共 {total} 個位置)} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {項目移回原來的 {initialPosition} 位置 (共 {total} 個位置)} false {項目已從 {initialPosition} 位置移到 {finalPosition} 位置 (共 {total} 個位置)} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndGroupLabel": "{count, plural, zero {{label}，0 個項目} one {{label}，1 個項目} other {{label}，{count} 個項目}}",
     "contentDisplayPreference.i18nStrings.columnFilteringCountText": "{count, plural, zero {0 個符合} one {1 個符合} other {{count} 個符合}}"
   },
   "copy-to-clipboard": {
@@ -163,14 +169,14 @@
     "i18nStrings.slashedDatePlaceholder": "YYYY/MM/DD",
     "i18nStrings.timePlaceholder": "hh:mm:ss",
     "i18nStrings.dateTimeConstraintText": "日期請使用 YYYY/MM/DD 格式。時間請使用 24 小時格式。",
-    "i18nStrings.dateConstraintText": "對於日期，請使用 YYYY/MM/DD。",
+    "i18nStrings.dateConstraintText": "日期請使用 YYYY/MM/DD 格式。",
     "i18nStrings.slashedDateTimeConstraintText": "日期請使用 YYYY/MM/DD 格式。時間請使用 24 小時格式。",
     "i18nStrings.isoDateTimeConstraintText": "日期請使用 YYYY-MM-DD 格式。時間請使用 24 小時格式。",
     "i18nStrings.slashedDateConstraintText": "日期請使用 YYYY/MM/DD 格式。",
     "i18nStrings.isoDateConstraintText": "日期請使用 YYYY-MM-DD 格式。",
     "i18nStrings.slashedMonthConstraintText": "月份請使用 YYYY/MM 格式。",
     "i18nStrings.isoMonthConstraintText": "月份請使用 YYYY-MM 格式。",
-    "i18nStrings.monthConstraintText": "對於月份，請使用 YYYY/MM。",
+    "i18nStrings.monthConstraintText": "月份請使用 YYYY/MM 格式。",
     "i18nStrings.errorIconAriaLabel": "錯誤",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "已選取從 {startDate} 到 {endDate} 的範圍",
     "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {最後{amount}秒} one {最後{amount}秒} other {最後{amount}秒}}} minute {{amount, plural, zero {最後{amount}分鐘} one {最後{amount}分鐘} other {最後{amount}分鐘}}} hour {{amount, plural, zero {最後{amount}小時} one {最後{amount}小時} other {最後{amount}小時}}} day {{amount, plural, zero {最後{amount}天} one {最後{amount}天} other {最後{amount}天}}} week {{amount, plural, zero {最後{amount}週} one {最後{amount}週} other {最後{amount}週}}} month {{amount, plural, zero {最後{amount}個月} one {最後{amount}個月} other {最後{amount}個月}}} year {{amount, plural, zero {最後{amount}年} one {最後{amount}年} other {最後{amount}年}}} other {}}",
@@ -256,7 +262,8 @@
     "ariaLabels.jumpToPageButtonLabel": "跳到頁面",
     "i18nStrings.jumpToPageInputLabel": "頁面",
     "i18nStrings.jumpToPageError": "頁面超出範圍。顯示最後一個可用頁面。",
-    "i18nStrings.jumpToPageLoadingText": "正在載入"
+    "i18nStrings.jumpToPageLoadingText": "正在載入",
+    "i18nStrings.pagesCompactText": "{openEnd, select, true {{currentPage}/{pagesCount}+} false {{currentPage}/{pagesCount}} other {}}"
   },
   "panel-resize-handle": {
     "i18nStrings.resizeHandleAriaLabel": "面板調整大小控點",
@@ -408,7 +415,22 @@
     "ariaLabels.expandButtonLabel": "展開",
     "ariaLabels.collapseButtonLabel": "摺疊",
     "columnDefinitions.editConfig.errorIconAriaLabel": "錯誤",
-    "columnDefinitions.editConfig.editIconAriaLabel": "可編輯"
+    "columnDefinitions.editConfig.editIconAriaLabel": "可編輯",
+    "i18nStrings.sortDropdownSortAscending": "遞增排序",
+    "i18nStrings.sortDropdownSortDescending": "遞減排序",
+    "i18nStrings.sortDropdownMultiColumnSortGroup": "多欄排序 (Shift + 按一下)",
+    "i18nStrings.sortDropdownAddToSortAscending": "新增至排序 (遞增)",
+    "i18nStrings.sortDropdownAddToSortDescending": "新增至排序 (遞減)",
+    "i18nStrings.sortDropdownRemoveFromSort": "從排序中移除",
+    "i18nStrings.sortDropdownAddToSortDisabledReason": "此欄已排序",
+    "i18nStrings.sortDropdownRemoveFromSortDisabledReason": "此欄未排序",
+    "i18nStrings.clearSort": "清除排序",
+    "ariaLabels.sortAscending": "升序",
+    "ariaLabels.sortDescending": "降序",
+    "ariaLabels.liveAnnouncementSortOrder": "資料表依 {columns} 排序",
+    "ariaLabels.liveAnnouncementSortCleared": "已清除排序",
+    "ariaLabels.sortPriority": "排序優先順序 {priority}",
+    "ariaLabels.sortMenuTriggerLabel": "排序選項"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "向左捲動",


### PR DESCRIPTION
### Description

Merging my button dropdown stuff, but there are also a number of other changes that contributors have been excluding from their PRs — makes sense to keep the PR relevant, but that means we have these "unowned" strings that will keep showing up until we merge them in.

Checking if the multi-column stuff is reasonably stable to merge asynchronously.

Related links, issue #, if available: n/a

### How has this been tested?

Static config changes, but should build successfully.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
