### PR TITLE
feat: add status log to status indicator

### DIFF
--- a/pages/status-indicator/permutations.page.tsx
+++ b/pages/status-indicator/permutations.page.tsx
@@ -10,7 +10,7 @@ import ScreenshotArea from '../utils/screenshot-area';
 
 const permutations = createPermutations<InternalStatusIndicatorProps>([
   {
-    type: ['error', 'warning', 'success', 'info', 'stopped', 'pending', 'in-progress', 'loading', 'not-started'],
+    type: ['error', 'warning', 'success', 'info', 'stopped', 'pending', 'in-progress', 'loading', 'not-started', 'log'],
   },
   {
     type: ['pending'],

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -27824,6 +27824,7 @@ We do not support using this attribute to apply custom styling.",
           "loading",
           "pending",
           "success",
+          "log",
           "warning",
           "info",
           "not-started",
@@ -27955,7 +27956,7 @@ The function is called for each step and should return an object with the follow
       "description": "An array of individual steps
 
 Each step definition has the following properties:
- * \`status\` (string) - Status of the step corresponding to a status indicator. The \`log\` status renders a neutral dot marker.
+ * \`status\` (string) - Status of the step corresponding to a status indicator.
  * \`statusIconAriaLabel\` - (string) - (Optional) Alternative text for the status icon.
  * \`header\` (ReactNode) - Summary corresponding to the step.
  * \`details\` (ReactNode) - (Optional) Additional information corresponding to the step.

--- a/src/status-indicator/interfaces.ts
+++ b/src/status-indicator/interfaces.ts
@@ -8,8 +8,7 @@ import { NativeAttributes } from '../types/native-attributes';
 
 export interface StatusIndicatorProps extends BaseComponentProps {
   /**
-   * Specifies the status type. The `log` type renders a neutral dot for events that don't
-   * imply success, error, or progress.
+   * Specifies the status type.
    */
   type?: StatusIndicatorProps.Type;
   /**

--- a/src/status-indicator/interfaces.ts
+++ b/src/status-indicator/interfaces.ts
@@ -8,7 +8,8 @@ import { NativeAttributes } from '../types/native-attributes';
 
 export interface StatusIndicatorProps extends BaseComponentProps {
   /**
-   * Specifies the status type.
+   * Specifies the status type. The `log` type renders a neutral dot for events that don't
+   * imply success, error, or progress.
    */
   type?: StatusIndicatorProps.Type;
   /**
@@ -54,6 +55,7 @@ export namespace StatusIndicatorProps {
     | 'pending'
     | 'in-progress'
     | 'loading'
-    | 'not-started';
+    | 'not-started'
+    | 'log';
   export type Color = 'blue' | 'grey' | 'green' | 'red' | 'yellow';
 }

--- a/src/status-indicator/internal-interfaces.ts
+++ b/src/status-indicator/internal-interfaces.ts
@@ -1,5 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-import { StatusIndicatorProps } from './interfaces';
-
-export type InternalStatusIndicatorType = StatusIndicatorProps.Type | 'log';

--- a/src/status-indicator/internal.tsx
+++ b/src/status-indicator/internal.tsx
@@ -9,22 +9,19 @@ import { IconProps } from '../icon/interfaces';
 import InternalIcon from '../icon/internal';
 import { getBaseProps } from '../internal/base-component';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import { SomeRequired } from '../internal/types';
 /**
  * @awsuiSystem core
  */
 import WithNativeAttributes from '../internal/utils/with-native-attributes';
 import InternalSpinner from '../spinner/internal';
 import { StatusIndicatorProps } from './interfaces';
-import { InternalStatusIndicatorType } from './internal-interfaces';
 
 import styles from './styles.css.js';
 
-export interface InternalStatusIndicatorProps extends Omit<StatusIndicatorProps, 'type'>, InternalBaseComponentProps {
-  /**
-   * Status type. The internal `log` value renders a plain dot for Steps.
-   */
-  type: InternalStatusIndicatorType;
-
+export interface InternalStatusIndicatorProps
+  extends SomeRequired<StatusIndicatorProps, 'type'>,
+    InternalBaseComponentProps {
   /**
    * Play an animation on the error icon when first rendered
    */
@@ -41,7 +38,7 @@ export interface InternalStatusIndicatorProps extends Omit<StatusIndicatorProps,
   __display?: 'inline' | 'inline-block';
 }
 
-const typeToIcon: (size: IconProps.Size) => Record<InternalStatusIndicatorType, JSX.Element> = size => ({
+const typeToIcon: (size: IconProps.Size) => Record<StatusIndicatorProps.Type, JSX.Element> = size => ({
   error: <InternalIcon name="status-negative" size={size} />,
   warning: <InternalIcon name="status-warning" size={size} />,
   success: <InternalIcon name="status-positive" size={size} />,

--- a/src/steps/interfaces.ts
+++ b/src/steps/interfaces.ts
@@ -56,7 +56,7 @@ export interface StepsProps extends BaseComponentProps {
 }
 
 export namespace StepsProps {
-  export type Status = StatusIndicatorProps.Type | 'log';
+  export type Status = StatusIndicatorProps.Type;
 
   export interface Step {
     status: Status;

--- a/src/steps/interfaces.ts
+++ b/src/steps/interfaces.ts
@@ -8,7 +8,7 @@ export interface StepsProps extends BaseComponentProps {
    * An array of individual steps
    *
    * Each step definition has the following properties:
-   *  * `status` (string) - Status of the step corresponding to a status indicator. The `log` status renders a neutral dot marker.
+   *  * `status` (string) - Status of the step corresponding to a status indicator.
    *  * `statusIconAriaLabel` - (string) - (Optional) Alternative text for the status icon.
    *  * `header` (ReactNode) - Summary corresponding to the step.
    *  * `details` (ReactNode) - (Optional) Additional information corresponding to the step.


### PR DESCRIPTION
### Description
Adds `log` as a public status type on the Status indicator component. The `log` type renders a neutral dot for events that don't imply success, error, or progress. It was previously an internal only value used by Steps added recently in this https://github.com/cloudscape-design/components/pull/4746, so this change promotes it to the public `StatusIndicatorProps.Type` union and removes the now redundant internal type.

Related links, issue #, if available: https://github.com/cloudscape-design/components/issues/4853

### How has this been tested?
1. Added a `log` permutation to the Status indicator permutations page for screenshot coverage.


<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
