### PR TITLE
fix: Improve disabled button contrast in one-theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10633,9 +10633,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     {
       "path": "lib/components/internal/widget-exports.js",
       "brotli": false,
-      "limit": "1370 kB",
+      "limit": "1380 kB",
       "ignore": "react-dom"
     }
   ],

--- a/pages/input/permutations.page.tsx
+++ b/pages/input/permutations.page.tsx
@@ -8,6 +8,8 @@ import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
 
+const longAdornment = 'A long decorative prefix or suffix that must not cover the editable value';
+
 const permutations = createPermutations<InputProps>([
   {
     disabled: [false, true],
@@ -47,6 +49,14 @@ const permutations = createPermutations<InputProps>([
     value: ['100000000'],
     placeholder: ['Short placeholder'],
   },
+  { value: ['10'], prefix: ['$'], suffix: [undefined] },
+  { value: ['10'], prefix: [undefined], suffix: ['USD'] },
+  { value: ['10'], prefix: ['$'], suffix: ['USD'], disabled: [false, true], readOnly: [false, true] },
+  { value: ['10'], prefix: ['$'], suffix: ['USD'], invalid: [true], warning: [false] },
+  { value: ['10'], prefix: ['$'], suffix: ['USD'], invalid: [false], warning: [true] },
+  { type: ['search'], value: ['', 'query'], prefix: ['$'], suffix: ['USD'], clearAriaLabel: ['Clear'] },
+  { value: ['10'], prefix: [longAdornment], suffix: [longAdornment] },
+  { value: ['10'], prefix: ['$'], suffix: ['USD'] },
 ]);
 
 export default function InputPermutations() {

--- a/pages/input/prefix-suffix.page.tsx
+++ b/pages/input/prefix-suffix.page.tsx
@@ -1,0 +1,148 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext } from 'react';
+
+import Box from '~components/box';
+import FormField from '~components/form-field';
+import Icon from '~components/icon';
+import Input, { InputProps } from '~components/input';
+import Select, { SelectProps } from '~components/select';
+import SpaceBetween from '~components/space-between';
+import Toggle from '~components/toggle';
+
+import AppContext, { AppContextType } from '../app/app-context';
+import { SimplePage } from '../app/templates';
+
+type PrefixSuffixMode = 'none' | 'short' | 'long' | 'icon';
+
+type PageContext = React.Context<
+  AppContextType<{
+    type?: InputProps.Type;
+    prefix?: PrefixSuffixMode;
+    suffix?: PrefixSuffixMode;
+    disabled?: boolean;
+    readOnly?: boolean;
+    invalid?: boolean;
+    warning?: boolean;
+    value?: string;
+  }>
+>;
+
+const typeOptions: ReadonlyArray<SelectProps.Option> = [
+  { value: 'text', label: 'Text' },
+  { value: 'password', label: 'Password' },
+  { value: 'number', label: 'Number' },
+  { value: 'email', label: 'Email' },
+  { value: 'url', label: 'URL' },
+  { value: 'search', label: 'Search' },
+];
+
+const prefixSuffixOptions: ReadonlyArray<SelectProps.Option> = [
+  { value: 'none', label: 'None' },
+  { value: 'short', label: 'Short text' },
+  { value: 'long', label: 'Long text' },
+  { value: 'icon', label: 'Icon' },
+];
+
+function getPrefix(mode: PrefixSuffixMode): React.ReactNode {
+  switch (mode) {
+    case 'short':
+      return '$';
+    case 'long':
+      return 'https://example.com/very-long-prefix-that-overflows';
+    case 'icon':
+      return <Icon name="search" />;
+    default:
+      return undefined;
+  }
+}
+
+function getSuffix(mode: PrefixSuffixMode): React.ReactNode {
+  switch (mode) {
+    case 'short':
+      return '%';
+    case 'long':
+      return '.ec2.internal.very-long-domain-that-overflows';
+    case 'icon':
+      return <Icon name="settings" />;
+    default:
+      return undefined;
+  }
+}
+
+export default function PrefixSuffixPage() {
+  const { urlParams, setUrlParams } = useContext(AppContext as PageContext);
+  const type = urlParams.type ?? 'text';
+  const prefixMode = urlParams.prefix ?? 'short';
+  const suffixMode = urlParams.suffix ?? 'short';
+  const disabled = urlParams.disabled ?? false;
+  const readOnly = urlParams.readOnly ?? false;
+  const invalid = urlParams.invalid ?? false;
+  const warning = urlParams.warning ?? false;
+
+  return (
+    <SimplePage
+      title="Input prefix and suffix"
+      settings={
+        <SpaceBetween direction="horizontal" size="s" alignItems="center">
+          <Select
+            inlineLabelText="Type"
+            selectedOption={typeOptions.find(option => option.value === type) ?? null}
+            options={typeOptions}
+            onChange={({ detail }) => setUrlParams({ type: detail.selectedOption.value as InputProps.Type })}
+          />
+          <Select
+            inlineLabelText="Prefix"
+            selectedOption={prefixSuffixOptions.find(option => option.value === prefixMode) ?? null}
+            options={prefixSuffixOptions}
+            onChange={({ detail }) => setUrlParams({ prefix: detail.selectedOption.value as PrefixSuffixMode })}
+          />
+          <Select
+            inlineLabelText="Suffix"
+            selectedOption={prefixSuffixOptions.find(option => option.value === suffixMode) ?? null}
+            options={prefixSuffixOptions}
+            onChange={({ detail }) => setUrlParams({ suffix: detail.selectedOption.value as PrefixSuffixMode })}
+          />
+          <Toggle checked={disabled} onChange={({ detail }) => setUrlParams({ disabled: detail.checked })}>
+            Disabled
+          </Toggle>
+          <Toggle checked={readOnly} onChange={({ detail }) => setUrlParams({ readOnly: detail.checked })}>
+            Read-only
+          </Toggle>
+          <Toggle checked={invalid} onChange={({ detail }) => setUrlParams({ invalid: detail.checked })}>
+            Invalid
+          </Toggle>
+          <Toggle checked={warning} onChange={({ detail }) => setUrlParams({ warning: detail.checked })}>
+            Warning
+          </Toggle>
+        </SpaceBetween>
+      }
+    >
+      <FormField
+        label="Input with prefix and suffix"
+        errorText={invalid ? 'Validation error.' : undefined}
+        warningText={warning && !invalid ? 'Validation warning.' : undefined}
+      >
+        <Input
+          value={urlParams.value ?? ''}
+          onChange={({ detail }) => setUrlParams({ value: detail.value })}
+          type={type}
+          prefix={getPrefix(prefixMode)}
+          suffix={getSuffix(suffixMode)}
+          disabled={disabled}
+          readOnly={readOnly}
+          invalid={invalid}
+          warning={warning}
+          placeholder="Enter a value"
+          clearAriaLabel="Clear"
+        />
+      </FormField>
+
+      {type === 'search' && (
+        <Box variant="small" color="text-body-secondary">
+          Prefix and suffix are ignored for search inputs.
+        </Box>
+      )}
+    </SimplePage>
+  );
+}

--- a/pages/input/style-permutations.page.tsx
+++ b/pages/input/style-permutations.page.tsx
@@ -15,6 +15,8 @@ const permutations = createPermutations<InputProps>([
     disabled: [false, true],
     readOnly: [false, true],
     onChange: [() => {}],
+    prefix: [undefined, '$'],
+    suffix: [undefined, 'USD'],
     style: [
       {
         root: {

--- a/pages/status-indicator/permutations.page.tsx
+++ b/pages/status-indicator/permutations.page.tsx
@@ -10,7 +10,7 @@ import ScreenshotArea from '../utils/screenshot-area';
 
 const permutations = createPermutations<InternalStatusIndicatorProps>([
   {
-    type: ['error', 'warning', 'success', 'info', 'stopped', 'pending', 'in-progress', 'loading', 'not-started'],
+    type: ['error', 'warning', 'success', 'info', 'stopped', 'pending', 'in-progress', 'loading', 'not-started', 'log'],
   },
   {
     type: ['pending'],

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -27824,6 +27824,7 @@ We do not support using this attribute to apply custom styling.",
           "loading",
           "pending",
           "success",
+          "log",
           "warning",
           "info",
           "not-started",
@@ -27955,7 +27956,7 @@ The function is called for each step and should return an object with the follow
       "description": "An array of individual steps
 
 Each step definition has the following properties:
- * \`status\` (string) - Status of the step corresponding to a status indicator. The \`log\` status renders a neutral dot marker.
+ * \`status\` (string) - Status of the step corresponding to a status indicator.
  * \`statusIconAriaLabel\` - (string) - (Optional) Alternative text for the status icon.
  * \`header\` (ReactNode) - Summary corresponding to the step.
  * \`details\` (ReactNode) - (Optional) Additional information corresponding to the step.

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -17404,7 +17404,18 @@ with the input using \`ariaDescribedby\`.",
       "type": "boolean",
     },
   ],
-  "regions": [],
+  "regions": [
+    {
+      "description": "Use for content rendered before the editable value.",
+      "isDefault": false,
+      "name": "prefix",
+    },
+    {
+      "description": "Use for content rendered after the editable value.",
+      "isDefault": false,
+      "name": "suffix",
+    },
+  ],
   "releaseStatus": "stable",
 }
 `;
@@ -35507,6 +35518,32 @@ Supported options:
           },
         },
         {
+          "name": "findPrefix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSuffix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
           "inheritedFrom": {
             "name": "BaseInputWrapper.focus",
           },
@@ -37161,6 +37198,22 @@ To find a specific row use the \`findRow(n)\` function as chaining \`findRows().
           },
         },
         {
+          "inheritedFrom": {
+            "name": "InputWrapper.findPrefix",
+          },
+          "name": "findPrefix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
           "name": "findStatusIndicator",
           "parameters": [
             {
@@ -37173,6 +37226,22 @@ To find a specific row use the \`findRow(n)\` function as chaining \`findRows().
               "typeName": "{ expandToViewport: boolean; }",
             },
           ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "InputWrapper.findSuffix",
+          },
+          "name": "findSuffix",
+          "parameters": [],
           "returnType": {
             "isNullable": true,
             "name": "ElementWrapper",
@@ -43463,6 +43532,22 @@ and this method will have no effect.",
           },
         },
         {
+          "inheritedFrom": {
+            "name": "InputWrapper.findPrefix",
+          },
+          "name": "findPrefix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
           "description": "Returns custom property form cancel button.",
           "name": "findPropertyCancelButton",
           "parameters": [
@@ -43543,6 +43628,22 @@ and this method will have no effect.",
               "typeName": "{ expandToViewport: boolean; }",
             },
           ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "InputWrapper.findSuffix",
+          },
+          "name": "findSuffix",
+          "parameters": [],
           "returnType": {
             "isNullable": true,
             "name": "ElementWrapper",
@@ -48001,6 +48102,22 @@ Supported options:
             "name": "ElementWrapper",
           },
         },
+        {
+          "name": "findPrefix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSuffix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
       ],
       "name": "InputWrapper",
     },
@@ -49138,6 +49255,17 @@ To find a specific row use the \`findRow(n)\` function as chaining \`findRows().
           },
         },
         {
+          "inheritedFrom": {
+            "name": "InputWrapper.findPrefix",
+          },
+          "name": "findPrefix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
           "name": "findStatusIndicator",
           "parameters": [
             {
@@ -49152,6 +49280,17 @@ To find a specific row use the \`findRow(n)\` function as chaining \`findRows().
               "typeName": "{ expandToViewport: boolean; }",
             },
           ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "InputWrapper.findSuffix",
+          },
+          "name": "findSuffix",
+          "parameters": [],
           "returnType": {
             "isNullable": false,
             "name": "ElementWrapper",
@@ -53637,6 +53776,17 @@ In this case, use findContentEditableElement() instead.",
           },
         },
         {
+          "inheritedFrom": {
+            "name": "InputWrapper.findPrefix",
+          },
+          "name": "findPrefix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
           "description": "Returns custom property form cancel button.",
           "name": "findPropertyCancelButton",
           "parameters": [
@@ -53713,6 +53863,17 @@ In this case, use findContentEditableElement() instead.",
               "typeName": "{ expandToViewport: boolean; }",
             },
           ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "InputWrapper.findSuffix",
+          },
+          "name": "findSuffix",
+          "parameters": [],
           "returnType": {
             "isNullable": false,
             "name": "ElementWrapper",

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -378,6 +378,8 @@ exports[`test-utils selectors 1`] = `
   "input": [
     "awsui_input-button-right_2rhyz",
     "awsui_input-container_2rhyz",
+    "awsui_input-prefix_2rhyz",
+    "awsui_input-suffix_2rhyz",
     "awsui_input_2rhyz",
     "awsui_root_2rhyz",
   ],

--- a/src/button-dropdown/__tests__/button-dropdown-focus-leave.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-focus-leave.test.tsx
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+
+import ButtonDropdown, { ButtonDropdownProps } from '../../../lib/components/button-dropdown';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+const items: ButtonDropdownProps.Items = [
+  { id: 'i1', text: 'Item 1' },
+  { id: 'i2', text: 'Item 2' },
+];
+
+function renderButtonDropdown(props: Partial<ButtonDropdownProps> = {}) {
+  const { container } = render(
+    <>
+      <ButtonDropdown {...props} items={props.items ?? items} ariaLabel="dropdown" />
+      <button data-testid="outside">outside</button>
+    </>
+  );
+  const wrapper = createWrapper(container).findButtonDropdown()!;
+  const outside = container.querySelector<HTMLButtonElement>('[data-testid="outside"]')!;
+  return { wrapper, outside };
+}
+
+describe('ButtonDropdown closes when focus leaves the whole widget', () => {
+  test('closes when focus moves to an element outside the dropdown', () => {
+    const { wrapper, outside } = renderButtonDropdown();
+    wrapper.openDropdown();
+    expect(wrapper.findOpenDropdown()).not.toBe(null);
+
+    fireEvent.blur(wrapper.findNativeButton().getElement(), { relatedTarget: outside });
+    expect(wrapper.findOpenDropdown()).toBe(null);
+  });
+
+  test('closes when focus leaves to another frame (relatedTarget is null)', () => {
+    // Moving focus into a different browsing context (iframe) reports relatedTarget === null;
+    // this is the AWSUI-62068 case where an outside click never reaches this frame.
+    const { wrapper } = renderButtonDropdown();
+    wrapper.openDropdown();
+    expect(wrapper.findOpenDropdown()).not.toBe(null);
+
+    fireEvent.blur(wrapper.findNativeButton().getElement(), { relatedTarget: null });
+    expect(wrapper.findOpenDropdown()).toBe(null);
+  });
+
+  test('does not close when focus moves to an item inside the dropdown', () => {
+    const { wrapper } = renderButtonDropdown();
+    wrapper.openDropdown();
+    const menuItem = wrapper.findOpenDropdown()!.getElement().querySelector<HTMLElement>('[role="menuitem"]')!;
+
+    fireEvent.blur(wrapper.findNativeButton().getElement(), { relatedTarget: menuItem });
+    expect(wrapper.findOpenDropdown()).not.toBe(null);
+  });
+});

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -122,6 +122,7 @@ const InternalButtonDropdown = React.forwardRef(
       onItemActivate,
       onGroupToggle,
       onDropdownFocusLeave,
+      onDropdownBlur,
       toggleDropdown,
       closeDropdown,
       setIsUsingMouse,
@@ -456,6 +457,7 @@ const InternalButtonDropdown = React.forwardRef(
           preferredAlignment={preferCenter ? 'center' : 'start'}
           onOutsideClick={() => toggleDropdown()}
           onFocusLeave={onDropdownFocusLeave}
+          onBlur={onDropdownBlur}
           trigger={trigger}
           dropdownId={dropdownId}
           header={filterElement}

--- a/src/button-dropdown/utils/use-button-dropdown.ts
+++ b/src/button-dropdown/utils/use-button-dropdown.ts
@@ -27,6 +27,7 @@ interface UseButtonDropdownApi extends HighlightProps {
   onItemActivate: ItemActivate;
   onGroupToggle: GroupToggle;
   onDropdownFocusLeave: () => void;
+  onDropdownBlur: () => void;
   toggleDropdown: (options?: { moveHighlightOnOpen?: boolean }) => void;
   closeDropdown: () => void;
   setIsUsingMouse: (isUsingMouse: boolean) => void;
@@ -107,6 +108,15 @@ export function useButtonDropdown({
         // Returning the focus to the trigger instead.
         onReturnFocus();
       }
+      closeDropdown();
+    }
+  };
+
+  // Close when focus leaves the entire widget (trigger and menu), for example when focus
+  // moves to an app layout drawer or an element in a different frame. The filtering variant
+  // keeps focus inside the dropdown content and closes via onDropdownFocusLeave instead.
+  const onDropdownBlur = () => {
+    if (isOpen && !hasFiltering) {
       closeDropdown();
     }
   };
@@ -279,6 +289,7 @@ export function useButtonDropdown({
     onItemActivate,
     onGroupToggle,
     onDropdownFocusLeave,
+    onDropdownBlur,
     toggleDropdown,
     closeDropdown,
     setIsUsingMouse,

--- a/src/i18n/__tests__/use-custom-i18n.test.tsx
+++ b/src/i18n/__tests__/use-custom-i18n.test.tsx
@@ -1,0 +1,108 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { I18nProvider, I18nProviderProps, useCustomI18n } from '../../../lib/components/i18n';
+import { MESSAGES, TestComponent } from './test-component';
+
+const THIRD_PARTY_NAMESPACE = 'third-party-library';
+const OTHER_NAMESPACE = 'other-library';
+const COMPONENT = 'test-component';
+
+interface ThirdPartyFormatArgTypes {
+  'test-component': {
+    label: never;
+    itemCount: { count: number };
+  };
+}
+
+interface OtherFormatArgTypes {
+  'test-component': {
+    label: never;
+  };
+}
+
+const THIRD_PARTY_MESSAGES: I18nProviderProps.Messages = {
+  [THIRD_PARTY_NAMESPACE]: {
+    en: {
+      [COMPONENT]: {
+        label: 'Provider label',
+        itemCount: '{count, plural, one {# item} other {# items}}',
+      },
+    },
+  },
+};
+
+const OTHER_MESSAGES: I18nProviderProps.Messages = {
+  [OTHER_NAMESPACE]: {
+    en: {
+      [COMPONENT]: {
+        label: 'Other namespace label',
+      },
+    },
+  },
+};
+
+function ThirdPartyComponent({ id = 'third-party-result' }: { id?: string }) {
+  const i18n = useCustomI18n<ThirdPartyFormatArgTypes, typeof COMPONENT>(THIRD_PARTY_NAMESPACE, COMPONENT);
+
+  return (
+    <>
+      <span id={id}>{i18n('label', undefined)}</span>
+      <span id={`${id}-count`}>{i18n('itemCount', undefined, format => format({ count: 2 }))}</span>
+    </>
+  );
+}
+
+function MultiNamespaceComponent() {
+  const thirdPartyI18n = useCustomI18n<ThirdPartyFormatArgTypes, typeof COMPONENT>(THIRD_PARTY_NAMESPACE, COMPONENT);
+  const otherI18n = useCustomI18n<OtherFormatArgTypes, typeof COMPONENT>(OTHER_NAMESPACE, COMPONENT);
+
+  return (
+    <>
+      <span id="third-party">{thirdPartyI18n('label', undefined)}</span>
+      <span id="third-party-count">{thirdPartyI18n('itemCount', undefined, format => format({ count: 2 }))}</span>
+      <span id="other">{otherI18n('label', undefined)}</span>
+    </>
+  );
+}
+
+it('resolves messages independently across multiple namespaces', () => {
+  const { container } = render(
+    <I18nProvider messages={[THIRD_PARTY_MESSAGES, OTHER_MESSAGES]} locale="en">
+      <MultiNamespaceComponent />
+    </I18nProvider>
+  );
+
+  expect(container.querySelector('#third-party')).toHaveTextContent('Provider label');
+  expect(container.querySelector('#third-party-count')).toHaveTextContent('2 items');
+  expect(container.querySelector('#other')).toHaveTextContent('Other namespace label');
+});
+
+it('merges messages from nested providers across namespaces', () => {
+  const { container } = render(
+    <I18nProvider messages={[THIRD_PARTY_MESSAGES]} locale="en">
+      <I18nProvider messages={[OTHER_MESSAGES]} locale="en">
+        <MultiNamespaceComponent />
+      </I18nProvider>
+    </I18nProvider>
+  );
+
+  expect(container.querySelector('#third-party')).toHaveTextContent('Provider label');
+  expect(container.querySelector('#other')).toHaveTextContent('Other namespace label');
+});
+
+it('allows Cloudscape and third-party components to share one provider', () => {
+  const { container } = render(
+    <I18nProvider messages={[MESSAGES, THIRD_PARTY_MESSAGES]} locale="en">
+      <TestComponent />
+      <ThirdPartyComponent />
+    </I18nProvider>
+  );
+
+  expect(container.querySelector('#top-level-string')).toHaveTextContent('top level string');
+  expect(container.querySelector('#third-party-result')).toHaveTextContent('Provider label');
+  expect(container.querySelector('#third-party-result-count')).toHaveTextContent('2 items');
+});

--- a/src/i18n/context.ts
+++ b/src/i18n/context.ts
@@ -41,35 +41,64 @@ export function useLocale(): string | null {
  */
 type StringKeyOf<T> = Extract<keyof T, string>;
 
-export interface ComponentFormatFunction<ComponentName extends StringKeyOf<I18nFormatArgTypes>> {
-  <MessageKey extends StringKeyOf<I18nFormatArgTypes[ComponentName]>>(
+export interface GenericI18nFormatArgTypes {
+  [componentName: string]: {
+    [messageKey: string]: Record<string, string | number> | never;
+  };
+}
+
+export interface GenericI18nFormatFunction<
+  NamespaceTypes = GenericI18nFormatArgTypes,
+  ComponentName extends StringKeyOf<NamespaceTypes> = StringKeyOf<NamespaceTypes>,
+> {
+  <MessageKey extends StringKeyOf<NamespaceTypes[ComponentName]>>(
     key: MessageKey,
     provided: string,
-    handler?: CustomHandler<string, I18nFormatArgTypes[ComponentName][MessageKey]>
+    handler?: CustomHandler<string, NamespaceTypes[ComponentName][MessageKey]>
   ): string;
-  <MessageKey extends StringKeyOf<I18nFormatArgTypes[ComponentName]>>(
+  <MessageKey extends StringKeyOf<NamespaceTypes[ComponentName]>>(
     key: MessageKey,
     provided: string | undefined,
-    handler?: CustomHandler<string, I18nFormatArgTypes[ComponentName][MessageKey]>
+    handler?: CustomHandler<string | undefined, NamespaceTypes[ComponentName][MessageKey]>
   ): string | undefined;
-  <MessageKey extends StringKeyOf<I18nFormatArgTypes[ComponentName]>, ReturnValue>(
+  <MessageKey extends StringKeyOf<NamespaceTypes[ComponentName]>, ReturnValue>(
     key: MessageKey,
     provided: ReturnValue,
-    handler: I18nFormatArgTypes[ComponentName][MessageKey] extends never
+    handler: NamespaceTypes[ComponentName][MessageKey] extends never
       ? never
-      : CustomHandler<ReturnValue, I18nFormatArgTypes[ComponentName][MessageKey]>
+      : CustomHandler<ReturnValue, NamespaceTypes[ComponentName][MessageKey]>
   ): ReturnValue;
+}
+
+export type I18nFormatFunction<
+  NamespaceTypes = GenericI18nFormatArgTypes,
+  ComponentName extends StringKeyOf<NamespaceTypes> = StringKeyOf<NamespaceTypes>,
+> = GenericI18nFormatFunction<NamespaceTypes, ComponentName>;
+
+export type ComponentFormatFunction<ComponentName extends StringKeyOf<I18nFormatArgTypes>> = I18nFormatFunction<
+  I18nFormatArgTypes,
+  ComponentName
+>;
+
+/**
+ * Public hook for third-party component libraries to resolve translations
+ * through I18nProvider under their own namespace.
+ */
+export function useCustomI18n<
+  NamespaceTypes = GenericI18nFormatArgTypes,
+  ComponentName extends StringKeyOf<NamespaceTypes> = StringKeyOf<NamespaceTypes>,
+>(namespace: string, componentName: ComponentName): I18nFormatFunction<NamespaceTypes, ComponentName> {
+  const { format } = useContext(InternalI18nContext) ?? defaultContextValue;
+  const formatFunction = <MessageKey extends StringKeyOf<NamespaceTypes[ComponentName]>, ValueType>(
+    key: MessageKey,
+    provided: ValueType,
+    customHandler?: CustomHandler<ValueType, NamespaceTypes[ComponentName][MessageKey]>
+  ) => format(namespace, componentName, key, provided, customHandler);
+  return formatFunction;
 }
 
 export function useInternalI18n<ComponentName extends StringKeyOf<I18nFormatArgTypes>>(
   componentName: ComponentName
 ): ComponentFormatFunction<ComponentName> {
-  const { format } = useContext(InternalI18nContext) ?? defaultContextValue;
-  return <MessageKey extends StringKeyOf<I18nFormatArgTypes[ComponentName]>, ValueType>(
-    key: MessageKey,
-    provided: ValueType,
-    customHandler?: CustomHandler<ValueType, I18nFormatArgTypes[ComponentName][MessageKey]>
-  ) => {
-    return format(namespace, componentName, key, provided, customHandler);
-  };
+  return useCustomI18n<I18nFormatArgTypes, ComponentName>(namespace, componentName);
 }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -4,3 +4,5 @@
 'use client';
 export { I18nProvider as default, I18nProvider, I18nProviderProps } from './provider';
 export { importMessages } from './dynamic';
+export { useCustomI18n } from './context';
+export type { I18nFormatFunction } from './context';

--- a/src/input/__tests__/adornments.test.tsx
+++ b/src/input/__tests__/adornments.test.tsx
@@ -1,0 +1,166 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import '../../__a11y__/to-validate-a11y';
+import Input, { InputProps } from '../../../lib/components/input';
+import InternalInput from '../../../lib/components/input/internal';
+import customCssProps from '../../../lib/components/internal/generated/custom-css-properties';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+import styles from '../../../lib/components/input/styles.css.js';
+
+function renderInput(props: Partial<InputProps> = {}) {
+  const { container, rerender } = render(<Input value="" onChange={() => {}} {...props} />);
+  const wrapper = createWrapper(container).findInput()!;
+  return { wrapper, rerender };
+}
+
+describe('prefix and suffix adornments', () => {
+  test('does not render adornment container, prefix, or suffix by default', () => {
+    const { wrapper } = renderInput();
+    expect(wrapper.findByClassName(styles['input-adorned-container'])).toBeNull();
+    expect(wrapper.findPrefix()).toBeNull();
+    expect(wrapper.findSuffix()).toBeNull();
+    expect(wrapper.findNativeInput().getElement()).not.toHaveClass(styles['input-adorned']);
+  });
+
+  test('renders a prefix', () => {
+    const { wrapper } = renderInput({ prefix: '$' });
+    expect(wrapper.findPrefix()!.getElement()).toHaveTextContent('$');
+    expect(wrapper.findSuffix()).toBeNull();
+    expect(wrapper.findByClassName(styles['input-adorned-container'])).not.toBeNull();
+    expect(wrapper.findNativeInput().getElement()).toHaveClass(styles['input-adorned']);
+  });
+
+  test('renders a suffix', () => {
+    const { wrapper } = renderInput({ suffix: '%' });
+    expect(wrapper.findSuffix()!.getElement()).toHaveTextContent('%');
+    expect(wrapper.findPrefix()).toBeNull();
+    expect(wrapper.findNativeInput().getElement()).toHaveClass(styles['input-adorned']);
+  });
+
+  test('renders both a prefix and a suffix', () => {
+    const { wrapper } = renderInput({ prefix: 'https://', suffix: '.com' });
+    expect(wrapper.findPrefix()!.getElement()).toHaveTextContent('https://');
+    expect(wrapper.findSuffix()!.getElement()).toHaveTextContent('.com');
+  });
+
+  test('renders a divider only on sides that have an adornment', () => {
+    const { wrapper, rerender } = renderInput({ prefix: '$' });
+    expect(wrapper.findAllByClassName(styles['input-adornment-divider'])).toHaveLength(1);
+
+    rerender(<Input value="" onChange={() => {}} prefix="$" suffix="%" />);
+    expect(wrapper.findAllByClassName(styles['input-adornment-divider'])).toHaveLength(2);
+  });
+
+  test('renders arbitrary React nodes', () => {
+    const { wrapper } = renderInput({ prefix: <span data-testid="custom">node</span> });
+    expect(wrapper.findPrefix()!.find('[data-testid="custom"]')).not.toBeNull();
+  });
+
+  test('renders truthy numeric adornments', () => {
+    const { wrapper } = renderInput({ prefix: 1, suffix: 1 });
+    expect(wrapper.findPrefix()!.getElement()).toHaveTextContent('1');
+    expect(wrapper.findSuffix()!.getElement()).toHaveTextContent('1');
+  });
+
+  test('applies custom Input styles to the adorned container', () => {
+    const style: InputProps['style'] = {
+      root: {
+        backgroundColor: { default: '#ffffff', hover: '#f2f3f3' },
+        borderColor: { default: '#000000', hover: '#111111' },
+        borderRadius: '6px',
+        borderWidth: '2px',
+        color: { default: '#222222', disabled: '#999999' },
+        paddingBlock: '12px',
+        paddingInline: '16px',
+      },
+    };
+    const { wrapper } = renderInput({ prefix: '$', style });
+    const container = wrapper.findByClassName(styles['input-adorned-container'])!.getElement();
+
+    expect(container).toHaveStyle({ borderRadius: '6px', borderWidth: '2px' });
+    expect(container.style.getPropertyValue(customCssProps.styleBackgroundHover)).toBe('#f2f3f3');
+    expect(container.style.getPropertyValue(customCssProps.styleBorderColorHover)).toBe('#111111');
+    expect(container.style.getPropertyValue(customCssProps.styleColorDisabled)).toBe('#999999');
+
+    // paddingBlock and paddingInline go to the native input, NOT the container
+    const nativeInput = wrapper.findNativeInput()!.getElement();
+    expect(nativeInput.style.paddingBlock).toBe('12px');
+    expect(nativeInput.style.paddingInline).toBe('16px');
+  });
+
+  test('contains the end icon within the adorned focus container', () => {
+    const { container } = render(<InternalInput value="" onChange={() => {}} prefix="$" __endIcon="settings" />);
+    const adornedContainer = container.querySelector(`.${styles['input-adorned-container']}`)!;
+    const endIcon = container.querySelector(`.${styles['input-icon-end']}`)!;
+
+    expect(adornedContainer).toContainElement(endIcon as HTMLElement);
+    endIcon.querySelector('button')!.focus();
+    expect(adornedContainer.contains(document.activeElement)).toBe(true);
+  });
+
+  test.each([null, false, 0, undefined, ''] as const)(
+    'does not render an adornment cell or divider for non-rendered React child %p',
+    absentContent => {
+      const { wrapper } = renderInput({ prefix: absentContent, suffix: absentContent });
+      expect(wrapper.findPrefix()).toBeNull();
+      expect(wrapper.findSuffix()).toBeNull();
+      expect(wrapper.findByClassName(styles['input-adorned-container'])).toBeNull();
+      expect(wrapper.findAllByClassName(styles['input-adornment-divider'])).toHaveLength(0);
+    }
+  );
+
+  describe('adornment container reflects validation and interaction state', () => {
+    const getContainer = (props: Partial<InputProps>) =>
+      renderInput({ prefix: '$', ...props })
+        .wrapper.findByClassName(styles['input-adorned-container'])!
+        .getElement();
+
+    test('adds the invalid modifier when invalid', () => {
+      expect(getContainer({ invalid: true })).toHaveClass(styles['input-adorned-container-invalid']);
+    });
+
+    test('prefers the invalid modifier over the warning modifier', () => {
+      const container = getContainer({ invalid: true, warning: true });
+      expect(container).toHaveClass(styles['input-adorned-container-invalid']);
+      expect(container).not.toHaveClass(styles['input-adorned-container-warning']);
+    });
+
+    test('adds the warning modifier when warning and not invalid', () => {
+      expect(getContainer({ warning: true })).toHaveClass(styles['input-adorned-container-warning']);
+    });
+
+    test('adds the disabled modifier when disabled', () => {
+      expect(getContainer({ disabled: true })).toHaveClass(styles['input-adorned-container-disabled']);
+    });
+
+    test('adds the readonly modifier when readOnly and not disabled', () => {
+      const container = getContainer({ readOnly: true });
+      expect(container).toHaveClass(styles['input-adorned-container-readonly']);
+    });
+
+    test('prefers the disabled modifier over the readonly modifier', () => {
+      const container = getContainer({ disabled: true, readOnly: true });
+      expect(container).toHaveClass(styles['input-adorned-container-disabled']);
+      expect(container).not.toHaveClass(styles['input-adorned-container-readonly']);
+    });
+  });
+
+  describe('accessibility', () => {
+    test('marks adornments as decorative with aria-hidden', () => {
+      const { wrapper } = renderInput({ prefix: '$', suffix: '%' });
+      expect(wrapper.findPrefix()!.getElement()).toHaveAttribute('aria-hidden', 'true');
+      expect(wrapper.findSuffix()!.getElement()).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    test('has no axe violations', async () => {
+      const { container } = render(
+        <Input value="123" onChange={() => {}} ariaLabel="Amount" prefix="$" suffix="USD" />
+      );
+      await expect(container).toValidateA11y();
+    });
+  });
+});

--- a/src/input/__tests__/analytics-metadata.test.tsx
+++ b/src/input/__tests__/analytics-metadata.test.tsx
@@ -38,7 +38,7 @@ beforeAll(() => {
   activateAnalyticsMetadata(true);
 });
 describe('Input renders correct analytics metadata', () => {
-  describe('on the right button', () => {
+  describe('on the end button', () => {
     test('when it is the clear button', () => {
       const renderResult = render(<Input value="value" onChange={() => {}} type="search" clearAriaLabel="clear" />);
       const clearInputButton = createWrapper(renderResult.container).findInput()!.findClearButton()!.getElement();
@@ -51,11 +51,11 @@ describe('Input renders correct analytics metadata', () => {
       });
     });
     test('when it is not the clear button', () => {
-      const renderResult = render(<InternalInput value="value" onChange={() => {}} __rightIcon="settings" />);
-      const rightIconButton = createWrapper(renderResult.container)
-        .findByClassName(styles['input-icon-right'])!
+      const renderResult = render(<InternalInput value="value" onChange={() => {}} __endIcon="settings" />);
+      const endIconButton = createWrapper(renderResult.container)
+        .findByClassName(styles['input-icon-end'])!
         .getElement();
-      expect(getGeneratedAnalyticsMetadata(rightIconButton)).toEqual({});
+      expect(getGeneratedAnalyticsMetadata(endIconButton)).toEqual({});
     });
   });
   describe('on the component', () => {

--- a/src/input/__tests__/search-input.test.tsx
+++ b/src/input/__tests__/search-input.test.tsx
@@ -3,8 +3,15 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+
 import Input, { InputProps } from '../../../lib/components/input';
 import createWrapper, { InputWrapper } from '../../../lib/components/test-utils/dom';
+
+jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
+  ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
+  warnOnce: jest.fn(),
+}));
 
 function renderInput(
   props: Omit<InputProps, 'value'> & { value?: string } & React.RefAttributes<HTMLInputElement> = {}
@@ -20,6 +27,74 @@ function getNativeInput(wrapper: InputWrapper) {
 function getClearButton(wrapper: InputWrapper) {
   return wrapper.findClearButton()!.getElement();
 }
+
+describe('Development warnings for prefix/suffix on search type', () => {
+  afterEach(() => {
+    (warnOnce as jest.Mock).mockReset();
+  });
+
+  test('warns when prefix is supplied with type search', () => {
+    renderInput({ type: 'search', prefix: '$' });
+    expect(warnOnce).toHaveBeenCalledWith('Input', 'prefix and suffix are ignored when type is search.');
+  });
+
+  test('warns when suffix is supplied with type search', () => {
+    renderInput({ type: 'search', suffix: '%' });
+    expect(warnOnce).toHaveBeenCalledWith('Input', 'prefix and suffix are ignored when type is search.');
+  });
+
+  test('warns when both prefix and suffix are supplied with type search', () => {
+    renderInput({ type: 'search', prefix: '$', suffix: '%' });
+    expect(warnOnce).toHaveBeenCalledWith('Input', 'prefix and suffix are ignored when type is search.');
+  });
+
+  test('does not warn when neither prefix nor suffix is supplied with type search', () => {
+    renderInput({ type: 'search' });
+    expect(warnOnce).not.toHaveBeenCalled();
+  });
+
+  test('does not warn when prefix/suffix are supplied with non-search type', () => {
+    renderInput({ type: 'text', prefix: '$', suffix: '%' });
+    expect(warnOnce).not.toHaveBeenCalled();
+  });
+});
+
+describe('Prefix/suffix suppression for search type', () => {
+  test('does not render prefix when type is search', () => {
+    const wrapper = renderInput({ type: 'search', prefix: '$' });
+    expect(wrapper.findPrefix()).toBeNull();
+  });
+
+  test('does not render suffix when type is search', () => {
+    const wrapper = renderInput({ type: 'search', suffix: '%' });
+    expect(wrapper.findSuffix()).toBeNull();
+  });
+
+  test('does not render prefix and suffix together when type is search', () => {
+    const wrapper = renderInput({ type: 'search', prefix: 'https://', suffix: '.com' });
+    expect(wrapper.findPrefix()).toBeNull();
+    expect(wrapper.findSuffix()).toBeNull();
+  });
+
+  test('still renders clear button for populated search input with prefix/suffix props', () => {
+    const wrapper = renderInput({ type: 'search', value: 'query', prefix: '$', suffix: '%' });
+    expect(wrapper.findClearButton()).not.toBeNull();
+    expect(wrapper.findPrefix()).toBeNull();
+    expect(wrapper.findSuffix()).toBeNull();
+  });
+
+  test('renders prefix for non-search type', () => {
+    const wrapper = renderInput({ type: 'text', prefix: '$' });
+    expect(wrapper.findPrefix()).not.toBeNull();
+    expect(wrapper.findPrefix()!.getElement().textContent).toBe('$');
+  });
+
+  test('renders suffix for non-search type', () => {
+    const wrapper = renderInput({ type: 'text', suffix: '%' });
+    expect(wrapper.findSuffix()).not.toBeNull();
+    expect(wrapper.findSuffix()!.getElement().textContent).toBe('%');
+  });
+});
 
 describe('Clear field', () => {
   const baseProps: Omit<InputProps, 'value'> = {

--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -44,6 +44,8 @@ const Input = React.forwardRef(
       clearAriaLabel,
       nativeInputAttributes,
       style,
+      prefix,
+      suffix,
       ...rest
     }: InputProps,
     ref: Ref<InputProps.Ref>
@@ -101,6 +103,8 @@ const Input = React.forwardRef(
           clearAriaLabel,
           nativeInputAttributes,
           style,
+          prefix,
+          suffix,
         }}
         className={clsx(styles.root, baseProps.className)}
         __inheritFormFieldProps={true}

--- a/src/input/interfaces.ts
+++ b/src/input/interfaces.ts
@@ -1,5 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { ReactNode } from 'react';
+
 import { BaseComponentProps } from '../types/base-component';
 import { BaseKeyDetail, CancelableEventHandler, NonCancelableEventHandler } from '../types/events';
 import { FormFieldValidationControlProps } from '../types/form-field';
@@ -188,6 +190,16 @@ export interface InputProps
    * @awsuiSystem core
    */
   style?: InputProps.Style;
+
+  /**
+   * Use for content rendered before the editable value.
+   */
+  prefix?: ReactNode;
+
+  /**
+   * Use for content rendered after the editable value.
+   */
+  suffix?: ReactNode;
 }
 
 export namespace InputProps {

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -3,7 +3,7 @@
 import React, { Ref, useRef } from 'react';
 import clsx from 'clsx';
 
-import { useMergeRefs } from '@cloudscape-design/component-toolkit/internal';
+import { useMergeRefs, warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import {
   copyAnalyticsMetadataAttribute,
   getAnalyticsMetadataAttribute,
@@ -18,6 +18,7 @@ import { useFormFieldContext } from '../internal/context/form-field-context';
 import { fireKeyboardEvent, fireNonCancelableEvent } from '../internal/events';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useDebounceCallback } from '../internal/hooks/use-debounce-callback';
+import { isDevelopment } from '../internal/is-development';
 import WithNativeAttributes, { SkipWarnings } from '../internal/utils/with-native-attributes';
 import { BaseComponentProps } from '../types/base-component';
 import { NonCancelableEventHandler } from '../types/events';
@@ -40,12 +41,12 @@ export interface InternalInputProps
     FormFieldValidationControlProps,
     InternalBaseComponentProps {
   type?: InputProps['type'] | 'visualSearch';
-  __leftIcon?: IconProps['name'];
-  __leftIconVariant?: IconProps['variant'];
-  __onLeftIconClick?: () => void;
+  __startIcon?: IconProps['name'];
+  __startIconVariant?: IconProps['variant'];
+  __onStartIconClick?: () => void;
 
-  __rightIcon?: IconProps['name'];
-  __onRightIconClick?: () => void;
+  __endIcon?: IconProps['name'];
+  __onEndIconClick?: () => void;
 
   __noBorderRadius?: boolean;
 
@@ -77,14 +78,14 @@ function InternalInput(
     spellcheck,
     __noBorderRadius,
 
-    __leftIcon,
-    __leftIconVariant = 'subtle',
-    __onLeftIconClick,
+    __startIcon,
+    __startIconVariant = 'subtle',
+    __onStartIconClick,
 
     ariaRequired,
 
-    __rightIcon,
-    __onRightIconClick,
+    __endIcon,
+    __onEndIconClick,
 
     onKeyDown,
     onKeyUp,
@@ -101,6 +102,8 @@ function InternalInput(
     __inlineLabelText,
     __fullWidth,
     style,
+    prefix,
+    suffix,
     ...rest
   }: InternalInputProps,
   ref: Ref<HTMLInputElement>
@@ -116,14 +119,39 @@ function InternalInput(
 
   const inputRef = useRef<HTMLInputElement>(null);
   const searchProps = useSearchProps(type, disabled, readOnly, value, inputRef, handleChange);
-  __leftIcon = __leftIcon ?? searchProps.__leftIcon;
-  __rightIcon = __rightIcon ?? searchProps.__rightIcon;
-  __onRightIconClick = __onRightIconClick ?? searchProps.__onRightIconClick;
+  __startIcon = __startIcon ?? searchProps.__startIcon;
+  __endIcon = __endIcon ?? searchProps.__endIcon;
+  __onEndIconClick = __onEndIconClick ?? searchProps.__onEndIconClick;
+
+  // Search inputs use built-in search and clear icons that would overlap adornments.
+  const isSearch = type === 'search' || type === 'visualSearch';
+  if (isDevelopment) {
+    if (isSearch && (prefix !== undefined || suffix !== undefined)) {
+      warnOnce('Input', 'prefix and suffix are ignored when type is search.');
+    }
+  }
+  if (isSearch) {
+    prefix = undefined;
+    suffix = undefined;
+  }
 
   const formFieldContext = useFormFieldContext(rest);
   const { ariaLabelledby, ariaDescribedby, controlId, invalid, warning } = __inheritFormFieldProps
     ? formFieldContext
     : rest;
+
+  const hasPrefix = !!prefix;
+  const hasSuffix = !!suffix;
+  const hasPrefixOrSuffix = hasPrefix || hasSuffix;
+  const inputStyles = getInputStyles(style);
+  const nativeInputStyles =
+    hasPrefixOrSuffix && inputStyles
+      ? { ...inputStyles, borderRadius: undefined, borderWidth: undefined }
+      : inputStyles;
+  const adornedContainerStyles =
+    hasPrefixOrSuffix && inputStyles
+      ? { ...inputStyles, paddingBlock: undefined, paddingInline: undefined }
+      : undefined;
 
   const attributes: React.InputHTMLAttributes<HTMLInputElement> = {
     'aria-label': ariaLabel,
@@ -139,13 +167,14 @@ function InternalInput(
     className: clsx(
       styles.input,
       type && styles[`input-type-${type}`],
-      __rightIcon && styles['input-has-icon-right'],
-      __leftIcon && styles['input-has-icon-left'],
+      __endIcon && styles['input-has-icon-end'],
+      __startIcon && styles['input-has-icon-start'],
       __noBorderRadius && styles['input-has-no-border-radius'],
+      hasPrefixOrSuffix && styles['input-adorned'],
       {
         [styles['input-readonly']]: readOnly,
-        [styles['input-invalid']]: invalid,
-        [styles['input-warning']]: warning && !invalid,
+        [styles['input-invalid']]: invalid && !hasPrefixOrSuffix,
+        [styles['input-warning']]: warning && !invalid && !hasPrefixOrSuffix,
       }
     ),
     autoComplete: convertAutoComplete(autoComplete),
@@ -211,9 +240,49 @@ function InternalInput(
       nativeAttributes={nativeInputAttributes}
       skipWarnings={__skipNativeAttributesWarnings}
       ref={mergedRef}
-      style={getInputStyles(style)}
+      style={nativeInputStyles}
     />
   );
+
+  const inputWithLabel = __inlineLabelText ? (
+    <div className={clsx(styles['inline-label-wrapper'], __fullWidth && styles['inline-label-wrapper-full-width'])}>
+      <label htmlFor={controlId} className={styles['inline-label']}>
+        {__inlineLabelText}
+      </label>
+      <div
+        className={clsx(
+          styles['inline-label-trigger-wrapper'],
+          __fullWidth && styles['inline-label-trigger-wrapper-full-width']
+        )}
+      >
+        {mainInput}
+      </div>
+    </div>
+  ) : (
+    mainInput
+  );
+
+  const endIcon = __endIcon ? (
+    <span
+      className={styles['input-icon-end']}
+      {...(__endIcon === 'close'
+        ? getAnalyticsMetadataAttribute({
+            action: 'clearInput',
+          } as Partial<GeneratedAnalyticsMetadataInputClearInput>)
+        : {})}
+    >
+      <InternalButton
+        // Used for test utils
+        className={styles['input-button-right']}
+        variant="inline-icon-pointer-target"
+        formAction="none"
+        iconName={__endIcon}
+        onClick={__onEndIconClick}
+        ariaLabel={i18n('clearAriaLabel', clearAriaLabelOverride)}
+        disabled={disabled}
+      />
+    </span>
+  ) : null;
 
   return (
     <div
@@ -225,49 +294,47 @@ function InternalInput(
         ? getAnalyticsMetadataAttribute({ component: componentAnalyticsMetadata })
         : copyAnalyticsMetadataAttribute(rest))}
     >
-      {__leftIcon && (
-        <span onClick={__onLeftIconClick} className={styles['input-icon-left']}>
-          <InternalIcon name={__leftIcon} variant={disabled || readOnly ? 'disabled' : __leftIconVariant} />
+      {__startIcon && (
+        <span onClick={__onStartIconClick} className={styles['input-icon-start']}>
+          <InternalIcon name={__startIcon} variant={disabled || readOnly ? 'disabled' : __startIconVariant} />
         </span>
       )}
-      {__inlineLabelText ? (
-        <div className={clsx(styles['inline-label-wrapper'], __fullWidth && styles['inline-label-wrapper-full-width'])}>
-          <label htmlFor={controlId} className={styles['inline-label']}>
-            {__inlineLabelText}
-          </label>
-          <div
-            className={clsx(
-              styles['inline-label-trigger-wrapper'],
-              __fullWidth && styles['inline-label-trigger-wrapper-full-width']
-            )}
-          >
-            {mainInput}
-          </div>
+      {hasPrefixOrSuffix ? (
+        // [prefix][divider][input][divider][suffix] - one flex bar owns the border and focus ring.
+        <div
+          className={clsx(
+            styles['input-adorned-container'],
+            invalid && styles['input-adorned-container-invalid'],
+            warning && !invalid && styles['input-adorned-container-warning'],
+            disabled && styles['input-adorned-container-disabled'],
+            readOnly && !disabled && styles['input-adorned-container-readonly']
+          )}
+          aria-disabled={disabled || undefined}
+          style={adornedContainerStyles}
+        >
+          {hasPrefix && (
+            <>
+              <span className={styles['input-prefix']} aria-hidden="true">
+                <span className={styles['input-adornment-content']}>{prefix}</span>
+              </span>
+              <span className={styles['input-adornment-divider']} />
+            </>
+          )}
+          {inputWithLabel}
+          {hasSuffix && (
+            <>
+              <span className={styles['input-adornment-divider']} />
+              <span className={styles['input-suffix']} aria-hidden="true">
+                <span className={styles['input-adornment-content']}>{suffix}</span>
+              </span>
+            </>
+          )}
+          {endIcon}
         </div>
       ) : (
-        mainInput
+        inputWithLabel
       )}
-      {__rightIcon && (
-        <span
-          className={styles['input-icon-right']}
-          {...(__rightIcon === 'close'
-            ? getAnalyticsMetadataAttribute({
-                action: 'clearInput',
-              } as Partial<GeneratedAnalyticsMetadataInputClearInput>)
-            : {})}
-        >
-          <InternalButton
-            // Used for test utils
-            className={styles['input-button-right']}
-            variant="inline-icon-pointer-target"
-            formAction="none"
-            iconName={__rightIcon}
-            onClick={__onRightIconClick}
-            ariaLabel={i18n('clearAriaLabel', clearAriaLabelOverride)}
-            disabled={disabled}
-          />
-        </span>
-      )}
+      {!hasPrefixOrSuffix && endIcon}
     </div>
   );
 }

--- a/src/input/styles.scss
+++ b/src/input/styles.scss
@@ -28,6 +28,47 @@
   }
 }
 
+%input-default-styles {
+  background-color: var(#{custom-props.$styleBackgroundDefault}, awsui.$color-background-input-default);
+  border-block: awsui.$border-width-field solid
+    var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-default);
+  border-inline: awsui.$border-width-field solid
+    var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-default);
+  box-shadow: var(#{custom-props.$styleBoxShadowDefault});
+}
+
+%input-hover-styles {
+  border-color: var(
+    #{custom-props.$styleBorderColorHover},
+    var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-default)
+  );
+  background-color: var(
+    #{custom-props.$styleBackgroundHover},
+    var(#{custom-props.$styleBackgroundDefault}, awsui.$color-background-input-default)
+  );
+  box-shadow: var(#{custom-props.$styleBoxShadowHover}, #{custom-props.$styleBoxShadowDefault});
+}
+
+%input-readonly-styles {
+  @include styles.form-readonly-element(
+    $background-color: var(
+        #{custom-props.$styleBackgroundReadonly},
+        var(#{custom-props.$styleBackgroundDefault}, awsui.$color-background-input-default)
+      ),
+    $border-color: var(
+        #{custom-props.$styleBorderColorReadonly},
+        var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-disabled)
+      )
+  );
+}
+
+%input-focus-styles {
+  @include styles.form-focus-element(
+    $border-color: var(#{custom-props.$styleBorderColorFocus}, awsui.$color-border-input-focused),
+    $box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light)
+  );
+}
+
 .root {
   /* used in test-utils for component to distinguish input from other input-like components, for example autosuggest */
 }
@@ -40,54 +81,31 @@
   inline-size: 100%;
   cursor: text;
   box-sizing: border-box;
-  background-color: var(#{custom-props.$styleBackgroundDefault}, awsui.$color-background-input-default);
   border-start-start-radius: styles.$control-border-radius;
   border-start-end-radius: styles.$control-border-radius;
   border-end-start-radius: styles.$control-border-radius;
   border-end-end-radius: styles.$control-border-radius;
 
-  border-block: awsui.$border-width-field solid
-    var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-default);
-  border-inline: awsui.$border-width-field solid
-    var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-default);
-
-  box-shadow: var(#{custom-props.$styleBoxShadowDefault});
-
   @include styles.font-body-m;
   min-block-size: awsui.$size-vertical-input;
 
+  @extend %input-default-styles;
+
   &:hover {
-    border-color: var(
-      #{custom-props.$styleBorderColorHover},
-      var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-default)
-    );
     color: var(
       #{custom-props.$styleColorHover},
       var(#{custom-props.$styleBorderColorDefault}, awsui.$color-text-body-default)
     );
-    background-color: var(
-      #{custom-props.$styleBackgroundHover},
-      var(#{custom-props.$styleBackgroundDefault}, awsui.$color-background-input-default)
-    );
-    box-shadow: var(#{custom-props.$styleBoxShadowHover}, #{custom-props.$styleBoxShadowDefault});
+    @extend %input-hover-styles;
   }
 
   &.input-readonly {
-    @include styles.form-readonly-element(
-      $background-color: var(
-          #{custom-props.$styleBackgroundReadonly},
-          var(#{custom-props.$styleBackgroundDefault}, awsui.$color-background-input-default)
-        ),
-      $border-color: var(
-          #{custom-props.$styleBorderColorReadonly},
-          var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-disabled)
-        )
-    );
     color: var(
       #{custom-props.$styleColorReadonly},
       var(#{custom-props.$styleColorDefault}, awsui.$color-text-body-default)
     );
     box-shadow: var(#{custom-props.$styleBoxShadowReadonly});
+    @extend %input-readonly-styles;
   }
 
   @include placeholder {
@@ -100,12 +118,9 @@
   }
 
   &:focus {
-    @include styles.form-focus-element(
-      $border-color: var(#{custom-props.$styleBorderColorFocus}, awsui.$color-border-input-focused),
-      $box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light)
-    );
     color: var(#{custom-props.$styleColorFocus}, awsui.$color-text-body-default);
     background-color: var(#{custom-props.$styleBackgroundFocus}, awsui.$color-background-input-default);
+    @extend %input-focus-styles;
   }
 
   &:disabled {
@@ -134,7 +149,7 @@
       $border-color: var(#{custom-props.$styleBorderColorDefault}, awsui.$color-text-status-error),
       $focus-box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light-invalid)
     );
-    &.input-has-icon-left {
+    &.input-has-icon-start {
       padding-inline-start: calc(
         #{styles.$control-icon-horizontal-padding} -
           (#{styles.$invalid-control-left-border} - #{awsui.$border-width-field})
@@ -148,7 +163,7 @@
       $border-color: var(#{custom-props.$styleBorderColorDefault}, awsui.$color-text-status-warning),
       $focus-box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light-invalid)
     );
-    &.input-has-icon-left {
+    &.input-has-icon-start {
       padding-inline-start: calc(
         #{styles.$control-icon-horizontal-padding} -
           (#{styles.$invalid-control-left-border} - #{awsui.$border-width-field})
@@ -169,10 +184,10 @@
       display: none;
     }
   }
-  &.input-has-icon-left {
+  &.input-has-icon-start {
     padding-inline-start: styles.$control-icon-horizontal-padding;
   }
-  &.input-has-icon-right {
+  &.input-has-icon-end {
     padding-inline-end: styles.$control-icon-horizontal-padding;
   }
   &.input-has-no-border-radius {
@@ -188,14 +203,14 @@
   position: relative;
 }
 
-.input-icon-left {
+.input-icon-start {
   position: absolute;
   pointer-events: none;
   inset-inline-start: styles.$control-icon-horizontal-offset;
   inset-block-start: styles.$control-icon-vertical-offset;
 }
 
-.input-icon-right {
+.input-icon-end {
   position: absolute;
   inset-block-start: calc(#{styles.$control-icon-vertical-offset} - #{awsui.$space-xxxs});
   inset-inline-end: calc(#{styles.$control-icon-horizontal-offset} - #{awsui.$space-xxs});
@@ -223,4 +238,183 @@
 
 .inline-label {
   @include forms.inline-label;
+}
+
+.input-adorned-container {
+  display: flex;
+  align-items: stretch;
+  inline-size: 100%;
+  box-sizing: border-box;
+  color: var(#{custom-props.$styleColorDefault}, awsui.$color-text-form-secondary);
+  border-start-start-radius: styles.$control-border-radius;
+  border-start-end-radius: styles.$control-border-radius;
+  border-end-start-radius: styles.$control-border-radius;
+  border-end-end-radius: styles.$control-border-radius;
+  min-block-size: awsui.$size-vertical-input;
+
+  @extend %input-default-styles;
+
+  &:hover {
+    @extend %input-hover-styles;
+    color: var(
+      #{custom-props.$styleColorHover},
+      var(#{custom-props.$styleColorDefault}, awsui.$color-text-form-secondary)
+    );
+  }
+
+  &.input-adorned-container-readonly {
+    @extend %input-readonly-styles;
+    color: var(
+      #{custom-props.$styleColorReadonly},
+      var(#{custom-props.$styleColorDefault}, awsui.$color-text-form-secondary)
+    );
+  }
+
+  &:focus-within {
+    @extend %input-focus-styles;
+    color: var(
+      #{custom-props.$styleColorFocus},
+      var(#{custom-props.$styleColorDefault}, awsui.$color-text-form-secondary)
+    );
+  }
+
+  &.input-adorned-container-invalid {
+    @include styles.form-invalid-control(
+      $color: var(#{custom-props.$styleColorDefault}, awsui.$color-text-status-error),
+      $border-color: var(#{custom-props.$styleBorderColorDefault}, awsui.$color-text-status-error),
+      $focus-box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light-invalid)
+    ) {
+      padding-inline-start: 0;
+    }
+
+    &:focus-within {
+      box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light-invalid);
+    }
+  }
+
+  &.input-adorned-container-warning {
+    @include styles.form-warning-control(
+      $color: var(#{custom-props.$styleColorDefault}, awsui.$color-text-status-warning),
+      $border-color: var(#{custom-props.$styleBorderColorDefault}, awsui.$color-text-status-warning),
+      $focus-box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light-invalid)
+    ) {
+      padding-inline-start: 0;
+    }
+
+    &:focus-within {
+      box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light-invalid);
+    }
+  }
+
+  &.input-adorned-container-disabled {
+    @include styles.form-disabled-element(
+      $background-color: var(#{custom-props.$styleBackgroundDisabled}, awsui.$color-background-input-disabled),
+      $border-color: var(#{custom-props.$styleBorderColorDisabled}, awsui.$color-border-input-disabled),
+      $color: var(#{custom-props.$styleColorDisabled}, awsui.$color-text-input-disabled),
+      $cursor: default
+    );
+    box-shadow: var(#{custom-props.$styleBoxShadowDisabled});
+  }
+}
+
+.input-prefix,
+.input-suffix {
+  display: flex;
+  align-items: center;
+  flex-shrink: 1;
+  max-inline-size: max(0px, calc((100% - 12rem) / 2));
+  min-inline-size: 0;
+  padding-block: styles.$control-padding-vertical;
+  padding-inline: styles.$control-padding-horizontal;
+  color: inherit;
+  @include styles.font-body-m;
+}
+
+.input-adornment-content {
+  display: block;
+  flex: 1;
+  min-inline-size: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.input-adornment-divider {
+  display: block;
+  flex-shrink: 0;
+  inline-size: awsui.$border-width-field;
+  background-color: awsui.$color-border-divider-default;
+  align-self: stretch;
+}
+
+.input-adorned {
+  flex: 1;
+  min-inline-size: 0;
+  border-block: none;
+  border-inline: none;
+  border-start-start-radius: 0;
+  border-start-end-radius: 0;
+  border-end-start-radius: 0;
+  border-end-end-radius: 0;
+  background-color: transparent;
+  box-shadow: none;
+  min-block-size: unset;
+
+  &.input:focus {
+    border-block: 0;
+    border-inline: 0;
+    box-shadow: none;
+    outline: none;
+  }
+
+  &:hover {
+    border-color: transparent;
+    background-color: transparent;
+  }
+
+  &:disabled {
+    background-color: transparent;
+    border-color: transparent;
+    border-block: 0;
+    border-inline: 0;
+  }
+
+  &.input-readonly {
+    background-color: transparent;
+    border-color: transparent;
+    border-block: 0;
+    border-inline: 0;
+  }
+
+  &.input-invalid,
+  &.input-warning {
+    padding-inline-start: styles.$control-padding-horizontal;
+    border-block: 0;
+    border-inline: 0;
+    border-inline-start-width: 0;
+    box-shadow: none;
+
+    &:focus {
+      border-block: 0;
+      border-inline: 0;
+      box-shadow: none;
+      outline: none;
+    }
+  }
+}
+
+.input-adorned-container-invalid,
+.input-adorned-container-warning {
+  > .input-prefix,
+  > .input-adorned:first-child {
+    padding-inline-start: styles.$invalid-control-left-padding;
+  }
+
+  > .input-prefix,
+  > .input-suffix {
+    max-inline-size: max(
+      0px,
+      calc((100% - 12rem + #{styles.$invalid-control-left-border} - #{awsui.$border-width-field}) / 2)
+    );
+  }
 }

--- a/src/input/utils.ts
+++ b/src/input/utils.ts
@@ -18,11 +18,11 @@ export const useSearchProps = (
     onChange('');
   }, [inputRef, onChange]);
   if (type === 'search' || type === 'visualSearch') {
-    searchProps.__leftIcon = 'search';
+    searchProps.__startIcon = 'search';
 
     if (!disabled && !readOnly && value) {
-      searchProps.__rightIcon = 'close';
-      searchProps.__onRightIconClick = handleIconClick;
+      searchProps.__endIcon = 'close';
+      searchProps.__onEndIconClick = handleIconClick;
     }
   }
   return searchProps;

--- a/src/internal/components/chart-legend/styles.scss
+++ b/src/internal/components/chart-legend/styles.scss
@@ -32,6 +32,7 @@
 }
 
 .marker {
+  @include styles.text-wrapping;
   display: inline-flex;
   align-items: flex-start;
   padding-block: 0;

--- a/src/status-indicator/interfaces.ts
+++ b/src/status-indicator/interfaces.ts
@@ -54,6 +54,7 @@ export namespace StatusIndicatorProps {
     | 'pending'
     | 'in-progress'
     | 'loading'
-    | 'not-started';
+    | 'not-started'
+    | 'log';
   export type Color = 'blue' | 'grey' | 'green' | 'red' | 'yellow';
 }

--- a/src/status-indicator/internal-interfaces.ts
+++ b/src/status-indicator/internal-interfaces.ts
@@ -1,5 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-import { StatusIndicatorProps } from './interfaces';
-
-export type InternalStatusIndicatorType = StatusIndicatorProps.Type | 'log';

--- a/src/status-indicator/internal.tsx
+++ b/src/status-indicator/internal.tsx
@@ -9,22 +9,19 @@ import { IconProps } from '../icon/interfaces';
 import InternalIcon from '../icon/internal';
 import { getBaseProps } from '../internal/base-component';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import { SomeRequired } from '../internal/types';
 /**
  * @awsuiSystem core
  */
 import WithNativeAttributes from '../internal/utils/with-native-attributes';
 import InternalSpinner from '../spinner/internal';
 import { StatusIndicatorProps } from './interfaces';
-import { InternalStatusIndicatorType } from './internal-interfaces';
 
 import styles from './styles.css.js';
 
-export interface InternalStatusIndicatorProps extends Omit<StatusIndicatorProps, 'type'>, InternalBaseComponentProps {
-  /**
-   * Status type. The internal `log` value renders a plain dot for Steps.
-   */
-  type: InternalStatusIndicatorType;
-
+export interface InternalStatusIndicatorProps
+  extends SomeRequired<StatusIndicatorProps, 'type'>,
+    InternalBaseComponentProps {
   /**
    * Play an animation on the error icon when first rendered
    */
@@ -41,7 +38,7 @@ export interface InternalStatusIndicatorProps extends Omit<StatusIndicatorProps,
   __display?: 'inline' | 'inline-block';
 }
 
-const typeToIcon: (size: IconProps.Size) => Record<InternalStatusIndicatorType, JSX.Element> = size => ({
+const typeToIcon: (size: IconProps.Size) => Record<StatusIndicatorProps.Type, JSX.Element> = size => ({
   error: <InternalIcon name="status-negative" size={size} />,
   warning: <InternalIcon name="status-warning" size={size} />,
   success: <InternalIcon name="status-positive" size={size} />,

--- a/src/steps/interfaces.ts
+++ b/src/steps/interfaces.ts
@@ -8,7 +8,7 @@ export interface StepsProps extends BaseComponentProps {
    * An array of individual steps
    *
    * Each step definition has the following properties:
-   *  * `status` (string) - Status of the step corresponding to a status indicator. The `log` status renders a neutral dot marker.
+   *  * `status` (string) - Status of the step corresponding to a status indicator.
    *  * `statusIconAriaLabel` - (string) - (Optional) Alternative text for the status icon.
    *  * `header` (ReactNode) - Summary corresponding to the step.
    *  * `details` (ReactNode) - (Optional) Additional information corresponding to the step.
@@ -56,7 +56,7 @@ export interface StepsProps extends BaseComponentProps {
 }
 
 export namespace StepsProps {
-  export type Status = StatusIndicatorProps.Type | 'log';
+  export type Status = StatusIndicatorProps.Type;
 
   export interface Step {
     status: Status;

--- a/src/test-utils/dom/input/index.ts
+++ b/src/test-utils/dom/input/index.ts
@@ -12,4 +12,12 @@ export default class InputWrapper extends BaseInputWrapper {
   findClearButton(): ElementWrapper | null {
     return this.find(`.${inputSelectors['input-button-right']}`);
   }
+
+  findPrefix(): ElementWrapper | null {
+    return this.find(`.${inputSelectors['input-prefix']}`);
+  }
+
+  findSuffix(): ElementWrapper | null {
+    return this.find(`.${inputSelectors['input-suffix']}`);
+  }
 }

--- a/style-dictionary/one-theme/colors.ts
+++ b/style-dictionary/one-theme/colors.ts
@@ -43,6 +43,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorTextButtonNormalHover: { light: '{colorNeutral850}', dark: '{colorNeutral250}' },
   colorTextButtonNormalActive: { light: '{colorNeutral850}', dark: '{colorNeutral350}' },
   colorTextButtonNormalDisabled: { light: '{colorNeutral500}', dark: '{colorNeutral600}' },
+  colorTextInteractiveDisabled: { light: '{colorNeutral500}', dark: '{colorNeutral600}' },
 
   // Inline-link and icon buttons adopt the link hover color in one-theme.
   colorTextButtonInlineLinkHover: '{colorTextLinkHover}',
@@ -62,11 +63,11 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorBackgroundButtonPrimaryDefault: { light: '{colorNeutral800}', dark: '{colorNeutral300}' },
   colorBackgroundButtonPrimaryHover: { light: '{colorNeutral700}', dark: '{colorNeutral200}' },
   colorBackgroundButtonPrimaryActive: { light: '{colorNeutral800}', dark: '{colorNeutral300}' },
-  colorBackgroundButtonPrimaryDisabled: { light: '{colorNeutral400}', dark: '{colorNeutral700}' },
+  colorBackgroundButtonPrimaryDisabled: { light: '{colorNeutral250}', dark: '{colorNeutral700}' },
   colorTextButtonPrimaryDefault: { light: '{colorNeutral100}', dark: '{colorNeutral950}' },
   colorTextButtonPrimaryHover: { light: '{colorNeutral50}', dark: '{colorNeutral950}' },
   colorTextButtonPrimaryActive: { light: '{colorNeutral50}', dark: '{colorNeutral950}' },
-  colorTextButtonPrimaryDisabled: { light: '{colorNeutral100}', dark: '{colorNeutral950}' },
+  colorTextButtonPrimaryDisabled: { light: '{colorNeutral500}', dark: '{colorNeutral950}' },
 
   // ── Toggle button ─────────────────────────────────────────────────────────
   colorBackgroundToggleButtonNormalPressed: { light: '{colorWhite}', dark: '{colorNeutral1000}' },

--- a/style-dictionary/one-theme/colors.ts
+++ b/style-dictionary/one-theme/colors.ts
@@ -42,7 +42,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorTextButtonNormalDefault: { light: '{colorNeutral700}', dark: '{colorNeutral350}' },
   colorTextButtonNormalHover: { light: '{colorNeutral850}', dark: '{colorNeutral250}' },
   colorTextButtonNormalActive: { light: '{colorNeutral850}', dark: '{colorNeutral350}' },
-  colorTextButtonNormalDisabled: { light: '{colorNeutral450}', dark: '{colorNeutral600}' },
+  colorTextButtonNormalDisabled: { light: '{colorNeutral500}', dark: '{colorNeutral600}' },
 
   // Inline-link and icon buttons adopt the link hover color in one-theme.
   colorTextButtonInlineLinkHover: '{colorTextLinkHover}',


### PR DESCRIPTION
### Description
Ensure parts of graphical objects essential for understanding content have sufficient contrast

Update primary button disabled state to use the following values in light mode:
background: grey250
text and icon: grey500

updates Interactive disabled from neutral400 (#b7b7b7) to neutral500 (#909090) in 
light mode only