### PR TITLE
test: Add multi-column sort screenshot definition

### DIFF
--- a/test/definitions/index.ts
+++ b/test/definitions/index.ts
@@ -29,6 +29,7 @@ import breadcrumbGroupSuite from './visual/breadcrumb-group';
 import buttonSuite from './visual/button';
 import buttonDropdownSuite from './visual/button-dropdown';
 import buttonGroupSuite from './visual/button-group';
+import tableSuite from './visual/table';
 
 // Per-component exports (grouped by component)
 export const actionCard: TestSuite[] = [actionCardSuite];
@@ -56,6 +57,7 @@ export const breadcrumbGroup: TestSuite[] = [breadcrumbGroupSuite];
 export const button: TestSuite[] = [buttonSuite];
 export const buttonDropdown: TestSuite[] = [buttonDropdownSuite];
 export const buttonGroup: TestSuite[] = [buttonGroupSuite];
+export const table: TestSuite[] = [tableSuite];
 
 export const allSuites: TestSuite[] = [
   ...actionCard,
@@ -71,4 +73,5 @@ export const allSuites: TestSuite[] = [
   ...button,
   ...buttonDropdown,
   ...buttonGroup,
+  ...table,
 ];

--- a/test/definitions/visual/table.ts
+++ b/test/definitions/visual/table.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { TestSuite } from '../types';
+
+const suite: TestSuite = {
+  description: 'Table',
+  componentName: 'table',
+  tests: [
+    {
+      description: 'multi-column sort permutations',
+      path: 'table/multi-column-sort.permutations',
+      screenshotType: 'permutations',
+    },
+  ],
+};
+
+export default suite;


### PR DESCRIPTION
### Description

Adds a `Table` visual-regression suite to the github screenshot test system, covering the multi-column sort feature (merged in #4713).

The new `test/definitions/visual/table.ts` points at the existing multi-column sort permutations dev page (`table/multi-column-sort.permutations`) with `screenshotType: 'permutations'`, so every documented state is captured and cropped individually: no-sort / single-column / two-column sort, with and without selection, the resizable + wrapped-lines layout variants, and the pagination + "Clear sort" header-tools alignment row. It is registered in `test/definitions/index.ts` following the existing per-component export + `allSuites` pattern.

Related links, issue #, if available: follow-up to #4713

### How has this been tested?

- `npx eslint` passes on both changed files.
- The suite reuses the same `permutations` screenshot contract as the existing `alert` suite; it captures the permutations dev page that already ships on `main` from #4713.
