### PR TITLE
fix: Sass stripping calc out

### DIFF
--- a/src/input/styles.scss
+++ b/src/input/styles.scss
@@ -322,7 +322,7 @@
   display: flex;
   align-items: center;
   flex-shrink: 1;
-  max-inline-size: #{'max(0px, calc((100% - 12rem) / 2))'};
+  max-inline-size: calc(50% - 6rem);
   min-inline-size: 0;
   padding-block: styles.$control-padding-vertical;
   padding-inline: styles.$control-padding-horizontal;
@@ -412,6 +412,6 @@
 
   > .input-prefix,
   > .input-suffix {
-    max-inline-size: #{'max(0px, calc((100% - 12rem + #{styles.$invalid-control-left-border} - #{awsui.$border-width-field}) / 2))'};
+    max-inline-size: calc(50% - 6rem + (#{styles.$invalid-control-left-border} - #{awsui.$border-width-field}) / 2);
   }
 }

--- a/src/input/styles.scss
+++ b/src/input/styles.scss
@@ -412,6 +412,6 @@
 
   > .input-prefix,
   > .input-suffix {
-    max-inline-size: #{'max( 0px, calc((100% - 12rem + #{styles.$invalid-control-left-border} - #{awsui.$border-width-field}) / 2))'};
+    max-inline-size: #{'max(0px, calc((100% - 12rem + #{styles.$invalid-control-left-border} - #{awsui.$border-width-field}) / 2))'};
   }
 }

--- a/src/input/styles.scss
+++ b/src/input/styles.scss
@@ -322,7 +322,7 @@
   display: flex;
   align-items: center;
   flex-shrink: 1;
-  max-inline-size: max(0px, calc((100% - 12rem) / 2));
+  max-inline-size: #{'max(0px, calc((100% - 12rem) / 2))'};
   min-inline-size: 0;
   padding-block: styles.$control-padding-vertical;
   padding-inline: styles.$control-padding-horizontal;
@@ -412,9 +412,6 @@
 
   > .input-prefix,
   > .input-suffix {
-    max-inline-size: max(
-      0px,
-      calc((100% - 12rem + #{styles.$invalid-control-left-border} - #{awsui.$border-width-field}) / 2)
-    );
+    max-inline-size: #{'max( 0px, calc((100% - 12rem + #{styles.$invalid-control-left-border} - #{awsui.$border-width-field}) / 2))'};
   }
 }


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
Fix SassError from #4755  

Error:
```
SassError: Incompatible units rem and %.
  max-inline-size: max(0px, (100% - 12rem) / 2);
```

<!-- Also include relevant motivation and context. -->

Related links, build: 7968250649

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
