### PR TITLE
feat: Add resize property to textarea

### DIFF
--- a/pages/textarea/permutations.page.tsx
+++ b/pages/textarea/permutations.page.tsx
@@ -43,6 +43,10 @@ const permutations = createPermutations<TextareaProps>([
     placeholder: ['Placeholder with\nmultiple lines'],
     value: [''],
   },
+  {
+    resize: ['both', 'horizontal', 'vertical', 'none'],
+    value: ['Resizable in the direction given by the resize property'],
+  },
 ]);
 
 export default function TextareaPermutations() {

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -31111,6 +31111,30 @@ Don't use read-only inputs outside a form.",
       "type": "boolean",
     },
     {
+      "defaultValue": "'both'",
+      "description": "Specifies the directions in which the user can resize the textarea:
+
+* \`both\` (default) - The user can change both the width and the height.
+* \`vertical\` - The user can only change the height. Use this when the textarea
+  is next to other content that a width change would disrupt.
+* \`horizontal\` - The user can only change the width.
+* \`none\` - The user can't resize the textarea. Longer content scrolls instead.
+  Consider using the \`rows\` property to make the initial height fit the expected content.",
+      "inlineType": {
+        "name": "TextareaProps.Resize",
+        "type": "union",
+        "values": [
+          "none",
+          "both",
+          "horizontal",
+          "vertical",
+        ],
+      },
+      "name": "resize",
+      "optional": true,
+      "type": "string",
+    },
+    {
       "description": "Specifies the number of lines of text to set the height to.",
       "name": "rows",
       "optional": true,

--- a/src/textarea/__tests__/textarea.test.tsx
+++ b/src/textarea/__tests__/textarea.test.tsx
@@ -248,6 +248,31 @@ describe('Textarea', () => {
     });
   });
 
+  describe('resize', () => {
+    test('allows resizing in both directions by default', () => {
+      const { textarea } = renderTextarea();
+      expect(textarea).toHaveClass(styles['textarea-resize-both']);
+    });
+
+    test.each<TextareaProps.Resize>(['both', 'horizontal', 'vertical', 'none'])('can be set to %s', resize => {
+      const { textarea } = renderTextarea({ resize });
+      expect(textarea).toHaveClass(styles[`textarea-resize-${resize}`]);
+    });
+
+    test('applies only the class matching the given value', () => {
+      const { textarea } = renderTextarea({ resize: 'vertical' });
+      expect(textarea).toHaveClass(styles['textarea-resize-vertical']);
+      expect(textarea).not.toHaveClass(styles['textarea-resize-both']);
+      expect(textarea).not.toHaveClass(styles['textarea-resize-horizontal']);
+      expect(textarea).not.toHaveClass(styles['textarea-resize-none']);
+    });
+
+    test('does not render a resize attribute on the native textarea', () => {
+      const { textarea } = renderTextarea({ resize: 'none' });
+      expect(textarea).not.toHaveAttribute('resize');
+    });
+  });
+
   describe('id and controlId', () => {
     test('id is rendered on the outer tag', () => {
       const { textareaWrapper } = renderTextarea({ id: 'something-specific' });

--- a/src/textarea/index.tsx
+++ b/src/textarea/index.tsx
@@ -40,6 +40,7 @@ const Textarea = React.forwardRef(
       ariaRequired,
       name,
       rows,
+      resize = 'both',
       placeholder,
       autoFocus,
       ariaLabel,
@@ -50,7 +51,15 @@ const Textarea = React.forwardRef(
     ref: Ref<TextareaProps.Ref>
   ) => {
     const { __internalRootRef } = useBaseComponent('Textarea', {
-      props: { autoComplete, autoFocus, disableBrowserAutocorrect, disableBrowserSpellcheck, readOnly, spellcheck },
+      props: {
+        autoComplete,
+        autoFocus,
+        disableBrowserAutocorrect,
+        disableBrowserSpellcheck,
+        readOnly,
+        resize,
+        spellcheck,
+      },
     });
     const { ariaLabelledby, ariaDescribedby, controlId, invalid, warning } = useFormFieldContext(rest);
 
@@ -68,7 +77,7 @@ const Textarea = React.forwardRef(
       name,
       placeholder,
       autoFocus,
-      className: clsx(styles.textarea, {
+      className: clsx(styles.textarea, styles[`textarea-resize-${resize}`], {
         [styles['textarea-readonly']]: readOnly,
         [styles['textarea-invalid']]: invalid,
         [styles['textarea-warning']]: warning && !invalid,

--- a/src/textarea/interfaces.ts
+++ b/src/textarea/interfaces.ts
@@ -29,6 +29,18 @@ export interface TextareaProps
   rows?: number;
 
   /**
+   * Specifies the directions in which the user can resize the textarea:
+   *
+   * * `both` (default) - The user can change both the width and the height.
+   * * `vertical` - The user can only change the height. Use this when the textarea
+   *   is next to other content that a width change would disrupt.
+   * * `horizontal` - The user can only change the width.
+   * * `none` - The user can't resize the textarea. Longer content scrolls instead.
+   *   Consider using the `rows` property to make the initial height fit the expected content.
+   */
+  resize?: TextareaProps.Resize;
+
+  /**
    * Specifies whether to disable browser spellcheck feature.
    * If you set this to `true`, it disables native browser capability
    * that checks for spelling/grammar errors.
@@ -61,6 +73,8 @@ export interface TextareaProps
 
 export namespace TextareaProps {
   export type KeyDetail = BaseKeyDetail;
+
+  export type Resize = 'both' | 'horizontal' | 'vertical' | 'none';
 
   export interface ChangeDetail {
     /**

--- a/src/textarea/styles.scss
+++ b/src/textarea/styles.scss
@@ -14,8 +14,8 @@
 
 .textarea {
   @include styles.styles-reset;
-  // Restore browsers' default resize values
-  resize: auto;
+  // Matches browsers' default for textarea; overridden by the resize modifiers below
+  resize: both;
   // Restore default text cursor
   cursor: text;
   // Allow multi-line placeholders
@@ -43,6 +43,25 @@
   box-shadow: var(#{custom-props.$styleBoxShadowDefault});
 
   @include styles.font-body-m;
+
+  // Physical axes are used here rather than logical ones: resize axes follow
+  // `writing-mode`, which is always horizontal-tb, so `block`/`inline` would
+  // resolve identically in both LTR and RTL.
+  &.textarea-resize-both {
+    resize: both;
+  }
+
+  &.textarea-resize-horizontal {
+    resize: horizontal;
+  }
+
+  &.textarea-resize-vertical {
+    resize: vertical;
+  }
+
+  &.textarea-resize-none {
+    resize: none;
+  }
 
   &:hover {
     border-color: var(


### PR DESCRIPTION
### Description

Adds a `resize` property to `Textarea` so consumers can constrain the resize handle. Values mirror the CSS property: `both` (default), `horizontal`, `vertical`, `none`.

Previously the component hard-coded `resize: auto` in its stylesheet with no supported override. The only workaround was `nativeTextareaAttributes.style`, which is internal-only and whose own docs state it must not be used for custom styling.

Two notes on the implementation:

**Physical axis names, not logical.** CSS also offers `block`/`inline`, but resize axes follow `writing-mode`, not `direction` — so in `horizontal-tb` (used throughout Cloudscape) they resolve identically to `vertical`/`horizontal` in both LTR and RTL. I verified this by drag-resizing in Chrome across `dir` × `writing-mode`; the axes only swap under `vertical-rl`/`vertical-lr`, which isn't supported. Offering both spellings would add redundant surface area for identical behavior. Physical names also match every existing axis-valued prop (`Divider.Orientation`, `SpaceBetween.Direction`, `RadioGroup.direction`, `NavigableGroup.navigationDirection`); no component currently uses `block`/`inline` as an axis name.

**`resize: auto` → `resize: both` in the base rule.** `auto` isn't a spec value for `resize`; browsers compute it to `both` for textarea. Rendering is unchanged, the off-spec value is gone, and the default is now stated in the API docs.

Closes #4877

### How has this been tested?

- 4 new unit tests in `src/textarea/__tests__/textarea.test.tsx`; all 71 textarea tests pass, plus 3176 tests across the textarea, input, prompt-input, and snapshot suites.
- Verified end-to-end in Chrome 151 by driving the built `permutations` page with Puppeteer: computed style and actual drag behavior match the expected axis for all four values, in both LTR and RTL (8/8).
- New permutations entry gives visual-regression coverage of all four values.
- `documenter` snapshot updated; stylelint, eslint, and prettier are clean.

<details>
  <summary>Review checklist</summary>

#### Correctness

- [x] Changes include appropriate documentation updates (JSDoc on the new property).
- [x] Changes are backward-compatible — `resize` defaults to `both`, which is what `resize: auto` already computed to.
- [x] No unsupported browser features used — the physical `resize` keywords have been supported since Chrome 4 / Firefox 4 / Safari 4.
- [x] Changes were manually tested for accessibility — the property only affects the native resize handle; keyboard navigation and screen reader behavior are unchanged.

#### Security

- [x] No URL handling introduced.

#### Testing

- [x] Changes are covered with new unit tests.
- [x] Visual regression coverage added via the permutations page.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
