### PR TITLE
chore: Remediate 11 Dependabot security alerts (lockfile only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5343,9 +5343,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5481,9 +5481,9 @@
       }
     },
     "node_modules/@wdio/config/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6148,9 +6148,9 @@
       }
     },
     "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6914,9 +6914,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11893,9 +11893,9 @@
       }
     },
     "node_modules/html-validate/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12312,7 +12312,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15340,16 +15342,16 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/minimist": {
@@ -17871,9 +17873,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21082,9 +21084,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -21453,9 +21455,9 @@
       }
     },
     "node_modules/webdriver/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Automated Dependabot security-alert remediation

Alert-driven remediation of this repository's **open** Dependabot security alerts.
Baseline: `6db998486` on `main`.

### Alerts resolved (11 of 11)

| Alert | Sev | Package | Major line | Vulnerable range | First patched | Now resolved to | Advisory |
|---|---|---|---|---|---|---|---|
| #272 | medium | `ip-address` | 10.x | `>= 10.1.1, <= 10.2.0` | 10.2.1 | `10.4.0` | [GHSA-22jq-vg5j-6vgg](https://github.com/advisories/GHSA-22jq-vg5j-6vgg) (CVE-2026-54272) |
| #273 | medium | `ip-address` | 10.x | `>= 10.1.1, <= 10.2.1` | 10.2.2 | `10.4.0` | [GHSA-4xrf-jv44-h6hh](https://github.com/advisories/GHSA-4xrf-jv44-h6hh) (CVE-2026-69198) |
| #280 | high | `ip-address` | 10.x | `<= 10.3.0` | 10.3.1 | `10.4.0` | [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr) (CVE-2026-69192) |
| #274 | medium | `undici` | 7.x | `>= 7.0.0, < 7.29.0` | 7.29.0 | `7.29.0, 6.28.0` | [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) (CVE-2026-16728) |
| #275 | high | `undici` | 7.x | `>= 7.0.0, < 7.29.0` | 7.29.0 | `7.29.0, 6.28.0` | [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) (CVE-2026-13697) |
| #276 | medium | `undici` | 7.x | `>= 7.0.0, < 7.29.0` | 7.29.0 | `7.29.0, 6.28.0` | [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) (CVE-2026-16729) |
| #277 | medium | `undici` | 7.x | `>= 7.0.0, < 7.29.0` | 7.29.0 | `7.29.0, 6.28.0` | [GHSA-jr45-8vmc-qm54](https://github.com/advisories/GHSA-jr45-8vmc-qm54) (CVE-2026-14643) |
| #278 | medium | `undici` | 7.x | `>= 7.0.0, < 7.29.0` | 7.29.0 | `7.29.0, 6.28.0` | [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5) (CVE-2026-15157) |
| #281 | medium | `undici` | 6.x | `< 6.28.0` | 6.28.0 | `7.29.0, 6.28.0` | [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5) (CVE-2026-15157) |
| #282 | medium | `undici` | 6.x | `< 6.28.0` | 6.28.0 | `7.29.0, 6.28.0` | [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) (CVE-2026-16728) |
| #284 | medium | `undici` | 6.x | `< 6.28.0` | 6.28.0 | `7.29.0, 6.28.0` | [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) (CVE-2026-16729) |

### How this was remediated

* **Rung 1 — `npm audit fix --package-lock-only --ignore-scripts`** (no `--force` was used anywhere in this run).
* The repo's own `prepare-package-lock` convention (`postinstall` in `@cloudscape-design/build-tools`) was applied afterwards, so no `@cloudscape-design/*` entries are (re-)introduced into the lockfile.
* npm's full reconciliation additionally healed unrelated pre-existing lockfile drift (stale entries, `dev`/`optional` flags, unrelated minor bumps). **That collateral was deliberately discarded**: only the security-relevant entries from npm's computed result were applied on top of the committed lockfile, so this diff contains alert-driven changes only.
* Verified with `npm ls --package-lock-only --all`: **zero new** unmet/invalid dependency problems versus `main`.

### Lockfile changes (10)

| Package | From | To | Scope | Lockfile path |
|---|---|---|---|---|
| `brace-expansion` | 2.1.2 | 2.1.4 | dev | `node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion` |
| `brace-expansion` | 2.1.2 | 2.1.4 | dev | `node_modules/@wdio/config/node_modules/brace-expansion` |
| `brace-expansion` | 2.1.2 | 2.1.4 | dev | `node_modules/archiver-utils/node_modules/brace-expansion` |
| `brace-expansion` | 1.1.16 | 1.1.18 | dev | `node_modules/brace-expansion` |
| `brace-expansion` | 2.1.2 | 2.1.4 | dev | `node_modules/html-validate/node_modules/brace-expansion` |
| `brace-expansion` | 5.0.7 | 5.0.9 | dev | `node_modules/minimatch/node_modules/brace-expansion` |
| `brace-expansion` | 2.1.2 | 2.1.4 | dev | `node_modules/readdir-glob/node_modules/brace-expansion` |
| `ip-address` | 10.2.0 | 10.4.0 | dev | `node_modules/ip-address` |
| `undici` | 7.28.0 | 7.29.0 | dev | `node_modules/undici` |
| `undici` | 6.27.0 | 6.28.0 | dev | `node_modules/webdriver/node_modules/undici` |

### NPMPM (NpmPrettyMuch) availability — internal build safety

**Not applicable — 0 non-dev dependencies changed.** Every version bump in this PR is `dev: true`, which the NPMPM availability check skips, so there is no internal-build (Brazil) impact and the check should come back green.

### Does merging clear this repository's alert list?

**Yes.** Merging this PR is expected to close **all 11** of this repository's currently-open Dependabot security alerts.

---

<sub>Existing Dependabot-authored PRs were deliberately **not** touched, reviewed, rebased, or closed by this run.</sub>

> Opened by roko-dependabot on behalf of @ernst-dev. Alert-driven remediation; not merged — a human must review and merge.
