### PR TITLE
chore: Migrate color-severity and color-charts tokens to use stable hashes

### DIFF
--- a/build-tools/utils/__tests__/token-versions.test.js
+++ b/build-tools/utils/__tests__/token-versions.test.js
@@ -22,6 +22,7 @@ test('versions border + typography tokens matched by the default groups and leav
   expect(getTokenVersions(variablesMap)).toEqual({
     borderRadiusButton: 'v3-1',
     borderWidthField: 'v3-1',
+    colorChartsPurple300: 'v3-1',
     fontFamilyBase: 'v3-1',
   });
 });

--- a/build-tools/utils/token-versions.js
+++ b/build-tools/utils/token-versions.js
@@ -10,6 +10,7 @@ const DEFAULT_TOKEN_VERSION = 'v3-1';
 const versionGroups = [
   { pattern: /^border-/, version: DEFAULT_TOKEN_VERSION },
   { pattern: /^(font|letter-spacing|line-height)-/, version: DEFAULT_TOKEN_VERSION },
+  { pattern: /^color-(charts|severity)-/, version: DEFAULT_TOKEN_VERSION },
 ];
 
 // Builds the token -> version allowlist from the full token -> cssName map.


### PR DESCRIPTION
### Description

Being extremely cautious with these, but if these two color ones go through smoothly, I'm sending the remaining color tokens in a big batch.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
