### PR TITLE
Chore: Force Sass to not strip out calc

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     {
       "path": "lib/components/internal/widget-exports.js",
       "brotli": false,
-      "limit": "1370 kB",
+      "limit": "1380 kB",
       "ignore": "react-dom"
     }
   ],

--- a/pages/input/adornments.page.tsx
+++ b/pages/input/adornments.page.tsx
@@ -1,0 +1,148 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext } from 'react';
+
+import Box from '~components/box';
+import FormField from '~components/form-field';
+import Icon from '~components/icon';
+import Input, { InputProps } from '~components/input';
+import Select, { SelectProps } from '~components/select';
+import SpaceBetween from '~components/space-between';
+import Toggle from '~components/toggle';
+
+import AppContext, { AppContextType } from '../app/app-context';
+import { SimplePage } from '../app/templates';
+
+type AdornmentMode = 'none' | 'short' | 'long' | 'icon';
+
+type PageContext = React.Context<
+  AppContextType<{
+    type?: InputProps.Type;
+    prefix?: AdornmentMode;
+    suffix?: AdornmentMode;
+    disabled?: boolean;
+    readOnly?: boolean;
+    invalid?: boolean;
+    warning?: boolean;
+    value?: string;
+  }>
+>;
+
+const typeOptions: ReadonlyArray<SelectProps.Option> = [
+  { value: 'text', label: 'Text' },
+  { value: 'password', label: 'Password' },
+  { value: 'number', label: 'Number' },
+  { value: 'email', label: 'Email' },
+  { value: 'url', label: 'URL' },
+  { value: 'search', label: 'Search' },
+];
+
+const adornmentOptions: ReadonlyArray<SelectProps.Option> = [
+  { value: 'none', label: 'None' },
+  { value: 'short', label: 'Short text' },
+  { value: 'long', label: 'Long text' },
+  { value: 'icon', label: 'Icon' },
+];
+
+function getPrefix(mode: AdornmentMode): React.ReactNode {
+  switch (mode) {
+    case 'short':
+      return '$';
+    case 'long':
+      return 'https://example.com/very-long-prefix-that-overflows';
+    case 'icon':
+      return <Icon name="search" />;
+    default:
+      return undefined;
+  }
+}
+
+function getSuffix(mode: AdornmentMode): React.ReactNode {
+  switch (mode) {
+    case 'short':
+      return '%';
+    case 'long':
+      return '.ec2.internal.very-long-domain-that-overflows';
+    case 'icon':
+      return <Icon name="settings" />;
+    default:
+      return undefined;
+  }
+}
+
+export default function AdornmentsPage() {
+  const { urlParams, setUrlParams } = useContext(AppContext as PageContext);
+  const type = urlParams.type ?? 'text';
+  const prefixMode = urlParams.prefix ?? 'short';
+  const suffixMode = urlParams.suffix ?? 'short';
+  const disabled = urlParams.disabled ?? false;
+  const readOnly = urlParams.readOnly ?? false;
+  const invalid = urlParams.invalid ?? false;
+  const warning = urlParams.warning ?? false;
+
+  return (
+    <SimplePage
+      title="Input prefix and suffix"
+      settings={
+        <SpaceBetween direction="horizontal" size="s" alignItems="center">
+          <Select
+            inlineLabelText="Type"
+            selectedOption={typeOptions.find(option => option.value === type) ?? null}
+            options={typeOptions}
+            onChange={({ detail }) => setUrlParams({ type: detail.selectedOption.value as InputProps.Type })}
+          />
+          <Select
+            inlineLabelText="Prefix"
+            selectedOption={adornmentOptions.find(option => option.value === prefixMode) ?? null}
+            options={adornmentOptions}
+            onChange={({ detail }) => setUrlParams({ prefix: detail.selectedOption.value as AdornmentMode })}
+          />
+          <Select
+            inlineLabelText="Suffix"
+            selectedOption={adornmentOptions.find(option => option.value === suffixMode) ?? null}
+            options={adornmentOptions}
+            onChange={({ detail }) => setUrlParams({ suffix: detail.selectedOption.value as AdornmentMode })}
+          />
+          <Toggle checked={disabled} onChange={({ detail }) => setUrlParams({ disabled: detail.checked })}>
+            Disabled
+          </Toggle>
+          <Toggle checked={readOnly} onChange={({ detail }) => setUrlParams({ readOnly: detail.checked })}>
+            Read-only
+          </Toggle>
+          <Toggle checked={invalid} onChange={({ detail }) => setUrlParams({ invalid: detail.checked })}>
+            Invalid
+          </Toggle>
+          <Toggle checked={warning} onChange={({ detail }) => setUrlParams({ warning: detail.checked })}>
+            Warning
+          </Toggle>
+        </SpaceBetween>
+      }
+    >
+      <FormField
+        label="Input with prefix and suffix"
+        errorText={invalid ? 'Validation error.' : undefined}
+        warningText={warning && !invalid ? 'Validation warning.' : undefined}
+      >
+        <Input
+          value={urlParams.value ?? ''}
+          onChange={({ detail }) => setUrlParams({ value: detail.value })}
+          type={type}
+          prefix={getPrefix(prefixMode)}
+          suffix={getSuffix(suffixMode)}
+          disabled={disabled}
+          readOnly={readOnly}
+          invalid={invalid}
+          warning={warning}
+          placeholder="Enter a value"
+          clearAriaLabel="Clear"
+        />
+      </FormField>
+
+      {type === 'search' && (
+        <Box variant="small" color="text-body-secondary">
+          Prefix and suffix are ignored for search inputs.
+        </Box>
+      )}
+    </SimplePage>
+  );
+}

--- a/pages/input/permutations.page.tsx
+++ b/pages/input/permutations.page.tsx
@@ -55,7 +55,6 @@ const permutations = createPermutations<InputProps>([
   { value: ['10'], prefix: ['$'], suffix: ['USD'], invalid: [true], warning: [false] },
   { value: ['10'], prefix: ['$'], suffix: ['USD'], invalid: [false], warning: [true] },
   { type: ['search'], value: ['', 'query'], prefix: ['$'], suffix: ['USD'], clearAriaLabel: ['Clear'] },
-  { value: ['10'], prefix: [0], suffix: [0] },
   { value: ['10'], prefix: [longAdornment], suffix: [longAdornment] },
   { value: ['10'], prefix: ['$'], suffix: ['USD'] },
 ]);

--- a/pages/input/permutations.page.tsx
+++ b/pages/input/permutations.page.tsx
@@ -58,7 +58,6 @@ const permutations = createPermutations<InputProps>([
   { value: ['10'], prefix: [0], suffix: [0] },
   { value: ['10'], prefix: [longAdornment], suffix: [longAdornment] },
   { value: ['10'], prefix: ['$'], suffix: ['USD'] },
-  { value: ['10'], prefix: ['$'], suffix: ['USD'] },
 ]);
 
 export default function InputPermutations() {

--- a/pages/input/permutations.page.tsx
+++ b/pages/input/permutations.page.tsx
@@ -8,6 +8,8 @@ import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
 
+const longAdornment = 'A long decorative prefix or suffix that must not cover the editable value';
+
 const permutations = createPermutations<InputProps>([
   {
     disabled: [false, true],
@@ -47,6 +49,16 @@ const permutations = createPermutations<InputProps>([
     value: ['100000000'],
     placeholder: ['Short placeholder'],
   },
+  { value: ['10'], prefix: ['$'], suffix: [undefined] },
+  { value: ['10'], prefix: [undefined], suffix: ['USD'] },
+  { value: ['10'], prefix: ['$'], suffix: ['USD'], disabled: [false, true], readOnly: [false, true] },
+  { value: ['10'], prefix: ['$'], suffix: ['USD'], invalid: [true], warning: [false] },
+  { value: ['10'], prefix: ['$'], suffix: ['USD'], invalid: [false], warning: [true] },
+  { type: ['search'], value: ['', 'query'], prefix: ['$'], suffix: ['USD'], clearAriaLabel: ['Clear'] },
+  { value: ['10'], prefix: [0], suffix: [0] },
+  { value: ['10'], prefix: [longAdornment], suffix: [longAdornment] },
+  { value: ['10'], prefix: ['$'], suffix: ['USD'] },
+  { value: ['10'], prefix: ['$'], suffix: ['USD'] },
 ]);
 
 export default function InputPermutations() {

--- a/pages/input/prefix-suffix.page.tsx
+++ b/pages/input/prefix-suffix.page.tsx
@@ -13,13 +13,13 @@ import Toggle from '~components/toggle';
 import AppContext, { AppContextType } from '../app/app-context';
 import { SimplePage } from '../app/templates';
 
-type AdornmentMode = 'none' | 'short' | 'long' | 'icon';
+type PrefixSuffixMode = 'none' | 'short' | 'long' | 'icon';
 
 type PageContext = React.Context<
   AppContextType<{
     type?: InputProps.Type;
-    prefix?: AdornmentMode;
-    suffix?: AdornmentMode;
+    prefix?: PrefixSuffixMode;
+    suffix?: PrefixSuffixMode;
     disabled?: boolean;
     readOnly?: boolean;
     invalid?: boolean;
@@ -37,14 +37,14 @@ const typeOptions: ReadonlyArray<SelectProps.Option> = [
   { value: 'search', label: 'Search' },
 ];
 
-const adornmentOptions: ReadonlyArray<SelectProps.Option> = [
+const prefixSuffixOptions: ReadonlyArray<SelectProps.Option> = [
   { value: 'none', label: 'None' },
   { value: 'short', label: 'Short text' },
   { value: 'long', label: 'Long text' },
   { value: 'icon', label: 'Icon' },
 ];
 
-function getPrefix(mode: AdornmentMode): React.ReactNode {
+function getPrefix(mode: PrefixSuffixMode): React.ReactNode {
   switch (mode) {
     case 'short':
       return '$';
@@ -57,7 +57,7 @@ function getPrefix(mode: AdornmentMode): React.ReactNode {
   }
 }
 
-function getSuffix(mode: AdornmentMode): React.ReactNode {
+function getSuffix(mode: PrefixSuffixMode): React.ReactNode {
   switch (mode) {
     case 'short':
       return '%';
@@ -70,7 +70,7 @@ function getSuffix(mode: AdornmentMode): React.ReactNode {
   }
 }
 
-export default function AdornmentsPage() {
+export default function PrefixSuffixPage() {
   const { urlParams, setUrlParams } = useContext(AppContext as PageContext);
   const type = urlParams.type ?? 'text';
   const prefixMode = urlParams.prefix ?? 'short';
@@ -93,15 +93,15 @@ export default function AdornmentsPage() {
           />
           <Select
             inlineLabelText="Prefix"
-            selectedOption={adornmentOptions.find(option => option.value === prefixMode) ?? null}
-            options={adornmentOptions}
-            onChange={({ detail }) => setUrlParams({ prefix: detail.selectedOption.value as AdornmentMode })}
+            selectedOption={prefixSuffixOptions.find(option => option.value === prefixMode) ?? null}
+            options={prefixSuffixOptions}
+            onChange={({ detail }) => setUrlParams({ prefix: detail.selectedOption.value as PrefixSuffixMode })}
           />
           <Select
             inlineLabelText="Suffix"
-            selectedOption={adornmentOptions.find(option => option.value === suffixMode) ?? null}
-            options={adornmentOptions}
-            onChange={({ detail }) => setUrlParams({ suffix: detail.selectedOption.value as AdornmentMode })}
+            selectedOption={prefixSuffixOptions.find(option => option.value === suffixMode) ?? null}
+            options={prefixSuffixOptions}
+            onChange={({ detail }) => setUrlParams({ suffix: detail.selectedOption.value as PrefixSuffixMode })}
           />
           <Toggle checked={disabled} onChange={({ detail }) => setUrlParams({ disabled: detail.checked })}>
             Disabled

--- a/pages/input/style-permutations.page.tsx
+++ b/pages/input/style-permutations.page.tsx
@@ -15,6 +15,8 @@ const permutations = createPermutations<InputProps>([
     disabled: [false, true],
     readOnly: [false, true],
     onChange: [() => {}],
+    prefix: [undefined, '$'],
+    suffix: [undefined, 'USD'],
     style: [
       {
         root: {

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -17404,7 +17404,18 @@ with the input using \`ariaDescribedby\`.",
       "type": "boolean",
     },
   ],
-  "regions": [],
+  "regions": [
+    {
+      "description": "Use for content rendered before the editable value.",
+      "isDefault": false,
+      "name": "prefix",
+    },
+    {
+      "description": "Use for content rendered after the editable value.",
+      "isDefault": false,
+      "name": "suffix",
+    },
+  ],
   "releaseStatus": "stable",
 }
 `;
@@ -35506,6 +35517,32 @@ Supported options:
           },
         },
         {
+          "name": "findPrefix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "name": "findSuffix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
           "inheritedFrom": {
             "name": "BaseInputWrapper.focus",
           },
@@ -37160,6 +37197,22 @@ To find a specific row use the \`findRow(n)\` function as chaining \`findRows().
           },
         },
         {
+          "inheritedFrom": {
+            "name": "InputWrapper.findPrefix",
+          },
+          "name": "findPrefix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
           "name": "findStatusIndicator",
           "parameters": [
             {
@@ -37172,6 +37225,22 @@ To find a specific row use the \`findRow(n)\` function as chaining \`findRows().
               "typeName": "{ expandToViewport: boolean; }",
             },
           ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "InputWrapper.findSuffix",
+          },
+          "name": "findSuffix",
+          "parameters": [],
           "returnType": {
             "isNullable": true,
             "name": "ElementWrapper",
@@ -43462,6 +43531,22 @@ and this method will have no effect.",
           },
         },
         {
+          "inheritedFrom": {
+            "name": "InputWrapper.findPrefix",
+          },
+          "name": "findPrefix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
           "description": "Returns custom property form cancel button.",
           "name": "findPropertyCancelButton",
           "parameters": [
@@ -43542,6 +43627,22 @@ and this method will have no effect.",
               "typeName": "{ expandToViewport: boolean; }",
             },
           ],
+          "returnType": {
+            "isNullable": true,
+            "name": "ElementWrapper",
+            "typeArguments": [
+              {
+                "name": "HTMLElement",
+              },
+            ],
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "InputWrapper.findSuffix",
+          },
+          "name": "findSuffix",
+          "parameters": [],
           "returnType": {
             "isNullable": true,
             "name": "ElementWrapper",
@@ -48000,6 +48101,22 @@ Supported options:
             "name": "ElementWrapper",
           },
         },
+        {
+          "name": "findPrefix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "name": "findSuffix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
       ],
       "name": "InputWrapper",
     },
@@ -49137,6 +49254,17 @@ To find a specific row use the \`findRow(n)\` function as chaining \`findRows().
           },
         },
         {
+          "inheritedFrom": {
+            "name": "InputWrapper.findPrefix",
+          },
+          "name": "findPrefix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
           "name": "findStatusIndicator",
           "parameters": [
             {
@@ -49151,6 +49279,17 @@ To find a specific row use the \`findRow(n)\` function as chaining \`findRows().
               "typeName": "{ expandToViewport: boolean; }",
             },
           ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "InputWrapper.findSuffix",
+          },
+          "name": "findSuffix",
+          "parameters": [],
           "returnType": {
             "isNullable": false,
             "name": "ElementWrapper",
@@ -53636,6 +53775,17 @@ In this case, use findContentEditableElement() instead.",
           },
         },
         {
+          "inheritedFrom": {
+            "name": "InputWrapper.findPrefix",
+          },
+          "name": "findPrefix",
+          "parameters": [],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
           "description": "Returns custom property form cancel button.",
           "name": "findPropertyCancelButton",
           "parameters": [
@@ -53712,6 +53862,17 @@ In this case, use findContentEditableElement() instead.",
               "typeName": "{ expandToViewport: boolean; }",
             },
           ],
+          "returnType": {
+            "isNullable": false,
+            "name": "ElementWrapper",
+          },
+        },
+        {
+          "inheritedFrom": {
+            "name": "InputWrapper.findSuffix",
+          },
+          "name": "findSuffix",
+          "parameters": [],
           "returnType": {
             "isNullable": false,
             "name": "ElementWrapper",

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -378,6 +378,8 @@ exports[`test-utils selectors 1`] = `
   "input": [
     "awsui_input-button-right_2rhyz",
     "awsui_input-container_2rhyz",
+    "awsui_input-prefix_2rhyz",
+    "awsui_input-suffix_2rhyz",
     "awsui_input_2rhyz",
     "awsui_root_2rhyz",
   ],

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -376,7 +376,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_icon_h11ix",
   ],
   "input": [
-    "awsui_input-button-end_2rhyz",
+    "awsui_input-button-right_2rhyz",
     "awsui_input-container_2rhyz",
     "awsui_input-prefix_2rhyz",
     "awsui_input-suffix_2rhyz",

--- a/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -376,7 +376,7 @@ exports[`test-utils selectors 1`] = `
     "awsui_icon_h11ix",
   ],
   "input": [
-    "awsui_input-button-right_2rhyz",
+    "awsui_input-button-end_2rhyz",
     "awsui_input-container_2rhyz",
     "awsui_input-prefix_2rhyz",
     "awsui_input-suffix_2rhyz",

--- a/src/input/__tests__/adornments.test.tsx
+++ b/src/input/__tests__/adornments.test.tsx
@@ -1,0 +1,166 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import '../../__a11y__/to-validate-a11y';
+import Input, { InputProps } from '../../../lib/components/input';
+import InternalInput from '../../../lib/components/input/internal';
+import customCssProps from '../../../lib/components/internal/generated/custom-css-properties';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+import styles from '../../../lib/components/input/styles.css.js';
+
+function renderInput(props: Partial<InputProps> = {}) {
+  const { container, rerender } = render(<Input value="" onChange={() => {}} {...props} />);
+  const wrapper = createWrapper(container).findInput()!;
+  return { wrapper, rerender };
+}
+
+describe('prefix and suffix adornments', () => {
+  test('does not render adornment container, prefix, or suffix by default', () => {
+    const { wrapper } = renderInput();
+    expect(wrapper.findByClassName(styles['input-adorned-container'])).toBeNull();
+    expect(wrapper.findPrefix()).toBeNull();
+    expect(wrapper.findSuffix()).toBeNull();
+    expect(wrapper.findNativeInput().getElement()).not.toHaveClass(styles['input-adorned']);
+  });
+
+  test('renders a prefix', () => {
+    const { wrapper } = renderInput({ prefix: '$' });
+    expect(wrapper.findPrefix()!.getElement()).toHaveTextContent('$');
+    expect(wrapper.findSuffix()).toBeNull();
+    expect(wrapper.findByClassName(styles['input-adorned-container'])).not.toBeNull();
+    expect(wrapper.findNativeInput().getElement()).toHaveClass(styles['input-adorned']);
+  });
+
+  test('renders a suffix', () => {
+    const { wrapper } = renderInput({ suffix: '%' });
+    expect(wrapper.findSuffix()!.getElement()).toHaveTextContent('%');
+    expect(wrapper.findPrefix()).toBeNull();
+    expect(wrapper.findNativeInput().getElement()).toHaveClass(styles['input-adorned']);
+  });
+
+  test('renders both a prefix and a suffix', () => {
+    const { wrapper } = renderInput({ prefix: 'https://', suffix: '.com' });
+    expect(wrapper.findPrefix()!.getElement()).toHaveTextContent('https://');
+    expect(wrapper.findSuffix()!.getElement()).toHaveTextContent('.com');
+  });
+
+  test('renders a divider only on sides that have an adornment', () => {
+    const { wrapper, rerender } = renderInput({ prefix: '$' });
+    expect(wrapper.findAllByClassName(styles['input-adornment-divider'])).toHaveLength(1);
+
+    rerender(<Input value="" onChange={() => {}} prefix="$" suffix="%" />);
+    expect(wrapper.findAllByClassName(styles['input-adornment-divider'])).toHaveLength(2);
+  });
+
+  test('renders arbitrary React nodes', () => {
+    const { wrapper } = renderInput({ prefix: <span data-testid="custom">node</span> });
+    expect(wrapper.findPrefix()!.find('[data-testid="custom"]')).not.toBeNull();
+  });
+
+  test('renders numeric adornments', () => {
+    const { wrapper } = renderInput({ prefix: 0, suffix: 0 });
+    expect(wrapper.findPrefix()!.getElement()).toHaveTextContent('0');
+    expect(wrapper.findSuffix()!.getElement()).toHaveTextContent('0');
+  });
+
+  test('applies custom Input styles to the adorned container', () => {
+    const style: InputProps['style'] = {
+      root: {
+        backgroundColor: { default: '#ffffff', hover: '#f2f3f3' },
+        borderColor: { default: '#000000', hover: '#111111' },
+        borderRadius: '6px',
+        borderWidth: '2px',
+        color: { default: '#222222', disabled: '#999999' },
+        paddingBlock: '12px',
+        paddingInline: '16px',
+      },
+    };
+    const { wrapper } = renderInput({ prefix: '$', style });
+    const container = wrapper.findByClassName(styles['input-adorned-container'])!.getElement();
+
+    expect(container).toHaveStyle({ borderRadius: '6px', borderWidth: '2px' });
+    expect(container.style.getPropertyValue(customCssProps.styleBackgroundHover)).toBe('#f2f3f3');
+    expect(container.style.getPropertyValue(customCssProps.styleBorderColorHover)).toBe('#111111');
+    expect(container.style.getPropertyValue(customCssProps.styleColorDisabled)).toBe('#999999');
+
+    // paddingBlock and paddingInline go to the native input, NOT the container
+    const nativeInput = wrapper.findNativeInput()!.getElement();
+    expect(nativeInput.style.paddingBlock).toBe('12px');
+    expect(nativeInput.style.paddingInline).toBe('16px');
+  });
+
+  test('contains the right icon within the adorned focus container', () => {
+    const { container } = render(<InternalInput value="" onChange={() => {}} prefix="$" __rightIcon="settings" />);
+    const adornedContainer = container.querySelector(`.${styles['input-adorned-container']}`)!;
+    const rightIcon = container.querySelector(`.${styles['input-icon-right']}`)!;
+
+    expect(adornedContainer).toContainElement(rightIcon as HTMLElement);
+    rightIcon.querySelector('button')!.focus();
+    expect(adornedContainer.contains(document.activeElement)).toBe(true);
+  });
+
+  test.each([null, false, true, undefined, ''] as const)(
+    'does not render an adornment cell or divider for non-rendered React child %p',
+    absentContent => {
+      const { wrapper } = renderInput({ prefix: absentContent, suffix: absentContent });
+      expect(wrapper.findPrefix()).toBeNull();
+      expect(wrapper.findSuffix()).toBeNull();
+      expect(wrapper.findByClassName(styles['input-adorned-container'])).toBeNull();
+      expect(wrapper.findAllByClassName(styles['input-adornment-divider'])).toHaveLength(0);
+    }
+  );
+
+  describe('adornment container reflects validation and interaction state', () => {
+    const getContainer = (props: Partial<InputProps>) =>
+      renderInput({ prefix: '$', ...props })
+        .wrapper.findByClassName(styles['input-adorned-container'])!
+        .getElement();
+
+    test('adds the invalid modifier when invalid', () => {
+      expect(getContainer({ invalid: true })).toHaveClass(styles['input-adorned-container-invalid']);
+    });
+
+    test('prefers the invalid modifier over the warning modifier', () => {
+      const container = getContainer({ invalid: true, warning: true });
+      expect(container).toHaveClass(styles['input-adorned-container-invalid']);
+      expect(container).not.toHaveClass(styles['input-adorned-container-warning']);
+    });
+
+    test('adds the warning modifier when warning and not invalid', () => {
+      expect(getContainer({ warning: true })).toHaveClass(styles['input-adorned-container-warning']);
+    });
+
+    test('adds the disabled modifier when disabled', () => {
+      expect(getContainer({ disabled: true })).toHaveClass(styles['input-adorned-container-disabled']);
+    });
+
+    test('adds the readonly modifier when readOnly and not disabled', () => {
+      const container = getContainer({ readOnly: true });
+      expect(container).toHaveClass(styles['input-adorned-container-readonly']);
+    });
+
+    test('prefers the disabled modifier over the readonly modifier', () => {
+      const container = getContainer({ disabled: true, readOnly: true });
+      expect(container).toHaveClass(styles['input-adorned-container-disabled']);
+      expect(container).not.toHaveClass(styles['input-adorned-container-readonly']);
+    });
+  });
+
+  describe('accessibility', () => {
+    test('marks adornments as decorative with aria-hidden', () => {
+      const { wrapper } = renderInput({ prefix: '$', suffix: '%' });
+      expect(wrapper.findPrefix()!.getElement()).toHaveAttribute('aria-hidden', 'true');
+      expect(wrapper.findSuffix()!.getElement()).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    test('has no axe violations', async () => {
+      const { container } = render(
+        <Input value="123" onChange={() => {}} ariaLabel="Amount" prefix="$" suffix="USD" />
+      );
+      await expect(container).toValidateA11y();
+    });
+  });
+});

--- a/src/input/__tests__/adornments.test.tsx
+++ b/src/input/__tests__/adornments.test.tsx
@@ -60,10 +60,10 @@ describe('prefix and suffix adornments', () => {
     expect(wrapper.findPrefix()!.find('[data-testid="custom"]')).not.toBeNull();
   });
 
-  test('renders numeric adornments', () => {
-    const { wrapper } = renderInput({ prefix: 0, suffix: 0 });
-    expect(wrapper.findPrefix()!.getElement()).toHaveTextContent('0');
-    expect(wrapper.findSuffix()!.getElement()).toHaveTextContent('0');
+  test('renders truthy numeric adornments', () => {
+    const { wrapper } = renderInput({ prefix: 1, suffix: 1 });
+    expect(wrapper.findPrefix()!.getElement()).toHaveTextContent('1');
+    expect(wrapper.findSuffix()!.getElement()).toHaveTextContent('1');
   });
 
   test('applies custom Input styles to the adorned container', () => {
@@ -102,7 +102,7 @@ describe('prefix and suffix adornments', () => {
     expect(adornedContainer.contains(document.activeElement)).toBe(true);
   });
 
-  test.each([null, false, true, undefined, ''] as const)(
+  test.each([null, false, 0, undefined, ''] as const)(
     'does not render an adornment cell or divider for non-rendered React child %p',
     absentContent => {
       const { wrapper } = renderInput({ prefix: absentContent, suffix: absentContent });

--- a/src/input/__tests__/adornments.test.tsx
+++ b/src/input/__tests__/adornments.test.tsx
@@ -92,13 +92,13 @@ describe('prefix and suffix adornments', () => {
     expect(nativeInput.style.paddingInline).toBe('16px');
   });
 
-  test('contains the right icon within the adorned focus container', () => {
-    const { container } = render(<InternalInput value="" onChange={() => {}} prefix="$" __rightIcon="settings" />);
+  test('contains the end icon within the adorned focus container', () => {
+    const { container } = render(<InternalInput value="" onChange={() => {}} prefix="$" __endIcon="settings" />);
     const adornedContainer = container.querySelector(`.${styles['input-adorned-container']}`)!;
-    const rightIcon = container.querySelector(`.${styles['input-icon-right']}`)!;
+    const endIcon = container.querySelector(`.${styles['input-icon-end']}`)!;
 
-    expect(adornedContainer).toContainElement(rightIcon as HTMLElement);
-    rightIcon.querySelector('button')!.focus();
+    expect(adornedContainer).toContainElement(endIcon as HTMLElement);
+    endIcon.querySelector('button')!.focus();
     expect(adornedContainer.contains(document.activeElement)).toBe(true);
   });
 

--- a/src/input/__tests__/analytics-metadata.test.tsx
+++ b/src/input/__tests__/analytics-metadata.test.tsx
@@ -38,7 +38,7 @@ beforeAll(() => {
   activateAnalyticsMetadata(true);
 });
 describe('Input renders correct analytics metadata', () => {
-  describe('on the right button', () => {
+  describe('on the end button', () => {
     test('when it is the clear button', () => {
       const renderResult = render(<Input value="value" onChange={() => {}} type="search" clearAriaLabel="clear" />);
       const clearInputButton = createWrapper(renderResult.container).findInput()!.findClearButton()!.getElement();
@@ -51,11 +51,11 @@ describe('Input renders correct analytics metadata', () => {
       });
     });
     test('when it is not the clear button', () => {
-      const renderResult = render(<InternalInput value="value" onChange={() => {}} __rightIcon="settings" />);
-      const rightIconButton = createWrapper(renderResult.container)
-        .findByClassName(styles['input-icon-right'])!
+      const renderResult = render(<InternalInput value="value" onChange={() => {}} __endIcon="settings" />);
+      const endIconButton = createWrapper(renderResult.container)
+        .findByClassName(styles['input-icon-end'])!
         .getElement();
-      expect(getGeneratedAnalyticsMetadata(rightIconButton)).toEqual({});
+      expect(getGeneratedAnalyticsMetadata(endIconButton)).toEqual({});
     });
   });
   describe('on the component', () => {

--- a/src/input/__tests__/search-input.test.tsx
+++ b/src/input/__tests__/search-input.test.tsx
@@ -3,8 +3,15 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+
 import Input, { InputProps } from '../../../lib/components/input';
 import createWrapper, { InputWrapper } from '../../../lib/components/test-utils/dom';
+
+jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
+  ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
+  warnOnce: jest.fn(),
+}));
 
 function renderInput(
   props: Omit<InputProps, 'value'> & { value?: string } & React.RefAttributes<HTMLInputElement> = {}
@@ -20,6 +27,74 @@ function getNativeInput(wrapper: InputWrapper) {
 function getClearButton(wrapper: InputWrapper) {
   return wrapper.findClearButton()!.getElement();
 }
+
+describe('Development warnings for prefix/suffix on search type', () => {
+  afterEach(() => {
+    (warnOnce as jest.Mock).mockReset();
+  });
+
+  test('warns when prefix is supplied with type search', () => {
+    renderInput({ type: 'search', prefix: '$' });
+    expect(warnOnce).toHaveBeenCalledWith('Input', 'prefix and suffix are ignored when type is search.');
+  });
+
+  test('warns when suffix is supplied with type search', () => {
+    renderInput({ type: 'search', suffix: '%' });
+    expect(warnOnce).toHaveBeenCalledWith('Input', 'prefix and suffix are ignored when type is search.');
+  });
+
+  test('warns when both prefix and suffix are supplied with type search', () => {
+    renderInput({ type: 'search', prefix: '$', suffix: '%' });
+    expect(warnOnce).toHaveBeenCalledWith('Input', 'prefix and suffix are ignored when type is search.');
+  });
+
+  test('does not warn when neither prefix nor suffix is supplied with type search', () => {
+    renderInput({ type: 'search' });
+    expect(warnOnce).not.toHaveBeenCalled();
+  });
+
+  test('does not warn when prefix/suffix are supplied with non-search type', () => {
+    renderInput({ type: 'text', prefix: '$', suffix: '%' });
+    expect(warnOnce).not.toHaveBeenCalled();
+  });
+});
+
+describe('Prefix/suffix suppression for search type', () => {
+  test('does not render prefix when type is search', () => {
+    const wrapper = renderInput({ type: 'search', prefix: '$' });
+    expect(wrapper.findPrefix()).toBeNull();
+  });
+
+  test('does not render suffix when type is search', () => {
+    const wrapper = renderInput({ type: 'search', suffix: '%' });
+    expect(wrapper.findSuffix()).toBeNull();
+  });
+
+  test('does not render prefix and suffix together when type is search', () => {
+    const wrapper = renderInput({ type: 'search', prefix: 'https://', suffix: '.com' });
+    expect(wrapper.findPrefix()).toBeNull();
+    expect(wrapper.findSuffix()).toBeNull();
+  });
+
+  test('still renders clear button for populated search input with prefix/suffix props', () => {
+    const wrapper = renderInput({ type: 'search', value: 'query', prefix: '$', suffix: '%' });
+    expect(wrapper.findClearButton()).not.toBeNull();
+    expect(wrapper.findPrefix()).toBeNull();
+    expect(wrapper.findSuffix()).toBeNull();
+  });
+
+  test('renders prefix for non-search type', () => {
+    const wrapper = renderInput({ type: 'text', prefix: '$' });
+    expect(wrapper.findPrefix()).not.toBeNull();
+    expect(wrapper.findPrefix()!.getElement().textContent).toBe('$');
+  });
+
+  test('renders suffix for non-search type', () => {
+    const wrapper = renderInput({ type: 'text', suffix: '%' });
+    expect(wrapper.findSuffix()).not.toBeNull();
+    expect(wrapper.findSuffix()!.getElement().textContent).toBe('%');
+  });
+});
 
 describe('Clear field', () => {
   const baseProps: Omit<InputProps, 'value'> = {

--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -44,6 +44,8 @@ const Input = React.forwardRef(
       clearAriaLabel,
       nativeInputAttributes,
       style,
+      prefix,
+      suffix,
       ...rest
     }: InputProps,
     ref: Ref<InputProps.Ref>
@@ -101,6 +103,8 @@ const Input = React.forwardRef(
           clearAriaLabel,
           nativeInputAttributes,
           style,
+          prefix,
+          suffix,
         }}
         className={clsx(styles.root, baseProps.className)}
         __inheritFormFieldProps={true}

--- a/src/input/interfaces.ts
+++ b/src/input/interfaces.ts
@@ -1,5 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { ReactNode } from 'react';
+
 import { BaseComponentProps } from '../types/base-component';
 import { BaseKeyDetail, CancelableEventHandler, NonCancelableEventHandler } from '../types/events';
 import { FormFieldValidationControlProps } from '../types/form-field';
@@ -188,6 +190,16 @@ export interface InputProps
    * @awsuiSystem core
    */
   style?: InputProps.Style;
+
+  /**
+   * Use for content rendered before the editable value.
+   */
+  prefix?: ReactNode;
+
+  /**
+   * Use for content rendered after the editable value.
+   */
+  suffix?: ReactNode;
 }
 
 export namespace InputProps {

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -311,6 +311,7 @@ function InternalInput(
             disabled && styles['input-adorned-container-disabled'],
             readOnly && !disabled && styles['input-adorned-container-readonly']
           )}
+          aria-disabled={disabled || undefined}
           style={adornedContainerStyles}
         >
           {hasPrefix && (

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -41,12 +41,12 @@ export interface InternalInputProps
     FormFieldValidationControlProps,
     InternalBaseComponentProps {
   type?: InputProps['type'] | 'visualSearch';
-  __leftIcon?: IconProps['name'];
-  __leftIconVariant?: IconProps['variant'];
-  __onLeftIconClick?: () => void;
+  __startIcon?: IconProps['name'];
+  __startIconVariant?: IconProps['variant'];
+  __onStartIconClick?: () => void;
 
-  __rightIcon?: IconProps['name'];
-  __onRightIconClick?: () => void;
+  __endIcon?: IconProps['name'];
+  __onEndIconClick?: () => void;
 
   __noBorderRadius?: boolean;
 
@@ -78,14 +78,14 @@ function InternalInput(
     spellcheck,
     __noBorderRadius,
 
-    __leftIcon,
-    __leftIconVariant = 'subtle',
-    __onLeftIconClick,
+    __startIcon,
+    __startIconVariant = 'subtle',
+    __onStartIconClick,
 
     ariaRequired,
 
-    __rightIcon,
-    __onRightIconClick,
+    __endIcon,
+    __onEndIconClick,
 
     onKeyDown,
     onKeyUp,
@@ -119,9 +119,9 @@ function InternalInput(
 
   const inputRef = useRef<HTMLInputElement>(null);
   const searchProps = useSearchProps(type, disabled, readOnly, value, inputRef, handleChange);
-  __leftIcon = __leftIcon ?? searchProps.__leftIcon;
-  __rightIcon = __rightIcon ?? searchProps.__rightIcon;
-  __onRightIconClick = __onRightIconClick ?? searchProps.__onRightIconClick;
+  __startIcon = __startIcon ?? searchProps.__startIcon;
+  __endIcon = __endIcon ?? searchProps.__endIcon;
+  __onEndIconClick = __onEndIconClick ?? searchProps.__onEndIconClick;
 
   // Search inputs use built-in search and clear icons that would overlap adornments.
   const isSearch = type === 'search' || type === 'visualSearch';
@@ -169,8 +169,8 @@ function InternalInput(
     className: clsx(
       styles.input,
       type && styles[`input-type-${type}`],
-      __rightIcon && styles['input-has-icon-right'],
-      __leftIcon && styles['input-has-icon-left'],
+      __endIcon && styles['input-has-icon-end'],
+      __startIcon && styles['input-has-icon-start'],
       __noBorderRadius && styles['input-has-no-border-radius'],
       hasPrefixOrSuffix && styles['input-adorned'],
       {
@@ -264,10 +264,10 @@ function InternalInput(
     mainInput
   );
 
-  const rightIcon = __rightIcon ? (
+  const endIcon = __endIcon ? (
     <span
-      className={styles['input-icon-right']}
-      {...(__rightIcon === 'close'
+      className={styles['input-icon-end']}
+      {...(__endIcon === 'close'
         ? getAnalyticsMetadataAttribute({
             action: 'clearInput',
           } as Partial<GeneratedAnalyticsMetadataInputClearInput>)
@@ -275,11 +275,11 @@ function InternalInput(
     >
       <InternalButton
         // Used for test utils
-        className={styles['input-button-right']}
+        className={styles['input-button-end']}
         variant="inline-icon-pointer-target"
         formAction="none"
-        iconName={__rightIcon}
-        onClick={__onRightIconClick}
+        iconName={__endIcon}
+        onClick={__onEndIconClick}
         ariaLabel={i18n('clearAriaLabel', clearAriaLabelOverride)}
         disabled={disabled}
       />
@@ -296,9 +296,9 @@ function InternalInput(
         ? getAnalyticsMetadataAttribute({ component: componentAnalyticsMetadata })
         : copyAnalyticsMetadataAttribute(rest))}
     >
-      {__leftIcon && (
-        <span onClick={__onLeftIconClick} className={styles['input-icon-left']}>
-          <InternalIcon name={__leftIcon} variant={disabled || readOnly ? 'disabled' : __leftIconVariant} />
+      {__startIcon && (
+        <span onClick={__onStartIconClick} className={styles['input-icon-start']}>
+          <InternalIcon name={__startIcon} variant={disabled || readOnly ? 'disabled' : __startIconVariant} />
         </span>
       )}
       {hasPrefixOrSuffix ? (
@@ -330,12 +330,12 @@ function InternalInput(
               </span>
             </>
           )}
-          {rightIcon}
+          {endIcon}
         </div>
       ) : (
         inputWithLabel
       )}
-      {!hasPrefixOrSuffix && rightIcon}
+      {!hasPrefixOrSuffix && endIcon}
     </div>
   );
 }

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -140,10 +140,8 @@ function InternalInput(
     ? formFieldContext
     : rest;
 
-  const hasAdornmentContent = (content: React.ReactNode) =>
-    content !== null && content !== undefined && typeof content !== 'boolean' && content !== '';
-  const hasPrefix = hasAdornmentContent(prefix);
-  const hasSuffix = hasAdornmentContent(suffix);
+  const hasPrefix = !!prefix;
+  const hasSuffix = !!suffix;
   const hasPrefixOrSuffix = hasPrefix || hasSuffix;
   const inputStyles = getInputStyles(style);
   const nativeInputStyles =
@@ -275,7 +273,7 @@ function InternalInput(
     >
       <InternalButton
         // Used for test utils
-        className={styles['input-button-end']}
+        className={styles['input-button-right']}
         variant="inline-icon-pointer-target"
         formAction="none"
         iconName={__endIcon}

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -3,7 +3,7 @@
 import React, { Ref, useRef } from 'react';
 import clsx from 'clsx';
 
-import { useMergeRefs } from '@cloudscape-design/component-toolkit/internal';
+import { useMergeRefs, warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import {
   copyAnalyticsMetadataAttribute,
   getAnalyticsMetadataAttribute,
@@ -18,6 +18,7 @@ import { useFormFieldContext } from '../internal/context/form-field-context';
 import { fireKeyboardEvent, fireNonCancelableEvent } from '../internal/events';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useDebounceCallback } from '../internal/hooks/use-debounce-callback';
+import { isDevelopment } from '../internal/is-development';
 import WithNativeAttributes, { SkipWarnings } from '../internal/utils/with-native-attributes';
 import { BaseComponentProps } from '../types/base-component';
 import { NonCancelableEventHandler } from '../types/events';
@@ -101,6 +102,8 @@ function InternalInput(
     __inlineLabelText,
     __fullWidth,
     style,
+    prefix,
+    suffix,
     ...rest
   }: InternalInputProps,
   ref: Ref<HTMLInputElement>
@@ -120,10 +123,37 @@ function InternalInput(
   __rightIcon = __rightIcon ?? searchProps.__rightIcon;
   __onRightIconClick = __onRightIconClick ?? searchProps.__onRightIconClick;
 
+  // Search inputs use built-in search and clear icons that would overlap adornments.
+  const isSearch = type === 'search' || type === 'visualSearch';
+  if (isDevelopment) {
+    if (isSearch && (prefix !== undefined || suffix !== undefined)) {
+      warnOnce('Input', 'prefix and suffix are ignored when type is search.');
+    }
+  }
+  if (isSearch) {
+    prefix = undefined;
+    suffix = undefined;
+  }
+
   const formFieldContext = useFormFieldContext(rest);
   const { ariaLabelledby, ariaDescribedby, controlId, invalid, warning } = __inheritFormFieldProps
     ? formFieldContext
     : rest;
+
+  const hasAdornmentContent = (content: React.ReactNode) =>
+    content !== null && content !== undefined && typeof content !== 'boolean' && content !== '';
+  const hasPrefix = hasAdornmentContent(prefix);
+  const hasSuffix = hasAdornmentContent(suffix);
+  const hasPrefixOrSuffix = hasPrefix || hasSuffix;
+  const inputStyles = getInputStyles(style);
+  const nativeInputStyles =
+    hasPrefixOrSuffix && inputStyles
+      ? { ...inputStyles, borderRadius: undefined, borderWidth: undefined }
+      : inputStyles;
+  const adornedContainerStyles =
+    hasPrefixOrSuffix && inputStyles
+      ? { ...inputStyles, paddingBlock: undefined, paddingInline: undefined }
+      : undefined;
 
   const attributes: React.InputHTMLAttributes<HTMLInputElement> = {
     'aria-label': ariaLabel,
@@ -142,10 +172,11 @@ function InternalInput(
       __rightIcon && styles['input-has-icon-right'],
       __leftIcon && styles['input-has-icon-left'],
       __noBorderRadius && styles['input-has-no-border-radius'],
+      hasPrefixOrSuffix && styles['input-adorned'],
       {
         [styles['input-readonly']]: readOnly,
-        [styles['input-invalid']]: invalid,
-        [styles['input-warning']]: warning && !invalid,
+        [styles['input-invalid']]: invalid && !hasPrefixOrSuffix,
+        [styles['input-warning']]: warning && !invalid && !hasPrefixOrSuffix,
       }
     ),
     autoComplete: convertAutoComplete(autoComplete),
@@ -211,9 +242,49 @@ function InternalInput(
       nativeAttributes={nativeInputAttributes}
       skipWarnings={__skipNativeAttributesWarnings}
       ref={mergedRef}
-      style={getInputStyles(style)}
+      style={nativeInputStyles}
     />
   );
+
+  const inputWithLabel = __inlineLabelText ? (
+    <div className={clsx(styles['inline-label-wrapper'], __fullWidth && styles['inline-label-wrapper-full-width'])}>
+      <label htmlFor={controlId} className={styles['inline-label']}>
+        {__inlineLabelText}
+      </label>
+      <div
+        className={clsx(
+          styles['inline-label-trigger-wrapper'],
+          __fullWidth && styles['inline-label-trigger-wrapper-full-width']
+        )}
+      >
+        {mainInput}
+      </div>
+    </div>
+  ) : (
+    mainInput
+  );
+
+  const rightIcon = __rightIcon ? (
+    <span
+      className={styles['input-icon-right']}
+      {...(__rightIcon === 'close'
+        ? getAnalyticsMetadataAttribute({
+            action: 'clearInput',
+          } as Partial<GeneratedAnalyticsMetadataInputClearInput>)
+        : {})}
+    >
+      <InternalButton
+        // Used for test utils
+        className={styles['input-button-right']}
+        variant="inline-icon-pointer-target"
+        formAction="none"
+        iconName={__rightIcon}
+        onClick={__onRightIconClick}
+        ariaLabel={i18n('clearAriaLabel', clearAriaLabelOverride)}
+        disabled={disabled}
+      />
+    </span>
+  ) : null;
 
   return (
     <div
@@ -230,44 +301,41 @@ function InternalInput(
           <InternalIcon name={__leftIcon} variant={disabled || readOnly ? 'disabled' : __leftIconVariant} />
         </span>
       )}
-      {__inlineLabelText ? (
-        <div className={clsx(styles['inline-label-wrapper'], __fullWidth && styles['inline-label-wrapper-full-width'])}>
-          <label htmlFor={controlId} className={styles['inline-label']}>
-            {__inlineLabelText}
-          </label>
-          <div
-            className={clsx(
-              styles['inline-label-trigger-wrapper'],
-              __fullWidth && styles['inline-label-trigger-wrapper-full-width']
-            )}
-          >
-            {mainInput}
-          </div>
+      {hasPrefixOrSuffix ? (
+        // [prefix][divider][input][divider][suffix] - one flex bar owns the border and focus ring.
+        <div
+          className={clsx(
+            styles['input-adorned-container'],
+            invalid && styles['input-adorned-container-invalid'],
+            warning && !invalid && styles['input-adorned-container-warning'],
+            disabled && styles['input-adorned-container-disabled'],
+            readOnly && !disabled && styles['input-adorned-container-readonly']
+          )}
+          style={adornedContainerStyles}
+        >
+          {hasPrefix && (
+            <>
+              <span className={styles['input-prefix']} aria-hidden="true">
+                {prefix}
+              </span>
+              <span className={styles['input-adornment-divider']} />
+            </>
+          )}
+          {inputWithLabel}
+          {hasSuffix && (
+            <>
+              <span className={styles['input-adornment-divider']} />
+              <span className={styles['input-suffix']} aria-hidden="true">
+                {suffix}
+              </span>
+            </>
+          )}
+          {rightIcon}
         </div>
       ) : (
-        mainInput
+        inputWithLabel
       )}
-      {__rightIcon && (
-        <span
-          className={styles['input-icon-right']}
-          {...(__rightIcon === 'close'
-            ? getAnalyticsMetadataAttribute({
-                action: 'clearInput',
-              } as Partial<GeneratedAnalyticsMetadataInputClearInput>)
-            : {})}
-        >
-          <InternalButton
-            // Used for test utils
-            className={styles['input-button-right']}
-            variant="inline-icon-pointer-target"
-            formAction="none"
-            iconName={__rightIcon}
-            onClick={__onRightIconClick}
-            ariaLabel={i18n('clearAriaLabel', clearAriaLabelOverride)}
-            disabled={disabled}
-          />
-        </span>
-      )}
+      {!hasPrefixOrSuffix && rightIcon}
     </div>
   );
 }

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -316,7 +316,7 @@ function InternalInput(
           {hasPrefix && (
             <>
               <span className={styles['input-prefix']} aria-hidden="true">
-                {prefix}
+                <span className={styles['input-adornment-content']}>{prefix}</span>
               </span>
               <span className={styles['input-adornment-divider']} />
             </>
@@ -326,7 +326,7 @@ function InternalInput(
             <>
               <span className={styles['input-adornment-divider']} />
               <span className={styles['input-suffix']} aria-hidden="true">
-                {suffix}
+                <span className={styles['input-adornment-content']}>{suffix}</span>
               </span>
             </>
           )}

--- a/src/input/styles.scss
+++ b/src/input/styles.scss
@@ -216,7 +216,7 @@
   inset-inline-end: calc(#{styles.$control-icon-horizontal-offset} - #{awsui.$space-xxs});
 }
 
-.input-button-end {
+.input-button-right {
   /* used in test-utils */
 }
 

--- a/src/input/styles.scss
+++ b/src/input/styles.scss
@@ -324,15 +324,21 @@
   flex-shrink: 1;
   max-inline-size: max(0px, calc((100% - 12rem) / 2));
   min-inline-size: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   padding-block: styles.$control-padding-vertical;
   padding-inline: styles.$control-padding-horizontal;
   color: inherit;
   user-select: none;
   cursor: default;
   @include styles.font-body-m;
+}
+
+.input-adornment-content {
+  display: block;
+  flex: 1;
+  min-inline-size: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .input-adornment-divider {
@@ -404,5 +410,13 @@
   > .input-prefix,
   > .input-adorned:first-child {
     padding-inline-start: styles.$invalid-control-left-padding;
+  }
+
+  > .input-prefix,
+  > .input-suffix {
+    max-inline-size: max(
+      0px,
+      calc((100% - 12rem + #{styles.$invalid-control-left-border} - #{awsui.$border-width-field}) / 2)
+    );
   }
 }

--- a/src/input/styles.scss
+++ b/src/input/styles.scss
@@ -149,7 +149,7 @@
       $border-color: var(#{custom-props.$styleBorderColorDefault}, awsui.$color-text-status-error),
       $focus-box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light-invalid)
     );
-    &.input-has-icon-left {
+    &.input-has-icon-start {
       padding-inline-start: calc(
         #{styles.$control-icon-horizontal-padding} -
           (#{styles.$invalid-control-left-border} - #{awsui.$border-width-field})
@@ -163,7 +163,7 @@
       $border-color: var(#{custom-props.$styleBorderColorDefault}, awsui.$color-text-status-warning),
       $focus-box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light-invalid)
     );
-    &.input-has-icon-left {
+    &.input-has-icon-start {
       padding-inline-start: calc(
         #{styles.$control-icon-horizontal-padding} -
           (#{styles.$invalid-control-left-border} - #{awsui.$border-width-field})
@@ -184,10 +184,10 @@
       display: none;
     }
   }
-  &.input-has-icon-left {
+  &.input-has-icon-start {
     padding-inline-start: styles.$control-icon-horizontal-padding;
   }
-  &.input-has-icon-right {
+  &.input-has-icon-end {
     padding-inline-end: styles.$control-icon-horizontal-padding;
   }
   &.input-has-no-border-radius {
@@ -203,20 +203,20 @@
   position: relative;
 }
 
-.input-icon-left {
+.input-icon-start {
   position: absolute;
   pointer-events: none;
   inset-inline-start: styles.$control-icon-horizontal-offset;
   inset-block-start: styles.$control-icon-vertical-offset;
 }
 
-.input-icon-right {
+.input-icon-end {
   position: absolute;
   inset-block-start: calc(#{styles.$control-icon-vertical-offset} - #{awsui.$space-xxxs});
   inset-inline-end: calc(#{styles.$control-icon-horizontal-offset} - #{awsui.$space-xxs});
 }
 
-.input-button-right {
+.input-button-end {
   /* used in test-utils */
 }
 

--- a/src/input/styles.scss
+++ b/src/input/styles.scss
@@ -322,7 +322,7 @@
   display: flex;
   align-items: center;
   flex-shrink: 1;
-  max-inline-size: max(0px, calc((100% - 12rem) / 2));
+  max-inline-size: #{'max(0px, calc((100% - 12rem) / 2))'};
   min-inline-size: 0;
   padding-block: styles.$control-padding-vertical;
   padding-inline: styles.$control-padding-horizontal;
@@ -412,9 +412,6 @@
 
   > .input-prefix,
   > .input-suffix {
-    max-inline-size: max(
-      0px,
-      calc((100% - 12rem + #{styles.$invalid-control-left-border} - #{awsui.$border-width-field}) / 2)
-    );
+    max-inline-size: #{'max( 0px, calc((100% - 12rem + #{styles.$invalid-control-left-border} - #{awsui.$border-width-field}) / 2))'};
   }
 }

--- a/src/input/styles.scss
+++ b/src/input/styles.scss
@@ -327,8 +327,6 @@
   padding-block: styles.$control-padding-vertical;
   padding-inline: styles.$control-padding-horizontal;
   color: inherit;
-  user-select: text;
-  cursor: text;
   @include styles.font-body-m;
 }
 

--- a/src/input/styles.scss
+++ b/src/input/styles.scss
@@ -327,8 +327,8 @@
   padding-block: styles.$control-padding-vertical;
   padding-inline: styles.$control-padding-horizontal;
   color: inherit;
-  user-select: none;
-  cursor: default;
+  user-select: text;
+  cursor: text;
   @include styles.font-body-m;
 }
 

--- a/src/input/styles.scss
+++ b/src/input/styles.scss
@@ -28,6 +28,47 @@
   }
 }
 
+%input-default-styles {
+  background-color: var(#{custom-props.$styleBackgroundDefault}, awsui.$color-background-input-default);
+  border-block: awsui.$border-width-field solid
+    var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-default);
+  border-inline: awsui.$border-width-field solid
+    var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-default);
+  box-shadow: var(#{custom-props.$styleBoxShadowDefault});
+}
+
+%input-hover-styles {
+  border-color: var(
+    #{custom-props.$styleBorderColorHover},
+    var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-default)
+  );
+  background-color: var(
+    #{custom-props.$styleBackgroundHover},
+    var(#{custom-props.$styleBackgroundDefault}, awsui.$color-background-input-default)
+  );
+  box-shadow: var(#{custom-props.$styleBoxShadowHover}, #{custom-props.$styleBoxShadowDefault});
+}
+
+%input-readonly-styles {
+  @include styles.form-readonly-element(
+    $background-color: var(
+        #{custom-props.$styleBackgroundReadonly},
+        var(#{custom-props.$styleBackgroundDefault}, awsui.$color-background-input-default)
+      ),
+    $border-color: var(
+        #{custom-props.$styleBorderColorReadonly},
+        var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-disabled)
+      )
+  );
+}
+
+%input-focus-styles {
+  @include styles.form-focus-element(
+    $border-color: var(#{custom-props.$styleBorderColorFocus}, awsui.$color-border-input-focused),
+    $box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light)
+  );
+}
+
 .root {
   /* used in test-utils for component to distinguish input from other input-like components, for example autosuggest */
 }
@@ -40,54 +81,31 @@
   inline-size: 100%;
   cursor: text;
   box-sizing: border-box;
-  background-color: var(#{custom-props.$styleBackgroundDefault}, awsui.$color-background-input-default);
   border-start-start-radius: styles.$control-border-radius;
   border-start-end-radius: styles.$control-border-radius;
   border-end-start-radius: styles.$control-border-radius;
   border-end-end-radius: styles.$control-border-radius;
 
-  border-block: awsui.$border-width-field solid
-    var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-default);
-  border-inline: awsui.$border-width-field solid
-    var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-default);
-
-  box-shadow: var(#{custom-props.$styleBoxShadowDefault});
-
   @include styles.font-body-m;
   min-block-size: awsui.$size-vertical-input;
 
+  @extend %input-default-styles;
+
   &:hover {
-    border-color: var(
-      #{custom-props.$styleBorderColorHover},
-      var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-default)
-    );
     color: var(
       #{custom-props.$styleColorHover},
       var(#{custom-props.$styleBorderColorDefault}, awsui.$color-text-body-default)
     );
-    background-color: var(
-      #{custom-props.$styleBackgroundHover},
-      var(#{custom-props.$styleBackgroundDefault}, awsui.$color-background-input-default)
-    );
-    box-shadow: var(#{custom-props.$styleBoxShadowHover}, #{custom-props.$styleBoxShadowDefault});
+    @extend %input-hover-styles;
   }
 
   &.input-readonly {
-    @include styles.form-readonly-element(
-      $background-color: var(
-          #{custom-props.$styleBackgroundReadonly},
-          var(#{custom-props.$styleBackgroundDefault}, awsui.$color-background-input-default)
-        ),
-      $border-color: var(
-          #{custom-props.$styleBorderColorReadonly},
-          var(#{custom-props.$styleBorderColorDefault}, awsui.$color-border-input-disabled)
-        )
-    );
     color: var(
       #{custom-props.$styleColorReadonly},
       var(#{custom-props.$styleColorDefault}, awsui.$color-text-body-default)
     );
     box-shadow: var(#{custom-props.$styleBoxShadowReadonly});
+    @extend %input-readonly-styles;
   }
 
   @include placeholder {
@@ -100,12 +118,9 @@
   }
 
   &:focus {
-    @include styles.form-focus-element(
-      $border-color: var(#{custom-props.$styleBorderColorFocus}, awsui.$color-border-input-focused),
-      $box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light)
-    );
     color: var(#{custom-props.$styleColorFocus}, awsui.$color-text-body-default);
     background-color: var(#{custom-props.$styleBackgroundFocus}, awsui.$color-background-input-default);
+    @extend %input-focus-styles;
   }
 
   &:disabled {
@@ -223,4 +238,171 @@
 
 .inline-label {
   @include forms.inline-label;
+}
+
+.input-adorned-container {
+  display: flex;
+  align-items: stretch;
+  inline-size: 100%;
+  box-sizing: border-box;
+  color: var(#{custom-props.$styleColorDefault}, awsui.$color-text-form-secondary);
+  border-start-start-radius: styles.$control-border-radius;
+  border-start-end-radius: styles.$control-border-radius;
+  border-end-start-radius: styles.$control-border-radius;
+  border-end-end-radius: styles.$control-border-radius;
+  min-block-size: awsui.$size-vertical-input;
+
+  @extend %input-default-styles;
+
+  &:hover {
+    @extend %input-hover-styles;
+    color: var(
+      #{custom-props.$styleColorHover},
+      var(#{custom-props.$styleColorDefault}, awsui.$color-text-form-secondary)
+    );
+  }
+
+  &.input-adorned-container-readonly {
+    @extend %input-readonly-styles;
+    color: var(
+      #{custom-props.$styleColorReadonly},
+      var(#{custom-props.$styleColorDefault}, awsui.$color-text-form-secondary)
+    );
+  }
+
+  &:focus-within {
+    @extend %input-focus-styles;
+    color: var(
+      #{custom-props.$styleColorFocus},
+      var(#{custom-props.$styleColorDefault}, awsui.$color-text-form-secondary)
+    );
+  }
+
+  &.input-adorned-container-invalid {
+    @include styles.form-invalid-control(
+      $color: var(#{custom-props.$styleColorDefault}, awsui.$color-text-status-error),
+      $border-color: var(#{custom-props.$styleBorderColorDefault}, awsui.$color-text-status-error),
+      $focus-box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light-invalid)
+    ) {
+      padding-inline-start: 0;
+    }
+
+    &:focus-within {
+      box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light-invalid);
+    }
+  }
+
+  &.input-adorned-container-warning {
+    @include styles.form-warning-control(
+      $color: var(#{custom-props.$styleColorDefault}, awsui.$color-text-status-warning),
+      $border-color: var(#{custom-props.$styleBorderColorDefault}, awsui.$color-text-status-warning),
+      $focus-box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light-invalid)
+    ) {
+      padding-inline-start: 0;
+    }
+
+    &:focus-within {
+      box-shadow: var(#{custom-props.$styleBoxShadowFocus}, foundation.$box-shadow-focused-light-invalid);
+    }
+  }
+
+  &.input-adorned-container-disabled {
+    @include styles.form-disabled-element(
+      $background-color: var(#{custom-props.$styleBackgroundDisabled}, awsui.$color-background-input-disabled),
+      $border-color: var(#{custom-props.$styleBorderColorDisabled}, awsui.$color-border-input-disabled),
+      $color: var(#{custom-props.$styleColorDisabled}, awsui.$color-text-input-disabled),
+      $cursor: default
+    );
+    box-shadow: var(#{custom-props.$styleBoxShadowDisabled});
+  }
+}
+
+.input-prefix,
+.input-suffix {
+  display: flex;
+  align-items: center;
+  flex-shrink: 1;
+  max-inline-size: max(0px, calc((100% - 12rem) / 2));
+  min-inline-size: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-block: styles.$control-padding-vertical;
+  padding-inline: styles.$control-padding-horizontal;
+  color: inherit;
+  user-select: none;
+  cursor: default;
+  @include styles.font-body-m;
+}
+
+.input-adornment-divider {
+  display: block;
+  flex-shrink: 0;
+  inline-size: awsui.$border-width-field;
+  background-color: awsui.$color-border-divider-default;
+  align-self: stretch;
+}
+
+.input-adorned {
+  flex: 1;
+  min-inline-size: 0;
+  border-block: none;
+  border-inline: none;
+  border-start-start-radius: 0;
+  border-start-end-radius: 0;
+  border-end-start-radius: 0;
+  border-end-end-radius: 0;
+  background-color: transparent;
+  box-shadow: none;
+  min-block-size: unset;
+
+  &.input:focus {
+    border-block: 0;
+    border-inline: 0;
+    box-shadow: none;
+    outline: none;
+  }
+
+  &:hover {
+    border-color: transparent;
+    background-color: transparent;
+  }
+
+  &:disabled {
+    background-color: transparent;
+    border-color: transparent;
+    border-block: 0;
+    border-inline: 0;
+  }
+
+  &.input-readonly {
+    background-color: transparent;
+    border-color: transparent;
+    border-block: 0;
+    border-inline: 0;
+  }
+
+  &.input-invalid,
+  &.input-warning {
+    padding-inline-start: styles.$control-padding-horizontal;
+    border-block: 0;
+    border-inline: 0;
+    border-inline-start-width: 0;
+    box-shadow: none;
+
+    &:focus {
+      border-block: 0;
+      border-inline: 0;
+      box-shadow: none;
+      outline: none;
+    }
+  }
+}
+
+.input-adorned-container-invalid,
+.input-adorned-container-warning {
+  > .input-prefix,
+  > .input-adorned:first-child {
+    padding-inline-start: styles.$invalid-control-left-padding;
+  }
 }

--- a/src/input/utils.ts
+++ b/src/input/utils.ts
@@ -18,11 +18,11 @@ export const useSearchProps = (
     onChange('');
   }, [inputRef, onChange]);
   if (type === 'search' || type === 'visualSearch') {
-    searchProps.__leftIcon = 'search';
+    searchProps.__startIcon = 'search';
 
     if (!disabled && !readOnly && value) {
-      searchProps.__rightIcon = 'close';
-      searchProps.__onRightIconClick = handleIconClick;
+      searchProps.__endIcon = 'close';
+      searchProps.__onEndIconClick = handleIconClick;
     }
   }
   return searchProps;

--- a/src/test-utils/dom/input/index.ts
+++ b/src/test-utils/dom/input/index.ts
@@ -10,7 +10,7 @@ export default class InputWrapper extends BaseInputWrapper {
   static rootSelector: string = inputSelectors.root;
 
   findClearButton(): ElementWrapper | null {
-    return this.find(`.${inputSelectors['input-button-right']}`);
+    return this.find(`.${inputSelectors['input-button-end']}`);
   }
 
   findPrefix(): ElementWrapper | null {

--- a/src/test-utils/dom/input/index.ts
+++ b/src/test-utils/dom/input/index.ts
@@ -10,7 +10,7 @@ export default class InputWrapper extends BaseInputWrapper {
   static rootSelector: string = inputSelectors.root;
 
   findClearButton(): ElementWrapper | null {
-    return this.find(`.${inputSelectors['input-button-end']}`);
+    return this.find(`.${inputSelectors['input-button-right']}`);
   }
 
   findPrefix(): ElementWrapper | null {

--- a/src/test-utils/dom/input/index.ts
+++ b/src/test-utils/dom/input/index.ts
@@ -12,4 +12,12 @@ export default class InputWrapper extends BaseInputWrapper {
   findClearButton(): ElementWrapper | null {
     return this.find(`.${inputSelectors['input-button-right']}`);
   }
+
+  findPrefix(): ElementWrapper | null {
+    return this.find(`.${inputSelectors['input-prefix']}`);
+  }
+
+  findSuffix(): ElementWrapper | null {
+    return this.find(`.${inputSelectors['input-suffix']}`);
+  }
 }


### PR DESCRIPTION
- **feat: Input prefix suffix**
- **chore: truncate long text**
- **chore: Change naming into RTL friendly name**
- **chore: Make prefixes cursor selectable and ally**
- **chore: Remove duplicate prmutation entry**
- **chore: replace adornment with prefix suffix**
- **fix: revert back test util change**
- **chore: falsy 0 value ignored as edgecase**
- **chore: clean up default style**
- **Avoid calc getting stripped out Fix build error**

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
