### PR TITLE
fix: Add colorTextInteractiveDisabled override in one-theme

### DIFF
--- a/style-dictionary/one-theme/colors.ts
+++ b/style-dictionary/one-theme/colors.ts
@@ -43,6 +43,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorTextButtonNormalHover: { light: '{colorNeutral850}', dark: '{colorNeutral250}' },
   colorTextButtonNormalActive: { light: '{colorNeutral850}', dark: '{colorNeutral350}' },
   colorTextButtonNormalDisabled: { light: '{colorNeutral500}', dark: '{colorNeutral600}' },
+  colorTextInteractiveDisabled: { light: '{colorNeutral500}', dark: '{colorNeutral600}' },
 
   // Inline-link and icon buttons adopt the link hover color in one-theme.
   colorTextButtonInlineLinkHover: '{colorTextLinkHover}',


### PR DESCRIPTION
### Description

Issue:
Loading spinners and icons in disabled interactive elements (inline-link buttons)
in the one-theme have a color contrast ratio of only 2.00:1 (#b7b7b7 on #ffffff), which fails the 
WCAG 3:1 minimum contrast requirement for non-text graphical elements. Users with low vision have 
difficulty identifying this content.

Fix:
Added a colorTextInteractiveDisabled override in the one-theme, changing the light mode value from 
#b7b7b7 to #909090. This brings the contrast ratio to 3.94:1 
against white backgrounds, meeting the 3:1 requirement. The dark mode value remains unchanged at 
colorNeutral600.
