### PR TITLE
fix: Prevent creating a setTimeout on initial mount of form field

### DIFF
--- a/src/form-field/__tests__/form-field-rendering.test.tsx
+++ b/src/form-field/__tests__/form-field-rendering.test.tsx
@@ -190,8 +190,14 @@ describe('FormField component', () => {
     describe('debouncing', () => {
       const DEBOUNCE_TIME_MS = 1000;
 
-      beforeEach(() => jest.useFakeTimers());
-      afterEach(() => jest.useRealTimers());
+      beforeEach(() => {
+        jest.useFakeTimers();
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+      });
 
       test('renders characterCountText directly on initial render', () => {
         const { wrapper } = renderFormField({ characterCountText: 'this is a string' });
@@ -201,7 +207,7 @@ describe('FormField component', () => {
       test('does not schedule a debounce timer on initial mount', () => {
         const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
         renderFormField({ characterCountText: 'this is a string' });
-        expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.anything(), DEBOUNCE_TIME_MS);
+        expect(setTimeoutSpy).not.toHaveBeenCalled();
       });
 
       test("wrapper.findCharacterCount() doesn't return the debounced version of the slot", () => {

--- a/src/form-field/__tests__/form-field-rendering.test.tsx
+++ b/src/form-field/__tests__/form-field-rendering.test.tsx
@@ -198,6 +198,12 @@ describe('FormField component', () => {
         expect(wrapper.findCharacterCount()!.getElement()).toHaveTextContent('this is a string');
       });
 
+      test('does not schedule a debounce timer on initial mount', () => {
+        const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
+        renderFormField({ characterCountText: 'this is a string' });
+        expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.anything(), DEBOUNCE_TIME_MS);
+      });
+
       test("wrapper.findCharacterCount() doesn't return the debounced version of the slot", () => {
         const { wrapper, rerender } = renderFormField({ characterCountText: 'this is a string' });
         expect(wrapper.findCharacterCount()!.getElement()).toHaveTextContent('this is a string');

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -22,6 +22,7 @@ import { getBaseProps } from '../internal/base-component';
 import ScreenreaderOnly from '../internal/components/screenreader-only';
 import { FormFieldContext, useFormFieldContext } from '../internal/context/form-field-context';
 import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
+import { useEffectOnUpdate } from '../internal/hooks/use-effect-on-update';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { joinStrings } from '../internal/utils/strings';
 import InternalLiveRegion from '../live-region/internal';
@@ -183,7 +184,9 @@ export default function InternalFormField({
   const debounceTimeoutRef = useRef<number | undefined>();
   const [debouncedCharacterCountText, setDebouncedCharacterCountText] = useState(characterCountText);
 
-  useEffect(() => {
+  // Don't schedule a debounce when the component first renders, only when
+  // characterCountText changes.
+  useEffectOnUpdate(() => {
     debounceTimeoutRef.current = setTimeout(() => {
       setDebouncedCharacterCountText(characterCountText);
     }, CHARACTER_COUNT_DEBOUNCE_MS);


### PR DESCRIPTION
### Description

I wrote the initial code; didn't feel like there were any performance issues with just calling a setTimeout, but it turns there are some testing situations where the existence of the debounce timer cause the tests to sit and wait for the duration of the debounce.

Related links, issue #, if available: AWSUI-62183

### How has this been tested?

Added a unit test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
