### PR TITLE
feat: export per-component selectors

### DIFF
--- a/build-tools/tasks/__tests__/package-json.test.js
+++ b/build-tools/tasks/__tests__/package-json.test.js
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+const { getComponentsExports } = require('../package-json');
+const { listPublicItems } = require('../../utils/files');
+
+describe('getComponentsExports', () => {
+  const exportsMap = getComponentsExports();
+
+  test('keeps the test-utils barrel entry points', () => {
+    expect(exportsMap['./test-utils/dom']).toBe('./test-utils/dom/index.js');
+    expect(exportsMap['./test-utils/selectors']).toBe('./test-utils/selectors/index.js');
+  });
+
+  test('exposes every public component wrapper for dom and selectors', () => {
+    const wrappers = listPublicItems('src/test-utils/dom');
+    expect(wrappers).toContain('button');
+    for (const wrapper of wrappers) {
+      expect(exportsMap[`./test-utils/dom/${wrapper}`]).toBe(`./test-utils/dom/${wrapper}/index.js`);
+      expect(exportsMap[`./test-utils/selectors/${wrapper}`]).toBe(`./test-utils/selectors/${wrapper}/index.js`);
+    }
+  });
+
+  test('does not expose the internal test-utils directory as a component wrapper', () => {
+    expect(exportsMap['./test-utils/dom/internal']).toBeUndefined();
+    expect(exportsMap['./test-utils/selectors/internal']).toBeUndefined();
+    // curated internal entry points remain explicitly exported
+    expect(exportsMap['./test-utils/dom/internal/drag-handle']).toBe('./test-utils/dom/internal/drag-handle.js');
+  });
+});

--- a/build-tools/tasks/package-json.js
+++ b/build-tools/tasks/package-json.js
@@ -51,9 +51,11 @@ function getComponentsExports() {
     result[`./${component}`] = `./${component}/index.js`;
   }
 
-  // Per-component test-utils DOM wrappers (e.g. `.../test-utils/dom/button`).
+  // Per-component test-utils wrappers, both DOM and selectors
+  // (e.g. `.../test-utils/dom/button` and `.../test-utils/selectors/button`).
   for (const component of listPublicItems('src/test-utils/dom')) {
     result[`./test-utils/dom/${component}`] = `./test-utils/dom/${component}/index.js`;
+    result[`./test-utils/selectors/${component}`] = `./test-utils/selectors/${component}/index.js`;
   }
 
   // Internationalization and messages
@@ -146,3 +148,4 @@ module.exports = parallel([
   testDefinitionsPackageJson,
 ]);
 module.exports.generatePackageJson = generatePackageJson;
+module.exports.getComponentsExports = getComponentsExports;


### PR DESCRIPTION
### Description

PR #4750 added per-component export entries for the DOM test-utils wrappers. This adds the
matching entries for the selectors wrappers.

Motivation: consumers who re-export or extend a subset of Cloudscape components need to import
individual wrappers so they can assemble their own `ElementWrapper`. Today the only selectors
entry point is the `./test-utils/selectors` barrel, and importing the barrel adds the finders for
every component to the shared `ElementWrapper`. There is no way to narrow that down or remove
components from it. With per-component entry points, consumers can import just the wrappers they
want. The DOM side already supports this, but selectors did not.

Related links, issue #, if available: n/a

### How has this been tested?

Added a unit test for `getComponentsExports` in `build-tools/tasks/__tests__/package-json.test.js`

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.