### PR TITLE
chore: Split base theme into a separate file that can be more easily removed/replaced at build-time

### DIFF
--- a/build-tools/tasks/package-json.js
+++ b/build-tools/tasks/package-json.js
@@ -76,7 +76,9 @@ function getSideEffects() {
     '*.css',
     // this file exposes `awsuiVersions` object
     './internal/base-component/index.js',
-    // this file contains css-variables overrides for dark and other modes
+    // this file contains the base theme css-variables and overrides for dark and other modes
+    './internal/base-theme/styles.css.js',
+    // this file contains other global styles and tokens
     './internal/base-component/styles.css.js',
   ];
 }

--- a/src/internal/base-component/index.ts
+++ b/src/internal/base-component/index.ts
@@ -8,6 +8,7 @@ import { BaseComponentProps } from '../../types/base-component';
 import { PACKAGE_SOURCE, PACKAGE_VERSION } from '../environment';
 
 // these styles needed to be imported for every public component
+import '../base-theme/styles.css.js';
 import './styles.css.js';
 
 initAwsUiVersions(PACKAGE_SOURCE, PACKAGE_VERSION);

--- a/src/internal/base-component/styles.scss
+++ b/src/internal/base-component/styles.scss
@@ -2,12 +2,6 @@
  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  SPDX-License-Identifier: Apache-2.0
 */
-
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
-@use 'awsui:globals';
 @use '../styles/global';
 @use '../generated/custom-css-properties' as custom-styles;
 

--- a/src/internal/base-theme/styles.scss
+++ b/src/internal/base-theme/styles.scss
@@ -1,0 +1,5 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+@use 'awsui:globals';


### PR DESCRIPTION
### Description

See Chorus/rzZV6TJY6Zav. What if, instead of creating a themed "copy" of the components libraries, you just create a stylesheet that contains all the design tokens that the components need with the values set to the themed values? And then, you can either override it (using cascade layers or putting it later in the DOM order) or just replace this file (using bunder overrides).

This is to support the replacement strategy. Nothing in theming core changes intentionally, so it's easy to revert, this is just to verify that moving the base styles doesn't break anything (technically, don't see why it should, but it's best to play it safe).

Related links, issue #, if available: n/a

### How has this been tested?

Doing a dry-run (7976441604).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
