### PR TITLE
fix: Close ButtonDropdown when focus leaves the component

### DIFF
--- a/src/button-dropdown/__tests__/button-dropdown-focus-leave.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-focus-leave.test.tsx
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+
+import ButtonDropdown, { ButtonDropdownProps } from '../../../lib/components/button-dropdown';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+const items: ButtonDropdownProps.Items = [
+  { id: 'i1', text: 'Item 1' },
+  { id: 'i2', text: 'Item 2' },
+];
+
+function renderButtonDropdown(props: Partial<ButtonDropdownProps> = {}) {
+  const { container } = render(
+    <>
+      <ButtonDropdown {...props} items={props.items ?? items} ariaLabel="dropdown" />
+      <button data-testid="outside">outside</button>
+    </>
+  );
+  const wrapper = createWrapper(container).findButtonDropdown()!;
+  const outside = container.querySelector<HTMLButtonElement>('[data-testid="outside"]')!;
+  return { wrapper, outside };
+}
+
+describe('ButtonDropdown closes when focus leaves the whole widget', () => {
+  test('closes when focus moves to an element outside the dropdown', () => {
+    const { wrapper, outside } = renderButtonDropdown();
+    wrapper.openDropdown();
+    expect(wrapper.findOpenDropdown()).not.toBe(null);
+
+    fireEvent.blur(wrapper.findNativeButton().getElement(), { relatedTarget: outside });
+    expect(wrapper.findOpenDropdown()).toBe(null);
+  });
+
+  test('closes when focus leaves to another frame (relatedTarget is null)', () => {
+    // Moving focus into a different browsing context (iframe) reports relatedTarget === null;
+    // this is the AWSUI-62068 case where an outside click never reaches this frame.
+    const { wrapper } = renderButtonDropdown();
+    wrapper.openDropdown();
+    expect(wrapper.findOpenDropdown()).not.toBe(null);
+
+    fireEvent.blur(wrapper.findNativeButton().getElement(), { relatedTarget: null });
+    expect(wrapper.findOpenDropdown()).toBe(null);
+  });
+
+  test('does not close when focus moves to an item inside the dropdown', () => {
+    const { wrapper } = renderButtonDropdown();
+    wrapper.openDropdown();
+    const menuItem = wrapper.findOpenDropdown()!.getElement().querySelector<HTMLElement>('[role="menuitem"]')!;
+
+    fireEvent.blur(wrapper.findNativeButton().getElement(), { relatedTarget: menuItem });
+    expect(wrapper.findOpenDropdown()).not.toBe(null);
+  });
+});

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -122,6 +122,7 @@ const InternalButtonDropdown = React.forwardRef(
       onItemActivate,
       onGroupToggle,
       onDropdownFocusLeave,
+      onDropdownBlur,
       toggleDropdown,
       closeDropdown,
       setIsUsingMouse,
@@ -456,6 +457,7 @@ const InternalButtonDropdown = React.forwardRef(
           preferredAlignment={preferCenter ? 'center' : 'start'}
           onOutsideClick={() => toggleDropdown()}
           onFocusLeave={onDropdownFocusLeave}
+          onBlur={onDropdownBlur}
           trigger={trigger}
           dropdownId={dropdownId}
           header={filterElement}

--- a/src/button-dropdown/utils/use-button-dropdown.ts
+++ b/src/button-dropdown/utils/use-button-dropdown.ts
@@ -27,6 +27,7 @@ interface UseButtonDropdownApi extends HighlightProps {
   onItemActivate: ItemActivate;
   onGroupToggle: GroupToggle;
   onDropdownFocusLeave: () => void;
+  onDropdownBlur: () => void;
   toggleDropdown: (options?: { moveHighlightOnOpen?: boolean }) => void;
   closeDropdown: () => void;
   setIsUsingMouse: (isUsingMouse: boolean) => void;
@@ -107,6 +108,15 @@ export function useButtonDropdown({
         // Returning the focus to the trigger instead.
         onReturnFocus();
       }
+      closeDropdown();
+    }
+  };
+
+  // Close when focus leaves the entire widget (trigger and menu), for example when focus
+  // moves to an app layout drawer or an element in a different frame. The filtering variant
+  // keeps focus inside the dropdown content and closes via onDropdownFocusLeave instead.
+  const onDropdownBlur = () => {
+    if (isOpen && !hasFiltering) {
       closeDropdown();
     }
   };
@@ -279,6 +289,7 @@ export function useButtonDropdown({
     onItemActivate,
     onGroupToggle,
     onDropdownFocusLeave,
+    onDropdownBlur,
     toggleDropdown,
     closeDropdown,
     setIsUsingMouse,


### PR DESCRIPTION
### Description

`ButtonDropdown` (without filtering) only dismissed on an outside click plus `Escape`/`Tab`. It never closed when focus left the whole component, so when focus moved away without a same-frame click the open menu stayed on screen. This happens when:

- an App Layout drawer / split panel is opened while the menu is open, and
- more generally in iframe/embedded console contexts, where the outside-click listener (registered on the component's own `window`) never observes a click that happens in a different frame, and the cross-frame focus move is reported with `relatedTarget === null`.

The shared `Dropdown` already exposes a whole-widget `onBlur` (fired only when focus actually leaves the trigger + menu, including the `relatedTarget === null` case) and Select/Multiselect already use it to close. This change wires that same `onBlur` into the non-filtering `ButtonDropdown`. The filtering variant is left on its existing `onFocusLeave` close, because its focus lives inside the dropdown content.

No public API change.

Related links, issue #, if available: AWSUI-62068

### How has this been tested?

- New unit tests (`src/button-dropdown/__tests__/button-dropdown-focus-leave.test.tsx`):
  - closes when focus moves to an element outside the dropdown;
  - closes when focus leaves to another frame (`relatedTarget === null`) — the reported case;
  - does **not** close when focus moves to an item inside the dropdown (guards against premature close).
- Full `src/button-dropdown` unit suite passes (19 suites, 408 tests, 1 skipped) with no regressions.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
