### PR TITLE
chore: Migrate typography tokens to use stable hashes

### DIFF
--- a/build-tools/utils/__tests__/token-versions.test.js
+++ b/build-tools/utils/__tests__/token-versions.test.js
@@ -7,27 +7,37 @@ const { getTokenVersions } = require('../token-versions');
 const variablesMap = {
   borderRadiusButton: 'border-radius-button',
   borderWidthField: 'border-width-field',
+  colorChartsPurple300: 'color-charts-purple-300',
   colorBorderButtonNormalDefault: 'color-border-button-normal-default',
+  colorBackgroundPopover: 'color-background-popover',
+  colorTextControlDisabled: 'color-text-control-disabled',
   colorTextAccent: 'color-text-accent',
   spaceScaledM: 'space-scaled-m',
+  sizeIconMedium: 'size-icon-m',
   fontFamilyBase: 'font-family-base',
+  shadowModal: 'shadow-modal',
 };
 
 test('versions border tokens matched by the default groups and leaves others (incl. border colors) version-less', () => {
   expect(getTokenVersions(variablesMap)).toEqual({
     borderRadiusButton: 'v3-1',
     borderWidthField: 'v3-1',
+    fontFamilyBase: 'v3-1',
   });
 });
 
 test('assigns the version of the first matching group', () => {
   const groups = [
     { pattern: /^color-border-/, version: 'v3-2' },
+    { pattern: /^color-text-/, version: 'v3-2' },
     { pattern: /^color-/, version: 'v3-1' },
   ];
   expect(getTokenVersions(variablesMap, groups)).toEqual({
+    colorBackgroundPopover: 'v3-1',
     colorBorderButtonNormalDefault: 'v3-2',
-    colorTextAccent: 'v3-1',
+    colorChartsPurple300: 'v3-1',
+    colorTextAccent: 'v3-2',
+    colorTextControlDisabled: 'v3-2',
   });
 });
 
@@ -37,6 +47,6 @@ test('a catch-all group versions every token', () => {
 });
 
 test('returns an empty map when no group matches', () => {
-  const groups = [{ pattern: /^color-background-/, version: 'v3-1' }];
+  const groups = [{ pattern: /^motion-duration-/, version: 'v3-1' }];
   expect(getTokenVersions(variablesMap, groups)).toEqual({});
 });

--- a/build-tools/utils/__tests__/token-versions.test.js
+++ b/build-tools/utils/__tests__/token-versions.test.js
@@ -18,7 +18,7 @@ const variablesMap = {
   shadowModal: 'shadow-modal',
 };
 
-test('versions border tokens matched by the default groups and leaves others (incl. border colors) version-less', () => {
+test('versions border + typography tokens matched by the default groups and leaves others (incl. border colors) version-less', () => {
   expect(getTokenVersions(variablesMap)).toEqual({
     borderRadiusButton: 'v3-1',
     borderWidthField: 'v3-1',

--- a/build-tools/utils/token-versions.js
+++ b/build-tools/utils/token-versions.js
@@ -4,8 +4,13 @@
 const DEFAULT_TOKEN_VERSION = 'v3-1';
 
 // Groups map a token-name pattern (matched against the token's CSS variable name) to a version.
-// Tokens matching no group stay version-less and keep the legacy value-based hashes.
-const versionGroups = [{ pattern: /^border-/, version: DEFAULT_TOKEN_VERSION }];
+// Tokens matching no group stay version-less and keep the legacy value-based hashes. Tokens are
+// being migrated in batches (one batch per line), and eventually all tokens will be migrated to
+// the new format.
+const versionGroups = [
+  { pattern: /^border-/, version: DEFAULT_TOKEN_VERSION },
+  { pattern: /^(font|letter-spacing|line-height)-/, version: DEFAULT_TOKEN_VERSION },
+];
 
 // Builds the token -> version allowlist from the full token -> cssName map.
 function getTokenVersions(variablesMap, groups = versionGroups) {


### PR DESCRIPTION
### Description

See https://github.com/cloudscape-design/theming-core/pull/190. We want design token CSS variable names to be more stable, and introducing a new stable method of determining the token suffix (based on token name and package version, not the value).

Out of an abundance of caution, we're migrating tokens in batches. A previous PR (https://github.com/cloudscape-design/components/pull/4718, merged 2 weeks ago) migrated all border tokens. This PR does the same for typography tokens.

Related links, issue #, if available: rzZV6TJY6Zav (Chorus)

### How has this been tested?

Will dry-run build this just in case.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
