### PR TITLE
fix: Allow item card actions to wrap their content

### DIFF
--- a/pages/item-card/common.tsx
+++ b/pages/item-card/common.tsx
@@ -88,6 +88,15 @@ export const wideActions = (
   </SpaceBetween>
 );
 
+export const wrappingActions = (
+  <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
+    <Badge color="grey">status</Badge>
+    <Button variant="normal">Action 1</Button>
+    <Button variant="normal">Action 2</Button>
+    <Button variant="primary">Action 3</Button>
+  </div>
+);
+
 export const icon = <Icon name="settings"></Icon>;
 
 export const imageContentEmbedded = (

--- a/pages/item-card/permutations.page.tsx
+++ b/pages/item-card/permutations.page.tsx
@@ -19,6 +19,7 @@ import {
   shortFooter,
   shortHeader,
   wideActions,
+  wrappingActions,
 } from './common';
 
 /* Content slot combinations: header, description, children, footer, actions, icon */
@@ -68,6 +69,12 @@ const permutations = createPermutations<ItemCardProps>([
   // Minimal: content only
   {
     children: [longContent],
+  },
+  // Wrapping actions
+  {
+    header: [shortHeader],
+    children: [longContent],
+    actions: [wrappingActions],
   },
 ]);
 

--- a/src/internal/components/structured-item/styles.scss
+++ b/src/internal/components/structured-item/styles.scss
@@ -26,6 +26,10 @@
   min-inline-size: 0;
 }
 
+.actions {
+  margin-inline-start: auto;
+}
+
 .content-wrap {
   flex-grow: 1;
   display: flex;
@@ -39,14 +43,13 @@
   &.wrap-actions {
     flex-wrap: wrap;
   }
+
+  &:not(.wrap-actions) > .actions {
+    flex-shrink: 0;
+  }
 }
 
 .content {
   flex-grow: 1;
   min-inline-size: 0;
-}
-
-.actions {
-  flex-shrink: 0;
-  margin-inline-start: auto;
 }


### PR DESCRIPTION
### Description

Ticket: `AWSUI-62141`

https://github.com/cloudscape-design/components/pull/4710 allowed item card header and actions to wrap, but there is still a possibility that despite occupying their own row, the actions content overflows their slot. This PR allows the content of the actions (not just the actions slot itself) to wrap.

Before:
<img width="419" height="160" alt="Screenshot 2026-07-29 at 13 57 59" src="https://github.com/user-attachments/assets/c6a4fdda-82e6-41c0-ae7f-0361fe2965b5" />

After:
<img width="381" height="199" alt="Screenshot 2026-07-29 at 13 55 04" src="https://github.com/user-attachments/assets/8e1ff3a1-0262-4f73-b683-183f243071e6" />

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
