### PR TITLE
fix: Do not open side navigation from close button

### DIFF
--- a/src/app-layout/__tests__/app-layout-navigation.test.tsx
+++ b/src/app-layout/__tests__/app-layout-navigation.test.tsx
@@ -63,6 +63,15 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
     expect(wrapper.findOpenNavigationPanel()).toBeTruthy();
   });
 
+  test('close button does not open navigation when already closed', () => {
+    const { wrapper } = renderComponent(<AppLayout navigation={<>Mock Navigation</>} />);
+    expect(wrapper.findOpenNavigationPanel()).toBeTruthy();
+    wrapper.findNavigationToggle().click();
+    expect(wrapper.findOpenNavigationPanel()).toBeFalsy();
+    wrapper.findNavigationClose().click();
+    expect(wrapper.findOpenNavigationPanel()).toBeFalsy();
+  });
+
   test(`Sets aria-expanded=false on toggle when navigation is closed`, () => {
     const { wrapper } = renderComponent(
       <AppLayout navigation={<>Mock Navigation</>} navigationOpen={false} content={<>Content</>} />

--- a/src/app-layout/__tests__/navigation-collapsed.test.tsx
+++ b/src/app-layout/__tests__/navigation-collapsed.test.tsx
@@ -53,41 +53,15 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
       expect(closeButton.querySelector(`.${iconStyles['name-angle-left']}`)).not.toBeNull();
     });
 
-    test('close button opens navigation when collapsed (navigationCloseBehavior="collapse")', () => {
-      const onNavigationChange = jest.fn();
+    test('close button toggles navigation open and closed when collapsible', () => {
       const { wrapper } = renderComponent(
-        <AppLayout
-          navigationCloseBehavior="collapse"
-          navigationOpen={false}
-          onNavigationChange={onNavigationChange}
-          navigation={<>Nav content</>}
-        />
+        <AppLayout navigationCloseBehavior="collapse" navigation={<>Nav content</>} />
       );
+      expect(wrapper.findOpenNavigationPanel()).toBeTruthy();
       wrapper.findNavigationClose().click();
-      expect(onNavigationChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { open: true } }));
-    });
-
-    test('close button closes navigation when open (navigationCloseBehavior="collapse")', () => {
-      const onNavigationChange = jest.fn();
-      const { wrapper } = renderComponent(
-        <AppLayout
-          navigationCloseBehavior="collapse"
-          navigationOpen={true}
-          onNavigationChange={onNavigationChange}
-          navigation={<>Nav content</>}
-        />
-      );
+      expect(wrapper.findOpenNavigationPanel()).toBeFalsy();
       wrapper.findNavigationClose().click();
-      expect(onNavigationChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { open: false } }));
-    });
-
-    test('close button does not open non-collapsible navigation when already closed', () => {
-      const onNavigationChange = jest.fn();
-      const { wrapper } = renderComponent(
-        <AppLayout navigationOpen={false} onNavigationChange={onNavigationChange} navigation={<>Nav content</>} />
-      );
-      wrapper.findNavigationClose().click();
-      expect(onNavigationChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { open: false } }));
+      expect(wrapper.findOpenNavigationPanel()).toBeTruthy();
     });
   });
 

--- a/src/app-layout/__tests__/navigation-collapsed.test.tsx
+++ b/src/app-layout/__tests__/navigation-collapsed.test.tsx
@@ -52,6 +52,43 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
       const closeButton = wrapper.findNavigationClose().getElement();
       expect(closeButton.querySelector(`.${iconStyles['name-angle-left']}`)).not.toBeNull();
     });
+
+    test('close button opens navigation when collapsed (navigationCloseBehavior="collapse")', () => {
+      const onNavigationChange = jest.fn();
+      const { wrapper } = renderComponent(
+        <AppLayout
+          navigationCloseBehavior="collapse"
+          navigationOpen={false}
+          onNavigationChange={onNavigationChange}
+          navigation={<>Nav content</>}
+        />
+      );
+      wrapper.findNavigationClose().click();
+      expect(onNavigationChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { open: true } }));
+    });
+
+    test('close button closes navigation when open (navigationCloseBehavior="collapse")', () => {
+      const onNavigationChange = jest.fn();
+      const { wrapper } = renderComponent(
+        <AppLayout
+          navigationCloseBehavior="collapse"
+          navigationOpen={true}
+          onNavigationChange={onNavigationChange}
+          navigation={<>Nav content</>}
+        />
+      );
+      wrapper.findNavigationClose().click();
+      expect(onNavigationChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { open: false } }));
+    });
+
+    test('close button does not open non-collapsible navigation when already closed', () => {
+      const onNavigationChange = jest.fn();
+      const { wrapper } = renderComponent(
+        <AppLayout navigationOpen={false} onNavigationChange={onNavigationChange} navigation={<>Nav content</>} />
+      );
+      wrapper.findNavigationClose().click();
+      expect(onNavigationChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { open: false } }));
+    });
   });
 
   describe('aria-expanded', () => {

--- a/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
@@ -91,7 +91,7 @@ export function AppLayoutNavigationImplementation({
             }
             ariaExpanded={navigationCollapsible && !isMobile ? navigationOpen : undefined}
             iconName={navigationCollapsed ? 'angle-right' : isMobile ? 'close' : 'angle-left'}
-            onClick={() => onNavigationToggle(!navigationOpen)}
+            onClick={() => onNavigationToggle(navigationCollapsible ? !navigationOpen : false)}
             variant="icon"
             formAction="none"
             className={testutilStyles['navigation-close']}


### PR DESCRIPTION
### Description

After #4688, clicking the side navigation close button works as a toggle button, i.e, it closes the side navigation when it is open, but it also opens it if it's closed. This is meant for the newly introduced "collapse" behavior. In the "hide" behavior the button cannot really be closed by real users because the close button has `display: close` when the side navigation is closed, but it is still accessible by the test utils, and this change in behavior broke a customer's tests (build: `7949323707`)

### How has this been tested?

- Added unit tests
- Dry run: `7950984806`

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
